### PR TITLE
fix(15305): Creating an adapter opens the correct tabs

### DIFF
--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/ProtocolAdapterPage.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/ProtocolAdapterPage.tsx
@@ -1,8 +1,8 @@
-import { FC } from 'react'
+import { FC, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Tab, TabList, TabPanel, TabPanels, Tabs } from '@chakra-ui/react'
 
-import { Outlet } from 'react-router-dom'
+import { Outlet, useLocation } from 'react-router-dom'
 
 import PageContainer from '@/components/PageContainer.tsx'
 import ProtocolAdapters from '@/modules/ProtocolAdapters/components/panels/ProtocolAdapters.tsx'
@@ -15,9 +15,22 @@ export enum ProtocolAdapterTabIndex {
 
 const ProtocolAdapterPage: FC = () => {
   const { t } = useTranslation()
+  const { state } = useLocation()
+  const [tabIndex, setTabIndex] = useState(0)
+
+  useEffect(() => {
+    if (state?.protocolAdapterTabIndex) {
+      setTabIndex(state.protocolAdapterTabIndex)
+    }
+  }, [state])
+
+  const handleTabsChange = (index: number) => {
+    setTabIndex(index)
+  }
+
   return (
     <PageContainer title={t('protocolAdapter.title') as string} subtitle={t('protocolAdapter.description') as string}>
-      <Tabs isLazy>
+      <Tabs onChange={handleTabsChange} index={tabIndex}>
         <TabList>
           <Tab fontSize="lg" fontWeight={'bold'}>
             {t('protocolAdapter.tabs.protocols')}

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/ProtocolAdapterPage.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/ProtocolAdapterPage.tsx
@@ -8,6 +8,11 @@ import PageContainer from '@/components/PageContainer.tsx'
 import ProtocolAdapters from '@/modules/ProtocolAdapters/components/panels/ProtocolAdapters.tsx'
 import ProtocolIntegrationStore from '@/modules/ProtocolAdapters/components/panels/ProtocolIntegrationStore.tsx'
 
+export enum ProtocolAdapterTabIndex {
+  protocols = 0,
+  adapters = 1,
+}
+
 const ProtocolAdapterPage: FC = () => {
   const { t } = useTranslation()
   return (

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/AdapterController.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/AdapterController.tsx
@@ -11,6 +11,7 @@ import { useCreateProtocolAdapter } from '@/api/hooks/useProtocolAdapters/useCre
 import { useTranslation } from 'react-i18next'
 import { ProblemDetailsExtended } from '@/api/types/http-problem-details.ts'
 import { useUpdateProtocolAdapter } from '@/api/hooks/useProtocolAdapters/useUpdateProtocolAdapter.tsx'
+import { ProtocolAdapterTabIndex } from '@/modules/ProtocolAdapters/ProtocolAdapterPage.tsx'
 
 interface AdapterEditorProps {
   isNew?: boolean
@@ -61,7 +62,7 @@ const AdapterController: FC<AdapterEditorProps> = ({ children, isNew }) => {
 
   const handleInstanceClose = () => {
     onInstanceClose()
-    navigate('/protocol-adapters')
+    navigate('/protocol-adapters', { state: { protocolAdapterTabIndex: ProtocolAdapterTabIndex.adapters } })
   }
 
   const handleInstanceSubmit: SubmitHandler<Adapter> = (props) => {


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/15305/details/

Correct the behaviour of creating a new adapter by, upon success, opening the "Adapter List" tab

![screenshot-localhost_3000-2023 07 05-09_10_56](https://github.com/hivemq/hivemq-edge/assets/2743481/5655bf12-67af-4bcb-b5da-aac019698b02)

