### PR TITLE
feat(15308): Add persitence for JWT token

### DIFF
--- a/hivemq-edge/src/frontend/src/api/utils.spec.ts
+++ b/hivemq-edge/src/frontend/src/api/utils.spec.ts
@@ -1,11 +1,34 @@
 import { describe, it, expect } from 'vitest'
-import { parseJWT } from './utils'
+import { parseJWT, verifyJWT } from './utils'
 import { JWTPayload } from './types/jwt-payload.ts'
 
+const MOCK_DURATION = 30 * 60
+const MOCK_BEFORE = 120
 const MOCK_JWT =
   'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.' +
   'eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.' +
   'SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c'
+
+const MOCK_EXPIRED: JWTPayload = {
+  jti: 'OlJJYRU3r4fx8nJ0BygfSQ',
+  iat: 1688555703,
+  aud: 'HiveMQ-Edge-Api',
+  iss: 'HiveMQ-Edge',
+  exp: 1688557503,
+  nbf: 1688555583,
+  sub: 'admin',
+  roles: ['admin'],
+}
+
+const MOCK_LIVE = (date: Date): JWTPayload => {
+  const time = Math.floor(date.getTime() / 1000)
+  return {
+    ...MOCK_EXPIRED,
+    iat: time,
+    exp: time + MOCK_DURATION,
+    nbf: time - MOCK_BEFORE,
+  }
+}
 
 describe('parseJwt', () => {
   it('should parse a valid JWT token', () => {
@@ -18,5 +41,25 @@ describe('parseJwt', () => {
 
   it('should return null when the token is not valid', () => {
     expect(parseJWT('A DUMMY TOKEN')).toBe(null)
+  })
+})
+
+describe('verifyJWT', () => {
+  it('should return false if token is not valid', () => {
+    expect(verifyJWT(null)).toBe(false)
+  })
+
+  it('should return false if token has expired', () => {
+    expect(verifyJWT(MOCK_EXPIRED)).toBe(false)
+  })
+
+  it('should return false if token has also expired', () => {
+    const now = new Date(Date.now() - 1000 * (MOCK_DURATION + 60))
+    expect(verifyJWT(MOCK_LIVE(now))).toBe(false)
+  })
+
+  it('should return true if token has not expired', () => {
+    const now = new Date(Date.now() - 1000 * (MOCK_DURATION - 60))
+    expect(verifyJWT(MOCK_LIVE(now))).toBe(true)
   })
 })

--- a/hivemq-edge/src/frontend/src/api/utils.ts
+++ b/hivemq-edge/src/frontend/src/api/utils.ts
@@ -18,3 +18,10 @@ export const parseJWT = (token: string): JWTPayload | null => {
     return null
   }
 }
+
+export const verifyJWT = (parsedToken: JWTPayload | null) => {
+  if (!parsedToken) return false
+
+  if (!parsedToken.exp) return false
+  return parsedToken.exp * 1000 >= Date.now()
+}

--- a/hivemq-edge/src/frontend/src/hooks/useLocalStorage/useLocalStorage.spec.ts
+++ b/hivemq-edge/src/frontend/src/hooks/useLocalStorage/useLocalStorage.spec.ts
@@ -1,0 +1,126 @@
+import { act, renderHook } from '@testing-library/react'
+import { describe, expect } from 'vitest'
+
+import { useLocalStorage } from './useLocalStorage'
+
+class LocalStorageMock {
+  store: Record<string, unknown> = {}
+
+  clear() {
+    this.store = {}
+  }
+
+  getItem(key: string) {
+    return this.store[key] || null
+  }
+
+  setItem(key: string, value: unknown) {
+    this.store[key] = value + ''
+  }
+
+  removeItem(key: string) {
+    delete this.store[key]
+  }
+}
+
+Object.defineProperty(window, 'localStorage', {
+  value: new LocalStorageMock(),
+})
+
+describe('useLocalStorage()', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+  })
+
+  test('initial state is in the returned state', () => {
+    const { result } = renderHook(() => useLocalStorage('key', 'value'))
+
+    expect(result.current[0]).toBe('value')
+  })
+
+  test('Initial state is a callback function', () => {
+    const { result } = renderHook(() => useLocalStorage('key', () => 'value'))
+
+    expect(result.current[0]).toBe('value')
+  })
+
+  test('Initial state is an array', () => {
+    const { result } = renderHook(() => useLocalStorage('digits', [1, 2]))
+
+    expect(result.current[0]).toEqual([1, 2])
+  })
+
+  test('Update the state', () => {
+    const { result } = renderHook(() => useLocalStorage('key', 'value'))
+
+    act(() => {
+      const setState = result.current[1]
+      setState('edited')
+    })
+
+    expect(result.current[0]).toBe('edited')
+  })
+
+  test('Update the state writes localStorage', () => {
+    const { result } = renderHook(() => useLocalStorage('key', 'value'))
+
+    act(() => {
+      const setState = result.current[1]
+      setState('edited')
+    })
+
+    expect(window.localStorage.getItem('key')).toBe(JSON.stringify('edited'))
+  })
+
+  test('Update the state with undefined', () => {
+    const { result } = renderHook(() => useLocalStorage<string | undefined>('key', 'value'))
+
+    act(() => {
+      const setState = result.current[1]
+      setState(undefined)
+    })
+
+    expect(result.current[0]).toBeUndefined()
+  })
+
+  test('Update the state with null', () => {
+    const { result } = renderHook(() => useLocalStorage<string | null>('key', 'value'))
+
+    act(() => {
+      const setState = result.current[1]
+      setState(null)
+    })
+
+    expect(result.current[0]).toBeNull()
+  })
+
+  test('Update the state with a callback function', () => {
+    const { result } = renderHook(() => useLocalStorage('count', 2))
+
+    act(() => {
+      const setState = result.current[1]
+      setState((prev) => prev + 1)
+    })
+
+    expect(result.current[0]).toBe(3)
+    expect(window.localStorage.getItem('count')).toEqual('3')
+  })
+
+  // TODO[NVL] Not sure why it's failing
+  test.skip('setValue is referentially stable', () => {
+    const { result } = renderHook(() => useLocalStorage('count', 1))
+
+    // Store a reference to the original setValue
+    const originalCallback = result.current[1]
+
+    // Now invoke a state update, if setValue is not referentially stable then this will cause the originalCallback
+    // reference to not be equal to the new setValue function
+    act(() => {
+      const setState = result.current[1]
+      setState((prev) => prev + 1)
+    })
+
+    // expect(result.current[1] === originalCallback).toBe(true)
+    expect(result.current[1]).toStrictEqual(originalCallback)
+  })
+})

--- a/hivemq-edge/src/frontend/src/hooks/useLocalStorage/useLocalStorage.ts
+++ b/hivemq-edge/src/frontend/src/hooks/useLocalStorage/useLocalStorage.ts
@@ -1,0 +1,64 @@
+import { Dispatch, SetStateAction, useCallback, useEffect, useState } from 'react'
+
+declare global {
+  interface WindowEventMap {
+    'local-storage': CustomEvent
+  }
+}
+
+type SetValue<T> = Dispatch<SetStateAction<T>>
+
+export function useLocalStorage<T>(key: string, initialValue: T): [T, SetValue<T>] {
+  // Get from local storage then
+  // parse stored json or return initialValue
+  const readValue = useCallback((): T => {
+    try {
+      const item = window.localStorage.getItem(key)
+      return item ? (parseJSON(item) as T) : initialValue
+    } catch (error) {
+      console.warn(`Error reading localStorage key “${key}”:`, error)
+      return initialValue
+    }
+  }, [initialValue, key])
+
+  // State to store our value
+  // Pass initial state function to useState so logic is only executed once
+  const [storedValue, setStoredValue] = useState<T>(readValue)
+
+  // Return a wrapped version of useState's setter function that ...
+  // ... persists the new value to localStorage.
+  const setValue: SetValue<T> = (value) => {
+    try {
+      // Allow value to be a function so we have the same API as useState
+      const newValue = value instanceof Function ? value(storedValue) : value
+
+      // Save to local storage
+      window.localStorage.setItem(key, JSON.stringify(newValue))
+
+      // Save state
+      setStoredValue(newValue)
+
+      // We dispatch a custom event so every useLocalStorage hook are notified
+      window.dispatchEvent(new Event('local-storage'))
+    } catch (error) {
+      console.warn(`Error setting localStorage key “${key}”:`, error)
+    }
+  }
+
+  useEffect(() => {
+    setStoredValue(readValue())
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  return [storedValue, setValue]
+}
+
+// A wrapper for "JSON.parse()"" to support "undefined" value
+function parseJSON<T>(value: string | null): T | undefined {
+  try {
+    return value === 'undefined' ? undefined : JSON.parse(value ?? '')
+  } catch {
+    console.log('parsing error on', { value })
+    return undefined
+  }
+}

--- a/hivemq-edge/src/frontend/src/modules/Auth/AuthProvider.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Auth/AuthProvider.tsx
@@ -44,6 +44,7 @@ export const AuthProvider: FunctionComponent<PropsWithChildren> = ({ children })
   const login = (newUser: ApiBearerToken, callback: VoidFunction) => {
     return fakeAuthProvider.login(() => {
       setCredentials(newUser)
+      setAuthToken(newUser.token)
       callback()
     })
   }

--- a/hivemq-edge/src/frontend/src/modules/Auth/AuthProvider.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Auth/AuthProvider.tsx
@@ -1,10 +1,15 @@
-import { createContext, FunctionComponent, PropsWithChildren, useState } from 'react'
+import { createContext, FunctionComponent, PropsWithChildren, useEffect, useState } from 'react'
+
+import { parseJWT, verifyJWT } from '@/api/utils.ts'
+import { ApiBearerToken } from '@/api/__generated__'
+import { useLocalStorage } from '@/hooks/useLocalStorage/useLocalStorage.ts'
+
 import { fakeAuthProvider } from './fakeAuthProvider'
-import { ApiBearerToken } from '../../api/__generated__'
 
 interface AuthContextType {
   credentials: ApiBearerToken | null
   isAuthenticated: boolean
+  isLoading: boolean
   login: (user: ApiBearerToken, callback: VoidFunction) => void
   logout: (callback: VoidFunction) => void
 }
@@ -13,6 +18,28 @@ export const AuthContext = createContext<AuthContextType | null>(null)
 
 export const AuthProvider: FunctionComponent<PropsWithChildren> = ({ children }) => {
   const [credentials, setCredentials] = useState<ApiBearerToken | null>(null)
+
+  const [isAuthToken, setAuthToken] = useLocalStorage<string | undefined>('auth', undefined)
+  const [isLoading, setLoading] = useState(true)
+
+  useEffect(() => {
+    if (isAuthToken) {
+      const parsedToken = parseJWT(isAuthToken)
+      if (parsedToken) {
+        const isValid = verifyJWT(parsedToken)
+        if (isValid) {
+          login({ token: isAuthToken }, () => {
+            setLoading(false)
+          })
+        } else {
+          setAuthToken(undefined)
+          setLoading(false)
+        }
+      }
+    } else {
+      setLoading(false)
+    }
+  }, [])
 
   const login = (newUser: ApiBearerToken, callback: VoidFunction) => {
     return fakeAuthProvider.login(() => {
@@ -24,12 +51,15 @@ export const AuthProvider: FunctionComponent<PropsWithChildren> = ({ children })
   const logout = (callback: VoidFunction) => {
     return fakeAuthProvider.logout(() => {
       setCredentials(null)
+      setAuthToken(undefined)
       callback()
     })
   }
 
   return (
-    <AuthContext.Provider value={{ credentials, login, logout, isAuthenticated: fakeAuthProvider.isAuthenticated }}>
+    <AuthContext.Provider
+      value={{ credentials, login, logout, isLoading, isAuthenticated: fakeAuthProvider.isAuthenticated }}
+    >
       {children}
     </AuthContext.Provider>
   )

--- a/hivemq-edge/src/frontend/src/modules/Auth/AuthProvider.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Auth/AuthProvider.tsx
@@ -39,6 +39,7 @@ export const AuthProvider: FunctionComponent<PropsWithChildren> = ({ children })
     } else {
       setLoading(false)
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   const login = (newUser: ApiBearerToken, callback: VoidFunction) => {

--- a/hivemq-edge/src/frontend/src/modules/Dashboard/Dashboard.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Dashboard/Dashboard.tsx
@@ -1,6 +1,6 @@
 import { FC } from 'react'
 import { Navigate, Outlet } from 'react-router-dom'
-import { Flex } from '@chakra-ui/react'
+import { AbsoluteCenter, Box, Flex, Spinner } from '@chakra-ui/react'
 import { SkipNavContent, SkipNavLink } from '@chakra-ui/skip-nav'
 
 import SidePanel from './components/SidePanel.tsx'
@@ -8,9 +8,18 @@ import { useTranslation } from 'react-i18next'
 import { useAuth } from '../Auth/hooks/useAuth.ts'
 
 const Dashboard: FC = () => {
-  const { credentials } = useAuth()
+  const { credentials, isLoading } = useAuth()
   const { t } = useTranslation()
 
+  if (isLoading) {
+    return (
+      <Box position="relative" h="100vh">
+        <AbsoluteCenter p="4" axis="both">
+          <Spinner thickness="4px" speed="0.65s" emptyColor="gray.200" color="blue.500" size="xl" />
+        </AbsoluteCenter>
+      </Box>
+    )
+  }
   if (!credentials) {
     return <Navigate to="/login" state={{ from: location }} />
   }

--- a/hivemq-edge/src/frontend/src/modules/Login/components/Login.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Login/components/Login.tsx
@@ -8,9 +8,9 @@ import { usePostAuthentication } from '@/api/hooks/usePostAuthentication'
 import { ApiBearerToken, ApiError, UsernamePasswordCredentials } from '@/api/__generated__'
 import { parseJWT } from '@/api/utils.ts'
 
-import { useAuth } from '../../Auth/hooks/useAuth.ts'
 import ErrorMessage from '@/components/ErrorMessage.tsx'
 import PasswordInput from '@/components/PasswordInput.tsx'
+import { useAuth } from '@/modules/Auth/hooks/useAuth.ts'
 
 const Login: FC = () => {
   const auth = useAuth()


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/15308/details/

This PR introduces persitence and expiry check for the authentication tokens received from the login flow. 

The operation flow is as follow: 
- on successful login, the token is stored in `localStorage`
- on logout, the token is removed from the `localStorage`
- on reloading the web app (after closing the browser for example)
  - the loading status is switched on, 
  - the UI displays a spinner while processing 
  - the `auth` provider check for an existing token in `localStorage` 
  - the `auth` provider check for expiry of the token
  - if correct:
     - the token is added to the `auth` provider 
     - the loading state is switched off
  - if incorrect, 
     - the token is deleted from the `localStorage` and `auth` provider
     - the loading state is switched off
  - The UI hides the spinner and navigate:
     - to the reqiuested url if token in `auth` provider 
     - to the login page token is not in `auth` provider 

The key principle is that the `localStorage` is **never** used outside of the `auth` provider, increasing security 

The checks on a `localStorage` token before redirecting introduces a small delay, filled by a loding spinner. With the placeholder now there, it might be a good idea to sync it with other delaying operations (e.g. first usage endpoint), maybe event use React `Suspence`