### PR TITLE
feature (15441) - Allow JWT reissue in CORS

### DIFF
--- a/hivemq-edge/src/main/java/com/hivemq/http/filters/CorsFilter.java
+++ b/hivemq-edge/src/main/java/com/hivemq/http/filters/CorsFilter.java
@@ -27,6 +27,7 @@ public class CorsFilter implements ContainerResponseFilter {
             ContainerRequestContext requestContext, ContainerResponseContext responseContext) throws IOException {
         responseContext.getHeaders().add("Access-Control-Allow-Origin", "*");
         responseContext.getHeaders().add("Access-Control-Allow-Credentials", "true");
+        //-- Added the re-issuance header to the allow headers list for use on the UI
         responseContext.getHeaders().add("Access-Control-Allow-Headers", "origin, content-type, accept, authorization, X-Bearer-Token-Reissue");
         responseContext.getHeaders().add("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS, HEAD");
     }


### PR DESCRIPTION
Add the reissuance header to the CORS filter. see https://hivemq.kanbanize.com/ctrl_board/57/cards/15441/details/