### PR TITLE
fix(15302): The Switch component now properly persist form's data

### DIFF
--- a/hivemq-edge/src/frontend/src/hooks/useEdgeToast/useEdgeToast.tsx
+++ b/hivemq-edge/src/frontend/src/hooks/useEdgeToast/useEdgeToast.tsx
@@ -15,7 +15,6 @@ export const useEdgeToast = () => {
 
   const errorToast = (options: UseToastOptions, err: ApiError) => {
     const { body } = err
-    console.log('XX  XXXXXXX', { ...err })
     createToast({
       ...DEFAULT_TOAST_OPTION,
       ...options,

--- a/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/SecurityPanel.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/SecurityPanel.spec.cy.tsx
@@ -1,0 +1,71 @@
+/// <reference types="cypress" />
+import { useForm } from 'react-hook-form'
+import { FC } from 'react'
+
+import { Bridge } from '@/api/__generated__'
+import { mockBridge } from '@/api/hooks/useGetBridges/__handlers__'
+import ButtonCTA from '@/components/Chakra/ButtonCTA.tsx'
+import SecurityPanel from './SecurityPanel.tsx'
+
+interface TestingComponentProps {
+  onSubmit: (data: Bridge) => void
+  defaultValues: Bridge
+}
+
+const TestingComponent: FC<TestingComponentProps> = ({ onSubmit, defaultValues }) => {
+  const form = useForm<Bridge>({
+    mode: 'all',
+    criteriaMode: 'all',
+    defaultValues: defaultValues,
+  })
+  return (
+    <div>
+      <form id="bridge-form" onSubmit={form.handleSubmit(onSubmit)}>
+        <SecurityPanel form={form} />
+      </form>
+      <ButtonCTA type={'submit'} form="bridge-form" data-testid={'form-submit'} mt={8}>
+        Submit
+      </ButtonCTA>
+    </div>
+  )
+}
+
+describe('SecurityPanel', () => {
+  beforeEach(() => {
+    cy.viewport(800, 800)
+  })
+
+  it('should be accessible', () => {
+    cy.injectAxe()
+    cy.mountWithProviders(<TestingComponent onSubmit={cy.stub} defaultValues={mockBridge} />)
+    cy.checkAccessibility()
+    cy.percySnapshot('Component: SecurityPanel')
+  })
+
+  it('should render unexpanded', () => {
+    const mockOnSubmit = cy.stub().as('onSubmit')
+    cy.mountWithProviders(<TestingComponent onSubmit={mockOnSubmit} defaultValues={mockBridge} />)
+
+    cy.getByTestId('form-submit').click()
+    cy.get('@onSubmit').should(
+      'have.been.calledWith',
+      Cypress.sinon.match({ ...mockBridge, tlsConfiguration: { enabled: false } })
+    )
+  })
+
+  it('should render expanded', () => {
+    const mockOnSubmit = cy.stub().as('onSubmit')
+    cy.mountWithProviders(
+      <TestingComponent
+        onSubmit={mockOnSubmit}
+        defaultValues={{ ...mockBridge, tlsConfiguration: { enabled: true } }}
+      />
+    )
+
+    cy.getByTestId('form-submit').click()
+    cy.get('@onSubmit').should(
+      'have.been.calledWith',
+      Cypress.sinon.match({ ...mockBridge, tlsConfiguration: { enabled: true } })
+    )
+  })
+})

--- a/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/SecurityPanel.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/SecurityPanel.tsx
@@ -19,7 +19,7 @@ const SecurityPanel: FC<BridgePanelType> = ({ form }) => {
     <Flex flexDirection={'column'} mt={8} maxW={600} gap={4}>
       <FormControl>
         <FormLabel htmlFor={'tlsConfiguration.enabled'}>{t('bridge.security.enabled.label')}</FormLabel>
-        <Switch {...register('tlsConfiguration.enabled')} />
+        <Switch id={'tlsConfiguration.enabled'} {...register('tlsConfiguration.enabled')} />
         <FormHelperText>{t('bridge.security.enabled.helper')}</FormHelperText>
       </FormControl>
 

--- a/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/SecurityPanel.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/SecurityPanel.tsx
@@ -10,6 +10,7 @@ import { BridgePanelType } from '../../types.ts'
 const SecurityPanel: FC<BridgePanelType> = ({ form }) => {
   const { t } = useTranslation()
   const {
+    register,
     formState: { errors },
   } = form
   const isTlsEnabled = useWatch({ name: 'tlsConfiguration.enabled', control: form.control })
@@ -18,13 +19,7 @@ const SecurityPanel: FC<BridgePanelType> = ({ form }) => {
     <Flex flexDirection={'column'} mt={8} maxW={600} gap={4}>
       <FormControl>
         <FormLabel htmlFor={'tlsConfiguration.enabled'}>{t('bridge.security.enabled.label')}</FormLabel>
-        <Controller
-          name={'tlsConfiguration.enabled'}
-          control={form.control}
-          render={({ field: { value, ...rest } }) => (
-            <Switch id={'tlsConfiguration.enabled'} {...rest} value={value ? 'true' : undefined} />
-          )}
-        />
+        <Switch {...register('tlsConfiguration.enabled')} />
         <FormHelperText>{t('bridge.security.enabled.helper')}</FormHelperText>
       </FormControl>
 

--- a/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/SubscriptionsPanel.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/SubscriptionsPanel.tsx
@@ -40,6 +40,7 @@ const SubscriptionsPanel: FC<BridgeSubscriptionsProps> = ({ form, type }) => {
   })
 
   const {
+    register,
     formState: { errors },
   } = form
 
@@ -209,11 +210,7 @@ const SubscriptionsPanel: FC<BridgeSubscriptionsProps> = ({ form, type }) => {
                         <FormLabel htmlFor={`${type}.${index}.preserveRetain`}>
                           {t('bridge.subscription.preserveRetain.label')}
                         </FormLabel>
-                        <Controller
-                          name={`${type}.${index}.preserveRetain`}
-                          render={({ field }) => <Switch {...field} id={`${type}.${index}.preserveRetain`} value={1} />}
-                          control={form.control}
-                        />
+                        <Switch {...register(`${type}.${index}.preserveRetain`)} />
                         <FormErrorMessage>{errors[type]?.[index]?.filters?.message}</FormErrorMessage>
                       </FormControl>
 

--- a/hivemq-edge/src/frontend/src/modules/UnifiedNamespace/components/UnifiedNamespaceEditor.tsx
+++ b/hivemq-edge/src/frontend/src/modules/UnifiedNamespace/components/UnifiedNamespaceEditor.tsx
@@ -46,7 +46,6 @@ const UnifiedNamespaceEditor: FC<UnifiedNamespaceEditorProps> = () => {
   }
 
   const handleOnSubmit: SubmitHandler<ISA95ApiBean> = (data) => {
-    console.log('XXXXX enabled', data.enabled)
     mutateAsync({ requestBody: data })
       .then(() => {
         successToast({


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/15302/details/

The `TLS` enabling switch wasn't properly handling initial value when recovering the payload from the backend. 

The bug had bee nchanged, including in every other switch used in froms across the webap.

