### PR TITLE
feat(15309): Add middleware to axios for JWT reissuing and logout

### DIFF
--- a/hivemq-edge/src/frontend/package.json
+++ b/hivemq-edge/src/frontend/package.json
@@ -82,7 +82,7 @@
     "i18next-pseudo": "^2.2.1",
     "jsdom": "^22.0.0",
     "msw": "^1.2.1",
-    "openapi-typescript-codegen": "^0.24.0",
+    "openapi-typescript-codegen": "^0.25.0",
     "prettier": "2.8.8",
     "stylelint": "^15.6.2",
     "stylelint-config-standard": "^33.0.0",

--- a/hivemq-edge/src/frontend/pnpm-lock.yaml
+++ b/hivemq-edge/src/frontend/pnpm-lock.yaml
@@ -169,8 +169,8 @@ devDependencies:
     specifier: ^1.2.1
     version: 1.2.1(typescript@5.0.4)
   openapi-typescript-codegen:
-    specifier: ^0.24.0
-    version: 0.24.0
+    specifier: ^0.25.0
+    version: 0.25.0
   prettier:
     specifier: 2.8.8
     version: 2.8.8
@@ -3523,9 +3523,9 @@ packages:
     dependencies:
       delayed-stream: 1.0.0
 
-  /commander@10.0.1:
-    resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
-    engines: {node: '>=14'}
+  /commander@11.0.0:
+    resolution: {integrity: sha512-9HMlXtt/BNoYr8ooyjjNRdIilOTkVJXB+GhxMTtOKwk0R4j4lS4NpjuqmRxroBfnfTSHQIHQB7wryHhXarNjmQ==}
+    engines: {node: '>=16'}
     dev: true
 
   /commander@6.2.1:
@@ -5769,12 +5769,12 @@ packages:
       mimic-fn: 2.1.0
     dev: true
 
-  /openapi-typescript-codegen@0.24.0:
-    resolution: {integrity: sha512-rSt8t1XbMWhv6Db7GUI24NNli7FU5kzHLxcE8BpzgGWRdWyWt9IB2YoLyPahxNrVA7yOaVgnXPkrcTDRMQtJYg==}
+  /openapi-typescript-codegen@0.25.0:
+    resolution: {integrity: sha512-nN/TnIcGbP58qYgwEEy5FrAAjePcYgfMaCe3tsmYyTgI3v4RR9v8os14L+LEWDvV50+CmqiyTzRkKKtJeb6Ybg==}
     hasBin: true
     dependencies:
       camelcase: 6.3.0
-      commander: 10.0.1
+      commander: 11.0.0
       fs-extra: 11.1.1
       handlebars: 4.7.7
       json-schema-ref-parser: 9.0.9

--- a/hivemq-edge/src/frontend/src/__test-utils__/msw/mockServer.ts
+++ b/hivemq-edge/src/frontend/src/__test-utils__/msw/mockServer.ts
@@ -1,0 +1,3 @@
+import { setupServer } from 'msw/node'
+
+export const server = setupServer()

--- a/hivemq-edge/src/frontend/src/__test-utils__/setup.ts
+++ b/hivemq-edge/src/frontend/src/__test-utils__/setup.ts
@@ -1,1 +1,15 @@
 import '@testing-library/jest-dom'
+import { beforeAll, afterEach, afterAll } from 'vitest'
+import { server } from './msw/mockServer.ts'
+
+// Establish API mocking before all tests.
+beforeAll(() => {
+  server.listen()
+})
+
+// Reset any request handlers that we may add during the tests,
+// so they don't affect other tests.
+afterEach(() => server.resetHandlers())
+
+// Clean up after the tests are finished.
+afterAll(() => server.close())

--- a/hivemq-edge/src/frontend/src/api/__generated__/HiveMqClient.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/HiveMqClient.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
@@ -34,7 +35,7 @@ export class HiveMqClient {
     constructor(config?: Partial<OpenAPIConfig>, HttpRequest: HttpRequestConstructor = AxiosHttpRequest) {
         this.request = new HttpRequest({
             BASE: config?.BASE ?? '',
-            VERSION: config?.VERSION ?? '0.5',
+            VERSION: config?.VERSION ?? '2023.1',
             WITH_CREDENTIALS: config?.WITH_CREDENTIALS ?? false,
             CREDENTIALS: config?.CREDENTIALS ?? 'include',
             TOKEN: config?.TOKEN,

--- a/hivemq-edge/src/frontend/src/api/__generated__/core/ApiError.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/core/ApiError.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/hivemq-edge/src/frontend/src/api/__generated__/core/ApiRequestOptions.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/core/ApiRequestOptions.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/hivemq-edge/src/frontend/src/api/__generated__/core/ApiResult.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/core/ApiResult.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/hivemq-edge/src/frontend/src/api/__generated__/core/AxiosHttpRequest.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/core/AxiosHttpRequest.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/hivemq-edge/src/frontend/src/api/__generated__/core/BaseHttpRequest.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/core/BaseHttpRequest.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/hivemq-edge/src/frontend/src/api/__generated__/core/CancelablePromise.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/core/CancelablePromise.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/hivemq-edge/src/frontend/src/api/__generated__/core/OpenAPI.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/core/OpenAPI.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
@@ -11,16 +12,16 @@ export type OpenAPIConfig = {
     VERSION: string;
     WITH_CREDENTIALS: boolean;
     CREDENTIALS: 'include' | 'omit' | 'same-origin';
-    TOKEN?: string | Resolver<string>;
-    USERNAME?: string | Resolver<string>;
-    PASSWORD?: string | Resolver<string>;
-    HEADERS?: Headers | Resolver<Headers>;
-    ENCODE_PATH?: (path: string) => string;
+    TOKEN?: string | Resolver<string> | undefined;
+    USERNAME?: string | Resolver<string> | undefined;
+    PASSWORD?: string | Resolver<string> | undefined;
+    HEADERS?: Headers | Resolver<Headers> | undefined;
+    ENCODE_PATH?: ((path: string) => string) | undefined;
 };
 
 export const OpenAPI: OpenAPIConfig = {
     BASE: '',
-    VERSION: '0.5',
+    VERSION: '2023.1',
     WITH_CREDENTIALS: false,
     CREDENTIALS: 'include',
     TOKEN: undefined,

--- a/hivemq-edge/src/frontend/src/api/__generated__/core/request.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/core/request.ts
@@ -1,8 +1,9 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
 import axios from 'axios';
-import type { AxiosError, AxiosRequestConfig, AxiosResponse } from 'axios';
+import type { AxiosError, AxiosRequestConfig, AxiosResponse, AxiosInstance } from 'axios';
 import FormData from 'form-data';
 
 import { ApiError } from './ApiError';
@@ -12,19 +13,19 @@ import { CancelablePromise } from './CancelablePromise';
 import type { OnCancel } from './CancelablePromise';
 import type { OpenAPIConfig } from './OpenAPI';
 
-const isDefined = <T>(value: T | null | undefined): value is Exclude<T, null | undefined> => {
+export const isDefined = <T>(value: T | null | undefined): value is Exclude<T, null | undefined> => {
     return value !== undefined && value !== null;
 };
 
-const isString = (value: any): value is string => {
+export const isString = (value: any): value is string => {
     return typeof value === 'string';
 };
 
-const isStringWithValue = (value: any): value is string => {
+export const isStringWithValue = (value: any): value is string => {
     return isString(value) && value !== '';
 };
 
-const isBlob = (value: any): value is Blob => {
+export const isBlob = (value: any): value is Blob => {
     return (
         typeof value === 'object' &&
         typeof value.type === 'string' &&
@@ -37,15 +38,15 @@ const isBlob = (value: any): value is Blob => {
     );
 };
 
-const isFormData = (value: any): value is FormData => {
+export const isFormData = (value: any): value is FormData => {
     return value instanceof FormData;
 };
 
-const isSuccess = (status: number): boolean => {
+export const isSuccess = (status: number): boolean => {
     return status >= 200 && status < 300;
 };
 
-const base64 = (str: string): string => {
+export const base64 = (str: string): string => {
     try {
         return btoa(str);
     } catch (err) {
@@ -54,7 +55,7 @@ const base64 = (str: string): string => {
     }
 };
 
-const getQueryString = (params: Record<string, any>): string => {
+export const getQueryString = (params: Record<string, any>): string => {
     const qs: string[] = [];
 
     const append = (key: string, value: any) => {
@@ -107,7 +108,7 @@ const getUrl = (config: OpenAPIConfig, options: ApiRequestOptions): string => {
     return url;
 };
 
-const getFormData = (options: ApiRequestOptions): FormData | undefined => {
+export const getFormData = (options: ApiRequestOptions): FormData | undefined => {
     if (options.formData) {
         const formData = new FormData();
 
@@ -136,14 +137,14 @@ const getFormData = (options: ApiRequestOptions): FormData | undefined => {
 
 type Resolver<T> = (options: ApiRequestOptions) => Promise<T>;
 
-const resolve = async <T>(options: ApiRequestOptions, resolver?: T | Resolver<T>): Promise<T | undefined> => {
+export const resolve = async <T>(options: ApiRequestOptions, resolver?: T | Resolver<T>): Promise<T | undefined> => {
     if (typeof resolver === 'function') {
         return (resolver as Resolver<T>)(options);
     }
     return resolver;
 };
 
-const getHeaders = async (config: OpenAPIConfig, options: ApiRequestOptions, formData?: FormData): Promise<Record<string, string>> => {
+export const getHeaders = async (config: OpenAPIConfig, options: ApiRequestOptions, formData?: FormData): Promise<Record<string, string>> => {
     const token = await resolve(options, config.TOKEN);
     const username = await resolve(options, config.USERNAME);
     const password = await resolve(options, config.PASSWORD);
@@ -186,21 +187,22 @@ const getHeaders = async (config: OpenAPIConfig, options: ApiRequestOptions, for
     return headers;
 };
 
-const getRequestBody = (options: ApiRequestOptions): any => {
+export const getRequestBody = (options: ApiRequestOptions): any => {
     if (options.body) {
         return options.body;
     }
     return undefined;
 };
 
-const sendRequest = async <T>(
+export const sendRequest = async <T>(
     config: OpenAPIConfig,
     options: ApiRequestOptions,
     url: string,
     body: any,
     formData: FormData | undefined,
     headers: Record<string, string>,
-    onCancel: OnCancel
+    onCancel: OnCancel,
+    axiosClient: AxiosInstance
 ): Promise<AxiosResponse<T>> => {
     const source = axios.CancelToken.source();
 
@@ -216,7 +218,7 @@ const sendRequest = async <T>(
     onCancel(() => source.cancel('The user aborted a request.'));
 
     try {
-        return await axios.request(requestConfig);
+        return await axiosClient.request(requestConfig);
     } catch (error) {
         const axiosError = error as AxiosError<T>;
         if (axiosError.response) {
@@ -226,7 +228,7 @@ const sendRequest = async <T>(
     }
 };
 
-const getResponseHeader = (response: AxiosResponse<any>, responseHeader?: string): string | undefined => {
+export const getResponseHeader = (response: AxiosResponse<any>, responseHeader?: string): string | undefined => {
     if (responseHeader) {
         const content = response.headers[responseHeader];
         if (isString(content)) {
@@ -236,14 +238,14 @@ const getResponseHeader = (response: AxiosResponse<any>, responseHeader?: string
     return undefined;
 };
 
-const getResponseBody = (response: AxiosResponse<any>): any => {
+export const getResponseBody = (response: AxiosResponse<any>): any => {
     if (response.status !== 204) {
         return response.data;
     }
     return undefined;
 };
 
-const catchErrorCodes = (options: ApiRequestOptions, result: ApiResult): void => {
+export const catchErrorCodes = (options: ApiRequestOptions, result: ApiResult): void => {
     const errors: Record<number, string> = {
         400: 'Bad Request',
         401: 'Unauthorized',
@@ -261,7 +263,19 @@ const catchErrorCodes = (options: ApiRequestOptions, result: ApiResult): void =>
     }
 
     if (!result.ok) {
-        throw new ApiError(options, result, 'Generic Error');
+        const errorStatus = result.status ?? 'unknown';
+        const errorStatusText = result.statusText ?? 'unknown';
+        const errorBody = (() => {
+            try {
+                return JSON.stringify(result.body, null, 2);
+            } catch (e) {
+                return undefined;
+            }
+        })();
+
+        throw new ApiError(options, result,
+            `Generic Error: status: ${errorStatus}; status text: ${errorStatusText}; body: ${errorBody}`
+        );
     }
 };
 
@@ -269,10 +283,11 @@ const catchErrorCodes = (options: ApiRequestOptions, result: ApiResult): void =>
  * Request method
  * @param config The OpenAPI configuration object
  * @param options The request options from the service
+ * @param axiosClient The axios client instance to use
  * @returns CancelablePromise<T>
  * @throws ApiError
  */
-export const request = <T>(config: OpenAPIConfig, options: ApiRequestOptions): CancelablePromise<T> => {
+export const request = <T>(config: OpenAPIConfig, options: ApiRequestOptions, axiosClient: AxiosInstance = axios): CancelablePromise<T> => {
     return new CancelablePromise(async (resolve, reject, onCancel) => {
         try {
             const url = getUrl(config, options);
@@ -281,7 +296,7 @@ export const request = <T>(config: OpenAPIConfig, options: ApiRequestOptions): C
             const headers = await getHeaders(config, options, formData);
 
             if (!onCancel.isCancelled) {
-                const response = await sendRequest<T>(config, options, url, body, formData, headers, onCancel);
+                const response = await sendRequest<T>(config, options, url, body, formData, headers, onCancel, axiosClient);
                 const responseBody = getResponseBody(response);
                 const responseHeader = getResponseHeader(response, options.responseHeader);
 

--- a/hivemq-edge/src/frontend/src/api/__generated__/index.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/index.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
@@ -28,6 +29,7 @@ export type { Extension } from './models/Extension';
 export type { ExtensionList } from './models/ExtensionList';
 export type { FirstUseInformation } from './models/FirstUseInformation';
 export type { GatewayConfiguration } from './models/GatewayConfiguration';
+export type { HealthStatus } from './models/HealthStatus';
 export type { ISA95ApiBean } from './models/ISA95ApiBean';
 export type { JsonNode } from './models/JsonNode';
 export type { Link } from './models/Link';
@@ -66,6 +68,7 @@ export { $Extension } from './schemas/$Extension';
 export { $ExtensionList } from './schemas/$ExtensionList';
 export { $FirstUseInformation } from './schemas/$FirstUseInformation';
 export { $GatewayConfiguration } from './schemas/$GatewayConfiguration';
+export { $HealthStatus } from './schemas/$HealthStatus';
 export { $ISA95ApiBean } from './schemas/$ISA95ApiBean';
 export { $JsonNode } from './schemas/$JsonNode';
 export { $Link } from './schemas/$Link';

--- a/hivemq-edge/src/frontend/src/api/__generated__/models/Adapter.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/models/Adapter.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/hivemq-edge/src/frontend/src/api/__generated__/models/AdapterRuntimeInformation.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/models/AdapterRuntimeInformation.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/hivemq-edge/src/frontend/src/api/__generated__/models/AdaptersList.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/models/AdaptersList.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/hivemq-edge/src/frontend/src/api/__generated__/models/ApiErrorMessage.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/models/ApiErrorMessage.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/hivemq-edge/src/frontend/src/api/__generated__/models/Bridge.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/models/Bridge.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/hivemq-edge/src/frontend/src/api/__generated__/models/BridgeCustomUserProperty.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/models/BridgeCustomUserProperty.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/hivemq-edge/src/frontend/src/api/__generated__/models/BridgeList.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/models/BridgeList.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/hivemq-edge/src/frontend/src/api/__generated__/models/BridgeRuntimeInformation.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/models/BridgeRuntimeInformation.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/hivemq-edge/src/frontend/src/api/__generated__/models/BridgeSubscription.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/models/BridgeSubscription.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/hivemq-edge/src/frontend/src/api/__generated__/models/ConnectionStatus.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/models/ConnectionStatus.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/hivemq-edge/src/frontend/src/api/__generated__/models/ConnectionStatusList.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/models/ConnectionStatusList.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/hivemq-edge/src/frontend/src/api/__generated__/models/ConnectionStatusTransitionCommand.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/models/ConnectionStatusTransitionCommand.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/hivemq-edge/src/frontend/src/api/__generated__/models/DataPoint.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/models/DataPoint.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/hivemq-edge/src/frontend/src/api/__generated__/models/EnvironmentProperties.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/models/EnvironmentProperties.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/hivemq-edge/src/frontend/src/api/__generated__/models/Extension.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/models/Extension.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/hivemq-edge/src/frontend/src/api/__generated__/models/ExtensionList.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/models/ExtensionList.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/hivemq-edge/src/frontend/src/api/__generated__/models/FirstUseInformation.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/models/FirstUseInformation.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/hivemq-edge/src/frontend/src/api/__generated__/models/GatewayConfiguration.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/models/GatewayConfiguration.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/hivemq-edge/src/frontend/src/api/__generated__/models/HealthStatus.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/models/HealthStatus.ts
@@ -3,10 +3,7 @@
 /* tslint:disable */
 /* eslint-disable */
 
-export type ApiBearerToken = {
-    /**
-     * The token associated a set of authenticated credentials
-     */
-    token?: string;
+export type HealthStatus = {
+    status?: string;
 };
 

--- a/hivemq-edge/src/frontend/src/api/__generated__/models/ISA95ApiBean.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/models/ISA95ApiBean.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/hivemq-edge/src/frontend/src/api/__generated__/models/JsonNode.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/models/JsonNode.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/hivemq-edge/src/frontend/src/api/__generated__/models/Link.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/models/Link.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/hivemq-edge/src/frontend/src/api/__generated__/models/LinkList.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/models/LinkList.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/hivemq-edge/src/frontend/src/api/__generated__/models/Listener.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/models/Listener.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
@@ -10,6 +11,10 @@ export type Listener = {
      * The extension description
      */
     description?: string | null;
+    /**
+     * The external hostname
+     */
+    externalHostname?: string | null;
     /**
      * A mandatory ID hostName with the Listener
      */

--- a/hivemq-edge/src/frontend/src/api/__generated__/models/ListenerList.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/models/ListenerList.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/hivemq-edge/src/frontend/src/api/__generated__/models/Metric.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/models/Metric.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/hivemq-edge/src/frontend/src/api/__generated__/models/MetricList.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/models/MetricList.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/hivemq-edge/src/frontend/src/api/__generated__/models/Module.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/models/Module.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/hivemq-edge/src/frontend/src/api/__generated__/models/ModuleList.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/models/ModuleList.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/hivemq-edge/src/frontend/src/api/__generated__/models/Notification.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/models/Notification.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/hivemq-edge/src/frontend/src/api/__generated__/models/NotificationList.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/models/NotificationList.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/hivemq-edge/src/frontend/src/api/__generated__/models/ObjectNode.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/models/ObjectNode.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/hivemq-edge/src/frontend/src/api/__generated__/models/ProtocolAdapter.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/models/ProtocolAdapter.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/hivemq-edge/src/frontend/src/api/__generated__/models/ProtocolAdaptersList.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/models/ProtocolAdaptersList.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/hivemq-edge/src/frontend/src/api/__generated__/models/TlsConfiguration.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/models/TlsConfiguration.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/hivemq-edge/src/frontend/src/api/__generated__/models/UsernamePasswordCredentials.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/models/UsernamePasswordCredentials.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/hivemq-edge/src/frontend/src/api/__generated__/models/ValuesTree.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/models/ValuesTree.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/hivemq-edge/src/frontend/src/api/__generated__/schemas/$Adapter.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/schemas/$Adapter.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/hivemq-edge/src/frontend/src/api/__generated__/schemas/$AdapterRuntimeInformation.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/schemas/$AdapterRuntimeInformation.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/hivemq-edge/src/frontend/src/api/__generated__/schemas/$AdaptersList.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/schemas/$AdaptersList.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/hivemq-edge/src/frontend/src/api/__generated__/schemas/$ApiBearerToken.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/schemas/$ApiBearerToken.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/hivemq-edge/src/frontend/src/api/__generated__/schemas/$ApiErrorMessage.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/schemas/$ApiErrorMessage.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/hivemq-edge/src/frontend/src/api/__generated__/schemas/$Bridge.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/schemas/$Bridge.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/hivemq-edge/src/frontend/src/api/__generated__/schemas/$BridgeCustomUserProperty.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/schemas/$BridgeCustomUserProperty.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/hivemq-edge/src/frontend/src/api/__generated__/schemas/$BridgeList.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/schemas/$BridgeList.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/hivemq-edge/src/frontend/src/api/__generated__/schemas/$BridgeRuntimeInformation.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/schemas/$BridgeRuntimeInformation.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/hivemq-edge/src/frontend/src/api/__generated__/schemas/$BridgeSubscription.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/schemas/$BridgeSubscription.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/hivemq-edge/src/frontend/src/api/__generated__/schemas/$ConnectionStatus.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/schemas/$ConnectionStatus.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/hivemq-edge/src/frontend/src/api/__generated__/schemas/$ConnectionStatusList.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/schemas/$ConnectionStatusList.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/hivemq-edge/src/frontend/src/api/__generated__/schemas/$ConnectionStatusTransitionCommand.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/schemas/$ConnectionStatusTransitionCommand.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/hivemq-edge/src/frontend/src/api/__generated__/schemas/$DataPoint.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/schemas/$DataPoint.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/hivemq-edge/src/frontend/src/api/__generated__/schemas/$EnvironmentProperties.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/schemas/$EnvironmentProperties.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/hivemq-edge/src/frontend/src/api/__generated__/schemas/$Extension.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/schemas/$Extension.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/hivemq-edge/src/frontend/src/api/__generated__/schemas/$ExtensionList.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/schemas/$ExtensionList.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/hivemq-edge/src/frontend/src/api/__generated__/schemas/$FirstUseInformation.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/schemas/$FirstUseInformation.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/hivemq-edge/src/frontend/src/api/__generated__/schemas/$GatewayConfiguration.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/schemas/$GatewayConfiguration.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/hivemq-edge/src/frontend/src/api/__generated__/schemas/$HealthStatus.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/schemas/$HealthStatus.ts
@@ -2,12 +2,10 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-export const $Metric = {
-    description: `List of result items that are returned by this endpoint`,
+export const $HealthStatus = {
     properties: {
-        name: {
+        status: {
             type: 'string',
-            description: `The name of the metric`,
         },
     },
 } as const;

--- a/hivemq-edge/src/frontend/src/api/__generated__/schemas/$ISA95ApiBean.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/schemas/$ISA95ApiBean.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/hivemq-edge/src/frontend/src/api/__generated__/schemas/$JsonNode.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/schemas/$JsonNode.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/hivemq-edge/src/frontend/src/api/__generated__/schemas/$Link.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/schemas/$Link.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/hivemq-edge/src/frontend/src/api/__generated__/schemas/$LinkList.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/schemas/$LinkList.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/hivemq-edge/src/frontend/src/api/__generated__/schemas/$Listener.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/schemas/$Listener.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
@@ -7,6 +8,11 @@ export const $Listener = {
         description: {
             type: 'string',
             description: `The extension description`,
+            isNullable: true,
+        },
+        externalHostname: {
+            type: 'string',
+            description: `The external hostname`,
             isNullable: true,
         },
         hostName: {

--- a/hivemq-edge/src/frontend/src/api/__generated__/schemas/$ListenerList.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/schemas/$ListenerList.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/hivemq-edge/src/frontend/src/api/__generated__/schemas/$MetricList.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/schemas/$MetricList.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/hivemq-edge/src/frontend/src/api/__generated__/schemas/$Module.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/schemas/$Module.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/hivemq-edge/src/frontend/src/api/__generated__/schemas/$ModuleList.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/schemas/$ModuleList.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/hivemq-edge/src/frontend/src/api/__generated__/schemas/$Notification.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/schemas/$Notification.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/hivemq-edge/src/frontend/src/api/__generated__/schemas/$NotificationList.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/schemas/$NotificationList.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/hivemq-edge/src/frontend/src/api/__generated__/schemas/$ObjectNode.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/schemas/$ObjectNode.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/hivemq-edge/src/frontend/src/api/__generated__/schemas/$ProtocolAdapter.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/schemas/$ProtocolAdapter.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/hivemq-edge/src/frontend/src/api/__generated__/schemas/$ProtocolAdaptersList.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/schemas/$ProtocolAdaptersList.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/hivemq-edge/src/frontend/src/api/__generated__/schemas/$TlsConfiguration.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/schemas/$TlsConfiguration.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/hivemq-edge/src/frontend/src/api/__generated__/schemas/$UsernamePasswordCredentials.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/schemas/$UsernamePasswordCredentials.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/hivemq-edge/src/frontend/src/api/__generated__/schemas/$ValuesTree.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/schemas/$ValuesTree.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/hivemq-edge/src/frontend/src/api/__generated__/services/AuthenticationEndpointService.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/services/AuthenticationEndpointService.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/hivemq-edge/src/frontend/src/api/__generated__/services/AuthenticationService.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/services/AuthenticationService.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/hivemq-edge/src/frontend/src/api/__generated__/services/BridgesService.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/services/BridgesService.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/hivemq-edge/src/frontend/src/api/__generated__/services/DefaultService.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/services/DefaultService.ts
@@ -1,6 +1,9 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import type { HealthStatus } from '../models/HealthStatus';
+
 import type { CancelablePromise } from '../core/CancelablePromise';
 import type { BaseHttpRequest } from '../core/BaseHttpRequest';
 
@@ -12,7 +15,20 @@ export class DefaultService {
      * @returns any default response
      * @throws ApiError
      */
-    public liveness(): CancelablePromise<any> {
+    public getRoot(): CancelablePromise<any> {
+        return this.httpRequest.request({
+            method: 'GET',
+            url: '/',
+        });
+    }
+
+    /**
+     * Endpoint to determine whether the gateway is considered UP
+     * Endpoint to determine whether the gateway is considered UP.
+     * @returns HealthStatus Success
+     * @throws ApiError
+     */
+    public liveness(): CancelablePromise<HealthStatus> {
         return this.httpRequest.request({
             method: 'GET',
             url: '/api/v1/health/liveness',
@@ -20,10 +36,12 @@ export class DefaultService {
     }
 
     /**
-     * @returns any default response
+     * Endpoint to determine whether the gateway is considered ready
+     * Endpoint to determine whether the gateway is considered ready.
+     * @returns HealthStatus Success
      * @throws ApiError
      */
-    public readiness(): CancelablePromise<any> {
+    public readiness(): CancelablePromise<HealthStatus> {
         return this.httpRequest.request({
             method: 'GET',
             url: '/api/v1/health/readiness',

--- a/hivemq-edge/src/frontend/src/api/__generated__/services/FrontendService.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/services/FrontendService.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
@@ -61,6 +62,9 @@ export class FrontendService {
         return this.httpRequest.request({
             method: 'GET',
             url: '/api/v1/management/system/configuration',
+            errors: {
+                405: `Error - function not supported`,
+            },
         });
     }
 

--- a/hivemq-edge/src/frontend/src/api/__generated__/services/MetricsEndpointService.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/services/MetricsEndpointService.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/hivemq-edge/src/frontend/src/api/__generated__/services/MetricsService.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/services/MetricsService.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/hivemq-edge/src/frontend/src/api/__generated__/services/ProtocolAdaptersService.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/services/ProtocolAdaptersService.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
@@ -91,7 +92,49 @@ export class ProtocolAdaptersService {
     }
 
     /**
-     * Obtain a list of available data points
+     * Get the up to date status of a bridge
+     * Get the up to date status of a bridge.
+     * @param adapterId The name of the adapter to query.
+     * @returns ConnectionStatus Success
+     * @throws ApiError
+     */
+    public getConnectionStatus1(
+        adapterId: string,
+    ): CancelablePromise<ConnectionStatus> {
+        return this.httpRequest.request({
+            method: 'GET',
+            url: '/api/v1/management/protocol-adapters/adapters/{adapterId}/connection',
+            path: {
+                'adapterId': adapterId,
+            },
+        });
+    }
+
+    /**
+     * Transition the connection status of an adapter
+     * Transition the connection status of an adapter.
+     * @param adapterId The id of the adapter whose connection-status will change.
+     * @param requestBody The command to transition the adapter connection status.
+     * @returns any Success
+     * @throws ApiError
+     */
+    public changeConnectionStatus1(
+        adapterId: string,
+        requestBody: ConnectionStatusTransitionCommand,
+    ): CancelablePromise<any> {
+        return this.httpRequest.request({
+            method: 'PUT',
+            url: '/api/v1/management/protocol-adapters/adapters/{adapterId}/connection',
+            path: {
+                'adapterId': adapterId,
+            },
+            body: requestBody,
+            mediaType: 'application/json',
+        });
+    }
+
+    /**
+     * Discover a list of available data points
      * Obtain a list of available values accessible via this protocol adapter.
      * @param adapterId The adapter Id.
      * @param root The root to browse.
@@ -99,14 +142,14 @@ export class ProtocolAdaptersService {
      * @returns ValuesTree Success
      * @throws ApiError
      */
-    public listAvailableValues(
+    public discoverDataPoints(
         adapterId: string,
         root?: string,
         depth?: number,
     ): CancelablePromise<ValuesTree> {
         return this.httpRequest.request({
             method: 'GET',
-            url: '/api/v1/management/protocol-adapters/adapters/{adapterId}/values',
+            url: '/api/v1/management/protocol-adapters/adapters/{adapterId}/discover',
             path: {
                 'adapterId': adapterId,
             },
@@ -182,48 +225,6 @@ export class ProtocolAdaptersService {
             path: {
                 'adapterType': adapterType,
             },
-        });
-    }
-
-    /**
-     * Get the up to date status of a bridge
-     * Get the up to date status of a bridge.
-     * @param adapterId The name of the adapter to query.
-     * @returns ConnectionStatus Success
-     * @throws ApiError
-     */
-    public getConnectionStatus1(
-        adapterId: string,
-    ): CancelablePromise<ConnectionStatus> {
-        return this.httpRequest.request({
-            method: 'GET',
-            url: '/api/v1/management/protocol-adapters/{adapterId}/connection',
-            path: {
-                'adapterId': adapterId,
-            },
-        });
-    }
-
-    /**
-     * Transition the connection status of an adapter
-     * Transition the connection status of an adapter.
-     * @param adapterId The id of the adapter whose connection-status will change.
-     * @param requestBody The command to transition the adapter connection status.
-     * @returns any Success
-     * @throws ApiError
-     */
-    public changeConnectionStatus1(
-        adapterId: string,
-        requestBody: ConnectionStatusTransitionCommand,
-    ): CancelablePromise<any> {
-        return this.httpRequest.request({
-            method: 'PUT',
-            url: '/api/v1/management/protocol-adapters/{adapterId}/connection',
-            path: {
-                'adapterId': adapterId,
-            },
-            body: requestBody,
-            mediaType: 'application/json',
         });
     }
 

--- a/hivemq-edge/src/frontend/src/api/__generated__/services/UnsService.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/services/UnsService.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do no edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/hivemq-edge/src/frontend/src/api/hooks/useHttpClient/useHttpClient.spec.tsx
+++ b/hivemq-edge/src/frontend/src/api/hooks/useHttpClient/useHttpClient.spec.tsx
@@ -1,0 +1,170 @@
+import { MemoryRouter } from 'react-router-dom'
+import { RequestHandler, rest } from 'msw'
+import { vi, expect, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+
+import config from '@/config'
+import { server } from '@/__test-utils__/msw/mockServer.ts'
+import { AuthProvider } from '@/modules/Auth/AuthProvider.tsx'
+
+import { AxiosHttpRequestWithInterceptors, useHttpClient } from './useHttpClient.ts'
+import { ApiBearerToken, ApiError } from '@/api/__generated__'
+
+enum auth {
+  HEADER_ATTACHED = 'HEADER_ATTACHED',
+  HEADER_MISSING = 'HEADER_MISSING',
+}
+
+interface MockAuthContextType {
+  credentials: ApiBearerToken | undefined
+  isAuthenticated?: boolean
+  isLoading?: boolean
+  login?: (user: ApiBearerToken, callback: VoidFunction) => void
+  logout?: (callback: VoidFunction) => void
+}
+
+const { mockedMethod } = vi.hoisted(() => {
+  return {
+    mockedMethod: vi.fn<[], MockAuthContextType>(() => ({ credentials: { token: 'fake token' } })),
+  }
+})
+
+vi.mock('@/modules/Auth/hooks/useAuth.ts', () => ({ useAuth: mockedMethod }))
+
+const successURL = '/my-successful-endpoint'
+const errorURL = '/my-error-endpoint'
+const reissueURL = '/my-reissue-endpoint'
+const handlers: RequestHandler[] = [
+  rest.get(`${config.apiBaseUrl}${successURL}`, (req, res, ctx) => {
+    let bodyContent = auth.HEADER_MISSING
+    const authHeader = req.headers.get('authorization') ?? null
+    if (authHeader?.startsWith('Bearer ')) {
+      const token = authHeader.substring(7, authHeader.length)
+      if (token) {
+        bodyContent = auth.HEADER_ATTACHED
+      }
+    }
+
+    return res(
+      ctx.status(200),
+      ctx.json({
+        bodyContent: bodyContent,
+      })
+    )
+  }),
+
+  rest.get(`${config.apiBaseUrl}${errorURL}`, (_, res, ctx) => {
+    return res(
+      ctx.status(401),
+      ctx.json({
+        bodyContent: 'an error message',
+      })
+    )
+  }),
+
+  rest.get(`${config.apiBaseUrl}${reissueURL}`, (_, res, ctx) => {
+    return res(
+      ctx.status(200),
+      ctx.set({
+        'X-Bearer-Token-Reissue': 'a-new-token',
+      }),
+      ctx.json({
+        bodyContent: 'A new token has been added to the response',
+      })
+    )
+  }),
+]
+
+const wrapper: React.JSXElementConstructor<{ children: React.ReactElement }> = ({ children }) => (
+  <AuthProvider>
+    <MemoryRouter>{children}</MemoryRouter>
+  </AuthProvider>
+)
+
+describe('useSpringClient', () => {
+  beforeEach(() => {
+    server.resetHandlers()
+  })
+
+  it('should attach a jwt token to the authorization header', async () => {
+    server.use(...handlers)
+    mockedMethod.mockReturnValue({
+      credentials: { token: 'one' },
+    })
+
+    const { result } = renderHook(useHttpClient, {
+      wrapper,
+    })
+    const currentClient = result.current.request as AxiosHttpRequestWithInterceptors
+
+    const serverResponse = await currentClient.request<string>({
+      method: 'GET',
+      url: successURL,
+    })
+
+    expect(serverResponse).toStrictEqual({ bodyContent: auth.HEADER_ATTACHED })
+  })
+
+  it('should not have a token if not authenticated', async () => {
+    server.use(...handlers)
+    mockedMethod.mockReturnValue({
+      credentials: { token: undefined },
+    })
+
+    const { result } = renderHook(useHttpClient, {
+      wrapper,
+    })
+    const currentClient = result.current.request as AxiosHttpRequestWithInterceptors
+
+    const serverResponse = await currentClient.request<string>({
+      method: 'GET',
+      url: successURL,
+    })
+
+    expect(serverResponse).toStrictEqual({ bodyContent: auth.HEADER_MISSING })
+  })
+
+  it('should logout when 401 is returned ', async () => {
+    const mockLogout = vi.fn()
+    server.use(...handlers)
+    mockedMethod.mockReturnValue({
+      credentials: { token: undefined },
+      logout: mockLogout,
+    })
+
+    const { result } = renderHook(useHttpClient, {
+      wrapper,
+    })
+    const currentClient = result.current.request as AxiosHttpRequestWithInterceptors
+
+    await currentClient
+      .request<string>({
+        method: 'GET',
+        url: errorURL,
+      })
+      .catch((err: ApiError) => {
+        expect(err).toHaveProperty('status', 401)
+        expect(err).toHaveProperty('statusText', 'Unauthorized')
+        expect(err).toHaveProperty('body.bodyContent', 'an error message')
+        expect(mockLogout).toHaveBeenCalledOnce()
+      })
+  })
+
+  it.skip("should change the JWT credentials when a 'x-bearer-token-reissue' is intercepted", async () => {
+    const mockLogout = vi.fn()
+    server.use(...handlers)
+    mockedMethod.mockReturnValue({
+      credentials: { token: undefined },
+      logout: mockLogout,
+    })
+
+    const { result } = renderHook(useHttpClient, {
+      wrapper,
+    })
+    const currentClient = result.current.request as AxiosHttpRequestWithInterceptors
+    await currentClient.request<string>({
+      method: 'GET',
+      url: successURL,
+    })
+  })
+})

--- a/hivemq-edge/src/frontend/src/api/hooks/useHttpClient/useHttpClient.ts
+++ b/hivemq-edge/src/frontend/src/api/hooks/useHttpClient/useHttpClient.ts
@@ -7,6 +7,7 @@ import { request as __request } from '@/api/__generated__/core/request.ts'
 
 import config from '@/config'
 import { useAuth } from '@/modules/Auth/hooks/useAuth.ts'
+import { useNavigate } from 'react-router-dom'
 
 const axiosInstance = axios.create()
 
@@ -21,7 +22,8 @@ class AxiosHttpRequestWithInterceptors extends BaseHttpRequest {
 }
 
 export const useHttpClient = () => {
-  const { credentials } = useAuth()
+  const { credentials, logout } = useAuth()
+  const navigate = useNavigate()
   const [client] = useState<HiveMqClient>(createInstance)
 
   function createInstance() {
@@ -37,7 +39,9 @@ export const useHttpClient = () => {
       function (error: AxiosError) {
         // Any status codes that falls outside the range of 2xx cause this function to trigger
         // Do something with response error
-
+        if (error.response?.status === 401) {
+          logout(() => navigate('/login'))
+        }
         return Promise.reject(error)
       }
     )

--- a/hivemq-edge/src/frontend/src/api/hooks/useHttpClient/useHttpClient.ts
+++ b/hivemq-edge/src/frontend/src/api/hooks/useHttpClient/useHttpClient.ts
@@ -1,17 +1,54 @@
 import { useState } from 'react'
+import axios, { AxiosError } from 'axios'
+
+import { BaseHttpRequest, CancelablePromise, HiveMqClient, OpenAPIConfig } from '@/api/__generated__'
+import { ApiRequestOptions } from '@/api/__generated__/core/ApiRequestOptions.ts'
+import { request as __request } from '@/api/__generated__/core/request.ts'
+
+import config from '@/config'
 import { useAuth } from '@/modules/Auth/hooks/useAuth.ts'
-import { HiveMqClient } from '../../__generated__'
-import config from '../../../config'
+
+const axiosInstance = axios.create()
+
+class AxiosHttpRequestWithInterceptors extends BaseHttpRequest {
+  constructor(config: OpenAPIConfig) {
+    super(config)
+  }
+
+  public override request<T>(options: ApiRequestOptions): CancelablePromise<T> {
+    return __request(this.config, options, axiosInstance)
+  }
+}
 
 export const useHttpClient = () => {
   const { credentials } = useAuth()
   const [client] = useState<HiveMqClient>(createInstance)
 
   function createInstance() {
-    return new HiveMqClient({
-      BASE: config.apiBaseUrl,
-      TOKEN: credentials?.token,
-    })
+    // Make sure to clear the interceptors, since axiosInstance is global
+    axiosInstance.interceptors.response.clear()
+    axiosInstance.interceptors.response.use(
+      function (response) {
+        // Any status code that lie within the range of 2xx cause this function to trigger
+        // Do something with response data
+
+        return response
+      },
+      function (error: AxiosError) {
+        // Any status codes that falls outside the range of 2xx cause this function to trigger
+        // Do something with response error
+
+        return Promise.reject(error)
+      }
+    )
+
+    return new HiveMqClient(
+      {
+        BASE: config.apiBaseUrl,
+        TOKEN: credentials?.token,
+      },
+      AxiosHttpRequestWithInterceptors
+    )
   }
 
   return client


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/15309/details/
See https://hivemq.kanbanize.com/ctrl_board/57/cards/15310/details/

This PR updates the script generating the OpenAPI stubs in order to support the injection of a custom Axios instance into the HTTP client.

It gives us access to Axios middleware, enabling two operations for Edge:
- automatically logging the user out when a HTTP request returns a 401 (closes 15309)
- automatically updating the JWT token stored in the frontend when the relevant header occurs in a request (closes 15310)

