### PR TITLE
fix(15315): Fix layout of the warning message component

### DIFF
--- a/hivemq-edge/src/frontend/src/components/WarningMessage.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/components/WarningMessage.spec.cy.tsx
@@ -1,9 +1,8 @@
 /// <reference types="cypress" />
 import WarningMessage from '@/components/WarningMessage.tsx'
-import { Flex } from '@chakra-ui/react'
 
-// const MOCK_TITLE = 'This is a test'
 const MOCK_PROMPT = 'This is a prompt'
+const MOCK_TITLE = 'Nothing in here'
 const MOCK_ALT = 'my image'
 
 describe('WarningMessage', () => {
@@ -14,13 +13,15 @@ describe('WarningMessage', () => {
   })
 
   it('should renders', () => {
-    cy.mountWithProviders(
-      <Flex width={'96vw'} height={'96vh'} flexDirection={'column'}>
-        <WarningMessage prompt={MOCK_PROMPT} alt={MOCK_ALT} />
-      </Flex>
-    )
-
-    // cy.get('h2').should('contain.text', MOCK_TITLE)
+    cy.mountWithProviders(<WarningMessage title={MOCK_TITLE} prompt={MOCK_PROMPT} alt={MOCK_ALT} />)
+    cy.get('h2').should('contain.text', MOCK_TITLE)
     cy.get(`img[alt="${MOCK_ALT}"]`).should('exist')
+  })
+
+  it('should be accessible', () => {
+    cy.injectAxe()
+    cy.mountWithProviders(<WarningMessage title={MOCK_TITLE} prompt={MOCK_PROMPT} alt={MOCK_ALT} />)
+    cy.checkAccessibility()
+    cy.percySnapshot('Component: WarningMessage')
   })
 })

--- a/hivemq-edge/src/frontend/src/components/WarningMessage.tsx
+++ b/hivemq-edge/src/frontend/src/components/WarningMessage.tsx
@@ -1,27 +1,29 @@
 import { FC } from 'react'
-import { AbsoluteCenter, Box, Circle, Flex, Image, Text } from '@chakra-ui/react'
+import { Circle, Flex, Heading, Image, Text, type HTMLChakraProps } from '@chakra-ui/react'
 import DefaultLogo from '@/assets/app/bridge-empty.svg'
 
-interface WarningMessageProps {
+interface WarningMessageProps extends HTMLChakraProps<'div'> {
+  title?: string
   image?: string | undefined
   prompt: string
   alt: string
 }
 
-const WarningMessage: FC<WarningMessageProps> = ({ image = DefaultLogo, prompt, alt }) => {
+const WarningMessage: FC<WarningMessageProps> = ({ image = DefaultLogo, prompt, alt, title, ...rest }) => {
   return (
-    <Box w={1} textAlign={'center'}>
-      <AbsoluteCenter axis="both">
-        <Circle size="500px" bg="gray.100">
-          <Flex flexDirection={'column'} alignItems={'center'}>
-            <Image objectFit="cover" maxW={{ base: '150px', md: '100%' }} src={image} alt={alt} />
-            <Text align={'center'} maxW={'400'}>
-              {prompt}
-            </Text>
-          </Flex>
-        </Circle>
-      </AbsoluteCenter>
-    </Box>
+    <Flex flexDirection={'column'} alignItems={'center'} gap={4} {...rest}>
+      {title && (
+        <Heading as={'h2'} size="md" color={'gray.500'}>
+          {title}
+        </Heading>
+      )}
+      <Circle size="335" bg="gray.100">
+        <Image objectFit="cover" src={image} alt={alt} />
+      </Circle>
+      <Text align={'center'} maxW={'400'} color={'gray.600'}>
+        {prompt}
+      </Text>
+    </Flex>
   )
 }
 

--- a/hivemq-edge/src/frontend/src/modules/Bridges/Bridges.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Bridges/Bridges.tsx
@@ -35,7 +35,13 @@ const Bridges: FC = () => {
   }
   if (isEmpty)
     return (
-      <WarningMessage image={BridgeEmptyLogo} prompt={t('bridge.noDataWarning.description')} alt={t('bridge.title')} />
+      <WarningMessage
+        image={BridgeEmptyLogo}
+        prompt={t('bridge.noDataWarning.description')}
+        title={t('bridge.noDataWarning.title') as string}
+        alt={t('bridge.title')}
+        mt={10}
+      />
     )
 
   return (

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/panels/ProtocolAdapters.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/panels/ProtocolAdapters.tsx
@@ -107,8 +107,10 @@ const ProtocolAdapters: FC = () => {
     return (
       <WarningMessage
         image={AdapterEmptyLogo}
+        title={t('protocolAdapter.noDataWarning.title') as string}
         prompt={t('protocolAdapter.noDataWarning.description')}
         alt={t('protocolAdapter.title')}
+        mt={10}
       />
     )
 

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/panels/ProtocolIntegrationStore.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/panels/ProtocolIntegrationStore.tsx
@@ -61,6 +61,7 @@ const ProtocolIntegrationStore: FC = () => {
         image={AdapterEmptyLogo}
         prompt={t('protocolAdapter.noDataWarning.description')}
         alt={t('protocolAdapter.title')}
+        mt={10}
       />
     )
 


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/15315/details/

The PR removes the "absolute centre" layout of the component since it centres on the whole page, regardless of the container

The fix improves the layout and the accessibility of the component, especially with a responsive design

### Before
![screenshot-localhost_3000-2023 07 11-15_42_33](https://github.com/hivemq/hivemq-edge/assets/2743481/0ea26a22-ee2b-4502-bc07-2e3cc740238f)

### After
![screenshot-localhost_3000-2023 07 11-15_43_06](https://github.com/hivemq/hivemq-edge/assets/2743481/3e1b137f-33b7-42c5-bd8a-8332e10958bb)
