### PR TITLE
fix(15560): Fix rerendering of the adapter editor

### DIFF
--- a/hivemq-edge/src/frontend/src/api/hooks/useHttpClient/useHttpClient.ts
+++ b/hivemq-edge/src/frontend/src/api/hooks/useHttpClient/useHttpClient.ts
@@ -22,7 +22,7 @@ export class AxiosHttpRequestWithInterceptors extends BaseHttpRequest {
 }
 
 export const useHttpClient = () => {
-  const { credentials, logout, login } = useAuth()
+  const { credentials, logout } = useAuth()
   const navigate = useNavigate()
   const [client] = useState<HiveMqClient>(createInstance)
 
@@ -35,7 +35,8 @@ export const useHttpClient = () => {
         // Do something with response data
         const { 'x-bearer-token-reissue': reissuedToken } = response.headers
         if (reissuedToken) {
-          login({ token: reissuedToken }, () => undefined)
+          // TODO[NVL] Deactivating the reissuing, see https://hivemq.kanbanize.com/ctrl_board/57/cards/15303/details/
+          // login({ token: reissuedToken }, () => undefined)
         }
         return response
       },

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/ProtocolAdapterPage.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/ProtocolAdapterPage.tsx
@@ -30,7 +30,7 @@ const ProtocolAdapterPage: FC = () => {
 
   return (
     <PageContainer title={t('protocolAdapter.title') as string} subtitle={t('protocolAdapter.description') as string}>
-      <Tabs onChange={handleTabsChange} index={tabIndex}>
+      <Tabs onChange={handleTabsChange} index={tabIndex} isLazy>
         <TabList>
           <Tab fontSize="lg" fontWeight={'bold'}>
             {t('protocolAdapter.tabs.protocols')}

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/AdapterController.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/AdapterController.tsx
@@ -12,8 +12,6 @@ import { useEdgeToast } from '@/hooks/useEdgeToast/useEdgeToast.tsx'
 
 import { ProtocolAdapterTabIndex } from '@/modules/ProtocolAdapters/ProtocolAdapterPage.tsx'
 import AdapterInstanceDrawer from '@/modules/ProtocolAdapters/components/drawers/AdapterInstanceDrawer.tsx'
-import ProtocolSelectorDrawer from '@/modules/ProtocolAdapters/components/drawers/ProtocolSelectorDrawer.tsx'
-import { AdapterType } from '@/modules/ProtocolAdapters/types.ts'
 
 interface AdapterEditorProps {
   isNew?: boolean
@@ -25,7 +23,6 @@ const AdapterController: FC<AdapterEditorProps> = ({ children, isNew }) => {
   const { successToast, errorToast } = useEdgeToast()
 
   const [adaptorType, setAdaptorType] = useState<string | undefined>(undefined)
-  const { isOpen: isSelectorOpen, onClose: onSelectorClose } = useDisclosure()
   const { isOpen: isInstanceOpen, onOpen: onInstanceOpen, onClose: onInstanceClose } = useDisclosure()
   const createProtocolAdapter = useCreateProtocolAdapter()
   const updateProtocolAdapter = useUpdateProtocolAdapter()
@@ -44,16 +41,6 @@ const AdapterController: FC<AdapterEditorProps> = ({ children, isNew }) => {
       onInstanceOpen()
     }
   }, [adaptorType, onInstanceOpen])
-
-  const handleSelectorClose = () => {
-    onSelectorClose()
-    navigate('/protocol-adapters')
-  }
-
-  const handleSelectorSubmit: SubmitHandler<AdapterType> = ({ adapterType }) => {
-    setAdaptorType(adapterType)
-    onSelectorClose()
-  }
 
   const handleInstanceClose = () => {
     onInstanceClose()
@@ -122,7 +109,6 @@ const AdapterController: FC<AdapterEditorProps> = ({ children, isNew }) => {
 
   return (
     <div>
-      <ProtocolSelectorDrawer onClose={handleSelectorClose} isOpen={isSelectorOpen} onSubmit={handleSelectorSubmit} />
       <AdapterInstanceDrawer
         adapterType={adaptorType}
         isNewAdapter={isNew}

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/drawers/ProtocolSelectorDrawer.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/drawers/ProtocolSelectorDrawer.tsx
@@ -22,6 +22,9 @@ interface ProtocolSelectorDrawerProps {
   onSubmit: (data: AdapterType) => void
 }
 
+/**
+ * @deprecated
+ */
 const ProtocolSelectorDrawer: FC<ProtocolSelectorDrawerProps> = ({ isOpen, onClose, onSubmit }) => {
   const { t } = useTranslation()
 


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/15560/details/

The PR temporarility deactivates the reussing of the JWT token, following unappropriate re-rendering of the adapter UI. 

Chain of actions has not yet been identified. 

The PR also uproves the rendering of the list of adapters by memoising the columns 