### PR TITLE
bug(15580): API allows invalid bridge subscribe topics to be defined

### DIFF
--- a/hivemq-edge/src/main/java/com/hivemq/configuration/reader/BridgeConfigurator.java
+++ b/hivemq-edge/src/main/java/com/hivemq/configuration/reader/BridgeConfigurator.java
@@ -148,7 +148,7 @@ public class BridgeConfigurator {
         return builder.build();
     }
 
-    private void validateTopicFilters(final @NotNull String name, final @Nullable List<String> filters) {
+    public static void validateTopicFilters(final @NotNull String name, final @Nullable List<String> filters) {
         if (filters == null || filters.isEmpty()) {
             log.error("Topic filters are missing for bridge '{}'.", name);
             throw new UnrecoverableException(false);


### PR DESCRIPTION
It is possible to add invalid topic filters to bridge configuration via the API (UI) which just renders the in memory bridge as dormant. When in mutable config mode, the platform then fails to start with valdiation error of the stored bridges