### PR TITLE
fix(15303): Ensure that all defaults for the forms come from the OpenAPI schemas

### DIFF
--- a/hivemq-edge/src/frontend/src/__test-utils__/setup.ts
+++ b/hivemq-edge/src/frontend/src/__test-utils__/setup.ts
@@ -5,7 +5,6 @@ import { server } from './msw/mockServer.ts'
 // Establish API mocking before all tests.
 beforeAll(() => {
   server.listen()
-  console.log('XXXXXXXX', import.meta.env.MODE, import.meta.env.VITE_API_BASE_URL)
 })
 
 // Reset any request handlers that we may add during the tests,

--- a/hivemq-edge/src/frontend/src/api/hooks/useValidationRules/useValidationRules.spec.ts
+++ b/hivemq-edge/src/frontend/src/api/hooks/useValidationRules/useValidationRules.spec.ts
@@ -1,0 +1,87 @@
+import { vi, expect } from 'vitest'
+import { renderHook } from '@testing-library/react'
+
+import { useValidationRules } from '@/api/hooks/useValidationRules/useValidationRules.ts'
+import '@/config/i18n.config.ts'
+import { RegisterOptions } from 'react-hook-form'
+
+interface Suite {
+  schema: Record<string, unknown>
+  expected: RegisterOptions
+  shouldWarn?: boolean
+}
+
+const validationSuite: Suite[] = [
+  {
+    schema: {},
+    expected: {},
+  },
+  {
+    schema: { test: 'random value' },
+    expected: {},
+  },
+  {
+    schema: {
+      type: 'string',
+      isRequired: true,
+    },
+    expected: {
+      required: { value: true, message: 'This property is required' },
+    },
+  },
+  {
+    schema: { type: 'fakeString', maxLength: 255 },
+    expected: {
+      maxLength: { value: 255, message: 'No more than 255 characters allowed for the property' },
+    },
+    shouldWarn: true,
+  },
+  {
+    schema: { type: 'string', maxLength: 255 },
+    expected: {
+      maxLength: { value: 255, message: 'No more than 255 characters allowed for the property' },
+    },
+  },
+  {
+    schema: { type: 'number', minimum: 10 },
+    expected: {
+      min: { value: 10, message: 'Should be at least 10' },
+    },
+  },
+  {
+    schema: { type: 'number', maximum: 10 },
+    expected: {
+      max: { value: 10, message: 'Should not be more than 10' },
+    },
+  },
+  {
+    schema: { type: 'string', pattern: '[a]' },
+    expected: {
+      // TODO Warning, not a deep check on RegExp
+      pattern: { value: new RegExp('[a]'), message: 'Should match the regular expression [a]' },
+    },
+  },
+
+  {
+    schema: { type: 'string', pattern: '(a' },
+    expected: {},
+    shouldWarn: true,
+  },
+]
+
+describe('useValidationRules', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it.each<Suite>(validationSuite)('$schema', ({ schema, expected, shouldWarn }) => {
+    const { result } = renderHook(useValidationRules)
+    const getValidationRulesFor = result.current
+
+    vi.spyOn(console, 'warn')
+
+    expect(1)
+    expect(getValidationRulesFor(schema)).toMatchObject(expected)
+    expect(console.warn).toHaveBeenCalledTimes(shouldWarn ? 1 : 0)
+  })
+})

--- a/hivemq-edge/src/frontend/src/api/hooks/useValidationRules/useValidationRules.ts
+++ b/hivemq-edge/src/frontend/src/api/hooks/useValidationRules/useValidationRules.ts
@@ -34,8 +34,11 @@ export const useValidationRules = () => {
     }
     if (schema.pattern) {
       assert('string')
+      let patternString = schema.pattern as string
+      if (!patternString.startsWith('^')) patternString = `^${patternString}`
+      if (!patternString.endsWith('$')) patternString = `${patternString}$`
       try {
-        const pattern = new RegExp(schema.pattern as string)
+        const pattern = new RegExp(patternString)
         options.pattern = { value: pattern, message: t('validation.pattern', { pattern: schema.pattern }) }
       } catch (e: unknown) {
         const error = e as Error

--- a/hivemq-edge/src/frontend/src/api/hooks/useValidationRules/useValidationRules.ts
+++ b/hivemq-edge/src/frontend/src/api/hooks/useValidationRules/useValidationRules.ts
@@ -1,0 +1,41 @@
+import { RegisterOptions } from 'react-hook-form'
+import { useTranslation } from 'react-i18next'
+
+export const useValidationRules = () => {
+  const { t } = useTranslation()
+
+  const getValidationRulesFor = (schema: Record<string, unknown>): RegisterOptions => {
+    const options: RegisterOptions = {}
+
+    if (schema.isRequired) {
+      options.required = { value: true, message: t('validation.required') }
+    }
+    if (schema.maxLength) {
+      const length = schema.maxLength as number
+      options.maxLength = { value: length, message: t('validation.maxLength', { count: length }) }
+    }
+    if (schema.minimum) {
+      // TODO[NVL] exclusiveMinimum
+      const minimum = schema.minimum as number
+      options.min = { value: minimum, message: t('validation.minimum', { count: minimum }) }
+    }
+    if (schema.maximum) {
+      // TODO[NVL] exclusiveMaximum
+      const maximum = schema.maximum as number
+      options.max = { value: maximum, message: t('validation.maximum', { count: maximum }) }
+    }
+    if (schema.pattern) {
+      try {
+        const maximum = new RegExp(schema.pattern as string)
+        options.pattern = { value: maximum, message: t('validation.pattern', { pattern: schema.pattern }) }
+      } catch (e: unknown) {
+        const error = e as Error
+        console.warn(`[openAPI - ${error.name}]`, error.message)
+      }
+    }
+    // TODO[NVL] multipleOf, minLength
+    return options
+  }
+
+  return getValidationRulesFor
+}

--- a/hivemq-edge/src/frontend/src/api/hooks/useValidationRules/useValidationRules.ts
+++ b/hivemq-edge/src/frontend/src/api/hooks/useValidationRules/useValidationRules.ts
@@ -1,33 +1,42 @@
 import { RegisterOptions } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 
+// See https://swagger.io/docs/specification/data-models/data-types/
 export const useValidationRules = () => {
   const { t } = useTranslation()
 
   const getValidationRulesFor = (schema: Record<string, unknown>): RegisterOptions => {
     const options: RegisterOptions = {}
 
+    const assert = (type: 'string' | 'number') => {
+      if (schema.type !== type) console.warn(`[openAPI - SyntaxError] Expecting type to be "string"`, { schema })
+    }
+
     if (schema.isRequired) {
       options.required = { value: true, message: t('validation.required') }
     }
     if (schema.maxLength) {
+      assert('string')
       const length = schema.maxLength as number
       options.maxLength = { value: length, message: t('validation.maxLength', { count: length }) }
     }
     if (schema.minimum) {
       // TODO[NVL] exclusiveMinimum
+      assert('number')
       const minimum = schema.minimum as number
       options.min = { value: minimum, message: t('validation.minimum', { count: minimum }) }
     }
     if (schema.maximum) {
       // TODO[NVL] exclusiveMaximum
+      assert('number')
       const maximum = schema.maximum as number
       options.max = { value: maximum, message: t('validation.maximum', { count: maximum }) }
     }
     if (schema.pattern) {
+      assert('string')
       try {
-        const maximum = new RegExp(schema.pattern as string)
-        options.pattern = { value: maximum, message: t('validation.pattern', { pattern: schema.pattern }) }
+        const pattern = new RegExp(schema.pattern as string)
+        options.pattern = { value: pattern, message: t('validation.pattern', { pattern: schema.pattern }) }
       } catch (e: unknown) {
         const error = e as Error
         console.warn(`[openAPI - ${error.name}]`, error.message)

--- a/hivemq-edge/src/frontend/src/config/i18n.config.ts
+++ b/hivemq-edge/src/frontend/src/config/i18n.config.ts
@@ -23,7 +23,7 @@ i18n
   .init({
     resources,
     lng: 'en',
-    debug: true,
+    debug: import.meta.env.MODE === 'development',
     interpolation: {
       escapeValue: false, // react already safes from xss
     },

--- a/hivemq-edge/src/frontend/src/locales/en/translation.json
+++ b/hivemq-edge/src/frontend/src/locales/en/translation.json
@@ -518,5 +518,12 @@
       "header": "Define the subscription pattern",
       "submit": "Add Subscription"
     }
+  },
+  "validation": {
+    "required": "This property is required",
+    "maxLength": "No more than {{ count }} characters allowed for the property",
+    "minimum": "Should be at least {{ count }}",
+    "maximum": "Should not be more than {{ count }}",
+    "pattern": "Should match the regular expression {{ pattern }}"
   }
 }

--- a/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/ConnectionPanel.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/ConnectionPanel.tsx
@@ -1,5 +1,5 @@
 import { FC } from 'react'
-import { BridgePanelType } from '@/modules/Bridges/types.ts'
+import { useTranslation } from 'react-i18next'
 import {
   Box,
   Flex,
@@ -13,12 +13,14 @@ import {
   NumberInputField,
   NumberInputStepper,
 } from '@chakra-ui/react'
+
 import { $Bridge } from '@/api/__generated__'
-// import { FaConnectdevelop } from 'react-icons/fa'
-import { useTranslation } from 'react-i18next'
+import { useValidationRules } from '@/api/hooks/useValidationRules/useValidationRules.ts'
+import { BridgePanelType } from '@/modules/Bridges/types.ts'
 
 const ConnectionPanel: FC<BridgePanelType> = ({ form }) => {
   const { t } = useTranslation()
+  const getRulesForProperty = useValidationRules()
   const {
     register,
     formState: { errors },
@@ -30,16 +32,7 @@ const ConnectionPanel: FC<BridgePanelType> = ({ form }) => {
         <Box flexGrow={1}>
           <FormControl isInvalid={!!errors.host} isRequired>
             <FormLabel htmlFor="host">{t('bridge.connection.host')}</FormLabel>
-            <Input
-              id="host"
-              type="text"
-              required
-              {...register('host', {
-                required: 'This is required',
-                // minLength: { value: 4, message: 'Minimum length should be 4' },
-                pattern: { value: /[A-Za-z]{3}/, message: 'Minimum length should be 4' },
-              })}
-            />
+            <Input id="host" type="text" required {...register('host', getRulesForProperty($Bridge.properties.host))} />
             <FormErrorMessage>{errors.host && errors.host.message}</FormErrorMessage>
           </FormControl>
         </Box>
@@ -47,16 +40,7 @@ const ConnectionPanel: FC<BridgePanelType> = ({ form }) => {
           <FormControl isInvalid={!!errors.port} isRequired>
             <FormLabel htmlFor="port">{t('bridge.connection.port')}</FormLabel>
             <NumberInput allowMouseWheel focusInputOnChange w={'100px'} id="port" step={1} min={1}>
-              <NumberInputField
-                {...register('port', {
-                  required: 'This field is required',
-                  min: { value: 10, message: 'min should be 0' },
-                  max: {
-                    value: $Bridge.properties.port.maximum,
-                    message: `max length should be ${$Bridge.properties.port.maximum}`,
-                  },
-                })}
-              />
+              <NumberInputField {...register('port', getRulesForProperty($Bridge.properties.port))} />
               <NumberInputStepper>
                 <NumberIncrementStepper />
                 <NumberDecrementStepper />
@@ -75,12 +59,7 @@ const ConnectionPanel: FC<BridgePanelType> = ({ form }) => {
               id="username"
               type="text"
               autoComplete="username"
-              {...register('username', {
-                pattern: {
-                  value: new RegExp($Bridge.properties.username.pattern),
-                  message: 'Minimum length should be 4',
-                },
-              })}
+              {...register('username', getRulesForProperty($Bridge.properties.username))}
             />
             <FormErrorMessage>{errors.username && errors.username.message}</FormErrorMessage>
           </FormControl>
@@ -92,12 +71,7 @@ const ConnectionPanel: FC<BridgePanelType> = ({ form }) => {
               id="password"
               type="password"
               autoComplete="current-password"
-              {...register('password', {
-                pattern: {
-                  value: new RegExp($Bridge.properties.password.pattern),
-                  message: 'Minimum length should be 4',
-                },
-              })}
+              {...register('password', getRulesForProperty($Bridge.properties.password))}
             />
             <FormErrorMessage>{errors.password && errors.password.message}</FormErrorMessage>
           </FormControl>

--- a/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/NamePanel.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/NamePanel.tsx
@@ -1,10 +1,11 @@
 import { FC } from 'react'
+import { useTranslation } from 'react-i18next'
 import { FormControl, FormErrorMessage, FormHelperText, FormLabel, Input } from '@chakra-ui/react'
 
-import { useTranslation } from 'react-i18next'
-import { BridgePanelType } from '@/modules/Bridges/types.ts'
-import { useListBridges } from '@/api/hooks/useGetBridges/useListBridges.tsx'
 import { $Bridge } from '@/api/__generated__'
+import { useListBridges } from '@/api/hooks/useGetBridges/useListBridges.tsx'
+import { useValidationRules } from '@/api/hooks/useValidationRules/useValidationRules.ts'
+import { BridgePanelType } from '@/modules/Bridges/types.ts'
 
 const NamePanel: FC<BridgePanelType> = ({ form, isNewBridge = false }) => {
   const { t } = useTranslation()
@@ -13,6 +14,7 @@ const NamePanel: FC<BridgePanelType> = ({ form, isNewBridge = false }) => {
     formState: { errors: validationErrors },
   } = form
   const { data } = useListBridges()
+  const getRulesForProperty = useValidationRules()
 
   return (
     <FormControl isInvalid={!!validationErrors.id} isRequired={isNewBridge}>
@@ -25,11 +27,7 @@ const NamePanel: FC<BridgePanelType> = ({ form, isNewBridge = false }) => {
         autoComplete={'name'}
         placeholder={t('bridge.options.id.placeholder') as string}
         {...register('id', {
-          required: {
-            value: $Bridge.properties.id.isRequired,
-            message: t('bridge.options.id.error.required') as string,
-          },
-          pattern: { value: /^[a-zA-Z0-9_-]+$/, message: t('bridge.options.id.error.pattern') as string },
+          ...getRulesForProperty($Bridge.properties.id),
           validate: {
             notUnique: (value) => {
               if (!isNewBridge) return true

--- a/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/OptionsPanel.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/OptionsPanel.tsx
@@ -1,5 +1,5 @@
 import { FC } from 'react'
-import { BridgePanelType } from '@/modules/Bridges/types.ts'
+import { useTranslation } from 'react-i18next'
 import {
   Checkbox,
   Flex,
@@ -14,8 +14,9 @@ import {
   NumberInputField,
   NumberInputStepper,
 } from '@chakra-ui/react'
-import { useTranslation } from 'react-i18next'
 import { $Bridge } from '@/api/__generated__'
+import { useValidationRules } from '@/api/hooks/useValidationRules/useValidationRules.ts'
+import { BridgePanelType } from '@/modules/Bridges/types.ts'
 
 const OptionsPanel: FC<BridgePanelType> = ({ form }) => {
   const { t } = useTranslation()
@@ -23,6 +24,7 @@ const OptionsPanel: FC<BridgePanelType> = ({ form }) => {
     register,
     formState: { errors },
   } = form
+  const getRulesForProperty = useValidationRules()
 
   return (
     <Flex flexDirection={'column'} gap={4}>
@@ -36,15 +38,10 @@ const OptionsPanel: FC<BridgePanelType> = ({ form }) => {
 
       <FormControl isInvalid={!!errors.keepAlive}>
         <FormLabel htmlFor="keepAlive">{t('bridge.options.keepAlive.label')}</FormLabel>
-        <NumberInput id="keepAlive" step={1} min={0} max={$Bridge.properties.keepAlive.maximum}>
+        <NumberInput id="keepAlive" step={1}>
           <NumberInputField
             {...register('keepAlive', {
-              required: 'This field is required',
-              min: { value: 0, message: 'min should be 0' },
-              max: {
-                value: $Bridge.properties.keepAlive.maximum,
-                message: `max length should be ${$Bridge.properties.keepAlive.maximum}`,
-              },
+              ...getRulesForProperty($Bridge.properties.keepAlive),
             })}
           />
           <NumberInputStepper>
@@ -58,15 +55,10 @@ const OptionsPanel: FC<BridgePanelType> = ({ form }) => {
 
       <FormControl>
         <FormLabel htmlFor="sessionExpiry">{t('bridge.options.sessionExpiry.label')}</FormLabel>
-        <NumberInput id="sessionExpiry" step={1} min={1} max={$Bridge.properties.sessionExpiry.maximum}>
+        <NumberInput id="sessionExpiry" step={1} max={$Bridge.properties.sessionExpiry.maximum}>
           <NumberInputField
             {...register('sessionExpiry', {
-              required: 'This field is required',
-              min: { value: 0, message: 'min should be 0' },
-              max: {
-                value: $Bridge.properties.sessionExpiry.maximum,
-                message: `max length should be ${$Bridge.properties.sessionExpiry.maximum}`,
-              },
+              ...getRulesForProperty($Bridge.properties.sessionExpiry),
             })}
           />
           <NumberInputStepper>
@@ -78,7 +70,12 @@ const OptionsPanel: FC<BridgePanelType> = ({ form }) => {
       </FormControl>
 
       <FormControl isInvalid={!!errors.loopPreventionEnabled} mt={3}>
-        <Checkbox defaultChecked {...register('loopPreventionEnabled')}>
+        <Checkbox
+          defaultChecked
+          {...register('loopPreventionEnabled', {
+            ...getRulesForProperty($Bridge.properties.loopPreventionEnabled),
+          })}
+        >
           {t('bridge.options.loopPrevention.label')}
         </Checkbox>
         <FormErrorMessage>{errors.loopPreventionEnabled && errors.loopPreventionEnabled.message}</FormErrorMessage>
@@ -86,10 +83,10 @@ const OptionsPanel: FC<BridgePanelType> = ({ form }) => {
 
       <FormControl isInvalid={!!errors.loopPreventionHopCount}>
         <FormLabel htmlFor="loopPreventionHopCount">{t('bridge.options.hopCount.label')}</FormLabel>
-        <NumberInput id="loopPreventionHopCount" step={1} min={1} max={100}>
+        <NumberInput id="loopPreventionHopCount" step={1}>
           <NumberInputField
             {...register('loopPreventionHopCount', {
-              min: { value: 1, message: 'min should be 1' },
+              ...getRulesForProperty($Bridge.properties.loopPreventionHopCount),
             })}
           />
           <NumberInputStepper>
@@ -107,10 +104,7 @@ const OptionsPanel: FC<BridgePanelType> = ({ form }) => {
           id="clientId"
           type="text"
           {...register('clientId', {
-            pattern: {
-              value: new RegExp($Bridge.properties.clientId.pattern),
-              message: 'Minimum length should be 4',
-            },
+            ...getRulesForProperty($Bridge.properties.clientId),
           })}
         />
         <FormHelperText> {t('bridge.options.clientid.helper')}</FormHelperText>

--- a/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/OptionsPanel.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/OptionsPanel.tsx
@@ -108,7 +108,7 @@ const OptionsPanel: FC<BridgePanelType> = ({ form }) => {
           type="text"
           {...register('clientId', {
             pattern: {
-              value: new RegExp($Bridge.properties.password.pattern),
+              value: new RegExp($Bridge.properties.clientId.pattern),
               message: 'Minimum length should be 4',
             },
           })}

--- a/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/SecurityPanel.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/SecurityPanel.tsx
@@ -4,6 +4,9 @@ import { Select } from 'chakra-react-select'
 import { useTranslation } from 'react-i18next'
 import { Controller, useWatch } from 'react-hook-form'
 
+import { useValidationRules } from '@/api/hooks/useValidationRules/useValidationRules.ts'
+import { $TlsConfiguration } from '@/api/__generated__'
+
 import { CYPHER_SUITES, TLS_PROTOCOLS } from '../../utils/tlsConfiguration.ts'
 import { BridgePanelType } from '../../types.ts'
 
@@ -13,13 +16,20 @@ const SecurityPanel: FC<BridgePanelType> = ({ form }) => {
     register,
     formState: { errors },
   } = form
+  const getRulesForProperty = useValidationRules()
+
   const isTlsEnabled = useWatch({ name: 'tlsConfiguration.enabled', control: form.control })
 
   return (
     <Flex flexDirection={'column'} mt={8} maxW={600} gap={4}>
       <FormControl>
         <FormLabel htmlFor={'tlsConfiguration.enabled'}>{t('bridge.security.enabled.label')}</FormLabel>
-        <Switch id={'tlsConfiguration.enabled'} {...register('tlsConfiguration.enabled')} />
+        <Switch
+          id={'tlsConfiguration.enabled'}
+          {...register('tlsConfiguration.enabled', {
+            ...getRulesForProperty($TlsConfiguration.properties.enabled),
+          })}
+        />
         <FormHelperText>{t('bridge.security.enabled.helper')}</FormHelperText>
       </FormControl>
 

--- a/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/SubscriptionsPanel.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/SubscriptionsPanel.spec.cy.tsx
@@ -48,4 +48,16 @@ describe('SubscriptionsPanel', () => {
     cy.checkAccessibility()
     cy.percySnapshot('Component: SecurityPanel')
   })
+
+  it('should initialise with OpenAPI defaults', () => {
+    cy.mountWithProviders(<TestingComponent onSubmit={cy.stub} defaultValues={mockBridge} />)
+    cy.getByTestId('bridge-subscription-add').click()
+    // force validation to trigger error messages. Better alternative?
+    cy.getByTestId(`form-submit`).click()
+
+    cy.getByTestId(`${MOCK_TYPE}.0.filters`).should('be.visible').find('label').should('have.attr', 'data-invalid')
+
+    cy.get('input[id="remoteSubscriptions.0.filters"').type('my topic{Enter}')
+    cy.getByTestId(`${MOCK_TYPE}.0.destination`).should('be.visible').find('label').should('have.attr', 'data-invalid')
+  })
 })

--- a/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/SubscriptionsPanel.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/SubscriptionsPanel.spec.cy.tsx
@@ -1,0 +1,51 @@
+/// <reference types="cypress" />
+import { useForm } from 'react-hook-form'
+import { FC } from 'react'
+
+import { Bridge } from '@/api/__generated__'
+import { mockBridge } from '@/api/hooks/useGetBridges/__handlers__'
+import ButtonCTA from '@/components/Chakra/ButtonCTA.tsx'
+
+import SubscriptionsPanel from './SubscriptionsPanel.tsx'
+import { SubscriptionType } from '@/modules/Bridges/types.ts'
+
+interface TestingComponentProps {
+  onSubmit: (data: Bridge) => void
+  defaultValues: Bridge
+}
+
+const MOCK_TYPE: SubscriptionType = 'remoteSubscriptions'
+
+const TestingComponent: FC<TestingComponentProps> = ({ onSubmit, defaultValues }) => {
+  const form = useForm<Bridge>({
+    mode: 'all',
+    criteriaMode: 'all',
+    defaultValues: defaultValues,
+  })
+  return (
+    <div>
+      <form id="bridge-form" onSubmit={form.handleSubmit(onSubmit)}>
+        <SubscriptionsPanel form={form} type={MOCK_TYPE} />
+      </form>
+      <ButtonCTA type={'submit'} form="bridge-form" data-testid={'form-submit'} mt={8}>
+        Submit
+      </ButtonCTA>
+    </div>
+  )
+}
+
+describe('SubscriptionsPanel', () => {
+  beforeEach(() => {
+    cy.viewport(800, 800)
+  })
+
+  it('should be accessible', () => {
+    cy.injectAxe()
+    cy.mountWithProviders(<TestingComponent onSubmit={cy.stub} defaultValues={mockBridge} />)
+    cy.getByTestId('bridge-subscription-add').click()
+    cy.getByTestId('bridge-subscription-add').click()
+    cy.getByTestId(`${MOCK_TYPE}.0.advanced`).click()
+    cy.checkAccessibility()
+    cy.percySnapshot('Component: SecurityPanel')
+  })
+})

--- a/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/SubscriptionsPanel.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/SubscriptionsPanel.spec.cy.tsx
@@ -45,7 +45,14 @@ describe('SubscriptionsPanel', () => {
     cy.getByTestId('bridge-subscription-add').click()
     cy.getByTestId('bridge-subscription-add').click()
     cy.getByTestId(`${MOCK_TYPE}.0.advanced`).click()
-    cy.checkAccessibility()
+    cy.getByTestId(`${MOCK_TYPE}.0.maxQoS`).should('be.visible')
+
+    cy.checkAccessibility(undefined, {
+      rules: {
+        // TODO[NVL] Font too small, creating accessibility issues. Need fix
+        'color-contrast': { enabled: false },
+      },
+    })
     cy.percySnapshot('Component: SecurityPanel')
   })
 

--- a/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/SubscriptionsPanel.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/SubscriptionsPanel.tsx
@@ -122,7 +122,7 @@ const SubscriptionsPanel: FC<BridgeSubscriptionsProps> = ({ form, type }) => {
                           ...getRulesForProperty($BridgeSubscription.properties.destination),
                         }}
                       />
-                      {!errors[type]?.[index]?.filters && (
+                      {!errors[type]?.[index]?.destination && (
                         <FormHelperText>{t('bridge.subscription.destination.helper')}</FormHelperText>
                       )}
                       <FormErrorMessage>{errors[type]?.[index]?.destination?.message}</FormErrorMessage>

--- a/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/SubscriptionsPanel.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/SubscriptionsPanel.tsx
@@ -206,7 +206,10 @@ const SubscriptionsPanel: FC<BridgeSubscriptionsProps> = ({ form, type }) => {
                         <FormLabel htmlFor={`${type}.${index}.preserveRetain`}>
                           {t('bridge.subscription.preserveRetain.label')}
                         </FormLabel>
-                        <Switch {...register(`${type}.${index}.preserveRetain`)} />
+                        <Switch
+                          id={`${type}.${index}.preserveRetain`}
+                          {...register(`${type}.${index}.preserveRetain`)}
+                        />
                         <FormErrorMessage>{errors[type]?.[index]?.filters?.message}</FormErrorMessage>
                       </FormControl>
 

--- a/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/SubscriptionsPanel.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/SubscriptionsPanel.tsx
@@ -55,7 +55,11 @@ const SubscriptionsPanel: FC<BridgeSubscriptionsProps> = ({ form, type }) => {
               <HStack>
                 <CardBody>
                   <Flex gap={4}>
-                    <FormControl isInvalid={!!errors[type]?.[index]?.filters} isRequired>
+                    <FormControl
+                      data-testid={`${type}.${index}.filters`}
+                      isInvalid={!!errors[type]?.[index]?.filters}
+                      isRequired
+                    >
                       <FormLabel htmlFor={`${type}.${index}.filters`}>
                         {t('bridge.subscription.filters.label')}
                       </FormLabel>
@@ -70,10 +74,7 @@ const SubscriptionsPanel: FC<BridgeSubscriptionsProps> = ({ form, type }) => {
                               value={formatValue}
                               onChange={(values) => onChange(values.map((item) => item.value))}
                               inputId={`${type}.${index}.filters`}
-                              // options={[{ value: 'ddfd', label: 'fgg' }]}
-                              // menuIsOpen={false}
                               isClearable={true}
-                              placeholder={'ddd'}
                               isMulti={true}
                               components={{
                                 DropdownIndicator: null,
@@ -92,7 +93,11 @@ const SubscriptionsPanel: FC<BridgeSubscriptionsProps> = ({ form, type }) => {
                       <FormErrorMessage>{errors[type]?.[index]?.filters?.message}</FormErrorMessage>
                     </FormControl>
 
-                    <FormControl isInvalid={!!errors[type]?.[index]?.destination} isRequired>
+                    <FormControl
+                      data-testid={`${type}.${index}.destination`}
+                      isInvalid={!!errors[type]?.[index]?.destination}
+                      isRequired
+                    >
                       <FormLabel htmlFor={`${type}.${index}.destination`}>
                         {t('bridge.subscription.destination.label')}
                       </FormLabel>
@@ -108,7 +113,6 @@ const SubscriptionsPanel: FC<BridgeSubscriptionsProps> = ({ form, type }) => {
                               value={formatValue}
                               onChange={(item) => onChange(item?.value)}
                               options={[{ value: '{#}', label: '{#} - original message topic' }]}
-                              // menuIsOpen={false}
                               isClearable={true}
                               isMulti={false}
                               components={{

--- a/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/SubscriptionsPanel.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/SubscriptionsPanel.tsx
@@ -141,7 +141,7 @@ const SubscriptionsPanel: FC<BridgeSubscriptionsProps> = ({ form, type }) => {
               </HStack>
               <CardBody p={0}>
                 <Accordion allowMultiple>
-                  <AccordionItem isDisabled={!!errors[type]?.[index]}>
+                  <AccordionItem isDisabled={!!errors[type]?.[index]} data-testid={`${type}.${index}.advanced`}>
                     <AccordionButton>
                       <AccordionIcon />
                       <Box as="span" flex="1" textAlign="left">
@@ -223,6 +223,7 @@ const SubscriptionsPanel: FC<BridgeSubscriptionsProps> = ({ form, type }) => {
         })}
         <Box>
           <IconButton
+            data-testid={'bridge-subscription-add'}
             isDisabled={!!errors[type]}
             aria-label={t('bridge.subscription.add')}
             icon={<AddIcon />}

--- a/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/SubscriptionsPanel.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/SubscriptionsPanel.tsx
@@ -1,6 +1,7 @@
 import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Controller, useFieldArray } from 'react-hook-form'
+import { CreatableSelect } from 'chakra-react-select'
 import {
   Accordion,
   AccordionItem,
@@ -27,9 +28,9 @@ import {
 } from '@chakra-ui/react'
 import { AddIcon, DeleteIcon } from '@chakra-ui/icons'
 
-import { CreatableSelect } from 'chakra-react-select'
-
-import CustomUserProperties from '../../components/panels/CustomUserProperties.tsx'
+import { $BridgeSubscription } from '@/api/__generated__'
+import { useValidationRules } from '@/api/hooks/useValidationRules/useValidationRules.ts'
+import CustomUserProperties from './CustomUserProperties.tsx'
 import { BridgeSubscriptionsProps } from '../../types.ts'
 
 const SubscriptionsPanel: FC<BridgeSubscriptionsProps> = ({ form, type }) => {
@@ -38,6 +39,7 @@ const SubscriptionsPanel: FC<BridgeSubscriptionsProps> = ({ form, type }) => {
     control: form.control, // control props comes from useForm (optional: if you are using FormContext)
     name: type, // unique name for your Field Array
   })
+  const getRulesForProperty = useValidationRules()
 
   const {
     register,
@@ -81,10 +83,7 @@ const SubscriptionsPanel: FC<BridgeSubscriptionsProps> = ({ form, type }) => {
                         }}
                         control={form.control}
                         rules={{
-                          required: {
-                            value: true,
-                            message: t('bridge.subscription.filters.error.required') as string,
-                          },
+                          ...getRulesForProperty($BridgeSubscription.properties.filters),
                         }}
                       />
                       {!errors[type]?.[index]?.filters && (
@@ -120,10 +119,7 @@ const SubscriptionsPanel: FC<BridgeSubscriptionsProps> = ({ form, type }) => {
                         }}
                         control={form.control}
                         rules={{
-                          required: {
-                            value: true,
-                            message: t('bridge.subscription.filters.error.required') as string,
-                          },
+                          ...getRulesForProperty($BridgeSubscription.properties.destination),
                         }}
                       />
                       {!errors[type]?.[index]?.filters && (
@@ -172,7 +168,7 @@ const SubscriptionsPanel: FC<BridgeSubscriptionsProps> = ({ form, type }) => {
                             </RadioGroup>
                           )}
                           rules={{
-                            required: { value: true, message: 'This is required.' },
+                            ...getRulesForProperty($BridgeSubscription.properties.maxQoS),
                           }}
                         />
                       </FormControl>

--- a/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/SubscriptionsPanel.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/SubscriptionsPanel.tsx
@@ -156,7 +156,7 @@ const SubscriptionsPanel: FC<BridgeSubscriptionsProps> = ({ form, type }) => {
 
                     <AccordionPanel m={1}>
                       <FormControl>
-                        <FormLabel htmlFor={`${type}.${index}.maxQoS`}>
+                        <FormLabel htmlFor={`${type}.${index}.maxQoS`} data-testid={`${type}.${index}.maxQoS`}>
                           {t('bridge.subscription.maxQoS.label')}
                         </FormLabel>
                         <Controller

--- a/hivemq-edge/src/frontend/src/modules/UnifiedNamespace/components/NamespaceForm.tsx
+++ b/hivemq-edge/src/frontend/src/modules/UnifiedNamespace/components/NamespaceForm.tsx
@@ -13,7 +13,8 @@ import {
 } from '@chakra-ui/react'
 import { useTranslation } from 'react-i18next'
 
-import { ISA95ApiBean } from '@/api/__generated__'
+import { $ISA95ApiBean, ISA95ApiBean } from '@/api/__generated__'
+import { useValidationRules } from '@/api/hooks/useValidationRules/useValidationRules.ts'
 
 import NamespaceDisplay from './NamespaceDisplay.tsx'
 import { NAMESPACE_SEPARATOR } from '../namespace-utils.ts'
@@ -39,6 +40,8 @@ const NamespaceForm: FC<NamespaceFormProps> = ({ defaultValues, onSubmit }) => {
   } = useForm<ISA95ApiBean>({
     defaultValues: { ...defaultValues, enabled: true },
   })
+  const getRulesForProperty = useValidationRules()
+
   const preview = watch()
 
   return (
@@ -53,7 +56,12 @@ const NamespaceForm: FC<NamespaceFormProps> = ({ defaultValues, onSubmit }) => {
           <Grid templateColumns="repeat(2, 1fr 20px)" gap={6}>
             <FormControl isInvalid={!!errors.enterprise}>
               <FormLabel htmlFor={'unifiedNamespace-enterprise'}>{t('unifiedNamespace.enterprise.label')}</FormLabel>
-              <Input id={'unifiedNamespace-enterprise'} {...register('enterprise')} />
+              <Input
+                id={'unifiedNamespace-enterprise'}
+                {...register('enterprise', {
+                  ...getRulesForProperty($ISA95ApiBean.properties.enterprise),
+                })}
+              />
               {!errors.enterprise && <FormHelperText>{t('unifiedNamespace.enterprise.helper')}</FormHelperText>}
               <FormErrorMessage>{errors.enterprise && errors.enterprise.message}</FormErrorMessage>
             </FormControl>
@@ -62,7 +70,12 @@ const NamespaceForm: FC<NamespaceFormProps> = ({ defaultValues, onSubmit }) => {
 
             <FormControl>
               <FormLabel htmlFor={'unifiedNamespace-site'}>{t('unifiedNamespace.site.label')}</FormLabel>
-              <Input id={'unifiedNamespace-site'} {...register('site')} />
+              <Input
+                id={'unifiedNamespace-site'}
+                {...register('site', {
+                  ...getRulesForProperty($ISA95ApiBean.properties.site),
+                })}
+              />
               <FormHelperText>{t('unifiedNamespace.site.helper')}</FormHelperText>
             </FormControl>
 
@@ -70,7 +83,12 @@ const NamespaceForm: FC<NamespaceFormProps> = ({ defaultValues, onSubmit }) => {
 
             <FormControl>
               <FormLabel htmlFor={'unifiedNamespace-area'}>{t('unifiedNamespace.area.label')}</FormLabel>
-              <Input id={'unifiedNamespace-area'} {...register('area')} />
+              <Input
+                id={'unifiedNamespace-area'}
+                {...register('area', {
+                  ...getRulesForProperty($ISA95ApiBean.properties.area),
+                })}
+              />
               <FormHelperText>{t('unifiedNamespace.area.helper')}</FormHelperText>
             </FormControl>
 
@@ -80,7 +98,12 @@ const NamespaceForm: FC<NamespaceFormProps> = ({ defaultValues, onSubmit }) => {
               <FormLabel htmlFor={'unifiedNamespace-productionLine'}>
                 {t('unifiedNamespace.productionLine.label')}
               </FormLabel>
-              <Input id={'unifiedNamespace-productionLine'} {...register('productionLine')} />
+              <Input
+                id={'unifiedNamespace-productionLine'}
+                {...register('productionLine', {
+                  ...getRulesForProperty($ISA95ApiBean.properties.productionLine),
+                })}
+              />
               <FormHelperText>{t('unifiedNamespace.productionLine.helper')}</FormHelperText>
             </FormControl>
 
@@ -88,7 +111,12 @@ const NamespaceForm: FC<NamespaceFormProps> = ({ defaultValues, onSubmit }) => {
 
             <FormControl>
               <FormLabel htmlFor={'unifiedNamespace-workCell'}>{t('unifiedNamespace.workCell.label')}</FormLabel>
-              <Input id={'unifiedNamespace-workCell'} {...register('workCell')} />
+              <Input
+                id={'unifiedNamespace-workCell'}
+                {...register('workCell', {
+                  ...getRulesForProperty($ISA95ApiBean.properties.workCell),
+                })}
+              />
               <FormHelperText>{t('unifiedNamespace.workCell.helper')}</FormHelperText>
             </FormControl>
           </Grid>
@@ -99,7 +127,9 @@ const NamespaceForm: FC<NamespaceFormProps> = ({ defaultValues, onSubmit }) => {
           <Checkbox
             data-testid="unifiedNamespace-prefixAllTopics"
             id={'unifiedNamespace-prefixAllTopics'}
-            {...register('prefixAllTopics')}
+            {...register('prefixAllTopics', {
+              ...getRulesForProperty($ISA95ApiBean.properties.prefixAllTopics),
+            })}
           >
             {t('unifiedNamespace.prefixAllTopics.label')}
           </Checkbox>

--- a/hivemq-edge/src/frontend/vitest.config.ts
+++ b/hivemq-edge/src/frontend/vitest.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
     environment: 'jsdom',
     setupFiles: './src/__test-utils__/setup.ts',
     coverage: {
+      exclude: ['**/src/api/__generated__/**'],
       provider: 'istanbul', // or 'v8'
       reporter: ['text', 'json', 'html', 'lcov'],
     },


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/15303/details/ 

This PR changes all the React-Hook-Form forms in the web app (Bridge and Universal Names, Protocol being handled differently) so that their default values are exclusively coming from the OpenAPI specs. For example: 

``
 clientId: {
            type: 'string',
            description: `The client identifier associated the the MQTT connection.`,
            isNullable: true,
            format: 'string',
            maxLength: 65535,
            pattern: '([a-zA-Z_0-9\\-])*',
        },
``

The changes also imposed the standardisation of the error messages, for example: 

```
 "validation": {
    "required": "This property is required",
    "maxLength": "No more than {{ count }} characters allowed for the property",
    "minimum": "Should be at least {{ count }}",
    "maximum": "Should not be more than {{ count }}",
    "pattern": "Should match the regular expression {{ pattern }}"
  }
```


Note that, as of v0.25.0, openapi-typescript-codegen used to generate the OpenAPI stubs still mishandles default values set to 0. See https://github.com/ferdikoomen/openapi-typescript-codegen/issues/1558