### PR TITLE
chore(15690): Add Lighthouse performance testing to the pipeline

### DIFF
--- a/.github/workflows/frontend-cli.yml
+++ b/.github/workflows/frontend-cli.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: 🚚 Setup pnpm
-        uses: pnpm/action-setup@v2.0.1
+        uses: pnpm/action-setup@v2.2.4
         with:
           version: 8.4.0
 
@@ -87,4 +87,23 @@ jobs:
 
       - name: 📸 Run Percy visual tests
         run: pnpm cypress:percy
+        env:
+          PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
 
+      - name: 🚥 Run Lighthouse audits
+        uses: treosh/lighthouse-ci-action@v10
+        id: lighthouse
+        with:
+          temporaryPublicStorage: true # upload lighthouse report to the temporary storage
+          ## budgetPath: ./budget.json # test performance budgets
+          uploadArtifacts: true # save results as an action artifacts
+          configPath: 'hivemq-edge/src/frontend/.lighthouserc.cjs'
+
+      - name: 💾 Job successful feedback
+        if: ${{ success() }}
+        run: |
+          echo '### Lighthouse results 🚦' >> $GITHUB_STEP_SUMMARY
+          echo "Performance: ${{ fromJSON(steps.lighthouse.outputs.manifest)[0].summary.performance }}" >> $GITHUB_STEP_SUMMARY
+          echo "Accessibility: ${{ fromJSON(steps.lighthouse.outputs.manifest)[0].summary.accessibility }}" >> $GITHUB_STEP_SUMMARY
+          echo "Best-practices: ${{ fromJSON(steps.lighthouse.outputs.manifest)[0].summary.best-practices }}" >> $GITHUB_STEP_SUMMARY
+          echo "SEO: ${{ fromJSON(steps.lighthouse.outputs.manifest)[0].summary.seo }}" >> $GITHUB_STEP_SUMMARY

--- a/hivemq-edge/src/frontend/.lighthouserc.cjs
+++ b/hivemq-edge/src/frontend/.lighthouserc.cjs
@@ -1,0 +1,38 @@
+const TARGET_PERFORMANCE = 0.9
+const TARGET_ACCEPTABILITY = 1
+const TARGET_BEST_PRACTICE = 1
+const TARGET_SEO = 1
+
+module.exports = {
+  ci: {
+    collect: {
+      // collect options here
+      staticDistDir: 'hivemq-edge/src/frontend/dist',
+      url: ['http://localhost/app/login'],
+      isSinglePageApplication: true,
+      numberOfRuns: 3,
+      settings: {
+        preset: 'desktop',
+        onlyCategories: ['performance', 'accessibility', 'best-practices', 'seo'],
+        skipAudits: ['uses-http2'],
+        chromeFlags: '--no-sandbox',
+      },
+    },
+    assert: {
+      // assert options here
+      // preset: 'lighthouse:recommended',
+      assertions: {
+        'categories:performance': ['error', { minScore: TARGET_PERFORMANCE, aggregationMethod: 'median-run' }],
+        'categories:accessibility': ['error', { minScore: TARGET_ACCEPTABILITY, aggregationMethod: 'pessimistic' }],
+        'categories:best-practices': ['error', { minScore: TARGET_BEST_PRACTICE, aggregationMethod: 'pessimistic' }],
+        'categories:seo': ['warn', { minScore: TARGET_SEO, aggregationMethod: 'pessimistic' }],
+      },
+    },
+    upload: {
+      // upload options here
+    },
+    server: {
+      // server options here
+    },
+  },
+}

--- a/hivemq-edge/src/frontend/.lighthouserc.cjs
+++ b/hivemq-edge/src/frontend/.lighthouserc.cjs
@@ -1,5 +1,5 @@
 const TARGET_PERFORMANCE = 0.9
-const TARGET_ACCEPTABILITY = 1
+const TARGET_ACCESSIBILITY = 1
 const TARGET_BEST_PRACTICE = 1
 const TARGET_SEO = 1
 
@@ -23,7 +23,7 @@ module.exports = {
       // preset: 'lighthouse:recommended',
       assertions: {
         'categories:performance': ['error', { minScore: TARGET_PERFORMANCE, aggregationMethod: 'median-run' }],
-        'categories:accessibility': ['error', { minScore: TARGET_ACCEPTABILITY, aggregationMethod: 'pessimistic' }],
+        'categories:accessibility': ['error', { minScore: TARGET_ACCESSIBILITY, aggregationMethod: 'pessimistic' }],
         'categories:best-practices': ['error', { minScore: TARGET_BEST_PRACTICE, aggregationMethod: 'pessimistic' }],
         'categories:seo': ['warn', { minScore: TARGET_SEO, aggregationMethod: 'pessimistic' }],
       },

--- a/hivemq-edge/src/frontend/README.md
+++ b/hivemq-edge/src/frontend/README.md
@@ -119,6 +119,6 @@ It contains - and enforces - parts of the testing pyramid for frontend applicati
 
 ### Axe - Accessibility testing
 
-### Percy - Visual testing More Test
+### Percy - Visual testing
 
-https://percy.io/f896bbdc/hivemq-edge
+### Lighthouse - Performance testing


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/15690/details/

The PR install Lighthouse in the `frontend` CI/CD pipeline and configure some basic gates:

- Performance = 90%
- Accessibility = 100%
- Best practice = 100%
- SEA = 100% (warning only)

![Screenshot 2023-07-21 at 10 23 02](https://github.com/hivemq/hivemq-edge/assets/2743481/90d531bf-1f30-4134-b09a-ccb90a758d4f)

See https://www.semrush.com/blog/google-lighthouse/ for a good introduction to Lighthouse

The PR also fixes the Percy integration.