### PR TITLE
fix(15345): Fix the layout of the onboarding task

### DIFF
--- a/hivemq-edge/src/frontend/src/modules/Welcome/WelcomePage.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Welcome/WelcomePage.tsx
@@ -6,15 +6,17 @@ import ReactLogo from '@/assets/welcome-first-time-logo.svg'
 
 import PageContainer from '@/components/PageContainer.tsx'
 import Onboarding from '@/modules/Welcome/components/Onboarding.tsx'
+import { useOnboarding } from '@/modules/Welcome/hooks/useOnboarding.tsx'
 
 const WelcomePage: FC = () => {
   const { t } = useTranslation()
+  const content = useOnboarding()
 
   return (
     <PageContainer title={t('welcome.title') as string} subtitle={t('welcome.description') as string}>
       <Flex flexDirection={'column'}>
         <Flex flexDirection={{ base: 'column', lg: 'row' }}>
-          <Onboarding flex={1} />
+          <Onboarding tasks={content} flex={1} />
           <Center flex={1} m={4}>
             <Image boxSize={400} src={ReactLogo} alt={t('branding.appName') as string} />
           </Center>

--- a/hivemq-edge/src/frontend/src/modules/Welcome/WelcomePage.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Welcome/WelcomePage.tsx
@@ -14,7 +14,7 @@ const WelcomePage: FC = () => {
     <PageContainer title={t('welcome.title') as string} subtitle={t('welcome.description') as string}>
       <Flex flexDirection={'column'}>
         <Flex flexDirection={{ base: 'column', lg: 'row' }}>
-          <Onboarding />
+          <Onboarding flex={1} />
           <Center flex={1} m={4}>
             <Image boxSize={400} src={ReactLogo} alt={t('branding.appName') as string} />
           </Center>

--- a/hivemq-edge/src/frontend/src/modules/Welcome/components/Onboarding.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Welcome/components/Onboarding.spec.cy.tsx
@@ -1,0 +1,56 @@
+/// <reference types="cypress" />
+import { IoLinkOutline } from 'react-icons/io5'
+
+import Onboarding from './Onboarding.tsx'
+
+const MOCK_ONBOARDING = [
+  {
+    header: 'Heading 1',
+    sections: [
+      {
+        title: 'Task 1',
+        label: 'Get Started',
+        to: '/link1',
+        leftIcon: <IoLinkOutline />,
+      },
+      {
+        title: 'Task  2',
+        label: 'Get Started',
+        to: '/link2',
+        leftIcon: <IoLinkOutline />,
+      },
+    ],
+  },
+  {
+    header: 'Heading 2',
+    sections: [
+      {
+        title: 'Task 3',
+        label: 'Get Started',
+        to: '/link3',
+        leftIcon: <IoLinkOutline />,
+      },
+    ],
+  },
+]
+
+describe('Onboarding', () => {
+  beforeEach(() => {
+    cy.viewport(500, 800)
+  })
+
+  it('should be accessible', () => {
+    cy.injectAxe()
+    cy.mountWithProviders(<Onboarding tasks={MOCK_ONBOARDING} />)
+    cy.checkAccessibility()
+    cy.percySnapshot('Component: Onboarding')
+  })
+
+  it('should render properly', () => {
+    cy.mountWithProviders(<Onboarding tasks={MOCK_ONBOARDING} />)
+    cy.get('a[aria-label="Get Started"]').should('have.length', 3)
+    cy.get('a[aria-label="Get Started"]').eq(0).should('have.attr', 'href', '/link1')
+    cy.get('a[aria-label="Get Started"]').eq(1).should('have.attr', 'href', '/link2')
+    cy.get('a[aria-label="Get Started"]').eq(2).should('have.attr', 'href', '/link3')
+  })
+})

--- a/hivemq-edge/src/frontend/src/modules/Welcome/components/Onboarding.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Welcome/components/Onboarding.tsx
@@ -1,19 +1,35 @@
 import { FC } from 'react'
-import { Box, Button, Heading, HTMLChakraProps, SimpleGrid, Stack, StackDivider } from '@chakra-ui/react'
-
-import { Card, CardHeader, CardBody, Text } from '@chakra-ui/react'
 import { Link as RouterLink } from 'react-router-dom'
-import { useOnboarding } from '@/modules/Welcome/hooks/useOnboarding.tsx'
 import { useTranslation } from 'react-i18next'
+import {
+  Box,
+  Button,
+  Heading,
+  HTMLChakraProps,
+  SimpleGrid,
+  Stack,
+  StackDivider,
+  Card,
+  CardHeader,
+  CardBody,
+  Text,
+} from '@chakra-ui/react'
 
-const Onboarding: FC<HTMLChakraProps<'div'>> = (props) => {
+import { OnboardingTask } from '@/modules/Welcome/types.ts'
+
+interface OnboardingProps extends HTMLChakraProps<'div'> {
+  tasks: OnboardingTask[]
+}
+
+const Onboarding: FC<OnboardingProps> = (props) => {
   const { t } = useTranslation()
-  const content = useOnboarding()
+  const { tasks } = props
+
   return (
     <Box mt={6} {...props}>
       <Heading>{t('welcome.onboarding.title')}</Heading>
-      <SimpleGrid spacing={6} templateColumns="repeat(auto-fill, minmax(30vw, 10fr))">
-        {content.map((e) => (
+      <SimpleGrid spacing={6} templateColumns="repeat(auto-fill, minmax(33vw, 10fr))">
+        {tasks.map((e) => (
           <Card flex={1} key={e.header}>
             <CardHeader>
               <Heading size="md">{e.header}</Heading>

--- a/hivemq-edge/src/frontend/src/modules/Welcome/components/Onboarding.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Welcome/components/Onboarding.tsx
@@ -1,16 +1,16 @@
 import { FC } from 'react'
-import { Box, Button, Heading, SimpleGrid, Stack, StackDivider } from '@chakra-ui/react'
+import { Box, Button, Heading, HTMLChakraProps, SimpleGrid, Stack, StackDivider } from '@chakra-ui/react'
 
 import { Card, CardHeader, CardBody, Text } from '@chakra-ui/react'
 import { Link as RouterLink } from 'react-router-dom'
 import { useOnboarding } from '@/modules/Welcome/hooks/useOnboarding.tsx'
 import { useTranslation } from 'react-i18next'
 
-const Onboarding: FC = () => {
+const Onboarding: FC<HTMLChakraProps<'div'>> = (props) => {
   const { t } = useTranslation()
   const content = useOnboarding()
   return (
-    <Box mt={6}>
+    <Box mt={6} {...props}>
       <Heading>{t('welcome.onboarding.title')}</Heading>
       <SimpleGrid spacing={6} templateColumns="repeat(auto-fill, minmax(30vw, 10fr))">
         {content.map((e) => (

--- a/hivemq-edge/src/frontend/src/modules/Welcome/hooks/useOnboarding.spec.ts
+++ b/hivemq-edge/src/frontend/src/modules/Welcome/hooks/useOnboarding.spec.ts
@@ -1,0 +1,25 @@
+import { renderHook } from '@testing-library/react'
+import { describe, expect } from 'vitest'
+import '@/config/i18n.config.ts'
+
+import { useOnboarding } from './useOnboarding.tsx'
+
+describe('useOnboarding()', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+  })
+
+  it('should return the correct list of tasks', () => {
+    const { result } = renderHook(() => useOnboarding())
+
+    expect(result.current).toHaveLength(2)
+    expect(result.current[0].sections).toHaveLength(1)
+    expect(result.current[1].sections).toHaveLength(1)
+    expect(result.current[0].sections).toEqual(
+      expect.arrayContaining([expect.objectContaining({ to: '/protocol-adapters' })])
+    )
+    expect(result.current[1].sections).toEqual(
+      expect.arrayContaining([expect.objectContaining({ to: '/mqtt-bridges' })])
+    )
+  })
+})

--- a/hivemq-edge/src/frontend/src/modules/Welcome/hooks/useOnboarding.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Welcome/hooks/useOnboarding.tsx
@@ -1,7 +1,8 @@
 import { useTranslation } from 'react-i18next'
 import { IoLinkOutline } from 'react-icons/io5'
+import { OnboardingTask } from '@/modules/Welcome/types.ts'
 
-export const useOnboarding = () => {
+export const useOnboarding = (): OnboardingTask[] => {
   const { t } = useTranslation()
 
   return [

--- a/hivemq-edge/src/frontend/src/modules/Welcome/types.ts
+++ b/hivemq-edge/src/frontend/src/modules/Welcome/types.ts
@@ -1,0 +1,13 @@
+import React from 'react'
+
+export interface OnboardingAction {
+  title: string
+  label: string
+  to: string
+  leftIcon: React.ReactElement
+}
+
+export interface OnboardingTask {
+  header: string
+  sections: OnboardingAction[]
+}


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/15345/details/

This PR fixes the layout of the list of welcome task, especially when the description of the task is getting longer than a short text

### Before
![screenshot-localhost_3000-2023 07 21-17_08_51](https://github.com/hivemq/hivemq-edge/assets/2743481/c6b0fc98-77bc-4ddb-9240-db7cdcf4e55e)


### After
![screenshot-localhost_3000-2023 07 21-17_08_28](https://github.com/hivemq/hivemq-edge/assets/2743481/c717ad7d-4704-42dd-b2b8-4e483d48ee62)

![screenshot-localhost_3000-2023 07 21-17_09_46](https://github.com/hivemq/hivemq-edge/assets/2743481/c2be0419-b538-4b5d-bbac-2c4225d01ed0)

