### PR TITLE
fix(15689): integrate Percy pipeline

### DIFF
--- a/hivemq-edge/src/frontend/package.json
+++ b/hivemq-edge/src/frontend/package.json
@@ -18,7 +18,7 @@
     "cypress:run:component": "cypress run --component",
     "cypress:run:e2e": "cypress run --e2e",
     "cypress:run": "npx cypress run --e2e --browser chrome && npx cypress run --component --browser chrome",
-    "cypress:percy": "percy exec -- cypress run",
+    "cypress:percy": "LOCAL_NONCE=$(date '+%s') && PERCY_PARALLEL_NONCE=$LOCAL_NONCE percy exec --parallel -- cypress run --e2e && PERCY_PARALLEL_NONCE=$LOCAL_NONCE percy exec --parallel -- cypress run --component && PERCY_PARALLEL_NONCE=$LOCAL_NONCE percy build:finalize ",
     "test": "vitest",
     "test:coverage": "vitest run --coverage",
     "test:ui": "vitest --ui",

--- a/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/SubscriptionsPanel.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/SubscriptionsPanel.spec.cy.tsx
@@ -53,7 +53,7 @@ describe('SubscriptionsPanel', () => {
         'color-contrast': { enabled: false },
       },
     })
-    cy.percySnapshot('Component: SecurityPanel')
+    cy.percySnapshot('Component: SubscriptionsPanel')
   })
 
   it('should initialise with OpenAPI defaults', () => {


### PR DESCRIPTION
Resolves [#15689](https://hivemq.kanbanize.com/ctrl_board/57/cards/15689/details/)

This PR fixes the script associated with the `Percy` GitHub action. It allows `Percy` to run in parallel both E2E and component snapshots, as defined in the `Cypress` tests: 

```js
  it('should be accessible', () => {
    ...
    cy.percySnapshot('Component: WarningMessage')
  })
```

The test results are available from the `Percy` dashboard: https://percy.io/f896bbdc/hivemq-edge


### Before
![screenshot-percy io-2023 08 09-11_42_59](https://github.com/hivemq/hivemq-edge/assets/2743481/00f3a024-a7d9-4079-819c-fac02a364c5b)

### After
![screenshot-percy io-2023 08 09-11_43_35](https://github.com/hivemq/hivemq-edge/assets/2743481/b22b423e-cac8-470e-b6e5-b031d74b440b)
