### PR TITLE
feat(16123): Ensure image URLs are served from API server

### DIFF
--- a/hivemq-edge/src/main/java/com/hivemq/api/resources/impl/ProtocolAdaptersResourceImpl.java
+++ b/hivemq-edge/src/main/java/com/hivemq/api/resources/impl/ProtocolAdaptersResourceImpl.java
@@ -31,6 +31,7 @@ import com.hivemq.api.model.connection.ConnectionStatusList;
 import com.hivemq.api.model.connection.ConnectionStatusTransitionCommand;
 import com.hivemq.api.resources.ProtocolAdaptersApi;
 import com.hivemq.api.utils.ApiErrorUtils;
+import com.hivemq.api.utils.ApiUtils;
 import com.hivemq.configuration.service.ConfigurationService;
 import com.hivemq.edge.HiveMQEdgeConstants;
 import com.hivemq.edge.modules.adapters.impl.ProtocolAdapterDiscoveryOutputImpl;
@@ -69,13 +70,19 @@ public class ProtocolAdaptersResourceImpl extends AbstractApi implements Protoco
     public @NotNull Response getAdapterTypes() {
         final ImmutableList.Builder<ProtocolAdapter> adapters = ImmutableList.builder();
         for (ProtocolAdapterInformation info : protocolAdapterManager.getAllAvailableAdapterTypes().values()) {
+            String logoUrl = info.getLogoUrl();
+            if(Boolean.getBoolean(HiveMQEdgeConstants.DEVELOPMENT_MODE)){
+                //-- when we're in developer mode, ensure we make the logo urls fully qualified
+                //-- as the FE maybe being run from a different development server.
+              logoUrl = ApiUtils.getWebContextRoot(configurationService.apiConfiguration(), false) + logoUrl;
+            }
             adapters.add(new ProtocolAdapter(info.getProtocolId(),
                     info.getProtocolName(),
                     info.getName(),
                     info.getDescription(),
                     info.getUrl(),
                     info.getVersion(),
-                    info.getLogoUrl(),
+                    logoUrl,
                     info.getAuthor(),
                     protocolAdapterManager.getSchemaManager(info).generateSchemaNode()));
         }

--- a/hivemq-edge/src/main/java/com/hivemq/api/utils/ApiUtils.java
+++ b/hivemq-edge/src/main/java/com/hivemq/api/utils/ApiUtils.java
@@ -19,6 +19,7 @@ import com.google.common.base.Preconditions;
 import com.hivemq.api.config.ApiListener;
 import com.hivemq.api.config.HttpsListener;
 import com.hivemq.configuration.service.ApiConfigurationService;
+import com.hivemq.extension.sdk.api.annotations.NotNull;
 import com.hivemq.http.core.UsernamePasswordRoles;
 
 import java.net.InetAddress;
@@ -38,7 +39,7 @@ public class ApiUtils {
         return false;
     }
 
-    public static String getWebContextRoot(ApiConfigurationService apiConfigurationService, boolean trailingSlash){
+    public static String getWebContextRoot(final @NotNull ApiConfigurationService apiConfigurationService, final boolean trailingSlash){
 
         List<ApiListener> listeners = apiConfigurationService.getListeners();
         if(listeners == null || listeners.isEmpty()){
@@ -66,7 +67,7 @@ public class ApiUtils {
         }
     }
 
-    public static String getHostName(final String name) throws UnknownHostException {
+    public static String getHostName(final @NotNull String name) throws UnknownHostException {
         Preconditions.checkNotNull(name);
         if("0.0.0.0".equals(name)){
             return InetAddress.getLocalHost().getHostName();

--- a/hivemq-edge/src/main/java/com/hivemq/edge/HiveMQEdgeConstants.java
+++ b/hivemq-edge/src/main/java/com/hivemq/edge/HiveMQEdgeConstants.java
@@ -25,6 +25,8 @@ public interface HiveMQEdgeConstants {
     int MAX_UINT16 = 65535;
     String MAX_UINT16_String = "65535";
 
+    String DEVELOPMENT_MODE = "hivemq.edge.workspace.modules";
+
     String HOSTNAME_REGEX = "^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9])$";
 
     //credits: Regular Expressions Cookbook by Steven Levithan, Jan Goyvaerts


### PR DESCRIPTION
Whilst working in developer mode, it important that images render when running Frontend on a different developer server. For this reason, when specified, the developer flag will enable logoUrls to be fully qualified.