### PR TITLE
feat (15617) - Ensure modules are loaded from workspace in development mode

### DIFF
--- a/modules/hivemq-edge-module-modbus/build.gradle.kts
+++ b/modules/hivemq-edge-module-modbus/build.gradle.kts
@@ -70,6 +70,14 @@ tasks.test {
     }
 }
 
+tasks.register<Copy>("copyAllDependencies") {
+    shouldRunAfter("assemble")
+    from(configurations.runtimeClasspath)
+    into("${buildDir}/deps/libs")
+}
+
+tasks.named("assemble") { finalizedBy("copyAllDependencies") }
+
 /* ******************** artifacts ******************** */
 
 val releaseBinary: Configuration by configurations.creating {

--- a/modules/hivemq-edge-module-opcua/build.gradle.kts
+++ b/modules/hivemq-edge-module-opcua/build.gradle.kts
@@ -74,6 +74,15 @@ tasks.test {
     }
 }
 
+tasks.register<Copy>("copyAllDependencies") {
+    shouldRunAfter("assemble")
+    from(configurations.runtimeClasspath)
+    into("${buildDir}/deps/libs")
+}
+
+tasks.named("assemble") { finalizedBy("copyAllDependencies") }
+
+
 /* ******************** artifacts ******************** */
 
 val releaseBinary: Configuration by configurations.creating {


### PR DESCRIPTION
It is currently difficult to develop modules in a full runtime, due to the nature of the module loader only considering the built artefacts. Allow the build/ contributes workspace directories to be considered ahead of the lib contributed .jar files.