### PR TITLE
fix (16220) - Backed off (terminal) error jobs are not removed from pool

### DIFF
--- a/hivemq-edge/src/main/java/com/hivemq/edge/modules/adapters/impl/ProtocolAdapterPollingServiceImpl.java
+++ b/hivemq-edge/src/main/java/com/hivemq/edge/modules/adapters/impl/ProtocolAdapterPollingServiceImpl.java
@@ -122,7 +122,7 @@ public class ProtocolAdapterPollingServiceImpl implements ProtocolAdapterPolling
             Future<?> future = pollingJob.getFuture();
             if(!future.isCancelled()){
                 log.info("Stopping Polling Job {}", pollingJob.getId());
-                if(future.cancel(false)){
+                if(future.cancel(true)){
                     pollingJob.getInput().close();
                 }
             }

--- a/hivemq-edge/src/main/java/com/hivemq/edge/modules/adapters/params/ProtocolAdapterPollingInput.java
+++ b/hivemq-edge/src/main/java/com/hivemq/edge/modules/adapters/params/ProtocolAdapterPollingInput.java
@@ -41,6 +41,8 @@ public interface ProtocolAdapterPollingInput {
      */
     void close();
 
+    boolean isClosed();
+
     default int getMaxErrorsBeforeRemoval(){
         return 25;
     }

--- a/hivemq-edge/src/main/java/com/hivemq/edge/modules/adapters/params/ProtocolAdapterPollingInput.java
+++ b/hivemq-edge/src/main/java/com/hivemq/edge/modules/adapters/params/ProtocolAdapterPollingInput.java
@@ -36,6 +36,11 @@ public interface ProtocolAdapterPollingInput {
      */
     void execute() throws Exception;
 
+    /**
+     * Called when the job is remove from the pool
+     */
+    void close();
+
     default int getMaxErrorsBeforeRemoval(){
         return 25;
     }

--- a/hivemq-edge/src/main/java/com/hivemq/edge/modules/adapters/params/impl/ProtocolAdapterPollingInputImpl.java
+++ b/hivemq-edge/src/main/java/com/hivemq/edge/modules/adapters/params/impl/ProtocolAdapterPollingInputImpl.java
@@ -58,4 +58,9 @@ public abstract class ProtocolAdapterPollingInputImpl implements ProtocolAdapter
     public int getMaxErrorsBeforeRemoval() {
         return maxErrorsBeforeRemoval;
     }
+
+    @Override
+    public void close() {
+
+    }
 }

--- a/hivemq-edge/src/main/java/com/hivemq/edge/modules/adapters/params/impl/ProtocolAdapterPollingInputImpl.java
+++ b/hivemq-edge/src/main/java/com/hivemq/edge/modules/adapters/params/impl/ProtocolAdapterPollingInputImpl.java
@@ -18,8 +18,11 @@ package com.hivemq.edge.modules.adapters.params.impl;
 import com.google.common.base.Preconditions;
 import com.hivemq.edge.modules.adapters.params.ProtocolAdapterPollingInput;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
+import io.reactivex.internal.schedulers.NewThreadWorker;
 
+import java.nio.channels.ClosedByInterruptException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * @author Simon L Johnson
@@ -30,6 +33,7 @@ public abstract class ProtocolAdapterPollingInputImpl implements ProtocolAdapter
     private final long period;
     private final TimeUnit unit;
     private final int maxErrorsBeforeRemoval;
+    protected AtomicBoolean closed = new AtomicBoolean(false);
 
     public ProtocolAdapterPollingInputImpl(final long initialDelay, final long period, final @NotNull TimeUnit unit, final int maxErrorsBeforeRemoval) {
         Preconditions.checkNotNull(unit);
@@ -61,6 +65,11 @@ public abstract class ProtocolAdapterPollingInputImpl implements ProtocolAdapter
 
     @Override
     public void close() {
+        closed.set(true);
+    }
 
+    @Override
+    public boolean isClosed() {
+        return closed.get();
     }
 }

--- a/modules/hivemq-edge-module-modbus/src/main/java/com/hivemq/edge/adapters/modbus/ModbusProtocolAdapter.java
+++ b/modules/hivemq-edge-module-modbus/src/main/java/com/hivemq/edge/adapters/modbus/ModbusProtocolAdapter.java
@@ -245,6 +245,7 @@ public class ModbusProtocolAdapter extends AbstractProtocolAdapter {
                 log.warn("error closing/disconnecting from modbus client;", e);
             } finally {
                 modbusClient = null;
+                super.close();
             }
         }
 

--- a/modules/hivemq-edge-module-modbus/src/main/java/com/hivemq/edge/adapters/modbus/ModbusProtocolAdapter.java
+++ b/modules/hivemq-edge-module-modbus/src/main/java/com/hivemq/edge/adapters/modbus/ModbusProtocolAdapter.java
@@ -103,7 +103,6 @@ public class ModbusProtocolAdapter extends AbstractProtocolAdapter {
                 if (modbusClient == null) {
                     log.info("Creating new Instance Of ModbusClient with {}", adapterConfig);
                     modbusClient = new ModbusClient(adapterConfig);
-
                 }
             }
         }
@@ -112,17 +111,10 @@ public class ModbusProtocolAdapter extends AbstractProtocolAdapter {
 
     @Override
     public CompletableFuture<Void> stop() {
-        if (modbusClient != null) {
-            try {
-                //-- Stop polling jobs
-                protocolAdapterPollingService.getPollingJobsForAdapter(getId()).stream().forEach(
-                        protocolAdapterPollingService::stopPolling);
-                //-- Disconnect client
-                modbusClient.disconnect();
-            } catch (ProtocolAdapterException e) {
-                log.error("Error disconnecting from Modbus Client", e);
-            }
-        }
+
+        //-- Stop polling jobs
+        protocolAdapterPollingService.getPollingJobsForAdapter(getId()).stream().forEach(
+                protocolAdapterPollingService::stopPolling);
         return CompletableFuture.completedFuture(null);
     }
 
@@ -230,12 +222,29 @@ public class ModbusProtocolAdapter extends AbstractProtocolAdapter {
 
         @Override
         public void execute() throws Exception {
-            if (!modbusClient.isConnected()) {
-                modbusClient.connect();
+            //-- If a previously linked job has terminally disconnected the client
+            //-- we need to ensure any orphaned jobs tidy themselves up properly
+            if(modbusClient != null){
+                if (!modbusClient.isConnected()) {
+                    modbusClient.connect();
+                }
+                ModBusData data = readAddresses(addressRange);
+                if (data != null) {
+                    captured(data);
+                }
             }
-            ModBusData data = readAddresses(addressRange);
-            if (data != null) {
-                captured(data);
+        }
+
+        @Override
+        public void close() {
+            try {
+                if(modbusClient != null){
+                    modbusClient.disconnect();
+                }
+            } catch (ProtocolAdapterException e) {
+                log.warn("error closing/disconnecting from modbus client;", e);
+            } finally {
+                modbusClient = null;
             }
         }
 

--- a/modules/hivemq-edge-module-modbus/src/main/java/com/hivemq/edge/adapters/modbus/impl/ModbusClient.java
+++ b/modules/hivemq-edge-module-modbus/src/main/java/com/hivemq/edge/adapters/modbus/impl/ModbusClient.java
@@ -40,9 +40,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 public class ModbusClient implements IModbusClient {
 
     private final @NotNull ModbusAdapterConfig adapterConfig;
-
     private final Object lock = new Object();
-
     private ModbusTcpMaster modbusClient;
     private AtomicBoolean connected = new AtomicBoolean(false);
 
@@ -162,8 +160,10 @@ public class ModbusClient implements IModbusClient {
 
     @Override
     public boolean disconnect() {
-        if (isConnected()) {
-            getOrCreateClient().disconnect();
+        //-- If the client is manually disconnected before connection established ensure we still call into the client
+        //-- to shut it all down.
+        if (modbusClient != null) {
+            modbusClient.disconnect();
             return true;
         }
         return false;


### PR DESCRIPTION
Added a callback hook, so that jobs who directly manage the connections through a sync API can callback and close underlying instances aligning it to the backoff job pool terminal event code path. For example when Job A exceeds its threshold and Job B shares the connection, Job A will be removed from the pool and will close the underlying resource that JobB shares - Job B will then need to be safe against bad connection handles. NOTE: The failure of Job A should NOT remove Job B by design, since Job A may have failed for a reason unrelated to the underlying connection resource, and thus Job B may still have a valid handle to work with (this becomes adapter dependant).