### PR TITLE
fix (16221 - 16225) - Ensure the Protocol XML adapter created wrapper type correctly

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -5,7 +5,7 @@
 </p>
 ++++
 
-= HiveMQ Edge
+== HiveMQ Edge
 
 image:https://img.shields.io/github/actions/workflow/status/hivemq/hivemq-edge/check.yml?branch=master[GitHub Workflow Status (with branch),link=https://github.com/hivemq/hivemq-edge/actions/workflows/check.yml?query=branch%3Amaster]
 

--- a/hivemq-edge/src/main/java/com/hivemq/configuration/reader/ConfigFileReaderWriter.java
+++ b/hivemq-edge/src/main/java/com/hivemq/configuration/reader/ConfigFileReaderWriter.java
@@ -84,6 +84,7 @@ public class ConfigFileReaderWriter {
     private final @NotNull ProtocolAdapterConfigurator protocolAdapterConfigurator;
     private HiveMQConfigEntity configEntity;
     private final Object lock = new Object();
+    private boolean defaultBackupConfig = true;
 
     public ConfigFileReaderWriter(
             final @NotNull ConfigurationFile configurationFile,
@@ -120,7 +121,11 @@ public class ConfigFileReaderWriter {
     }
 
     public void writeConfig() {
-        writeConfigToXML(configurationFile, true);
+        writeConfigToXML(configurationFile, defaultBackupConfig);
+    }
+
+    public void setDefaultBackupConfig(final boolean defaultBackupConfig) {
+        this.defaultBackupConfig = defaultBackupConfig;
     }
 
     public void writeConfig(@NotNull final ConfigurationFile file, boolean rollConfig) {

--- a/hivemq-edge/src/test/java/com/hivemq/configuration/writer/AbstractConfigWriterTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/configuration/writer/AbstractConfigWriterTest.java
@@ -38,6 +38,7 @@ import util.TestConfigurationBootstrap;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 
 import static org.mockito.Mockito.mock;
 
@@ -45,9 +46,6 @@ import static org.mockito.Mockito.mock;
  * @author Simon L Johnson
  */
 public abstract class AbstractConfigWriterTest {
-
-    @TempDir
-    protected File tempDir;
 
     protected ConfigurationService configurationService;
 
@@ -68,13 +66,15 @@ public abstract class AbstractConfigWriterTest {
                 new DynamicConfigConfigurator(configurationService.gatewayConfiguration()),
                 new UsageTrackingConfigurator(configurationService.usageTrackingConfiguration()),
                 new ProtocolAdapterConfigurator(configurationService.protocolAdapterConfigurationService()));
+        configFileReader.setDefaultBackupConfig(false);
         return configFileReader;
     }
 
     protected File loadTestConfigFile() throws IOException {
         try (final InputStream is =
                      AbstractConfigWriterTest.class.getResourceAsStream("/test-config.xml")){
-            final File tempFile = new File(tempDir, "original-config.xml");
+            final File tempFile = new File(System.getProperty("java.io.tmpdir"), "original-config.xml");
+            tempFile.deleteOnExit();
             FileUtils.copyInputStreamToFile(is, tempFile);
             return tempFile;
         }

--- a/hivemq-edge/src/test/java/com/hivemq/configuration/writer/ConfigFileWriterTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/configuration/writer/ConfigFileWriterTest.java
@@ -43,7 +43,8 @@ public class ConfigFileWriterTest extends AbstractConfigWriterTest {
         final ConfigFileReaderWriter configFileReader = createFileReaderWriter(tempFile);
         HiveMQConfigEntity hiveMQConfigEntity = configFileReader.applyConfig();
 
-        final File tempCopyFile = new File(tempDir, "copy-config.xml");
+        final File tempCopyFile = new File(System.getProperty("java.io.tmpdir"), "copy-config.xml");
+        tempFile.deleteOnExit();
         configFileReader.writeConfig(new ConfigurationFile(tempCopyFile), false);
 
         String copiedFileContent = FileUtils.readFileToString(tempCopyFile, UTF_8);

--- a/hivemq-edge/src/test/java/com/hivemq/configuration/writer/ConfigurationServiceSyncTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/configuration/writer/ConfigurationServiceSyncTest.java
@@ -74,9 +74,6 @@ public class ConfigurationServiceSyncTest extends AbstractConfigWriterTest {
         HiveMQConfigEntity hiveMQConfigEntity = configFileReader.applyConfig();
         configurationService.setConfigFileReaderWriter(configFileReader);
 
-//        String copiedFileContent = FileUtils.readFileToString(tempFile, StandardCharsets.UTF_8);
-//        System.err.println(copiedFileContent);
-
         Map<String, Object> config =
                 configurationService.protocolAdapterConfigurationService().getAllConfigs();
 


### PR DESCRIPTION
Ensure the the arbitrary XML adapter DOES NOT wrap root instances, but DOES wrap lists with attribute names ending 's' where <> root node. Further, do not create empty elements where there exist empty lists.