### PR TITLE
fix(16308): Allows Edge frontend to initiate backend requests when offline 

### DIFF
--- a/hivemq-edge/src/frontend/src/api/hooks/useHttpClient/useHttpClient.ts
+++ b/hivemq-edge/src/frontend/src/api/hooks/useHttpClient/useHttpClient.ts
@@ -29,6 +29,12 @@ export const useHttpClient = () => {
   function createInstance() {
     // Make sure to clear the interceptors, since axiosInstance is global
     axiosInstance.interceptors.response.clear()
+    axiosInstance.interceptors.request.clear()
+    axiosInstance.interceptors.request.use((internalConfig) => {
+      internalConfig.timeout = config.httpClient.axiosTimeout
+      return internalConfig
+    })
+
     axiosInstance.interceptors.response.use(
       function (response) {
         // Any status code that lie within the range of 2xx cause this function to trigger

--- a/hivemq-edge/src/frontend/src/api/queryClient.ts
+++ b/hivemq-edge/src/frontend/src/api/queryClient.ts
@@ -1,4 +1,5 @@
 import { QueryClient } from '@tanstack/react-query'
+import config from '@/config'
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -7,10 +8,10 @@ const queryClient = new QueryClient({
       refetchOnWindowFocus: false,
       refetchOnReconnect: false,
       refetchOnMount: true,
-      networkMode: 'always',
+      networkMode: config.httpClient.networkMode,
     },
     mutations: {
-      networkMode: 'always',
+      networkMode: config.httpClient.networkMode,
     },
   },
 })

--- a/hivemq-edge/src/frontend/src/api/queryClient.ts
+++ b/hivemq-edge/src/frontend/src/api/queryClient.ts
@@ -7,6 +7,10 @@ const queryClient = new QueryClient({
       refetchOnWindowFocus: false,
       refetchOnReconnect: false,
       refetchOnMount: true,
+      networkMode: 'always',
+    },
+    mutations: {
+      networkMode: 'always',
     },
   },
 })

--- a/hivemq-edge/src/frontend/src/config/index.ts
+++ b/hivemq-edge/src/frontend/src/config/index.ts
@@ -7,6 +7,7 @@ const config = {
   documentationUrl: import.meta.env.VITE_APP_DOCUMENTATION,
 
   httpClient: {
+    axiosTimeout: 15000,
     pollingRefetchInterval: 5 * 1000,
   },
 

--- a/hivemq-edge/src/frontend/src/config/index.ts
+++ b/hivemq-edge/src/frontend/src/config/index.ts
@@ -1,4 +1,30 @@
-const config = {
+import { NetworkMode } from '@tanstack/react-query'
+
+interface configType {
+  environment: string
+  apiBaseUrl: string
+
+  version: string
+  documentationUrl: string
+
+  httpClient: {
+    axiosTimeout: number
+    networkMode: NetworkMode
+    pollingRefetchInterval: number
+  }
+
+  features: {
+    PROTOCOL_ADAPTER_FACET: boolean
+    METRICS_SELECT_PANEL: boolean
+    METRICS_DEFAULTS: string[]
+  }
+
+  documentation: {
+    namespace: string
+  }
+}
+
+const config: configType = {
   environment: import.meta.env.MODE,
 
   apiBaseUrl: import.meta.env.VITE_API_BASE_URL,
@@ -7,7 +33,22 @@ const config = {
   documentationUrl: import.meta.env.VITE_APP_DOCUMENTATION,
 
   httpClient: {
+    /**
+     * Number of milliseconds before Axios times out the request
+     * @see  https://axios-http.com/docs/req_config
+     */
     axiosTimeout: 15000,
+
+    /**
+     * React Query network mode
+     * @see https://tanstack.com/query/v5/docs/react/guides/network-mode
+     */
+    networkMode: 'always',
+
+    /**
+     * https://tanstack.com/query/v5/docs/react/reference/useQuery
+     * @see https://tanstack.com/query/v5/docs/react/reference/useQuery
+     */
     pollingRefetchInterval: 5 * 1000,
   },
 


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/16308/details/

This PR fixes the problem of API requests not being fired when their is no connectivity.

The main problem was with the configuration of `ReactQuery`, see documentation (https://tanstack.com/query/v4/docs/react/guides/network-mode). By default, the `Network Mode` is set to `online`, in which Queries and Mutations will not fire unless you have network connection, setting the query into a `paused` state.

The PR switches the `Network Mode` to `always`, in which Queries and Mutations are always sent and ReactQuery basically ignore online/offline status.  

The PR also introduces a `timeout` limit to all `Axios` requests (by default set to 0, implying a permanent loading).