### PR TITLE
fix(16313) - Use coersive manipulation of empty strings for pojo types

### DIFF
--- a/hivemq-edge/src/main/java/com/hivemq/api/resources/impl/ProtocolAdaptersResourceImpl.java
+++ b/hivemq-edge/src/main/java/com/hivemq/api/resources/impl/ProtocolAdaptersResourceImpl.java
@@ -15,6 +15,7 @@
  */
 package com.hivemq.api.resources.impl;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
 import com.google.common.collect.ImmutableList;
 import com.hivemq.api.AbstractApi;
@@ -57,13 +58,16 @@ public class ProtocolAdaptersResourceImpl extends AbstractApi implements Protoco
 
     private final @NotNull ConfigurationService configurationService;
     private final @NotNull ProtocolAdapterManager protocolAdapterManager;
+    private final @NotNull ObjectMapper objectMapper;
 
     @Inject
     public ProtocolAdaptersResourceImpl(
             final @NotNull ConfigurationService configurationService,
-            final @NotNull ProtocolAdapterManager protocolAdapterManager) {
+            final @NotNull ProtocolAdapterManager protocolAdapterManager,
+            final @NotNull ObjectMapper objectMapper) {
         this.configurationService = configurationService;
         this.protocolAdapterManager = protocolAdapterManager;
+        this.objectMapper = objectMapper;
     }
 
     @Override
@@ -143,7 +147,7 @@ public class ProtocolAdaptersResourceImpl extends AbstractApi implements Protoco
         Map<String, Object> configObject;
         try {
             Thread.currentThread().setContextClassLoader(value.getAdapterFactory().getClass().getClassLoader());
-            configObject = value.getAdapterFactory().unconvertConfigObject(value.getConfigObject());
+            configObject = value.getAdapterFactory().unconvertConfigObject(objectMapper, value.getConfigObject());
         } finally {
             Thread.currentThread().setContextClassLoader(contextClassLoader);
         }

--- a/hivemq-edge/src/main/java/com/hivemq/api/resources/impl/ProtocolAdaptersResourceImpl.java
+++ b/hivemq-edge/src/main/java/com/hivemq/api/resources/impl/ProtocolAdaptersResourceImpl.java
@@ -42,6 +42,7 @@ import com.hivemq.extension.sdk.api.annotations.NotNull;
 import com.hivemq.extension.sdk.api.annotations.Nullable;
 import com.hivemq.protocols.AdapterInstance;
 import com.hivemq.protocols.ProtocolAdapterManager;
+import com.hivemq.protocols.ProtocolAdapterUtils;
 import com.hivemq.protocols.params.NodeTreeImpl;
 import com.networknt.schema.ValidationMessage;
 
@@ -67,7 +68,7 @@ public class ProtocolAdaptersResourceImpl extends AbstractApi implements Protoco
             final @NotNull ObjectMapper objectMapper) {
         this.configurationService = configurationService;
         this.protocolAdapterManager = protocolAdapterManager;
-        this.objectMapper = objectMapper;
+        this.objectMapper = ProtocolAdapterUtils.createProtocolAdapterMapper(objectMapper);
     }
 
     @Override

--- a/hivemq-edge/src/main/java/com/hivemq/edge/modules/adapters/simulation/SimulationConfigConverter.java
+++ b/hivemq-edge/src/main/java/com/hivemq/edge/modules/adapters/simulation/SimulationConfigConverter.java
@@ -23,13 +23,11 @@ import java.util.Map;
 
 public class SimulationConfigConverter {
 
-    public static @NotNull SimulationAdapterConfig convertConfig(final @NotNull Map<String, Object> config) {
-        final ObjectMapper objectMapper = new ObjectMapper();
+    public static @NotNull SimulationAdapterConfig convertConfig(final @NotNull ObjectMapper objectMapper, final @NotNull Map<String, Object> config) {
         return objectMapper.convertValue(config, SimulationAdapterConfig.class);
     }
 
-    public static @NotNull Map<String, Object> unconvertConfig(final @NotNull CustomConfig config) {
-        final ObjectMapper objectMapper = new ObjectMapper();
+    public static @NotNull Map<String, Object> unconvertConfig(final @NotNull ObjectMapper objectMapper, final @NotNull CustomConfig config) {
         return objectMapper.convertValue(config, Map.class);
     }
 }

--- a/hivemq-edge/src/main/java/com/hivemq/edge/modules/adapters/simulation/SimulationProtocolAdapterFactory.java
+++ b/hivemq-edge/src/main/java/com/hivemq/edge/modules/adapters/simulation/SimulationProtocolAdapterFactory.java
@@ -15,6 +15,7 @@
  */
 package com.hivemq.edge.modules.adapters.simulation;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hivemq.edge.modules.api.adapters.ProtocolAdapter;
 import com.hivemq.edge.modules.api.adapters.ProtocolAdapterFactory;
 import com.hivemq.edge.modules.api.adapters.ProtocolAdapterInformation;
@@ -37,13 +38,13 @@ public class SimulationProtocolAdapterFactory implements ProtocolAdapterFactory<
     }
 
     @Override
-    public @NotNull SimulationAdapterConfig convertConfigObject(final @NotNull Map<@NotNull String, Object> config) {
-        return SimulationConfigConverter.convertConfig(config);
+    public @NotNull SimulationAdapterConfig convertConfigObject(final @NotNull ObjectMapper objectMapper, final @NotNull Map<@NotNull String, Object> config) {
+        return SimulationConfigConverter.convertConfig(objectMapper, config);
     }
 
     @Override
-    public Map<String, Object> unconvertConfigObject(final CustomConfig config) {
-        return SimulationConfigConverter.unconvertConfig(config);
+    public Map<String, Object> unconvertConfigObject(final @NotNull ObjectMapper objectMapper, final CustomConfig config) {
+        return SimulationConfigConverter.unconvertConfig(objectMapper, config);
     }
 
     @Override

--- a/hivemq-edge/src/main/java/com/hivemq/edge/modules/api/adapters/ProtocolAdapterFactory.java
+++ b/hivemq-edge/src/main/java/com/hivemq/edge/modules/api/adapters/ProtocolAdapterFactory.java
@@ -15,6 +15,7 @@
  */
 package com.hivemq.edge.modules.api.adapters;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hivemq.edge.modules.adapters.params.ProtocolAdapterInput;
 import com.hivemq.edge.modules.config.CustomConfig;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
@@ -27,9 +28,9 @@ public interface ProtocolAdapterFactory<E extends CustomConfig> {
 
     @NotNull ProtocolAdapter createAdapter(@NotNull ProtocolAdapterInformation adapterInformation, @NotNull ProtocolAdapterInput<E> input);
 
-    @NotNull E convertConfigObject(final @NotNull Map<String, Object> config);
+    @NotNull E convertConfigObject(final @NotNull ObjectMapper objectMapper, final @NotNull Map<String, Object> config);
 
-    @NotNull Map<String, Object> unconvertConfigObject(final CustomConfig config);
+    @NotNull Map<String, Object> unconvertConfigObject(final @NotNull ObjectMapper objectMapper, final CustomConfig config);
 
     @NotNull Class<E> getConfigClass();
 }

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/ProtocolAdapterManager.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/ProtocolAdapterManager.java
@@ -79,7 +79,7 @@ public class ProtocolAdapterManager {
         this.configurationService = configurationService;
         this.metricRegistry = metricRegistry;
         this.moduleServices = moduleServices;
-        this.objectMapper = objectMapper;
+        this.objectMapper = ProtocolAdapterUtils.createProtocolAdapterMapper(objectMapper);
         this.moduleLoader = moduleLoader;
         this.remoteService = remoteService;
     }

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/ProtocolAdapterManager.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/ProtocolAdapterManager.java
@@ -135,7 +135,7 @@ public class ProtocolAdapterManager {
             try {
                 Thread.currentThread().setContextClassLoader(protocolAdapterFactory.getClass().getClassLoader());
                 for (Map<String, Object> adapterConfig : adapterConfigs) {
-                    final CustomConfig configObject = protocolAdapterFactory.convertConfigObject(adapterConfig);
+                    final CustomConfig configObject = protocolAdapterFactory.convertConfigObject(objectMapper, adapterConfig);
                     final ProtocolAdapter protocolAdapter =
                             protocolAdapterFactory.createAdapter(protocolAdapterFactory.getInformation(),
                                     new ProtocolAdapterInputImpl(configObject, metricRegistry));
@@ -322,7 +322,7 @@ public class ProtocolAdapterManager {
         final ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
         try {
             Thread.currentThread().setContextClassLoader(protocolAdapterFactory.getClass().getClassLoader());
-            final CustomConfig configObject = protocolAdapterFactory.convertConfigObject(config);
+            final CustomConfig configObject = protocolAdapterFactory.convertConfigObject(objectMapper, config);
             final ProtocolAdapter protocolAdapter =
                     protocolAdapterFactory.createAdapter(protocolAdapterFactory.getInformation(),
                             new ProtocolAdapterInputImpl(configObject, metricRegistry));

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/ProtocolAdapterUtils.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/ProtocolAdapterUtils.java
@@ -1,0 +1,20 @@
+package com.hivemq.protocols;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.cfg.CoercionAction;
+import com.fasterxml.jackson.databind.cfg.CoercionInputShape;
+import com.fasterxml.jackson.databind.type.LogicalType;
+import com.hivemq.extension.sdk.api.annotations.NotNull;
+
+/**
+ * @author Simon L Johnson
+ */
+public class ProtocolAdapterUtils {
+
+    public static @NotNull ObjectMapper createProtocolAdapterMapper(@NotNull final ObjectMapper objectMapper){
+        ObjectMapper copyObjectMapper = objectMapper.copy();
+        copyObjectMapper.coercionConfigFor(LogicalType.POJO).
+                setCoercion(CoercionInputShape.EmptyString, CoercionAction.AsNull);
+        return copyObjectMapper;
+    }
+}

--- a/modules/hivemq-edge-module-modbus/src/main/java/com/hivemq/edge/adapters/modbus/ModbusConfigConverter.java
+++ b/modules/hivemq-edge-module-modbus/src/main/java/com/hivemq/edge/adapters/modbus/ModbusConfigConverter.java
@@ -23,13 +23,13 @@ import java.util.Map;
 
 public class ModbusConfigConverter {
 
-    public static @NotNull ModbusAdapterConfig convertConfig(final @NotNull Map<String, Object> config) {
-        final ObjectMapper objectMapper = new ObjectMapper();
+    public static @NotNull ModbusAdapterConfig convertConfig(final @NotNull ObjectMapper objectMapper,
+                                                             final @NotNull Map<String, Object> config) {
         return objectMapper.convertValue(config, ModbusAdapterConfig.class);
     }
 
-    public static @NotNull Map<String, Object> unconvertConfig(final @NotNull CustomConfig config) {
-        final ObjectMapper objectMapper = new ObjectMapper();
+    public static @NotNull Map<String, Object> unconvertConfig(final @NotNull ObjectMapper objectMapper,
+                                                               final @NotNull CustomConfig config) {
         //noinspection unchecked
         return objectMapper.convertValue(config, Map.class);
     }

--- a/modules/hivemq-edge-module-modbus/src/main/java/com/hivemq/edge/adapters/modbus/ModbusProtocolAdapterFactory.java
+++ b/modules/hivemq-edge-module-modbus/src/main/java/com/hivemq/edge/adapters/modbus/ModbusProtocolAdapterFactory.java
@@ -15,6 +15,7 @@
  */
 package com.hivemq.edge.adapters.modbus;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hivemq.edge.modules.api.adapters.ProtocolAdapter;
 import com.hivemq.edge.modules.api.adapters.ProtocolAdapterFactory;
 import com.hivemq.edge.modules.api.adapters.ProtocolAdapterInformation;
@@ -37,13 +38,13 @@ public class ModbusProtocolAdapterFactory implements ProtocolAdapterFactory<Modb
     }
 
     @Override
-    public @NotNull ModbusAdapterConfig convertConfigObject(final @NotNull Map<@NotNull String, Object> config) {
-        return ModbusConfigConverter.convertConfig(config);
+    public @NotNull ModbusAdapterConfig convertConfigObject(final @NotNull ObjectMapper objectMapper, final @NotNull Map<@NotNull String, Object> config) {
+        return ModbusConfigConverter.convertConfig(objectMapper, config);
     }
 
     @Override
-    public Map<String, Object> unconvertConfigObject(final CustomConfig config) {
-        return ModbusConfigConverter.unconvertConfig(config);
+    public Map<String, Object> unconvertConfigObject(final @NotNull ObjectMapper objectMapper, final CustomConfig config) {
+        return ModbusConfigConverter.unconvertConfig(objectMapper, config);
     }
 
     @Override

--- a/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/OpcUaProtocolAdapterFactory.java
+++ b/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/OpcUaProtocolAdapterFactory.java
@@ -15,6 +15,7 @@
  */
 package com.hivemq.edge.adapters.opcua;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hivemq.edge.adapters.opcua.client.OpcUaConfigConverter;
 import com.hivemq.edge.modules.api.adapters.ProtocolAdapter;
 import com.hivemq.edge.modules.api.adapters.ProtocolAdapterFactory;
@@ -40,13 +41,15 @@ public class OpcUaProtocolAdapterFactory implements ProtocolAdapterFactory<OpcUa
     }
 
     @Override
-    public @NotNull OpcUaAdapterConfig convertConfigObject(final @NotNull Map<@NotNull String, Object> config) {
-        return OpcUaConfigConverter.convertConfig(config);
+    public @NotNull OpcUaAdapterConfig convertConfigObject(final @NotNull ObjectMapper objectMapper,
+                                                           final @NotNull Map<@NotNull String, Object> config) {
+        return OpcUaConfigConverter.convertConfig(objectMapper, config);
     }
 
     @Override
-    public Map<String, Object> unconvertConfigObject(final CustomConfig config) {
-        return OpcUaConfigConverter.unconvertConfig(config);
+    public Map<String, Object> unconvertConfigObject(final @NotNull ObjectMapper objectMapper,
+                                                     final @NotNull CustomConfig config) {
+        return OpcUaConfigConverter.unconvertConfig(objectMapper, config);
     }
 
     @Override

--- a/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/client/OpcUaConfigConverter.java
+++ b/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/client/OpcUaConfigConverter.java
@@ -16,6 +16,9 @@
 package com.hivemq.edge.adapters.opcua.client;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.cfg.CoercionAction;
+import com.fasterxml.jackson.databind.cfg.CoercionInputShape;
+import com.fasterxml.jackson.databind.type.LogicalType;
 import com.hivemq.edge.adapters.opcua.OpcUaAdapterConfig;
 import com.hivemq.edge.modules.config.CustomConfig;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
@@ -24,13 +27,15 @@ import java.util.Map;
 
 public class OpcUaConfigConverter {
 
-    public static @NotNull OpcUaAdapterConfig convertConfig(final @NotNull Map<String, Object> config) {
-        final ObjectMapper objectMapper = new ObjectMapper();
+    public static @NotNull OpcUaAdapterConfig convertConfig(final @NotNull ObjectMapper objectMapper, final @NotNull Map<String, Object> config) {
+//        final ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.coercionConfigFor(LogicalType.POJO).
+                setCoercion(CoercionInputShape.EmptyString, CoercionAction.AsNull);
         return objectMapper.convertValue(config, OpcUaAdapterConfig.class);
     }
 
-    public static @NotNull Map<String, Object> unconvertConfig(final @NotNull CustomConfig config) {
-        final ObjectMapper objectMapper = new ObjectMapper();
+    public static @NotNull Map<String, Object> unconvertConfig(final @NotNull ObjectMapper objectMapper, final @NotNull CustomConfig config) {
+//        final ObjectMapper objectMapper = new ObjectMapper();
         //noinspection unchecked
         return objectMapper.convertValue(config, Map.class);
     }

--- a/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/client/OpcUaConfigConverter.java
+++ b/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/client/OpcUaConfigConverter.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.cfg.CoercionAction;
 import com.fasterxml.jackson.databind.cfg.CoercionInputShape;
 import com.fasterxml.jackson.databind.type.LogicalType;
+import com.google.common.collect.ObjectArrays;
 import com.hivemq.edge.adapters.opcua.OpcUaAdapterConfig;
 import com.hivemq.edge.modules.config.CustomConfig;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
@@ -27,16 +28,15 @@ import java.util.Map;
 
 public class OpcUaConfigConverter {
 
-    public static @NotNull OpcUaAdapterConfig convertConfig(final @NotNull ObjectMapper objectMapper, final @NotNull Map<String, Object> config) {
-//        final ObjectMapper objectMapper = new ObjectMapper();
+    public static @NotNull OpcUaAdapterConfig convertConfig(@NotNull ObjectMapper objectMapper, final @NotNull Map<String, Object> config) {
+
+        objectMapper = objectMapper.copy();
         objectMapper.coercionConfigFor(LogicalType.POJO).
                 setCoercion(CoercionInputShape.EmptyString, CoercionAction.AsNull);
         return objectMapper.convertValue(config, OpcUaAdapterConfig.class);
     }
 
     public static @NotNull Map<String, Object> unconvertConfig(final @NotNull ObjectMapper objectMapper, final @NotNull CustomConfig config) {
-//        final ObjectMapper objectMapper = new ObjectMapper();
-        //noinspection unchecked
         return objectMapper.convertValue(config, Map.class);
     }
 }

--- a/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/client/OpcUaConfigConverter.java
+++ b/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/client/OpcUaConfigConverter.java
@@ -29,10 +29,6 @@ import java.util.Map;
 public class OpcUaConfigConverter {
 
     public static @NotNull OpcUaAdapterConfig convertConfig(@NotNull ObjectMapper objectMapper, final @NotNull Map<String, Object> config) {
-
-        objectMapper = objectMapper.copy();
-        objectMapper.coercionConfigFor(LogicalType.POJO).
-                setCoercion(CoercionInputShape.EmptyString, CoercionAction.AsNull);
         return objectMapper.convertValue(config, OpcUaAdapterConfig.class);
     }
 


### PR DESCRIPTION
The XML adapter may create empty xml elements which should be treated as null by the configuration loader for the adapters. This means we need to update the interface between the core and the module system to pass in a shared preconfigured mapper which has the correct coersion settings.