### PR TITLE
feat(16258): Show which protocol the user is creating/editing and adapter for

### DIFF
--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/drawers/AdapterInstanceDrawer.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/drawers/AdapterInstanceDrawer.spec.cy.tsx
@@ -1,0 +1,74 @@
+/// <reference types="cypress" />
+
+import AdapterInstanceDrawer from './AdapterInstanceDrawer.tsx'
+import { mockAdapter, mockProtocolAdapter } from '@/api/hooks/useProtocolAdapters/__handlers__'
+
+describe('AdapterInstanceDrawer', () => {
+  beforeEach(() => {
+    cy.viewport(800, 900)
+    cy.intercept('/api/v1/management/protocol-adapters/types', { items: [mockProtocolAdapter] })
+    cy.intercept('api/v1/management/protocol-adapters/adapters', { items: [mockAdapter] })
+  })
+
+  it('should close panel on clicking close icon', () => {
+    cy.mountWithProviders(
+      <AdapterInstanceDrawer
+        adapterType={mockProtocolAdapter.id}
+        isOpen={true}
+        isSubmitting={false}
+        onSubmit={cy.stub().as('onSubmit')}
+        onClose={cy.stub().as('onClose')}
+      />
+    )
+    cy.get('.chakra-modal__close-btn').click()
+    cy.get('@onClose').should('have.been.called')
+  })
+
+  it('should not close the panel when clicking submit on an invalid form', () => {
+    cy.mountWithProviders(
+      <AdapterInstanceDrawer
+        adapterType={mockProtocolAdapter.id}
+        isOpen={true}
+        isSubmitting={false}
+        onSubmit={cy.stub().as('onSubmit')}
+        onClose={cy.stub().as('onClose')}
+      />
+    )
+    cy.get('button[type="submit"]').click()
+    cy.get('@onSubmit').should('not.have.been.called')
+  })
+
+  it('should close the panel when clicking submit on a valid form', () => {
+    cy.mountWithProviders(
+      <AdapterInstanceDrawer
+        adapterType={mockProtocolAdapter.id}
+        isOpen={true}
+        isSubmitting={false}
+        onSubmit={cy.stub().as('onSubmit')}
+        onClose={cy.stub().as('onClose')}
+      />
+    )
+
+    cy.get('#root_id').type('my-id')
+    cy.get('#root_host').type('my-host')
+    cy.get('#root_port').type('1234')
+
+    cy.get('button[type="submit"]').click()
+    cy.get('@onSubmit').should('have.been.called')
+  })
+
+  it('should be accessible', () => {
+    cy.injectAxe()
+    cy.mountWithProviders(
+      <AdapterInstanceDrawer
+        adapterType={mockProtocolAdapter.id}
+        isOpen={true}
+        isSubmitting={false}
+        onSubmit={cy.stub().as('onSubmit')}
+        onClose={cy.stub().as('onClose')}
+      />
+    )
+    cy.checkAccessibility()
+    cy.percySnapshot('Component: AdapterInstanceDrawer')
+  })
+})

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/drawers/AdapterInstanceDrawer.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/drawers/AdapterInstanceDrawer.tsx
@@ -8,6 +8,9 @@ import {
   DrawerContent,
   DrawerCloseButton,
   Flex,
+  Text,
+  Image,
+  HStack,
 } from '@chakra-ui/react'
 import { useTranslation } from 'react-i18next'
 import { useParams } from 'react-router-dom'
@@ -49,10 +52,10 @@ const AdapterInstanceDrawer: FC<AdapterInstanceDrawerProps> = ({
   const { data: allAdapters } = useListProtocolAdapters()
   const { adapterId } = useParams()
 
-  const schema = useMemo(() => {
+  const { schema, name, logo } = useMemo(() => {
     const adapter: ProtocolAdapter | undefined = data?.items?.find((e) => e.id === adapterType)
     const { configSchema } = adapter || {}
-    return configSchema
+    return { schema: configSchema, name: adapter?.name, logo: adapter?.logoUrl }
   }, [data, adapterType])
 
   const defaultValues = useMemo(() => {
@@ -70,36 +73,49 @@ const AdapterInstanceDrawer: FC<AdapterInstanceDrawerProps> = ({
     <Drawer closeOnOverlayClick={false} size={'lg'} isOpen={isOpen} placement="right" onClose={onClose}>
       <DrawerOverlay />
       <DrawerContent aria-label={t('protocolAdapter.drawer.label') as string}>
-        <DrawerCloseButton />
-        <DrawerHeader id={'adapter-instance-header'} borderBottomWidth="1px">
-          {isNewAdapter ? t('protocolAdapter.drawer.title.create') : t('protocolAdapter.drawer.title.update')}
-        </DrawerHeader>
+        {!schema && <LoaderSpinner />}
+        {schema && (
+          <>
+            <DrawerCloseButton />
+            <DrawerHeader id={'adapter-instance-header'} borderBottomWidth="1px">
+              <Text>
+                {isNewAdapter ? t('protocolAdapter.drawer.title.create') : t('protocolAdapter.drawer.title.update')}
+              </Text>
+              <HStack>
+                <Image boxSize="30px" objectFit="scale-down" src={logo} aria-label={name} />
+                <Text fontSize={'md'} fontWeight={'500'}>
+                  {name}
+                </Text>
+              </HStack>
+            </DrawerHeader>
+            <DrawerBody>
+              {schema && (
+                <>
+                  <Form
+                    id="adapter-instance-form"
+                    schema={schema}
+                    uiSchema={uiSchema}
+                    templates={{ ObjectFieldTemplate }}
+                    liveValidate
+                    onSubmit={onValidate}
+                    validator={validator}
+                    showErrorList={'bottom'}
+                    onError={(errors) => console.log('XXXXXXX', errors)}
+                    formData={defaultValues}
+                  />
+                </>
+              )}
+            </DrawerBody>
 
-        <DrawerBody>
-          {!schema && <LoaderSpinner />}
-          {schema && (
-            <Form
-              id="adapter-instance-form"
-              schema={schema}
-              uiSchema={uiSchema}
-              templates={{ ObjectFieldTemplate }}
-              liveValidate
-              onSubmit={onValidate}
-              validator={validator}
-              showErrorList={'bottom'}
-              onError={(errors) => console.log('XXXXXXX', errors)}
-              formData={defaultValues}
-            />
-          )}
-        </DrawerBody>
-
-        <DrawerFooter borderTopWidth="1px">
-          <Flex flexGrow={1} justifyContent={'flex-end'}>
-            <ButtonCTA type="submit" form="adapter-instance-form">
-              {isNewAdapter ? t('protocolAdapter.action.create') : t('protocolAdapter.action.update')}
-            </ButtonCTA>
-          </Flex>
-        </DrawerFooter>
+            <DrawerFooter borderTopWidth="1px">
+              <Flex flexGrow={1} justifyContent={'flex-end'}>
+                <ButtonCTA type="submit" form="adapter-instance-form">
+                  {isNewAdapter ? t('protocolAdapter.action.create') : t('protocolAdapter.action.update')}
+                </ButtonCTA>
+              </Flex>
+            </DrawerFooter>
+          </>
+        )}
       </DrawerContent>
     </Drawer>
   )


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/16258/details/

The PR adds the name and the icon of the protocol being edited (for both creation or modification), in the header of the side panel.

It allows the user to immediatly see which protocol the form is associated with.

### Before
![screenshot-localhost_3000-2023 08 22-11_41_42](https://github.com/hivemq/hivemq-edge/assets/2743481/910ff642-f26a-412e-a4de-9cbb9ebe51d7)


### After
![screenshot-localhost_3000-2023 08 22-11_41_29](https://github.com/hivemq/hivemq-edge/assets/2743481/641878f0-f4fe-4aa6-8cb8-d15e4171ce8a)
