### PR TITLE
feat(16263): Add type icon to adapter instance list

### DIFF
--- a/hivemq-edge/src/frontend/src/api/hooks/useProtocolAdapters/__handlers__/index.ts
+++ b/hivemq-edge/src/frontend/src/api/hooks/useProtocolAdapters/__handlers__/index.ts
@@ -88,7 +88,7 @@ export const mockAdapterConfig: Record<string, Record<string, unknown>> = {}
 
 export const mockAdapter: Adapter = {
   id: 'my-id',
-  type: 'string',
+  type: 'simulation-adapter',
   config: mockAdapterConfig,
 }
 

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/adapters/AdapterTypeSummary.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/adapters/AdapterTypeSummary.tsx
@@ -23,7 +23,7 @@ const AdapterTypeSummary: FC<AdapterTypeSummaryProps> = ({ id, searchQuery }) =>
   if (!selectedType) return null
   return (
     <Flex m={0}>
-      <Image boxSize="100px" objectFit="scale-down" src={selectedType.logoUrl} />
+      <Image boxSize="100px" objectFit="scale-down" src={selectedType.logoUrl} aria-label={selectedType.id} />
       <Box ml="3">
         <Text fontWeight="bold">
           <AdapterHighlight query={searchQuery || ''}>{selectedType.name || ''}</AdapterHighlight>

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/panels/ProtocolAdapters.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/panels/ProtocolAdapters.spec.cy.tsx
@@ -1,0 +1,22 @@
+/// <reference types="cypress" />
+
+import ProtocolAdapters from '@/modules/ProtocolAdapters/components/panels/ProtocolAdapters.tsx'
+import { mockAdapter, mockProtocolAdapter } from '@/api/hooks/useProtocolAdapters/__handlers__'
+
+describe('ProtocolAdapters', () => {
+  beforeEach(() => {
+    cy.viewport(800, 900)
+    cy.intercept('/api/v1/management/protocol-adapters/types', { items: [mockProtocolAdapter] }).as('getProtocols')
+    cy.intercept('api/v1/management/protocol-adapters/adapters', { items: [mockAdapter] }).as('getAdapters')
+  })
+
+  it('should be accessible', () => {
+    cy.injectAxe()
+    cy.mountWithProviders(<ProtocolAdapters />)
+    cy.wait('@getAdapters')
+    cy.wait('@getProtocols')
+
+    cy.checkAccessibility()
+    cy.percySnapshot('Component: ProtocolAdapters')
+  })
+})


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/16263/details/

The PR changes the content of the `type` column in the list of adapters, replacing the internal type by the proper name and icon of the protocol.

The PR also fixes accessibility of the protocol icon (adding a `alt` property)
