### PR TITLE
fix (16310) - Ensure OPC adapter does not block on initialisation thread

### DIFF
--- a/hivemq-edge/src/main/java/com/hivemq/HiveMQEdgeGateway.java
+++ b/hivemq-edge/src/main/java/com/hivemq/HiveMQEdgeGateway.java
@@ -63,7 +63,7 @@ public class HiveMQEdgeGateway {
             payloadPersistence.init();
             extensionBootstrap.startExtensionSystem(embeddedExtension).get();
             bridgeService.updateBridges();
-            protocolAdapterManager.start().get();
+            protocolAdapterManager.start();
 
             final List<ListenerStartupInformation> startupInformation = nettyBootstrap.bootstrapServer().get();
             Checkpoints.checkpoint("listener-started");


### PR DESCRIPTION
OPC was reporting to stop the gateway coming up when the OPC host was unavailable. Removed the synchronous nature of the startup futures from stopping Edge starting. Also centralised management of instance creation and startup in anticipation of adapter manager refactor.