### PR TITLE
feat(16309): Add HiveMQ Edge Version number to the UI

### DIFF
--- a/hivemq-edge/src/frontend/src/api/hooks/useGatewayPortal/__handlers__/index.ts
+++ b/hivemq-edge/src/frontend/src/api/hooks/useGatewayPortal/__handlers__/index.ts
@@ -7,7 +7,7 @@ const lorem =
 export const mockGatewayConfiguration: GatewayConfiguration = {
   environment: {
     properties: {
-      'environment-type': 'TEST',
+      version: '2023.version',
     },
   },
   cloudLink: {

--- a/hivemq-edge/src/frontend/src/modules/Dashboard/components/SidePanel.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Dashboard/components/SidePanel.spec.cy.tsx
@@ -1,0 +1,15 @@
+/// <reference types="cypress" />
+
+import SidePanel from '@/modules/Dashboard/components/SidePanel.tsx'
+
+describe('SidePanel', () => {
+  beforeEach(() => {
+    cy.viewport(350, 800)
+  })
+
+  it('should be accessible', () => {
+    cy.injectAxe()
+    cy.mountWithProviders(<SidePanel />)
+    cy.checkAccessibility()
+  })
+})

--- a/hivemq-edge/src/frontend/src/modules/Dashboard/components/SidePanel.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Dashboard/components/SidePanel.spec.cy.tsx
@@ -2,9 +2,19 @@
 
 import SidePanel from '@/modules/Dashboard/components/SidePanel.tsx'
 
+import { mockGatewayConfiguration } from '@/api/hooks/useGatewayPortal/__handlers__'
+
 describe('SidePanel', () => {
   beforeEach(() => {
     cy.viewport(350, 800)
+    cy.intercept('/api/v1/frontend/configuration', mockGatewayConfiguration).as('getConfig')
+  })
+
+  it('should contain the version', () => {
+    cy.injectAxe()
+    cy.mountWithProviders(<SidePanel />)
+
+    cy.getByTestId('edge-release').should('contain.text', '[ 2023.version ]')
   })
 
   it('should be accessible', () => {

--- a/hivemq-edge/src/frontend/src/modules/Dashboard/components/SidePanel.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Dashboard/components/SidePanel.tsx
@@ -1,16 +1,19 @@
 import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
-import { Box, Button, Flex, Image } from '@chakra-ui/react'
+import { Box, Button, Flex, Image, Text } from '@chakra-ui/react'
+import { FiLogOut } from 'react-icons/fi'
 
 import NavLinksBlock from './NavLinksBlock.tsx'
 
+import { useGetConfiguration } from '@/api/hooks/useGatewayPortal/useGetConfiguration.tsx'
 import logo from '@/assets/edge/03-hivemq-industrial-edge-vert.svg'
 import { useAuth } from '@/modules/Auth/hooks/useAuth.ts'
+
 import useGetNavItems from '../hooks/useGetNavItems.tsx'
-import { FiLogOut } from 'react-icons/fi'
 
 const SidePanel: FC = () => {
+  const { data: configuration } = useGetConfiguration()
   const items = useGetNavItems()
   const auth = useAuth()
   const navigate = useNavigate()
@@ -21,6 +24,11 @@ const SidePanel: FC = () => {
       <Flex flexDirection="column" w={256} h={'100%'} bgColor={'#f5f5f5'}>
         <Box p={4} m={'auto'} mb={10}>
           <Image src={logo} alt={t('branding.company') as string} boxSize="200px" />
+          {configuration && (
+            <Text fontSize="xs" textAlign={'center'}>
+              [ {configuration.environment?.properties?.version} ]
+            </Text>
+          )}
         </Box>
 
         <Flex flexDirection="column" flex={1}>

--- a/hivemq-edge/src/frontend/src/modules/Dashboard/components/SidePanel.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Dashboard/components/SidePanel.tsx
@@ -25,7 +25,7 @@ const SidePanel: FC = () => {
         <Box p={4} m={'auto'} mb={10}>
           <Image src={logo} alt={t('branding.company') as string} boxSize="200px" />
           {configuration && (
-            <Text fontSize="xs" textAlign={'center'}>
+            <Text data-testid="edge-release" fontSize="xs" textAlign={'center'}>
               [ {configuration.environment?.properties?.version} ]
             </Text>
           )}


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/16309/details/

Add the `release version` to the main navigation bar. 

Note that the version comes from the backend `configuration` API. It will be `[ Development Snapshot ]` when running in `dev`, sometinhg like `[ 2023.5 ]` when running in `prod`

### Before
![screenshot-localhost_3000-2023 08 22-14_05_40](https://github.com/hivemq/hivemq-edge/assets/2743481/98382383-fb72-4285-ac8a-476847cd3033)

### After
 
![screenshot-localhost_3000-2023 08 22-14_05_24](https://github.com/hivemq/hivemq-edge/assets/2743481/a91ae4e5-fea9-4ca1-aafc-94c36f17d79a)
