### PR TITLE
fix (16316) - Set and agent value in user properties

### DIFF
--- a/hivemq-edge/src/main/java/com/hivemq/bridge/BridgeMqttClientFactory.java
+++ b/hivemq-edge/src/main/java/com/hivemq/bridge/BridgeMqttClientFactory.java
@@ -20,6 +20,7 @@ import com.hivemq.bridge.config.MqttBridge;
 import com.hivemq.bridge.mqtt.BridgeInterceptorHandler;
 import com.hivemq.bridge.mqtt.BridgeMqttClient;
 import com.hivemq.configuration.HivemqId;
+import com.hivemq.configuration.info.SystemInformation;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
 
 import javax.inject.Inject;
@@ -30,19 +31,22 @@ public class BridgeMqttClientFactory {
 
     private final @NotNull BridgeInterceptorHandler bridgeInterceptorHandler;
     private final @NotNull HivemqId hivemqId;
+    private final @NotNull SystemInformation systemInformation;
     private final @NotNull MetricRegistry metricRegistry;
 
     @Inject
     public BridgeMqttClientFactory(
             final @NotNull BridgeInterceptorHandler bridgeInterceptorHandler,
             final @NotNull HivemqId hivemqId,
+            final @NotNull SystemInformation systemInformation,
             final @NotNull MetricRegistry metricRegistry) {
         this.bridgeInterceptorHandler = bridgeInterceptorHandler;
         this.hivemqId = hivemqId;
+        this.systemInformation = systemInformation;
         this.metricRegistry = metricRegistry;
     }
 
     public @NotNull BridgeMqttClient createRemoteClient(final @NotNull MqttBridge bridge) {
-        return new BridgeMqttClient(bridge, bridgeInterceptorHandler, hivemqId, metricRegistry);
+        return new BridgeMqttClient(systemInformation, bridge, bridgeInterceptorHandler, hivemqId, metricRegistry);
     }
 }

--- a/hivemq-edge/src/main/java/com/hivemq/edge/HiveMQEdgeConstants.java
+++ b/hivemq-edge/src/main/java/com/hivemq/edge/HiveMQEdgeConstants.java
@@ -24,6 +24,8 @@ public interface HiveMQEdgeConstants {
     String VERSION = "2023.3";
 
     String VERSION_PROPERTY = "version";
+    String CLIENT_AGENT_PROPERTY = "client-agent";
+    String CLIENT_AGENT_PROPERTY_VALUE = "HiveMQ-Edge; %s";
 
     int MAX_ID_LEN = 500;
     String ID_REGEX = "([a-zA-Z_0-9\\-])*";


### PR DESCRIPTION
As a HiveMQ, we want to identify edge installations connected to our brokers, either enterprise installed on-premise or managed cloud. 

==

Example from development env:
client-agent: “HiveMQ-Edge; Development Snapshot”