### PR TITLE
fix(16318): ID attribute is disabled if adapter modified rather than created

### DIFF
--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/drawers/AdapterInstanceDrawer.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/drawers/AdapterInstanceDrawer.spec.cy.tsx
@@ -42,6 +42,7 @@ describe('AdapterInstanceDrawer', () => {
     cy.mountWithProviders(
       <AdapterInstanceDrawer
         adapterType={mockProtocolAdapter.id}
+        isNewAdapter={true}
         isOpen={true}
         isSubmitting={false}
         onSubmit={cy.stub().as('onSubmit')}
@@ -62,6 +63,7 @@ describe('AdapterInstanceDrawer', () => {
     cy.mountWithProviders(
       <AdapterInstanceDrawer
         adapterType={mockProtocolAdapter.id}
+        isNewAdapter={true}
         isOpen={true}
         isSubmitting={false}
         onSubmit={cy.stub().as('onSubmit')}

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/drawers/AdapterInstanceDrawer.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/drawers/AdapterInstanceDrawer.tsx
@@ -63,7 +63,7 @@ const AdapterInstanceDrawer: FC<AdapterInstanceDrawerProps> = ({
     const { config } = allAdapters?.find((e) => e.id === adapterId) || {}
     return config
   }, [allAdapters, adapterId, isNewAdapter])
-  const uiSchema = useGetUiSchema()
+  const uiSchema = useGetUiSchema(isNewAdapter)
 
   const onValidate = (data: IChangeEvent<Adapter, RJSFSchema>) => {
     if (data.formData) onSubmit(data.formData)

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/hooks/useGetUISchema.spec.ts
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/hooks/useGetUISchema.spec.ts
@@ -1,0 +1,22 @@
+import { renderHook } from '@testing-library/react'
+import { describe, expect } from 'vitest'
+import useGetUiSchema from './useGetUISchema.ts'
+import '@/config/i18n.config.ts'
+
+describe('useGetUiSchema()', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+  })
+
+  it('should render the id property editable', () => {
+    const { result } = renderHook(() => useGetUiSchema())
+
+    expect(result.current).toEqual(expect.objectContaining({ id: expect.objectContaining({ 'ui:disabled': false }) }))
+  })
+
+  it('should render the id property disabled', () => {
+    const { result } = renderHook(() => useGetUiSchema(false))
+
+    expect(result.current).toEqual(expect.objectContaining({ id: expect.objectContaining({ 'ui:disabled': true }) }))
+  })
+})

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/hooks/useGetUISchema.ts
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/hooks/useGetUISchema.ts
@@ -1,7 +1,8 @@
 import { UIGroup } from '@/modules/ProtocolAdapters/types.ts'
 import { useTranslation } from 'react-i18next'
+import { UiSchema } from '@rjsf/utils'
 
-const useGetUiSchema = () => {
+const useGetUiSchema = (isNewAdapter = true) => {
   const { t } = useTranslation()
 
   const groups: UIGroup[] = [
@@ -28,12 +29,18 @@ const useGetUiSchema = () => {
     },
   ]
 
-  const uiSchema = {
+  const uiSchema: UiSchema = {
     'ui:groups': groups,
 
     'ui:submitButtonOptions': {
       norender: true,
     },
+
+    // TODO[NVL] Make sure only the top-level id is disabled. See 16318
+    id: {
+      'ui:disabled': !isNewAdapter,
+    },
+
     // pollingIntervalMillis: {
     //   'ui:widget': 'range',
     // },


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/16318/details/

The PR add, through the `UISchema`, a `disabled` state to the `id` property if the adapter is modified rather than created

Notes:
- The `UISchema` is based on property names, like `id`. There it is expected that the unique identifier (or name) of an adapter is always attributed to a `id` property 
- The fix propsed in the PR needs to be tested for nested properties that might be named `id` 

### Before
![screenshot-localhost_3000-2023 08 22-16_36_35](https://github.com/hivemq/hivemq-edge/assets/2743481/e07df0df-2c36-4da7-9f8c-e3c1049decf8)

### After
![screenshot-localhost_3000-2023 08 22-16_36_20](https://github.com/hivemq/hivemq-edge/assets/2743481/d6eb394a-0cc7-4071-b858-c65663df4eac)
