### PR TITLE
feat(16264) - Create initial adapter abstractions ready for roll out of more adapters

### DIFF
--- a/ext/hivemq-edge-openapi-2023.4.yaml
+++ b/ext/hivemq-edge-openapi-2023.4.yaml
@@ -1697,6 +1697,9 @@ components:
         author:
           type: string
           description: The author of the adapter
+        category:
+          type: string
+          description: The category of the adapter
         configSchema:
           $ref: '#/components/schemas/JsonNode'
         description:
@@ -1704,6 +1707,10 @@ components:
           description: The description
         id:
           type: string
+          description: The id assigned to the protocol adapter type
+        installed:
+          type: boolean
+          description: Is the adapter installed?
         logoUrl:
           type: string
           description: The logo of the adapter
@@ -1713,6 +1720,12 @@ components:
         protocol:
           type: string
           description: The supported protocol
+        tags:
+          type: array
+          description: The search tags associated with this adapter
+          items:
+            type: string
+            description: The search tags associated with this adapter
         url:
           type: string
           description: The url of the adapter

--- a/hivemq-edge/src/main/java/com/hivemq/api/model/adapters/ProtocolAdapter.java
+++ b/hivemq-edge/src/main/java/com/hivemq/api/model/adapters/ProtocolAdapter.java
@@ -18,11 +18,15 @@ package com.hivemq.api.model.adapters;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
+import com.hivemq.extension.sdk.api.annotations.Nullable;
 import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
 
 public class ProtocolAdapter {
 
     @JsonProperty("id")
+    @Schema(description = "The id assigned to the protocol adapter type")
     private final @NotNull String id;
 
     @JsonProperty("protocol")
@@ -53,6 +57,18 @@ public class ProtocolAdapter {
     @Schema(description = "The author of the adapter")
     private final @NotNull String author;
 
+    @JsonProperty("installed")
+    @Schema(description = "Is the adapter installed?")
+    private final @NotNull Boolean installed;
+
+    @JsonProperty("category")
+    @Schema(description = "The category of the adapter")
+    private final @NotNull String category;
+
+    @JsonProperty("tags")
+    @Schema(description = "The search tags associated with this adapter")
+    private final @NotNull List<String> tags;
+
     @JsonProperty("configSchema")
     @Schema(description = "JSONSchema in the \'https://json-schema.org/draft/2020-12/schema\' format, which describes the configuration requirements for the adapter.")
     private final @NotNull JsonNode configSchema;
@@ -66,6 +82,9 @@ public class ProtocolAdapter {
             @JsonProperty("version") final @NotNull String version,
             @JsonProperty("logoUrl") final @NotNull String logoUrl,
             @JsonProperty("author") final @NotNull String author,
+            @JsonProperty("installed") final @Nullable  Boolean installed,
+            @JsonProperty("category") final @Nullable  String category,
+            @JsonProperty("tags") final @Nullable  List<String> tags,
             @JsonProperty("configSchema") final @NotNull JsonNode configSchema) {
         this.id = id;
         this.protocol = protocol;
@@ -75,6 +94,9 @@ public class ProtocolAdapter {
         this.version = version;
         this.logoUrl = logoUrl;
         this.author = author;
+        this.installed = installed;
+        this.category = category;
+        this.tags = tags;
         this.configSchema = configSchema;
     }
 
@@ -112,5 +134,17 @@ public class ProtocolAdapter {
 
     public @NotNull JsonNode getConfigSchema() {
         return configSchema;
+    }
+
+    public @Nullable Boolean getInstalled() {
+        return installed;
+    }
+
+    public @Nullable List<String> getTags() {
+        return tags;
+    }
+
+    public @Nullable String getCategory() {
+        return category;
     }
 }

--- a/hivemq-edge/src/main/java/com/hivemq/api/resources/impl/ProtocolAdaptersResourceImpl.java
+++ b/hivemq-edge/src/main/java/com/hivemq/api/resources/impl/ProtocolAdaptersResourceImpl.java
@@ -89,6 +89,10 @@ public class ProtocolAdaptersResourceImpl extends AbstractApi implements Protoco
                     info.getVersion(),
                     logoUrl,
                     info.getAuthor(),
+                    true,
+                    info == null ? null : info.getCategory().toString().toLowerCase(),
+                    info.getTags() == null ? null : info.getTags().stream().
+                            map(Enum::toString).collect(Collectors.toList()),
                     protocolAdapterManager.getSchemaManager(info).generateSchemaNode()));
         }
         return Response.status(200).entity(new ProtocolAdaptersList(adapters.build())).build();

--- a/hivemq-edge/src/main/java/com/hivemq/edge/HiveMQEdgeConstants.java
+++ b/hivemq-edge/src/main/java/com/hivemq/edge/HiveMQEdgeConstants.java
@@ -21,7 +21,7 @@ package com.hivemq.edge;
 public interface HiveMQEdgeConstants {
 
     //TODO this should be build driven for modules but use single constant for now
-    String VERSION = "2023.3";
+    String VERSION = "2023.4";
 
     String VERSION_PROPERTY = "version";
     String CLIENT_AGENT_PROPERTY = "client-agent";

--- a/hivemq-edge/src/main/java/com/hivemq/edge/modules/adapters/ProtocolAdapterConstants.java
+++ b/hivemq-edge/src/main/java/com/hivemq/edge/modules/adapters/ProtocolAdapterConstants.java
@@ -20,6 +20,20 @@ package com.hivemq.edge.modules.adapters;
  */
 public interface ProtocolAdapterConstants {
 
+    enum TAG {
+        UDP,
+        TCP,
+        SERIAL,
+        ETHERNET
+    }
+
+    enum CATEGORY {
+        INDUSTRIAL,
+        BUILDING,
+        TRANSPORTATION,
+        SIMULATION
+    }
+
     String ADAPTER_NAME_TOKEN = "adapter.name";
     String ADAPTER_VERSION_TOKEN = "adapter.version";
     String ADAPTER_CLASS_TOKEN = "adapter.class";

--- a/hivemq-edge/src/main/java/com/hivemq/edge/modules/adapters/impl/AbstractProtocolAdapterInformation.java
+++ b/hivemq-edge/src/main/java/com/hivemq/edge/modules/adapters/impl/AbstractProtocolAdapterInformation.java
@@ -1,0 +1,58 @@
+package com.hivemq.edge.modules.adapters.impl;
+
+import com.hivemq.edge.HiveMQEdgeConstants;
+import com.hivemq.edge.modules.adapters.ProtocolAdapterConstants;
+import com.hivemq.edge.modules.api.adapters.ProtocolAdapterInformation;
+import com.hivemq.extension.sdk.api.annotations.NotNull;
+
+import java.util.List;
+
+import static com.hivemq.configuration.info.SystemInformationImpl.DEVELOPMENT_VERSION;
+
+/**
+ * @author Simon L Johnson
+ */
+public abstract class AbstractProtocolAdapterInformation implements ProtocolAdapterInformation {
+
+    protected final @NotNull String hivemqVersion;
+
+    protected AbstractProtocolAdapterInformation() {
+//        final String versionFromManifest =
+//                ManifestUtils.getValueFromManifest(getClass(), "HiveMQ-Edge-Version");
+        if (Boolean.getBoolean(HiveMQEdgeConstants.DEVELOPMENT_MODE)) {
+            hivemqVersion = DEVELOPMENT_VERSION;
+        } else {
+            //-- The version we compiled against (for now)
+            hivemqVersion = HiveMQEdgeConstants.VERSION;
+        }
+    }
+
+    public @NotNull String getUrl() {
+        return "https://github.com/hivemq/hivemq-edge/wiki/Protocol-adapters#" + getProtocolId();
+    }
+
+    @Override
+    public @NotNull String getVersion() {
+        return hivemqVersion;
+    }
+
+    @Override
+    public @NotNull String getLogoUrl() {
+        return String.format("/images/%s-icon.png", getProtocolId());
+    }
+
+    @Override
+    public @NotNull String getAuthor() {
+        return "HiveMQ";
+    }
+
+    @Override
+    public ProtocolAdapterConstants.CATEGORY getCategory() {
+        return ProtocolAdapterConstants.CATEGORY.INDUSTRIAL;
+    }
+
+    @Override
+    public List<ProtocolAdapterConstants.TAG> getTags() {
+        return List.of();
+    }
+}

--- a/hivemq-edge/src/main/java/com/hivemq/edge/modules/adapters/simulation/SimulationAdapterConfig.java
+++ b/hivemq-edge/src/main/java/com/hivemq/edge/modules/adapters/simulation/SimulationAdapterConfig.java
@@ -15,28 +15,15 @@
  */
 package com.hivemq.edge.modules.adapters.simulation;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.hivemq.edge.HiveMQEdgeConstants;
 import com.hivemq.edge.modules.adapters.annotations.ModuleConfigField;
-import com.hivemq.edge.modules.config.CustomConfig;
+import com.hivemq.edge.modules.config.impl.AbstractProtocolAdapterConfig;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
-import com.hivemq.extension.sdk.api.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
 
-public class SimulationAdapterConfig implements CustomConfig {
-
-    @JsonProperty(value = "id", required = true)
-    @ModuleConfigField(title = "Identifier",
-                       description = "Unique identifier for this protocol adapter",
-                       format = ModuleConfigField.FieldType.IDENTIFIER,
-                       required = true,
-                       stringPattern = HiveMQEdgeConstants.ID_REGEX,
-                       stringMinLength = 1,
-                       stringMaxLength = 1024)
-    private @NotNull String id;
+public class SimulationAdapterConfig extends AbstractProtocolAdapterConfig {
 
     @JsonProperty(value = "pollingIntervalMillis")
     @ModuleConfigField(title = "Polling interval [ms]",
@@ -62,14 +49,6 @@ public class SimulationAdapterConfig implements CustomConfig {
         this.subscriptions = subscriptions;
     }
 
-    public @NotNull String getId() {
-        return id;
-    }
-
-    public void setId(String id) {
-        this.id = id;
-    }
-
     public int getPollingIntervalMillis() {
         return pollingIntervalMillis;
     }
@@ -86,41 +65,4 @@ public class SimulationAdapterConfig implements CustomConfig {
         return subscriptions;
     }
 
-    public static class Subscription {
-
-        @JsonProperty(value = "destination", required = true)
-        @ModuleConfigField(title = "Destination Topic",
-                           description = "The topic to publish data on",
-                           required = true,
-                           format = ModuleConfigField.FieldType.MQTT_TOPIC)
-        private @Nullable String destination;
-
-        @JsonProperty(value = "qos", required = true)
-        @ModuleConfigField(title = "QoS",
-                           description = "MQTT quality of service level",
-                           required = true,
-                           numberMin = 0,
-                           numberMax = 2,
-                           defaultValue = "0")
-        private int qos = 0;
-
-        public Subscription() {
-        }
-
-        @JsonCreator
-        public Subscription(
-                @JsonProperty("destination") @Nullable final String destination,
-                @JsonProperty("qos") final int qos) {
-            this.destination = destination;
-            this.qos = qos;
-        }
-
-        public String getDestination() {
-            return destination;
-        }
-
-        public int getQos() {
-            return qos;
-        }
-    }
 }

--- a/hivemq-edge/src/main/java/com/hivemq/edge/modules/adapters/simulation/SimulationProtocolAdapterInformation.java
+++ b/hivemq-edge/src/main/java/com/hivemq/edge/modules/adapters/simulation/SimulationProtocolAdapterInformation.java
@@ -15,27 +15,17 @@
  */
 package com.hivemq.edge.modules.adapters.simulation;
 
-import com.hivemq.HiveMQEdgeGateway;
+import com.hivemq.edge.modules.adapters.impl.AbstractProtocolAdapterInformation;
 import com.hivemq.edge.modules.api.adapters.ProtocolAdapterInformation;
 import com.hivemq.edge.modules.config.CustomConfig;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
-import com.hivemq.util.ManifestUtils;
 
-import static com.hivemq.configuration.info.SystemInformationImpl.DEVELOPMENT_VERSION;
-
-public class SimulationProtocolAdapterInformation implements ProtocolAdapterInformation {
+public class SimulationProtocolAdapterInformation
+        extends AbstractProtocolAdapterInformation {
 
     public static final ProtocolAdapterInformation INSTANCE = new SimulationProtocolAdapterInformation();
-    private final @NotNull String hivemqVersion;
 
     private SimulationProtocolAdapterInformation() {
-        final String versionFromManifest =
-                ManifestUtils.getValueFromManifest(HiveMQEdgeGateway.class, "HiveMQ-Edge-Version");
-        if (versionFromManifest == null || versionFromManifest.length() < 1) {
-            hivemqVersion = DEVELOPMENT_VERSION;
-        } else {
-            hivemqVersion = versionFromManifest;
-        }
     }
 
     @Override
@@ -59,23 +49,8 @@ public class SimulationProtocolAdapterInformation implements ProtocolAdapterInfo
     }
 
     @Override
-    public @NotNull String getUrl() {
-        return "https://github.com/hivemq/hivemq-edge/wiki/Protocol-adapters#simulation-adapter";
-    }
-
-    @Override
-    public @NotNull String getVersion() {
-        return hivemqVersion;
-    }
-
-    @Override
     public @NotNull String getLogoUrl() {
         return "/images/hivemq-icon.png";
-    }
-
-    @Override
-    public @NotNull String getAuthor() {
-        return "HiveMQ";
     }
 
     @Override

--- a/hivemq-edge/src/main/java/com/hivemq/edge/modules/api/adapters/ProtocolAdapterInformation.java
+++ b/hivemq-edge/src/main/java/com/hivemq/edge/modules/api/adapters/ProtocolAdapterInformation.java
@@ -15,9 +15,12 @@
  */
 package com.hivemq.edge.modules.api.adapters;
 
+import com.hivemq.edge.modules.adapters.ProtocolAdapterConstants;
 import com.hivemq.edge.modules.config.CustomConfig;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
 import com.hivemq.extension.sdk.api.annotations.Nullable;
+
+import java.util.List;
 
 public interface ProtocolAdapterInformation {
 
@@ -36,6 +39,10 @@ public interface ProtocolAdapterInformation {
     @NotNull String getLogoUrl();
 
     @NotNull String getAuthor();
+
+    @Nullable ProtocolAdapterConstants.CATEGORY getCategory();
+
+    @Nullable List<ProtocolAdapterConstants.TAG> getTags();
 
     @NotNull Class<? extends CustomConfig> getConfigClass();
 

--- a/hivemq-edge/src/main/java/com/hivemq/edge/modules/config/CustomConfig.java
+++ b/hivemq-edge/src/main/java/com/hivemq/edge/modules/config/CustomConfig.java
@@ -16,14 +16,16 @@
 package com.hivemq.edge.modules.config;
 
 import com.hivemq.edge.HiveMQEdgeConstants;
+import com.hivemq.extension.sdk.api.annotations.NotNull;
 
 /** Marker interface **/
 
 public interface CustomConfig {
 
-    String ID_PATTERN = HiveMQEdgeConstants.ID_REGEX;
     int PORT_MIN = 1;
     int PORT_MAX = HiveMQEdgeConstants.MAX_UINT16;
     int DEFAULT_PUBLISHING_INTERVAL = 1000;
     int DEFAULT_MAX_POLLING_ERROR_BEFORE_REMOVAL = 10;
+
+    @NotNull String getId();
 }

--- a/hivemq-edge/src/main/java/com/hivemq/edge/modules/config/impl/AbstractProtocolAdapterConfig.java
+++ b/hivemq-edge/src/main/java/com/hivemq/edge/modules/config/impl/AbstractProtocolAdapterConfig.java
@@ -1,0 +1,72 @@
+package com.hivemq.edge.modules.config.impl;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.hivemq.edge.HiveMQEdgeConstants;
+import com.hivemq.edge.modules.adapters.annotations.ModuleConfigField;
+import com.hivemq.edge.modules.config.CustomConfig;
+import com.hivemq.extension.sdk.api.annotations.NotNull;
+import com.hivemq.extension.sdk.api.annotations.Nullable;
+
+/**
+ * @author Simon L Johnson
+ */
+public class AbstractProtocolAdapterConfig implements CustomConfig {
+
+    @JsonProperty(value = "id", required = true)
+    @ModuleConfigField(title = "Identifier",
+                       description = "Unique identifier for this protocol adapter",
+                       format = ModuleConfigField.FieldType.IDENTIFIER,
+                       required = true,
+                       stringPattern = HiveMQEdgeConstants.ID_REGEX,
+                       stringMinLength = 1,
+                       stringMaxLength = 1024)
+    protected @NotNull String id;
+
+    public @NotNull String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public static class Subscription {
+
+        @JsonProperty(value = "destination", required = true)
+        @ModuleConfigField(title = "Destination Topic",
+                           description = "The topic to publish data on",
+                           required = true,
+                           format = ModuleConfigField.FieldType.MQTT_TOPIC)
+        private @Nullable String destination;
+
+        @JsonProperty(value = "qos", required = true)
+        @ModuleConfigField(title = "QoS",
+                           description = "MQTT Quality of Service level",
+                           required = true,
+                           numberMin = 0,
+                           numberMax = 2,
+                           defaultValue = "0")
+        private int qos = 0;
+
+        public Subscription() {
+        }
+
+        @JsonCreator
+        public Subscription(
+                @JsonProperty("destination") @Nullable final String destination,
+                @JsonProperty("qos") final int qos) {
+            this.destination = destination;
+            this.qos = qos;
+        }
+
+        public String getDestination() {
+            return destination;
+        }
+
+        public int getQos() {
+            return qos;
+        }
+    }
+
+}

--- a/hivemq-edge/src/main/java/com/hivemq/logging/LogLevelModifier.java
+++ b/hivemq-edge/src/main/java/com/hivemq/logging/LogLevelModifier.java
@@ -50,7 +50,8 @@ public class LogLevelModifier extends TurboFilter {
         if (level == Level.DEBUG) {
             if (logger.getName().startsWith("com.github.victools.jsonschema") ||
                     logger.getName().startsWith("org.jose4j")) {
-                logger.trace(marker, format, params);
+                //Actually we dont want this at all its far too noisy
+//                logger.trace(marker, format, params);
                 return FilterReply.DENY;
             }
         }

--- a/modules/hivemq-edge-module-modbus/src/main/java/com/hivemq/edge/adapters/modbus/ModbusAdapterConfig.java
+++ b/modules/hivemq-edge-module-modbus/src/main/java/com/hivemq/edge/adapters/modbus/ModbusAdapterConfig.java
@@ -18,6 +18,7 @@ package com.hivemq.edge.adapters.modbus;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.hivemq.edge.modules.adapters.annotations.ModuleConfigField;
 import com.hivemq.edge.modules.config.CustomConfig;
+import com.hivemq.edge.modules.config.impl.AbstractProtocolAdapterConfig;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
 
 import java.util.ArrayList;
@@ -25,17 +26,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public class ModbusAdapterConfig implements CustomConfig {
-
-    @JsonProperty("id")
-    @ModuleConfigField(title = "Identifier",
-            description = "Unique identifier for this protocol adapter",
-            format = ModuleConfigField.FieldType.IDENTIFIER,
-            required = true,
-            stringPattern = ID_PATTERN,
-            stringMinLength = 1,
-            stringMaxLength = 1024)
-    private @NotNull String id;
+public class ModbusAdapterConfig extends AbstractProtocolAdapterConfig {
 
     @JsonProperty("port")
     @ModuleConfigField(title = "Port",
@@ -89,10 +80,6 @@ public class ModbusAdapterConfig implements CustomConfig {
         return maxPollingErrorsBeforeRemoval;
     }
 
-    public @NotNull String getId() {
-        return id;
-    }
-
     public int getPort() {
         return port;
     }
@@ -109,50 +96,12 @@ public class ModbusAdapterConfig implements CustomConfig {
         return subscriptions;
     }
 
-
-    public static class Subscription {
-
+    public static class Subscription extends AbstractProtocolAdapterConfig.Subscription {
         @JsonProperty("holding-registers")
         private @NotNull AddressRange holdingRegisters;
 
-//        @JsonProperty("input-registers")
-//        private @NotNull AddressRange inputRegisters;
-//
-//        @JsonProperty("coils")
-//        private @NotNull AddressRange coils;
-
-        @JsonProperty("destination")
-        @ModuleConfigField(title = "Destination MQTT topic",
-                description = "The MQTT topic to publish to",
-                format = ModuleConfigField.FieldType.MQTT_TOPIC,
-                required = true)
-        private @NotNull String destination;
-
-        @JsonProperty("qos")
-        @ModuleConfigField(title = "MQTT QoS",
-                description = "MQTT quality of service level",
-                numberMin = 0,
-                numberMax = 2,
-                defaultValue = "0")
-        private @NotNull int qos = 0;
-
-//        public @NotNull AddressRange getInputRegisters() {
-//            return inputRegisters;
-//        }
-
         public @NotNull AddressRange getHoldingRegisters() {
             return holdingRegisters;
-        }
-//        public @NotNull AddressRange getCoils() {
-//            return coils;
-//        }
-
-        public @NotNull String getDestination() {
-            return destination;
-        }
-
-        public int getQos() {
-            return qos;
         }
     }
 

--- a/modules/hivemq-edge-module-modbus/src/main/java/com/hivemq/edge/adapters/modbus/ModbusProtocolAdapterInformation.java
+++ b/modules/hivemq-edge-module-modbus/src/main/java/com/hivemq/edge/adapters/modbus/ModbusProtocolAdapterInformation.java
@@ -15,16 +15,20 @@
  */
 package com.hivemq.edge.adapters.modbus;
 
-import com.hivemq.edge.HiveMQEdgeConstants;
+import com.hivemq.edge.modules.adapters.ProtocolAdapterConstants;
+import com.hivemq.edge.modules.adapters.impl.AbstractProtocolAdapterInformation;
 import com.hivemq.edge.modules.api.adapters.ProtocolAdapterInformation;
 import com.hivemq.edge.modules.config.CustomConfig;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
 
-public class ModbusProtocolAdapterInformation implements ProtocolAdapterInformation {
+import java.util.List;
+
+public class ModbusProtocolAdapterInformation
+        extends AbstractProtocolAdapterInformation {
 
     public static final ProtocolAdapterInformation INSTANCE = new ModbusProtocolAdapterInformation();
 
-    private ModbusProtocolAdapterInformation() {
+    protected ModbusProtocolAdapterInformation() {
     }
 
     @Override
@@ -53,18 +57,8 @@ public class ModbusProtocolAdapterInformation implements ProtocolAdapterInformat
     }
 
     @Override
-    public @NotNull String getVersion() {
-        return HiveMQEdgeConstants.VERSION;
-    }
-
-    @Override
-    public @NotNull String getLogoUrl() {
-        return "/images/modbus-icon.png";
-    }
-
-    @Override
-    public @NotNull String getAuthor() {
-        return "HiveMQ";
+    public List<ProtocolAdapterConstants.TAG> getTags() {
+        return List.of(ProtocolAdapterConstants.TAG.TCP, ProtocolAdapterConstants.TAG.ETHERNET);
     }
 
     @Override

--- a/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/OpcUaAdapterConfig.java
+++ b/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/OpcUaAdapterConfig.java
@@ -17,7 +17,7 @@ package com.hivemq.edge.adapters.opcua;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.hivemq.edge.modules.adapters.annotations.ModuleConfigField;
-import com.hivemq.edge.modules.config.CustomConfig;
+import com.hivemq.edge.modules.config.impl.AbstractProtocolAdapterConfig;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
 import com.hivemq.extension.sdk.api.annotations.Nullable;
 import org.eclipse.milo.opcua.stack.core.security.SecurityPolicy;
@@ -25,17 +25,7 @@ import org.eclipse.milo.opcua.stack.core.security.SecurityPolicy;
 import java.util.ArrayList;
 import java.util.List;
 
-public class OpcUaAdapterConfig implements CustomConfig {
-
-    @JsonProperty("id")
-    @ModuleConfigField(title = "Identifier",
-                       description = "Unique identifier for this protocol adapter",
-                       format = ModuleConfigField.FieldType.IDENTIFIER,
-                       required = true,
-                       stringPattern = "[a-z0-9_\\-].+",
-                       stringMinLength = 1,
-                       stringMaxLength = 1024)
-    private @NotNull String id;
+public class OpcUaAdapterConfig extends AbstractProtocolAdapterConfig {
 
     @JsonProperty("uri")
     @ModuleConfigField(title = "OPC-UA Server URI",
@@ -63,14 +53,6 @@ public class OpcUaAdapterConfig implements CustomConfig {
             final @NotNull String id, final @NotNull String uri) {
         this.id = id;
         this.uri = uri;
-    }
-
-    public @NotNull String getId() {
-        return id;
-    }
-
-    public void setId(final @NotNull String id) {
-        this.id = id;
     }
 
     public @NotNull String getUri() {

--- a/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/OpcUaProtocolAdapterInformation.java
+++ b/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/OpcUaProtocolAdapterInformation.java
@@ -15,12 +15,13 @@
  */
 package com.hivemq.edge.adapters.opcua;
 
-import com.hivemq.edge.HiveMQEdgeConstants;
+import com.hivemq.edge.modules.adapters.impl.AbstractProtocolAdapterInformation;
 import com.hivemq.edge.modules.api.adapters.ProtocolAdapterInformation;
 import com.hivemq.edge.modules.config.CustomConfig;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
 
-public class OpcUaProtocolAdapterInformation implements ProtocolAdapterInformation {
+public class OpcUaProtocolAdapterInformation
+        extends AbstractProtocolAdapterInformation {
 
     public static final ProtocolAdapterInformation INSTANCE = new OpcUaProtocolAdapterInformation();
 
@@ -53,18 +54,8 @@ public class OpcUaProtocolAdapterInformation implements ProtocolAdapterInformati
     }
 
     @Override
-    public @NotNull String getVersion() {
-        return HiveMQEdgeConstants.VERSION;
-    }
-
-    @Override
     public @NotNull String getLogoUrl() {
         return "/images/opc-ua-icon.jpg";
-    }
-
-    @Override
-    public @NotNull String getAuthor() {
-        return "HiveMQ";
     }
 
     @Override


### PR DESCRIPTION
We need to start enforcing some small constraints on the adapters, especially around configuration and control. This is the first step to create abstractions of information and config so we know at least of the information provided is consistent.