### PR TITLE
add improvements to com.hivemq.util.ObjectMemoryEstimation

### DIFF
--- a/hivemq-edge/src/main/java/com/hivemq/mqtt/message/connect/MqttWillPublish.java
+++ b/hivemq-edge/src/main/java/com/hivemq/mqtt/message/connect/MqttWillPublish.java
@@ -28,7 +28,7 @@ import com.hivemq.mqtt.message.mqtt5.MqttUserProperty;
 import com.hivemq.mqtt.message.publish.PUBLISH;
 import com.hivemq.persistence.Sizable;
 import com.hivemq.util.Bytes;
-import com.hivemq.util.ObjectMemoryEstimation;
+import com.hivemq.util.MemoryEstimator;
 
 /**
  * @author Silvio Giebl
@@ -229,25 +229,25 @@ public class MqttWillPublish implements Sizable {
             return sizeInMemory;
         }
         int size = 0;
-        size += ObjectMemoryEstimation.objectShellSize(); // the will himself
-        size += ObjectMemoryEstimation.intSize(); // sizeInMemory
-        size += ObjectMemoryEstimation.stringSize(topic);
-        size += ObjectMemoryEstimation.byteArraySize(payload);
-        size += ObjectMemoryEstimation.byteArraySize(correlationData);
-        size += ObjectMemoryEstimation.stringSize(responseTopic);
-        size += ObjectMemoryEstimation.stringSize(hivemqId);
-        size += ObjectMemoryEstimation.stringSize(contentType);
+        size += MemoryEstimator.OBJECT_SHELL_SIZE; // the will himself
+        size += MemoryEstimator.INT_SIZE; // sizeInMemory
+        size += MemoryEstimator.stringSize(topic);
+        size += MemoryEstimator.byteArraySize(payload);
+        size += MemoryEstimator.byteArraySize(correlationData);
+        size += MemoryEstimator.stringSize(responseTopic);
+        size += MemoryEstimator.stringSize(hivemqId);
+        size += MemoryEstimator.stringSize(contentType);
 
         size += 24; //User Properties Overhead
         for (final MqttUserProperty userProperty : getUserProperties().asList()) {
             size += 24; //UserProperty Object Overhead
-            size += ObjectMemoryEstimation.stringSize(userProperty.getName());
-            size += ObjectMemoryEstimation.stringSize(userProperty.getValue());
+            size += MemoryEstimator.stringSize(userProperty.getName());
+            size += MemoryEstimator.stringSize(userProperty.getValue());
         }
-        size += ObjectMemoryEstimation.longSize(); // messageExpiryInterval
-        size += ObjectMemoryEstimation.enumSize(); // QoS
-        size += ObjectMemoryEstimation.enumSize(); // payloadFormatIndicator
-        size += ObjectMemoryEstimation.longSize(); // will delay interval
+        size += MemoryEstimator.LONG_SIZE; // messageExpiryInterval
+        size += MemoryEstimator.ENUM_OVERHEAD; // QoS
+        size += MemoryEstimator.ENUM_OVERHEAD; // payloadFormatIndicator
+        size += MemoryEstimator.LONG_SIZE; // will delay interval
 
         sizeInMemory = size;
         return sizeInMemory;

--- a/hivemq-edge/src/main/java/com/hivemq/mqtt/message/publish/PUBLISH.java
+++ b/hivemq-edge/src/main/java/com/hivemq/mqtt/message/publish/PUBLISH.java
@@ -29,7 +29,7 @@ import com.hivemq.mqtt.message.mqtt5.Mqtt5UserProperties;
 import com.hivemq.mqtt.message.mqtt5.MqttMessageWithUserProperties;
 import com.hivemq.mqtt.message.mqtt5.MqttUserProperty;
 import com.hivemq.persistence.payload.PublishPayloadPersistence;
-import com.hivemq.util.ObjectMemoryEstimation;
+import com.hivemq.util.MemoryEstimator;
 
 import java.util.Arrays;
 import java.util.Objects;
@@ -415,34 +415,34 @@ public class PUBLISH extends MqttMessageWithUserProperties implements Mqtt3PUBLI
             return sizeInMemory;
         }
         int size = 0;
-        size += ObjectMemoryEstimation.objectShellSize(); // the publish himself
-        size += ObjectMemoryEstimation.intSize(); // sizeInMemory
-        size += ObjectMemoryEstimation.longSize(); // timestamp
-        size += ObjectMemoryEstimation.stringSize(topic);
-        size += ObjectMemoryEstimation.byteArraySize(payload);
-        size += ObjectMemoryEstimation.byteArraySize(correlationData);
-        size += ObjectMemoryEstimation.stringSize(responseTopic);
-        size += ObjectMemoryEstimation.stringSize(uniqueId);
-        size += ObjectMemoryEstimation.stringSize(hivemqId);
-        size += ObjectMemoryEstimation.stringSize(contentType);
+        size += MemoryEstimator.OBJECT_SHELL_SIZE; // the publish himself
+        size += MemoryEstimator.INT_SIZE; // sizeInMemory
+        size += MemoryEstimator.LONG_SIZE; // timestamp
+        size += MemoryEstimator.stringSize(topic);
+        size += MemoryEstimator.byteArraySize(payload);
+        size += MemoryEstimator.byteArraySize(correlationData);
+        size += MemoryEstimator.stringSize(responseTopic);
+        size += MemoryEstimator.stringSize(uniqueId);
+        size += MemoryEstimator.stringSize(hivemqId);
+        size += MemoryEstimator.stringSize(contentType);
 
         size += 24; //User Properties Overhead
         final ImmutableList<MqttUserProperty> userProperties = getUserProperties().asList();
         for (int i = 0; i < userProperties.size(); i++) {
             final MqttUserProperty userProperty = userProperties.get(i);
             size += 24; //UserProperty Object Overhead
-            size += ObjectMemoryEstimation.stringSize(userProperty.getName());
-            size += ObjectMemoryEstimation.stringSize(userProperty.getValue());
+            size += MemoryEstimator.stringSize(userProperty.getName());
+            size += MemoryEstimator.stringSize(userProperty.getValue());
         }
-        size += ObjectMemoryEstimation.booleanSize(); // duplicateDelivery
-        size += ObjectMemoryEstimation.booleanSize(); // retain
-        size += ObjectMemoryEstimation.booleanSize(); // isNewTopicAlias
-        size += ObjectMemoryEstimation.longSize(); // messageExpiryInterval
-        size += ObjectMemoryEstimation.longSize(); // publishId
-        size += ObjectMemoryEstimation.longWrapperSize(); // payloadId
-        size += ObjectMemoryEstimation.enumSize(); // QoS
-        size += ObjectMemoryEstimation.enumSize(); // payloadFormatIndicator
-        size += ObjectMemoryEstimation.immutableIntArraySize(subscriptionIdentifiers);
+        size += MemoryEstimator.BOOLEAN_SIZE; // duplicateDelivery
+        size += MemoryEstimator.BOOLEAN_SIZE; // retain
+        size += MemoryEstimator.BOOLEAN_SIZE; // isNewTopicAlias
+        size += MemoryEstimator.LONG_SIZE; // messageExpiryInterval
+        size += MemoryEstimator.LONG_SIZE; // publishId
+        size += MemoryEstimator.LONG_WRAPPER_SIZE; // payloadId
+        size += MemoryEstimator.ENUM_OVERHEAD; // QoS
+        size += MemoryEstimator.ENUM_OVERHEAD; // payloadFormatIndicator
+        size += MemoryEstimator.immutableIntArraySize(subscriptionIdentifiers);
 
         sizeInMemory = size;
         return sizeInMemory;

--- a/hivemq-edge/src/main/java/com/hivemq/mqtt/message/pubrel/PUBREL.java
+++ b/hivemq-edge/src/main/java/com/hivemq/mqtt/message/pubrel/PUBREL.java
@@ -25,7 +25,7 @@ import com.hivemq.mqtt.message.mqtt5.MqttMessageWithUserProperties;
 import com.hivemq.mqtt.message.mqtt5.MqttUserProperty;
 import com.hivemq.mqtt.message.publish.PUBLISH;
 import com.hivemq.mqtt.message.reason.Mqtt5PubRelReasonCode;
-import com.hivemq.util.ObjectMemoryEstimation;
+import com.hivemq.util.MemoryEstimator;
 
 /**
  * @since 1.4
@@ -132,19 +132,19 @@ public class PUBREL extends MqttMessageWithUserProperties.MqttMessageWithIdAndRe
             return sizeInMemory;
         }
         int size = 0;
-        size += ObjectMemoryEstimation.objectShellSize();
-        size += ObjectMemoryEstimation.intSize(); // sizeInMemory
-        size += ObjectMemoryEstimation.intSize(); // packet id
-        size += ObjectMemoryEstimation.enumSize(); // reason code
-        size += ObjectMemoryEstimation.stringSize(getReasonString()); // reason code
-        size += ObjectMemoryEstimation.longWrapperSize(); //publish timestamp
-        size += ObjectMemoryEstimation.longWrapperSize(); //expiry interval
+        size += MemoryEstimator.OBJECT_SHELL_SIZE;
+        size += MemoryEstimator.INT_SIZE; // sizeInMemory
+        size += MemoryEstimator.INT_SIZE; // packet id
+        size += MemoryEstimator.ENUM_OVERHEAD; // reason code
+        size += MemoryEstimator.stringSize(getReasonString()); // reason code
+        size += MemoryEstimator.LONG_WRAPPER_SIZE; //publish timestamp
+        size += MemoryEstimator.LONG_WRAPPER_SIZE; //expiry interval
 
         size += 24; //User Properties Overhead
         for (final MqttUserProperty userProperty : getUserProperties().asList()) {
             size += 24; //UserProperty Object Overhead
-            size += ObjectMemoryEstimation.stringSize(userProperty.getName());
-            size += ObjectMemoryEstimation.stringSize(userProperty.getValue());
+            size += MemoryEstimator.stringSize(userProperty.getName());
+            size += MemoryEstimator.stringSize(userProperty.getValue());
         }
 
         sizeInMemory = size;

--- a/hivemq-edge/src/main/java/com/hivemq/mqtt/message/subscribe/Topic.java
+++ b/hivemq-edge/src/main/java/com/hivemq/mqtt/message/subscribe/Topic.java
@@ -21,7 +21,7 @@ import com.hivemq.extension.sdk.api.packets.subscribe.Subscription;
 import com.hivemq.mqtt.message.QoS;
 import com.hivemq.mqtt.message.mqtt5.Mqtt5RetainHandling;
 import com.hivemq.persistence.Sizable;
-import com.hivemq.util.ObjectMemoryEstimation;
+import com.hivemq.util.MemoryEstimator;
 
 import java.io.Serializable;
 import java.util.Objects;
@@ -190,13 +190,13 @@ public class Topic implements Serializable, Comparable<Topic>, Mqtt3Topic, Mqtt5
         }
         int size = 0;
 
-        size += ObjectMemoryEstimation.objectShellSize();
-        size += ObjectMemoryEstimation.stringSize(topic);
-        size += ObjectMemoryEstimation.enumSize(); // QoS
-        size += ObjectMemoryEstimation.booleanSize(); // no local
-        size += ObjectMemoryEstimation.booleanSize(); // retain as published
-        size += ObjectMemoryEstimation.enumSize(); // retain handling
-        size += ObjectMemoryEstimation.intWrapperSize(); // sub id
+        size += MemoryEstimator.OBJECT_SHELL_SIZE;
+        size += MemoryEstimator.stringSize(topic);
+        size += MemoryEstimator.ENUM_OVERHEAD; // QoS
+        size += MemoryEstimator.BOOLEAN_SIZE; // no local
+        size += MemoryEstimator.BOOLEAN_SIZE; // retain as published
+        size += MemoryEstimator.ENUM_OVERHEAD; // retain handling
+        size += MemoryEstimator.INT_WRAPPER_SIZE; // sub id
 
         sizeInMemory = size;
         return sizeInMemory;

--- a/hivemq-edge/src/main/java/com/hivemq/persistence/IterablePersistenceEntry.java
+++ b/hivemq-edge/src/main/java/com/hivemq/persistence/IterablePersistenceEntry.java
@@ -17,7 +17,7 @@ package com.hivemq.persistence;
 
 import com.hivemq.extension.sdk.api.annotations.Immutable;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
-import com.hivemq.util.ObjectMemoryEstimation;
+import com.hivemq.util.MemoryEstimator;
 
 import java.util.Collection;
 
@@ -53,10 +53,10 @@ public class IterablePersistenceEntry<T extends Collection<? extends Sizable>> i
     }
 
     public static int getFixedSize(){
-        int size = ObjectMemoryEstimation.objectShellSize(); // object overhead
-        size += ObjectMemoryEstimation.longSize(); // timestamp
-        size += ObjectMemoryEstimation.intSize(); // sizeInMemory
-        size += ObjectMemoryEstimation.collectionOverhead(); // collection overhead
+        int size = MemoryEstimator.OBJECT_SHELL_SIZE; // object overhead
+        size += MemoryEstimator.LONG_SIZE; // timestamp
+        size += MemoryEstimator.INT_SIZE; // sizeInMemory
+        size += MemoryEstimator.COLLECTION_OVERHEAD; // collection overhead
         return size;
     }
 
@@ -69,7 +69,7 @@ public class IterablePersistenceEntry<T extends Collection<? extends Sizable>> i
 
         int size = getFixedSize();
         for (final Sizable item : object) {
-            size += ObjectMemoryEstimation.objectRefSize();
+            size += MemoryEstimator.OBJECT_REF_SIZE;
             size += item.getEstimatedSize();
         }
 

--- a/hivemq-edge/src/main/java/com/hivemq/persistence/PersistenceEntry.java
+++ b/hivemq-edge/src/main/java/com/hivemq/persistence/PersistenceEntry.java
@@ -17,7 +17,7 @@ package com.hivemq.persistence;
 
 import com.hivemq.extension.sdk.api.annotations.Immutable;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
-import com.hivemq.util.ObjectMemoryEstimation;
+import com.hivemq.util.MemoryEstimator;
 
 /**
  * @author Lukas Brandl
@@ -57,12 +57,12 @@ public class PersistenceEntry<T extends Sizable> implements Sizable {
             return sizeInMemory;
         }
 
-        int size = ObjectMemoryEstimation.objectShellSize();
-        size += ObjectMemoryEstimation.longSize(); // timestamp
-        size += ObjectMemoryEstimation.intSize(); // sizeInMemory
+        int size = MemoryEstimator.OBJECT_SHELL_SIZE;
+        size += MemoryEstimator.LONG_SIZE; // timestamp
+        size += MemoryEstimator.INT_SIZE; // sizeInMemory
 
         // contained object
-        size += ObjectMemoryEstimation.objectRefSize();
+        size += MemoryEstimator.OBJECT_REF_SIZE;
         size += object.getEstimatedSize();
 
         sizeInMemory = size;

--- a/hivemq-edge/src/main/java/com/hivemq/persistence/RetainedMessage.java
+++ b/hivemq-edge/src/main/java/com/hivemq/persistence/RetainedMessage.java
@@ -24,7 +24,7 @@ import com.hivemq.mqtt.message.QoS;
 import com.hivemq.mqtt.message.mqtt5.Mqtt5UserProperties;
 import com.hivemq.mqtt.message.mqtt5.MqttUserProperty;
 import com.hivemq.mqtt.message.publish.PUBLISH;
-import com.hivemq.util.ObjectMemoryEstimation;
+import com.hivemq.util.MemoryEstimator;
 
 import java.util.Arrays;
 import java.util.Objects;
@@ -136,24 +136,24 @@ public class RetainedMessage {
         }
         int size = 0;
         // The payload size is not calculated because the payload is removed before the message is stored
-        size += ObjectMemoryEstimation.enumSize(); // QoS
-        size += ObjectMemoryEstimation.longWrapperSize(); // Payload ID
-        size += ObjectMemoryEstimation.longSize(); // expiry interval
+        size += MemoryEstimator.ENUM_OVERHEAD; // QoS
+        size += MemoryEstimator.LONG_WRAPPER_SIZE; // Payload ID
+        size += MemoryEstimator.LONG_SIZE; // expiry interval
 
         size += 24; //User Properties Overhead
         for (final MqttUserProperty userProperty : getUserProperties().asList()) {
             size += 24; //UserProperty Object Overhead
-            size += ObjectMemoryEstimation.stringSize(userProperty.getName());
-            size += ObjectMemoryEstimation.stringSize(userProperty.getValue());
+            size += MemoryEstimator.stringSize(userProperty.getName());
+            size += MemoryEstimator.stringSize(userProperty.getValue());
         }
 
-        size += ObjectMemoryEstimation.stringSize(responseTopic);
-        size += ObjectMemoryEstimation.stringSize(contentType);
-        size += ObjectMemoryEstimation.byteArraySize(correlationData);
+        size += MemoryEstimator.stringSize(responseTopic);
+        size += MemoryEstimator.stringSize(contentType);
+        size += MemoryEstimator.byteArraySize(correlationData);
 
-        size += ObjectMemoryEstimation.enumSize(); // Payload format indicator
-        size += ObjectMemoryEstimation.longSize(); // timestamp
-        size += ObjectMemoryEstimation.intSize(); // size
+        size += MemoryEstimator.ENUM_OVERHEAD; // Payload format indicator
+        size += MemoryEstimator.LONG_SIZE; // timestamp
+        size += MemoryEstimator.INT_SIZE; // size
 
         sizeInMemory = size;
         return sizeInMemory;

--- a/hivemq-edge/src/main/java/com/hivemq/persistence/clientsession/ClientSession.java
+++ b/hivemq-edge/src/main/java/com/hivemq/persistence/clientsession/ClientSession.java
@@ -19,7 +19,7 @@ import com.google.common.base.Preconditions;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
 import com.hivemq.extension.sdk.api.annotations.Nullable;
 import com.hivemq.persistence.Sizable;
-import com.hivemq.util.ObjectMemoryEstimation;
+import com.hivemq.util.MemoryEstimator;
 
 import static com.hivemq.mqtt.message.connect.Mqtt5CONNECT.SESSION_EXPIRE_ON_DISCONNECT;
 
@@ -98,17 +98,17 @@ public class ClientSession implements Sizable {
             return inMemorySize;
         }
 
-        int size = ObjectMemoryEstimation.objectShellSize();
-        size += ObjectMemoryEstimation.intSize(); // inMemorySize
-        size += ObjectMemoryEstimation.booleanSize(); // connected
-        size += ObjectMemoryEstimation.longSize(); // sessionExpiryInterval
+        int size = MemoryEstimator.OBJECT_SHELL_SIZE;
+        size += MemoryEstimator.INT_SIZE; // inMemorySize
+        size += MemoryEstimator.BOOLEAN_SIZE; // connected
+        size += MemoryEstimator.LONG_SIZE; // sessionExpiryInterval
 
-        size += ObjectMemoryEstimation.objectRefSize(); // reference to will
+        size += MemoryEstimator.OBJECT_REF_SIZE; // reference to will
         if (willPublish != null) {
             size += willPublish.getEstimatedSize();
         }
         if (queueLimit != null) {
-            size += ObjectMemoryEstimation.longSize();
+            size += MemoryEstimator.LONG_SIZE;
         }
 
         inMemorySize = size;

--- a/hivemq-edge/src/main/java/com/hivemq/persistence/clientsession/ClientSessionWill.java
+++ b/hivemq-edge/src/main/java/com/hivemq/persistence/clientsession/ClientSessionWill.java
@@ -22,7 +22,7 @@ import com.hivemq.mqtt.message.QoS;
 import com.hivemq.mqtt.message.connect.MqttWillPublish;
 import com.hivemq.mqtt.message.mqtt5.Mqtt5UserProperties;
 import com.hivemq.persistence.Sizable;
-import com.hivemq.util.ObjectMemoryEstimation;
+import com.hivemq.util.MemoryEstimator;
 
 /**
  * @author Lukas Brandl
@@ -115,11 +115,11 @@ public class ClientSessionWill implements Sizable {
             return inMemorySize;
         }
 
-        int size = ObjectMemoryEstimation.objectShellSize(); // will himself
-        size += ObjectMemoryEstimation.intSize(); // inMemorySize
+        int size = MemoryEstimator.OBJECT_SHELL_SIZE; // will himself
+        size += MemoryEstimator.INT_SIZE; // inMemorySize
 
-        size += ObjectMemoryEstimation.longWrapperSize(); //payload id
-        size += ObjectMemoryEstimation.objectRefSize(); // will publish reference
+        size += MemoryEstimator.LONG_WRAPPER_SIZE; //payload id
+        size += MemoryEstimator.OBJECT_REF_SIZE; // will publish reference
         size += mqttWillPublish.getEstimatedSize();
 
         inMemorySize = size;

--- a/hivemq-edge/src/main/java/com/hivemq/persistence/local/memory/ClientQueueMemoryLocalPersistence.java
+++ b/hivemq-edge/src/main/java/com/hivemq/persistence/local/memory/ClientQueueMemoryLocalPersistence.java
@@ -34,7 +34,7 @@ import com.hivemq.mqtt.message.publish.PUBLISH;
 import com.hivemq.mqtt.message.pubrel.PUBREL;
 import com.hivemq.persistence.clientqueue.ClientQueueLocalPersistence;
 import com.hivemq.persistence.payload.PublishPayloadPersistence;
-import com.hivemq.util.ObjectMemoryEstimation;
+import com.hivemq.util.MemoryEstimator;
 import com.hivemq.util.Strings;
 import com.hivemq.util.ThreadPreConditions;
 import org.slf4j.Logger;
@@ -733,9 +733,9 @@ public class ClientQueueMemoryLocalPersistence implements ClientQueueLocalPersis
      */
     private void increaseQos0MessagesMemory(final int size) {
         if (size < 0) {
-            qos0MessagesMemory.addAndGet(size - ObjectMemoryEstimation.linkedListNodeOverhead());
+            qos0MessagesMemory.addAndGet(size - MemoryEstimator.LINKED_LIST_NODE_OVERHEAD);
         } else {
-            qos0MessagesMemory.addAndGet(size + ObjectMemoryEstimation.linkedListNodeOverhead());
+            qos0MessagesMemory.addAndGet(size + MemoryEstimator.LINKED_LIST_NODE_OVERHEAD);
         }
     }
 
@@ -744,9 +744,9 @@ public class ClientQueueMemoryLocalPersistence implements ClientQueueLocalPersis
      */
     private void increaseMessagesMemory(final int size) {
         if (size < 0) {
-            totalMemorySize.addAndGet(size - ObjectMemoryEstimation.linkedListNodeOverhead());
+            totalMemorySize.addAndGet(size - MemoryEstimator.LINKED_LIST_NODE_OVERHEAD);
         } else {
-            totalMemorySize.addAndGet(size + ObjectMemoryEstimation.linkedListNodeOverhead());
+            totalMemorySize.addAndGet(size + MemoryEstimator.LINKED_LIST_NODE_OVERHEAD);
         }
     }
 
@@ -755,9 +755,9 @@ public class ClientQueueMemoryLocalPersistence implements ClientQueueLocalPersis
      */
     private void increaseClientQos0MessagesMemory(final @NotNull Messages messages, final int size) {
         if (size < 0) {
-            messages.qos0Memory += size - ObjectMemoryEstimation.linkedListNodeOverhead();
+            messages.qos0Memory += size - MemoryEstimator.LINKED_LIST_NODE_OVERHEAD;
         } else {
-            messages.qos0Memory += size + ObjectMemoryEstimation.linkedListNodeOverhead();
+            messages.qos0Memory += size + MemoryEstimator.LINKED_LIST_NODE_OVERHEAD;
         }
         if (messages.qos0Memory < 0) {
             messages.qos0Memory = 0;
@@ -867,8 +867,8 @@ public class ClientQueueMemoryLocalPersistence implements ClientQueueLocalPersis
 
         int getEstimatedSize() {
             return getEstimatedSizeInMemory()  // publish
-                    + ObjectMemoryEstimation.objectShellSize() // the object itself
-                    + ObjectMemoryEstimation.booleanSize(); // retain flag
+                    + MemoryEstimator.OBJECT_SHELL_SIZE // the object itself
+                    + MemoryEstimator.BOOLEAN_SIZE; // retain flag
         }
     }
 
@@ -888,8 +888,8 @@ public class ClientQueueMemoryLocalPersistence implements ClientQueueLocalPersis
 
         private int getEstimatedSize() {
             return getEstimatedSizeInMemory()  // publish
-                    + ObjectMemoryEstimation.objectShellSize() // the object itself
-                    + ObjectMemoryEstimation.booleanSize(); // retain flag
+                    + MemoryEstimator.OBJECT_SHELL_SIZE // the object itself
+                    + MemoryEstimator.BOOLEAN_SIZE; // retain flag
         }
     }
 }

--- a/hivemq-edge/src/main/java/com/hivemq/persistence/local/memory/ClientSessionMemoryLocalPersistence.java
+++ b/hivemq-edge/src/main/java/com/hivemq/persistence/local/memory/ClientSessionMemoryLocalPersistence.java
@@ -35,7 +35,7 @@ import com.hivemq.persistence.exception.InvalidSessionExpiryIntervalException;
 import com.hivemq.persistence.local.ClientSessionLocalPersistence;
 import com.hivemq.persistence.local.xodus.bucket.BucketUtils;
 import com.hivemq.persistence.payload.PublishPayloadPersistence;
-import com.hivemq.util.ObjectMemoryEstimation;
+import com.hivemq.util.MemoryEstimator;
 import com.hivemq.util.ThreadPreConditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -215,7 +215,7 @@ public class ClientSessionMemoryLocalPersistence implements ClientSessionLocalPe
             final PersistenceEntry<ClientSession> newEntry = new PersistenceEntry<>(usedSession, timestamp);
             currentMemorySize.addAndGet(newEntry.getEstimatedSize());
             if (addClientIdSize) {
-                currentMemorySize.addAndGet(ObjectMemoryEstimation.stringSize(clientId));
+                currentMemorySize.addAndGet(MemoryEstimator.stringSize(clientId));
             }
 
             return newEntry;
@@ -240,7 +240,7 @@ public class ClientSessionMemoryLocalPersistence implements ClientSessionLocalPe
                 // we create a tombstone here which will be removed at next cleanup
                 final ClientSession clientSession = new ClientSession(false, SESSION_EXPIRE_ON_DISCONNECT);
                 final PersistenceEntry<ClientSession> persistenceEntry = new PersistenceEntry<>(clientSession, timestamp);
-                currentMemorySize.addAndGet(persistenceEntry.getEstimatedSize() + ObjectMemoryEstimation.stringSize(clientId));
+                currentMemorySize.addAndGet(persistenceEntry.getEstimatedSize() + MemoryEstimator.stringSize(clientId));
                 return persistenceEntry;
             }
 
@@ -295,7 +295,7 @@ public class ClientSessionMemoryLocalPersistence implements ClientSessionLocalPe
                 sessionsCount.decrementAndGet();
             }
             removeWillReference(clientSession);
-            currentMemorySize.addAndGet(-(remove.getEstimatedSize() + ObjectMemoryEstimation.stringSize(clientId)));
+            currentMemorySize.addAndGet(-(remove.getEstimatedSize() + MemoryEstimator.stringSize(clientId)));
         }
     }
 
@@ -327,7 +327,7 @@ public class ClientSessionMemoryLocalPersistence implements ClientSessionLocalPe
                 }
                 eventLog.clientSessionExpired(timestamp + sessionExpiryInterval * 1000, entry.getKey());
                 expiredClientIds.add(entry.getKey());
-                currentMemorySize.addAndGet(-(storedEntry.getEstimatedSize() + ObjectMemoryEstimation.stringSize(entry.getKey())));
+                currentMemorySize.addAndGet(-(storedEntry.getEstimatedSize() + MemoryEstimator.stringSize(entry.getKey())));
                 iterator.remove();
             }
         }

--- a/hivemq-edge/src/main/java/com/hivemq/persistence/local/memory/ClientSessionSubscriptionMemoryLocalPersistence.java
+++ b/hivemq-edge/src/main/java/com/hivemq/persistence/local/memory/ClientSessionSubscriptionMemoryLocalPersistence.java
@@ -30,7 +30,7 @@ import com.hivemq.mqtt.message.subscribe.Topic;
 import com.hivemq.persistence.IterablePersistenceEntry;
 import com.hivemq.persistence.local.ClientSessionSubscriptionLocalPersistence;
 import com.hivemq.persistence.local.xodus.bucket.BucketUtils;
-import com.hivemq.util.ObjectMemoryEstimation;
+import com.hivemq.util.MemoryEstimator;
 import com.hivemq.util.ThreadPreConditions;
 
 import javax.inject.Inject;
@@ -101,7 +101,7 @@ public class ClientSessionSubscriptionMemoryLocalPersistence implements ClientSe
             if (oldEntry == null) {
                 final IterablePersistenceEntry<ImmutableSet<Topic>> newEntry = new IterablePersistenceEntry<>(topics, timestamp);
                 currentMemorySize.addAndGet(newEntry.getEstimatedSize());
-                currentMemorySize.addAndGet(ObjectMemoryEstimation.stringSize(client));
+                currentMemorySize.addAndGet(MemoryEstimator.stringSize(client));
                 return newEntry;
             }
             currentMemorySize.addAndGet(-oldEntry.getEstimatedSize());
@@ -143,7 +143,7 @@ public class ClientSessionSubscriptionMemoryLocalPersistence implements ClientSe
             boolean remaining = false;
             for (final Topic topic : entry.getObject()) {
                 if (topics.contains(topic.getTopic())) {
-                    currentMemorySize.addAndGet(-(topic.getEstimatedSize() + ObjectMemoryEstimation.objectRefSize()));
+                    currentMemorySize.addAndGet(-(topic.getEstimatedSize() + MemoryEstimator.OBJECT_REF_SIZE));
                     continue;
                 }
                 remaining = true;
@@ -151,7 +151,7 @@ public class ClientSessionSubscriptionMemoryLocalPersistence implements ClientSe
             }
             if (!remaining) {
                 currentMemorySize.addAndGet(-IterablePersistenceEntry.getFixedSize());
-                currentMemorySize.addAndGet(-ObjectMemoryEstimation.stringSize(client));
+                currentMemorySize.addAndGet(-MemoryEstimator.stringSize(client));
                 return null;
             }
             return new IterablePersistenceEntry<>(remainingTopicsBuilder.build(), timestamp);
@@ -170,7 +170,7 @@ public class ClientSessionSubscriptionMemoryLocalPersistence implements ClientSe
             return;
         }
         currentMemorySize.addAndGet(-remove.getEstimatedSize());
-        currentMemorySize.addAndGet(-ObjectMemoryEstimation.stringSize(client));
+        currentMemorySize.addAndGet(-MemoryEstimator.stringSize(client));
     }
 
     @Override

--- a/hivemq-edge/src/main/java/com/hivemq/util/MemoryEstimator.java
+++ b/hivemq-edge/src/main/java/com/hivemq/util/MemoryEstimator.java
@@ -21,7 +21,7 @@ import com.hivemq.extension.sdk.api.annotations.Nullable;
 /**
  * @author Lukas Brandl
  */
-public class ObjectMemoryEstimation {
+public class MemoryEstimator {
 
     public static final int OBJECT_SHELL_SIZE = 12; //Class Pointer (4), Flags (4), Locks (4)
     public static final int OBJECT_REF_SIZE = 4;
@@ -37,10 +37,18 @@ public class ObjectMemoryEstimation {
     public static final int CHAR_SIZE = 2;
     public static final int BOOLEAN_SIZE = 1;
 
-    public static int enumSize() {
-        return ENUM_OVERHEAD;
+    private MemoryEstimator() {
+        //This is a utility class, don't instantiate it!
     }
 
+    /**
+     * Computes the size of a String.
+     * This size is computed as STRING_OVERHEAD plus the size of each character (defined by CHAR_SIZE)
+     * in the string
+     *
+     * @param string the input string
+     * @return the size of the string
+     */
     public static int stringSize(@Nullable final String string) {
         if (string == null) {
             return 0;
@@ -51,6 +59,13 @@ public class ObjectMemoryEstimation {
         return size;
     }
 
+    /**
+     * Computes the size of an array of bytes.
+     * This size is computed as ARRAY_OVERHEAD plus the length of the array.
+     *
+     * @param array the input array of bytes
+     * @return the size of the array of bytes
+     */
     public static int byteArraySize(@Nullable final byte[] array) {
         if (array == null) {
             return 0;
@@ -61,51 +76,22 @@ public class ObjectMemoryEstimation {
         return size;
     }
 
+    /**
+     * Computes the size of an {@link ImmutableIntArray}
+     * This size is computed as ARRAY_OVERHEAD plus 2 * INT_SIZE plus the size of each int in the array (defined by INT_SIZE)
+     *
+     * @param array the input {@link ImmutableIntArray}
+     * @return the size of the {@link ImmutableIntArray}
+     */
     public static int immutableIntArraySize(@Nullable final ImmutableIntArray array) {
         if (array == null) {
             return 0;
         }
 
         int size = ARRAY_OVERHEAD;
-        size += intSize(); // start;
-        size += intSize(); // end;
+        size += INT_SIZE; // start;
+        size += INT_SIZE; // end;
         size += array.length() * INT_SIZE;
         return size;
-    }
-
-    public static int longWrapperSize() {
-        return LONG_WRAPPER_SIZE;
-    }
-
-    public static int intWrapperSize() {
-        return INT_WRAPPER_SIZE;
-    }
-
-    public static int longSize() {
-        return LONG_SIZE;
-    }
-
-    public static int intSize() {
-        return INT_SIZE;
-    }
-
-    public static int booleanSize() {
-        return BOOLEAN_SIZE;
-    }
-
-    public static int objectShellSize() {
-        return OBJECT_SHELL_SIZE;
-    }
-
-    public static int objectRefSize() {
-        return OBJECT_REF_SIZE;
-    }
-
-    public static int collectionOverhead() {
-        return COLLECTION_OVERHEAD;
-    }
-
-    public static int linkedListNodeOverhead() {
-        return LINKED_LIST_NODE_OVERHEAD;
     }
 }

--- a/hivemq-edge/src/test/java/com/hivemq/mqtt/message/publish/PUBLISHTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/mqtt/message/publish/PUBLISHTest.java
@@ -20,7 +20,7 @@ import com.hivemq.mqtt.message.QoS;
 import com.hivemq.mqtt.message.mqtt5.Mqtt5UserProperties;
 import com.hivemq.mqtt.message.mqtt5.MqttUserProperty;
 import com.hivemq.persistence.payload.PublishPayloadPersistence;
-import com.hivemq.util.ObjectMemoryEstimation;
+import com.hivemq.util.MemoryEstimator;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -41,18 +41,18 @@ import static org.junit.Assert.assertFalse;
 public class PUBLISHTest {
 
     private static final int FIXED_SIZE =
-            ObjectMemoryEstimation.objectShellSize() +  // shell size
-                    ObjectMemoryEstimation.intSize() +  // size size
-                    ObjectMemoryEstimation.longSize() +  // timestamp
+            MemoryEstimator.OBJECT_SHELL_SIZE +  // shell size
+                    MemoryEstimator.INT_SIZE +  // size size
+                    MemoryEstimator.LONG_SIZE +  // timestamp
                     24 + // user props overhead
-                    ObjectMemoryEstimation.booleanSize() +  // duplicateDelivery
-                    ObjectMemoryEstimation.booleanSize() +  // retain
-                    ObjectMemoryEstimation.booleanSize() +  // isNewTopicAlias
-                    ObjectMemoryEstimation.longSize() +  // messageExpiryInterval
-                    ObjectMemoryEstimation.longSize() +  // publishId
-                    ObjectMemoryEstimation.longWrapperSize() + // payloadId
-                    ObjectMemoryEstimation.enumSize() +  // QoS
-                    ObjectMemoryEstimation.enumSize();   // payloadFormatIndicator
+                    MemoryEstimator.BOOLEAN_SIZE +  // duplicateDelivery
+                    MemoryEstimator.BOOLEAN_SIZE +  // retain
+                    MemoryEstimator.BOOLEAN_SIZE +  // isNewTopicAlias
+                    MemoryEstimator.LONG_SIZE +  // messageExpiryInterval
+                    MemoryEstimator.LONG_SIZE +  // publishId
+                    MemoryEstimator.LONG_WRAPPER_SIZE + // payloadId
+                    MemoryEstimator.ENUM_OVERHEAD +  // QoS
+                    MemoryEstimator.ENUM_OVERHEAD;   // payloadFormatIndicator
 
     @Test(expected = NullPointerException.class)
     public void test_publish_qos_null() {
@@ -174,7 +174,7 @@ public class PUBLISHTest {
 
         for (final int size : sizeList) {
             //19 + 48 + 54 + 23 + 118 = 262
-            assertEquals(262 + 54 + FIXED_SIZE + ObjectMemoryEstimation.stringSize(publishMqtt5.getUniqueId()), size);
+            assertEquals(262 + 54 + FIXED_SIZE + MemoryEstimator.stringSize(publishMqtt5.getUniqueId()), size);
         }
 
     }
@@ -190,7 +190,7 @@ public class PUBLISHTest {
                 .withTopic("topic") // 10+38 = 48 bytes
                 .build();
 
-        assertEquals(67 + 54 + FIXED_SIZE + ObjectMemoryEstimation.stringSize(publishMqtt5.getUniqueId()), publishMqtt5.getEstimatedSizeInMemory());
+        assertEquals(67 + 54 + FIXED_SIZE + MemoryEstimator.stringSize(publishMqtt5.getUniqueId()), publishMqtt5.getEstimatedSizeInMemory());
 
     }
 
@@ -206,7 +206,7 @@ public class PUBLISHTest {
                 .withTopic("topic") // 10+38 = 48 bytes
                 .build();
 
-        assertEquals(48 + 54 + FIXED_SIZE + ObjectMemoryEstimation.stringSize(publishMqtt5.getUniqueId()), publishMqtt5.getEstimatedSizeInMemory());
+        assertEquals(48 + 54 + FIXED_SIZE + MemoryEstimator.stringSize(publishMqtt5.getUniqueId()), publishMqtt5.getEstimatedSizeInMemory());
 
     }
 
@@ -224,7 +224,7 @@ public class PUBLISHTest {
                 .withUserProperties(getManyProperties()) // 12.777.790 bytes
                 .build();
 
-        final long estimatedSize = ((1024 * 1024 * 5) * 2) + 54 + 24 + (130_038 * 2) + 12_777_790 + FIXED_SIZE + ObjectMemoryEstimation.stringSize(publishMqtt5.getUniqueId()); // 23_523_857 bytes + UniqueID Bytes
+        final long estimatedSize = ((1024 * 1024 * 5) * 2) + 54 + 24 + (130_038 * 2) + 12_777_790 + FIXED_SIZE + MemoryEstimator.stringSize(publishMqtt5.getUniqueId()); // 23_523_857 bytes + UniqueID Bytes
         assertEquals(estimatedSize, publishMqtt5.getEstimatedSizeInMemory());
 
     }

--- a/hivemq-edge/src/test/java/com/hivemq/mqtt/message/pubrel/PUBRELTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/mqtt/message/pubrel/PUBRELTest.java
@@ -20,7 +20,7 @@ import com.hivemq.extensions.packets.pubrel.PubrelPacketImpl;
 import com.hivemq.mqtt.message.mqtt5.Mqtt5UserProperties;
 import com.hivemq.mqtt.message.mqtt5.MqttUserProperty;
 import com.hivemq.mqtt.message.reason.Mqtt5PubRelReasonCode;
-import com.hivemq.util.ObjectMemoryEstimation;
+import com.hivemq.util.MemoryEstimator;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -93,12 +93,12 @@ public class PUBRELTest {
         final int userPropertiesSize =
                 3 * (
                         24 + // overhead
-                                ObjectMemoryEstimation.stringSize("userx") +
-                                ObjectMemoryEstimation.stringSize("valuex")
+                                MemoryEstimator.stringSize("userx") +
+                                MemoryEstimator.stringSize("valuex")
                 );
 
         final String reasonString = "reasonString";
-        final int reasonStringSize = ObjectMemoryEstimation.stringSize(reasonString);
+        final int reasonStringSize = MemoryEstimator.stringSize(reasonString);
 
         final PUBREL pubrel1 = new PUBREL(1);
         final PUBREL pubrel2 = new PUBREL(1, 100L, 100L);
@@ -115,12 +115,12 @@ public class PUBRELTest {
                 100L,
                 100L);
 
-        final int fixedSize = ObjectMemoryEstimation.objectShellSize() +
-                ObjectMemoryEstimation.intSize() + // sizeInMemory
-                ObjectMemoryEstimation.intSize() + // packet id
-                ObjectMemoryEstimation.enumSize() + // reason code
-                ObjectMemoryEstimation.longWrapperSize() + //publish timestamp
-                ObjectMemoryEstimation.longWrapperSize() + //expiry interval
+        final int fixedSize = MemoryEstimator.OBJECT_SHELL_SIZE +
+                MemoryEstimator.INT_SIZE + // sizeInMemory
+                MemoryEstimator.INT_SIZE + // packet id
+                MemoryEstimator.ENUM_OVERHEAD + // reason code
+                MemoryEstimator.LONG_WRAPPER_SIZE + //publish timestamp
+                MemoryEstimator.LONG_WRAPPER_SIZE + //expiry interval
                 24; //user props overhead
 
         final int pubrel3Size = fixedSize + reasonStringSize + userPropertiesSize;

--- a/hivemq-edge/src/test/java/com/hivemq/persistence/local/memory/ClientQueueMemoryLocalPersistenceTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/persistence/local/memory/ClientQueueMemoryLocalPersistenceTest.java
@@ -31,7 +31,7 @@ import com.hivemq.mqtt.message.pubrel.PUBREL;
 import com.hivemq.persistence.local.memory.ClientQueueMemoryLocalPersistence.PublishWithRetained;
 import com.hivemq.persistence.local.xodus.bucket.BucketUtils;
 import com.hivemq.persistence.payload.PublishPayloadPersistence;
-import com.hivemq.util.ObjectMemoryEstimation;
+import com.hivemq.util.MemoryEstimator;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.After;
 import org.junit.Before;
@@ -828,9 +828,9 @@ public class ClientQueueMemoryLocalPersistenceTest {
         persistence.add("client1", false, publish2, 100L, DISCARD, false, 0);
         persistence.add("client1", false, publish3, 100L, DISCARD, false, 0);
 
-        final int size = new PublishWithRetained(publish1, false).getEstimatedSize() + ObjectMemoryEstimation.linkedListNodeOverhead() +
-                new PublishWithRetained(publish2, false).getEstimatedSize() + ObjectMemoryEstimation.linkedListNodeOverhead() +
-                new PublishWithRetained(publish3, false).getEstimatedSize() + ObjectMemoryEstimation.linkedListNodeOverhead();
+        final int size = new PublishWithRetained(publish1, false).getEstimatedSize() + MemoryEstimator.LINKED_LIST_NODE_OVERHEAD +
+                new PublishWithRetained(publish2, false).getEstimatedSize() + MemoryEstimator.LINKED_LIST_NODE_OVERHEAD +
+                new PublishWithRetained(publish3, false).getEstimatedSize() + MemoryEstimator.LINKED_LIST_NODE_OVERHEAD;
 
         assertEquals(size, gauge.getValue().longValue());
 
@@ -843,7 +843,7 @@ public class ClientQueueMemoryLocalPersistenceTest {
         verify(payloadPersistence, times(2)).decrementReferenceCounter(anyLong());
 
         assertTrue(gauge.getValue() > 0);
-        assertEquals(new PublishWithRetained(messages.get(0), false).getEstimatedSize() + ObjectMemoryEstimation.linkedListNodeOverhead(), gauge.getValue().longValue());
+        assertEquals(new PublishWithRetained(messages.get(0), false).getEstimatedSize() + MemoryEstimator.LINKED_LIST_NODE_OVERHEAD, gauge.getValue().longValue());
     }
 
     @Test

--- a/hivemq-edge/src/test/java/com/hivemq/persistence/local/memory/ClientSessionSubscriptionMemoryLocalPersistenceTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/persistence/local/memory/ClientSessionSubscriptionMemoryLocalPersistenceTest.java
@@ -28,7 +28,7 @@ import com.hivemq.mqtt.message.subscribe.Topic;
 import com.hivemq.persistence.IterablePersistenceEntry;
 import com.hivemq.persistence.local.xodus.bucket.BucketUtils;
 import com.hivemq.util.LocalPersistenceFileUtil;
-import com.hivemq.util.ObjectMemoryEstimation;
+import com.hivemq.util.MemoryEstimator;
 import net.jodah.concurrentunit.Waiter;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.Before;
@@ -91,10 +91,10 @@ public class ClientSessionSubscriptionMemoryLocalPersistenceTest {
 
         int size = 0;
         for (final Topic subscription : subscriptions) {
-            size += ObjectMemoryEstimation.objectRefSize();
+            size += MemoryEstimator.OBJECT_REF_SIZE;
             size += subscription.getEstimatedSize();
         }
-        size += ObjectMemoryEstimation.stringSize("clientid");
+        size += MemoryEstimator.stringSize("clientid");
         size += IterablePersistenceEntry.getFixedSize();
 
         assertEquals(size, value.intValue());
@@ -134,10 +134,10 @@ public class ClientSessionSubscriptionMemoryLocalPersistenceTest {
 
         int size = 0;
         for (final Topic subscription : subscriptions) {
-            size += ObjectMemoryEstimation.objectRefSize();
+            size += MemoryEstimator.OBJECT_REF_SIZE;
             size += subscription.getEstimatedSize();
         }
-        size += ObjectMemoryEstimation.stringSize("clientid");
+        size += MemoryEstimator.stringSize("clientid");
         size += IterablePersistenceEntry.getFixedSize();
 
         assertEquals(size, value.intValue());
@@ -463,10 +463,10 @@ public class ClientSessionSubscriptionMemoryLocalPersistenceTest {
 
         int size = 0;
         for (final Topic subscription : subs) {
-            size += ObjectMemoryEstimation.objectRefSize();
+            size += MemoryEstimator.OBJECT_REF_SIZE;
             size += subscription.getEstimatedSize();
         }
-        size += ObjectMemoryEstimation.stringSize("client");
+        size += MemoryEstimator.stringSize("client");
         size += IterablePersistenceEntry.getFixedSize();
 
         assertEquals(size, value.intValue());
@@ -544,10 +544,10 @@ public class ClientSessionSubscriptionMemoryLocalPersistenceTest {
         for (final Map.Entry<String, Set<Topic>> entry : all.entrySet()) {
             assertEquals(2, entry.getValue().size());
             for (final Topic topic : entry.getValue()) {
-                size += ObjectMemoryEstimation.objectRefSize();
+                size += MemoryEstimator.OBJECT_REF_SIZE;
                 size += topic.getEstimatedSize();
             }
-            size += ObjectMemoryEstimation.stringSize(entry.getKey());
+            size += MemoryEstimator.stringSize(entry.getKey());
             size += IterablePersistenceEntry.getFixedSize();
         }
         final Long value = (Long) metricRegistry.getGauges()

--- a/hivemq-edge/src/test/java/com/hivemq/util/MemoryEstimatorTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/util/MemoryEstimatorTest.java
@@ -1,0 +1,39 @@
+package com.hivemq.util;
+
+import com.google.common.primitives.ImmutableIntArray;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class MemoryEstimatorTest {
+
+    @Test
+    public void test_string_size_when_null_argument() {
+        assertEquals(0, MemoryEstimator.stringSize(null));
+    }
+
+    @Test
+    public void test_string_size_when_non_null_argument() {
+        assertEquals(48, MemoryEstimator.stringSize("hello"));
+    }
+
+    @Test
+    public void test_byte_array_size_when_null_argument() {
+        assertEquals(0, MemoryEstimator.byteArraySize(null));
+    }
+
+    @Test
+    public void test_byte_array_size_when_non_null_argument() {
+        assertEquals(16, MemoryEstimator.byteArraySize(new byte[] {0x4f, 0x08, 0x2b, 0x30}));
+    }
+
+    @Test
+    public void test_immutable_int_array_size_when_null_argument() {
+        assertEquals(0, MemoryEstimator.immutableIntArraySize(null));
+    }
+
+    @Test
+    public void test_immutable_int_array_size_when_non_null_argument() {
+        assertEquals(36, MemoryEstimator.immutableIntArraySize(ImmutableIntArray.of(10, 20, 30, 40)));
+    }
+}


### PR DESCRIPTION
**Motivation**
Add improvements for com.hivemq.util.ObjectMemoryEstimation

Resolves #https://github.com/hivemq/hivemq-edge/issues/57

**Changes**
- rename to `MemoryEstimator` (in my opinion it's a more readable name)
- remove method calls that retrieve constant values, [here](https://rules.sonarsource.com/java/RSPEC-3400/) is explained why it's better to use the constant value instead of having a function that returns a constant value
- add unit tests
- add Java doc
