### PR TITLE
60 - add improvements for Strings.convertBytes

### DIFF
--- a/hivemq-edge/src/main/java/com/hivemq/persistence/local/memory/ClientQueueMemoryLocalPersistence.java
+++ b/hivemq-edge/src/main/java/com/hivemq/persistence/local/memory/ClientQueueMemoryLocalPersistence.java
@@ -128,7 +128,7 @@ public class ClientQueueMemoryLocalPersistence implements ClientQueueLocalPersis
         } else {
             maxHardLimit = maxHeap / hardLimitDivisor;
         }
-        log.debug("{} allocated for qos 0 inflight messages", Strings.convertBytes(maxHardLimit));
+        log.debug("{} allocated for qos 0 inflight messages", Strings.toHumanReadableFormat(maxHardLimit));
         return maxHardLimit;
     }
 

--- a/hivemq-edge/src/main/java/com/hivemq/util/Strings.java
+++ b/hivemq-edge/src/main/java/com/hivemq/util/Strings.java
@@ -15,7 +15,6 @@
  */
 package com.hivemq.util;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
 import io.netty.buffer.ByteBuf;
 
@@ -134,8 +133,7 @@ public class Strings {
      * @param bytes the long value to convert
      * @return the human readable converted String
      */
-    @VisibleForTesting
-    public static String convertBytes(final long bytes) {
+    public static String toHumanReadableFormat(final long bytes) {
         final long kbDivisor = 1024L;
         final long mbDivisor = kbDivisor * kbDivisor;
         final long gbDivisor = mbDivisor * kbDivisor;

--- a/hivemq-edge/src/test/java/com/hivemq/util/StringsTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/util/StringsTest.java
@@ -17,6 +17,7 @@ package com.hivemq.util;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
 import org.junit.Before;
@@ -126,5 +127,30 @@ public class StringsTest {
     @Test(expected = NullPointerException.class)
     public void test_create_prefixed_bytes_null_buffer() throws Exception {
         Strings.createPrefixedBytesFromString("string", null);
+    }
+
+    @Test
+    public void test_to_human_readable_B() {
+        assertEquals("1023 B", Strings.toHumanReadableFormat(1023L));
+    }
+
+    @Test
+    public void test_to_human_readable_KB() {
+        assertEquals("1.11 KB", Strings.toHumanReadableFormat(1024L + 110L));
+    }
+
+    @Test
+    public void test_to_human_readable_MB() {
+        assertEquals("1.11 MB", Strings.toHumanReadableFormat(1024L * 1024L + 110 * 1024L));
+    }
+
+    @Test
+    public void test_to_human_readable_GB() {
+        assertEquals("1.11 GB", Strings.toHumanReadableFormat(1024L * 1024L * 1024L + 110 * 1024L * 1024L));
+    }
+
+    @Test
+    public void test_to_human_readable_TB() {
+        assertEquals("1.11 TB", Strings.toHumanReadableFormat(1024L * 1024L * 1024L * 1024L + 110 * 1024L * 1024L * 1024L));
     }
 }


### PR DESCRIPTION
**Motivation**
Method `com.hivemq.util.Strings.convertBytes` has no unit tests.

Resolves #60 

**Changes**
- rename to `toHumanReadableFormat`, I think that it's a more descriptive name
- add unit tests. 

Question. Method `FileUtils.byteCountToDisplaySize` from the commons-io library (already used in the project) does almost the same thing, more details [here](https://www.educative.io/answers/what-is-fileutilsbytecounttodisplaysize-in-java), the exception is that `FileUtils.byteCountToDisplaySize` is less precise (sizes without additional decimal points, e.g. 4 GB).

Should `com.hivemq.util.Strings.convertBytes` be deleted, and `FileUtils.byteCountToDisplaySize` be used instead?
