### PR TITLE
fix(16511) - Ensure pings are NOT sent during a non-tracked runtime

### DIFF
--- a/hivemq-edge/src/main/java/com/hivemq/edge/impl/HiveMQRemoteServiceImpl.java
+++ b/hivemq-edge/src/main/java/com/hivemq/edge/impl/HiveMQRemoteServiceImpl.java
@@ -68,7 +68,8 @@ public class HiveMQRemoteServiceImpl implements HiveMQEdgeRemoteService, HiveMQS
 
     protected final @NotNull HiveMQEdgeHttpServiceImpl initHttpService() {
         return new HiveMQEdgeHttpServiceImpl(systemInformation.getHiveMQVersion(),
-                objectMapper, HiveMQEdgeHttpServiceImpl.SERVICE_DISCOVERY_URL, TIMEOUT, TIMEOUT, REFRESH);
+                objectMapper, HiveMQEdgeHttpServiceImpl.SERVICE_DISCOVERY_URL, TIMEOUT, TIMEOUT, REFRESH,
+                configurationService.usageTrackingConfiguration().isUsageTrackingEnabled());
     }
 
     @Override


### PR DESCRIPTION
Pings are sent directly by the HttpService. This means they were not considering the runtime configuration which was functionally considered in the layer above. We now pass an indication as to whether to start the usage tracking service through the API via contructor - which determines if the tracking engine is started.