### PR TITLE
feat(16490): Enable navigation from an adapter to its workspace node

### DIFF
--- a/hivemq-edge/src/frontend/src/locales/en/translation.json
+++ b/hivemq-edge/src/frontend/src/locales/en/translation.json
@@ -392,6 +392,7 @@
       "actions": {
         "label": "Actions",
         "connect": "Connect",
+        "workspace": "View on workspace",
         "disconnect": "Disconnect",
         "create": "Create similar",
         "edit": "Edit",

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/adapters/AdapterActionMenu.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/adapters/AdapterActionMenu.tsx
@@ -1,5 +1,5 @@
 import { FC } from 'react'
-import { IconButton, Menu, MenuButton, MenuItem, MenuList, Text } from '@chakra-ui/react'
+import { IconButton, Menu, MenuButton, MenuDivider, MenuItem, MenuList, Text } from '@chakra-ui/react'
 import { ChevronDownIcon } from '@chakra-ui/icons'
 import { useTranslation } from 'react-i18next'
 
@@ -10,9 +10,10 @@ interface AdapterActionMenuProps {
   onCreate?: (type: string | undefined) => void
   onEdit?: (id: string, type: string) => void
   onDelete?: (id: string) => void
+  onViewWorkspace?: (id: string, type: string) => void
 }
 
-const AdapterActionMenu: FC<AdapterActionMenuProps> = ({ adapter, onCreate, onEdit, onDelete }) => {
+const AdapterActionMenu: FC<AdapterActionMenuProps> = ({ adapter, onCreate, onEdit, onDelete, onViewWorkspace }) => {
   const { t } = useTranslation()
 
   const { type, id, adapterRuntimeInformation: { connectionStatus } = {} } = adapter
@@ -31,6 +32,10 @@ const AdapterActionMenu: FC<AdapterActionMenuProps> = ({ adapter, onCreate, onEd
             ? t('protocolAdapter.table.actions.connect')
             : t('protocolAdapter.table.actions.disconnect')}
         </MenuItem>
+        <MenuItem data-testid={'adapter-action-workspace'} onClick={() => onViewWorkspace?.(id, type as string)}>
+          {t('protocolAdapter.table.actions.workspace')}
+        </MenuItem>
+        <MenuDivider />
         <MenuItem data-testid={'adapter-action-create'} onClick={() => onCreate?.(type as string)}>
           {t('protocolAdapter.table.actions.create')}
         </MenuItem>

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/panels/ProtocolAdapters.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/panels/ProtocolAdapters.tsx
@@ -1,9 +1,10 @@
 import { FC, useMemo, useState } from 'react'
-import { Box, Flex, HStack, Image, Skeleton, Text, useDisclosure, useTheme } from '@chakra-ui/react'
+import { Box, Flex, HStack, IconButton, Image, Skeleton, Text, useDisclosure, useTheme } from '@chakra-ui/react'
 import { ColumnDef, Row } from '@tanstack/react-table'
 import { useTranslation } from 'react-i18next'
 import { DateTime } from 'luxon'
 import { useLocation, useNavigate } from 'react-router-dom'
+import { FaShareNodes } from 'react-icons/fa6'
 
 import { Adapter, ApiError, ProtocolAdapter } from '@/api/__generated__'
 import { useListProtocolAdapters } from '@/api/hooks/useProtocolAdapters/useListProtocolAdapters.tsx'
@@ -74,6 +75,10 @@ const ProtocolAdapters: FC = () => {
       onConfirmDeleteOpen()
     }
 
+    const handleViewWorkspace = (adapterId: string, type: string) => {
+      if (adapterId) navigate(`/edge-flow`, { state: { selectedAdapter: { adapterId, type } } })
+    }
+
     return [
       {
         accessorKey: 'id',
@@ -108,19 +113,32 @@ const ProtocolAdapters: FC = () => {
         header: t('protocolAdapter.table.header.actions') as string,
         sortingFn: undefined,
         cell: (info) => {
-          // const { type, id, adapterRuntimeInformation: { connectionStatus } = {} } = info.row.original
+          const { id, type } = info.row.original
+          const { selectedAdapter } = state || {}
           return (
-            <AdapterActionMenu
-              adapter={info.row.original}
-              onCreate={handleCreateInstance}
-              onEdit={handleEditInstance}
-              onDelete={handleOnDelete}
-            />
+            <>
+              <AdapterActionMenu
+                adapter={info.row.original}
+                onCreate={handleCreateInstance}
+                onEdit={handleEditInstance}
+                onDelete={handleOnDelete}
+                onViewWorkspace={handleViewWorkspace}
+              />
+              {id === selectedAdapter?.adapterId && (
+                <IconButton
+                  size={'sm'}
+                  ml={2}
+                  onClick={() => handleViewWorkspace(type as string, id)}
+                  aria-label={t('bridge.subscription.delete')}
+                  icon={<FaShareNodes />}
+                />
+              )}
+            </>
           )
         },
       },
     ]
-  }, [navigate, onConfirmDeleteOpen, t, allAdapters?.items])
+  }, [state, navigate, onConfirmDeleteOpen, t, allAdapters?.items])
 
   const handleConfirmOnClose = () => {
     onConfirmDeleteClose()


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/16490/details/

This PR adds CTAs on the action menu, and inline for a highlighted adapter, to allow direct navigation to the relevant node on the workspace graph.

Note that the inline icon is temporary, only to provide immediate feedback to the user when an adapter has been created or edited. UX will need to be validated

### Before 
![screenshot-localhost_3000-2023 09 04-10_56_49](https://github.com/hivemq/hivemq-edge/assets/2743481/573fb5b6-de6c-47a8-bc7e-fbdb5c1099c6)

### After 
![screenshot-localhost_3000-2023 09 04-10_56_02](https://github.com/hivemq/hivemq-edge/assets/2743481/66d4ae43-b131-4f87-a3a3-91c5776c3e55)
