### PR TITLE
fix(16607): fix title of the welcome page

### DIFF
--- a/hivemq-edge/src/frontend/src/locales/en/translation.json
+++ b/hivemq-edge/src/frontend/src/locales/en/translation.json
@@ -78,7 +78,7 @@
     }
   },
   "welcome": {
-    "title": "Welcome to HiveMQ",
+    "title": "Welcome to HiveMQ Edge",
     "description": "Connect from and to any device and send streams of data to your enterprise.",
     "onboarding": {
       "title": "Get data flowing",


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/16607/details/

Replace `HiveMQ` by `HiveMQ Edge`

### Before
![screenshot-localhost_3000-2023 09 06-16_46_33](https://github.com/hivemq/hivemq-edge/assets/2743481/94207aff-815e-417a-8381-29c70d38e0f2)

### After
![screenshot-localhost_3000-2023 09 06-16_46_01](https://github.com/hivemq/hivemq-edge/assets/2743481/5002ffae-fc86-497b-abaa-bd00fb21196c)
