### PR TITLE
fix(16608): add optimistic update of status to the creation of adapters

### DIFF
--- a/hivemq-edge/src/frontend/src/api/hooks/useConnection/useGetAdaptersStatus.tsx
+++ b/hivemq-edge/src/frontend/src/api/hooks/useConnection/useGetAdaptersStatus.tsx
@@ -7,7 +7,7 @@ export const useGetAdaptersStatus = () => {
   const appClient = useHttpClient()
 
   return useQuery(
-    [QUERY_KEYS.PROTOCOLS, 'connection.status'],
+    [QUERY_KEYS.ADAPTERS, QUERY_KEYS.CONNECTION_STATUS],
     async () => {
       const item = await appClient.protocolAdapters.status1()
       return item

--- a/hivemq-edge/src/frontend/src/api/hooks/useConnection/useGetBridgesStatus.tsx
+++ b/hivemq-edge/src/frontend/src/api/hooks/useConnection/useGetBridgesStatus.tsx
@@ -7,7 +7,7 @@ export const useGetBridgesStatus = () => {
   const appClient = useHttpClient()
 
   return useQuery(
-    [QUERY_KEYS.BRIDGES, 'connection.status'],
+    [QUERY_KEYS.BRIDGES, QUERY_KEYS.CONNECTION_STATUS],
     async () => {
       const item = await appClient.bridges.status()
       return item

--- a/hivemq-edge/src/frontend/src/api/hooks/useGetBridges/useGetBridgeConnectionStatus.tsx
+++ b/hivemq-edge/src/frontend/src/api/hooks/useGetBridges/useGetBridgeConnectionStatus.tsx
@@ -11,7 +11,7 @@ export const useGetBridgeConnectionStatus = (name: string | undefined) => {
   const appClient = useHttpClient()
 
   return useQuery(
-    [QUERY_KEYS.BRIDGES, name, 'connection.status'],
+    [QUERY_KEYS.BRIDGES, name, QUERY_KEYS.CONNECTION_STATUS],
     async () => {
       const item = await appClient.bridges.getConnectionStatus(name as string)
       return item

--- a/hivemq-edge/src/frontend/src/api/hooks/useGetBridges/useSetConnectionStatus.tsx
+++ b/hivemq-edge/src/frontend/src/api/hooks/useGetBridges/useSetConnectionStatus.tsx
@@ -19,7 +19,7 @@ export const useSetConnectionStatus = () => {
 
   return useMutation<string, ApiError, SetConnectionStatusProps>(setConnectionStatus, {
     onSuccess: () => {
-      // queryClient.invalidateQueries(['bridges', variables.name, 'connection.status'])
+      // queryClient.invalidateQueries(['bridges', variables.name, QUERY_KEYS.CONNECTION_STATUS])
       queryClient.invalidateQueries([QUERY_KEYS.BRIDGES])
     },
   })

--- a/hivemq-edge/src/frontend/src/api/hooks/useProtocolAdapters/useCreateProtocolAdapter.tsx
+++ b/hivemq-edge/src/frontend/src/api/hooks/useProtocolAdapters/useCreateProtocolAdapter.tsx
@@ -1,5 +1,5 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { Adapter, ApiError } from '../../__generated__'
+import { Adapter, ApiError, ConnectionStatus, ConnectionStatusList } from '../../__generated__'
 
 import { useHttpClient } from '@/api/hooks/useHttpClient/useHttpClient.ts'
 import { QUERY_KEYS } from '@/api/utils.ts'
@@ -18,6 +18,18 @@ export const useCreateProtocolAdapter = () => {
   }
 
   return useMutation<unknown, ApiError, CreateProtocolAdapterProps>(createProtocolAdapter, {
+    onMutate: (a) => {
+      queryClient.setQueryData<ConnectionStatusList>([QUERY_KEYS.ADAPTERS, QUERY_KEYS.CONNECTION_STATUS], (old) => {
+        const optimisticUpdate: ConnectionStatus = {
+          status: ConnectionStatus.status.CONNECTING,
+          id: a.requestBody.id,
+          type: a.requestBody.type,
+        }
+        return {
+          items: [...(old?.items || []), optimisticUpdate],
+        }
+      })
+    },
     onSuccess: () => {
       queryClient.invalidateQueries([QUERY_KEYS.ADAPTERS])
     },


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/166608/details/

An `ERROR` could be seen on the status of a new adapter, because its updated from the pooled Status request which, immediately after sending the create request, doesn't have a record for the new adapter. It gets fixed with the next call of Status

The PR utilises `ReactQuery` optimistic update to add a temporary `CONNECTING` item in the cache for the status. 

The PR also fix the ley for the request, which will also force an update of the `GET adapters` when creating a new one






