### PR TITLE
fix(16528): Allow remote adapters to be surfaced in the catalog

### DIFF
--- a/hivemq-edge/src/frontend/src/api/hooks/useProtocolAdapters/__handlers__/index.ts
+++ b/hivemq-edge/src/frontend/src/api/hooks/useProtocolAdapters/__handlers__/index.ts
@@ -72,6 +72,7 @@ export const mockProtocolAdapter: ProtocolAdapter = {
   logoUrl: 'http://localhost:8080/images/hivemq-icon.png',
   author: 'HiveMQ',
   configSchema: mockJSONSchema,
+  installed: true,
   category: {
     description: 'Industrial, typically field bus protocols.',
     displayName: 'Industrial',

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/IntegrationStore/ProtocolsBrowser.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/IntegrationStore/ProtocolsBrowser.spec.cy.tsx
@@ -112,6 +112,29 @@ describe('ProtocolsBrowser', () => {
     cy.get('@createAdapter').should('have.been.calledWith', 'simulation3')
   })
 
+  it('should render non-installed adapters', () => {
+    const mockOnCreate = cy.stub()
+
+    cy.mountWithProviders(
+      <ProtocolsBrowser
+        items={[
+          ...MOCK_ADAPTERS.slice(0, 2),
+          {
+            ...mockProtocolAdapter,
+            id: 'simulation-soon',
+            name: 'Simulation Server Preview',
+            version: 'Available Soon',
+            installed: undefined,
+          },
+        ]}
+        facet={{ search: undefined }}
+        onCreate={mockOnCreate}
+      />
+    )
+    cy.getByTestId('protocol-name').should('have.length', 3)
+    cy.getByTestId('protocol-create-adapter').should('have.length', 2)
+  })
+
   it('should be accessible', () => {
     cy.injectAxe()
     cy.mountWithProviders(

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/IntegrationStore/ProtocolsBrowser.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/IntegrationStore/ProtocolsBrowser.tsx
@@ -44,15 +44,17 @@ const ProtocolsBrowser: FC<ProtocolsBrowserProps> = ({ items, facet, onCreate })
             <AdapterTypeSummary key={e.id} adapter={e} searchQuery={facet?.search} />
           </CardBody>
           <CardFooter p={2}>
-            <Button
-              data-testid={'protocol-create-adapter'}
-              variant={'outline'}
-              size={'sm'}
-              rightIcon={<ArrowForwardIcon />}
-              onClick={() => onCreate?.(e.id)}
-            >
-              {t('protocolAdapter.action.createInstance')}
-            </Button>
+            {!!e.installed && (
+              <Button
+                data-testid={'protocol-create-adapter'}
+                variant={'outline'}
+                size={'sm'}
+                rightIcon={<ArrowForwardIcon />}
+                onClick={() => onCreate?.(e.id)}
+              >
+                {t('protocolAdapter.action.createInstance')}
+              </Button>
+            )}
           </CardFooter>
         </Card>
       ))}


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/16528/details/

The PR hides the `create` button for adapters that are not yet installed

### out-of-scope
- filter for `installed` / `not installed` will be done in a different ticket
- handling UX (link to installation procedure or release update) will be done in a different ticket 


### After
(no non-installed adapter on my runtime so screenshot of the Cypress test :-) )
![Screenshot 2023-09-06 at 18 19 35](https://github.com/hivemq/hivemq-edge/assets/2743481/fe2ae441-43fc-4877-bfb4-a907b4be13d1)

