### PR TITLE
chore(github): Split frontend pipeline for visual testing

### DIFF
--- a/.github/workflows/frontend-cli.yml
+++ b/.github/workflows/frontend-cli.yml
@@ -39,7 +39,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-      #          cache: 'pnpm'
 
       - name: 📦 Install dependencies
         run: pnpm install
@@ -86,11 +85,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: 📸 Run Percy visual tests
-        run: pnpm cypress:percy
-        ## Percy should not block the pipeline
-        continue-on-error: true
-        env:
-          PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
+        run: echo "Check the Percy tests on the other workflow"
 
       - name: 🚥 Run Lighthouse audits
         uses: treosh/lighthouse-ci-action@v10

--- a/.github/workflows/frontend-visual.yml
+++ b/.github/workflows/frontend-visual.yml
@@ -4,7 +4,6 @@
 name: Frontend - Visual Testing (Percy)
 
 on:
-  push:
   pull_request:
     branches: [master]
     paths:

--- a/.github/workflows/frontend-visual.yml
+++ b/.github/workflows/frontend-visual.yml
@@ -4,6 +4,7 @@
 name: Frontend - Visual Testing (Percy)
 
 on:
+  push:
   pull_request:
     branches: [master]
     paths:
@@ -40,6 +41,19 @@ jobs:
 
       - name: 🏗️ Build Application
         run: pnpm run build
+
+      - name: 🧪 Run Cypress E2E
+        uses: cypress-io/github-action@v5
+        with:
+          working-directory: ./hivemq-edge/src/frontend/
+          start: pnpm dev
+
+      - name: 🧪 Run Cypress Component
+        uses: cypress-io/github-action@v5
+        with:
+          working-directory: ./hivemq-edge/src/frontend/
+          component: true
+          start: pnpm dev
 
       - name: 📸 Run Percy visual tests
         run: pnpm cypress:percy

--- a/.github/workflows/frontend-visual.yml
+++ b/.github/workflows/frontend-visual.yml
@@ -1,0 +1,50 @@
+# This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
+
+name: Frontend - Visual Testing (Percy)
+
+on:
+  push:
+  pull_request:
+    branches: [master]
+    paths:
+      - hivemq-edge/src/frontend/**
+env:
+  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./hivemq-edge/src/frontend/
+    strategy:
+      matrix:
+        node-version: [18.16.0]
+
+    steps:
+      - name: 👓 Checkout repository
+        uses: actions/checkout@v3
+
+      - name: 🚚 Setup pnpm
+        uses: pnpm/action-setup@v2.2.4
+        with:
+          version: 8.4.0
+
+      - name: 🔻 Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: 📦 Install dependencies
+        run: pnpm install
+
+      - name: 🏗️ Build Application
+        run: pnpm run build
+
+      - name: 📸 Run Percy visual tests
+        run: pnpm cypress:percy
+        ## Percy should block the pipeline except if no money left on the plan :-)
+        continue-on-error: true
+        env:
+          PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}

--- a/hivemq-edge/src/frontend/README.md
+++ b/hivemq-edge/src/frontend/README.md
@@ -103,9 +103,12 @@ with the following options:
 
 ## Pipeline
 
-A frontend-specific workflow has been added to the repository, see `.github/workflows/frontend-cli.yml`
+Two frontend-specific workflows have been added to the repository
 
-It contains - and enforces - parts of the testing pyramid for frontend applications:
+- `.github/workflows/frontend-cli.yml` for the main CI/CD pipeline
+- `.github/workflows/frontend-visual.yml` for visual testing (Percy)
+
+Together. they contain - and enforce - parts of the testing pyramid for frontend applications:
 
 - Code quality checks (ESLint, Prettier)
 - Interaction testing (Cypress - Component)

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/hooks/useGetUISchema.ts
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/hooks/useGetUISchema.ts
@@ -14,7 +14,7 @@ const useGetUiSchema = (isNewAdapter = true) => {
     {
       id: 'subFields',
       title: 'Subscription',
-      children: ['subscriptions']
+      children: ['subscriptions'],
     },
     {
       id: 'security',
@@ -24,7 +24,7 @@ const useGetUiSchema = (isNewAdapter = true) => {
     {
       id: 'publishing',
       title: t('protocolAdapter.uiSchema.groups.publishing'),
-      children: ['maxPollingErrorsBeforeRemoval', 'publishChangedDataOnly', 'publishingInterval','destination','qos'],
+      children: ['maxPollingErrorsBeforeRemoval', 'publishChangedDataOnly', 'publishingInterval', 'destination', 'qos'],
     },
     {
       id: 'authentication',
@@ -34,8 +34,15 @@ const useGetUiSchema = (isNewAdapter = true) => {
     {
       id: 'http',
       title: t('protocolAdapter.uiSchema.groups.http'),
-      children: ['httpRequestMethod', 'httpRequestBodyContentType', 'httpRequestBody','httpHeaders', 'httpConnectTimeout', 'httpPublishSuccessStatusCodeOnly'],
-    }
+      children: [
+        'httpRequestMethod',
+        'httpRequestBodyContentType',
+        'httpRequestBody',
+        'httpHeaders',
+        'httpConnectTimeout',
+        'httpPublishSuccessStatusCodeOnly',
+      ],
+    },
   ]
 
   const uiSchema: UiSchema = {
@@ -52,8 +59,8 @@ const useGetUiSchema = (isNewAdapter = true) => {
     port: {
       'ui:widget': 'updown',
     },
-    httpRequestBody : {
-      "ui:widget": "textarea"
+    httpRequestBody: {
+      'ui:widget': 'textarea',
     },
     'ui:order': ['id', 'host', 'port', '*', 'subscriptions'],
     subscriptions: {


### PR DESCRIPTION
The PR splits the frontend workflow into two: 
- `frontend-cli.yml` for the main CI/CD pipeline, running on both commits and PRs
- `frontend-visual.yml` for the Percy visual test, running on PRs only


Note that `Cypress` tests have been replicated on both pipeline, as they seem to bew required 