### PR TITLE
fix(2023.5): Fix double click on node

### DIFF
--- a/hivemq-edge/src/frontend/src/modules/EdgeVisualisation/components/nodes/NodeAdapter.tsx
+++ b/hivemq-edge/src/frontend/src/modules/EdgeVisualisation/components/nodes/NodeAdapter.tsx
@@ -28,8 +28,13 @@ const NodeAdapter: FC<NodeProps<Adapter>> = ({ id, data: adapter, selected }) =>
 
   return (
     <>
-      <NodeWrapper p={2} {...(selected ? { ...selectedStyle } : {})} w={CONFIG_ADAPTER_WIDTH}>
-        <VStack onDoubleClick={() => navigate(`/edge-flow/node/${id}`)}>
+      <NodeWrapper
+        p={2}
+        {...(selected ? { ...selectedStyle } : {})}
+        w={CONFIG_ADAPTER_WIDTH}
+        onDoubleClick={() => navigate(`/edge-flow/node/${id}`)}
+      >
+        <VStack>
           <HStack w={'100%'}>
             <Image aria-label={adapter.type} boxSize="20px" objectFit="scale-down" src={adapterProtocol?.logoUrl} />
             <Text flex={1} data-testid={'adapter-node-name'}>


### PR DESCRIPTION
The PR fixes a bug where a double click on a node doesn't open the observability panel

See  https://www.loom.com/share/6fa4ed35a40948cca811c1902cb981e1?sid=29e86280-8f09-4c90-8f95-4cf1dcd3b963