### PR TITLE
Fix(16649) - Edge started events being missed

### DIFF
--- a/hivemq-edge/src/main/java/com/hivemq/edge/impl/HiveMQRemoteServiceImpl.java
+++ b/hivemq-edge/src/main/java/com/hivemq/edge/impl/HiveMQRemoteServiceImpl.java
@@ -72,12 +72,12 @@ public class HiveMQRemoteServiceImpl implements HiveMQEdgeRemoteService, HiveMQS
 
     protected final void initHttpService() {
         try {
-            HiveMQEdgeEvent event = new HiveMQEdgeEvent(HiveMQEdgeEvent.EVENT_TYPE.EDGE_STARTED);
-            event.addAll(HiveMQEdgeEnvironmentUtils.generateEnvironmentMap());
-            fireUsageEvent(event);
             hiveMQEdgeHttpService = new HiveMQEdgeHttpServiceImpl(systemInformation.getHiveMQVersion(),
                     objectMapper, HiveMQEdgeHttpServiceImpl.SERVICE_DISCOVERY_URL, TIMEOUT, TIMEOUT, REFRESH,
                     true);
+            HiveMQEdgeEvent event = new HiveMQEdgeEvent(HiveMQEdgeEvent.EVENT_TYPE.EDGE_STARTED);
+            event.addAll(HiveMQEdgeEnvironmentUtils.generateEnvironmentMap());
+            fireUsageEvent(event);
         } finally {
             if(logger.isTraceEnabled()){
                 logger.trace("Initialized remote HTTP service(s), usage tracking enabled (this can be disabled in configuration)");


### PR DESCRIPTION
We are missing EDGE started events because the event was fired before initialisation, the order of which was changed in last build. Revert the order to ensure we get started events