### PR TITLE
Feat(92) - Add default run configurations for developer runtime and adapter creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ out/
 /src/website/*
 /website/
 /ext/reporting.sql
+/hivemq-edge/src/distribution/log/event.log
+/hivemq-edge/src/distribution/log/hivemq.log
+/hivemq-edge/src/distribution/log/migration.log

--- a/.idea/runConfigurations/HiveMQ_Edge___Developer.xml
+++ b/.idea/runConfigurations/HiveMQ_Edge___Developer.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="HiveMQ Edge - Developer" type="Application" factoryName="Application" nameIsGenerated="true">
-    <option name="ALTERNATIVE_JRE_PATH" value="11" />
+    <option name="ALTERNATIVE_JRE_PATH" value="BUNDLED" />
     <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
     <envs>
       <env name="HIVEMQ_HOME" value="$USER_HOME$/hivemq-edge-home" />

--- a/.idea/runConfigurations/HiveMQ_Edge___Developer.xml
+++ b/.idea/runConfigurations/HiveMQ_Edge___Developer.xml
@@ -7,7 +7,7 @@
     </envs>
     <option name="MAIN_CLASS_NAME" value="com.hivemq.HiveMQEdgeMain" />
     <module name="com.hivemq.hivemq-edge.main" />
-    <option name="VM_PARAMETERS" value="-Djava.net.preferIPv4Stack=true -Duser.language=en -Duser.region=US -Dhivemq.home=${HOME}/hivemq-edge-home -Dhivemq.edge.workspace.modules=true -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=9010 -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -noverify --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED --add-exports java.base/jdk.internal.misc=ALL-UNNAMED" />
+      <option name="VM_PARAMETERS" value="-Djava.net.preferIPv4Stack=true -Duser.language=en -Duser.region=US -Dhivemq.home=hivemq-edge/src/distribution -Dhivemq.edge.config.xml=developer-config.xml -Dhivemq.edge.workspace.modules=true -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=9010 -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -noverify --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED --add-exports java.base/jdk.internal.misc=ALL-UNNAMED" />
     <extension name="coverage">
       <pattern>
         <option name="PATTERN" value="com.hivemq.*" />

--- a/.idea/runConfigurations/HiveMQ_Edge___Developer.xml
+++ b/.idea/runConfigurations/HiveMQ_Edge___Developer.xml
@@ -1,0 +1,21 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="HiveMQ Edge - Developer" type="Application" factoryName="Application" nameIsGenerated="true">
+    <option name="ALTERNATIVE_JRE_PATH" value="11" />
+    <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
+    <envs>
+      <env name="HIVEMQ_HOME" value="$USER_HOME$/hivemq-edge-home" />
+    </envs>
+    <option name="MAIN_CLASS_NAME" value="com.hivemq.HiveMQEdgeMain" />
+    <module name="com.hivemq.hivemq-edge.main" />
+    <option name="VM_PARAMETERS" value="-Djava.net.preferIPv4Stack=true -Duser.language=en -Duser.region=US -Dhivemq.home=${HOME}/hivemq-edge-home -Dhivemq.edge.workspace.modules=true -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=9010 -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -noverify --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED --add-exports java.base/jdk.internal.misc=ALL-UNNAMED" />
+    <extension name="coverage">
+      <pattern>
+        <option name="PATTERN" value="com.hivemq.*" />
+        <option name="ENABLED" value="true" />
+      </pattern>
+    </extension>
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.idea/runConfigurations/HiveMQ_Edge___New_Adapter.xml
+++ b/.idea/runConfigurations/HiveMQ_Edge___New_Adapter.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="HiveMQ Edge - New Adapter" type="Application" factoryName="Application">
-    <option name="ALTERNATIVE_JRE_PATH" value="11" />
+    <option name="ALTERNATIVE_JRE_PATH" value="BUNDLED" />
     <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
     <option name="MAIN_CLASS_NAME" value="com.hivemq.tools.CreateAdapterBlueprint" />
     <module name="com.hivemq.hivemq-edge.main" />

--- a/.idea/runConfigurations/HiveMQ_Edge___New_Adapter.xml
+++ b/.idea/runConfigurations/HiveMQ_Edge___New_Adapter.xml
@@ -1,0 +1,11 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="HiveMQ Edge - New Adapter" type="Application" factoryName="Application">
+    <option name="ALTERNATIVE_JRE_PATH" value="11" />
+    <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
+    <option name="MAIN_CLASS_NAME" value="com.hivemq.tools.CreateAdapterBlueprint" />
+    <module name="com.hivemq.hivemq-edge.main" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/hivemq-edge/src/distribution/conf/developer-config.xml
+++ b/hivemq-edge/src/distribution/conf/developer-config.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<!--
+
+    Copyright 2023-present HiveMQ GmbH
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    WARNING - This file is for use when running from your development environment ONLY,
+    it should not be used in production.
+-->
+<hivemq xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="developer-config.xsd">
+
+    <mqtt-listeners>
+        <tcp-listener>
+            <port>1883</port>
+            <bind-address>0.0.0.0</bind-address>
+        </tcp-listener>
+    </mqtt-listeners>
+
+</hivemq>

--- a/hivemq-edge/src/main/java/com/hivemq/configuration/ioc/ConfigurationFileProvider.java
+++ b/hivemq-edge/src/main/java/com/hivemq/configuration/ioc/ConfigurationFileProvider.java
@@ -17,6 +17,7 @@ package com.hivemq.configuration.ioc;
 
 import com.hivemq.configuration.info.SystemInformation;
 import com.hivemq.configuration.reader.ConfigurationFile;
+import com.hivemq.edge.HiveMQEdgeConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,15 +31,21 @@ import java.io.File;
 public class ConfigurationFileProvider {
 
     private static final Logger log = LoggerFactory.getLogger(ConfigurationFileProvider.class);
+    private static String DEFAULT_CONFIG_FILENAME = "config.xml";
 
 
     public static ConfigurationFile get(final SystemInformation systemInformation) {
 
         final File configFileFolder = systemInformation.getConfigFolder();
-
         final boolean configFolderOk = checkConfigFolder(configFileFolder);
 
-        final File configFile = new File(configFileFolder, "config.xml");
+        String configFilename = DEFAULT_CONFIG_FILENAME;
+        //-- allow a custom config filename to be used when running in development mode
+        if(System.getProperty(HiveMQEdgeConstants.CONFIG_FILE_NAME) != null){
+            configFilename = System.getProperty(HiveMQEdgeConstants.CONFIG_FILE_NAME);
+        }
+
+        final File configFile = new File(configFileFolder, configFilename);
 
         boolean configFileOk = false;
         if (configFolderOk) {

--- a/hivemq-edge/src/main/java/com/hivemq/edge/HiveMQEdgeConstants.java
+++ b/hivemq-edge/src/main/java/com/hivemq/edge/HiveMQEdgeConstants.java
@@ -22,7 +22,8 @@ public interface HiveMQEdgeConstants {
 
     //TODO this should be build driven for modules but use single constant for now
     String VERSION = "2023.5";
-
+    String DEVELOPMENT_MODE = "hivemq.edge.workspace.modules";
+    String CONFIG_FILE_NAME = "hivemq.edge.config.xml";
     String MUTABLE_CONFIGURAION_ENABLED = "mutable.configuration.enabled";
     String CONFIGURATION_EXPORT_ENABLED = "configuration.export.enabled";
     String VERSION_PROPERTY = "version";
@@ -35,7 +36,6 @@ public interface HiveMQEdgeConstants {
     String NAME_REGEX = "^([a-zA-Z_0-9\\- ])*$";
     int MAX_UINT16 = 65535;
     String MAX_UINT16_String = "65535";
-    String DEVELOPMENT_MODE = "hivemq.edge.workspace.modules";
     String HOSTNAME_REGEX = "^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9])$";
 
     //credits: Regular Expressions Cookbook by Steven Levithan, Jan Goyvaerts


### PR DESCRIPTION
Created 2 new run configuration when running in open-source project mode:

1 - Java configuration for development mode, which bootstraps the modules from your local workspace not export location
 2 - Java configuration for creating a new module (CreateAdapterBlueprint#main)