### PR TITLE
fix(101) - UNS API validation is not aligned with UI and is flawed

### DIFF
--- a/hivemq-edge/src/main/java/com/hivemq/api/model/uns/ISA95ApiBean.java
+++ b/hivemq-edge/src/main/java/com/hivemq/api/model/uns/ISA95ApiBean.java
@@ -39,25 +39,25 @@ public class ISA95ApiBean {
     @JsonProperty("workCell")
     @Schema(name = "workCell",
             description = "The workCell",
-            nullable = true, pattern = "^[a-zA-Z0-9 -_]*")
+            nullable = true, pattern = "^[a-zA-Z0-9 -_]*$")
     private final @Nullable String workCell;
 
     @JsonProperty("productionLine")
     @Schema(name = "productionLine",
             description = "The productionLine",
-            nullable = true, pattern = "^[a-zA-Z0-9 -_]*")
+            nullable = true, pattern = "^[a-zA-Z0-9 -_]*$")
     private final @Nullable String productionLine;
 
     @JsonProperty("area")
     @Schema(name = "area",
             description = "The area",
-            nullable = true, pattern = "^[a-zA-Z0-9 -_]*")
+            nullable = true, pattern = "^[a-zA-Z0-9 -_]*$")
     private final @Nullable String area;
 
     @JsonProperty("site")
     @Schema(name = "site",
             description = "The site",
-            nullable = true, pattern = "^[a-zA-Z0-9 -_]*")
+            nullable = true, pattern = "^[a-zA-Z0-9 -_]*$")
     private final @Nullable String site;
 
     @JsonProperty("enterprise")

--- a/hivemq-edge/src/main/java/com/hivemq/api/resources/impl/UnsResourceImpl.java
+++ b/hivemq-edge/src/main/java/com/hivemq/api/resources/impl/UnsResourceImpl.java
@@ -59,19 +59,19 @@ public class UnsResourceImpl extends AbstractApi implements UnsApi {
 
         //-- Ensure we apply all validation
         ApiErrorUtils.validateRequiredEntity(errorMessages, "isa95", isa95);
-        if(!ApiValidation.validAlphaNumericSpaces(isa95.getEnterprise(), true)){
+        if(!ApiValidation.validAlphaNumericSpacesAndDashes(isa95.getEnterprise(), true)){
             ApiErrorUtils.addValidationError(errorMessages, "enterprise", "Must be a valid alpha-numeric string with spaces");
         }
-        if(!ApiValidation.validAlphaNumericSpaces(isa95.getArea(), true)){
+        if(!ApiValidation.validAlphaNumericSpacesAndDashes(isa95.getArea(), true)){
             ApiErrorUtils.addValidationError(errorMessages, "area", "Must be a valid alpha-numeric string with spaces");
         }
-        if(!ApiValidation.validAlphaNumericSpaces(isa95.getSite(), true)){
+        if(!ApiValidation.validAlphaNumericSpacesAndDashes(isa95.getSite(), true)){
             ApiErrorUtils.addValidationError(errorMessages, "site", "Must be a valid alpha-numeric string with spaces");
         }
-        if(!ApiValidation.validAlphaNumericSpaces(isa95.getProductionLine(), true)){
+        if(!ApiValidation.validAlphaNumericSpacesAndDashes(isa95.getProductionLine(), true)){
             ApiErrorUtils.addValidationError(errorMessages, "productionLine", "Must be a valid alpha-numeric string with spaces");
         }
-        if(!ApiValidation.validAlphaNumericSpaces(isa95.getWorkCell(), true)){
+        if(!ApiValidation.validAlphaNumericSpacesAndDashes(isa95.getWorkCell(), true)){
             ApiErrorUtils.addValidationError(errorMessages, "workCell", "Must be a valid alpha-numeric string with spaces");
         }
 

--- a/hivemq-edge/src/main/java/com/hivemq/api/utils/ApiValidation.java
+++ b/hivemq-edge/src/main/java/com/hivemq/api/utils/ApiValidation.java
@@ -22,25 +22,38 @@ import java.util.regex.Pattern;
  */
 public class ApiValidation {
 
-    static final String ALPHA_NUM = "[A-Za-z0-9]";
-    static final String ALPHA_NUM_SPACES = "[A-Za-z0-9 ]";
+    static final String ALPHA_NUM = "^[A-Za-z0-9]*$";
+    static final String ALPHA_NUM_SPACES = "^[A-Za-z0-9\\s]*$";
+    static final String ALPHA_NUM_SPACES_AND_DASHES = "^[A-Za-z0-9\\s-_]*$";
     static Pattern alphaNumPattern = Pattern.compile(ALPHA_NUM);
     static Pattern alphaNumSpacesPattern = Pattern.compile(ALPHA_NUM_SPACES);
+    static Pattern alphaNumSpacesAndDashesPattern = Pattern.compile(ALPHA_NUM_SPACES_AND_DASHES);
+
+    public static boolean validAlphaNumericSpacesAndDashes(final String value, final boolean allowEmptyOrNull){
+        if(allowEmptyOrNull){
+            if(value == null || "".equals(value)) return true;
+        } else {
+            if(value == null || "".equals(value)) return false;
+        }
+        return alphaNumSpacesAndDashesPattern.matcher(value).matches();
+    }
 
     public static boolean validAlphaNumericSpaces(final String value, final boolean allowEmptyOrNull){
         if(allowEmptyOrNull){
-            if(value == null) return true;
-            if("".equals(value)) return true;
+            if(value == null || "".equals(value)) return true;
+        } else {
+            if(value == null || "".equals(value)) return false;
         }
-        return !alphaNumSpacesPattern.matcher(value).matches();
+        return alphaNumSpacesPattern.matcher(value).matches();
     }
 
     public static boolean validAlphaNumeric(final String value, final boolean allowEmptyOrNull){
         if(allowEmptyOrNull){
-            if(value == null) return true;
-            if("".equals(value)) return true;
+            if(value == null || "".equals(value)) return true;
+        } else {
+            if(value == null || "".equals(value)) return false;
         }
-        return !alphaNumPattern.matcher(value).matches();
+        return alphaNumPattern.matcher(value).matches();
     }
 
 }

--- a/hivemq-edge/src/test/java/com/hivemq/uns/UnsModelTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/uns/UnsModelTest.java
@@ -1,0 +1,125 @@
+package com.hivemq.uns;
+
+import com.hivemq.api.utils.ApiValidation;
+import com.hivemq.edge.HiveMQEdgeConstants;
+import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.regex.Pattern;
+
+/**
+ * @author Simon L Johnson
+ */
+public class UnsModelTest {
+
+    @Test
+    void testApiAlphaNumValidation_empty_null() {
+
+        Assert.assertTrue("Empty string should be allowed when specified",
+                ApiValidation.validAlphaNumericSpaces("", true));
+        Assert.assertFalse("Empty string should NOT be allowed when specified",
+                ApiValidation.validAlphaNumericSpaces("", false));
+
+        Assert.assertTrue("<null> string should be allowed when specified",
+                ApiValidation.validAlphaNumericSpaces(null, true));
+        Assert.assertFalse("<null> string should NOT be allowed when specified",
+                ApiValidation.validAlphaNumericSpaces(null, false));
+    }
+
+    @Test
+    void testApiAlphaNumSpacesValidation() {
+
+        Assert.assertTrue("Valid value (with spaces) should be valid",
+                ApiValidation.validAlphaNumericSpaces("valid value", false));
+
+        Assert.assertTrue("Valid value (without spaces) should be valid",
+                ApiValidation.validAlphaNumericSpaces("validvalue", false));
+
+        Assert.assertTrue("Multi character should be valid",
+                ApiValidation.validAlphaNumericSpaces("vv", false));
+
+        Assert.assertTrue("Multi character with space should be valid",
+                ApiValidation.validAlphaNumericSpaces("v ", false));
+
+        Assert.assertTrue("Single character should be valid",
+                ApiValidation.validAlphaNumericSpaces("v", false));
+
+        Assert.assertFalse("Special char should not be invalid",
+                ApiValidation.validAlphaNumericSpaces("\'", false));
+
+        Assert.assertTrue("Mixed case should be valid",
+                ApiValidation.validAlphaNumericSpaces("aAb", false));
+    }
+
+    @Test
+    void testApiAlphaNumValidation() {
+
+        Assert.assertFalse("Invalid value (with spaces) should be invalid",
+                ApiValidation.validAlphaNumeric("invalid value", false));
+
+        Assert.assertTrue("Valid value (without spaces) should be valid",
+                ApiValidation.validAlphaNumeric("validvalue", false));
+
+        Assert.assertTrue("Multi character should be valid",
+                ApiValidation.validAlphaNumeric("vv", false));
+
+        Assert.assertFalse("Multi character with space should NOT be valid",
+                ApiValidation.validAlphaNumeric("v ", false));
+
+        Assert.assertTrue("Single character should be valid",
+                ApiValidation.validAlphaNumeric("v", false));
+
+        Assert.assertFalse("Special char should not be invalid",
+                ApiValidation.validAlphaNumeric("\'", false));
+
+        Assert.assertTrue("Mixed case should be valid",
+                ApiValidation.validAlphaNumericSpaces("aAb", false));
+    }
+
+    @Test
+    void testApiAlphaNumSpacesAndDashesValidation() {
+
+        Assert.assertTrue("Valid value (with spaces) should be valid",
+                ApiValidation.validAlphaNumericSpacesAndDashes("valid value", false));
+
+        Assert.assertTrue("Valid value (without spaces) should be valid",
+                ApiValidation.validAlphaNumericSpacesAndDashes("validvalue", false));
+
+        Assert.assertTrue("Multi character should be valid",
+                ApiValidation.validAlphaNumericSpacesAndDashes("vv", false));
+
+        Assert.assertTrue("Multi character with space should be valid",
+                ApiValidation.validAlphaNumericSpacesAndDashes("v ", false));
+
+        Assert.assertTrue("Single character should be valid",
+                ApiValidation.validAlphaNumericSpacesAndDashes("v", false));
+
+        Assert.assertFalse("Special char should not be invalid",
+                ApiValidation.validAlphaNumericSpacesAndDashes("\'", false));
+
+        Assert.assertTrue("Mixed case should be valid",
+                ApiValidation.validAlphaNumericSpacesAndDashes("aAb", false));
+
+        Assert.assertTrue("Dashes should be valid",
+                ApiValidation.validAlphaNumericSpacesAndDashes("a-b", false));
+
+        Assert.assertTrue("Leading dashes should be valid",
+                ApiValidation.validAlphaNumericSpacesAndDashes("-ab", false));
+
+        Assert.assertTrue("Trailing dashes should be valid",
+                ApiValidation.validAlphaNumericSpacesAndDashes("ab-", false));
+
+        Assert.assertTrue("Underscores should be valid",
+                ApiValidation.validAlphaNumericSpacesAndDashes("a_b", false));
+
+        Assert.assertTrue("Trailing Underscores should be valid",
+                ApiValidation.validAlphaNumericSpacesAndDashes("a_", false));
+
+        Assert.assertTrue("Leading Underscores should be valid",
+                ApiValidation.validAlphaNumericSpacesAndDashes("_a", false));
+    }
+}


### PR DESCRIPTION
The API validation applied to the ISA 95 bean was flawed and did not provide anchors nor did it allow -_ or single characters. This PR updates regex(s), supplies tests and uses the correct business logic for validation.