### PR TITLE
feat(107): Extraction of topics from generic adapters

### DIFF
--- a/hivemq-edge/src/frontend/src/__test-utils__/adapters/http.ts
+++ b/hivemq-edge/src/frontend/src/__test-utils__/adapters/http.ts
@@ -1,0 +1,152 @@
+import { ProtocolAdapter } from '@/api/__generated__'
+
+export const MOCK_PROTOCOL_HTTP: ProtocolAdapter = {
+  id: 'http',
+  protocol: 'HTTP(s) over TCP',
+  name: 'HTTP(s) to MQTT Protocol Adapter',
+  description:
+    'Connects HiveMQ Edge to arbitrary web endpoint URLs via HTTP(s), consuming structured JSON or plain data.',
+  url: 'https://github.com/hivemq/hivemq-edge/wiki/Protocol-adapters#http',
+  version: 'Development Snapshot (BETA)',
+  logoUrl: 'http://localhost:8080/images/http-icon.png',
+  author: 'HiveMQ',
+  installed: true,
+  // capabilities: ['READ'],
+  category: {
+    name: 'CONNECTIVITY',
+    displayName: 'Connectivity',
+    description: 'A standard connectivity based protocol, typically web standard.',
+  },
+  tags: ['INTERNET', 'TCP', 'WEB'],
+  configSchema: {
+    $schema: 'https://json-schema.org/draft/2020-12/schema',
+    type: 'object',
+    properties: {
+      url: {
+        type: 'string',
+        title: 'URL',
+        description: 'The url of the http request you would like to make',
+        pattern:
+          'https?:\\/\\/(?:w{1,3}\\.)?[^\\s.]+(?:\\.[a-z]+)*(?::\\d+)?((?:\\/\\w+)|(?:-\\w+))*\\/?(?![^<]*(?:<\\/\\w+>|\\/?>))',
+      },
+      destination: {
+        type: 'string',
+        title: 'Destination Topic',
+        description: 'The topic to publish data on',
+        format: 'mqtt-topic',
+      },
+      qos: {
+        type: 'integer',
+        title: 'QoS',
+        description: 'MQTT Quality of Service level',
+        default: 0,
+        minimum: 0,
+        maximum: 2,
+      },
+      httpRequestMethod: {
+        type: 'string',
+        enum: ['GET', 'POST', 'PUT'],
+        title: 'Http Method',
+        description: 'Http method associated with the request',
+        default: 'GET',
+      },
+      httpConnectTimeout: {
+        type: 'integer',
+        title: 'Http Connection Timeout',
+        description: 'Timeout (in second) to apply to the HTTP Request',
+        default: 10,
+      },
+      httpRequestBodyContentType: {
+        type: 'string',
+        enum: ['JSON', 'PLAIN', 'HTML', 'XML', 'YAML'],
+        title: 'Http Request Content Type',
+        description: 'Content Type associated with the request',
+        default: 'JSON',
+      },
+      httpRequestBody: {
+        type: 'string',
+        title: 'Http Request Body',
+        description: 'The body to include in the HTTP request',
+      },
+      httpPublishSuccessStatusCodeOnly: {
+        type: 'boolean',
+        title: 'Only publish data when HTTP response code is successful ( 200 - 299 )',
+        default: true,
+        format: 'boolean',
+      },
+      httpHeaders: {
+        title: 'HTTP Headers',
+        description: 'HTTP headers to be added to your requests',
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            name: {
+              type: 'string',
+              title: 'Http Header Name',
+              description: 'The name of the HTTP header',
+            },
+            value: {
+              type: 'string',
+              title: 'Http Header Value',
+              description: 'The value of the HTTP header',
+            },
+          },
+          title: 'HTTP Headers',
+          description: 'HTTP headers to be added to your requests',
+        },
+      },
+      id: {
+        type: 'string',
+        title: 'Identifier',
+        description: 'Unique identifier for this protocol adapter',
+        minLength: 1,
+        maxLength: 1024,
+        format: 'identifier',
+        pattern: '([a-zA-Z_0-9\\-])*',
+      },
+      publishingInterval: {
+        type: 'integer',
+        title: 'Polling interval [ms]',
+        description: 'Time in millisecond that this URL will be called',
+        default: 1000,
+        minimum: 1,
+      },
+      maxPollingErrorsBeforeRemoval: {
+        type: 'integer',
+        title: 'Max. Polling Errors',
+        description: 'Max. errors polling the endpoint before the polling daemon is stopped',
+        default: 10,
+        minimum: 3,
+      },
+    },
+    required: ['url', 'destination', 'qos', 'httpConnectTimeout', 'id', 'publishingInterval'],
+  },
+}
+
+export const MOCK_ADAPTER_HTTP = {
+  id: '678',
+  type: 'http',
+  config: {
+    url: 'http://s',
+    destination: 'a/valid/topic/http/1',
+    qos: 0,
+    httpRequestMethod: 'GET',
+    httpConnectTimeout: 10,
+    httpRequestBodyContentType: 'JSON',
+    httpPublishSuccessStatusCodeOnly: true,
+    httpHeaders: [],
+    id: '678',
+    publishingInterval: 1000,
+    maxPollingErrorsBeforeRemoval: 10,
+  },
+  adapterRuntimeInformation: {
+    lastStartedAttemptTime: '2023-09-13T09:52:07.554+01',
+    numberOfDaemonProcesses: 1,
+    connectionStatus: {
+      status: 'CONNECTED',
+      id: '678',
+      type: 'adapter',
+    },
+  },
+}

--- a/hivemq-edge/src/frontend/src/__test-utils__/adapters/modbus.ts
+++ b/hivemq-edge/src/frontend/src/__test-utils__/adapters/modbus.ts
@@ -1,0 +1,152 @@
+import { GenericObjectType } from '@rjsf/utils'
+import { ProtocolAdapter } from '@/api/__generated__'
+
+export const MOCK_PROTOCOL_MODBUS: ProtocolAdapter = {
+  id: 'modbus',
+  protocol: 'Modbus TCP',
+  name: 'Modbus to MQTT Protocol Adapter',
+  description: 'Connects HiveMQ Edge to existing Modbus devices, bringing data from coils & registers into MQTT.',
+  url: 'https://github.com/hivemq/hivemq-edge/wiki/Protocol-adapters#modbus-tcp-adapter',
+  version: 'Development Snapshot',
+  logoUrl: 'http://localhost:8080/images/modbus-icon.png',
+  author: 'HiveMQ',
+  installed: true,
+  // capabilities: ['READ', 'DISCOVER'],
+  category: {
+    name: 'INDUSTRIAL',
+    displayName: 'Industrial',
+    description: 'Industrial, typically field bus protocols.',
+  },
+  tags: ['TCP'],
+  configSchema: {
+    $schema: 'https://json-schema.org/draft/2020-12/schema',
+    type: 'object',
+    properties: {
+      host: {
+        type: 'string',
+        title: 'Host',
+        description: 'IP Address or hostname of the device you wish to connect to',
+        format: 'hostname',
+      },
+      id: {
+        type: 'string',
+        title: 'Identifier',
+        description: 'Unique identifier for this protocol adapter',
+        minLength: 1,
+        maxLength: 1024,
+        format: 'identifier',
+        pattern: '([a-zA-Z_0-9\\-])*',
+      },
+      maxPollingErrorsBeforeRemoval: {
+        type: 'integer',
+        title: 'Max. Polling Errors',
+        description: 'Max. errors polling the endpoint before the polling daemon is stopped',
+        default: 10,
+        minimum: 3,
+      },
+      port: {
+        type: 'integer',
+        title: 'Port',
+        description: 'The port number on the device you wish to connect to',
+        minimum: 1,
+        maximum: 65535,
+      },
+      publishChangedDataOnly: {
+        type: 'boolean',
+        title: 'Only publish data items that have changed since last poll',
+        default: true,
+        format: 'boolean',
+      },
+      publishingInterval: {
+        type: 'integer',
+        title: 'Publishing interval [ms]',
+        description: 'Publishing interval in milliseconds for this subscription on the server',
+        default: 1000,
+        minimum: 1,
+      },
+      subscriptions: {
+        title: 'Subscriptions',
+        description: 'Map your sensor data to MQTT Topics',
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            destination: {
+              type: 'string',
+              title: 'Destination Topic',
+              description: 'The topic to publish data on',
+              format: 'mqtt-topic',
+            },
+            'holding-registers': {
+              type: 'object',
+              properties: {
+                startIdx: {
+                  type: 'integer',
+                  title: 'Start Index',
+                  description: 'The Starting Index (Incl.) of the Address Range',
+                  default: 0,
+                  minimum: 0,
+                  maximum: 65535,
+                },
+                endIdx: {
+                  type: 'integer',
+                  title: 'End Index',
+                  description: 'The Finishing Index (Incl.) of the Address Range',
+                  default: 1,
+                  minimum: 1,
+                  maximum: 65535,
+                },
+              },
+              title: 'Holding Registers',
+              description: 'Define the start and end index values for your holding registers',
+            },
+            qos: {
+              type: 'integer',
+              title: 'QoS',
+              description: 'MQTT Quality of Service level',
+              default: 0,
+              minimum: 0,
+              maximum: 2,
+            },
+          },
+          required: ['destination', 'qos'],
+          title: 'Subscriptions',
+          description: 'Map your sensor data to MQTT Topics',
+        },
+      },
+    },
+    required: ['host', 'id', 'port', 'publishingInterval'],
+  },
+}
+
+export const MOCK_ADAPTER_MODBUS: GenericObjectType = {
+  id: 'fg',
+  type: 'modbus',
+  config: {
+    id: 'fg',
+    port: 3,
+    host: 'cvvccvvb.bvc.vb.vb.vb.bvbv',
+    publishingInterval: 1000,
+    maxPollingErrorsBeforeRemoval: 10,
+    publishChangedDataOnly: true,
+    subscriptions: [
+      {
+        destination: 'a/valid/topic/modbus/1',
+        qos: 0,
+        'holding-registers': {
+          startIdx: 0,
+          endIdx: 1,
+        },
+      },
+    ],
+  },
+  adapterRuntimeInformation: {
+    lastStartedAttemptTime: '2023-09-12T11:41:45.534+01',
+    numberOfDaemonProcesses: 0,
+    connectionStatus: {
+      status: 'DISCONNECTED',
+      id: 'fg',
+      type: 'adapter',
+    },
+  },
+}

--- a/hivemq-edge/src/frontend/src/__test-utils__/adapters/opc-ua.ts
+++ b/hivemq-edge/src/frontend/src/__test-utils__/adapters/opc-ua.ts
@@ -1,0 +1,234 @@
+import { GenericObjectType } from '@rjsf/utils'
+import { ProtocolAdapter } from '@/api/__generated__'
+
+export const MOCK_PROTOCOL_OPC_UA: ProtocolAdapter = {
+  id: 'opc-ua-client',
+  protocol: 'OPC-UA Client',
+  name: 'OPC-UA to MQTT Protocol Adapter',
+  description:
+    'Connects HiveMQ Edge to existing OPC-UA services as a client and enables a seamless exchange of data between MQTT and OPC-UA.',
+  url: 'https://github.com/hivemq/hivemq-edge/wiki/Protocol-adapters#opc-ua-adapter',
+  version: 'Development Snapshot',
+  logoUrl: 'http://localhost:8080/images/opc-ua-icon.jpg',
+  author: 'HiveMQ',
+  installed: true,
+  // capabilities: ['READ', 'DISCOVER'],
+  category: {
+    name: 'INDUSTRIAL',
+    displayName: 'Industrial',
+    description: 'Industrial, typically field bus protocols.',
+  },
+  tags: [],
+  configSchema: {
+    $schema: 'https://json-schema.org/draft/2020-12/schema',
+    type: 'object',
+    properties: {
+      auth: {
+        type: 'object',
+        properties: {
+          basic: {
+            type: 'object',
+            properties: {
+              password: {
+                type: 'string',
+                title: 'Password',
+                description: 'Password for basic authentication',
+              },
+              username: {
+                type: 'string',
+                title: 'Username',
+                description: 'Username for basic authentication',
+              },
+            },
+            title: 'Basic Authentication',
+            description: 'Username / password based authentication',
+          },
+          x509: {
+            type: 'object',
+            properties: {
+              enabled: {
+                type: 'boolean',
+              },
+            },
+            title: 'X509 Authentication',
+            description: 'Authentication based on certificate / private key',
+          },
+        },
+      },
+      id: {
+        type: 'string',
+        title: 'Identifier',
+        description: 'Unique identifier for this protocol adapter',
+        minLength: 1,
+        maxLength: 1024,
+        format: 'identifier',
+        pattern: '([a-zA-Z_0-9\\-])*',
+      },
+      security: {
+        type: 'object',
+        properties: {
+          policy: {
+            type: 'string',
+            enum: [
+              'NONE',
+              'BASIC128RSA15',
+              'BASIC256',
+              'BASIC256SHA256',
+              'AES128_SHA256_RSAOAEP',
+              'AES256_SHA256_RSAPSS',
+            ],
+            title: 'OPC UA security policy',
+            description: 'Security policy to use for communication with the server.',
+          },
+        },
+      },
+      subscriptions: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            'message-expiry-interval': {
+              type: 'integer',
+              title: 'MQTT message expiry interval [s]',
+              description: 'Time in seconds until a MQTT message expires',
+              minimum: 1,
+              maximum: 4294967295,
+            },
+            'mqtt-topic': {
+              type: 'string',
+              title: 'Destination MQTT topic',
+              description: 'The MQTT topic to publish to',
+              format: 'mqtt-topic',
+            },
+            node: {
+              type: 'string',
+              title: 'Source Node ID',
+              description: 'identifier of the node on the OPC-UA server. Example: "ns=3;s=85/0:Temperature"',
+            },
+            'publishing-interval': {
+              type: 'integer',
+              title: 'OPC UA publishing interval [ms]',
+              description: 'OPC UA publishing interval in milliseconds for this subscription on the server',
+              default: 1000,
+              minimum: 1,
+            },
+            qos: {
+              type: 'integer',
+              title: 'MQTT QoS',
+              description: 'MQTT quality of service level',
+              default: 0,
+              minimum: 0,
+              maximum: 2,
+            },
+            'server-queue-size': {
+              type: 'integer',
+              title: 'OPC UA server queue size',
+              description: 'OPC UA queue size for this subscription on the server',
+              default: 1,
+              minimum: 1,
+            },
+          },
+          required: ['mqtt-topic', 'node'],
+        },
+      },
+      tls: {
+        type: 'object',
+        properties: {
+          enabled: {
+            type: 'boolean',
+            title: 'Enable TLS',
+            description: 'Enables TLS encrypted connection',
+          },
+          keystore: {
+            type: 'object',
+            properties: {
+              password: {
+                type: 'string',
+                title: 'Keystore password',
+                description: 'Password to open the keystore.',
+              },
+              path: {
+                type: 'string',
+                title: 'Keystore path',
+                description: 'Path on the local file system to the keystore.',
+              },
+              'private-key-password': {
+                type: 'string',
+                title: 'Private key password',
+                description: 'Password to access the private key.',
+              },
+            },
+            title: 'Keystore',
+            description:
+              'Keystore that contains the client certificate including the chain. Required for X509 authentication.',
+          },
+          truststore: {
+            type: 'object',
+            properties: {
+              password: {
+                type: 'string',
+                title: 'Truststore password',
+                description: 'Password to open the truststore.',
+              },
+              path: {
+                type: 'string',
+                title: 'Truststore path',
+                description: 'Path on the local file system to the truststore.',
+              },
+            },
+            title: 'Truststore',
+            description: 'Truststore wich contains the trusted server certificates or trusted intermediates.',
+          },
+        },
+      },
+      uri: {
+        type: 'string',
+        title: 'OPC-UA Server URI',
+        description: 'URI of the OPC-UA server to connect to',
+        format: 'uri',
+      },
+    },
+    required: ['id', 'uri'],
+  },
+}
+
+export const MOCK_ADAPTER_OPC_UA: GenericObjectType = {
+  id: 'dd',
+  type: 'opc-ua-client',
+  config: {
+    id: 'dd',
+    uri: 'h:/ffgf',
+    subscriptions: [
+      {
+        node: 'dd1',
+        'mqtt-topic': 'a/valid/topic/opc-ua-client/1',
+        'publishing-interval': 1000,
+        'server-queue-size': 1,
+        qos: 0,
+      },
+      {
+        node: 'dd2',
+        'mqtt-topic': 'a/valid/topic/opc-ua-client/2',
+        'publishing-interval': 1000,
+        'server-queue-size': 1,
+        qos: 0,
+      },
+    ],
+    auth: {},
+    tls: {
+      enabled: false,
+    },
+    security: {
+      policy: 'NONE',
+    },
+  },
+  adapterRuntimeInformation: {
+    lastStartedAttemptTime: '2023-09-12T11:42:31.411+01',
+    numberOfDaemonProcesses: 0,
+    connectionStatus: {
+      status: 'DISCONNECTED',
+      id: 'dd',
+      type: 'adapter',
+    },
+  },
+}

--- a/hivemq-edge/src/frontend/src/__test-utils__/adapters/simulation.ts
+++ b/hivemq-edge/src/frontend/src/__test-utils__/adapters/simulation.ts
@@ -1,0 +1,96 @@
+import { GenericObjectType } from '@rjsf/utils'
+import { ProtocolAdapter } from '@/api/__generated__'
+
+export const MOCK_PROTOCOL_SIMULATION: ProtocolAdapter = {
+  id: 'simulation',
+  protocol: 'Simulation',
+  name: 'Simulated Edge Device',
+  description: 'Without needing to configure real devices, simulate traffic from an edge device into HiveMQ Edge.',
+  url: 'https://github.com/hivemq/hivemq-edge/wiki/Protocol-adapters#simulation',
+  version: 'Development Snapshot',
+  logoUrl: 'http://localhost:8080/images/hivemq-icon.png',
+  author: 'HiveMQ',
+  installed: true,
+  // capabilities: ['READ'],
+  category: {
+    name: 'SIMULATION',
+    displayName: 'Simulation',
+    description: 'Simulation protocols, that emulate real world devices',
+  },
+  tags: [],
+  configSchema: {
+    $schema: 'https://json-schema.org/draft/2020-12/schema',
+    type: 'object',
+    properties: {
+      id: {
+        type: 'string',
+        title: 'Identifier',
+        description: 'Unique identifier for this protocol adapter',
+        minLength: 1,
+        maxLength: 1024,
+        format: 'identifier',
+        pattern: '([a-zA-Z_0-9\\-])*',
+      },
+      pollingIntervalMillis: {
+        type: 'integer',
+        title: 'Polling interval [ms]',
+        description: 'Interval in milliseconds to poll for changes',
+        default: 10000,
+        minimum: 100,
+        maximum: 86400000,
+      },
+      subscriptions: {
+        title: 'Subscriptions',
+        description: 'List of subscriptions for the simulation',
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            destination: {
+              type: 'string',
+              title: 'Destination Topic',
+              description: 'The topic to publish data on',
+              format: 'mqtt-topic',
+            },
+            qos: {
+              type: 'integer',
+              title: 'QoS',
+              description: 'MQTT Quality of Service level',
+              default: 0,
+              minimum: 0,
+              maximum: 2,
+            },
+          },
+          required: ['destination', 'qos'],
+          title: 'Subscriptions',
+          description: 'List of subscriptions for the simulation',
+        },
+      },
+    },
+    required: ['id', 'subscriptions'],
+  },
+}
+
+export const MOCK_ADAPTER_SIMULATION: GenericObjectType = {
+  id: '345',
+  type: 'simulation',
+  config: {
+    id: '345',
+    pollingIntervalMillis: 10000,
+    subscriptions: [
+      {
+        destination: 'a/valid/topic/simulation/1',
+        qos: 0,
+      },
+    ],
+  },
+  adapterRuntimeInformation: {
+    lastStartedAttemptTime: '2023-09-13T09:45:02.202+01',
+    numberOfDaemonProcesses: 1,
+    connectionStatus: {
+      status: 'CONNECTED',
+      id: '345',
+      type: 'adapter',
+    },
+  },
+}

--- a/hivemq-edge/src/frontend/src/api/types/json-schema.ts
+++ b/hivemq-edge/src/frontend/src/api/types/json-schema.ts
@@ -1,0 +1,3 @@
+export const CustomFormat = {
+  MQTT_TOPIC: 'mqtt-topic',
+}

--- a/hivemq-edge/src/frontend/src/modules/EdgeVisualisation/components/nodes/NodeAdapter.tsx
+++ b/hivemq-edge/src/frontend/src/modules/EdgeVisualisation/components/nodes/NodeAdapter.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react'
+import { FC, useMemo } from 'react'
 import { Handle, NodeProps, Position } from 'reactflow'
 import { Box, HStack, Image, Text, VStack, type BoxProps } from '@chakra-ui/react'
 import { useNavigate } from 'react-router-dom'
@@ -9,16 +9,21 @@ import { ConnectionStatusBadge } from '@/components/ConnectionStatusBadge'
 
 import NodeWrapper from '../parts/NodeWrapper.tsx'
 import TopicsContainer from '../parts/TopicsContainer.tsx'
-import { getAdapterTopics } from '../../utils/topics-utils.ts'
+import { discoverAdapterTopics } from '../../utils/topics-utils.ts'
 import { CONFIG_ADAPTER_WIDTH } from '../../utils/nodes-utils.ts'
 import { useEdgeFlowContext } from '../../hooks/useEdgeFlowContext.tsx'
+import { TopicFilter } from '@/modules/EdgeVisualisation/types.ts'
 
 const NodeAdapter: FC<NodeProps<Adapter>> = ({ id, data: adapter, selected }) => {
   const { data: protocols } = useGetAdapterTypes()
   const adapterProtocol = protocols?.items?.find((e) => e.id === adapter.type)
-  const topics = getAdapterTopics(adapter)
   const { options } = useEdgeFlowContext()
   const navigate = useNavigate()
+  const topics = useMemo<TopicFilter[]>(() => {
+    if (!adapterProtocol) return []
+    if (!adapter.config) return []
+    return discoverAdapterTopics(adapterProtocol, adapter.config).map((e) => ({ topic: e }))
+  }, [adapter.config, adapterProtocol])
 
   const selectedStyle: Partial<BoxProps> = {
     boxShadow: 'dark-lg',

--- a/hivemq-edge/src/frontend/src/modules/EdgeVisualisation/utils/topics-utils.spec.ts
+++ b/hivemq-edge/src/frontend/src/modules/EdgeVisualisation/utils/topics-utils.spec.ts
@@ -1,8 +1,23 @@
 import { expect } from 'vitest'
-import { getAdapterTopics, getBridgeTopics } from '@/modules/EdgeVisualisation/utils/topics-utils.ts'
+import { GenericObjectType, RJSFSchema } from '@rjsf/utils'
+
 import { mockBridge } from '@/api/hooks/useGetBridges/__handlers__'
-import { TopicFilter } from '@/modules/EdgeVisualisation/types.ts'
 import { mockAdapter } from '@/api/hooks/useProtocolAdapters/__handlers__'
+import { TopicFilter } from '@/modules/EdgeVisualisation/types.ts'
+
+import { MOCK_PROTOCOL_MODBUS, MOCK_ADAPTER_MODBUS } from '@/__test-utils__/adapters/modbus.ts'
+import { MOCK_PROTOCOL_SIMULATION, MOCK_ADAPTER_SIMULATION } from '@/__test-utils__/adapters/simulation.ts'
+import { MOCK_PROTOCOL_OPC_UA, MOCK_ADAPTER_OPC_UA } from '@/__test-utils__/adapters/opc-ua.ts'
+import { MOCK_PROTOCOL_HTTP, MOCK_ADAPTER_HTTP } from '@/__test-utils__/adapters/http.ts'
+
+import {
+  discoverAdapterTopics,
+  flattenObject,
+  getAdapterTopics,
+  getBridgeTopics,
+  getTopicPaths,
+} from './topics-utils.ts'
+import { ProtocolAdapter } from '@/api/__generated__'
 
 describe('getBridgeTopics', () => {
   it('should extract topics from a Bridge', async () => {
@@ -40,4 +55,97 @@ describe('getAdapterTopics', () => {
 
     expect(actual).toStrictEqual(expected)
   })
+})
+
+interface Suite {
+  protocol: NonNullable<ProtocolAdapter>
+  formData?: GenericObjectType
+  expectedPath: string[]
+  expectedTopics: string[]
+}
+
+const validationSuite: Suite[] = [
+  {
+    protocol: MOCK_PROTOCOL_MODBUS,
+    formData: MOCK_ADAPTER_MODBUS,
+    expectedPath: ['subscriptions.*.destination'],
+    expectedTopics: ['a/valid/topic/modbus/1'],
+  },
+  {
+    protocol: MOCK_PROTOCOL_SIMULATION,
+    formData: MOCK_ADAPTER_SIMULATION,
+    expectedPath: ['subscriptions.*.destination'],
+    expectedTopics: ['a/valid/topic/simulation/1'],
+  },
+  {
+    protocol: MOCK_PROTOCOL_OPC_UA,
+    formData: MOCK_ADAPTER_OPC_UA,
+    expectedPath: ['subscriptions.*.mqtt-topic'],
+    expectedTopics: ['a/valid/topic/opc-ua-client/1', 'a/valid/topic/opc-ua-client/2'],
+  },
+  {
+    protocol: MOCK_PROTOCOL_HTTP,
+    formData: MOCK_ADAPTER_HTTP,
+    expectedPath: ['destination'],
+    expectedTopics: ['a/valid/topic/http/1'],
+  },
+
+  {
+    protocol: {
+      ...MOCK_PROTOCOL_HTTP,
+      id: 'http-without-subscription',
+      configSchema: {
+        ...MOCK_PROTOCOL_HTTP.configSchema,
+        properties: {
+          ...MOCK_PROTOCOL_HTTP.configSchema?.properties,
+          destination: {
+            ...MOCK_PROTOCOL_HTTP.configSchema?.properties.destination,
+            format: 'something else',
+          },
+        },
+      },
+    },
+    expectedPath: [],
+    expectedTopics: [],
+  },
+  {
+    protocol: {},
+    expectedPath: [],
+    expectedTopics: [],
+  },
+]
+
+describe('flattenObject', () => {
+  it('should work', () => {
+    expect(flattenObject({})).toStrictEqual({})
+    expect(flattenObject({ a: 1 })).toStrictEqual({
+      a: 1,
+    })
+    expect(flattenObject({ a: 1, b: { c: 1 } })).toStrictEqual({
+      a: 1,
+      'b.c': 1,
+    })
+    expect(flattenObject({ a: 1, b: { c: 1, d: undefined, 'long-one': 1, 'with.dangerous-token': 1 } })).toStrictEqual({
+      a: 1,
+      'b.c': 1,
+      'b.d': undefined,
+      'b.long-one': 1,
+      'b.with.dangerous-token': 1,
+    })
+  })
+})
+
+describe('discoverAdapterTopics', () => {
+  it.each<Suite>(validationSuite)(
+    `should return $expectedTopics.length with $protocol.id`,
+    ({ protocol, formData, expectedPath, expectedTopics }) => {
+      const paths = getTopicPaths(protocol?.configSchema as RJSFSchema)
+
+      expect(paths).toEqual(expectedPath)
+
+      if (!formData) return
+
+      expect(discoverAdapterTopics(protocol, formData?.config)).toEqual(expectedTopics)
+    }
+  )
 })

--- a/hivemq-edge/src/frontend/src/modules/EdgeVisualisation/utils/topics-utils.ts
+++ b/hivemq-edge/src/frontend/src/modules/EdgeVisualisation/utils/topics-utils.ts
@@ -4,6 +4,7 @@ import { GenericObjectType, RJSFSchema } from '@rjsf/utils'
 import { OpcUaClient } from '@/api/__generated__/adapters/opc-ua-client'
 import { Modbus } from '@/api/__generated__/adapters/modbus'
 import { Simulation } from '@/api/__generated__/adapters/simulation'
+import { CustomFormat } from '@/api/types/json-schema.ts'
 
 import { TopicFilter } from '../types.ts'
 
@@ -64,7 +65,7 @@ export const getTopicPaths = (configSchema: RJSFSchema) => {
   return (
     Object.entries(flattenSchema)
       // Only interested in topics, internally defined by the string format `format: 'mqtt-topic'`
-      .filter(([k, v]) => k.endsWith('format') && v === 'mqtt-topic')
+      .filter(([k, v]) => k.endsWith('format') && v === CustomFormat.MQTT_TOPIC)
       .map(([path]) =>
         path
           // The root of the path will always be "properties" [?]


### PR DESCRIPTION
Fixes https://github.com/hivemq/hivemq-edge/issues/107

This PR implements routines for identifying and extracting topics from any adapters, regardless of its internals (i.e. `JSONSchema`).

The process is based on the fact that, for all the known adapters, topics are clearly identified by a custom `format` for the property. 

This is true regardless of the name and location of the `JSONSchema` property holding this information, 

The routine is based on three simple steps:
- flatten the `JSONSchema` into a list of path-defined properties
- clean the paths to isolate `mqtt-topic` and multiple items 
- recursively traverse the form data associated with the active adapter to isolate the value of the `mqtt-topic` properties

When applied to the Workspace configuration, it eliminates the need for hardcoded types or external knowledge of the adapters, since it is in fact internally exposed. 


### Before
![screenshot-localhost_3000-2023 09 14-22_10_59](https://github.com/hivemq/hivemq-edge/assets/2743481/f655c68e-f7ee-42e1-9ad3-29d3510405c6)

### After
![screenshot-localhost_3000-2023 09 14-22_10_03](https://github.com/hivemq/hivemq-edge/assets/2743481/f328b62f-d519-4f49-a024-915bb5f6ea8a)
