### PR TITLE
fix(125): Change namespace CTA label

### DIFF
--- a/hivemq-edge/src/frontend/src/locales/en/translation.json
+++ b/hivemq-edge/src/frontend/src/locales/en/translation.json
@@ -473,7 +473,7 @@
     "description": "Set your unified namespace architecture.",
     "standard": "ISA-95",
     "action": {
-      "define": "Set up a unified namespace"
+      "define": "Modify the unified namespace"
     },
     "error": {
       "loading": "We cannot load your namespace for the time being. Please try again later"


### PR DESCRIPTION
Fixes #125


Change the text for the namespace CTA to remove ambiguity of "setting up" 