### PR TITLE
fix(123): Change the text and colour of the stateless status badge

### DIFF
--- a/hivemq-edge/src/frontend/src/locales/en/translation.json
+++ b/hivemq-edge/src/frontend/src/locales/en/translation.json
@@ -21,7 +21,7 @@
       "status_STARTED": "On",
       "status_CONNECTED": "Connected",
       "status_DISCONNECTED": "Disconnected",
-      "status_STATELESS": "Stateless",
+      "status_STATELESS": "Running",
       "status_UNKNOWN": "Unknown",
       "status_ERROR": "Error"
     }

--- a/hivemq-edge/src/frontend/src/modules/Theme/themeHiveMQ.ts
+++ b/hivemq-edge/src/frontend/src/modules/Theme/themeHiveMQ.ts
@@ -74,7 +74,7 @@ export const themeHiveMQ = extendTheme({
       error: baseTheme.colors.red,
       connected: baseTheme.colors.green,
       disconnected: baseTheme.colors.orange,
-      stateless: baseTheme.colors.gray,
+      stateless: baseTheme.colors.green,
     },
     // Based on 20-scale palette. One in two, omitting #fff
     brand: {


### PR DESCRIPTION
See #123

The PR change the visual aspect ofthe `STATELESS` status (for adapters) so that their "ok" status is in line with the others:
- showing `Running` instead of `Stateless`
- badge in green as with the `connected` status of other adapter

The internal status flow remains the same

### Before

![screenshot-localhost_3000-2023 09 29-11_31_39](https://github.com/hivemq/hivemq-edge/assets/2743481/50b3fe92-df25-4a2c-8d46-6f3a5f162c9e)

![screenshot-localhost_3000-2023 09 29-11_31_21](https://github.com/hivemq/hivemq-edge/assets/2743481/167c98fb-9e97-4f86-b462-cdcf643bc442)

### After

![screenshot-localhost_3000-2023 09 29-11_30_51](https://github.com/hivemq/hivemq-edge/assets/2743481/7ee9421b-8609-4324-aec3-f6f71c704bb7)

![screenshot-localhost_3000-2023 09 29-11_31_01](https://github.com/hivemq/hivemq-edge/assets/2743481/5852e414-84b4-4360-86ba-880df0931eab)
