### PR TITLE
fix(119): change icon for bridge and adapter navigation menu

### DIFF
--- a/hivemq-edge/src/frontend/src/api/hooks/useFrontendServices/__handlers__/index.ts
+++ b/hivemq-edge/src/frontend/src/api/hooks/useFrontendServices/__handlers__/index.ts
@@ -103,7 +103,7 @@ export const mockGatewayConfiguration: GatewayConfiguration = {
 }
 
 export const handlers = [
-  rest.get('*/frontend/configuration', (_, res, ctx) => {
+  rest.get('**/frontend/configuration', (_, res, ctx) => {
     return res(ctx.json<GatewayConfiguration>(mockGatewayConfiguration), ctx.status(200))
   }),
 ]

--- a/hivemq-edge/src/frontend/src/modules/Dashboard/components/SidePanel.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Dashboard/components/SidePanel.tsx
@@ -14,7 +14,7 @@ import useGetNavItems from '../hooks/useGetNavItems.tsx'
 
 const SidePanel: FC = () => {
   const { data: configuration } = useGetConfiguration()
-  const items = useGetNavItems()
+  const { data: items } = useGetNavItems()
   const auth = useAuth()
   const navigate = useNavigate()
   const { t } = useTranslation()

--- a/hivemq-edge/src/frontend/src/modules/Dashboard/hooks/useGetNavItems.spec.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Dashboard/hooks/useGetNavItems.spec.tsx
@@ -1,0 +1,41 @@
+import { expect, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClientProvider } from '@tanstack/react-query'
+
+import { MemoryRouter } from 'react-router-dom'
+
+import { server } from '@/__test-utils__/msw/mockServer.ts'
+import queryClient from '@/api/queryClient.ts'
+import { handlers } from '@/api/hooks/useFrontendServices/__handlers__'
+import { AuthProvider } from '@/modules/Auth/AuthProvider.tsx'
+
+import '@/config/i18n.config.ts'
+
+import useGetNavItems from './useGetNavItems.tsx'
+
+const wrapper: React.JSXElementConstructor<{ children: React.ReactElement }> = ({ children }) => (
+  <QueryClientProvider client={queryClient}>
+    <AuthProvider>
+      <MemoryRouter>{children}</MemoryRouter>
+    </AuthProvider>
+  </QueryClientProvider>
+)
+
+describe('useSpringClient', () => {
+  beforeEach(() => {
+    server.resetHandlers()
+  })
+
+  it('should retrieve all the menu items', async () => {
+    server.use(...handlers)
+    server.printHandlers()
+    const { result } = renderHook(useGetNavItems, { wrapper })
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBeTruthy()
+    })
+
+    expect(result.current.data.map((e) => e.title)).toStrictEqual(['HiveMQ Edge', 'Extensions', 'External resources'])
+    expect(result.current.data[0].items).toHaveLength(5)
+  })
+})

--- a/hivemq-edge/src/frontend/src/modules/Dashboard/hooks/useGetNavItems.spec.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Dashboard/hooks/useGetNavItems.spec.tsx
@@ -28,7 +28,6 @@ describe('useSpringClient', () => {
 
   it('should retrieve all the menu items', async () => {
     server.use(...handlers)
-    server.printHandlers()
     const { result } = renderHook(useGetNavItems, { wrapper })
 
     await waitFor(() => {
@@ -37,5 +36,10 @@ describe('useSpringClient', () => {
 
     expect(result.current.data.map((e) => e.title)).toStrictEqual(['HiveMQ Edge', 'Extensions', 'External resources'])
     expect(result.current.data[0].items).toHaveLength(5)
+    expect(result.current.data[2].items.map((e) => e.href)).toStrictEqual([
+      'https://www.hivemq.com/articles/power-of-iot-data-management-in-smart-manufacturing/',
+      'https://github.com/hivemq/hivemq-edge',
+      'https://github.com/hivemq/hivemq-edge/wiki',
+    ])
   })
 })

--- a/hivemq-edge/src/frontend/src/modules/Dashboard/hooks/useGetNavItems.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Dashboard/hooks/useGetNavItems.tsx
@@ -15,9 +15,9 @@ import config from '@/config'
 
 import { NavLinksBlockType } from '../types.ts'
 
-const useGetNavItems = (): NavLinksBlockType[] => {
+const useGetNavItems = (): { data: NavLinksBlockType[]; isSuccess: boolean } => {
   const { t } = useTranslation()
-  const { data } = useGetConfiguration()
+  const { data, isSuccess } = useGetConfiguration()
 
   const workspaceLink = config.features.WORKSPACE_FLOW_PANEL
     ? [
@@ -29,7 +29,7 @@ const useGetNavItems = (): NavLinksBlockType[] => {
       ]
     : []
 
-  return [
+  const menu = [
     {
       title: t('translation:navigation.gateway.title'),
       items: [
@@ -98,6 +98,8 @@ const useGetNavItems = (): NavLinksBlockType[] => {
       ],
     },
   ]
+
+  return { data: menu, isSuccess }
 }
 
 export default useGetNavItems

--- a/hivemq-edge/src/frontend/src/modules/Dashboard/hooks/useGetNavItems.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Dashboard/hooks/useGetNavItems.tsx
@@ -1,14 +1,17 @@
 import { useTranslation } from 'react-i18next'
-import { IoHomeOutline, IoLinkOutline } from 'react-icons/io5'
+import { Icon } from '@chakra-ui/react'
+
+import { IoHomeOutline } from 'react-icons/io5'
+import { PiBridgeThin, PiPlugsConnectedFill } from 'react-icons/pi'
 import { BiListUl } from 'react-icons/bi'
 import { BsIntersect } from 'react-icons/bs'
 import { HiOutlinePuzzle } from 'react-icons/hi'
 import { GoLinkExternal } from 'react-icons/go'
 
 import { useGetConfiguration } from '@/api/hooks/useFrontendServices/useGetConfiguration.tsx'
+import WorkspaceIcon from '@/components/Icons/WorkspaceIcon.tsx'
 
 import config from '@/config'
-import WorkspaceIcon from '@/components/Icons/WorkspaceIcon.tsx'
 
 import { NavLinksBlockType } from '../types.ts'
 
@@ -37,12 +40,12 @@ const useGetNavItems = (): NavLinksBlockType[] => {
         },
         ...workspaceLink,
         {
-          icon: <IoLinkOutline />,
+          icon: <Icon as={PiBridgeThin} fontSize={'20px'} />,
           href: '/mqtt-bridges',
           label: t('translation:navigation.gateway.routes.bridges') as string,
         },
         {
-          icon: <IoLinkOutline />,
+          icon: <PiPlugsConnectedFill />,
           href: '/protocol-adapters',
           label: t('translation:navigation.gateway.routes.protocolAdapters') as string,
         },


### PR DESCRIPTION
See #119

Simple swap of icons. tests added

### Before 
![screenshot-localhost_3000-2023 10 05-11_22_01](https://github.com/hivemq/hivemq-edge/assets/2743481/e5baa364-3915-475a-ae4a-6467f90550fe)

### After
![screenshot-localhost_3000-2023 10 05-11_21_37](https://github.com/hivemq/hivemq-edge/assets/2743481/fe8b9a2a-f77b-47e1-b6ee-66fe98fce1f5)

