### PR TITLE
fix(123): fix status rendering on links in workspace

### DIFF
--- a/hivemq-edge/src/frontend/package.json
+++ b/hivemq-edge/src/frontend/package.json
@@ -46,6 +46,7 @@
     "@types/d3-hierarchy": "^3.1.3",
     "axios": "^1.4.0",
     "chakra-react-select": "^4.7.2",
+    "csstype": "^3.1.2",
     "d3-array": "^3.2.4",
     "d3-hierarchy": "^3.1.2",
     "form-data": "^4.0.0",

--- a/hivemq-edge/src/frontend/pnpm-lock.yaml
+++ b/hivemq-edge/src/frontend/pnpm-lock.yaml
@@ -64,6 +64,9 @@ dependencies:
   chakra-react-select:
     specifier: ^4.7.2
     version: 4.7.2(@chakra-ui/form-control@2.0.18)(@chakra-ui/icon@3.0.16)(@chakra-ui/layout@2.2.0)(@chakra-ui/media-query@3.2.12)(@chakra-ui/menu@2.1.15)(@chakra-ui/spinner@2.0.13)(@chakra-ui/system@2.5.8)(@emotion/react@11.11.1)(@types/react@18.0.28)(react-dom@18.2.0)(react@18.2.0)
+  csstype:
+    specifier: ^3.1.2
+    version: 3.1.2
   d3-array:
     specifier: ^3.2.4
     version: 3.2.4

--- a/hivemq-edge/src/frontend/src/__test-utils__/react-flow/utils.ts
+++ b/hivemq-edge/src/frontend/src/__test-utils__/react-flow/utils.ts
@@ -22,6 +22,9 @@ export const MOCK_THEME: Partial<WithCSSVar<Dict>> = {
       error: {
         500: '#E53E3E',
       },
+      stateless: {
+        500: '#38A169',
+      },
     },
   },
 }

--- a/hivemq-edge/src/frontend/src/modules/EdgeVisualisation/utils/nodes-utils.ts
+++ b/hivemq-edge/src/frontend/src/modules/EdgeVisualisation/utils/nodes-utils.ts
@@ -35,7 +35,10 @@ export const createBridgeNode = (
   positionStorage?: Record<string, XYPosition>
 ) => {
   const idBridge = `${IdStubs.BRIDGE_NODE}@${bridge.id}`
-  const isConnected = bridge.status?.connection === Status.connection.CONNECTED
+  const isConnected =
+    bridge.status?.connection === Status.connection.CONNECTED ||
+    (bridge.status?.runtime === Status.runtime.STARTED && bridge.status?.connection === Status.connection.STATELESS)
+
   const { local, remote } = getBridgeTopics(bridge)
 
   const nodeBridge: Node<Bridge, NodeTypes.BRIDGE_NODE> = {
@@ -145,7 +148,9 @@ export const createAdapterNode = (
   positionStorage?: Record<string, XYPosition>
 ) => {
   const idAdapter = `${IdStubs.ADAPTER_NODE}@${adapter.id}`
-  const isConnected = adapter.status?.connection === Status.connection.CONNECTED
+  const isConnected =
+    adapter.status?.connection === Status.connection.CONNECTED ||
+    (adapter.status?.runtime === Status.runtime.STARTED && adapter.status?.connection === Status.connection.STATELESS)
   const topics = discoverAdapterTopics(type, adapter.config as GenericObjectType)
 
   const posX = nbAdapter % MAX_ADAPTERS
@@ -163,6 +168,7 @@ export const createAdapterNode = (
     },
   }
 
+  console.log('XXXXXXX idAdapter', adapter.status)
   const edgeConnector: Edge = {
     id: `${IdStubs.CONNECTOR}-${IdStubs.EDGE_NODE}-${idAdapter}`,
     target: IdStubs.EDGE_NODE,

--- a/hivemq-edge/src/frontend/src/modules/EdgeVisualisation/utils/nodes-utils.ts
+++ b/hivemq-edge/src/frontend/src/modules/EdgeVisualisation/utils/nodes-utils.ts
@@ -7,6 +7,7 @@ import { Adapter, Bridge, Status, Listener, ProtocolAdapter } from '@/api/__gene
 
 import { EdgeTypes, IdStubs, NodeTypes } from '../types.ts'
 import { getBridgeTopics, discoverAdapterTopics } from '../utils/topics-utils.ts'
+import { getThemeForStatus } from '@/modules/EdgeVisualisation/utils/status-utils.ts'
 
 export const CONFIG_ADAPTER_WIDTH = 245
 
@@ -58,12 +59,12 @@ export const createBridgeNode = (
       type: MarkerType.ArrowClosed,
       width: 20,
       height: 20,
-      color: isConnected ? theme.colors.status.connected[500] : theme.colors.status.disconnected[500],
+      color: getThemeForStatus(theme, bridge.status),
     },
     animated: isConnected && !!remote.length,
     style: {
       strokeWidth: isConnected ? 1.5 : 0.5,
-      stroke: isConnected ? theme.colors.status.connected[500] : theme.colors.status.disconnected[500],
+      stroke: getThemeForStatus(theme, bridge.status),
     },
   }
 
@@ -89,12 +90,12 @@ export const createBridgeNode = (
       type: MarkerType.ArrowClosed,
       width: 20,
       height: 20,
-      color: isConnected ? theme.colors.status.connected[500] : theme.colors.status.disconnected[500],
+      color: getThemeForStatus(theme, bridge.status),
     },
     animated: isConnected && !!local.length,
     style: {
       strokeWidth: isConnected ? 1.5 : 0.5,
-      stroke: isConnected ? theme.colors.status.connected[500] : theme.colors.status.disconnected[500],
+      stroke: getThemeForStatus(theme, bridge.status),
     },
   }
 
@@ -172,12 +173,12 @@ export const createAdapterNode = (
       type: MarkerType.ArrowClosed,
       width: 20,
       height: 20,
-      color: isConnected ? theme.colors.status.connected[500] : theme.colors.status.disconnected[500],
+      color: getThemeForStatus(theme, adapter.status),
     },
     animated: isConnected && !!topics.length,
     style: {
       strokeWidth: isConnected ? 1.5 : 0.5,
-      stroke: isConnected ? theme.colors.status.connected[500] : theme.colors.status.disconnected[500],
+      stroke: getThemeForStatus(theme, adapter.status),
     },
   }
 

--- a/hivemq-edge/src/frontend/src/modules/EdgeVisualisation/utils/status-utils.ts
+++ b/hivemq-edge/src/frontend/src/modules/EdgeVisualisation/utils/status-utils.ts
@@ -1,6 +1,14 @@
 import { Node } from 'reactflow'
+import { WithCSSVar } from '@chakra-ui/react'
+import { Dict } from '@chakra-ui/utils'
+
 import { Adapter, Bridge, Status } from '@/api/__generated__'
 import { NodeTypes } from '@/modules/EdgeVisualisation/types.ts'
+
+export const getThemeForStatus = (theme: Partial<WithCSSVar<Dict>>, status: Status | undefined) => {
+  const isConnected = status?.connection === Status.connection.CONNECTED
+  return isConnected ? theme.colors.status.connected[500] : theme.colors.status.disconnected[500]
+}
 
 export const updateNodeStatus = (currentNodes: Node[], updates: Status[]) => {
   return currentNodes.map((n): Node<Bridge> => {

--- a/hivemq-edge/src/frontend/src/modules/EdgeVisualisation/utils/status-utils.ts
+++ b/hivemq-edge/src/frontend/src/modules/EdgeVisualisation/utils/status-utils.ts
@@ -13,11 +13,12 @@ import { NodeTypes } from '@/modules/EdgeVisualisation/types.ts'
  * @see ConnectionStatusBadge
  */
 export const getThemeForStatus = (theme: Partial<WithCSSVar<Dict>>, status: Status | undefined) => {
+  if (status?.runtime === Status.runtime.STOPPED) return theme.colors.status.error[500]
+
   if (status?.connection === Status.connection.CONNECTED) return theme.colors.status.connected[500]
   if (status?.connection === Status.connection.DISCONNECTED) return theme.colors.status.disconnected[500]
   if (status?.connection === Status.connection.STATELESS) return theme.colors.status.stateless[500]
 
-  // if (status?.runtime === Status.runtime.STOPPED) return theme.colors.status.error[500]
   // if (status?.connection === Status.connection.ERROR) return theme.colors.status.error[500]
   // if (status?.connection === Status.connection.UNKNOWN) return theme.colors.status.error[500]
   return theme.colors.status.error[500]

--- a/hivemq-edge/src/frontend/src/modules/EdgeVisualisation/utils/status-utils.ts
+++ b/hivemq-edge/src/frontend/src/modules/EdgeVisualisation/utils/status-utils.ts
@@ -5,9 +5,22 @@ import { Dict } from '@chakra-ui/utils'
 import { Adapter, Bridge, Status } from '@/api/__generated__'
 import { NodeTypes } from '@/modules/EdgeVisualisation/types.ts'
 
+/**
+ * @param theme
+ * @param status
+ *
+ * TODO[NVL] Unify the styling with ConnectionStatusBadge
+ * @see ConnectionStatusBadge
+ */
 export const getThemeForStatus = (theme: Partial<WithCSSVar<Dict>>, status: Status | undefined) => {
-  const isConnected = status?.connection === Status.connection.CONNECTED
-  return isConnected ? theme.colors.status.connected[500] : theme.colors.status.disconnected[500]
+  if (status?.connection === Status.connection.CONNECTED) return theme.colors.status.connected[500]
+  if (status?.connection === Status.connection.DISCONNECTED) return theme.colors.status.disconnected[500]
+  if (status?.connection === Status.connection.STATELESS) return theme.colors.status.stateless[500]
+
+  // if (status?.runtime === Status.runtime.STOPPED) return theme.colors.status.error[500]
+  // if (status?.connection === Status.connection.ERROR) return theme.colors.status.error[500]
+  // if (status?.connection === Status.connection.UNKNOWN) return theme.colors.status.error[500]
+  return theme.colors.status.error[500]
 }
 
 export const updateNodeStatus = (currentNodes: Node[], updates: Status[]) => {


### PR DESCRIPTION
See #123

This PR adds the proper handling of the "connection" status to the workspace following the changes made in the overall start/restart and status of the "devices" in a previous ticket.

The rendering of the links should match the colour of the status badge. As before, an animated link is rendered when there are topics defined and when the "device" is connected (status is `connected` or `stateless` and runtime `on`)

### Before
![screenshot-localhost_3000-2023 10 12-15_01_13](https://github.com/hivemq/hivemq-edge/assets/2743481/da7606d6-d9b6-42c1-a238-a3b74b4bf33e)

### After
![screenshot-localhost_3000-2023 10 12-15_00_50](https://github.com/hivemq/hivemq-edge/assets/2743481/6859b507-c994-4315-ab2c-866da3deb0f8)
