### PR TITLE
fix(64) added option "updateEndpoint" to OpcUaClient

### DIFF
--- a/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/OpcUaAdapterConfig.java
+++ b/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/OpcUaAdapterConfig.java
@@ -34,6 +34,13 @@ public class OpcUaAdapterConfig extends AbstractProtocolAdapterConfig {
                        required = true)
     private @NotNull String uri;
 
+    @JsonProperty("updateEndpoint")
+    @ModuleConfigField(title = "Update Endpoint",
+                       description = "Updates endpoint with hostname and port from given URI.",
+                       format = ModuleConfigField.FieldType.BOOLEAN,
+                       required = false)
+    private @NotNull Boolean updateEndpoint = true;    
+
     @JsonProperty("subscriptions")
     private @NotNull List<Subscription> subscriptions = new ArrayList<>();
 
@@ -45,13 +52,6 @@ public class OpcUaAdapterConfig extends AbstractProtocolAdapterConfig {
 
     @JsonProperty("security")
     private @NotNull Security security = new Security(SecPolicy.DEFAULT);
-
-    @JsonProperty("updateEndpoint")
-    @ModuleConfigField(title = "Update Endpoint",
-                       description = "Updates endpoint with hostname and port from given URI.",
-                       format = ModuleConfigField.FieldType.BOOLEAN,
-                       required = false)
-    private @NotNull Boolean updateEndpoint = true;
 
     public OpcUaAdapterConfig() {
     }

--- a/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/OpcUaAdapterConfig.java
+++ b/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/OpcUaAdapterConfig.java
@@ -46,6 +46,13 @@ public class OpcUaAdapterConfig extends AbstractProtocolAdapterConfig {
     @JsonProperty("security")
     private @NotNull Security security = new Security(SecPolicy.DEFAULT);
 
+    @JsonProperty("updateEndpoint")
+    @ModuleConfigField(title = "Update Endpoint",
+                       description = "Updates endpoint with hostname and port from given URI.",
+                       format = ModuleConfigField.FieldType.BOOLEAN,
+                       required = false)
+    private @NotNull Boolean updateEndpoint = true;
+
     public OpcUaAdapterConfig() {
     }
 
@@ -94,6 +101,10 @@ public class OpcUaAdapterConfig extends AbstractProtocolAdapterConfig {
     public void setSecurity(final @NotNull Security security) {
         this.security = security;
     }
+
+    public @NotNull Boolean getUpdateEndpoint() { return updateEndpoint; }
+
+    public void setUpdateEndpoint(final @NotNull Boolean updateEndpoint) { this.updateEndpoint = updateEndpoint; }
 
     @Override
     public @NotNull String toString() {

--- a/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/client/OpcUaEndpointFilter.java
+++ b/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/client/OpcUaEndpointFilter.java
@@ -71,8 +71,8 @@ public class OpcUaEndpointFilter implements Function<List<EndpointDescription>, 
     }
 
     private EndpointDescription endpointUpdater(EndpointDescription endpoint) {
-        if (true) { // TODO: make this configurable
-            String[] parts = configPolicyUri.split("://|:|/");
+        if (adapterConfig.getUpdateEndpoint()) {
+            String[] parts = adapterConfig.getUri().split("://|:|/");
             if (parts.length == 1) {
                 return EndpointUtil.updateUrl(endpoint, parts[1]);
             } else if (parts.length > 1) {

--- a/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/client/OpcUaEndpointFilter.java
+++ b/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/client/OpcUaEndpointFilter.java
@@ -19,6 +19,7 @@ import com.hivemq.edge.adapters.opcua.OpcUaAdapterConfig;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
 import org.eclipse.milo.opcua.stack.core.security.SecurityPolicy;
 import org.eclipse.milo.opcua.stack.core.types.structured.EndpointDescription;
+import org.eclipse.milo.opcua.stack.core.util.EndpointUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -66,7 +67,22 @@ public class OpcUaEndpointFilter implements Function<List<EndpointDescription>, 
                 return 1;
             }
             return -1 * Integer.compare(policy1.getPriority(), policy2.getPriority());
-        });
+        }).map(endpointDescription -> endpointUpdater(endpointDescription));
+    }
+
+    private EndpointDescription endpointUpdater(EndpointDescription endpoint) {
+        if (true) { // TODO: make this configurable
+            String[] parts = configPolicyUri.split("://|:|/");
+            if (parts.length == 1) {
+                return EndpointUtil.updateUrl(endpoint, parts[1]);
+            } else if (parts.length > 1) {
+                return EndpointUtil.updateUrl(endpoint, parts[1], Integer.parseInt(parts[2]));
+            } else {
+                return endpoint;
+            }
+        } else {
+            return endpoint;
+        }
     }
 
     private boolean isKeystoreAvailable() {


### PR DESCRIPTION
**Motivation**
It can happen quiet often that a OPC UA server returns a (by the client) not resolvable hostname and/or port.

Resolves #64

**Changes**
Added option "UpdateEndpoint" to the OpcUaClient. It will update the URI from the server with the configured hostname and port. It's optionally in the configuration page of the OpcUaClient connection.  