### PR TITLE
Add github dependency submission Job

### DIFF
--- a/.github/workflows/gradle-dependency-submission.yml
+++ b/.github/workflows/gradle-dependency-submission.yml
@@ -1,0 +1,39 @@
+name: Gradle Dependency Submission
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  build:
+    name: Dependencies
+    runs-on: ubuntu-latest
+    permissions: # The Dependency Submission API requires write permission
+      contents: write
+    steps:
+      - name: Checkout Gradle Build Cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+            !~/.gradle/wrapper/dists/**/gradle*.zip
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
+          restore-keys: |
+            gradle-${{ runner.os }}-
+      - name: 'Checkout Repository'
+        uses: actions/checkout@v3
+      - name: Run snapshot action
+        uses: mikepenz/gradle-dependency-submission@main
+        with:
+          gradle-project-path: "."
+          gradle-build-module: |-
+            :hivemq-edge
+            :hivemq-edge:hivemq-edge-frontend
+            :hivemq-edge-module-plc4x
+            :hivemq-edge-module-http
+            :hivemq-edge-module-modbus
+            :hivemq-edge-module-opcua
+          sub-module-mode: 'IGNORE'
+          include-build-environment: true
+


### PR DESCRIPTION
**Motivation**

According to GitHub [documentation](https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/using-the-dependency-submission-api#about-the-dependency-submission-api), we can use the REST Submission API to submit dependencies for a project. All submitted dependencies will receive Dependabot alerts and Dependabot security updates for any known vulnerabilities.

This task could be accomplished through a [pre-made](https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/using-the-dependency-submission-api#using-pre-made-actions) GitHub action.

https://github.com/marketplace/actions/gradle-dependency-submission
