### PR TITLE
Renamed datagov-classes to something more meaningful

### DIFF
--- a/hivemq-edge/src/main/java/com/hivemq/bootstrap/ioc/Injector.java
+++ b/hivemq-edge/src/main/java/com/hivemq/bootstrap/ioc/Injector.java
@@ -25,7 +25,7 @@ import com.hivemq.common.shutdown.ShutdownHooks;
 import com.hivemq.configuration.info.SystemInformation;
 import com.hivemq.configuration.ioc.ConfigurationModule;
 import com.hivemq.configuration.service.ConfigurationService;
-import com.hivemq.context.ioc.HiveMQModule;
+import com.hivemq.context.ioc.HiveMQEdgeModule;
 import com.hivemq.edge.modules.ModuleLoader;
 import com.hivemq.edge.modules.api.adapters.ModuleServices;
 import com.hivemq.edge.modules.ioc.ModulesModule;
@@ -63,7 +63,7 @@ import java.util.Set;
         ApiModule.class,
         ModulesModule.class,
         UnsServiceModule.class,
-        HiveMQModule.class,
+        HiveMQEdgeModule.class,
         RemoteServiceModule.class})
 @Singleton
 public interface Injector {

--- a/hivemq-edge/src/main/java/com/hivemq/bootstrap/ioc/Injector.java
+++ b/hivemq-edge/src/main/java/com/hivemq/bootstrap/ioc/Injector.java
@@ -25,7 +25,7 @@ import com.hivemq.common.shutdown.ShutdownHooks;
 import com.hivemq.configuration.info.SystemInformation;
 import com.hivemq.configuration.ioc.ConfigurationModule;
 import com.hivemq.configuration.service.ConfigurationService;
-import com.hivemq.datagov.ioc.DataGovernanceModule;
+import com.hivemq.context.ioc.HiveMQModule;
 import com.hivemq.edge.modules.ModuleLoader;
 import com.hivemq.edge.modules.api.adapters.ModuleServices;
 import com.hivemq.edge.modules.ioc.ModulesModule;
@@ -63,7 +63,7 @@ import java.util.Set;
         ApiModule.class,
         ModulesModule.class,
         UnsServiceModule.class,
-        DataGovernanceModule.class,
+        HiveMQModule.class,
         RemoteServiceModule.class})
 @Singleton
 public interface Injector {

--- a/hivemq-edge/src/main/java/com/hivemq/context/HiveMQEdgeContext.java
+++ b/hivemq-edge/src/main/java/com/hivemq/context/HiveMQEdgeContext.java
@@ -13,20 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.hivemq.datagov;
+package com.hivemq.context;
 
-import com.hivemq.datagov.model.DataGovernanceData;
-import com.hivemq.datagov.model.DataGovernanceResult;
-import com.hivemq.datagov.provider.DataGovernanceTokenProvider;
+import com.hivemq.context.model.Data;
+import com.hivemq.context.model.Result;
+import com.hivemq.context.provider.TokenProvider;
 
 import java.util.concurrent.ExecutorService;
 
-public interface DataGovernanceContext {
+public interface HiveMQEdgeContext {
 
-    DataGovernanceData getInput();
-    DataGovernanceResult getResult();
-    DataGovernanceTokenProvider getTokenProvider();
-    void setResult(DataGovernanceResult result);
+    Data getInput();
+    Result getResult();
+    TokenProvider getTokenProvider();
+    void setResult(Result result);
 
     ExecutorService getExecutorService();
     void setExecutorService(ExecutorService executorService);

--- a/hivemq-edge/src/main/java/com/hivemq/context/HiveMQEdgeException.java
+++ b/hivemq-edge/src/main/java/com/hivemq/context/HiveMQEdgeException.java
@@ -13,18 +13,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.hivemq.datagov.model;
-
-import com.hivemq.extension.sdk.api.annotations.NotNull;
-import com.hivemq.mqtt.message.publish.PUBLISH;
+package com.hivemq.context;
 
 /**
  * @author Simon L Johnson
  */
-public interface DataGovernanceData {
+public class HiveMQEdgeException extends Exception {
+    public HiveMQEdgeException() {
+    }
 
-    @NotNull String getClientId();
+    public HiveMQEdgeException(final String message) {
+        super(message);
+    }
 
-    @NotNull PUBLISH getPublish();
-    void setPublish(PUBLISH publish);
+    public HiveMQEdgeException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+
+    public HiveMQEdgeException(final Throwable cause) {
+        super(cause);
+    }
 }

--- a/hivemq-edge/src/main/java/com/hivemq/context/HiveMQEdgeService.java
+++ b/hivemq-edge/src/main/java/com/hivemq/context/HiveMQEdgeService.java
@@ -13,18 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.hivemq.datagov;
+package com.hivemq.context;
 
 import com.google.common.util.concurrent.ListenableFuture;
-import com.hivemq.datagov.model.DataGovernanceResult;
+import com.hivemq.context.model.Result;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
 import com.hivemq.mqtt.handler.publish.PublishReturnCode;
 
-public interface DataGovernanceService {
+public interface HiveMQEdgeService {
 
-    @NotNull ListenableFuture<DataGovernanceResult> apply(@NotNull DataGovernanceContext governanceContext);
+    @NotNull ListenableFuture<Result> apply(@NotNull HiveMQEdgeContext hiveMQEdgeContext);
 
-    @NotNull ListenableFuture<PublishReturnCode> applyAndPublish(@NotNull DataGovernanceContext governanceContext);
+    @NotNull ListenableFuture<PublishReturnCode> applyAndPublish(@NotNull HiveMQEdgeContext hiveMQEdgeContext);
 
 }
 

--- a/hivemq-edge/src/main/java/com/hivemq/context/impl/ContextImpl.java
+++ b/hivemq-edge/src/main/java/com/hivemq/context/impl/ContextImpl.java
@@ -13,12 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.hivemq.datagov.impl;
+package com.hivemq.context.impl;
 
-import com.hivemq.datagov.DataGovernanceContext;
-import com.hivemq.datagov.model.DataGovernanceData;
-import com.hivemq.datagov.model.DataGovernanceResult;
-import com.hivemq.datagov.provider.DataGovernanceTokenProvider;
+import com.hivemq.context.HiveMQEdgeContext;
+import com.hivemq.context.model.Data;
+import com.hivemq.context.model.Result;
+import com.hivemq.context.provider.TokenProvider;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
 import com.hivemq.extension.sdk.api.annotations.Nullable;
 
@@ -29,41 +29,41 @@ import java.util.concurrent.ExecutorService;
 /**
  * @author Simon L Johnson
  */
-public class DataGovernanceContextImpl implements DataGovernanceContext {
+public class ContextImpl implements HiveMQEdgeContext {
 
     private final @NotNull Map<String, String> tokenReplacements;
-    private final @NotNull DataGovernanceData input;
-    private @NotNull DataGovernanceResult result;
+    private final @NotNull Data input;
+    private @NotNull Result result;
     private @NotNull ExecutorService executorService;
 
-    public DataGovernanceContextImpl(final @NotNull DataGovernanceData input) {
+    public ContextImpl(final @NotNull Data input) {
         this.input = input;
         this.tokenReplacements = Collections.emptyMap();
     }
 
-    public DataGovernanceContextImpl(final @NotNull DataGovernanceData input,
-                                     final @NotNull Map<String, String> tokenReplacements) {
+    public ContextImpl(final @NotNull Data input,
+                       final @NotNull Map<String, String> tokenReplacements) {
         this.input = input;
         this.tokenReplacements = tokenReplacements;
     }
 
     @Override
-    public @NotNull DataGovernanceData getInput() {
+    public @NotNull Data getInput() {
         return input;
     }
 
     @Override
-    public @Nullable DataGovernanceResult getResult() {
+    public @Nullable Result getResult() {
         return result;
     }
 
     @Override
-    public void setResult(final @NotNull DataGovernanceResult result) {
+    public void setResult(final @NotNull Result result) {
         this.result = result;
     }
 
     @Override
-    public DataGovernanceTokenProvider getTokenProvider() {
+    public TokenProvider getTokenProvider() {
         return context -> tokenReplacements;
     }
 

--- a/hivemq-edge/src/main/java/com/hivemq/context/impl/UnifiedNamespacePolicy.java
+++ b/hivemq-edge/src/main/java/com/hivemq/context/impl/UnifiedNamespacePolicy.java
@@ -13,15 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.hivemq.datagov.impl;
+package com.hivemq.context.impl;
 
 import com.google.common.collect.ImmutableMap;
 import com.hivemq.client.mqtt.datatypes.MqttTopic;
 import com.hivemq.common.topic.TopicFilterProcessor;
-import com.hivemq.datagov.DataGovernanceContext;
-import com.hivemq.datagov.model.DataGovernanceData;
-import com.hivemq.datagov.model.DataGovernancePolicy;
-import com.hivemq.datagov.model.impl.DataGovernancePolicyImpl;
+import com.hivemq.context.HiveMQEdgeContext;
+import com.hivemq.context.model.Data;
+import com.hivemq.context.model.Policy;
+import com.hivemq.context.model.impl.PolicyImpl;
 import com.hivemq.mqtt.message.publish.PUBLISHFactory;
 import com.hivemq.uns.UnifiedNamespaceService;
 import com.hivemq.uns.config.ISA95;
@@ -32,7 +32,7 @@ import java.util.Map;
 /**
  * @author Simon L Johnson
  */
-public class UnifiedNamespaceDataGovernancePolicy extends DataGovernancePolicyImpl implements DataGovernancePolicy {
+public class UnifiedNamespacePolicy extends PolicyImpl implements Policy {
 
     static final String ID = "unified.namespace.policy";
     static final String NAME = "Unified Namespace Policy";
@@ -40,13 +40,13 @@ public class UnifiedNamespaceDataGovernancePolicy extends DataGovernancePolicyIm
     private final UnifiedNamespaceService unifiedNamespaceService;
 
     @Inject
-    public UnifiedNamespaceDataGovernancePolicy(
+    public UnifiedNamespacePolicy(
             final UnifiedNamespaceService unifiedNamespaceService) {
         super(ID, NAME);
         this.unifiedNamespaceService = unifiedNamespaceService;
     }
 
-    public void execute(final DataGovernanceContext context, final DataGovernanceData input){
+    public void execute(final HiveMQEdgeContext context, final Data input){
 
         ImmutableMap.Builder builder = ImmutableMap.<String, String>builder();
         Map<String, String> tokens = context.getTokenProvider().getTokenReplacements(context);

--- a/hivemq-edge/src/main/java/com/hivemq/context/ioc/HiveMQEdgeModule.java
+++ b/hivemq-edge/src/main/java/com/hivemq/context/ioc/HiveMQEdgeModule.java
@@ -28,7 +28,7 @@ import dagger.Provides;
 import javax.inject.Singleton;
 
 @dagger.Module
-public abstract class HiveMQModule {
+public abstract class HiveMQEdgeModule {
 
     @Binds
     abstract @NotNull HiveMQEdgeService dataGovernanceService(@NotNull ServiceImpl dataGovernanceService);

--- a/hivemq-edge/src/main/java/com/hivemq/context/ioc/HiveMQModule.java
+++ b/hivemq-edge/src/main/java/com/hivemq/context/ioc/HiveMQModule.java
@@ -13,26 +13,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.hivemq.datagov.ioc;
+package com.hivemq.context.ioc;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
-import com.hivemq.datagov.DataGovernanceService;
-import com.hivemq.datagov.impl.DataGovernanceServiceImpl;
+import com.hivemq.context.HiveMQEdgeService;
+import com.hivemq.context.impl.ServiceImpl;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
 import dagger.Binds;
-import dagger.Module;
 import dagger.Provides;
 
 import javax.inject.Singleton;
 
-@Module
-public abstract class DataGovernanceModule {
+@dagger.Module
+public abstract class HiveMQModule {
 
     @Binds
-    abstract @NotNull DataGovernanceService dataGovernanceService(@NotNull DataGovernanceServiceImpl dataGovernanceService);
+    abstract @NotNull HiveMQEdgeService dataGovernanceService(@NotNull ServiceImpl dataGovernanceService);
 
 //    @Binds
 //    abstract @NotNull DataGovernancePolicyProvider dataGovernancePolicyProvider(@NotNull DataGovernancePolicyProviderImpl dataGovernanceService);

--- a/hivemq-edge/src/main/java/com/hivemq/context/model/Data.java
+++ b/hivemq-edge/src/main/java/com/hivemq/context/model/Data.java
@@ -13,19 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.hivemq.datagov.model;
+package com.hivemq.context.model;
 
 import com.hivemq.extension.sdk.api.annotations.NotNull;
+import com.hivemq.mqtt.message.publish.PUBLISH;
 
 /**
  * @author Simon L Johnson
  */
-public interface DataGovernanceEntity {
+public interface Data {
 
-    @NotNull String getId();
+    @NotNull String getClientId();
 
-    @NotNull String getName();
-
-    @NotNull boolean isEnabled();
-
+    @NotNull PUBLISH getPublish();
+    void setPublish(PUBLISH publish);
 }

--- a/hivemq-edge/src/main/java/com/hivemq/context/model/Entity.java
+++ b/hivemq-edge/src/main/java/com/hivemq/context/model/Entity.java
@@ -13,19 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.hivemq.datagov.provider;
+package com.hivemq.context.model;
 
-import com.hivemq.datagov.DataGovernanceContext;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
-
-import java.util.Map;
 
 /**
  * @author Simon L Johnson
  */
-public interface DataGovernanceTokenProvider {
+public interface Entity {
 
-    @NotNull Map<String, String> getTokenReplacements(@NotNull final DataGovernanceContext context);
+    @NotNull String getId();
 
+    @NotNull String getName();
+
+    @NotNull boolean isEnabled();
 
 }

--- a/hivemq-edge/src/main/java/com/hivemq/context/model/Error.java
+++ b/hivemq-edge/src/main/java/com/hivemq/context/model/Error.java
@@ -13,22 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.hivemq.datagov.model.impl;
+package com.hivemq.context.model;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.hivemq.datagov.model.DataGovernancePolicy;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
+
+import java.util.Optional;
 
 /**
  * @author Simon L Johnson
  */
-public abstract class DataGovernancePolicyImpl extends AbstractDataGovernanceEntity implements DataGovernancePolicy {
+public interface Error {
 
-    @JsonCreator
-    public DataGovernancePolicyImpl(@JsonProperty("id") final @NotNull String id,
-                                    @JsonProperty("name") final @NotNull String name) {
-        super(id, name);
-    }
+    @NotNull Optional<Throwable> getError();
+
+    @NotNull Optional<String> getPipelineId();
+
+    @NotNull Optional<String> getFunctionId();
+
+    @NotNull Optional<String> getMessage();
 
 }

--- a/hivemq-edge/src/main/java/com/hivemq/context/model/Policy.java
+++ b/hivemq-edge/src/main/java/com/hivemq/context/model/Policy.java
@@ -13,23 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.hivemq.datagov.model;
+package com.hivemq.context.model;
 
-import com.hivemq.extension.sdk.api.annotations.NotNull;
-
-import java.util.Optional;
+import com.hivemq.context.HiveMQEdgeContext;
 
 /**
  * @author Simon L Johnson
  */
-public interface DataGovernanceError {
 
-    @NotNull Optional<Throwable> getError();
 
-    @NotNull Optional<String> getPipelineId();
+public interface Policy extends Entity {
 
-    @NotNull Optional<String> getFunctionId();
-
-    @NotNull Optional<String> getMessage();
-
+    void execute(final HiveMQEdgeContext context, final Data input);
 }

--- a/hivemq-edge/src/main/java/com/hivemq/context/model/Result.java
+++ b/hivemq-edge/src/main/java/com/hivemq/context/model/Result.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.hivemq.datagov.model;
+package com.hivemq.context.model;
 
 import com.hivemq.extension.sdk.api.annotations.NotNull;
 
@@ -23,7 +23,7 @@ import java.util.Optional;
 /**
  * @author Simon L Johnson
  */
-public interface DataGovernanceResult {
+public interface Result {
 
     enum STATUS {
         SUCCESS(false),
@@ -44,13 +44,13 @@ public interface DataGovernanceResult {
     }
 
     @NotNull STATUS getStatus();
-    @NotNull List<DataGovernanceError> getErrors();
+    @NotNull List<Error> getErrors();
 
     Optional<String> getMessage();
-    DataGovernanceData getOutput();
+    Data getOutput();
 
     void setStatus(@NotNull STATUS status);
-    void addError(@NotNull DataGovernanceError error, boolean fatal);
+    void addError(@NotNull Error error, boolean fatal);
     void setMessage(@NotNull String message);
     boolean hasErrors();
 

--- a/hivemq-edge/src/main/java/com/hivemq/context/model/impl/AbstractEntity.java
+++ b/hivemq-edge/src/main/java/com/hivemq/context/model/impl/AbstractEntity.java
@@ -13,10 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.hivemq.datagov.model.impl;
+package com.hivemq.context.model.impl;
 
 import com.google.common.base.Preconditions;
-import com.hivemq.datagov.model.DataGovernanceEntity;
+import com.hivemq.context.model.Entity;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
 
 import java.util.Objects;
@@ -24,21 +24,21 @@ import java.util.Objects;
 /**
  * @author Simon L Johnson
  */
-public abstract class AbstractDataGovernanceEntity implements DataGovernanceEntity {
+public abstract class AbstractEntity implements Entity {
 
     private @NotNull final String id;
     private @NotNull final String name;
     private boolean enabled = true;
     private boolean mutable = false;
 
-    public AbstractDataGovernanceEntity(final @NotNull String id, final @NotNull String name) {
+    public AbstractEntity(final @NotNull String id, final @NotNull String name) {
         Preconditions.checkNotNull(id, "Id Must Exist On Policy Object");
         Preconditions.checkNotNull(name, "Name Must Exist On Policy Object");
         this.id = id;
         this.name = name;
     }
 
-    public AbstractDataGovernanceEntity(final @NotNull String id) {
+    public AbstractEntity(final @NotNull String id) {
         this(id, id);
     }
 
@@ -72,7 +72,7 @@ public abstract class AbstractDataGovernanceEntity implements DataGovernanceEnti
     public boolean equals(final Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        AbstractDataGovernanceEntity that = (AbstractDataGovernanceEntity) o;
+        AbstractEntity that = (AbstractEntity) o;
         return Objects.equals(id, that.id);
     }
 

--- a/hivemq-edge/src/main/java/com/hivemq/context/model/impl/DataImpl.java
+++ b/hivemq-edge/src/main/java/com/hivemq/context/model/impl/DataImpl.java
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.hivemq.datagov.model.impl;
+package com.hivemq.context.model.impl;
 
-import com.hivemq.datagov.model.DataGovernanceData;
+import com.hivemq.context.model.Data;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
 import com.hivemq.mqtt.message.publish.PUBLISH;
 
@@ -24,12 +24,12 @@ import java.util.Objects;
 /**
  * @author Simon L Johnson
  */
-public class DataGovernanceDataImpl implements DataGovernanceData {
+public class DataImpl implements Data {
 
     private @NotNull String clientId;
     private @NotNull PUBLISH publish;
 
-    private DataGovernanceDataImpl(
+    private DataImpl(
             final @NotNull String clientId, final @NotNull PUBLISH publish) {
         this.clientId = clientId;
         this.publish = publish;
@@ -58,7 +58,7 @@ public class DataGovernanceDataImpl implements DataGovernanceData {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        DataGovernanceDataImpl that = (DataGovernanceDataImpl) o;
+        DataImpl that = (DataImpl) o;
         return Objects.equals(clientId, that.clientId) && Objects.equals(publish, that.publish);
     }
 
@@ -81,7 +81,7 @@ public class DataGovernanceDataImpl implements DataGovernanceData {
         private String clientId;
         private PUBLISH publish;
 
-        public Builder(final @NotNull DataGovernanceData data) {
+        public Builder(final @NotNull Data data) {
             withClientId(data.getClientId());
             withPublish(data.getPublish());
         }
@@ -99,8 +99,8 @@ public class DataGovernanceDataImpl implements DataGovernanceData {
             return this;
         }
 
-        public DataGovernanceData build() {
-            return new DataGovernanceDataImpl(this.clientId, this.publish);
+        public Data build() {
+            return new DataImpl(this.clientId, this.publish);
         }
     }
 }

--- a/hivemq-edge/src/main/java/com/hivemq/context/model/impl/ErrorImpl.java
+++ b/hivemq-edge/src/main/java/com/hivemq/context/model/impl/ErrorImpl.java
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.hivemq.datagov.model.impl;
+package com.hivemq.context.model.impl;
 
-import com.hivemq.datagov.model.DataGovernanceError;
+import com.hivemq.context.model.Error;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
 
 import java.util.Optional;
@@ -23,7 +23,7 @@ import java.util.Optional;
 /**
  * @author Simon L Johnson
  */
-public class DataGovernanceErrorImpl implements DataGovernanceError {
+public class ErrorImpl implements Error {
 
     private Optional<Throwable> error;
     private Optional<String> pipelineId;
@@ -31,12 +31,12 @@ public class DataGovernanceErrorImpl implements DataGovernanceError {
     private Optional<String> validatorId;
     private Optional<String> message;
 
-    public DataGovernanceErrorImpl(final @NotNull Throwable error) {
+    public ErrorImpl(final @NotNull Throwable error) {
         this.error = Optional.of(error);
         this.message = Optional.ofNullable(error.getMessage());
     }
 
-    public DataGovernanceErrorImpl(final @NotNull String message) {
+    public ErrorImpl(final @NotNull String message) {
         this.message = Optional.of(message);
     }
 
@@ -76,23 +76,23 @@ public class DataGovernanceErrorImpl implements DataGovernanceError {
         this.message = Optional.ofNullable(message);
     }
 
-    public static DataGovernanceError ofPipelineAndFunction(@NotNull final Throwable t,
-                                                            @NotNull final String pipelineId,
-                                                            @NotNull final String functionId){
-        DataGovernanceErrorImpl impl = new DataGovernanceErrorImpl(t);
+    public static Error ofPipelineAndFunction(@NotNull final Throwable t,
+                                              @NotNull final String pipelineId,
+                                              @NotNull final String functionId){
+        ErrorImpl impl = new ErrorImpl(t);
         impl.setFunctionId(functionId);
         impl.setPipelineId(pipelineId);
         return impl;
     }
 
-    public static DataGovernanceError ofPipeline(@NotNull final Throwable t, @NotNull final String pipelineId){
-        DataGovernanceErrorImpl impl = new DataGovernanceErrorImpl(t);
+    public static Error ofPipeline(@NotNull final Throwable t, @NotNull final String pipelineId){
+        ErrorImpl impl = new ErrorImpl(t);
         impl.setPipelineId(pipelineId);
         return impl;
     }
 
-    public static DataGovernanceError ofValidator(@NotNull final String message, @NotNull final String validatorId){
-        DataGovernanceErrorImpl impl = new DataGovernanceErrorImpl(message);
+    public static Error ofValidator(@NotNull final String message, @NotNull final String validatorId){
+        ErrorImpl impl = new ErrorImpl(message);
         impl.setValidatorId(validatorId);
         return impl;
     }

--- a/hivemq-edge/src/main/java/com/hivemq/context/model/impl/PolicyImpl.java
+++ b/hivemq-edge/src/main/java/com/hivemq/context/model/impl/PolicyImpl.java
@@ -13,16 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.hivemq.datagov.model;
+package com.hivemq.context.model.impl;
 
-import com.hivemq.datagov.DataGovernanceContext;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.hivemq.context.model.Policy;
+import com.hivemq.extension.sdk.api.annotations.NotNull;
 
 /**
  * @author Simon L Johnson
  */
+public abstract class PolicyImpl extends AbstractEntity implements Policy {
 
+    @JsonCreator
+    public PolicyImpl(@JsonProperty("id") final @NotNull String id,
+                      @JsonProperty("name") final @NotNull String name) {
+        super(id, name);
+    }
 
-public interface DataGovernancePolicy extends DataGovernanceEntity {
-
-    void execute(final DataGovernanceContext context, final DataGovernanceData input);
 }

--- a/hivemq-edge/src/main/java/com/hivemq/context/model/impl/ResultImpl.java
+++ b/hivemq-edge/src/main/java/com/hivemq/context/model/impl/ResultImpl.java
@@ -13,12 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.hivemq.datagov.model.impl;
+package com.hivemq.context.model.impl;
 
 import com.google.common.base.Preconditions;
-import com.hivemq.datagov.model.DataGovernanceData;
-import com.hivemq.datagov.model.DataGovernanceError;
-import com.hivemq.datagov.model.DataGovernanceResult;
+import com.hivemq.context.model.Data;
+import com.hivemq.context.model.Error;
+import com.hivemq.context.model.Result;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
 
 import java.util.ArrayList;
@@ -29,24 +29,24 @@ import java.util.Optional;
 /**
  * @author Simon L Johnson
  */
-public class DataGoveranceResultImpl implements DataGovernanceResult {
+public class ResultImpl implements Result {
 
-    private List<DataGovernanceError> errors;
+    private List<Error> errors;
     private String message;
     private STATUS status;
-    private DataGovernanceData output;
+    private Data output;
 
-    public DataGoveranceResultImpl(final @NotNull DataGovernanceData output) {
+    public ResultImpl(final @NotNull Data output) {
         this.status = STATUS.PENDING;
         this.output = output;
     }
 
     @Override
-    public List<DataGovernanceError> getErrors() {
+    public List<Error> getErrors() {
         return errors == null ? Collections.emptyList() : errors;
     }
 
-    public void addError(final DataGovernanceError error, boolean fatal) {
+    public void addError(final Error error, boolean fatal) {
         Preconditions.checkNotNull(error);
         if(fatal){
             status = STATUS.FAILURE;
@@ -76,7 +76,7 @@ public class DataGoveranceResultImpl implements DataGovernanceResult {
     }
 
     @Override
-    public DataGovernanceData getOutput() {
+    public Data getOutput() {
         return output;
     }
 

--- a/hivemq-edge/src/main/java/com/hivemq/context/provider/TokenProvider.java
+++ b/hivemq-edge/src/main/java/com/hivemq/context/provider/TokenProvider.java
@@ -13,24 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.hivemq.datagov;
+package com.hivemq.context.provider;
+
+import com.hivemq.context.HiveMQEdgeContext;
+import com.hivemq.extension.sdk.api.annotations.NotNull;
+
+import java.util.Map;
 
 /**
  * @author Simon L Johnson
  */
-public class DataGovernanceException extends Exception {
-    public DataGovernanceException() {
-    }
+public interface TokenProvider {
 
-    public DataGovernanceException(final String message) {
-        super(message);
-    }
+    @NotNull Map<String, String> getTokenReplacements(@NotNull final HiveMQEdgeContext context);
 
-    public DataGovernanceException(final String message, final Throwable cause) {
-        super(message, cause);
-    }
 
-    public DataGovernanceException(final Throwable cause) {
-        super(cause);
-    }
 }

--- a/hivemq-edge/src/main/java/com/hivemq/edge/modules/adapters/impl/ProtocolAdapterInterceptorHandler.java
+++ b/hivemq-edge/src/main/java/com/hivemq/edge/modules/adapters/impl/ProtocolAdapterInterceptorHandler.java
@@ -19,11 +19,11 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import com.hivemq.configuration.service.ConfigurationService;
-import com.hivemq.datagov.DataGovernanceContext;
-import com.hivemq.datagov.DataGovernanceService;
-import com.hivemq.datagov.impl.DataGovernanceContextImpl;
-import com.hivemq.datagov.model.DataGovernanceData;
-import com.hivemq.datagov.model.impl.DataGovernanceDataImpl;
+import com.hivemq.context.HiveMQEdgeContext;
+import com.hivemq.context.HiveMQEdgeService;
+import com.hivemq.context.impl.ContextImpl;
+import com.hivemq.context.model.Data;
+import com.hivemq.context.model.impl.DataImpl;
 import com.hivemq.edge.modules.adapters.ProtocolAdapterConstants;
 import com.hivemq.edge.modules.api.adapters.ProtocolAdapter;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
@@ -64,7 +64,7 @@ public class ProtocolAdapterInterceptorHandler {
 
     private static final Logger log = LoggerFactory.getLogger(ProtocolAdapterInterceptorHandler.class);
 
-    private final @NotNull DataGovernanceService dataGovernanceService;
+    private final @NotNull HiveMQEdgeService hiveMQEdgeService;
     private final @NotNull Interceptors interceptors;
     private final @NotNull ConfigurationService configurationService;
     private final @NotNull PluginOutPutAsyncer asyncer;
@@ -75,7 +75,7 @@ public class ProtocolAdapterInterceptorHandler {
 
     @Inject
     public ProtocolAdapterInterceptorHandler(
-            final @NotNull DataGovernanceService dataGovernanceService,
+            final @NotNull HiveMQEdgeService hiveMQEdgeService,
             final @NotNull Interceptors interceptors,
             final @NotNull ConfigurationService configurationService,
             final @NotNull PluginOutPutAsyncer asyncer,
@@ -83,7 +83,7 @@ public class ProtocolAdapterInterceptorHandler {
             final @NotNull MessageDroppedService messageDroppedService,
             final @NotNull PluginTaskExecutorService pluginTaskExecutorService,
             final @NotNull ServerInformation serverInformation) {
-        this.dataGovernanceService = dataGovernanceService;
+        this.hiveMQEdgeService = hiveMQEdgeService;
         this.interceptors = interceptors;
         this.configurationService = configurationService;
         this.asyncer = asyncer;
@@ -157,17 +157,17 @@ public class ProtocolAdapterInterceptorHandler {
 
     private @NotNull ListenableFuture<PublishReturnCode> processPublish(
             final @NotNull PUBLISH publish, final @NotNull ProtocolAdapter protocolAdapter) {
-        DataGovernanceData data =
-                new DataGovernanceDataImpl.Builder().withClientId(protocolAdapter.getId()).withPublish(publish).build();
-        DataGovernanceContext context = new ProtocolAdapterContext(data, protocolAdapter);
-        return dataGovernanceService.applyAndPublish(context);
+        Data data =
+                new DataImpl.Builder().withClientId(protocolAdapter.getId()).withPublish(publish).build();
+        HiveMQEdgeContext context = new ProtocolAdapterContext(data, protocolAdapter);
+        return hiveMQEdgeService.applyAndPublish(context);
     }
 
-    static class ProtocolAdapterContext extends DataGovernanceContextImpl {
+    static class ProtocolAdapterContext extends ContextImpl {
 
         final @NotNull ProtocolAdapter adapter;
 
-        public ProtocolAdapterContext(final @NotNull DataGovernanceData input, final @NotNull ProtocolAdapter adapter) {
+        public ProtocolAdapterContext(final @NotNull Data input, final @NotNull ProtocolAdapter adapter) {
             super(input, populateAdapterContextReplacements(adapter));
             this.adapter = adapter;
         }

--- a/hivemq-edge/src/main/java/com/hivemq/uns/ioc/UnsServiceModule.java
+++ b/hivemq-edge/src/main/java/com/hivemq/uns/ioc/UnsServiceModule.java
@@ -15,8 +15,8 @@
  */
 package com.hivemq.uns.ioc;
 
-import com.hivemq.datagov.impl.UnifiedNamespaceDataGovernancePolicy;
-import com.hivemq.datagov.model.DataGovernancePolicy;
+import com.hivemq.context.impl.UnifiedNamespacePolicy;
+import com.hivemq.context.model.Policy;
 import com.hivemq.uns.UnifiedNamespaceService;
 import com.hivemq.uns.impl.UnifiedNamespaceServiceImpl;
 import dagger.Binds;
@@ -38,6 +38,6 @@ public abstract class UnsServiceModule {
 
     @Binds
 //    @IntoSet
-    abstract DataGovernancePolicy provideDataGovernancePolicies(UnifiedNamespaceDataGovernancePolicy policy);
+    abstract Policy provideDataGovernancePolicies(UnifiedNamespacePolicy policy);
 
 }

--- a/hivemq-edge/src/test/java/com/hivemq/adapter/AdapterModelConverterTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/adapter/AdapterModelConverterTest.java
@@ -44,7 +44,7 @@ public class AdapterModelConverterTest {
     void testProtocolAdapterModuleConversionUtils() {
 
         ConfigurationService configurationService = mock(ConfigurationService.class);
-        Module testModule = HiveMQModuleModelTests.createTestModule();
+        Module testModule = HiveMQEdgeModuleModelTests.createTestModule();
         ProtocolAdapter adapter = ProtocolAdapterApiUtils.convertModuleAdapterType(testModule,configurationService);
         assertEquals(testModule.getName(), adapter.getName(), "Adapter name should match module name");
         assertEquals(testModule.getDescription(), adapter.getDescription(), "Adapter description should match");
@@ -89,7 +89,7 @@ public class AdapterModelConverterTest {
     void testProtocolAdapterDiscoveryDisabled() {
 
         ConfigurationService configurationService = mock(ConfigurationService.class);
-        Module testModule = HiveMQModuleModelTests.createTestModule();
+        Module testModule = HiveMQEdgeModuleModelTests.createTestModule();
         ProtocolAdapter adapter = ProtocolAdapterApiUtils.convertModuleAdapterType(testModule,configurationService);
         assertFalse(adapter.getCapabilities().contains(ProtocolAdapter.Capability.DISCOVER), "Module generated adapter should not support discovery");
     }
@@ -98,7 +98,7 @@ public class AdapterModelConverterTest {
     void testProtocolAdapterWriteDisabled() {
 
         ConfigurationService configurationService = mock(ConfigurationService.class);
-        Module testModule = HiveMQModuleModelTests.createTestModule();
+        Module testModule = HiveMQEdgeModuleModelTests.createTestModule();
         ProtocolAdapter adapter = ProtocolAdapterApiUtils.convertModuleAdapterType(testModule,configurationService);
         assertFalse(adapter.getCapabilities().contains(ProtocolAdapter.Capability.WRITE), "Module generated adapter should not support write");
     }
@@ -107,7 +107,7 @@ public class AdapterModelConverterTest {
     void testProtocolAdapterReadDisabled() {
 
         ConfigurationService configurationService = mock(ConfigurationService.class);
-        Module testModule = HiveMQModuleModelTests.createTestModule();
+        Module testModule = HiveMQEdgeModuleModelTests.createTestModule();
         ProtocolAdapter adapter = ProtocolAdapterApiUtils.convertModuleAdapterType(testModule,configurationService);
         assertFalse(adapter.getCapabilities().contains(ProtocolAdapter.Capability.READ), "Module generated adapter should not support read");
     }

--- a/hivemq-edge/src/test/java/com/hivemq/adapter/AdapterModelConverterTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/adapter/AdapterModelConverterTest.java
@@ -10,10 +10,7 @@ import com.hivemq.configuration.service.ConfigurationService;
 import com.hivemq.configuration.service.impl.ApiConfigurationServiceImpl;
 import com.hivemq.edge.HiveMQEdgeConstants;
 import com.hivemq.edge.modules.adapters.ProtocolAdapterConstants;
-import com.hivemq.edge.modules.adapters.impl.AbstractProtocolAdapterInformation;
 import com.hivemq.edge.modules.api.adapters.ProtocolAdapterCapability;
-import com.hivemq.edge.modules.api.adapters.ProtocolAdapterInformation;
-import com.hivemq.edge.modules.config.CustomConfig;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -47,7 +44,7 @@ public class AdapterModelConverterTest {
     void testProtocolAdapterModuleConversionUtils() {
 
         ConfigurationService configurationService = mock(ConfigurationService.class);
-        Module testModule = ModuleModelTests.createTestModule();
+        Module testModule = HiveMQModuleModelTests.createTestModule();
         ProtocolAdapter adapter = ProtocolAdapterApiUtils.convertModuleAdapterType(testModule,configurationService);
         assertEquals(testModule.getName(), adapter.getName(), "Adapter name should match module name");
         assertEquals(testModule.getDescription(), adapter.getDescription(), "Adapter description should match");
@@ -92,7 +89,7 @@ public class AdapterModelConverterTest {
     void testProtocolAdapterDiscoveryDisabled() {
 
         ConfigurationService configurationService = mock(ConfigurationService.class);
-        Module testModule = ModuleModelTests.createTestModule();
+        Module testModule = HiveMQModuleModelTests.createTestModule();
         ProtocolAdapter adapter = ProtocolAdapterApiUtils.convertModuleAdapterType(testModule,configurationService);
         assertFalse(adapter.getCapabilities().contains(ProtocolAdapter.Capability.DISCOVER), "Module generated adapter should not support discovery");
     }
@@ -101,7 +98,7 @@ public class AdapterModelConverterTest {
     void testProtocolAdapterWriteDisabled() {
 
         ConfigurationService configurationService = mock(ConfigurationService.class);
-        Module testModule = ModuleModelTests.createTestModule();
+        Module testModule = HiveMQModuleModelTests.createTestModule();
         ProtocolAdapter adapter = ProtocolAdapterApiUtils.convertModuleAdapterType(testModule,configurationService);
         assertFalse(adapter.getCapabilities().contains(ProtocolAdapter.Capability.WRITE), "Module generated adapter should not support write");
     }
@@ -110,7 +107,7 @@ public class AdapterModelConverterTest {
     void testProtocolAdapterReadDisabled() {
 
         ConfigurationService configurationService = mock(ConfigurationService.class);
-        Module testModule = ModuleModelTests.createTestModule();
+        Module testModule = HiveMQModuleModelTests.createTestModule();
         ProtocolAdapter adapter = ProtocolAdapterApiUtils.convertModuleAdapterType(testModule,configurationService);
         assertFalse(adapter.getCapabilities().contains(ProtocolAdapter.Capability.READ), "Module generated adapter should not support read");
     }

--- a/hivemq-edge/src/test/java/com/hivemq/adapter/HiveMQEdgeModuleModelTests.java
+++ b/hivemq-edge/src/test/java/com/hivemq/adapter/HiveMQEdgeModuleModelTests.java
@@ -11,7 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 /**
  * @author Simon L Johnson
  */
-public class HiveMQModuleModelTests {
+public class HiveMQEdgeModuleModelTests {
 
     static String MODULE_ID = "moduleId";
     static String MODULE_VERSION = "moduleVersion";

--- a/hivemq-edge/src/test/java/com/hivemq/adapter/HiveMQModuleModelTests.java
+++ b/hivemq-edge/src/test/java/com/hivemq/adapter/HiveMQModuleModelTests.java
@@ -11,7 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 /**
  * @author Simon L Johnson
  */
-public class ModuleModelTests {
+public class HiveMQModuleModelTests {
 
     static String MODULE_ID = "moduleId";
     static String MODULE_VERSION = "moduleVersion";

--- a/hivemq-edge/src/test/java/com/hivemq/mqtt/InternalPublishServiceImplTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/mqtt/InternalPublishServiceImplTest.java
@@ -18,7 +18,7 @@ package com.hivemq.mqtt;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.MoreExecutors;
-import com.hivemq.datagov.DataGovernanceService;
+import com.hivemq.context.HiveMQEdgeService;
 import com.hivemq.mqtt.handler.publish.PublishReturnCode;
 import com.hivemq.mqtt.message.QoS;
 import com.hivemq.mqtt.message.publish.PUBLISH;
@@ -75,7 +75,7 @@ public class InternalPublishServiceImplTest {
     private ExecutorService executorService;
 
     private InternalPublishServiceImpl publishService;
-    private DataGovernanceService dataGovernator;
+    private HiveMQEdgeService dataGovernator;
 
     @Before
     public void before() {


### PR DESCRIPTION
**Motivation**

There were several classes/packages with datagov in the name.

**Changes**
Adjust package and classnames to use HiveMQEdge where appropriate or remove the prefix completely.
