### PR TITLE
Slightly reduce memory consumption per Modbus subscription

### DIFF
--- a/modules/hivemq-edge-module-modbus/src/main/java/com/hivemq/edge/adapters/modbus/ModbusProtocolAdapter.java
+++ b/modules/hivemq-edge-module-modbus/src/main/java/com/hivemq/edge/adapters/modbus/ModbusProtocolAdapter.java
@@ -34,15 +34,15 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 public class ModbusProtocolAdapter extends AbstractPollingPerSubscriptionAdapter<ModbusAdapterConfig, ModBusData> {
     private static final Logger log = LoggerFactory.getLogger(ModbusProtocolAdapter.class);
     private final @NotNull Object lock = new Object();
+    private final @Nullable Map<ModBusData.TYPE, ModBusData> lastSamples = new EnumMap<>(ModBusData.TYPE.class);
     private volatile @Nullable IModbusClient modbusClient;
-    private @Nullable Map<ModBusData.TYPE, ModBusData> lastSamples = new HashMap<>();
 
     public ModbusProtocolAdapter(
             final @NotNull ProtocolAdapterInformation adapterInformation,


### PR DESCRIPTION
EnunMap is more space-efficient than HashMap for Enum keys.