### PR TITLE
Refactor monorepo gradle files in order to have a single dependencies version

### DIFF
--- a/hivemq-edge/build.gradle.kts
+++ b/hivemq-edge/build.gradle.kts
@@ -7,21 +7,21 @@ plugins {
     `java-library`
     `maven-publish`
     signing
-    id("com.github.johnrengelman.shadow")
-    id("com.github.sgtsilvio.gradle.utf8")
-    id("com.github.sgtsilvio.gradle.metadata")
-    id("com.github.sgtsilvio.gradle.javadoc-links")
-    id("com.github.breadmoirai.github-release")
-    id("com.github.hierynomus.license")
-    id("org.owasp.dependencycheck")
-    id("com.github.ben-manes.versions")
+    alias(libs.plugins.shadow)
+    alias(libs.plugins.utf8)
+    alias(libs.plugins.metadata)
+    alias(libs.plugins.javadocLinks)
+    alias(libs.plugins.githubRelease)
+    alias(libs.plugins.hierynomusLicense)
+    alias(libs.plugins.dependencycheck)
+    alias(libs.plugins.benManes)
 
     /* Code Quality Plugins */
-    id("jacoco")
-    id("pmd")
-    id("com.github.spotbugs")
-    id("de.thetaphi.forbiddenapis")
-    id("io.swagger.core.v3.swagger-gradle-plugin") version "2.2.8"
+    jacoco
+    pmd
+    alias(libs.plugins.spotbugs)
+    alias(libs.plugins.forbiddenapis)
+    alias(libs.plugins.swagger)
 }
 
 group = "com.hivemq"
@@ -100,113 +100,79 @@ repositories {
 // Runtime stuffs
 dependencies {
 
-    //HiveMQ
-    api("com.hivemq:hivemq-extension-sdk:${property("hivemq-extension-sdk.version")}")
-    api("com.hivemq:hivemq-edge-extension-sdk:${property("hivemq-edge-extension-sdk.version")}")
-
-    // netty
-    implementation("io.netty:netty-buffer:${property("netty.version")}")
-    implementation("io.netty:netty-codec:${property("netty.version")}")
-    implementation("io.netty:netty-codec-http:${property("netty.version")}")
-    implementation("io.netty:netty-common:${property("netty.version")}")
-    implementation("io.netty:netty-handler:${property("netty.version")}")
-    implementation("io.netty:netty-transport:${property("netty.version")}")
-
-    // logging
-    implementation("org.slf4j:slf4j-api:${property("slf4j.version")}")
-    implementation("org.slf4j:jul-to-slf4j:${property("slf4j.version")}")
-    implementation("ch.qos.logback:logback-classic:${property("logback.version")}")
-
-    // security
-    implementation("org.bouncycastle:bcprov-jdk15on:${property("bouncycastle.version")}")
-    implementation("org.bouncycastle:bcpkix-jdk15on:${property("bouncycastle.version")}")
+    api(libs.bundles.hivemq)
+    implementation(libs.bundles.netty)
+    implementation(libs.bundles.logs)
+    implementation(libs.bundles.security)
+    implementation(libs.bundles.metrics)
+    runtimeOnly(libs.metrics.logback)
 
     // override transitive dependencies that have security vulnerabilities
     constraints {
-        implementation("org.jetbrains.kotlin:kotlin-stdlib:${property("kotlin.version")}")
-        implementation("org.apache.commons:commons-compress:${property("commons-compress.version")}")
+        implementation(libs.kotlin.stdlib)
+        implementation(libs.commons.compress)
     }
 
     // config
-    implementation("jakarta.xml.bind:jakarta.xml.bind-api:${property("jakarta-xml-bind.version")}")
-    runtimeOnly("com.sun.xml.bind:jaxb-impl:${property("jaxb.version")}")
-
-    // metrics
-    implementation("io.dropwizard.metrics:metrics-core:${property("metrics.version")}")
-    implementation("io.dropwizard.metrics:metrics-jmx:${property("metrics.version")}")
-    runtimeOnly("io.dropwizard.metrics:metrics-logback:${property("metrics.version")}")
-    implementation("io.dropwizard.metrics:metrics-jvm:${property("metrics.version")}")
+    implementation(libs.jakarta.xml.bind.api)
+    runtimeOnly(libs.jaxb.impl)
 
     // dependency injection
-    implementation("com.google.dagger:dagger:${property("dagger.version")}")
-    annotationProcessor("com.google.dagger:dagger-compiler:${property("dagger.version")}")
+    implementation(libs.dagger)
+    annotationProcessor(libs.dagger.compiler)
 
-    implementation("javax.annotation:javax.annotation-api:${property("javax.annotation.version")}")
+    implementation(libs.annotation.api)
 
     // common
-    implementation("commons-io:commons-io:${property("commons-io.version")}")
-    implementation("org.apache.commons:commons-lang3:${property("commons-lang.version")}")
-    implementation("com.google.guava:guava:${property("guava.version")}") {
+    implementation(libs.commons.io)
+    implementation(libs.commons.lang3)
+    implementation(libs.guava) {
         exclude("org.checkerframework", "checker-qual")
         exclude("com.google.errorprone", "error_prone_annotations")
     }
-    implementation("net.javacrumbs.future-converter:future-converter-java8-guava:1.2.0")
+    implementation(libs.future.converter.java8.guava)
 
     // com.google.code.findbugs:jsr305 (transitive dependency of com.google.guava:guava) is used in imports
-    implementation("net.openhft:zero-allocation-hashing:${property("zero-allocation-hashing.version")}")
-    implementation("com.fasterxml.jackson.core:jackson-databind:${property("jackson.version")}")
-    implementation("org.jctools:jctools-core:${property("jctools.version")}")
+    implementation(libs.zero.allocation.hashing)
+    implementation(libs.jackson.databind)
+    implementation(libs.jctools.core)
 
     //mqtt-sn codec
-    implementation("com.github.simon622.mqtt-sn:mqtt-sn-codec:838f51d691")
+    implementation(libs.mqtt.sn.codec)
 
     //JAX-RS + Http Connector + Serializers
-    implementation("org.glassfish.jersey.containers:jersey-container-jdk-http:${property("jersey.jaxrs.sun.version")}")
-    implementation("org.glassfish.jersey.inject:jersey-hk2:${property("jersey.jaxrs.sun.version")}")
-    implementation("org.glassfish.jersey.media:jersey-media-json-jackson:${property("jersey.jaxrs.sun.version")}")
-    implementation("org.glassfish.jersey.media:jersey-media-multipart:${property("jersey.jaxrs.sun.version")}")
-    implementation("org.glassfish.jersey.inject:jersey-hk2:${property("jersey.jaxrs.sun.version")}")
-    implementation("com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:${property("jackson.version")}")
-    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${property("jackson.version")}")
+    implementation(libs.bundles.glassfish)
+    implementation(libs.bundles.jackson)
 
-    implementation("com.hivemq:hivemq-mqtt-client:1.3.1")
+    implementation(libs.hivemq.mqtt.client)
 
     //Open API
-    implementation("io.swagger.core.v3:swagger-annotations:${property("swagger.openapi.annotations.version")}")
-
-    //JWT
-    implementation("org.bitbucket.b_c:jose4j:${property("jose4j.version")}")
-
-    // crypto
-    implementation("org.bouncycastle:bcpkix-jdk15on")
-    implementation("org.bouncycastle:bcprov-jdk15on")
+    implementation(libs.swagger.annotations)
 
     //json schema
-    implementation("com.networknt:json-schema-validator:1.0.82")
-    implementation("com.github.victools:jsonschema-generator:4.31.1")
-    implementation("com.github.victools:jsonschema-module-jackson:4.31.1")
+    implementation(libs.jsonschema.validator)
+    implementation(libs.jsonschema.generator)
+    implementation(libs.jsonschema.module.jackson)
 }
 
 /* ******************** test ******************** */
 
 dependencies {
-    testAnnotationProcessor("com.google.dagger:dagger-compiler:${property("dagger.version")}")
-    testImplementation(platform("org.junit:junit-bom:${property("junit.jupiter.version")}"))
-    testImplementation("junit:junit:${property("junit.version")}")
+    testAnnotationProcessor(libs.dagger.compiler)
+    testImplementation(platform(libs.junit.jupiter.bom))
+    testImplementation(libs.junit.classic)
     testImplementation("org.junit.jupiter:junit-jupiter")
     testRuntimeOnly("org.junit.vintage:junit-vintage-engine")
-    testImplementation("org.mockito:mockito-core:${property("mockito.version")}")
-    testImplementation("org.mockito:mockito-junit-jupiter:${property("mockito.version")}")
-    testImplementation("nl.jqno.equalsverifier:equalsverifier:${property("equalsverifier.version")}")
-    testImplementation("net.jodah:concurrentunit:${property("concurrentunit.version")}")
-    testImplementation("org.jboss.shrinkwrap:shrinkwrap-api:${property("shrinkwrap.version")}")
-    testRuntimeOnly("org.jboss.shrinkwrap:shrinkwrap-impl-base:${property("shrinkwrap.version")}")
-    testImplementation("net.bytebuddy:byte-buddy:${property("bytebuddy.version")}")
-    testImplementation("com.github.tomakehurst:wiremock-jre8-standalone:${property("wiremock.version")}")
-    testImplementation("org.javassist:javassist:${property("javassist.version")}")
-    testImplementation("org.awaitility:awaitility:${property("awaitility.version")}")
-    testImplementation("org.assertj:assertj-core:${property("assertj.version")}")
-    testImplementation("com.github.stefanbirkner:system-rules:${property("system-rules.version")}") {
+    testImplementation(libs.bundles.mokito)
+    testImplementation(libs.equalsverifier)
+    testImplementation(libs.concurrentunit)
+    testImplementation(libs.bundles.shrinkwrap)
+    testImplementation(libs.byte.buddy)
+    testImplementation(libs.wiremock.jre8.standalone)
+    testImplementation(libs.javassist)
+    testImplementation(libs.awaitility)
+    testImplementation(libs.assertj.core)
+    testImplementation(libs.system.rules) {
         exclude("junit", "junit-dep")
     }
 }

--- a/hivemq-edge/gradle.properties
+++ b/hivemq-edge/gradle.properties
@@ -1,79 +1,12 @@
 version=2023.6
-#
-# main dependencies
-#
+
 hivemq-extension-sdk.version=4.16.0
-hivemq-edge-extension-sdk.version=2023.6
-# netty
-netty.version=4.1.79.Final
-# Jersey (JAXRS / Sun)
-jersey.jaxrs.sun.version=2.28
-# logging
-slf4j.version=2.0.7
-logback.version=1.4.7
-# security
-bouncycastle.version=1.70
-# persistence
-rocksdb.version=7.4.5
-xodus.version=1.2.3
-# config
-jaxb.version=2.3.8
-jakarta-xml-bind.version=2.3.3
-# metrics
-metrics.version=4.2.19
-# dependency injection
-dagger.version=2.43.2
-javax.annotation.version=1.3.2
-# common
-commons-io.version=2.13.0
-commons-lang.version=3.12.0
-commons-compress.version=1.23.0
-guava.version=32.0.1-jre
-zero-allocation-hashing.version=0.16
-jackson.version=2.15.2
-jctools.version=4.0.1
-kotlin.version=1.8.22
-# OpenAPI
-swagger.openapi.annotations.version=2.2.8
-# Protobuf
-protobuf.util.version=3.21.5
 
-# Jose4j (JWT)
-jose4j.version=0.9.3
-
-#
-# test dependencies
-#
-awaitility.version=4.2.0
-junit.jupiter.version=5.9.2
-junit.version=4.13.2
-mockito.version=4.11.0
-equalsverifier.version=3.14.2
-concurrentunit.version=0.4.6
-shrinkwrap.version=1.2.6
-bytebuddy.version=1.14.5
-wiremock.version=2.35.0
-javassist.version=3.29.2-GA
-system-rules.version=1.19.0
 #
 # tools
 #
 jacoco.version=0.8.7
 pmd.version=6.36.0
 spotbugs.version=4.3.0
-#
-# plugins
-#
-plugin.shadow.version=7.1.2
-plugin.license.version=0.16.1
-plugin.dependencycheck.version=7.1.1
-plugin.spotbugs.version=4.7.2
-plugin.forbiddenapis.version=3.5.1
-plugin.utf8.version=0.1.0
-plugin.metadata.version=0.3.0
-plugin.javadoc-links.version=0.5.0
-plugin.nexus-publish.version=1.1.0
-plugin.github-release.version=2.4.1
-plugin.versions.version=0.42.0
-plugin.node.version=5.0.0
-assertj.version=3.23.1
+
+

--- a/hivemq-edge/settings.gradle.kts
+++ b/hivemq-edge/settings.gradle.kts
@@ -17,20 +17,11 @@
 
 rootProject.name = "hivemq-edge"
 
-pluginManagement {
-    plugins {
-        id("com.github.johnrengelman.shadow") version "${extra["plugin.shadow.version"]}"
-        id("com.github.hierynomus.license") version "${extra["plugin.license.version"]}"
-        id("org.owasp.dependencycheck") version "${extra["plugin.dependencycheck.version"]}"
-        id("com.github.spotbugs") version "${extra["plugin.spotbugs.version"]}"
-        id("de.thetaphi.forbiddenapis") version "${extra["plugin.forbiddenapis.version"]}"
-        id("com.github.sgtsilvio.gradle.utf8") version "${extra["plugin.utf8.version"]}"
-        id("com.github.sgtsilvio.gradle.metadata") version "${extra["plugin.metadata.version"]}"
-        id("com.github.sgtsilvio.gradle.javadoc-links") version "${extra["plugin.javadoc-links.version"]}"
-        id("io.github.gradle-nexus.publish-plugin") version "${extra["plugin.nexus-publish.version"]}"
-        id("com.github.breadmoirai.github-release") version "${extra["plugin.github-release.version"]}"
-        id("com.github.ben-manes.versions") version "${extra["plugin.versions.version"]}"
-        id("com.github.node-gradle.node") version "${extra["plugin.node.version"]}"
+dependencyResolutionManagement {
+    versionCatalogs {
+        create("libs") {
+            from(files("../libs.versions.toml"))
+        }
     }
 }
 

--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -1,0 +1,154 @@
+[versions]
+hivemqExtensionSdkVersion="4.16.0"
+hivemqEdgeExtensionSdkVersion="2023.6"
+nettyVersion="4.1.79.Final"
+slf4jVersion="2.0.7"
+logbackVersion="1.4.7"
+bouncycastleVersion="1.70"
+kotlinVersion="1.8.22"
+commonsCompressVersion="1.23.0"
+jakartaXmlBindVersion="2.3.3"
+jaxbVersion="2.3.8"
+metricsVersion="4.2.19"
+daggerVersion="2.43.2"
+javaxAnnotationVersion="1.3.2"
+commonsIoVersion="2.13.0"
+commonsLangVersion="3.12.0"
+guavaVersion="32.0.1-jre"
+futureConverterJava8GuavaVersion="1.2.0"
+zeroAllocationHashingVersion="0.16"
+jacksonVersion="2.15.2"
+jctoolsVersion="4.0.1"
+mqttSnCodecVerion="838f51d691"
+jerseyJaxrsSunVersion="2.28"
+hivemqMqttClientVersion="1.3.1"
+jose4jVersion="0.9.3"
+jsonSchemaValidatorVersion="1.0.82"
+jsonschemaVersion="4.31.1"
+assertjVersion="3.23.1"
+miloVersion="0.6.9"
+
+# Test
+junitVersion="4.13.2"
+junitJupiterVersion="5.9.2"
+junitJupiterPlatformVersion="1.7.1"
+mockitoVersion="4.11.0"
+equalsVerifierVersion="3.14.2"
+concurrentunitVersion="0.4.6"
+shrinkwrapVersion="1.2.6"
+bytebuddyVersion="1.14.5"
+wiremockVersion="2.35.0"
+javassistVersion="3.29.2-GA"
+awaitilityVersion="4.2.0"
+systemRulesVersion="1.19.0"
+modbusMasterTcpVersion="1.2.0"
+orgApachePlc4xVersion="0.10.0"
+
+# plugins"
+shadowVersion="7.1.2"
+utf8Version="0.1.0"
+metadataVersion="0.3.0"
+javadocLinksVersion="0.5.0"
+githubReleasesVersion="2.4.1"
+hierynomusLicenseVersion="0.16.1"
+dependencycheckVersion="7.1.1"
+benManesVersion="0.42.0"
+spotbugsVersion="4.3.0"
+forbiddenapisVersion="3.5.1"
+swaggerVersion="2.2.8"
+
+
+[libraries]
+hivemq-extension-sdk = { module = "com.hivemq:hivemq-extension-sdk", version.ref ="hivemqExtensionSdkVersion"}
+hivemq-edge-extension-sdk = { module = "com.hivemq:hivemq-edge-extension-sdk", version.ref ="hivemqEdgeExtensionSdkVersion"}
+netty-buffer = { module = "io.netty:netty-buffer", version.ref ="nettyVersion"}
+netty-codec = { module = "io.netty:netty-codec", version.ref ="nettyVersion"}
+netty-codec-http = { module = "io.netty:netty-codec-http", version.ref ="nettyVersion"}
+netty-common = { module = "io.netty:netty-common", version.ref ="nettyVersion"}
+netty-handler = { module = "io.netty:netty-handler", version.ref ="nettyVersion"}
+netty-transport = { module = "io.netty:netty-transport", version.ref ="nettyVersion"}
+slf4j-api = { module = "org.slf4j:slf4j-api", version.ref ="slf4jVersion"}
+jul-to-slf4j = { module = "org.slf4j:jul-to-slf4j", version.ref ="slf4jVersion"}
+logback-classic = { module = "ch.qos.logback:logback-classic", version.ref ="logbackVersion"}
+bcprov-jdk15on = { module = "org.bouncycastle:bcprov-jdk15on", version.ref ="bouncycastleVersion"}
+bcpkix-jdk15on = { module = "org.bouncycastle:bcpkix-jdk15on", version.ref ="bouncycastleVersion"}
+kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref ="kotlinVersion"}
+commons-compress = { module = "org.apache.commons:commons-compress", version.ref ="commonsCompressVersion"}
+jakarta-xml-bind-api = { module = "jakarta.xml.bind:jakarta.xml.bind-api", version.ref ="jakartaXmlBindVersion"}
+jaxb-impl = { module = "com.sun.xml.bind:jaxb-impl", version.ref ="jaxbVersion"}
+metrics-core = { module = "io.dropwizard.metrics:metrics-core", version.ref ="metricsVersion"}
+metrics-jmx = { module = "io.dropwizard.metrics:metrics-jmx", version.ref ="metricsVersion"}
+metrics-logback = { module = "io.dropwizard.metrics:metrics-logback", version.ref ="metricsVersion"}
+metrics-jvm = { module = "io.dropwizard.metrics:metrics-jvm", version.ref ="metricsVersion"}
+dagger = { module = "com.google.dagger:dagger", version.ref ="daggerVersion"}
+dagger-compiler = { module = "com.google.dagger:dagger-compiler", version.ref ="daggerVersion"}
+annotation-api = { module = "javax.annotation:javax.annotation-api", version.ref ="javaxAnnotationVersion"}
+commons-io = { module = "commons-io:commons-io", version.ref ="commonsIoVersion"}
+commons-lang3 = { module = "org.apache.commons:commons-lang3", version.ref ="commonsLangVersion"}
+guava = { module = "com.google.guava:guava", version.ref ="guavaVersion"}
+future-converter-java8-guava = { module = "net.javacrumbs.future-converter:future-converter-java8-guava", version.ref ="futureConverterJava8GuavaVersion"}
+zero-allocation-hashing = { module = "net.openhft:zero-allocation-hashing", version.ref ="zeroAllocationHashingVersion"}
+jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref ="jacksonVersion"}
+jctools-core = { module = "org.jctools:jctools-core", version.ref ="jctoolsVersion"}
+mqtt-sn-codec = { module = "com.github.simon622.mqtt-sn:mqtt-sn-codec", version.ref ="mqttSnCodecVerion"}
+jersey-container-jdk-http = { module = "org.glassfish.jersey.containers:jersey-container-jdk-http", version.ref ="jerseyJaxrsSunVersion"}
+jersey-hk2 = { module = "org.glassfish.jersey.inject:jersey-hk2", version.ref ="jerseyJaxrsSunVersion"}
+jersey-media-json-jackson = { module = "org.glassfish.jersey.media:jersey-media-json-jackson", version.ref ="jerseyJaxrsSunVersion"}
+jersey-media-multipart = { module = "org.glassfish.jersey.media:jersey-media-multipart", version.ref ="jerseyJaxrsSunVersion"}
+jackson-jaxrs-json-provider = { module = "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider", version.ref ="jacksonVersion"}
+jackson-datatype-jsr310 = { module = "com.fasterxml.jackson.datatype:jackson-datatype-jsr310", version.ref ="jacksonVersion"}
+hivemq-mqtt-client = { module = "com.hivemq:hivemq-mqtt-client", version.ref ="hivemqMqttClientVersion"}
+swagger-annotations = { module = "io.swagger.core.v3:swagger-annotations", version.ref ="swaggerVersion"}
+jose4j = { module = "org.bitbucket.b_c:jose4j", version.ref ="jose4jVersion"}
+jsonschema-validator = { module = "com.networknt:json-schema-validator", version.ref ="jsonSchemaValidatorVersion"}
+jsonschema-generator = { module = "com.github.victools:jsonschema-generator", version.ref ="jsonschemaVersion"}
+jsonschema-module-jackson = { module = "com.github.victools:jsonschema-module-jackson", version.ref ="jsonschemaVersion"}
+modbus-master-tcp = { module = "com.digitalpetri.modbus:modbus-master-tcp", version.ref ="modbusMasterTcpVersion"}
+milo-sdk-client = { module = "org.eclipse.milo:sdk-client", version.ref ="miloVersion"}
+milo-dictionary-reader = { module = "org.eclipse.milo:dictionary-reader", version.ref ="miloVersion"}
+milo-bsd-parser-gson = { module = "org.eclipse.milo:bsd-parser-gson", version.ref ="miloVersion"}
+plc4j-api = { module = "org.apache.plc4x:plc4j-api", version.ref ="orgApachePlc4xVersion"}
+plc4j-driver-s7 = { module = "org.apache.plc4x:plc4j-driver-s7", version.ref ="orgApachePlc4xVersion"}
+
+# Test
+junit-Jupiter-bom= { module = "org.junit:junit-bom", version.ref ="junitJupiterVersion"}
+junit-classic= { module = "junit:junit", version.ref ="junitVersion"}
+mockito-core= { module = "org.mockito:mockito-core", version.ref ="mockitoVersion"}
+mockito-junit-jupiter= { module = "org.mockito:mockito-junit-jupiter", version.ref ="mockitoVersion"}
+equalsverifier= { module = "nl.jqno.equalsverifier:equalsverifier", version.ref ="equalsVerifierVersion"}
+concurrentunit= { module = "net.jodah:concurrentunit", version.ref ="concurrentunitVersion"}
+shrinkwrap-api= { module = "org.jboss.shrinkwrap:shrinkwrap-api", version.ref ="shrinkwrapVersion"}
+shrinkwrap-impl-base= { module = "org.jboss.shrinkwrap:shrinkwrap-impl-base", version.ref ="shrinkwrapVersion"}
+byte-buddy= { module = "net.bytebuddy:byte-buddy", version.ref ="bytebuddyVersion"}
+wiremock-jre8-standalone= { module = "com.github.tomakehurst:wiremock-jre8-standalone", version.ref ="wiremockVersion"}
+javassist= { module = "org.javassist:javassist", version.ref ="javassistVersion"}
+awaitility= { module = "org.awaitility:awaitility", version.ref ="awaitilityVersion"}
+assertj-core= { module = "org.assertj:assertj-core", version.ref ="assertjVersion"}
+system-rules= { module = "com.github.stefanbirkner:system-rules", version.ref ="systemRulesVersion"}
+junit-platform-launcher= { module = "org.junit.platform:junit-platform-launcher", version.ref ="junitJupiterPlatformVersion"}
+milo-sdk-server= { module = "org.eclipse.milo:sdk-server", version.ref ="miloVersion"}
+
+[bundles]
+hivemq = ["hivemq-extension-sdk", "hivemq-edge-extension-sdk"]
+netty = ["netty-buffer", "netty-codec", "netty-codec-http", "netty-common", "netty-handler", "netty-transport"]
+logs = ["slf4j-api", "jul-to-slf4j", "logback-classic"]
+security = ["bcprov-jdk15on", "bcpkix-jdk15on", "jose4j"]
+metrics = ["metrics-core", "metrics-jmx", "metrics-jvm"]
+glassfish = ["jersey-container-jdk-http", "jersey-hk2", "jersey-media-json-jackson", "jersey-media-multipart"]
+jackson = ["jackson-jaxrs-json-provider", "jackson-datatype-jsr310"]
+mokito = ["mockito-core", "mockito-junit-jupiter"]
+shrinkwrap = ["shrinkwrap-api", "shrinkwrap-impl-base"]
+milo = ["milo-sdk-client", "milo-dictionary-reader", "milo-bsd-parser-gson"]
+
+[plugins]
+shadow = { id = "com.github.johnrengelman.shadow", version.ref = "shadowVersion" }
+utf8 = { id = "com.github.sgtsilvio.gradle.utf8", version.ref = "utf8Version" }
+metadata = { id = "com.github.sgtsilvio.gradle.metadata", version.ref = "metadataVersion"}
+javadocLinks = { id = "com.github.sgtsilvio.gradle.javadoc-links", version.ref= "javadocLinksVersion"}
+githubRelease = { id = "com.github.breadmoirai.github-release", version.ref= "githubReleasesVersion"}
+hierynomusLicense = { id = "com.github.hierynomus.license", version.ref= "hierynomusLicenseVersion" }
+dependencycheck = { id = "org.owasp.dependencycheck", version.ref= "dependencycheckVersion" }
+benManes = { id = "com.github.ben-manes.versions", version.ref= "benManesVersion" }
+spotbugs = { id = "com.github.spotbugs", version.ref= "spotbugsVersion" }
+forbiddenapis = { id = "de.thetaphi.forbiddenapis", version.ref= "forbiddenapisVersion" }
+swagger = { id = "io.swagger.core.v3.swagger-gradle-plugin", version.ref= "swaggerVersion" }

--- a/modules/hivemq-edge-module-http/build.gradle.kts
+++ b/modules/hivemq-edge-module-http/build.gradle.kts
@@ -3,11 +3,11 @@ import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent.*
 
 plugins {
-    id("java")
-    id("com.github.sgtsilvio.gradle.utf8")
-    id("com.github.johnrengelman.shadow")
-    id("com.github.hierynomus.license")
-    id("org.owasp.dependencycheck")
+    java
+    alias(libs.plugins.utf8)
+    alias(libs.plugins.shadow)
+    alias(libs.plugins.hierynomusLicense)
+    alias(libs.plugins.dependencycheck)
 }
 
 group = "com.hivemq"
@@ -36,8 +36,8 @@ repositories {
 dependencies {
     compileOnly("com.hivemq:hivemq-edge")
     compileOnly("com.hivemq:hivemq-extension-sdk")
-    implementation("com.fasterxml.jackson.core:jackson-databind:${property("jackson.version")}")
-    runtimeOnly("com.google.guava:guava:${property("guava.version")}") {
+    implementation(libs.jackson.databind)
+    runtimeOnly(libs.guava) {
         exclude("org.checkerframework", "checker-qual")
         exclude("com.google.errorprone", "error_prone_annotations")
     }
@@ -55,15 +55,14 @@ configurations {
 dependencies {
     testImplementation("com.hivemq:hivemq-edge")
     compileOnly("com.hivemq:hivemq-extension-sdk")
-    testImplementation("org.apache.commons:commons-lang3:${property("commons-lang.version")}")
-    testImplementation("commons-io:commons-io:${property("commons-io.version")}")
-    testImplementation("org.mockito:mockito-core:${property("mockito.version")}")
-    testImplementation("org.junit.jupiter:junit-jupiter-api:${property("junit.jupiter.version")}")
-    testImplementation("org.junit.jupiter:junit-jupiter-params:${property("junit.jupiter.version")}")
-    testImplementation("org.junit.platform:junit-platform-launcher:${property("junit.jupiter.platform.version")}")
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:${property("junit.jupiter.version")}")
-    testImplementation("org.mockito:mockito-core:${property("mockito.version")}")
-    testImplementation("org.mockito:mockito-junit-jupiter:${property("mockito.version")}")
+    testImplementation(libs.commons.lang3)
+    testImplementation(libs.bundles.mokito)
+    testImplementation(libs.commons.io)
+    testImplementation(platform(libs.junit.jupiter.bom))
+    testImplementation("org.junit.jupiter:junit-jupiter-api")
+    testImplementation("org.junit.jupiter:junit-jupiter-params")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
+    testImplementation(libs.junit.platform.launcher)
 }
 
 tasks.test {

--- a/modules/hivemq-edge-module-http/gradle.properties
+++ b/modules/hivemq-edge-module-http/gradle.properties
@@ -1,28 +1,4 @@
 version=2023.6
-#
-# main dependencies
-#
+
 hivemq-extension-sdk.version=4.16.0
-jackson.version=2.13.3
-guava.version=32.0.1-jre
-
-#
-# test dependencies
-#
-junit.jupiter.version=5.7.1
-junit.jupiter.platform.version=1.7.1
-mockito.version=4.7.0
-commons-lang.version=3.11
-commons-io.version=2.8.0
-
-# logging
-slf4j.version=1.7.30
-logback.version=1.2.3
-#
-# plugins
-#
-plugin.utf8.version=0.1.0
-plugin.shadow.version=7.1.2
-plugin.license.version=0.16.1
-plugin.dependencycheck.version=7.1.1
 

--- a/modules/hivemq-edge-module-http/settings.gradle.kts
+++ b/modules/hivemq-edge-module-http/settings.gradle.kts
@@ -1,11 +1,10 @@
 rootProject.name = "hivemq-edge-module-http"
 
-pluginManagement {
-    plugins {
-        id("com.github.johnrengelman.shadow") version "${extra["plugin.shadow.version"]}"
-        id("com.github.sgtsilvio.gradle.utf8") version "${extra["plugin.utf8.version"]}"
-        id("com.github.hierynomus.license") version "${extra["plugin.license.version"]}"
-        id("org.owasp.dependencycheck") version "${extra["plugin.dependencycheck.version"]}"
+dependencyResolutionManagement {
+    versionCatalogs {
+        create("libs") {
+            from(files("../../libs.versions.toml"))
+        }
     }
 }
 

--- a/modules/hivemq-edge-module-modbus/build.gradle.kts
+++ b/modules/hivemq-edge-module-modbus/build.gradle.kts
@@ -3,11 +3,11 @@ import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent.*
 
 plugins {
-    id("java")
-    id("com.github.sgtsilvio.gradle.utf8")
-    id("com.github.johnrengelman.shadow")
-    id("com.github.hierynomus.license")
-    id("org.owasp.dependencycheck")
+    java
+    alias(libs.plugins.utf8)
+    alias(libs.plugins.shadow)
+    alias(libs.plugins.hierynomusLicense)
+    alias(libs.plugins.dependencycheck)
 }
 
 group = "com.hivemq"
@@ -36,12 +36,12 @@ repositories {
 dependencies {
     compileOnly("com.hivemq:hivemq-edge")
     compileOnly("com.hivemq:hivemq-extension-sdk")
-    implementation("com.fasterxml.jackson.core:jackson-databind:${property("jackson.version")}")
-    runtimeOnly("com.google.guava:guava:${property("guava.version")}") {
+    implementation(libs.jackson.databind)
+    runtimeOnly(libs.guava) {
         exclude("org.checkerframework", "checker-qual")
         exclude("com.google.errorprone", "error_prone_annotations")
     }
-    implementation("com.digitalpetri.modbus:modbus-master-tcp:1.2.0")
+    implementation(libs.modbus.master.tcp)
 }
 
 configurations {
@@ -54,12 +54,12 @@ configurations {
 }
 
 dependencies {
-    testImplementation("org.junit.jupiter:junit-jupiter-api:${property("junit.jupiter.version")}")
-    testImplementation("org.junit.jupiter:junit-jupiter-params:${property("junit.jupiter.version")}")
-    testImplementation("org.junit.platform:junit-platform-launcher:${property("junit.jupiter.platform.version")}")
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:${property("junit.jupiter.version")}")
-    testImplementation("org.mockito:mockito-core:${property("mockito.version")}")
-    testImplementation("org.mockito:mockito-junit-jupiter:${property("mockito.version")}")
+    testImplementation(libs.junit.platform.launcher)
+    testImplementation(platform(libs.junit.jupiter.bom))
+    testImplementation("org.junit.jupiter:junit-jupiter-api")
+    testImplementation("org.junit.jupiter:junit-jupiter-params")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
+    testImplementation(libs.bundles.mokito)
 }
 
 tasks.test {

--- a/modules/hivemq-edge-module-modbus/gradle.properties
+++ b/modules/hivemq-edge-module-modbus/gradle.properties
@@ -1,25 +1,5 @@
 version=2023.6
-#
-# main dependencies
-#
+
 hivemq-extension-sdk.version=4.16.0
-jlibmodbus.version=1.2.9.7
-jackson.version=2.13.3
-guava.version=32.0.1-jre
-#
-# test dependencies
-#
-junit.jupiter.version=5.7.1
-junit.jupiter.platform.version=1.7.1
-mockito.version=4.7.0
-# logging
-slf4j.version=1.7.30
-logback.version=1.2.3
-#
-# plugins
-#
-plugin.utf8.version=0.1.0
-plugin.shadow.version=7.1.2
-plugin.license.version=0.16.1
-plugin.dependencycheck.version=7.1.1
+
 

--- a/modules/hivemq-edge-module-modbus/settings.gradle.kts
+++ b/modules/hivemq-edge-module-modbus/settings.gradle.kts
@@ -1,11 +1,10 @@
 rootProject.name = "hivemq-edge-module-modbus"
 
-pluginManagement {
-    plugins {
-        id("com.github.johnrengelman.shadow") version "${extra["plugin.shadow.version"]}"
-        id("com.github.sgtsilvio.gradle.utf8") version "${extra["plugin.utf8.version"]}"
-        id("com.github.hierynomus.license") version "${extra["plugin.license.version"]}"
-        id("org.owasp.dependencycheck") version "${extra["plugin.dependencycheck.version"]}"
+dependencyResolutionManagement {
+    versionCatalogs {
+        create("libs") {
+            from(files("../../libs.versions.toml"))
+        }
     }
 }
 

--- a/modules/hivemq-edge-module-opcua/build.gradle.kts
+++ b/modules/hivemq-edge-module-opcua/build.gradle.kts
@@ -3,11 +3,11 @@ import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent.*
 
 plugins {
-    id("java")
-    id("com.github.sgtsilvio.gradle.utf8")
-    id("com.github.johnrengelman.shadow")
-    id("com.github.hierynomus.license")
-    id("org.owasp.dependencycheck")
+    java
+    alias(libs.plugins.utf8)
+    alias(libs.plugins.shadow)
+    alias(libs.plugins.hierynomusLicense)
+    alias(libs.plugins.dependencycheck)
 }
 
 group = "com.hivemq"
@@ -36,23 +36,21 @@ repositories {
 dependencies {
     compileOnly("com.hivemq:hivemq-edge")
     compileOnly("com.hivemq:hivemq-extension-sdk")
-    implementation("com.fasterxml.jackson.core:jackson-databind:${property("jackson.version")}")
-    runtimeOnly("com.google.guava:guava:${property("guava.version")}")
+    implementation(libs.jackson.databind)
+    runtimeOnly(libs.guava)
 
-    implementation("org.eclipse.milo:sdk-client:${property("milo.version")}")
-    implementation("org.eclipse.milo:dictionary-reader:${property("milo.version")}")
-    implementation("org.eclipse.milo:bsd-parser-gson:${property("milo.version")}")
+    implementation(libs.bundles.milo)
 
     testImplementation("com.hivemq:hivemq-edge")
-    testImplementation("org.eclipse.milo:sdk-server:${property("milo.version")}")
-    testImplementation("org.junit.jupiter:junit-jupiter-api:${property("junit.jupiter.version")}")
-    testImplementation("org.junit.jupiter:junit-jupiter-params:${property("junit.jupiter.version")}")
-    testImplementation("org.junit.platform:junit-platform-launcher:${property("junit.jupiter.platform.version")}")
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:${property("junit.jupiter.version")}")
-    testImplementation("org.mockito:mockito-core:${property("mockito.version")}")
-    testImplementation("org.mockito:mockito-junit-jupiter:${property("mockito.version")}")
-    testImplementation("org.assertj:assertj-core:${property("assertj.version")}")
-    testImplementation("org.awaitility:awaitility:${property("awaitility.version")}")
+    testImplementation(libs.milo.sdk.server)
+    testImplementation(libs.junit.platform.launcher)
+    testImplementation(platform(libs.junit.jupiter.bom))
+    testImplementation("org.junit.jupiter:junit-jupiter-api")
+    testImplementation("org.junit.jupiter:junit-jupiter-params")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
+    testImplementation(libs.bundles.mokito)
+    testImplementation(libs.assertj.core)
+    testImplementation(libs.awaitility)
 }
 
 configurations {

--- a/modules/hivemq-edge-module-opcua/gradle.properties
+++ b/modules/hivemq-edge-module-opcua/gradle.properties
@@ -1,26 +1,4 @@
 version=2023.6
-#
-# main dependencies
-#
+
 hivemq-extension-sdk.version=4.16.0
-milo.version=0.6.9
-jackson.version=2.13.3
-guava.version=32.0.1-jre
-#
-# test dependencies
-#
-junit.jupiter.version=5.7.1
-junit.jupiter.platform.version=1.7.1
-mockito.version=4.7.0
-assertj.version=3.23.1
-awaitility.version=4.0.3
-# logging
-slf4j.version=1.7.30
-logback.version=1.2.3
-#
-# plugins
-#
-plugin.utf8.version=0.1.0
-plugin.shadow.version=7.1.2
-plugin.license.version=0.16.1
-plugin.dependencycheck.version=7.1.1
+

--- a/modules/hivemq-edge-module-opcua/settings.gradle.kts
+++ b/modules/hivemq-edge-module-opcua/settings.gradle.kts
@@ -1,11 +1,10 @@
 rootProject.name = "hivemq-edge-module-opcua"
 
-pluginManagement {
-    plugins {
-        id("com.github.johnrengelman.shadow") version "${extra["plugin.shadow.version"]}"
-        id("com.github.sgtsilvio.gradle.utf8") version "${extra["plugin.utf8.version"]}"
-        id("com.github.hierynomus.license") version "${extra["plugin.license.version"]}"
-        id("org.owasp.dependencycheck") version "${extra["plugin.dependencycheck.version"]}"
+dependencyResolutionManagement {
+    versionCatalogs {
+        create("libs") {
+            from(files("../../libs.versions.toml"))
+        }
     }
 }
 

--- a/modules/hivemq-edge-module-plc4x/build.gradle.kts
+++ b/modules/hivemq-edge-module-plc4x/build.gradle.kts
@@ -3,11 +3,11 @@ import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent.*
 
 plugins {
-    id("java")
-    id("com.github.sgtsilvio.gradle.utf8")
-    id("com.github.johnrengelman.shadow")
-    id("com.github.hierynomus.license")
-    id("org.owasp.dependencycheck")
+    java
+    alias(libs.plugins.utf8)
+    alias(libs.plugins.shadow)
+    alias(libs.plugins.hierynomusLicense)
+    alias(libs.plugins.dependencycheck)
 }
 
 group = "com.hivemq"
@@ -36,14 +36,14 @@ repositories {
 dependencies {
     compileOnly("com.hivemq:hivemq-edge")
     compileOnly("com.hivemq:hivemq-extension-sdk")
-    implementation("org.apache.plc4x:plc4j-api:${property("org.apache.plc4x.version")}")
-    implementation("org.apache.plc4x:plc4j-driver-s7:${property("org.apache.plc4x.version")}")
+    implementation(libs.plc4j.api)
+    implementation(libs.plc4j.driver.s7)
 //    implementation("org.apache.plc4x:plc4j-driver-bacnet:${property("org.apache.plc4x.version")}")
 //    implementation("org.apache.plc4x:plc4j-driver-profinet:${property("org.apache.plc4x.version")}")
 //    implementation("org.apache.plc4x:plc4j-driver-eip:${property("org.apache.plc4x.version")}")
 
-    implementation("com.fasterxml.jackson.core:jackson-databind:${property("jackson.version")}")
-    runtimeOnly("com.google.guava:guava:${property("guava.version")}") {
+    implementation(libs.jackson.databind)
+    runtimeOnly(libs.guava) {
         exclude("org.checkerframework", "checker-qual")
         exclude("com.google.errorprone", "error_prone_annotations")
     }
@@ -59,12 +59,12 @@ configurations {
 }
 
 dependencies {
-    testImplementation("org.junit.jupiter:junit-jupiter-api:${property("junit.jupiter.version")}")
-    testImplementation("org.junit.jupiter:junit-jupiter-params:${property("junit.jupiter.version")}")
-    testImplementation("org.junit.platform:junit-platform-launcher:${property("junit.jupiter.platform.version")}")
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:${property("junit.jupiter.version")}")
-    testImplementation("org.mockito:mockito-core:${property("mockito.version")}")
-    testImplementation("org.mockito:mockito-junit-jupiter:${property("mockito.version")}")
+    testImplementation(platform(libs.junit.jupiter.bom))
+    testImplementation("org.junit.jupiter:junit-jupiter-api")
+    testImplementation("org.junit.jupiter:junit-jupiter-params")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
+    testImplementation(libs.junit.platform.launcher)
+    testImplementation(libs.bundles.mokito)
 }
 
 tasks.test {

--- a/modules/hivemq-edge-module-plc4x/gradle.properties
+++ b/modules/hivemq-edge-module-plc4x/gradle.properties
@@ -1,25 +1,3 @@
 version=2023.6.alpha
-#
-# main dependencies
-#
-hivemq-extension-sdk.version=4.16.0
-org.apache.plc4x.version=0.10.0
-jackson.version=2.13.3
-guava.version=32.0.1-jre
-#
-# test dependencies
-#
-junit.jupiter.version=5.7.1
-junit.jupiter.platform.version=1.7.1
-mockito.version=4.7.0
-# logging
-slf4j.version=1.7.30
-logback.version=1.2.3
-#
-# plugins
-#
-plugin.utf8.version=0.1.0
-plugin.shadow.version=7.1.2
-plugin.license.version=0.16.1
-plugin.dependencycheck.version=7.1.1
 
+hivemq-extension-sdk.version=4.16.0

--- a/modules/hivemq-edge-module-plc4x/settings.gradle.kts
+++ b/modules/hivemq-edge-module-plc4x/settings.gradle.kts
@@ -1,11 +1,10 @@
 rootProject.name = "hivemq-edge-module-plc4x"
 
-pluginManagement {
-    plugins {
-        id("com.github.johnrengelman.shadow") version "${extra["plugin.shadow.version"]}"
-        id("com.github.sgtsilvio.gradle.utf8") version "${extra["plugin.utf8.version"]}"
-        id("com.github.hierynomus.license") version "${extra["plugin.license.version"]}"
-        id("org.owasp.dependencycheck") version "${extra["plugin.dependencycheck.version"]}"
+dependencyResolutionManagement {
+    versionCatalogs {
+        create("libs") {
+            from(files("../../libs.versions.toml"))
+        }
     }
 }
 


### PR DESCRIPTION
**Motivation**

In order to avoid issues with transitive dependencies and reduce the number of vulnerabilities (CVEs), it's convenient to have a single version for third-party dependencies, all managed from a central point ([Gradle catalog](https://docs.gradle.org/current/userguide/platforms.html))

This PR is refactoring the current Gradle files to reuse the same dependency declarations and also creates common dependency bundles.

Note: the Gradle refactor was started in the Athens hackathon but I could not finish on time, It took me ..."one" extra day (I finished today (one day later), in the airport). 

IntelliJ will require gradle 8 or gradle 7 with this plugin: https://plugins.jetbrains.com/plugin/18949-gradle-libs-error-suppressor

My recommendation it´s to move on to Gradle 8 . No problem at all on Github Action or the terminal, is just a Intelij issue