### PR TITLE
Fix (17366) - OPC - UA Background connection monitoring

### DIFF
--- a/hivemq-edge/src/main/java/com/hivemq/api/model/core/Payload.java
+++ b/hivemq-edge/src/main/java/com/hivemq/api/model/core/Payload.java
@@ -1,6 +1,7 @@
 package com.hivemq.api.model.core;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Preconditions;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -57,6 +58,16 @@ public class Payload {
         Preconditions.checkNotNull(contentType);
         Preconditions.checkNotNull(data);
         return new Payload(contentType, data);
+    }
+
+    public static Payload fromObject(ObjectMapper mapper,  Object data){
+        try {
+            Preconditions.checkNotNull(mapper);
+            Preconditions.checkNotNull(data);
+            return new Payload(ContentType.JSON, mapper.writeValueAsString(data));
+        } catch(Exception e){
+            throw new RuntimeException(e);
+        }
     }
 }
 

--- a/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/OpcUaProtocolAdapter.java
+++ b/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/OpcUaProtocolAdapter.java
@@ -17,6 +17,7 @@ package com.hivemq.edge.adapters.opcua;
 
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.collect.ImmutableList;
+import com.hivemq.api.model.core.Payload;
 import com.hivemq.edge.adapters.opcua.client.OpcUaClientConfigurator;
 import com.hivemq.edge.adapters.opcua.client.OpcUaEndpointFilter;
 import com.hivemq.edge.adapters.opcua.client.OpcUaSubscriptionConsumer;
@@ -28,10 +29,15 @@ import com.hivemq.edge.modules.adapters.model.ProtocolAdapterDiscoveryOutput;
 import com.hivemq.edge.modules.adapters.model.ProtocolAdapterStartOutput;
 import com.hivemq.edge.modules.api.adapters.ProtocolAdapterInformation;
 import com.hivemq.edge.modules.api.adapters.ProtocolAdapterPublishService;
+import com.hivemq.edge.modules.api.events.EventUtils;
+import com.hivemq.edge.modules.api.events.model.Event;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
 import com.hivemq.extension.sdk.api.annotations.Nullable;
 import org.eclipse.milo.opcua.binaryschema.GenericBsdParser;
 import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
+import org.eclipse.milo.opcua.sdk.client.SessionActivityListener;
+import org.eclipse.milo.opcua.sdk.client.api.ServiceFaultListener;
+import org.eclipse.milo.opcua.sdk.client.api.UaSession;
 import org.eclipse.milo.opcua.sdk.client.dtd.DataTypeDictionarySessionInitializer;
 import org.eclipse.milo.opcua.stack.core.AttributeId;
 import org.eclipse.milo.opcua.stack.core.Identifiers;
@@ -46,6 +52,7 @@ import org.eclipse.milo.opcua.stack.core.types.structured.BrowseDescription;
 import org.eclipse.milo.opcua.stack.core.types.structured.BrowseResult;
 import org.eclipse.milo.opcua.stack.core.types.structured.ReadValueId;
 import org.eclipse.milo.opcua.stack.core.types.structured.ReferenceDescription;
+import org.eclipse.milo.opcua.stack.core.types.structured.ServiceFault;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -81,8 +88,6 @@ public class OpcUaProtocolAdapter extends AbstractProtocolAdapter<OpcUaAdapterCo
             final CompletableFuture<ProtocolAdapterStartOutput> resultFuture = new CompletableFuture<>();
 
             opcUaClient.connect().thenAccept(uaClient -> {
-
-                setConnectionStatus(ConnectionStatus.CONNECTED);
                 opcUaClient.getSubscriptionManager().addSubscriptionListener(createSubscriptionListener());
                 createAllSubscriptions(adapterPublishService).whenComplete((unused, throwable) -> {
                     if (throwable == null) {
@@ -95,7 +100,7 @@ public class OpcUaProtocolAdapter extends AbstractProtocolAdapter<OpcUaAdapterCo
 
             }).exceptionally(throwable -> {
                 log.error("Not able to connect and subscribe to OPC-UA server {}", adapterConfig.getUri(), throwable);
-                setRuntimeStatus(RuntimeStatus.STOPPED);
+                stop();
                 output.failStart(throwable, throwable.getMessage());
                 resultFuture.completeExceptionally(throwable);
                 return null;
@@ -117,10 +122,13 @@ public class OpcUaProtocolAdapter extends AbstractProtocolAdapter<OpcUaAdapterCo
             }
             else {
                 subscriptionMap.clear();
-                opcUaClient = null;
-                return opcUaClient.disconnect().thenAccept(client -> {
-                    setConnectionStatus(ConnectionStatus.DISCONNECTED);
-                });
+                try {
+                    return opcUaClient.disconnect().thenAccept(client -> {
+                        setConnectionStatus(ConnectionStatus.DISCONNECTED);
+                    });
+                } finally {
+                    opcUaClient = null;
+                }
             }
         } catch (Exception e) {
             return CompletableFuture.failedFuture(e);
@@ -209,6 +217,24 @@ public class OpcUaProtocolAdapter extends AbstractProtocolAdapter<OpcUaAdapterCo
                 new OpcUaClientConfigurator(adapterConfig));
         //Decoding a struct with custom DataType requires a DataTypeManager, so we register one that updates each time a session is activated.
         opcUaClient.addSessionInitializer(new DataTypeDictionarySessionInitializer(new GenericBsdParser()));
+
+        //-- Seems to be not connection monitoring hook, use the session activity listener
+        opcUaClient.addSessionActivityListener(new SessionActivityListener() {
+            @Override
+            public void onSessionInactive(final UaSession session) {
+                setConnectionStatus(ConnectionStatus.DISCONNECTED);
+            }
+            @Override
+            public void onSessionActive(final UaSession session) {
+                setConnectionStatus(ConnectionStatus.CONNECTED);
+            }
+        });
+        opcUaClient.addFaultListener(serviceFault -> {
+            eventService.fireEvent(
+                    eventBuilder(Event.SEVERITY.ERROR).
+                            withPayload(Payload.fromObject(objectMapper, serviceFault.getResponseHeader().getServiceResult())).
+                            withMessage("A Service Fault was Detected.").build());
+        });
         setRuntimeStatus(RuntimeStatus.STARTED);
     }
 


### PR DESCRIPTION
The OPC-UA adapter had no explicit connection monitoring, it was only reactive based on subscription events. 



 Remedy 

Needed to passively listen for session change notifications, along with reporting service faults (which are NOT used for session management as they could also be used for other things.