### PR TITLE
feat(17145): Add optional filtering to the paginated tables

### DIFF
--- a/hivemq-edge/src/frontend/src/components/PaginatedTable/PaginatedTable.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/components/PaginatedTable/PaginatedTable.spec.cy.tsx
@@ -77,21 +77,21 @@ describe('PaginatedTable', () => {
     cy.get('th').eq(0).should('have.text', 'item')
     checkRowOrder()
     cy.get('th').eq(0).click()
-    cy.get('th').eq(0).should('have.text', 'item 🔼')
+    cy.get('th').eq(0).should('have.attr', 'aria-sort', 'ascending')
     checkRowOrder('asc')
     cy.get('th').eq(0).click()
-    cy.get('th').eq(0).should('have.text', 'item 🔽')
+    cy.get('th').eq(0).should('have.attr', 'aria-sort', 'descending')
     checkRowOrder('desc')
   })
 
-  it.only('should indicate when there is no data to render', () => {
+  it('should indicate when there is no data to render', () => {
     cy.mountWithProviders(<PaginatedTable<MOCK_TYPE> data={[]} columns={MOCK_COLUMN} pageSizes={[5, 10, 20]} />)
 
     cy.get('[role="alert"]').should('contain.text', 'No data received yet.')
     cy.get('[role="alert"]').should('have.attr', 'data-status', 'info')
   })
 
-  it.only('should render the custom nodata message', () => {
+  it('should render the custom nodata message', () => {
     cy.mountWithProviders(
       <PaginatedTable<MOCK_TYPE>
         data={[]}

--- a/hivemq-edge/src/frontend/src/components/PaginatedTable/PaginatedTable.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/components/PaginatedTable/PaginatedTable.spec.cy.tsx
@@ -115,9 +115,18 @@ describe('PaginatedTable', () => {
       />
     )
 
+    cy.getByTestId('column1-clear').should('be.disabled')
+
     cy.get('th').eq(0).find('input').should('have.attr', 'placeholder', 'Search... (4)')
     cy.get('#column1-list option').should('have.length', 4)
-    cy.get('th').eq(0).find('input').type('0')
+    cy.get('th').eq(0).find('input').type('item 0')
+
+    // wait for Debounce (should be covered by timeout
+    cy.get('tbody').find('tr').should('have.length', 1)
+    cy.getByTestId('column1-clear').should('not.be.disabled')
+    cy.getByTestId('column1-clear').click()
+    cy.get('tbody').find('tr').should('have.length', 4)
+    cy.get('#column1-list').should('have.text', '')
 
     // TODO[NVL] Cannot test for datalist updates
   })

--- a/hivemq-edge/src/frontend/src/components/PaginatedTable/PaginatedTable.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/components/PaginatedTable/PaginatedTable.spec.cy.tsx
@@ -105,6 +105,19 @@ describe('PaginatedTable', () => {
     cy.get('[role="alert"]').should('have.attr', 'data-status', 'info')
   })
 
+  it('should render the filters', () => {
+    cy.mountWithProviders(
+      <PaginatedTable<MOCK_TYPE>
+        data={MOCK_DATA(4)}
+        columns={MOCK_COLUMN}
+        pageSizes={[5, 10, 20]}
+        enableColumnFilters
+      />
+    )
+
+    cy.get('th').eq(0).find('input').should('have.attr', 'placeholder', 'Search... (4)')
+  })
+
   it('should be accessible', () => {
     cy.injectAxe()
     cy.mountWithProviders(

--- a/hivemq-edge/src/frontend/src/components/PaginatedTable/PaginatedTable.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/components/PaginatedTable/PaginatedTable.spec.cy.tsx
@@ -116,6 +116,10 @@ describe('PaginatedTable', () => {
     )
 
     cy.get('th').eq(0).find('input').should('have.attr', 'placeholder', 'Search... (4)')
+    cy.get('#column1-list option').should('have.length', 4)
+    cy.get('th').eq(0).find('input').type('0')
+
+    // TODO[NVL] Cannot test for datalist updates
   })
 
   it('should be accessible', () => {

--- a/hivemq-edge/src/frontend/src/components/PaginatedTable/PaginatedTable.tsx
+++ b/hivemq-edge/src/frontend/src/components/PaginatedTable/PaginatedTable.tsx
@@ -32,6 +32,7 @@ import {
 import PaginationBar from './components/PaginationBar.tsx'
 import { Filter } from './components/Filter.tsx'
 import { BiSortDown, BiSortUp } from 'react-icons/bi'
+import { getAriaSort } from '@/components/PaginatedTable/utils/table-utils.ts'
 
 interface PaginatedTableProps<T> {
   data: Array<T>
@@ -86,7 +87,12 @@ const PaginatedTable = <T,>({
             {table.getHeaderGroups().map((headerGroup) => (
               <Tr key={headerGroup.id}>
                 {headerGroup.headers.map((header) => (
-                  <Th key={header.id} colSpan={header.colSpan} verticalAlign={'top'}>
+                  <Th
+                    key={header.id}
+                    colSpan={header.colSpan}
+                    verticalAlign={'top'}
+                    aria-sort={getAriaSort(header.column.getCanSort(), header.column.getIsSorted())}
+                  >
                     <VStack>
                       {header.isPlaceholder && null}
                       {!header.isPlaceholder && header.column.getCanSort() && (

--- a/hivemq-edge/src/frontend/src/components/PaginatedTable/PaginatedTable.tsx
+++ b/hivemq-edge/src/frontend/src/components/PaginatedTable/PaginatedTable.tsx
@@ -23,6 +23,7 @@ interface PaginatedTableProps<T> {
   columns: ColumnDef<T>[]
   pageSizes?: number[]
   noDataText?: string
+  enableColumnFilters?: boolean
   /**
    * Define row styles
    */
@@ -37,6 +38,7 @@ const PaginatedTable = <T,>({
   pageSizes = DEFAULT_PAGE_SIZES,
   noDataText,
   getRowStyles,
+  enableColumnFilters = false,
 }: PaginatedTableProps<T>) => {
   const { t } = useTranslation()
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([])
@@ -49,6 +51,7 @@ const PaginatedTable = <T,>({
       columnFilters,
       globalFilter,
     },
+    enableColumnFilters: enableColumnFilters,
     onColumnFiltersChange: setColumnFilters,
     onGlobalFilterChange: setGlobalFilter,
     getCoreRowModel: getCoreRowModel(),

--- a/hivemq-edge/src/frontend/src/components/PaginatedTable/PaginatedTable.tsx
+++ b/hivemq-edge/src/frontend/src/components/PaginatedTable/PaginatedTable.tsx
@@ -14,10 +14,24 @@ import {
   Row,
   useReactTable,
 } from '@tanstack/react-table'
-import { Table as TableUI, Thead, Tbody, Tr, Th, Td, TableContainer, Text, Alert, VStack } from '@chakra-ui/react'
+import {
+  Table as TableUI,
+  Thead,
+  Tbody,
+  Tr,
+  Th,
+  Td,
+  TableContainer,
+  Text,
+  Alert,
+  VStack,
+  Button,
+  Icon,
+} from '@chakra-ui/react'
 
 import PaginationBar from './components/PaginationBar.tsx'
 import { Filter } from './components/Filter.tsx'
+import { BiSortDown, BiSortUp } from 'react-icons/bi'
 
 interface PaginatedTableProps<T> {
   data: Array<T>
@@ -74,19 +88,30 @@ const PaginatedTable = <T,>({
                 {headerGroup.headers.map((header) => (
                   <Th key={header.id} colSpan={header.colSpan} verticalAlign={'top'}>
                     <VStack>
-                      {header.isPlaceholder ? null : (
-                        <Text
+                      {header.isPlaceholder && null}
+                      {!header.isPlaceholder && header.column.getCanSort() && (
+                        <Button
+                          onClick={header.column.getToggleSortingHandler()}
+                          size={'sm'}
+                          variant="ghost"
+                          textTransform={'inherit'}
+                          fontWeight={'inherit'}
+                          fontSize={'inherit'}
+                          height={'24px'}
                           userSelect={'none'}
-                          {...{
-                            className: header.column.getCanSort() ? 'cursor-pointer select-none' : '',
-                            onClick: header.column.getToggleSortingHandler(),
-                          }}
+                          rightIcon={
+                            {
+                              asc: <Icon as={BiSortUp} fontSize={'24px'} />,
+                              desc: <Icon as={BiSortDown} fontSize={'24px'} />,
+                            }[header.column.getIsSorted() as string] ?? undefined
+                          }
                         >
                           {flexRender(header.column.columnDef.header, header.getContext())}
-                          {{
-                            asc: ' 🔼',
-                            desc: ' 🔽',
-                          }[header.column.getIsSorted() as string] ?? null}
+                        </Button>
+                      )}
+                      {!header.isPlaceholder && !header.column.getCanSort() && (
+                        <Text userSelect={'none'} pt={1}>
+                          {flexRender(header.column.columnDef.header, header.getContext())}
                         </Text>
                       )}
                       {header.column.getCanFilter() && <Filter<T> column={header.column} table={table} />}

--- a/hivemq-edge/src/frontend/src/components/PaginatedTable/PaginatedTable.tsx
+++ b/hivemq-edge/src/frontend/src/components/PaginatedTable/PaginatedTable.tsx
@@ -120,7 +120,12 @@ const PaginatedTable = <T,>({
                           {flexRender(header.column.columnDef.header, header.getContext())}
                         </Text>
                       )}
-                      {header.column.getCanFilter() && <Filter<T> column={header.column} table={table} />}
+                      {header.column.getCanFilter() && (
+                        <Filter<T>
+                          {...header.column}
+                          firstValue={table.getPreFilteredRowModel().flatRows[0]?.getValue(header.column.id)}
+                        />
+                      )}
                     </VStack>
                   </Th>
                 ))}

--- a/hivemq-edge/src/frontend/src/components/PaginatedTable/PaginatedTable.tsx
+++ b/hivemq-edge/src/frontend/src/components/PaginatedTable/PaginatedTable.tsx
@@ -1,4 +1,5 @@
 import { useState, CSSProperties } from 'react'
+import { useTranslation } from 'react-i18next'
 import {
   ColumnDef,
   ColumnFiltersState,
@@ -13,10 +14,10 @@ import {
   Row,
   useReactTable,
 } from '@tanstack/react-table'
-import { Table as TableUI, Thead, Tbody, Tr, Th, Td, TableContainer, Text, Alert } from '@chakra-ui/react'
+import { Table as TableUI, Thead, Tbody, Tr, Th, Td, TableContainer, Text, Alert, VStack } from '@chakra-ui/react'
 
 import PaginationBar from './components/PaginationBar.tsx'
-import { useTranslation } from 'react-i18next'
+import { Filter } from './components/Filter.tsx'
 
 interface PaginatedTableProps<T> {
   data: Array<T>
@@ -70,11 +71,12 @@ const PaginatedTable = <T,>({
           <Thead>
             {table.getHeaderGroups().map((headerGroup) => (
               <Tr key={headerGroup.id}>
-                {headerGroup.headers.map((header) => {
-                  return (
-                    <Th key={header.id} colSpan={header.colSpan}>
+                {headerGroup.headers.map((header) => (
+                  <Th key={header.id} colSpan={header.colSpan} verticalAlign={'top'}>
+                    <VStack>
                       {header.isPlaceholder ? null : (
                         <Text
+                          userSelect={'none'}
                           {...{
                             className: header.column.getCanSort() ? 'cursor-pointer select-none' : '',
                             onClick: header.column.getToggleSortingHandler(),
@@ -87,9 +89,10 @@ const PaginatedTable = <T,>({
                           }[header.column.getIsSorted() as string] ?? null}
                         </Text>
                       )}
-                    </Th>
-                  )
-                })}
+                      {header.column.getCanFilter() && <Filter<T> column={header.column} table={table} />}
+                    </VStack>
+                  </Th>
+                ))}
               </Tr>
             ))}
           </Thead>

--- a/hivemq-edge/src/frontend/src/components/PaginatedTable/components/DebouncedInput.tsx
+++ b/hivemq-edge/src/frontend/src/components/PaginatedTable/components/DebouncedInput.tsx
@@ -1,16 +1,21 @@
 import React from 'react'
-import { Input } from '@chakra-ui/react'
+import { IconButton, Input, InputGroup, InputRightElement } from '@chakra-ui/react'
+import { CloseIcon } from '@chakra-ui/icons'
+import { useTranslation } from 'react-i18next'
 
 export const DebouncedInput = ({
   value: initialValue,
   onChange,
+  id,
   debounce = 500,
   ...props
 }: {
   value: string | number
+  id: string
   onChange: (value: string | number) => void
   debounce?: number
 } & Omit<React.InputHTMLAttributes<HTMLInputElement>, 'onChange'>) => {
+  const { t } = useTranslation()
   const [value, setValue] = React.useState(initialValue)
 
   React.useEffect(() => {
@@ -25,5 +30,20 @@ export const DebouncedInput = ({
     return () => clearTimeout(timeout)
   }, [debounce, onChange, value])
 
-  return <Input {...props} size="sm" value={value} onChange={(e) => setValue(e.target.value)} />
+  return (
+    <InputGroup size="md">
+      <Input {...props} size="sm" value={value} onChange={(e) => setValue(e.target.value)} />
+      <InputRightElement h={'32px'}>
+        <IconButton
+          data-testid={id + '-clear'}
+          isDisabled={value === ''}
+          size="xs"
+          variant={'ghost'}
+          onClick={() => onChange('')}
+          aria-label={t('components:pagination.filter.clear')}
+          icon={<CloseIcon />}
+        />
+      </InputRightElement>
+    </InputGroup>
+  )
 }

--- a/hivemq-edge/src/frontend/src/components/PaginatedTable/components/DebouncedInput.tsx
+++ b/hivemq-edge/src/frontend/src/components/PaginatedTable/components/DebouncedInput.tsx
@@ -1,0 +1,29 @@
+import React from 'react'
+import { Input } from '@chakra-ui/react'
+
+export const DebouncedInput = ({
+  value: initialValue,
+  onChange,
+  debounce = 500,
+  ...props
+}: {
+  value: string | number
+  onChange: (value: string | number) => void
+  debounce?: number
+} & Omit<React.InputHTMLAttributes<HTMLInputElement>, 'onChange'>) => {
+  const [value, setValue] = React.useState(initialValue)
+
+  React.useEffect(() => {
+    setValue(initialValue)
+  }, [initialValue])
+
+  React.useEffect(() => {
+    const timeout = setTimeout(() => {
+      onChange(value)
+    }, debounce)
+
+    return () => clearTimeout(timeout)
+  }, [debounce, onChange, value])
+
+  return <Input {...props} size="sm" value={value} onChange={(e) => setValue(e.target.value)} />
+}

--- a/hivemq-edge/src/frontend/src/components/PaginatedTable/components/Filter.tsx
+++ b/hivemq-edge/src/frontend/src/components/PaginatedTable/components/Filter.tsx
@@ -46,8 +46,9 @@ export const Filter = ({ column, table }: { column: Column<any, unknown>; table:
         type="text"
         value={(columnFilterValue ?? '') as string}
         onChange={(value) => column.setFilterValue(value)}
-        placeholder={`Search... (${column.getFacetedUniqueValues().size})`}
-        className="wss-36 border shadow rounded"
+        placeholder={
+          t('components:pagination.filter.placeholder', { size: column.getFacetedUniqueValues().size }) as string
+        }
         list={column.id + 'list'}
       />
     </>

--- a/hivemq-edge/src/frontend/src/components/PaginatedTable/components/Filter.tsx
+++ b/hivemq-edge/src/frontend/src/components/PaginatedTable/components/Filter.tsx
@@ -1,0 +1,55 @@
+import { Column, Table } from '@tanstack/react-table'
+import { DebouncedInput } from './DebouncedInput.tsx'
+import { useMemo } from 'react'
+
+export const Filter = ({ column, table }: { column: Column<any, unknown>; table: Table<any> }) => {
+  const firstValue = table.getPreFilteredRowModel().flatRows[0]?.getValue(column.id)
+
+  const columnFilterValue = column.getFilterValue()
+
+  const sortedUniqueValues = useMemo(
+    () => (typeof firstValue === 'number' ? [] : Array.from(column.getFacetedUniqueValues().keys()).sort()),
+    [column, firstValue]
+  )
+
+  return typeof firstValue === 'number' ? (
+    <div>
+      <div className="flex space-x-2">
+        <DebouncedInput
+          type="number"
+          min={Number(column.getFacetedMinMaxValues()?.[0] ?? '')}
+          max={Number(column.getFacetedMinMaxValues()?.[1] ?? '')}
+          value={(columnFilterValue as [number, number])?.[0] ?? ''}
+          onChange={(value) => column.setFilterValue((old: [number, number]) => [value, old?.[1]])}
+          placeholder={`Min ${column.getFacetedMinMaxValues()?.[0] ? `(${column.getFacetedMinMaxValues()?.[0]})` : ''}`}
+          className="w-24 border shadow rounded"
+        />
+        <DebouncedInput
+          type="number"
+          min={Number(column.getFacetedMinMaxValues()?.[0] ?? '')}
+          max={Number(column.getFacetedMinMaxValues()?.[1] ?? '')}
+          value={(columnFilterValue as [number, number])?.[1] ?? ''}
+          onChange={(value) => column.setFilterValue((old: [number, number]) => [old?.[0], value])}
+          placeholder={`Max ${column.getFacetedMinMaxValues()?.[1] ? `(${column.getFacetedMinMaxValues()?.[1]})` : ''}`}
+          className="w-24 border shadow rounded"
+        />
+      </div>
+    </div>
+  ) : (
+    <>
+      <datalist id={column.id + 'list'}>
+        {sortedUniqueValues.slice(0, 5000).map((value: any) => (
+          <option value={value} key={value} />
+        ))}
+      </datalist>
+      <DebouncedInput
+        type="text"
+        value={(columnFilterValue ?? '') as string}
+        onChange={(value) => column.setFilterValue(value)}
+        placeholder={`Search... (${column.getFacetedUniqueValues().size})`}
+        className="wss-36 border shadow rounded"
+        list={column.id + 'list'}
+      />
+    </>
+  )
+}

--- a/hivemq-edge/src/frontend/src/components/PaginatedTable/components/Filter.tsx
+++ b/hivemq-edge/src/frontend/src/components/PaginatedTable/components/Filter.tsx
@@ -82,6 +82,7 @@ export const Filter = <T,>({
       </datalist>
       <DebouncedInput
         type="text"
+        id={id}
         value={(columnFilterValue ?? '') as string}
         onChange={(value) => setFilterValue(value)}
         placeholder={t('components:pagination.filter.placeholder', { size: getFacetedUniqueValues().size }) as string}

--- a/hivemq-edge/src/frontend/src/components/PaginatedTable/components/Filter.tsx
+++ b/hivemq-edge/src/frontend/src/components/PaginatedTable/components/Filter.tsx
@@ -76,7 +76,7 @@ export const Filter = <T,>({
   return (
     <>
       <datalist id={id + '-list'}>
-        {sortedUniqueValues.slice(0, 5000).map((value: any) => (
+        {sortedUniqueValues.slice(0, 5000).map((value: string) => (
           <option value={value} key={value} />
         ))}
       </datalist>

--- a/hivemq-edge/src/frontend/src/components/PaginatedTable/components/Filter.tsx
+++ b/hivemq-edge/src/frontend/src/components/PaginatedTable/components/Filter.tsx
@@ -1,43 +1,81 @@
-import { Column, Table } from '@tanstack/react-table'
-import { DebouncedInput } from './DebouncedInput.tsx'
 import { useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Column } from '@tanstack/react-table'
+// import { RangeSlider, RangeSliderFilledTrack, RangeSliderThumb, RangeSliderTrack } from '@chakra-ui/react'
 
-export const Filter = ({ column, table }: { column: Column<any, unknown>; table: Table<any> }) => {
-  const firstValue = table.getPreFilteredRowModel().flatRows[0]?.getValue(column.id)
+import { DebouncedInput } from './DebouncedInput.tsx'
 
-  const columnFilterValue = column.getFilterValue()
+export interface FilterProps<T>
+  extends Pick<
+    Column<T, unknown>,
+    'id' | 'getFilterValue' | 'getFacetedUniqueValues' | 'getFacetedMinMaxValues' | 'setFilterValue'
+  > {
+  firstValue: unknown
+}
+
+// /**/export const Filter = <T,>({ column, table }: { column: Column<T, unknown>; table: Table<T> }) => {
+export const Filter = <T,>({
+  id,
+  getFilterValue,
+  getFacetedUniqueValues,
+  // getFacetedMinMaxValues,
+  setFilterValue,
+  firstValue,
+}: FilterProps<T>) => {
+  const { t } = useTranslation()
+  // const firstValue = table.getPreFilteredRowModel().flatRows[0]?.getValue(id)
+
+  const columnFilterValue = getFilterValue()
 
   const sortedUniqueValues = useMemo(
-    () => (typeof firstValue === 'number' ? [] : Array.from(column.getFacetedUniqueValues().keys()).sort()),
-    [column, firstValue]
+    () => (typeof firstValue === 'number' ? [] : Array.from(getFacetedUniqueValues().keys()).sort()),
+    [firstValue, getFacetedUniqueValues]
   )
 
-  return typeof firstValue === 'number' ? (
-    <div>
-      <div className="flex space-x-2">
-        <DebouncedInput
-          type="number"
-          min={Number(column.getFacetedMinMaxValues()?.[0] ?? '')}
-          max={Number(column.getFacetedMinMaxValues()?.[1] ?? '')}
-          value={(columnFilterValue as [number, number])?.[0] ?? ''}
-          onChange={(value) => column.setFilterValue((old: [number, number]) => [value, old?.[1]])}
-          placeholder={`Min ${column.getFacetedMinMaxValues()?.[0] ? `(${column.getFacetedMinMaxValues()?.[0]})` : ''}`}
-          className="w-24 border shadow rounded"
-        />
-        <DebouncedInput
-          type="number"
-          min={Number(column.getFacetedMinMaxValues()?.[0] ?? '')}
-          max={Number(column.getFacetedMinMaxValues()?.[1] ?? '')}
-          value={(columnFilterValue as [number, number])?.[1] ?? ''}
-          onChange={(value) => column.setFilterValue((old: [number, number]) => [old?.[0], value])}
-          placeholder={`Max ${column.getFacetedMinMaxValues()?.[1] ? `(${column.getFacetedMinMaxValues()?.[1]})` : ''}`}
-          className="w-24 border shadow rounded"
-        />
-      </div>
-    </div>
-  ) : (
+  // const FilterMulti = (
+  //   <div className="flex space-x-2">
+  //     <DebouncedInput
+  //       type="number"
+  //       min={Number(getFacetedMinMaxValues()?.[0] ?? '')}
+  //       max={Number(getFacetedMinMaxValues()?.[1] ?? '')}
+  //       value={(columnFilterValue as [number, number])?.[0] ?? ''}
+  //       onChange={(value) => setFilterValue((old: [number, number]) => [value, old?.[1]])}
+  //       placeholder={`Min ${getFacetedMinMaxValues()?.[0] ? `(${getFacetedMinMaxValues()?.[0]})` : ''}`}
+  //       className="w-24 border shadow rounded"
+  //     />
+  //     <DebouncedInput
+  //       type="number"
+  //       min={Number(getFacetedMinMaxValues()?.[0] ?? '')}
+  //       max={Number(getFacetedMinMaxValues()?.[1] ?? '')}
+  //       value={(columnFilterValue as [number, number])?.[1] ?? ''}
+  //       onChange={(value) => setFilterValue((old: [number, number]) => [old?.[0], value])}
+  //       placeholder={`Max ${getFacetedMinMaxValues()?.[1] ? `(${getFacetedMinMaxValues()?.[1]})` : ''}`}
+  //       className="w-24 border shadow rounded"
+  //     />
+  //   </div>
+  // )
+  //
+  // const FilterRangeSlider = (
+  //   <RangeSlider
+  //     onChangeEnd={(a) => console.log('XXXXX', a)}
+  //     aria-label={['min', 'max']}
+  //     defaultValue={[Number(getFacetedMinMaxValues()?.[0] ?? ''), Number(getFacetedMinMaxValues()?.[1] ?? '')]}
+  //     min={Number(getFacetedMinMaxValues()?.[0] ?? '')}
+  //     max={Number(getFacetedMinMaxValues()?.[1] ?? '')}
+  //   >
+  //     <RangeSliderTrack>
+  //       <RangeSliderFilledTrack />
+  //     </RangeSliderTrack>
+  //     <RangeSliderThumb index={0} />
+  //     <RangeSliderThumb index={1} />
+  //   </RangeSlider>
+  // )
+
+  if (typeof firstValue === 'number') return null
+
+  return (
     <>
-      <datalist id={column.id + 'list'}>
+      <datalist id={id + '-list'}>
         {sortedUniqueValues.slice(0, 5000).map((value: any) => (
           <option value={value} key={value} />
         ))}
@@ -45,11 +83,9 @@ export const Filter = ({ column, table }: { column: Column<any, unknown>; table:
       <DebouncedInput
         type="text"
         value={(columnFilterValue ?? '') as string}
-        onChange={(value) => column.setFilterValue(value)}
-        placeholder={
-          t('components:pagination.filter.placeholder', { size: column.getFacetedUniqueValues().size }) as string
-        }
-        list={column.id + 'list'}
+        onChange={(value) => setFilterValue(value)}
+        placeholder={t('components:pagination.filter.placeholder', { size: getFacetedUniqueValues().size }) as string}
+        list={id + '-list'}
       />
     </>
   )

--- a/hivemq-edge/src/frontend/src/components/PaginatedTable/utils/table-utils.spec.ts
+++ b/hivemq-edge/src/frontend/src/components/PaginatedTable/utils/table-utils.spec.ts
@@ -1,0 +1,23 @@
+import { expect } from 'vitest'
+import { AriaAttributes } from 'react'
+import { getAriaSort } from '@/components/PaginatedTable/utils/table-utils.ts'
+import { SortDirection } from '@tanstack/react-table'
+
+interface TestEachSuite {
+  canSort: boolean
+  isSorted: false | SortDirection
+  aria: AriaAttributes['aria-sort']
+}
+
+describe('getAriaSort', () => {
+  it.each<TestEachSuite>([
+    { canSort: false, isSorted: false, aria: undefined },
+    { canSort: false, isSorted: 'asc', aria: undefined },
+    { canSort: false, isSorted: 'desc', aria: undefined },
+    { canSort: true, isSorted: false, aria: 'none' },
+    { canSort: true, isSorted: 'asc', aria: 'ascending' },
+    { canSort: true, isSorted: 'desc', aria: 'descending' },
+  ])('should return $aria with $canSort + $isSorted', ({ canSort, isSorted, aria }) => {
+    expect(getAriaSort(canSort, isSorted)).toStrictEqual(aria)
+  })
+})

--- a/hivemq-edge/src/frontend/src/components/PaginatedTable/utils/table-utils.ts
+++ b/hivemq-edge/src/frontend/src/components/PaginatedTable/utils/table-utils.ts
@@ -1,0 +1,11 @@
+import { AriaAttributes } from 'react'
+import { SortDirection } from '@tanstack/react-table'
+
+export const getAriaSort = (canSort: boolean, isSorted: false | SortDirection): AriaAttributes['aria-sort'] => {
+  if (!canSort) return undefined
+  if (isSorted === 'asc') return 'ascending'
+  if (isSorted === 'desc') return 'descending'
+  // if (header.column.getIsSorted() === false) return "none"
+
+  return 'none'
+}

--- a/hivemq-edge/src/frontend/src/locales/en/components.json
+++ b/hivemq-edge/src/frontend/src/locales/en/components.json
@@ -4,7 +4,8 @@
   },
   "pagination": {
     "filter": {
-      "placeholder": "Search... ({{ size }})"
+      "placeholder": "Search... ({{ size }})",
+      "clear": "Clear filter"
     },
     "noDataText": "No data received yet.",
     "goFirstPage": "Go to the first page",

--- a/hivemq-edge/src/frontend/src/locales/en/components.json
+++ b/hivemq-edge/src/frontend/src/locales/en/components.json
@@ -4,7 +4,7 @@
   },
   "pagination": {
     "filter": {
-      "placeholder": "Search ... ({{ size }})"
+      "placeholder": "Search... ({{ size }})"
     },
     "noDataText": "No data received yet.",
     "goFirstPage": "Go to the first page",

--- a/hivemq-edge/src/frontend/src/locales/en/components.json
+++ b/hivemq-edge/src/frontend/src/locales/en/components.json
@@ -3,6 +3,9 @@
     "iconLabel": "Topic"
   },
   "pagination": {
+    "filter": {
+      "placeholder": "Search ... ({{ size }})"
+    },
     "noDataText": "No data received yet.",
     "goFirstPage": "Go to the first page",
     "goPreviousPage": "Go to the previous page",

--- a/hivemq-edge/src/frontend/src/modules/EventLog/components/table/EventLogTable.tsx
+++ b/hivemq-edge/src/frontend/src/modules/EventLog/components/table/EventLogTable.tsx
@@ -127,10 +127,11 @@ const EventLogTable: FC<EventLogTableProps> = ({ onOpen }) => {
         data={safeData}
         columns={columns}
         enableColumnFilters
-      // getRowStyles={(row) => {
-      //   return { backgroundColor: theme.colors.blue[50] }
-      // }}
-    /></>
+        // getRowStyles={(row) => {
+        //   return { backgroundColor: theme.colors.blue[50] }
+        // }}
+      />
+    </>
   )
 }
 

--- a/hivemq-edge/src/frontend/src/modules/EventLog/components/table/EventLogTable.tsx
+++ b/hivemq-edge/src/frontend/src/modules/EventLog/components/table/EventLogTable.tsx
@@ -55,9 +55,10 @@ const EventLogTable: FC<EventLogTableProps> = ({ onOpen }) => {
       {
         accessorKey: 'created',
         sortType: 'datetime',
+        accessorFn: (row) => DateTime.fromISO(row.created).toMillis(),
         cell: (info) => (
           <Skeleton isLoaded={!isLoading} whiteSpace={'nowrap'}>
-            {DateTime.fromISO(info.getValue() as string).toRelativeCalendar({ unit: 'minutes' })}
+            {DateTime.fromMillis(info.getValue() as number).toRelativeCalendar({ unit: 'minutes' })}
           </Skeleton>
         ),
         header: t('eventLog.table.header.created') as string,

--- a/hivemq-edge/src/frontend/src/modules/EventLog/components/table/EventLogTable.tsx
+++ b/hivemq-edge/src/frontend/src/modules/EventLog/components/table/EventLogTable.tsx
@@ -34,6 +34,7 @@ const EventLogTable: FC<EventLogTableProps> = ({ onOpen }) => {
         accessorKey: 'identifier.identifier',
         width: '25%',
         enableSorting: false,
+        enableColumnFilter: false,
         header: t('eventLog.table.header.id') as string,
         cell: (info) => {
           return (
@@ -84,6 +85,7 @@ const EventLogTable: FC<EventLogTableProps> = ({ onOpen }) => {
       {
         accessorKey: 'message',
         header: t('eventLog.table.header.message') as string,
+        enableColumnFilter: false,
         cell: (info) => {
           return (
             <Skeleton isLoaded={!isLoading} overflow={'hidden'}>
@@ -123,11 +125,11 @@ const EventLogTable: FC<EventLogTableProps> = ({ onOpen }) => {
       <PaginatedTable<Event>
         data={safeData}
         columns={columns}
-        // getRowStyles={(row) => {
-        //   return { backgroundColor: theme.colors.blue[50] }
-        // }}
-      />
-    </>
+        enableColumnFilters
+      // getRowStyles={(row) => {
+      //   return { backgroundColor: theme.colors.blue[50] }
+      // }}
+    /></>
   )
 }
 


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/17145/details/

This PR adds filters to selected columns of a paginated table. On a valid column, the table renders an input field that can be used to type a value to apply as a filter to the column: 
- only the rows showing the substring will be shown in the table
- a `datalist` will show the matching values that are available for select
-  All the other filterable columns act as "facets": their datalist only shows the matching values after filtering on other columns
- Each filter contains a "Clear" button that will remove the value from the filter and re-populate the table

The PR also fixes the accessibility of the column sorting, see https://hivemq.kanbanize.com/ctrl_board/57/cards/16518/details/:
- by wrapping the sortable column name in a button (for active area)
- by adding the proper `aria-sort` label to the table's column header
- by refactoring the sort icons to a more known type

### Out-of-scope

- number values (e.g. date) should be filtered by a `min` and a `max`. The custom UI will be implemented in a separate ticket
- The `debounce` component introduces too many cycles in the react tree. Improving the display will be addressed in a different ticket
- the `datalist` approach uses a native HTML component. An improved version using UI widgets (`Select`) will be implemented in a separate ticket.

### Before
![screenshot-localhost_3000-2023 10 31-16_39_04](https://github.com/hivemq/hivemq-edge/assets/2743481/2c4efb74-9616-4f1c-a68b-b6b6a1a2edc9)

### After  
![screenshot-localhost_3000-2023 11 01-11_09_43](https://github.com/hivemq/hivemq-edge/assets/2743481/a020e7d4-6916-4761-b3dd-6a2ba4c7a190)

![Screenshot 2023-11-01 at 11 11 02](https://github.com/hivemq/hivemq-edge/assets/2743481/6f1a69e7-acfe-49ac-9645-a5b95741fdb5)

![Screenshot 2023-11-01 at 11 10 33](https://github.com/hivemq/hivemq-edge/assets/2743481/99a6035c-2013-4bd5-b324-66bb67f20d91)

![Screenshot 2023-10-31 at 16 40 55](https://github.com/hivemq/hivemq-edge/assets/2743481/94c3ab61-a35e-49db-b706-70e67f415f75)
