### PR TITLE
fix(17265): Check bridge existence before opening editor

### DIFF
--- a/hivemq-edge/src/frontend/src/hooks/useEdgeToast/useEdgeToast.tsx
+++ b/hivemq-edge/src/frontend/src/hooks/useEdgeToast/useEdgeToast.tsx
@@ -13,25 +13,26 @@ export const useEdgeToast = () => {
       ...options,
     })
 
-  const errorToast = (options: UseToastOptions, err: ApiError) => {
-    const { body } = err
-    createToast({
-      ...DEFAULT_TOAST_OPTION,
-      ...options,
-      status: 'error',
-      description: (
-        <>
-          <Text>{options?.description}</Text>
-          {!body && <Text>{err.message}</Text>}
-          {body && body.message && <Text>{body.message}</Text>}
-          {body?.errors?.map((e: ProblemDetailsExtended) => (
-            <Text key={e.fieldName as string}>
-              {e.fieldName as string} : {e.detail || e.title}
-            </Text>
-          ))}
-        </>
-      ),
-    })
+  const errorToast = (options: UseToastOptions, err: Error) => {
+    const { body } = err as ApiError
+    if ((options.id && !createToast.isActive(options.id)) || !options.id)
+      createToast({
+        ...DEFAULT_TOAST_OPTION,
+        ...options,
+        status: 'error',
+        description: (
+          <>
+            <Text>{options?.description}</Text>
+            {!body && <Text>{err.message}</Text>}
+            {body && body.message && <Text>{body.message}</Text>}
+            {body?.errors?.map((e: ProblemDetailsExtended) => (
+              <Text key={e.fieldName as string}>
+                {e.fieldName as string} : {e.detail || e.title}
+              </Text>
+            ))}
+          </>
+        ),
+      })
   }
 
   return { successToast, errorToast }

--- a/hivemq-edge/src/frontend/src/locales/en/translation.json
+++ b/hivemq-edge/src/frontend/src/locales/en/translation.json
@@ -160,6 +160,11 @@
         "title": "Creating Bridge",
         "description": "We've successfully created a new bridge for you.",
         "error": "There was a problem trying to create the bridge"
+      },
+      "view": {
+        "title": "Viewing Bridge",
+        "error": "There was a problem trying to view the bridge",
+        "noLongerExist": "The bridge {{ id}} doesn't exist anymore"
       }
     },
     "status": {

--- a/hivemq-edge/src/frontend/src/locales/en/translation.json
+++ b/hivemq-edge/src/frontend/src/locales/en/translation.json
@@ -164,7 +164,7 @@
       "view": {
         "title": "Viewing Bridge",
         "error": "There was a problem trying to view the bridge",
-        "noLongerExist": "The bridge {{ id}} doesn't exist anymore"
+        "noLongerExist": "The bridge {{id}} doesn't exist anymore"
       }
     },
     "status": {

--- a/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/BridgeEditor.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/BridgeEditor.tsx
@@ -36,6 +36,7 @@ const BridgeEditor: FC<BridgeEditorProps> = ({ children }) => {
   const { isOpen: isConfirmDeleteOpen, onOpen: onConfirmDeleteOpen, onClose: onConfirmDeleteClose } = useDisclosure()
 
   useEffect(() => {
+    if (!data) return
     if (bridgeId) {
       const b = data?.find((e) => e.id === bridgeId)
       if (b) {

--- a/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/BridgeEditor.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/BridgeEditor.tsx
@@ -27,7 +27,7 @@ const BridgeEditor: FC<BridgeEditorProps> = ({ children }) => {
 
   const { isOpen, onOpen, onClose } = useDisclosure()
   const { bridgeId } = useParams()
-  const { bridge, setBridge } = useBridgeSetup()
+  const { setBridge } = useBridgeSetup()
   const { data } = useListBridges()
   const navigate = useNavigate()
   const createBridge = useCreateBridge()
@@ -40,15 +40,23 @@ const BridgeEditor: FC<BridgeEditorProps> = ({ children }) => {
       const b = data?.find((e) => e.id === bridgeId)
       if (b) {
         setBridge(b)
+        onOpen()
       } else {
-        // TODO[NVL] handle error for the edge cases of not finding the right datapoint
-        setBridge(bridgeInitialState)
+        errorToast(
+          {
+            id: 'bridge-open-noExist',
+            title: t('bridge.toast.view.title'),
+            description: t('bridge.toast.view.error'),
+          },
+          new Error(t('bridge.toast.view.noLongerExist', { id: bridgeId }) as string)
+        )
+        navigate('/mqtt-bridges', { replace: true })
       }
     } else {
       setBridge(bridgeInitialState)
+      onOpen()
     }
-    onOpen()
-  }, [bridgeId, bridge, data, setBridge, onOpen])
+  }, [bridgeId, data, setBridge, onOpen, errorToast, t, navigate])
 
   const handleEditorOnClose = () => {
     onClose()


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/17265/details/


The PR fixes one of the bugs when using the `event log`.
When accessing a bridge by clicking on the `source` link, the app navigates to the list of bridges but now checks that the required bridge exists before opening the side panel 

If it doesn't exist, an `error`  toast message is displayed

### Before
![screenshot-localhost_3000-2023 11 01-12_03_00](https://github.com/hivemq/hivemq-edge/assets/2743481/99b947e7-75f6-4591-91f2-bbe13cca7c0e)


### After
![screenshot-localhost_3000-2023 11 01-11_58_21](https://github.com/hivemq/hivemq-edge/assets/2743481/552a74ab-6674-4f46-a855-a88499bfcd46)
