### PR TITLE
fix(17265): fix navigation to active adapter's table

### DIFF
--- a/hivemq-edge/src/frontend/src/locales/en/translation.json
+++ b/hivemq-edge/src/frontend/src/locales/en/translation.json
@@ -468,6 +468,11 @@
         "title": "Creating Protocol Adapter",
         "description": "We've successfully created a new Protocol Adapter for you.",
         "error": "There was a problem trying to create the Protocol Adapter"
+      },
+      "view": {
+        "title": "Viewing Protocol Adapter",
+        "error": "There was a problem trying to view the protocol adapter",
+        "noLongerExist": "The Protocol Adapter {{id}} doesn't exist"
       }
     },
     "type": {

--- a/hivemq-edge/src/frontend/src/modules/EdgeVisualisation/components/drawers/NodePropertyDrawer.tsx
+++ b/hivemq-edge/src/frontend/src/modules/EdgeVisualisation/components/drawers/NodePropertyDrawer.tsx
@@ -24,7 +24,7 @@ import { DeviceTypes } from '@/api/types/api-devices.ts'
 import ConnectionController from '@/components/ConnectionController/ConnectionController.tsx'
 
 import Metrics from '@/modules/Welcome/components/Metrics.tsx'
-import { ProtocolAdapterTabIndex } from '@/modules/ProtocolAdapters/ProtocolAdapterPage.tsx'
+import { AdapterNavigateState, ProtocolAdapterTabIndex } from '@/modules/ProtocolAdapters/types.ts'
 import { NodeTypes } from '@/modules/EdgeVisualisation/types.ts'
 
 import { getDefaultMetricsFor } from '../../utils/nodes-utils.ts'
@@ -77,14 +77,16 @@ const NodePropertyDrawer: FC = () => {
               variant={'outline'}
               size={'sm'}
               rightIcon={<EditIcon />}
-              onClick={() =>
-                navigate('/protocol-adapters', {
-                  state: {
-                    protocolAdapterTabIndex: ProtocolAdapterTabIndex.adapters,
-                    selectedAdapter: { isNew: false, adapterId: (selected?.data as Adapter).id },
-                  },
+              onClick={() => {
+                const adapterNavigateState: AdapterNavigateState = {
+                  protocolAdapterTabIndex: ProtocolAdapterTabIndex.adapters,
+                  protocolAdapterType: (selected?.data as Adapter).type,
+                  selectedActiveAdapter: { isNew: false, isOpen: false, adapterId: (selected?.data as Adapter).id },
+                }
+                navigate(`/protocol-adapters/${(selected?.data as Adapter).id}`, {
+                  state: adapterNavigateState,
                 })
-              }
+              }}
             >
               {t('workspace.observability.adapter.modify')}
             </Button>

--- a/hivemq-edge/src/frontend/src/modules/EventLog/components/SourceLink.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/EventLog/components/SourceLink.spec.cy.tsx
@@ -9,35 +9,35 @@ describe('SourceLink', () => {
   })
 
   it('should render the bridge component', () => {
-    cy.mountWithProviders(<SourceLink event={mockEdgeEvent(5)[0].source} />)
+    cy.mountWithProviders(<SourceLink source={mockEdgeEvent(5)[0].source} />)
 
     cy.get('a').should('contain.text', 'BRIDGE-0')
     cy.get('a').should('have.attr', 'href', '/mqtt-bridges/BRIDGE-0')
   })
 
   it('should render the adapter component', () => {
-    cy.mountWithProviders(<SourceLink event={mockEdgeEvent(5)[1].source} />)
+    cy.mountWithProviders(<SourceLink source={mockEdgeEvent(5)[1].source} />)
 
     cy.get('a').should('contain.text', 'ADAPTER-1')
     cy.get('a').should('have.attr', 'href', '/protocol-adapters/ADAPTER-1')
   })
 
   it('should render the adapter component', () => {
-    cy.mountWithProviders(<SourceLink event={mockEdgeEvent(5)[2].source} />)
+    cy.mountWithProviders(<SourceLink source={mockEdgeEvent(5)[2].source} />)
 
     cy.get('div').should('contain.text', 'ADAPTER_TYPE-2')
     cy.get('a').should('not.exist')
   })
 
   it('should render the adapter component', () => {
-    cy.mountWithProviders(<SourceLink event={mockEdgeEvent(5)[3].source} />)
+    cy.mountWithProviders(<SourceLink source={mockEdgeEvent(5)[3].source} />)
 
     cy.get('div').should('contain.text', 'EVENT-3')
     cy.get('a').should('not.exist')
   })
 
   it('should render the adapter component', () => {
-    cy.mountWithProviders(<SourceLink event={mockEdgeEvent(5)[4].source} />)
+    cy.mountWithProviders(<SourceLink source={mockEdgeEvent(5)[4].source} />)
 
     cy.get('div').should('contain.text', 'USER-4')
     cy.get('a').should('not.exist')

--- a/hivemq-edge/src/frontend/src/modules/EventLog/components/SourceLink.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/EventLog/components/SourceLink.spec.cy.tsx
@@ -22,21 +22,21 @@ describe('SourceLink', () => {
     cy.get('a').should('have.attr', 'href', '/protocol-adapters/ADAPTER-1')
   })
 
-  it('should render the adapter component', () => {
+  it('should render the adapter type component', () => {
     cy.mountWithProviders(<SourceLink source={mockEdgeEvent(5)[2].source} />)
 
     cy.get('div').should('contain.text', 'ADAPTER_TYPE-2')
     cy.get('a').should('not.exist')
   })
 
-  it('should render the adapter component', () => {
+  it('should render the event component', () => {
     cy.mountWithProviders(<SourceLink source={mockEdgeEvent(5)[3].source} />)
 
     cy.get('div').should('contain.text', 'EVENT-3')
     cy.get('a').should('not.exist')
   })
 
-  it('should render the adapter component', () => {
+  it('should render the user component', () => {
     cy.mountWithProviders(<SourceLink source={mockEdgeEvent(5)[4].source} />)
 
     cy.get('div').should('contain.text', 'USER-4')

--- a/hivemq-edge/src/frontend/src/modules/EventLog/components/SourceLink.tsx
+++ b/hivemq-edge/src/frontend/src/modules/EventLog/components/SourceLink.tsx
@@ -45,7 +45,7 @@ const LinkWrapper: Record<TypeIdentifier.type, LinkWrapperProps> = {
 const SourceLink: FC<SourceLinkProps> = ({ source, type }) => {
   const SourceType = source?.type && LinkWrapper[source?.type]
 
-  if (!SourceType)
+  if (!SourceType?.To)
     return (
       <Box whiteSpace={'nowrap'} display={'inline-flex'}>
         {source?.identifier}
@@ -55,13 +55,13 @@ const SourceLink: FC<SourceLinkProps> = ({ source, type }) => {
   return (
     <ChakraLink
       as={ReactRouterLink}
-      to={source.identifier && SourceType.To?.(source.identifier)}
+      to={source?.identifier && SourceType.To?.(source.identifier)}
       state={type?.identifier && SourceType.State?.(type?.identifier)}
       whiteSpace={'nowrap'}
       display={'inline-flex'}
     >
-      {source.type && SourceType.Icon}
-      {source.identifier}
+      {source?.type && SourceType.Icon}
+      {source?.identifier}
     </ChakraLink>
   )
 }

--- a/hivemq-edge/src/frontend/src/modules/EventLog/components/SourceLink.tsx
+++ b/hivemq-edge/src/frontend/src/modules/EventLog/components/SourceLink.tsx
@@ -2,47 +2,66 @@ import { FC } from 'react'
 import { Link as ReactRouterLink } from 'react-router-dom'
 import { Box, Icon, Link as ChakraLink } from '@chakra-ui/react'
 import { PiBridgeThin, PiPlugsConnectedFill, PiUserFill } from 'react-icons/pi'
-
-import { TypeIdentifier } from '@/api/__generated__'
 import { MdOutlineEventNote } from 'react-icons/md'
 
+import { TypeIdentifier } from '@/api/__generated__'
+import { AdapterNavigateState, ProtocolAdapterTabIndex } from '@/modules/ProtocolAdapters/types.ts'
+
 interface SourceLinkProps {
-  event: TypeIdentifier | undefined
+  source: TypeIdentifier | undefined
+  type?: TypeIdentifier | undefined
 }
 
-const SourceLink: FC<SourceLinkProps> = ({ event }) => {
-  const IconComponent = {
-    [TypeIdentifier.type.ADAPTER]: <Icon as={PiPlugsConnectedFill} mr={2} />,
-    [TypeIdentifier.type.ADAPTER_TYPE]: <Icon as={PiPlugsConnectedFill} mr={2} />,
-    [TypeIdentifier.type.BRIDGE]: <Icon as={PiBridgeThin} fontSize={'20px'} mr={2} />,
-    [TypeIdentifier.type.EVENT]: <Icon as={MdOutlineEventNote} mr={2} />,
-    [TypeIdentifier.type.USER]: <Icon as={PiUserFill} mr={2} />,
-  }
+interface LinkWrapperProps {
+  Icon: JSX.Element
+  To?: (id: string) => string | undefined
+  State?: (id: string) => AdapterNavigateState
+}
 
-  const navRoute = {
-    [TypeIdentifier.type.ADAPTER]: (id: string | undefined) => `/protocol-adapters/${id}`,
-    [TypeIdentifier.type.ADAPTER_TYPE]: undefined,
-    [TypeIdentifier.type.BRIDGE]: (id: string | undefined) => `/mqtt-bridges/${id}`,
-    [TypeIdentifier.type.EVENT]: undefined,
-    [TypeIdentifier.type.USER]: undefined,
-  }
+const LinkWrapper: Record<TypeIdentifier.type, LinkWrapperProps> = {
+  [TypeIdentifier.type.ADAPTER]: {
+    Icon: <Icon as={PiPlugsConnectedFill} mr={2} />,
+    State: (id: string) => ({
+      protocolAdapterTabIndex: ProtocolAdapterTabIndex.adapters,
+      protocolAdapterType: id,
+    }),
+    To: (id: string) => `/protocol-adapters/${id}`,
+  },
+  [TypeIdentifier.type.ADAPTER_TYPE]: {
+    Icon: <Icon as={PiPlugsConnectedFill} mr={2} />,
+  },
+  [TypeIdentifier.type.BRIDGE]: {
+    Icon: <Icon as={PiBridgeThin} fontSize={'20px'} mr={2} />,
+    To: (id: string) => `/mqtt-bridges/${id}`,
+  },
+  [TypeIdentifier.type.EVENT]: {
+    Icon: <Icon as={MdOutlineEventNote} mr={2} />,
+  },
+  [TypeIdentifier.type.USER]: {
+    Icon: <Icon as={PiUserFill} mr={2} />,
+  },
+}
 
-  if (!event?.type || !navRoute[event?.type])
+const SourceLink: FC<SourceLinkProps> = ({ source, type }) => {
+  const SourceType = source?.type && LinkWrapper[source?.type]
+
+  if (!SourceType)
     return (
       <Box whiteSpace={'nowrap'} display={'inline-flex'}>
-        {event?.identifier}
+        {source?.identifier}
       </Box>
     )
 
   return (
     <ChakraLink
       as={ReactRouterLink}
-      to={navRoute[event.type]?.(event.identifier)}
+      to={source.identifier && SourceType.To?.(source.identifier)}
+      state={type?.identifier && SourceType.State?.(type?.identifier)}
       whiteSpace={'nowrap'}
       display={'inline-flex'}
     >
-      {event.type && IconComponent[event.type]}
-      {event.identifier}
+      {source.type && SourceType.Icon}
+      {source.identifier}
     </ChakraLink>
   )
 }

--- a/hivemq-edge/src/frontend/src/modules/EventLog/components/panel/EventDrawer.tsx
+++ b/hivemq-edge/src/frontend/src/modules/EventLog/components/panel/EventDrawer.tsx
@@ -72,13 +72,13 @@ const EventDrawer: FC<BridgeMainDrawerProps> = ({ event, isOpen, onClose }) => {
                       <Text>{t('eventLog.table.header.source')}</Text>
                     </GridItem>
                     <GridItem data-testid={'event-value-source'}>
-                      <SourceLink event={event?.source} />
+                      <SourceLink source={event?.source} />
                     </GridItem>
                     <GridItem data-testid={'event-title-associatedObject'}>
                       <Text>{t('eventLog.table.header.associatedObject')}</Text>
                     </GridItem>
                     <GridItem data-testid={'event-value-associatedObject'}>
-                      <SourceLink event={event?.associatedObject} />
+                      <SourceLink source={event?.associatedObject} />
                     </GridItem>
                   </Grid>
                 </CardBody>

--- a/hivemq-edge/src/frontend/src/modules/EventLog/components/table/EventLogTable.tsx
+++ b/hivemq-edge/src/frontend/src/modules/EventLog/components/table/EventLogTable.tsx
@@ -77,7 +77,7 @@ const EventLogTable: FC<EventLogTableProps> = ({ onOpen }) => {
         header: t('eventLog.table.header.source') as string,
         cell: (info) => (
           <Skeleton isLoaded={!isLoading}>
-            <SourceLink event={info.row.original.source} />
+            <SourceLink source={info.row.original.source} type={info.row.original.associatedObject} />
           </Skeleton>
         ),
       },

--- a/hivemq-edge/src/frontend/src/modules/EventLog/components/table/EventLogTable.tsx
+++ b/hivemq-edge/src/frontend/src/modules/EventLog/components/table/EventLogTable.tsx
@@ -72,7 +72,7 @@ const EventLogTable: FC<EventLogTableProps> = ({ onOpen }) => {
         ),
       },
       {
-        accessorKey: 'associatedObject.identifier',
+        accessorKey: 'source.identifier',
         sortType: 'alphanumeric',
         header: t('eventLog.table.header.source') as string,
         cell: (info) => (

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/ProtocolAdapterPage.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/ProtocolAdapterPage.tsx
@@ -15,7 +15,7 @@ const ProtocolAdapterPage: FC = () => {
   const [tabIndex, setTabIndex] = useState(0)
 
   useEffect(() => {
-    if (state?.protocolAdapterTabIndex) {
+    if ((state as AdapterNavigateState)?.protocolAdapterTabIndex) {
       setTabIndex(state.protocolAdapterTabIndex)
     }
   }, [state])

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/ProtocolAdapterPage.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/ProtocolAdapterPage.tsx
@@ -7,11 +7,7 @@ import { Outlet, useLocation } from 'react-router-dom'
 import PageContainer from '@/components/PageContainer.tsx'
 import ProtocolAdapters from '@/modules/ProtocolAdapters/components/panels/ProtocolAdapters.tsx'
 import ProtocolIntegrationStore from '@/modules/ProtocolAdapters/components/panels/ProtocolIntegrationStore.tsx'
-
-export enum ProtocolAdapterTabIndex {
-  protocols = 0,
-  adapters = 1,
-}
+import { AdapterNavigateState } from '@/modules/ProtocolAdapters/types.ts'
 
 const ProtocolAdapterPage: FC = () => {
   const { t } = useTranslation()

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/AdapterController.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/AdapterController.tsx
@@ -1,6 +1,6 @@
 import { FC, ReactNode, useEffect, useState } from 'react'
 import { useDisclosure } from '@chakra-ui/react'
-import { useLocation, useNavigate } from 'react-router-dom'
+import { useLocation, useNavigate, useParams } from 'react-router-dom'
 import { SubmitHandler } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 
@@ -12,6 +12,7 @@ import { useEdgeToast } from '@/hooks/useEdgeToast/useEdgeToast.tsx'
 
 import { AdapterNavigateState, ProtocolAdapterTabIndex } from '@/modules/ProtocolAdapters/types.ts'
 import AdapterInstanceDrawer from '@/modules/ProtocolAdapters/components/drawers/AdapterInstanceDrawer.tsx'
+import { useListProtocolAdapters } from '@/api/hooks/useProtocolAdapters/useListProtocolAdapters.tsx'
 
 interface AdapterEditorProps {
   isNew?: boolean
@@ -28,6 +29,8 @@ const AdapterController: FC<AdapterEditorProps> = ({ children, isNew }) => {
   const updateProtocolAdapter = useUpdateProtocolAdapter()
   const navigate = useNavigate()
   const { state } = useLocation()
+  const { data: allAdapters } = useListProtocolAdapters()
+  const { adapterId } = useParams()
 
   useEffect(() => {
     if ((state as AdapterNavigateState)?.protocolAdapterType) {
@@ -36,10 +39,25 @@ const AdapterController: FC<AdapterEditorProps> = ({ children, isNew }) => {
   }, [state])
 
   useEffect(() => {
+    if (!allAdapters) return
+    const instance = allAdapters?.find((e) => e.id === adapterId)
+    if (!isNew && !instance) {
+      errorToast(
+        {
+          id: 'adapter-open-noExist',
+          title: t('protocolAdapter.toast.view.title'),
+          description: t('protocolAdapter.toast.view.error'),
+        },
+        new Error(t('protocolAdapter.toast.view.noLongerExist', { id: adapterId }) as string)
+      )
+      navigate('/protocol-adapters', { replace: true })
+      return
+    }
+
     if (adaptorType) {
       onInstanceOpen()
     }
-  }, [adaptorType, onInstanceOpen])
+  }, [adapterId, adaptorType, allAdapters, errorToast, isNew, navigate, onInstanceOpen, t])
 
   const handleInstanceClose = () => {
     onInstanceClose()

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/AdapterController.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/AdapterController.tsx
@@ -105,11 +105,12 @@ const AdapterController: FC<AdapterEditorProps> = ({ children, isNew }) => {
     }
 
     onInstanceClose()
+    const adapterNavigateState: AdapterNavigateState = {
+      protocolAdapterTabIndex: ProtocolAdapterTabIndex.adapters,
+      selectedActiveAdapter: { isNew: !!isNew, isOpen: false, adapterId: id },
+    }
     navigate('/protocol-adapters', {
-      state: {
-        protocolAdapterTabIndex: ProtocolAdapterTabIndex.adapters,
-        selectedAdapter: { isNew: isNew, adapterId: id },
-      },
+      state: adapterNavigateState,
     })
   }
 

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/AdapterController.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/AdapterController.tsx
@@ -10,7 +10,7 @@ import { useUpdateProtocolAdapter } from '@/api/hooks/useProtocolAdapters/useUpd
 
 import { useEdgeToast } from '@/hooks/useEdgeToast/useEdgeToast.tsx'
 
-import { ProtocolAdapterTabIndex } from '@/modules/ProtocolAdapters/ProtocolAdapterPage.tsx'
+import { AdapterNavigateState, ProtocolAdapterTabIndex } from '@/modules/ProtocolAdapters/types.ts'
 import AdapterInstanceDrawer from '@/modules/ProtocolAdapters/components/drawers/AdapterInstanceDrawer.tsx'
 
 interface AdapterEditorProps {
@@ -28,13 +28,12 @@ const AdapterController: FC<AdapterEditorProps> = ({ children, isNew }) => {
   const updateProtocolAdapter = useUpdateProtocolAdapter()
   const navigate = useNavigate()
   const { state } = useLocation()
-  const { selectedAdapterId } = state || {}
 
   useEffect(() => {
-    if (selectedAdapterId) {
-      setAdaptorType(selectedAdapterId)
+    if ((state as AdapterNavigateState)?.protocolAdapterType) {
+      setAdaptorType(state.protocolAdapterType)
     }
-  }, [selectedAdapterId])
+  }, [state])
 
   useEffect(() => {
     if (adaptorType) {

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/panels/ProtocolAdapters.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/panels/ProtocolAdapters.tsx
@@ -136,7 +136,7 @@ const ProtocolAdapters: FC = () => {
         sortingFn: undefined,
         cell: (info) => {
           const { id, type } = info.row.original
-          const { selectedActiveAdapter } = state as AdapterNavigateState
+          const { selectedActiveAdapter } = (state || {}) as AdapterNavigateState
           return (
             <Skeleton isLoaded={!isLoading}>
               <AdapterActionMenu
@@ -225,7 +225,7 @@ const ProtocolAdapters: FC = () => {
         data={safeData}
         columns={columns}
         getRowStyles={(row: Row<Adapter>) => {
-          const { selectedActiveAdapter } = state as AdapterNavigateState
+          const { selectedActiveAdapter } = (state || {}) as AdapterNavigateState
           return row.original.id === selectedActiveAdapter?.adapterId ? { backgroundColor: colors.blue[50] } : {}
         }}
       />

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/panels/ProtocolAdapters.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/panels/ProtocolAdapters.tsx
@@ -26,6 +26,7 @@ import { useEdgeToast } from '@/hooks/useEdgeToast/useEdgeToast.tsx'
 import { compareStatus } from '../../utils/pagination-utils.ts'
 import AdapterActionMenu from '../adapters/AdapterActionMenu.tsx'
 import { mockAdapter } from '@/api/hooks/useProtocolAdapters/__handlers__'
+import { AdapterNavigateState, ProtocolAdapterTabIndex } from '@/modules/ProtocolAdapters/types.ts'
 
 const DEFAULT_PER_PAGE = 10
 
@@ -65,11 +66,21 @@ const ProtocolAdapters: FC = () => {
 
   const columns = useMemo<ColumnDef<Adapter>[]>(() => {
     const handleCreateInstance = (type: string | undefined) => {
-      navigate('/protocol-adapters/new', { state: { selectedAdapterId: type } })
+      const adapterNavigateState: AdapterNavigateState = {
+        protocolAdapterTabIndex: ProtocolAdapterTabIndex.adapters,
+        protocolAdapterType: type,
+        // selectedActiveAdapter: { isNew: false, isOpen: false, adapterId: (selected?.data as Adapter).id },
+      }
+      navigate('/protocol-adapters/new', { state: adapterNavigateState })
     }
 
     const handleEditInstance = (adapterId: string, type: string) => {
-      if (adapterId) navigate(`/protocol-adapters/${adapterId}`, { state: { selectedAdapterId: type } })
+      const adapterNavigateState: AdapterNavigateState = {
+        protocolAdapterTabIndex: ProtocolAdapterTabIndex.adapters,
+        protocolAdapterType: type,
+        // selectedActiveAdapter: { isNew: false, isOpen: false, adapterId: (selected?.data as Adapter).id },
+      }
+      if (adapterId) navigate(`/protocol-adapters/${adapterId}`, { state: adapterNavigateState })
     }
 
     const handleOnDelete = (adapterId: string) => {

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/panels/ProtocolAdapters.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/panels/ProtocolAdapters.tsx
@@ -69,7 +69,6 @@ const ProtocolAdapters: FC = () => {
       const adapterNavigateState: AdapterNavigateState = {
         protocolAdapterTabIndex: ProtocolAdapterTabIndex.adapters,
         protocolAdapterType: type,
-        // selectedActiveAdapter: { isNew: false, isOpen: false, adapterId: (selected?.data as Adapter).id },
       }
       navigate('/protocol-adapters/new', { state: adapterNavigateState })
     }
@@ -78,7 +77,6 @@ const ProtocolAdapters: FC = () => {
       const adapterNavigateState: AdapterNavigateState = {
         protocolAdapterTabIndex: ProtocolAdapterTabIndex.adapters,
         protocolAdapterType: type,
-        // selectedActiveAdapter: { isNew: false, isOpen: false, adapterId: (selected?.data as Adapter).id },
       }
       if (adapterId) navigate(`/protocol-adapters/${adapterId}`, { state: adapterNavigateState })
     }
@@ -138,7 +136,7 @@ const ProtocolAdapters: FC = () => {
         sortingFn: undefined,
         cell: (info) => {
           const { id, type } = info.row.original
-          const { selectedAdapter } = state || {}
+          const { selectedActiveAdapter } = state as AdapterNavigateState
           return (
             <Skeleton isLoaded={!isLoading}>
               <AdapterActionMenu
@@ -148,7 +146,7 @@ const ProtocolAdapters: FC = () => {
                 onDelete={handleOnDelete}
                 onViewWorkspace={handleViewWorkspace}
               />
-              {id === selectedAdapter?.adapterId && (
+              {id === selectedActiveAdapter?.adapterId && (
                 <IconButton
                   size={'sm'}
                   ml={2}
@@ -227,8 +225,8 @@ const ProtocolAdapters: FC = () => {
         data={safeData}
         columns={columns}
         getRowStyles={(row: Row<Adapter>) => {
-          const { selectedAdapter } = state || {}
-          return row.original.id === selectedAdapter?.adapterId ? { backgroundColor: colors.blue[50] } : {}
+          const { selectedActiveAdapter } = state as AdapterNavigateState
+          return row.original.id === selectedActiveAdapter?.adapterId ? { backgroundColor: colors.blue[50] } : {}
         }}
       />
 

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/panels/ProtocolIntegrationStore.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/panels/ProtocolIntegrationStore.tsx
@@ -14,7 +14,7 @@ import config from '@/config'
 import ErrorMessage from '@/components/ErrorMessage.tsx'
 import WarningMessage from '@/components/WarningMessage.tsx'
 
-import { ProtocolFacetType } from '../../types.ts'
+import { AdapterNavigateState, ProtocolAdapterTabIndex, ProtocolFacetType } from '../../types.ts'
 import ProtocolsBrowser from '../IntegrationStore/ProtocolsBrowser.tsx'
 import FacetSearch from '../IntegrationStore/FacetSearch.tsx'
 import { mockProtocolAdapter } from '@/api/hooks/useProtocolAdapters/__handlers__'
@@ -28,7 +28,14 @@ const ProtocolIntegrationStore: FC = () => {
   const safeData: ProtocolAdapter[] = data ? (data.items as ProtocolAdapter[]) : [mockProtocolAdapter]
 
   const handleCreateInstance = (adapterId: string | undefined) => {
-    navigate('/protocol-adapters/new', { state: { selectedAdapterId: adapterId } })
+    const adapterNavigateState: AdapterNavigateState = {
+      protocolAdapterTabIndex: ProtocolAdapterTabIndex.adapters,
+      protocolAdapterType: adapterId,
+      // selectedActiveAdapter: { isNew: false, isOpen: false, adapterId: (selected?.data as Adapter).id },
+    }
+    navigate('/protocol-adapters/new', {
+      state: adapterNavigateState,
+    })
   }
 
   const handleOnSearch = (value: ProtocolFacetType) => {

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/types.ts
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/types.ts
@@ -23,4 +23,19 @@ export interface UITab {
   properties: string[]
 }
 
+export enum ProtocolAdapterTabIndex {
+  protocols = 0,
+  adapters = 1,
+}
+
+export interface AdapterNavigateState {
+  protocolAdapterTabIndex: ProtocolAdapterTabIndex
+  protocolAdapterType?: string
+  selectedActiveAdapter?: {
+    isNew: boolean
+    isOpen: boolean
+    adapterId: string
+  }
+}
+
 export type AdapterConfig = NonNullable<Adapter['config']>


### PR DESCRIPTION
This PR fixes the navigation from the workspace or the event log. 

When clicking on a link to an adapter in either page, the user is now correctly navigated to the "Active Adapters" tab of the `app/protocol-adapters` page, with the editor opens whenthe source is a valide instance.

### Before 
![screenshot-localhost_3000-2023 11 01-15_54_48](https://github.com/hivemq/hivemq-edge/assets/2743481/677edd5e-9489-4acf-a3bd-851e607cb3c9)

![screenshot-localhost_3000-2023 11 01-15_55_08](https://github.com/hivemq/hivemq-edge/assets/2743481/c937c358-d8cb-4d32-9cac-6ac14803aac4)
### After
![screenshot-localhost_3000-2023 11 01-15_55_27](https://github.com/hivemq/hivemq-edge/assets/2743481/ae43c262-2231-42c0-a84d-9c94a8397a5f)
