### PR TITLE
feat(17328): Add manual reload to the event log

### DIFF
--- a/hivemq-edge/src/frontend/src/api/hooks/useEvents/useGetEvents.tsx
+++ b/hivemq-edge/src/frontend/src/api/hooks/useEvents/useGetEvents.tsx
@@ -2,21 +2,11 @@ import { useQuery } from '@tanstack/react-query'
 import { useHttpClient } from '@/api/hooks/useHttpClient/useHttpClient.ts'
 import { ApiError, EventList } from '@/api/__generated__'
 import { QUERY_KEYS } from '@/api/utils.ts'
-import config from '@/config'
 
 export const useGetEvents = () => {
   const appClient = useHttpClient()
 
-  return useQuery<EventList, ApiError>(
-    [QUERY_KEYS.EVENTS],
-    async () => {
-      return await appClient.events.getEvents()
-    },
-    {
-      retry: 0,
-      refetchInterval: () => {
-        return config.httpClient.pollingRefetchInterval
-      },
-    }
-  )
+  return useQuery<EventList, ApiError>([QUERY_KEYS.EVENTS], async () => {
+    return await appClient.events.getEvents()
+  })
 }

--- a/hivemq-edge/src/frontend/src/locales/en/translation.json
+++ b/hivemq-edge/src/frontend/src/locales/en/translation.json
@@ -671,7 +671,8 @@
         "payload": "Payload"
       },
       "cta": {
-        "open": "View details of event"
+        "open": "View details of event",
+        "refetch": "Update the Event Log"
       }
     },
     "panel": {

--- a/hivemq-edge/src/frontend/src/modules/EventLog/components/table/EventLogTable.tsx
+++ b/hivemq-edge/src/frontend/src/modules/EventLog/components/table/EventLogTable.tsx
@@ -24,7 +24,7 @@ interface EventLogTableProps {
 
 const EventLogTable: FC<EventLogTableProps> = ({ onOpen }) => {
   const { t } = useTranslation()
-  const { data, isLoading, error, refetch } = useGetEvents()
+  const { data, isLoading, isFetching, error, refetch } = useGetEvents()
 
   const safeData: Event[] = data && data.items ? data.items : [...mockEdgeEvent(5)]
 
@@ -110,7 +110,8 @@ const EventLogTable: FC<EventLogTableProps> = ({ onOpen }) => {
     <>
       <Flex justifyContent={'flex-end'}>
         <Button
-          variant={'ghost'}
+          isLoading={isFetching}
+          variant={'outline'}
           size={'sm'}
           leftIcon={<Icon as={BiRefresh} fontSize={20} />}
           onClick={() => refetch()}

--- a/hivemq-edge/src/frontend/src/modules/EventLog/components/table/EventLogTable.tsx
+++ b/hivemq-edge/src/frontend/src/modules/EventLog/components/table/EventLogTable.tsx
@@ -111,6 +111,7 @@ const EventLogTable: FC<EventLogTableProps> = ({ onOpen }) => {
       <Flex justifyContent={'flex-end'}>
         <Button
           isLoading={isFetching}
+          loadingText={t('eventLog.table.cta.refetch')}
           variant={'outline'}
           size={'sm'}
           leftIcon={<Icon as={BiRefresh} fontSize={20} />}

--- a/hivemq-edge/src/frontend/src/modules/EventLog/components/table/EventLogTable.tsx
+++ b/hivemq-edge/src/frontend/src/modules/EventLog/components/table/EventLogTable.tsx
@@ -2,8 +2,9 @@ import { FC, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { ColumnDef } from '@tanstack/react-table'
 import { DateTime } from 'luxon'
-import { Box, IconButton, Skeleton, Text } from '@chakra-ui/react'
+import { Box, Button, Flex, Icon, IconButton, Skeleton, Text } from '@chakra-ui/react'
 import { MdOutlineEventNote } from 'react-icons/md'
+import { BiRefresh } from 'react-icons/bi'
 
 import { Event } from '@/api/__generated__'
 import { ProblemDetails } from '@/api/types/http-problem-details.ts'
@@ -23,7 +24,7 @@ interface EventLogTableProps {
 
 const EventLogTable: FC<EventLogTableProps> = ({ onOpen }) => {
   const { t } = useTranslation()
-  const { data, isLoading, error } = useGetEvents()
+  const { data, isLoading, error, refetch } = useGetEvents()
 
   const safeData: Event[] = data && data.items ? data.items : [...mockEdgeEvent(5)]
 
@@ -106,13 +107,25 @@ const EventLogTable: FC<EventLogTableProps> = ({ onOpen }) => {
   }
 
   return (
-    <PaginatedTable<Event>
-      data={safeData}
-      columns={columns}
-      // getRowStyles={(row) => {
-      //   return { backgroundColor: theme.colors.blue[50] }
-      // }}
-    />
+    <>
+      <Flex justifyContent={'flex-end'}>
+        <Button
+          variant={'ghost'}
+          size={'sm'}
+          leftIcon={<Icon as={BiRefresh} fontSize={20} />}
+          onClick={() => refetch()}
+        >
+          {t('eventLog.table.cta.refetch')}
+        </Button>
+      </Flex>
+      <PaginatedTable<Event>
+        data={safeData}
+        columns={columns}
+        // getRowStyles={(row) => {
+        //   return { backgroundColor: theme.colors.blue[50] }
+        // }}
+      />
+    </>
   )
 }
 


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/17328/details/

This PR replaces the 5s polling of the events request by a user-triggered refetch mechanism. 

### Before
![screenshot-localhost_3000-2023 11 02-13_48_20](https://github.com/hivemq/hivemq-edge/assets/2743481/e3740aff-63ab-4a6b-b4a5-d55923bbd1df)


### After
![screenshot-localhost_3000-2023 11 02-13_48_05](https://github.com/hivemq/hivemq-edge/assets/2743481/0c1710c1-98bc-4f2a-859f-32face7449ba)
