### PR TITLE
fix(17457): Fix target for the dropdown menu

### DIFF
--- a/hivemq-edge/src/frontend/src/components/PaginatedTable/components/Filter.tsx
+++ b/hivemq-edge/src/frontend/src/components/PaginatedTable/components/Filter.tsx
@@ -35,6 +35,7 @@ export const Filter = <T,>({
       <CreatableSelect
         size={'sm'}
         inputId={id}
+        menuPortalTarget={document.body}
         // value={{ value: columnFilterValue, label: columnFilterValue }}
         onChange={(item) => setFilterValue(item?.value)}
         options={sortedUniqueValues.map((value: string) => ({ value: value, label: value, group: 'DDD' }))}


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/17457/details/

This quickfix PR changes the target of the portal containing the dropdown to the document's body, preventing it to be cropped by the table

### Before

### After