### PR TITLE
Flaky: Fix all tests in OpcUaProtocolAdapterAuthTest.

### DIFF
--- a/modules/hivemq-edge-module-opcua/src/test/java/com/hivemq/edge/adapters/opcua/OpcUaProtocolAdapterAuthTest.java
+++ b/modules/hivemq-edge-module-opcua/src/test/java/com/hivemq/edge/adapters/opcua/OpcUaProtocolAdapterAuthTest.java
@@ -20,6 +20,7 @@ import com.hivemq.edge.modules.adapters.model.ProtocolAdapterStartInput;
 import com.hivemq.edge.modules.adapters.model.ProtocolAdapterStartOutput;
 import com.hivemq.edge.modules.api.adapters.ModuleServices;
 import com.hivemq.edge.modules.api.adapters.ProtocolAdapter;
+import com.hivemq.edge.modules.api.events.EventService;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -28,6 +29,7 @@ import util.EmbeddedOpcUaServerExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @SuppressWarnings("NullabilityAnnotations")
 class OpcUaProtocolAdapterAuthTest {
@@ -97,13 +99,18 @@ class OpcUaProtocolAdapterAuthTest {
         assertEquals(ProtocolAdapter.ConnectionStatus.CONNECTED, protocolAdapter.getConnectionStatus());
     }
 
-
     private static class TestProtocolAdapterStartInput implements ProtocolAdapterStartInput {
+
+        private final @NotNull ModuleServices moduleServices;
+
+        TestProtocolAdapterStartInput() {
+            moduleServices = mock(ModuleServices.class);
+            when(moduleServices.eventService()).thenReturn(mock(EventService.class));
+        }
 
         @Override
         public @NotNull ModuleServices moduleServices() {
-            return mock(ModuleServices.class);
+            return moduleServices;
         }
     }
-
 }


### PR DESCRIPTION
OpcUa > Fix all tests in OpcUaProtocolAdapterAuthTest. Each test had the potential to fail when the async AbstractProtocolAdapter#onStartSuccess was called before the test had finished. The onStartSuccess tries to access the field eventService which is null and throws NPE. Completing the mock fixes the flakiness.