### PR TITLE
Test-Fix: OpcUaProtocolAdapterAuthTest now handles async update of ConnectionStatus correctly

### DIFF
--- a/modules/hivemq-edge-module-opcua/src/test/java/com/hivemq/edge/adapters/opcua/OpcUaProtocolAdapterAuthTest.java
+++ b/modules/hivemq-edge-module-opcua/src/test/java/com/hivemq/edge/adapters/opcua/OpcUaProtocolAdapterAuthTest.java
@@ -27,6 +27,8 @@ import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import util.EmbeddedOpcUaServerExtension;
 
+import static com.hivemq.edge.modules.api.adapters.ProtocolAdapter.*;
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -48,7 +50,7 @@ class OpcUaProtocolAdapterAuthTest {
         final ProtocolAdapterStartOutput out = mock(ProtocolAdapterStartOutput.class);
         protocolAdapter.start(in, out).get();
 
-        assertEquals(ProtocolAdapter.ConnectionStatus.CONNECTED, protocolAdapter.getConnectionStatus());
+        await().until(() -> ConnectionStatus.CONNECTED == protocolAdapter.getConnectionStatus());
     }
 
     @Test
@@ -63,7 +65,7 @@ class OpcUaProtocolAdapterAuthTest {
         final ProtocolAdapterStartOutput out = mock(ProtocolAdapterStartOutput.class);
         protocolAdapter.start(in, out).get();
 
-        assertEquals(ProtocolAdapter.ConnectionStatus.CONNECTED, protocolAdapter.getConnectionStatus());
+        await().until(() -> ConnectionStatus.CONNECTED == protocolAdapter.getConnectionStatus());
     }
 
     @Test
@@ -80,7 +82,7 @@ class OpcUaProtocolAdapterAuthTest {
         final ProtocolAdapterStartOutput out = mock(ProtocolAdapterStartOutput.class);
         protocolAdapter.start(in, out).get();
 
-        assertEquals(ProtocolAdapter.ConnectionStatus.CONNECTED, protocolAdapter.getConnectionStatus());
+        await().until(() -> ConnectionStatus.CONNECTED == protocolAdapter.getConnectionStatus());
     }
 
     @Test
@@ -96,7 +98,7 @@ class OpcUaProtocolAdapterAuthTest {
         final ProtocolAdapterStartOutput out = mock(ProtocolAdapterStartOutput.class);
         protocolAdapter.start(in, out).get();
 
-        assertEquals(ProtocolAdapter.ConnectionStatus.CONNECTED, protocolAdapter.getConnectionStatus());
+        await().until(() -> ConnectionStatus.CONNECTED == protocolAdapter.getConnectionStatus());
     }
 
     private static class TestProtocolAdapterStartInput implements ProtocolAdapterStartInput {


### PR DESCRIPTION

**Motivation**

Fixes frequent unit test failure 

**Changes**

Usage of await() instead of assertEquals()