### PR TITLE
feat(17451): add date filtering on the Event Log

### DIFF
--- a/hivemq-edge/src/frontend/src/components/DateTime/DateTimeRangeSelector.tsx
+++ b/hivemq-edge/src/frontend/src/components/DateTime/DateTimeRangeSelector.tsx
@@ -1,0 +1,78 @@
+import { FC, useState } from 'react'
+import { DateTime } from 'luxon'
+import { CreatableSelect, GroupBase, Options, OptionsOrGroups } from 'chakra-react-select'
+import { useTranslation } from 'react-i18next'
+
+import { Accessors, RangeOption } from './types.ts'
+import Option from './components/Option.tsx'
+
+const defaultRangeOption: readonly RangeOption[] = [
+  { value: 'purple', label: 'last minute', color: '#5243AA' },
+  { value: 'orange', label: 'last 5 minutes', color: '#FF8B00' },
+  { value: 'yellow', label: 'last 15 minutes ', color: '#FFC400' },
+  { value: 'green', label: 'last 30 minutes', color: '#36B37E' },
+  { value: 'forest', label: 'last hour', color: '#00875A' },
+  { value: 'slate', label: 'last 2 hours', color: '#253858' },
+  { value: 'silver', label: 'last 5 hours', color: '#666666' },
+  { value: 'more', label: 'More...', color: '#0052CC', isDisabled: true },
+]
+
+interface DateTimeRangeSelectorProps {
+  min?: DateTime
+  max?: DateTime
+  value?: DateTime
+}
+
+const DateTimeRangeSelector: FC<DateTimeRangeSelectorProps> = () => {
+  const { t } = useTranslation('components')
+  const [options, setOptions] = useState(defaultRangeOption)
+
+  const compareOption = (inputValue = '', option: RangeOption, accessors: Accessors<RangeOption>) => {
+    const candidate = String(inputValue).toLowerCase()
+    const optionValue = String(accessors.getOptionValue(option)).toLowerCase()
+    const optionLabel = String(accessors.getOptionLabel(option)).toLowerCase()
+    return optionValue === candidate || optionLabel === candidate
+  }
+
+  const handleCreate = (inputValue: string) => {
+    const newOption = { value: inputValue, label: inputValue, color: '#0052CC', isDisabled: true }
+    setOptions((prev) => [...prev, newOption])
+  }
+
+  const isValidNewOption = (
+    inputValue: string,
+    selectValue: Options<RangeOption>,
+    selectOptions: OptionsOrGroups<RangeOption, GroupBase<RangeOption>>,
+    accessors: Accessors<RangeOption>
+  ) => {
+    return !(
+      !inputValue ||
+      selectValue.some((option) => compareOption(inputValue, option, accessors)) ||
+      selectOptions.some((option) => compareOption(inputValue, option as RangeOption, accessors))
+    )
+  }
+
+  return (
+    <CreatableSelect<RangeOption>
+      size={'sm'}
+      menuPortalTarget={document.body}
+      // value={{ value: columnFilterValue, label: columnFilterValue }}
+      // onChange={(item) => setFilterValue(item?.value)}
+      options={options}
+      noOptionsMessage={() => t('DateTimeRangeSelector.noOptionsMessage')}
+      placeholder={t('DateTimeRangeSelector.placeholder')}
+      formatCreateLabel={(e) => t('DateTimeRangeSelector.formatCreateLabel', { date: e })}
+      aria-label={t('DateTimeRangeSelector.ariaLabel') as string}
+      isClearable={true}
+      isMulti={false}
+      components={{
+        DropdownIndicator: null,
+        Option,
+      }}
+      onCreateOption={handleCreate}
+      isValidNewOption={isValidNewOption}
+    />
+  )
+}
+
+export default DateTimeRangeSelector

--- a/hivemq-edge/src/frontend/src/components/DateTime/DateTimeRangeSelector.tsx
+++ b/hivemq-edge/src/frontend/src/components/DateTime/DateTimeRangeSelector.tsx
@@ -151,7 +151,8 @@ const DateTimeRangeSelector: FC<DateTimeRangeSelectorProps> = ({ min, max }) => 
         Option,
       }}
       onCreateOption={handleCreate}
-      isValidNewOption={isValidNewOption}
+      // TODO[NVL} Do not allow manual editing of custom date
+      isValidNewOption={() => false}
     />
   )
 }

--- a/hivemq-edge/src/frontend/src/components/DateTime/DateTimeRangeSelector.tsx
+++ b/hivemq-edge/src/frontend/src/components/DateTime/DateTimeRangeSelector.tsx
@@ -116,21 +116,14 @@ const DateTimeRangeSelector: FC<DateTimeRangeSelectorProps> = ({ min, max }) => 
   }, [min, max])
 
   const handleCreate = (inputValue: string) => {
-    const newOption = { value: inputValue, label: inputValue, color: '#0052CC', isDisabled: true }
-    setOptions((prev) => [...prev, newOption])
-  }
-
-  const isValidNewOption = (
-    inputValue: string,
-    selectValue: Options<RangeOption>,
-    selectOptions: OptionsOrGroups<RangeOption, GroupBase<RangeOption>>,
-    accessors: Accessors<RangeOption>
-  ) => {
-    return !(
-      !inputValue ||
-      selectValue.some((option) => compareOption(inputValue, option, accessors)) ||
-      selectOptions.some((option) => compareOption(inputValue, option as RangeOption, accessors))
-    )
+    const newOption: RangeOption = { value: inputValue, label: inputValue, colorScheme: '#0052CC' }
+    setOptions((prev) => {
+      const old = [...prev]
+      const last = old.pop()
+      const newOptions = [...old, newOption]
+      if (last) newOptions.push(last)
+      return newOptions
+    })
   }
 
   return (

--- a/hivemq-edge/src/frontend/src/components/DateTime/DateTimeRangeSelector.tsx
+++ b/hivemq-edge/src/frontend/src/components/DateTime/DateTimeRangeSelector.tsx
@@ -46,6 +46,7 @@ const DateTimeRangeSelector: FC<DateTimeRangeSelectorProps> = ({ min, max, setFi
 
   return (
     <CreatableSelect<RangeOption>
+      chakraStyles={{ menuList: (provided) => ({ ...provided, width: '200px' }) }}
       size={'sm'}
       menuPortalTarget={document.body}
       // value={{ value: columnFilterValue, label: columnFilterValue }}

--- a/hivemq-edge/src/frontend/src/components/DateTime/DateTimeRangeSelector.tsx
+++ b/hivemq-edge/src/frontend/src/components/DateTime/DateTimeRangeSelector.tsx
@@ -1,104 +1,11 @@
 import { FC, useEffect, useState } from 'react'
-import { DateTime, Duration } from 'luxon'
+import { DateTime } from 'luxon'
 import { ActionMeta, CreatableSelect, SingleValue } from 'chakra-react-select'
 import { useTranslation } from 'react-i18next'
 
 import { RangeOption } from './types.ts'
 import Option from './components/Option.tsx'
-
-const defaultRangeOption: readonly RangeOption[] = [
-  { value: 'more', label: 'More...', colorScheme: 'yellow', isCommand: true, isDisabled: true },
-]
-
-const makeDefaultRangeOption = (min: DateTime | undefined, max: DateTime | undefined): RangeOption[] => {
-  if (!min || !max) return []
-
-  const diff = max.diff(min, ['months', 'weeks', 'days', 'hours', 'minutes']).toObject()
-  const options: RangeOption[] = []
-
-  if (diff['months']) {
-    options.push({
-      value: 'month1',
-      label: 'last month',
-      colorScheme: 'whiteAlpha',
-      duration: Duration.fromDurationLike({ month: 1 }),
-    })
-  }
-  if (diff['weeks']) {
-    options.push({
-      value: 'week1',
-      label: 'last week',
-      colorScheme: 'red',
-      duration: Duration.fromDurationLike({ week: 1 }),
-    })
-  }
-  if (diff['days']) {
-    options.push({
-      value: 'day1',
-      label: 'last day',
-      colorScheme: 'green',
-      duration: Duration.fromDurationLike({ day: 1 }),
-    })
-  }
-  if (diff['hours']) {
-    options.push(
-      ...[
-        {
-          value: 'hour1',
-          label: 'last hour',
-          colorScheme: 'blue',
-          duration: Duration.fromDurationLike({ hour: 1 }),
-        },
-        {
-          value: 'hour2',
-          label: 'last 2 hours',
-          colorScheme: 'blue',
-          duration: Duration.fromDurationLike({ hours: 2 }),
-        },
-        {
-          value: 'hour6',
-          label: 'last 6 hours',
-          colorScheme: 'blue',
-          duration: Duration.fromDurationLike({ hours: 6 }),
-        },
-      ]
-    )
-  }
-  if (diff['minutes']) {
-    options.push(
-      ...[
-        {
-          value: 'minute1',
-          label: 'last minute',
-          colorScheme: 'orange',
-          duration: Duration.fromDurationLike({ minute: 1 }),
-        },
-        {
-          value: 'minute5',
-          label: 'last 5 minutes',
-          colorScheme: 'orange',
-          duration: Duration.fromDurationLike({ minute: 5 }),
-        },
-        {
-          value: 'minute15',
-          label: 'last 15 minutes ',
-          colorScheme: 'orange',
-          duration: Duration.fromDurationLike({ minute: 15 }),
-        },
-        {
-          value: 'minute30',
-          label: 'last 30 minutes',
-          colorScheme: 'orange',
-          duration: Duration.fromDurationLike({ minute: 30 }),
-        },
-      ]
-    )
-  }
-
-  options.push(...defaultRangeOption)
-
-  return options
-}
+import { makeDefaultRangeOption } from './utils/range-option.utils.ts'
 
 interface DateTimeRangeSelectorProps {
   min?: DateTime

--- a/hivemq-edge/src/frontend/src/components/DateTime/DateTimeRangeSelector.tsx
+++ b/hivemq-edge/src/frontend/src/components/DateTime/DateTimeRangeSelector.tsx
@@ -1,6 +1,6 @@
 import { FC, useEffect, useState } from 'react'
 import { DateTime, Duration } from 'luxon'
-import { CreatableSelect } from 'chakra-react-select'
+import { ActionMeta, CreatableSelect, SingleValue } from 'chakra-react-select'
 import { useTranslation } from 'react-i18next'
 
 import { RangeOption } from './types.ts'
@@ -104,9 +104,10 @@ interface DateTimeRangeSelectorProps {
   min?: DateTime
   max?: DateTime
   value?: DateTime
+  setFilterValue?: (value: number[] | undefined) => void
 }
 
-const DateTimeRangeSelector: FC<DateTimeRangeSelectorProps> = ({ min, max }) => {
+const DateTimeRangeSelector: FC<DateTimeRangeSelectorProps> = ({ min, max, setFilterValue }) => {
   const { t } = useTranslation('components')
   const [options, setOptions] = useState<RangeOption[]>([])
 
@@ -126,12 +127,22 @@ const DateTimeRangeSelector: FC<DateTimeRangeSelectorProps> = ({ min, max }) => 
     })
   }
 
+  const onHandleChange = (newValue: SingleValue<RangeOption>, actionMeta: ActionMeta<RangeOption>) => {
+    if (newValue?.duration?.isValid) {
+      const now = DateTime.now()
+      const min = now.minus(newValue.duration)
+      setFilterValue?.([min.toMillis(), now.toMillis()])
+    } else if (actionMeta.action === 'clear') {
+      setFilterValue?.(undefined)
+    }
+  }
+
   return (
     <CreatableSelect<RangeOption>
       size={'sm'}
       menuPortalTarget={document.body}
       // value={{ value: columnFilterValue, label: columnFilterValue }}
-      // onChange={(item) => setFilterValue(item?.value)}
+      onChange={onHandleChange}
       options={options}
       noOptionsMessage={() => t('DateTimeRangeSelector.noOptionsMessage')}
       placeholder={t('DateTimeRangeSelector.placeholder')}

--- a/hivemq-edge/src/frontend/src/components/DateTime/components/Option.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/components/DateTime/components/Option.spec.cy.tsx
@@ -1,0 +1,47 @@
+import { GroupBase, OptionProps } from 'chakra-react-select'
+
+import { RangeOption } from '../types.ts'
+import Option from '../components/Option.tsx'
+import { MOCK_RANGE_OPTION } from '@/components/DateTime/utils/range-option.mocks.ts'
+
+const MOCK_OPTIONS: readonly RangeOption[] = [{ value: 'purple', label: 'last minute', colorScheme: '#5243AA' }]
+
+const MOCK_PROPS: Partial<OptionProps<RangeOption, false, GroupBase<RangeOption>>> = {
+  hasValue: false,
+  isMulti: false,
+  isRtl: false,
+  options: [MOCK_RANGE_OPTION],
+  // @ts-ignore
+  selectProps: {
+    chakraStyles: {},
+  },
+  innerProps: {
+    id: 'react-select-15-option-3',
+    tabIndex: -1,
+  },
+  data: MOCK_RANGE_OPTION,
+  isDisabled: false,
+  isSelected: false,
+  label: 'last 30 minutes',
+  type: 'option',
+  value: 'minute30',
+  isFocused: false,
+  clearValue: () => console.log('sss'),
+  cx: () => '',
+  selectOption: (x) => console.log('select', x),
+  setValue: (x) => console.log('select', x),
+}
+
+describe('DateTimeRangeSelector > Option', () => {
+  beforeEach(() => {
+    cy.viewport(800, 150)
+  })
+
+  it('should render properly', () => {
+    // @ts-ignore force mocked partial object
+    cy.mountWithProviders(<Option children={MOCK_OPTIONS[0].label} {...MOCK_PROPS} />)
+
+    // cy.getByAriaLabel('Go to the first page').should('be.visible').click()
+    // cy.get('@setPageIndex').should('have.been.calledOnceWith', 0)
+  })
+})

--- a/hivemq-edge/src/frontend/src/components/DateTime/components/Option.tsx
+++ b/hivemq-edge/src/frontend/src/components/DateTime/components/Option.tsx
@@ -1,0 +1,22 @@
+import { ComponentType } from 'react'
+import { chakraComponents, GroupBase, OptionProps } from 'chakra-react-select'
+import { Icon } from '@chakra-ui/react'
+import { SiMqtt } from 'react-icons/si'
+
+import { RangeOption } from '../types.ts'
+
+const Option: ComponentType<OptionProps<RangeOption, false, GroupBase<RangeOption>>> = ({ children, ...props }) => {
+  const { value } = props.data
+
+  // Seems to be the best way of detecting the "Create option"
+  const isOptionCreate = value === ''
+
+  return (
+    <chakraComponents.Option {...props}>
+      {!isOptionCreate && <Icon as={SiMqtt} color={props.data.color} mr={2} h={5} w={5} />}
+      {children}
+    </chakraComponents.Option>
+  )
+}
+
+export default Option

--- a/hivemq-edge/src/frontend/src/components/DateTime/components/Option.tsx
+++ b/hivemq-edge/src/frontend/src/components/DateTime/components/Option.tsx
@@ -20,14 +20,18 @@ const Option: ComponentType<OptionProps<RangeOption, false, GroupBase<RangeOptio
     )
   }
 
-  const duration = props.data.duration?.toObject()
   // TODO[NVL] This is not i18n-friendly
-  const [a, v] = Object.entries({ ...duration })[0]
+  const duration = props.data.duration?.toObject()
+  let badge = ''
+  if (duration) {
+    const [a, v] = Object.entries({ ...duration })[0]
+    badge = `${v}${a[0]}`
+  }
 
   return (
     <chakraComponents.Option {...props}>
       <HStack flexWrap={'nowrap'}>
-        {!isOptionCreate && (
+        {!isOptionCreate && badge && (
           <Badge
             as={'p'}
             textAlign={'center'}
@@ -38,7 +42,7 @@ const Option: ComponentType<OptionProps<RangeOption, false, GroupBase<RangeOptio
             colorScheme={props.data.colorScheme}
             mr={2}
           >
-            {`${v}${a[0]}`}
+            {badge}
           </Badge>
         )}
         <Text>{children}</Text>

--- a/hivemq-edge/src/frontend/src/components/DateTime/components/Option.tsx
+++ b/hivemq-edge/src/frontend/src/components/DateTime/components/Option.tsx
@@ -1,10 +1,13 @@
 import { ComponentType } from 'react'
 import { chakraComponents, GroupBase, OptionProps } from 'chakra-react-select'
 import { Badge, Box, Button, HStack, Text } from '@chakra-ui/react'
+import { useTranslation } from 'react-i18next'
 
 import { RangeOption } from '../types.ts'
+import { badgeFrom } from '../utils/range-option.utils.ts'
 
 const Option: ComponentType<OptionProps<RangeOption, false, GroupBase<RangeOption>>> = ({ children, ...props }) => {
+  const { t } = useTranslation('components')
   const { value, label, isCommand } = props.data
 
   // Seems to be the best way of detecting the "Create option"
@@ -20,13 +23,7 @@ const Option: ComponentType<OptionProps<RangeOption, false, GroupBase<RangeOptio
     )
   }
 
-  // TODO[NVL] This is not i18n-friendly
-  const duration = props.data.duration?.toObject()
-  let badge = ''
-  if (duration) {
-    const [a, v] = Object.entries({ ...duration })[0]
-    badge = `${v}${a[0]}`
-  }
+  const badge = badgeFrom(props.data, t)
 
   return (
     <chakraComponents.Option {...props}>

--- a/hivemq-edge/src/frontend/src/components/DateTime/components/Option.tsx
+++ b/hivemq-edge/src/frontend/src/components/DateTime/components/Option.tsx
@@ -1,47 +1,25 @@
 import { ComponentType } from 'react'
 import { chakraComponents, GroupBase, OptionProps } from 'chakra-react-select'
-import { Badge, Box, Button, HStack, Text } from '@chakra-ui/react'
-import { useTranslation } from 'react-i18next'
+import { HStack, Text } from '@chakra-ui/react'
 
 import { RangeOption } from '../types.ts'
-import { badgeFrom } from '../utils/range-option.utils.ts'
+import OptionBadge from './OptionBadge.tsx'
+import OptionCommand from './OptionCommand.tsx'
 
 const Option: ComponentType<OptionProps<RangeOption, false, GroupBase<RangeOption>>> = ({ children, ...props }) => {
-  const { t } = useTranslation('components')
-  const { value, label, isCommand } = props.data
+  const { value, isCommand } = props.data
 
   // Seems to be the best way of detecting the "Create option"
   const isOptionCreate = value === ''
 
   if (isCommand) {
-    return (
-      <Box w={'100%'}>
-        <Button variant={'ghost'} size={'sm'} isDisabled>
-          {label}
-        </Button>
-      </Box>
-    )
+    return <OptionCommand data={props.data} />
   }
-
-  const badge = badgeFrom(props.data, t)
 
   return (
     <chakraComponents.Option {...props}>
       <HStack flexWrap={'nowrap'}>
-        {!isOptionCreate && badge && (
-          <Badge
-            as={'p'}
-            textAlign={'center'}
-            textTransform={'lowercase'}
-            size={'sm'}
-            data-testid={`dateRange-option-badge-${value}`}
-            variant="solid"
-            colorScheme={props.data.colorScheme}
-            mr={2}
-          >
-            {badge}
-          </Badge>
-        )}
+        {!isOptionCreate && <OptionBadge data={props.data} />}
         <Text>{children}</Text>
       </HStack>
     </chakraComponents.Option>

--- a/hivemq-edge/src/frontend/src/components/DateTime/components/Option.tsx
+++ b/hivemq-edge/src/frontend/src/components/DateTime/components/Option.tsx
@@ -1,20 +1,48 @@
 import { ComponentType } from 'react'
 import { chakraComponents, GroupBase, OptionProps } from 'chakra-react-select'
-import { Icon } from '@chakra-ui/react'
-import { SiMqtt } from 'react-icons/si'
+import { Badge, Box, Button, HStack, Text } from '@chakra-ui/react'
 
 import { RangeOption } from '../types.ts'
 
 const Option: ComponentType<OptionProps<RangeOption, false, GroupBase<RangeOption>>> = ({ children, ...props }) => {
-  const { value } = props.data
+  const { value, label, isCommand } = props.data
 
   // Seems to be the best way of detecting the "Create option"
   const isOptionCreate = value === ''
 
+  if (isCommand) {
+    return (
+      <Box w={'100%'}>
+        <Button variant={'ghost'} size={'sm'} isDisabled>
+          {label}
+        </Button>
+      </Box>
+    )
+  }
+
+  const duration = props.data.duration?.toObject()
+  // TODO[NVL] This is not i18n-friendly
+  const [a, v] = Object.entries({ ...duration })[0]
+
   return (
     <chakraComponents.Option {...props}>
-      {!isOptionCreate && <Icon as={SiMqtt} color={props.data.color} mr={2} h={5} w={5} />}
-      {children}
+      <HStack flexWrap={'nowrap'}>
+        {!isOptionCreate && (
+          <Badge
+            as={'p'}
+            textAlign={'center'}
+            textTransform={'lowercase'}
+            size={'sm'}
+            data-testid={`dateRange-option-badge-${value}`}
+            variant="solid"
+            colorScheme={props.data.colorScheme}
+            mr={2}
+          >
+            {`${v}${a[0]}`}
+          </Badge>
+        )}
+        <Text>{children}</Text>
+      </HStack>
     </chakraComponents.Option>
   )
 }

--- a/hivemq-edge/src/frontend/src/components/DateTime/components/OptionBadge.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/components/DateTime/components/OptionBadge.spec.cy.tsx
@@ -1,0 +1,24 @@
+/// <reference types="cypress" />
+
+import OptionBadge from './OptionBadge.tsx'
+import { MOCK_RANGE_OPTION } from '../utils/range-option.mocks.ts'
+
+describe('OptionBadge', () => {
+  beforeEach(() => {
+    cy.viewport(800, 400)
+  })
+
+  it('should render properly', () => {
+    cy.mountWithProviders(<OptionBadge data={MOCK_RANGE_OPTION} />)
+
+    cy.getByTestId(`dateRange-option-badge-${MOCK_RANGE_OPTION.value}`)
+      .should('contain.text', '1h')
+      .should('have.attr', 'data-group', MOCK_RANGE_OPTION.colorScheme)
+  })
+
+  it('should render properly', () => {
+    cy.mountWithProviders(<OptionBadge data={{ ...MOCK_RANGE_OPTION, duration: undefined }} />)
+
+    cy.getByTestId(`dateRange-option-badge-${MOCK_RANGE_OPTION.value}`).should('not.exist')
+  })
+})

--- a/hivemq-edge/src/frontend/src/components/DateTime/components/OptionBadge.tsx
+++ b/hivemq-edge/src/frontend/src/components/DateTime/components/OptionBadge.tsx
@@ -21,6 +21,7 @@ const OptionBadge: FC<OptionBadgeProps> = ({ data }) => {
       textTransform={'lowercase'}
       size={'sm'}
       data-testid={`dateRange-option-badge-${data.value}`}
+      data-group={data.colorScheme}
       variant="solid"
       colorScheme={data.colorScheme}
       mr={2}

--- a/hivemq-edge/src/frontend/src/components/DateTime/components/OptionBadge.tsx
+++ b/hivemq-edge/src/frontend/src/components/DateTime/components/OptionBadge.tsx
@@ -1,0 +1,33 @@
+import { FC } from 'react'
+import { Badge, type BadgeProps } from '@chakra-ui/react'
+
+import { RangeOption } from '../types.ts'
+import { useRangeTranslation } from '../hooks/useRangeTranslation.ts'
+
+interface OptionBadgeProps extends BadgeProps {
+  data: RangeOption
+}
+
+const OptionBadge: FC<OptionBadgeProps> = ({ data }) => {
+  const { translateBadgeFrom } = useRangeTranslation()
+  const badge = translateBadgeFrom(data)
+
+  if (!badge) return null
+
+  return (
+    <Badge
+      as={'p'}
+      textAlign={'center'}
+      textTransform={'lowercase'}
+      size={'sm'}
+      data-testid={`dateRange-option-badge-${data.value}`}
+      variant="solid"
+      colorScheme={data.colorScheme}
+      mr={2}
+    >
+      {badge}
+    </Badge>
+  )
+}
+
+export default OptionBadge

--- a/hivemq-edge/src/frontend/src/components/DateTime/components/OptionCommand.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/components/DateTime/components/OptionCommand.spec.cy.tsx
@@ -1,0 +1,16 @@
+/// <reference types="cypress" />
+
+import { MOCK_RANGE_OPTION } from '../utils/range-option.mocks.ts'
+import OptionCommand from './OptionCommand.tsx'
+
+describe('OptionBadge', () => {
+  beforeEach(() => {
+    cy.viewport(800, 400)
+  })
+
+  it('should render properly', () => {
+    cy.mountWithProviders(<OptionCommand data={MOCK_RANGE_OPTION} />)
+
+    cy.get('button').should('contain.text', MOCK_RANGE_OPTION.label).should('be.disabled')
+  })
+})

--- a/hivemq-edge/src/frontend/src/components/DateTime/components/OptionCommand.tsx
+++ b/hivemq-edge/src/frontend/src/components/DateTime/components/OptionCommand.tsx
@@ -1,0 +1,19 @@
+import { FC } from 'react'
+import { Box, Button } from '@chakra-ui/react'
+import { RangeOption } from '@/components/DateTime/types.ts'
+
+interface OptionCommandProps {
+  data: RangeOption
+}
+
+const OptionCommand: FC<OptionCommandProps> = ({ data }) => {
+  return (
+    <Box w={'100%'}>
+      <Button variant={'ghost'} size={'sm'} isDisabled>
+        {data.label}
+      </Button>
+    </Box>
+  )
+}
+
+export default OptionCommand

--- a/hivemq-edge/src/frontend/src/components/DateTime/hooks/useRangeTranslation.spec.ts
+++ b/hivemq-edge/src/frontend/src/components/DateTime/hooks/useRangeTranslation.spec.ts
@@ -1,0 +1,39 @@
+import { renderHook } from '@testing-library/react'
+import { describe, expect } from 'vitest'
+import { Duration } from 'luxon'
+
+import '@/config/i18n.config.ts'
+
+import { RangeOption } from '../types.ts'
+import { MOCK_RANGE_OPTION } from '../utils/range-option.mocks.ts'
+import { useRangeTranslation } from './useRangeTranslation.ts'
+
+interface TestSuite {
+  range: RangeOption
+  badge: string | undefined
+}
+
+const allTests: TestSuite[] = [
+  { range: { ...MOCK_RANGE_OPTION, duration: undefined }, badge: undefined },
+  { range: { ...MOCK_RANGE_OPTION, duration: Duration.fromObject({ second: 1 }) }, badge: '1s' },
+  { range: { ...MOCK_RANGE_OPTION, duration: Duration.fromObject({ second: 10 }) }, badge: '10s' },
+  { range: { ...MOCK_RANGE_OPTION, duration: Duration.fromObject({ minute: 1 }) }, badge: '1m' },
+  { range: { ...MOCK_RANGE_OPTION, duration: Duration.fromObject({ minute: 10 }) }, badge: '10m' },
+  { range: { ...MOCK_RANGE_OPTION, duration: Duration.fromObject({ hour: 1 }) }, badge: '1h' },
+  { range: { ...MOCK_RANGE_OPTION, duration: Duration.fromObject({ hour: 10 }) }, badge: '10h' },
+  { range: { ...MOCK_RANGE_OPTION, duration: Duration.fromObject({ day: 1 }) }, badge: '1d' },
+  { range: { ...MOCK_RANGE_OPTION, duration: Duration.fromObject({ day: 10 }) }, badge: '10d' },
+  { range: { ...MOCK_RANGE_OPTION, duration: Duration.fromObject({ week: 1 }) }, badge: '1w' },
+  { range: { ...MOCK_RANGE_OPTION, duration: Duration.fromObject({ week: 10 }) }, badge: '10w' },
+  { range: { ...MOCK_RANGE_OPTION, duration: Duration.fromObject({ months: 1 }) }, badge: '1mo' },
+  { range: { ...MOCK_RANGE_OPTION, duration: Duration.fromObject({ months: 10 }) }, badge: '10mo' },
+  { range: MOCK_RANGE_OPTION, badge: '1h' },
+]
+
+describe('useRangeTranslation()', () => {
+  it.each<TestSuite>(allTests)('should return $badge for $range.duration.values', ({ range, badge }) => {
+    const { result } = renderHook(useRangeTranslation)
+
+    expect(result.current.translateBadgeFrom(range)).toEqual(badge)
+  })
+})

--- a/hivemq-edge/src/frontend/src/components/DateTime/hooks/useRangeTranslation.ts
+++ b/hivemq-edge/src/frontend/src/components/DateTime/hooks/useRangeTranslation.ts
@@ -1,0 +1,19 @@
+import { useTranslation } from 'react-i18next'
+
+import { RangeOption } from '../types.ts'
+
+export const useRangeTranslation = () => {
+  const i18next = useTranslation('components')
+
+  const translateBadgeFrom = (range: RangeOption) => {
+    if (!range.duration) return undefined
+
+    const entries = Object.entries(range.duration.toObject())
+    if (!entries.length) return undefined
+
+    const [key, value] = entries[0]
+    return i18next.t(`DateTimeRangeSelector.label.badge.${key}`, { value })
+  }
+
+  return { ...i18next, translateBadgeFrom }
+}

--- a/hivemq-edge/src/frontend/src/components/DateTime/types.ts
+++ b/hivemq-edge/src/frontend/src/components/DateTime/types.ts
@@ -1,0 +1,14 @@
+import { GetOptionLabel, GetOptionValue } from 'chakra-react-select'
+
+// Not properly exported from chakra-react-select
+export interface Accessors<Option> {
+  getOptionValue: GetOptionValue<Option>
+  getOptionLabel: GetOptionLabel<Option>
+}
+
+export interface RangeOption {
+  readonly value: string
+  readonly label: string
+  readonly color: string
+  readonly isDisabled?: boolean
+}

--- a/hivemq-edge/src/frontend/src/components/DateTime/types.ts
+++ b/hivemq-edge/src/frontend/src/components/DateTime/types.ts
@@ -1,4 +1,5 @@
 import { GetOptionLabel, GetOptionValue } from 'chakra-react-select'
+import { ThemeTypings } from '@chakra-ui/react'
 
 // Not properly exported from chakra-react-select
 export interface Accessors<Option> {
@@ -9,6 +10,7 @@ export interface Accessors<Option> {
 export interface RangeOption {
   readonly value: string
   readonly label: string
-  readonly color: string
+  readonly colorScheme: ThemeTypings['colorSchemes']
+  readonly isCommand?: boolean
   readonly isDisabled?: boolean
 }

--- a/hivemq-edge/src/frontend/src/components/DateTime/types.ts
+++ b/hivemq-edge/src/frontend/src/components/DateTime/types.ts
@@ -1,5 +1,6 @@
 import { GetOptionLabel, GetOptionValue } from 'chakra-react-select'
 import { ThemeTypings } from '@chakra-ui/react'
+import { Duration } from 'luxon'
 
 // Not properly exported from chakra-react-select
 export interface Accessors<Option> {
@@ -13,4 +14,5 @@ export interface RangeOption {
   readonly colorScheme: ThemeTypings['colorSchemes']
   readonly isCommand?: boolean
   readonly isDisabled?: boolean
+  readonly duration?: Duration
 }

--- a/hivemq-edge/src/frontend/src/components/DateTime/utils/range-option.mocks.ts
+++ b/hivemq-edge/src/frontend/src/components/DateTime/utils/range-option.mocks.ts
@@ -1,0 +1,9 @@
+import { RangeOption } from '@/components/DateTime/types.ts'
+import { Duration } from 'luxon'
+
+export const MOCK_RANGE_OPTION: RangeOption = {
+  value: 'range1',
+  label: 'Range 1',
+  colorScheme: 'yellow',
+  duration: Duration.fromObject({ hour: 1 }),
+}

--- a/hivemq-edge/src/frontend/src/components/DateTime/utils/range-option.mocks.ts
+++ b/hivemq-edge/src/frontend/src/components/DateTime/utils/range-option.mocks.ts
@@ -1,5 +1,5 @@
 import { RangeOption } from '@/components/DateTime/types.ts'
-import { Duration } from 'luxon'
+import { DateTime, Duration } from 'luxon'
 
 export const MOCK_RANGE_OPTION: RangeOption = {
   value: 'range1',
@@ -7,3 +7,5 @@ export const MOCK_RANGE_OPTION: RangeOption = {
   colorScheme: 'yellow',
   duration: Duration.fromObject({ hour: 1 }),
 }
+
+export const MOCK_DATE_TIME_NOW = DateTime.fromObject({ year: 2023, month: 11, day: 10 })

--- a/hivemq-edge/src/frontend/src/components/DateTime/utils/range-option.utils.spec.ts
+++ b/hivemq-edge/src/frontend/src/components/DateTime/utils/range-option.utils.spec.ts
@@ -1,0 +1,61 @@
+import { describe, expect } from 'vitest'
+import { DateTime, Duration } from 'luxon'
+
+import { makeDefaultRangeOption, sortRangeOption } from '../utils/range-option.utils.ts'
+import { MOCK_DATE_TIME_NOW, MOCK_RANGE_OPTION } from '../utils/range-option.mocks.ts'
+
+describe('sortRangeOption', () => {
+  it('should sort RangeOption based on duration ', () => {
+    expect(sortRangeOption(MOCK_RANGE_OPTION, MOCK_RANGE_OPTION)).toEqual(0)
+    expect(sortRangeOption({ ...MOCK_RANGE_OPTION, duration: undefined }, MOCK_RANGE_OPTION)).toEqual(0)
+    expect(sortRangeOption(MOCK_RANGE_OPTION, { ...MOCK_RANGE_OPTION, duration: undefined })).toEqual(0)
+    expect(
+      sortRangeOption(
+        { ...MOCK_RANGE_OPTION, duration: Duration.fromObject({ minute: 1 }) },
+        { ...MOCK_RANGE_OPTION, duration: Duration.fromObject({ minute: 1 }) }
+      )
+    ).toEqual(0)
+    expect(
+      sortRangeOption(
+        { ...MOCK_RANGE_OPTION, duration: Duration.fromObject({ minute: 10 }) },
+        { ...MOCK_RANGE_OPTION, duration: Duration.fromObject({ minute: 1 }) }
+      )
+    ).toEqual(1)
+    expect(
+      sortRangeOption(
+        { ...MOCK_RANGE_OPTION, duration: Duration.fromObject({ minute: 1 }) },
+        { ...MOCK_RANGE_OPTION, duration: Duration.fromObject({ minute: 10 }) }
+      )
+    ).toEqual(-1)
+    expect(
+      sortRangeOption(
+        { ...MOCK_RANGE_OPTION, duration: Duration.fromObject({ minute: 1 }) },
+        { ...MOCK_RANGE_OPTION, duration: Duration.fromObject({ hour: 10 }) }
+      )
+    ).toEqual(-1)
+  })
+})
+
+interface DefaultOptionTestSuite {
+  min: DateTime | undefined
+  max: DateTime | undefined
+  items: string[]
+}
+
+const allTests: DefaultOptionTestSuite[] = [
+  { min: MOCK_DATE_TIME_NOW, max: undefined, items: [] },
+  { min: undefined, max: MOCK_DATE_TIME_NOW, items: [] },
+  {
+    min: MOCK_DATE_TIME_NOW,
+    max: MOCK_DATE_TIME_NOW.plus({ minute: 20 }),
+
+    items: ['minute1', 'minute5', 'minute15', 'minute30', 'more'],
+  },
+]
+
+describe('makeDefaultRangeOption', () => {
+  it.each<DefaultOptionTestSuite>(allTests)('should return $nbItems for $min $max', ({ min, max, items }) => {
+    const tt = makeDefaultRangeOption(min, max)
+    expect(tt.map((e) => e.value)).toEqual(items)
+  })
+})

--- a/hivemq-edge/src/frontend/src/components/DateTime/utils/range-option.utils.ts
+++ b/hivemq-edge/src/frontend/src/components/DateTime/utils/range-option.utils.ts
@@ -1,0 +1,107 @@
+import { DateTime, Duration } from 'luxon'
+import { RangeOption } from '@/components/DateTime/types.ts'
+
+const defaultRangeOption: readonly RangeOption[] = [
+  { value: 'more', label: 'More...', colorScheme: 'yellow', isCommand: true, isDisabled: true },
+]
+
+export const sortRangeOption = (a: RangeOption, b: RangeOption) => {
+  // not sure that's the case
+  if (!a.duration || !b.duration) return 0
+
+  if (a.duration?.toMillis() < b.duration?.toMillis()) return -1
+  else if (a.duration?.toMillis() > b.duration?.toMillis()) return 1
+  return 0
+}
+
+export const makeDefaultRangeOption = (min: DateTime | undefined, max: DateTime | undefined): RangeOption[] => {
+  if (!min || !max) return []
+
+  // TODO[NVL} wrong!!!
+  const diff = max.diff(min, ['months', 'weeks', 'days', 'hours', 'minutes']).toObject()
+  const options: RangeOption[] = []
+
+  if (diff['months']) {
+    options.push({
+      value: 'month1',
+      label: 'last month',
+      colorScheme: 'whiteAlpha',
+      duration: Duration.fromDurationLike({ month: 1 }),
+    })
+  }
+  if (diff['weeks']) {
+    options.push({
+      value: 'week1',
+      label: 'last week',
+      colorScheme: 'red',
+      duration: Duration.fromDurationLike({ week: 1 }),
+    })
+  }
+  if (diff['days']) {
+    options.push({
+      value: 'day1',
+      label: 'last day',
+      colorScheme: 'green',
+      duration: Duration.fromDurationLike({ day: 1 }),
+    })
+  }
+  if (diff['hours']) {
+    options.push(
+      ...[
+        {
+          value: 'hour1',
+          label: 'last hour',
+          colorScheme: 'blue',
+          duration: Duration.fromDurationLike({ hour: 1 }),
+        },
+        {
+          value: 'hour2',
+          label: 'last 2 hours',
+          colorScheme: 'blue',
+          duration: Duration.fromDurationLike({ hour: 2 }),
+        },
+        {
+          value: 'hour6',
+          label: 'last 6 hours',
+          colorScheme: 'blue',
+          duration: Duration.fromDurationLike({ hour: 6 }),
+        },
+      ]
+    )
+  }
+  if (diff['minutes']) {
+    options.push(
+      ...[
+        {
+          value: 'minute1',
+          label: 'last minute',
+          colorScheme: 'orange',
+          duration: Duration.fromDurationLike({ minute: 1 }),
+        },
+        {
+          value: 'minute5',
+          label: 'last 5 minutes',
+          colorScheme: 'orange',
+          duration: Duration.fromDurationLike({ minute: 5 }),
+        },
+        {
+          value: 'minute15',
+          label: 'last 15 minutes ',
+          colorScheme: 'orange',
+          duration: Duration.fromDurationLike({ minute: 15 }),
+        },
+        {
+          value: 'minute30',
+          label: 'last 30 minutes',
+          colorScheme: 'orange',
+          duration: Duration.fromDurationLike({ minute: 30 }),
+        },
+      ]
+    )
+  }
+
+  const sortedOptions = [...options].sort(sortRangeOption)
+  sortedOptions.push(...defaultRangeOption)
+
+  return sortedOptions
+}

--- a/hivemq-edge/src/frontend/src/components/DateTime/utils/range-option.utils.ts
+++ b/hivemq-edge/src/frontend/src/components/DateTime/utils/range-option.utils.ts
@@ -1,6 +1,5 @@
 import { DateTime, Duration } from 'luxon'
 import { RangeOption } from '@/components/DateTime/types.ts'
-import { Namespace, TFunction } from 'i18next'
 
 const defaultRangeOption: readonly RangeOption[] = [
   { value: 'more', label: 'More...', colorScheme: 'yellow', isCommand: true, isDisabled: true },
@@ -105,14 +104,4 @@ export const makeDefaultRangeOption = (min: DateTime | undefined, max: DateTime 
   sortedOptions.push(...defaultRangeOption)
 
   return sortedOptions
-}
-
-export const badgeFrom = (range: RangeOption, t: TFunction<Namespace>) => {
-  if (!range.duration) return undefined
-
-  const entries = Object.entries(range.duration.toObject())
-  if (!entries.length) return undefined
-
-  const [key, value] = entries[0]
-  return t(`DateTimeRangeSelector.label.badge.${key}`, { value })
 }

--- a/hivemq-edge/src/frontend/src/components/DateTime/utils/range-option.utils.ts
+++ b/hivemq-edge/src/frontend/src/components/DateTime/utils/range-option.utils.ts
@@ -1,5 +1,6 @@
 import { DateTime, Duration } from 'luxon'
 import { RangeOption } from '@/components/DateTime/types.ts'
+import { Namespace, TFunction } from 'i18next'
 
 const defaultRangeOption: readonly RangeOption[] = [
   { value: 'more', label: 'More...', colorScheme: 'yellow', isCommand: true, isDisabled: true },
@@ -104,4 +105,14 @@ export const makeDefaultRangeOption = (min: DateTime | undefined, max: DateTime 
   sortedOptions.push(...defaultRangeOption)
 
   return sortedOptions
+}
+
+export const badgeFrom = (range: RangeOption, t: TFunction<Namespace>) => {
+  if (!range.duration) return undefined
+
+  const entries = Object.entries(range.duration.toObject())
+  if (!entries.length) return undefined
+
+  const [key, value] = entries[0]
+  return t(`DateTimeRangeSelector.label.badge.${key}`, { value })
 }

--- a/hivemq-edge/src/frontend/src/components/PaginatedTable/components/Filter.tsx
+++ b/hivemq-edge/src/frontend/src/components/PaginatedTable/components/Filter.tsx
@@ -2,7 +2,10 @@ import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Column } from '@tanstack/react-table'
 import { CreatableSelect } from 'chakra-react-select'
-import { Box } from '@chakra-ui/react'
+import { Box, VStack } from '@chakra-ui/react'
+import { DateTime } from 'luxon'
+
+import DateTimeRangeSelector from '@/components/DateTime/DateTimeRangeSelector.tsx'
 
 export interface FilterProps<T>
   extends Pick<
@@ -28,6 +31,19 @@ export const Filter = <T,>({
     [facetedUniqueValues, firstValue]
   )
 
+  if (firstValue instanceof DateTime)
+    return (
+      <VStack width={'100%'} textTransform={'none'} fontWeight={'initial'}>
+        <Box w={'100%'}>
+          <DateTimeRangeSelector />
+        </Box>
+        <Box w={'100%'}>
+          <DateTimeRangeSelector />
+        </Box>
+      </VStack>
+    )
+
+  // we are not supporting numbers yet
   if (typeof firstValue === 'number') return null
 
   return (

--- a/hivemq-edge/src/frontend/src/components/PaginatedTable/components/Filter.tsx
+++ b/hivemq-edge/src/frontend/src/components/PaginatedTable/components/Filter.tsx
@@ -10,7 +10,7 @@ import DateTimeRangeSelector from '@/components/DateTime/DateTimeRangeSelector.t
 export interface FilterProps<T>
   extends Pick<
     Column<T, unknown>,
-    'id' | 'getFilterValue' | 'getFacetedUniqueValues' | 'getFacetedMinMaxValues' | 'setFilterValue'
+    'id' | 'getFilterValue' | 'getFacetedUniqueValues' | 'getFacetedMinMaxValues' | 'setFilterValue' | 'columnDef'
   > {
   firstValue: unknown
 }
@@ -22,6 +22,7 @@ export const Filter = <T,>({
   // getFacetedMinMaxValues,
   setFilterValue,
   firstValue,
+  columnDef,
 }: FilterProps<T>) => {
   const { t } = useTranslation()
 
@@ -31,7 +32,15 @@ export const Filter = <T,>({
     [facetedUniqueValues, firstValue]
   )
 
-  if (firstValue instanceof DateTime)
+  // @ts-ignore Find a better to fix this
+  const { sortType } = columnDef
+
+  if (typeof firstValue === 'number' && sortType === 'datetime') {
+    // TODO[NVL] This is a weird typing, as the function doesn't match the type
+    const [a, b] = getFacetedMinMaxValues() || [undefined, undefined]
+    const min = Number(a)
+    const max = Number(b)
+
     return (
       <VStack width={'100%'} textTransform={'none'} fontWeight={'initial'}>
         <Box w={'100%'}>

--- a/hivemq-edge/src/frontend/src/components/PaginatedTable/components/Filter.tsx
+++ b/hivemq-edge/src/frontend/src/components/PaginatedTable/components/Filter.tsx
@@ -19,7 +19,7 @@ export const Filter = <T,>({
   id,
   // getFilterValue,
   getFacetedUniqueValues,
-  // getFacetedMinMaxValues,
+  getFacetedMinMaxValues,
   setFilterValue,
   firstValue,
   columnDef,
@@ -44,13 +44,14 @@ export const Filter = <T,>({
     return (
       <VStack width={'100%'} textTransform={'none'} fontWeight={'initial'}>
         <Box w={'100%'}>
-          <DateTimeRangeSelector />
+          <DateTimeRangeSelector min={DateTime.fromMillis(min)} max={DateTime.fromMillis(max)} />
         </Box>
         <Box w={'100%'}>
-          <DateTimeRangeSelector />
+          <DateTimeRangeSelector min={DateTime.fromMillis(min)} max={DateTime.fromMillis(max)} />
         </Box>
       </VStack>
     )
+  }
 
   // we are not supporting numbers yet
   if (typeof firstValue === 'number') return null

--- a/hivemq-edge/src/frontend/src/components/PaginatedTable/components/Filter.tsx
+++ b/hivemq-edge/src/frontend/src/components/PaginatedTable/components/Filter.tsx
@@ -2,7 +2,7 @@ import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Column } from '@tanstack/react-table'
 import { CreatableSelect } from 'chakra-react-select'
-import { Box, VStack } from '@chakra-ui/react'
+import { Box } from '@chakra-ui/react'
 import { DateTime } from 'luxon'
 
 import DateTimeRangeSelector from '@/components/DateTime/DateTimeRangeSelector.tsx'
@@ -42,14 +42,16 @@ export const Filter = <T,>({
     const max = Number(b)
 
     return (
-      <VStack width={'100%'} textTransform={'none'} fontWeight={'initial'}>
-        <Box w={'100%'}>
-          <DateTimeRangeSelector min={DateTime.fromMillis(min)} max={DateTime.fromMillis(max)} />
-        </Box>
-        <Box w={'100%'}>
-          <DateTimeRangeSelector min={DateTime.fromMillis(min)} max={DateTime.fromMillis(max)} />
-        </Box>
-      </VStack>
+      <Box w={'100%'} textTransform={'none'} fontWeight={'initial'}>
+        <DateTimeRangeSelector
+          min={DateTime.fromMillis(min)}
+          max={DateTime.fromMillis(max)}
+          setFilterValue={(v) => {
+            if (v) setFilterValue([v[0], v[1]])
+            else setFilterValue(undefined)
+          }}
+        />
+      </Box>
     )
   }
 

--- a/hivemq-edge/src/frontend/src/locales/en/components.json
+++ b/hivemq-edge/src/frontend/src/locales/en/components.json
@@ -27,5 +27,11 @@
       "noOptionsMessage": "No topic loaded",
       "createLabel": "Add the topic ... {{topic}}"
     }
+  },
+  "DateTimeRangeSelector": {
+    "placeholder": "Select a date range",
+    "noOptionsMessage": "Not a valid date",
+    "formatCreateLabel": "Create {{ date }}",
+    "ariaLabel": "Select a date"
   }
 }

--- a/hivemq-edge/src/frontend/src/locales/en/components.json
+++ b/hivemq-edge/src/frontend/src/locales/en/components.json
@@ -32,6 +32,17 @@
     "placeholder": "Select a date",
     "noOptionsMessage": "Not a valid date",
     "formatCreateLabel": "Create {{ date }}",
-    "ariaLabel": "Select a date"
+    "ariaLabel": "Select a date",
+    "label": {
+      "badge": {
+        "years": "{{ value }}y",
+        "months": "{{ value }}mo",
+        "weeks": "{{ value }}w",
+        "days": "{{ value }}d",
+        "hours": "{{ value }}h",
+        "minutes": "{{ value }}m",
+        "seconds": "{{ value }}s"
+      }
+    }
   }
 }

--- a/hivemq-edge/src/frontend/src/locales/en/components.json
+++ b/hivemq-edge/src/frontend/src/locales/en/components.json
@@ -29,7 +29,7 @@
     }
   },
   "DateTimeRangeSelector": {
-    "placeholder": "Select a date range",
+    "placeholder": "Select a date",
     "noOptionsMessage": "Not a valid date",
     "formatCreateLabel": "Create {{ date }}",
     "ariaLabel": "Select a date"

--- a/hivemq-edge/src/frontend/src/modules/EventLog/components/table/EventLogTable.tsx
+++ b/hivemq-edge/src/frontend/src/modules/EventLog/components/table/EventLogTable.tsx
@@ -55,10 +55,10 @@ const EventLogTable: FC<EventLogTableProps> = ({ onOpen }) => {
       {
         accessorKey: 'created',
         sortType: 'datetime',
-        accessorFn: (row) => DateTime.fromISO(row.created).toMillis(),
+        accessorFn: (row) => DateTime.fromISO(row.created),
         cell: (info) => (
           <Skeleton isLoaded={!isLoading} whiteSpace={'nowrap'}>
-            {DateTime.fromMillis(info.getValue() as number).toRelativeCalendar({ unit: 'minutes' })}
+            {(info.getValue() as DateTime).toRelativeCalendar({ unit: 'minutes' })}
           </Skeleton>
         ),
         header: t('eventLog.table.header.created') as string,

--- a/hivemq-edge/src/frontend/src/modules/EventLog/components/table/EventLogTable.tsx
+++ b/hivemq-edge/src/frontend/src/modules/EventLog/components/table/EventLogTable.tsx
@@ -55,10 +55,10 @@ const EventLogTable: FC<EventLogTableProps> = ({ onOpen }) => {
       {
         accessorKey: 'created',
         sortType: 'datetime',
-        accessorFn: (row) => DateTime.fromISO(row.created),
+        accessorFn: (row) => DateTime.fromISO(row.created).toMillis(),
         cell: (info) => (
           <Skeleton isLoaded={!isLoading} whiteSpace={'nowrap'}>
-            {(info.getValue() as DateTime).toRelativeCalendar({ unit: 'minutes' })}
+            {DateTime.fromMillis(info.getValue() as number).toRelativeCalendar({ unit: 'minutes' })}
           </Skeleton>
         ),
         header: t('eventLog.table.header.created') as string,


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/17451/details/

This PR is the initial step of an evolutionary component for filtering a timestamped table by date and time. 

### Design 
It aims at replicating the pattern that is now common in many timestamped systems like `DataDog` or `Sentry` by creating a modular component that provides three levels of user interaction:
- a simple context-based list of predefined time/date filters (e.g. past 5 minutes)
- access to a full date/time picker for fine-tuned data entry
- a template-based open-text component allowing fine tuning and locale-based time range definition (e.g. "yesterday" or "past 12 minutes).

![1014514dEFLZu0L](https://github.com/hivemq/hivemq-edge/assets/2743481/a745d982-d9f9-440d-8875-31bb57abeee2)



### Implementation
In the `Event Log`: 
- the component is deployed in the paginated table as a single filter in the `Created` column, controlling a "from now to ..." pattern.
- the component is based on the same `select` component, ensuring consistency across the filters 
- only the predefined list of time ranges is implemented in the PR
- the choice of the listed patterns is context-based and depends on the minimum and maximum values of the table (e.g. if the presented data only covers the past hour, no "the past week" option will be accessible)
- The filter is faceted with the other filters (text-based)

### Out-of-scope
- the full date/time picker will be part of a subsequent ticket
- the open-text component will be part of a subsequent ticket 
- any provision for a "between ... and ..." range pattern will be part of a subsequent ticket 

### Before
![screenshot-localhost_3000-2023 11 10-12_51_24](https://github.com/hivemq/hivemq-edge/assets/2743481/8575e1f7-991e-4059-b534-87385cc187cb)

### After
![screenshot-localhost_3000-2023 11 10-12_53_30](https://github.com/hivemq/hivemq-edge/assets/2743481/e4639141-daed-40ad-8ecc-7e4e6ea58fa8)

![screenshot-localhost_3000-2023 11 10-12_54_37](https://github.com/hivemq/hivemq-edge/assets/2743481/63b028b7-7a29-4b3e-b02e-0228ceea2a09)

![screenshot-localhost_3000-2023 11 10-12_55_10](https://github.com/hivemq/hivemq-edge/assets/2743481/9cd14ca7-27a8-4dff-8993-b353de7b03e1)

![screenshot-localhost_3000-2023 11 10-12_55_39](https://github.com/hivemq/hivemq-edge/assets/2743481/b8e34450-8f87-4ee9-b13d-7203d03e8fb0)

![screenshot-localhost_3000-2023 11 10-12_56_12](https://github.com/hivemq/hivemq-edge/assets/2743481/9a6a17ca-5afa-40f1-b754-fade174a3949)
