### PR TITLE
feat(17327): Create a consistent user-friendly rendering of Data/Time info 

### DIFF
--- a/hivemq-edge/src/frontend/cypress/support/component.tsx
+++ b/hivemq-edge/src/frontend/cypress/support/component.tsx
@@ -70,12 +70,3 @@ Cypress.Commands.add('mountWithProviders', (component, options = {}) => {
 
   return mount(wrapped, mountOptions)
 })
-
-Cypress.on('test:before:run', () => {
-  Cypress.automation('remote:debugger:protocol', {
-    command: 'Emulation.setLocaleOverride',
-    params: {
-      locale: 'en-GB',
-    },
-  })
-})

--- a/hivemq-edge/src/frontend/cypress/support/component.tsx
+++ b/hivemq-edge/src/frontend/cypress/support/component.tsx
@@ -70,3 +70,12 @@ Cypress.Commands.add('mountWithProviders', (component, options = {}) => {
 
   return mount(wrapped, mountOptions)
 })
+
+Cypress.on('test:before:run', () => {
+  Cypress.automation('remote:debugger:protocol', {
+    command: 'Emulation.setLocaleOverride',
+    params: {
+      locale: 'en-GB',
+    },
+  })
+})

--- a/hivemq-edge/src/frontend/src/api/hooks/useEvents/__handlers__/index.ts
+++ b/hivemq-edge/src/frontend/src/api/hooks/useEvents/__handlers__/index.ts
@@ -50,10 +50,10 @@ export const mockEdgeEvent = (n = maxEvents): Event[] =>
 
     source: makeID(sourceKeys[x % sourceKeys.length] as TypeIdentifier.type, x),
     associatedObject: makeID(sourceKeys[x % sourceKeys.length] as TypeIdentifier.type, x),
-    created: DateTime.fromISO('2023-10-13T11:51:24.234+01')
+    created: DateTime.fromISO('2023-10-13T11:51:24.234')
       .plus({ minutes: x % 100 })
       .toISO({ format: 'basic' }) as string,
-    timestamp: DateTime.fromISO('2023-10-13T11:51:24.234+01')
+    timestamp: DateTime.fromISO('2023-10-13T11:51:24.234')
       .plus({ minutes: x % 100 })
       .toUnixInteger(),
   }))

--- a/hivemq-edge/src/frontend/src/components/DateTime/DateTimeRenderer.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/components/DateTime/DateTimeRenderer.spec.cy.tsx
@@ -1,0 +1,39 @@
+/// <reference types="cypress" />
+
+import DateTimeRenderer from '@/components/DateTime/DateTimeRenderer.tsx'
+import { MOCK_DATE_TIME_NOW } from './utils/range-option.mocks.ts'
+
+describe('DateTimeRenderer', () => {
+  beforeEach(() => {
+    cy.viewport(800, 400)
+  })
+
+  it('should render properly', () => {
+    const now = MOCK_DATE_TIME_NOW.plus({ day: 2 }).toJSDate()
+
+    cy.clock(now)
+    cy.mountWithProviders(<DateTimeRenderer date={MOCK_DATE_TIME_NOW} isApprox />)
+    cy.getByTestId('date-time-approx').should('contain.text', '2 days ago')
+  })
+
+  it('should open the tooltip when mouseover', () => {
+    const now = MOCK_DATE_TIME_NOW.plus({ day: 2 }).toJSDate()
+
+    // cy.clock(now)
+    cy.mountWithProviders(<DateTimeRenderer date={MOCK_DATE_TIME_NOW} isApprox />)
+
+    // mouseover doesn't trigger the tooltip; force a click
+    cy.get('p').click({ force: true })
+    cy.clock(now)
+    cy.getByTestId('date-time-tooltip').should('contain.text', '10 November 2023 at 00:00:00.000')
+  })
+
+  it('should render the plain date properly', () => {
+    const now = MOCK_DATE_TIME_NOW.plus({ day: 2 }).toJSDate()
+
+    cy.clock(now)
+    cy.mountWithProviders(<DateTimeRenderer date={MOCK_DATE_TIME_NOW} />)
+    cy.getByTestId('date-time-approx').should('not.exist')
+    cy.getByTestId('date-time-full').should('contain.text', 'Friday, 10 November 2023 at 00:00:00.000')
+  })
+})

--- a/hivemq-edge/src/frontend/src/components/DateTime/DateTimeRenderer.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/components/DateTime/DateTimeRenderer.spec.cy.tsx
@@ -6,6 +6,9 @@ import { MOCK_DATE_TIME_NOW } from './utils/range-option.mocks.ts'
 describe('DateTimeRenderer', () => {
   beforeEach(() => {
     cy.viewport(800, 400)
+    cy.window().then((win) => {
+      Object.defineProperty(win.navigator, 'language', { value: 'en-GB' })
+    })
   })
 
   it('should render properly', () => {

--- a/hivemq-edge/src/frontend/src/components/DateTime/DateTimeRenderer.tsx
+++ b/hivemq-edge/src/frontend/src/components/DateTime/DateTimeRenderer.tsx
@@ -1,0 +1,46 @@
+import { FC } from 'react'
+import { Text, Tooltip, type TextProps } from '@chakra-ui/react'
+import { DateTime } from 'luxon'
+
+import { toHuman } from './utils/duration.utils.ts'
+
+interface DateTimeRendererProps extends TextProps {
+  date: DateTime
+  isApprox?: boolean
+}
+
+const DateTimeRenderer: FC<DateTimeRendererProps> = ({ date, isApprox = false, ...props }) => {
+  const formatLongDate = new Intl.DateTimeFormat(navigator.language, {
+    weekday: 'long',
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: 'numeric',
+    second: 'numeric',
+    fractionalSecondDigits: 3,
+  })
+
+  if (isApprox)
+    return (
+      <Tooltip
+        data-testid={'date-time-tooltip'}
+        hasArrow
+        label={formatLongDate.format(date.toJSDate())}
+        placement="top"
+        maxW={'200px'}
+      >
+        <Text data-testid={'date-time-approx'} width={'fit-content'} {...props}>
+          {toHuman(date)}
+        </Text>
+      </Tooltip>
+    )
+
+  return (
+    <Text data-testid={'date-time-full'} {...props}>
+      {formatLongDate.format(date.toJSDate())}
+    </Text>
+  )
+}
+
+export default DateTimeRenderer

--- a/hivemq-edge/src/frontend/src/components/DateTime/utils/duration.utils.spec.ts
+++ b/hivemq-edge/src/frontend/src/components/DateTime/utils/duration.utils.spec.ts
@@ -13,7 +13,7 @@ const allTests: ToHumanTestSuite[] = [
   { date: MOCK_DATE_TIME_NOW.minus({ month: 2 }), expected: '2 months ago' },
   { date: MOCK_DATE_TIME_NOW.minus({ days: 9 }), expected: '9 days ago' },
   { date: MOCK_DATE_TIME_NOW, expected: 'in 0 seconds' },
-  { date: MOCK_DATE_TIME_NOW.plus({ days: 2 }), expected: 'in 2 days' },
+  { date: MOCK_DATE_TIME_NOW.plus({ days: 1 }), expected: 'in 1 day' },
   { date: MOCK_DATE_TIME_NOW.plus({ days: 3 }), expected: 'in 3 days' },
   { date: MOCK_DATE_TIME_NOW.plus({ days: 3, hour: 19 }), expected: 'in 3 days' },
 ]

--- a/hivemq-edge/src/frontend/src/components/DateTime/utils/duration.utils.spec.ts
+++ b/hivemq-edge/src/frontend/src/components/DateTime/utils/duration.utils.spec.ts
@@ -1,0 +1,25 @@
+import { describe, expect } from 'vitest'
+import { DateTime } from 'luxon'
+
+import { toHuman } from './duration.utils.ts'
+import { MOCK_DATE_TIME_NOW } from './range-option.mocks.ts'
+
+interface ToHumanTestSuite {
+  date: DateTime
+  expected: string
+}
+
+const allTests: ToHumanTestSuite[] = [
+  { date: MOCK_DATE_TIME_NOW.minus({ month: 2 }), expected: '2 months ago' },
+  { date: MOCK_DATE_TIME_NOW.minus({ days: 9 }), expected: '9 days ago' },
+  { date: MOCK_DATE_TIME_NOW, expected: 'in 0 seconds' },
+  { date: MOCK_DATE_TIME_NOW.plus({ days: 2 }), expected: 'in 2 days' },
+  { date: MOCK_DATE_TIME_NOW.plus({ days: 3 }), expected: 'in 3 days' },
+  { date: MOCK_DATE_TIME_NOW.plus({ days: 3, hour: 19 }), expected: 'in 3 days' },
+]
+
+describe('toHuman', () => {
+  it.each<ToHumanTestSuite>(allTests)('should return $expected', ({ date, expected }) => {
+    expect(toHuman(date, MOCK_DATE_TIME_NOW)).toEqual(expected)
+  })
+})

--- a/hivemq-edge/src/frontend/src/components/DateTime/utils/duration.utils.ts
+++ b/hivemq-edge/src/frontend/src/components/DateTime/utils/duration.utils.ts
@@ -1,0 +1,17 @@
+import { DateTime } from 'luxon'
+import { DurationUnits } from 'luxon/src/duration'
+
+// Better Duration.toHuman support https://github.com/moment/luxon/issues/1134
+export const toHuman = (timestamp: DateTime, alternativeNow?: DateTime) => {
+  const units: DurationUnits = ['weeks', 'days', 'hours', 'minutes', 'seconds']
+
+  // mostly used for testing
+  const diff = alternativeNow ? timestamp.diff(alternativeNow, units) : timestamp.diffNow(units)
+
+  const rescaledDuration = diff
+    .negate()
+    .mapUnits((x) => Math.floor(x))
+    .rescale()
+
+  return DateTime.local().minus(rescaledDuration).toRelative()
+}

--- a/hivemq-edge/src/frontend/src/modules/EventLog/components/panel/EventDrawer.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/EventLog/components/panel/EventDrawer.spec.cy.tsx
@@ -6,6 +6,9 @@ import EventDrawer from './EventDrawer.tsx'
 describe('EventDrawer', () => {
   beforeEach(() => {
     cy.viewport(1200, 800)
+    cy.window().then((win) => {
+      Object.defineProperty(win.navigator, 'language', { value: 'en-GB' })
+    })
   })
 
   it('should render the side panel', () => {
@@ -14,7 +17,7 @@ describe('EventDrawer', () => {
 
     cy.get('[data-status]').should('contain.text', 'INFO')
     cy.getByTestId('event-title-created').should('contain.text', 'Created')
-    cy.getByTestId('event-value-created').should('contain.text', 'minutes ago')
+    cy.getByTestId('event-value-created').should('contain.text', 'Friday, 13 October 2023 at 11:51:24.234')
     cy.getByTestId('event-title-source').should('contain.text', 'Source')
     cy.getByTestId('event-value-source').should('contain.text', 'BRIDGE-0')
     cy.getByTestId('event-title-associatedObject').should('contain.text', 'Associated Object')

--- a/hivemq-edge/src/frontend/src/modules/EventLog/components/panel/EventDrawer.tsx
+++ b/hivemq-edge/src/frontend/src/modules/EventLog/components/panel/EventDrawer.tsx
@@ -20,9 +20,11 @@ import {
 } from '@chakra-ui/react'
 
 import { Event, Payload } from '@/api/__generated__'
-import SourceLink from '../SourceLink.tsx'
 import SeverityBadge from '@/modules/EventLog/components/SeverityBadge.tsx'
 import { prettifyXml, prettyJSON } from '@/modules/EventLog/utils/payload-utils.ts'
+import DateTimeRenderer from '@/components/DateTime/DateTimeRenderer.tsx'
+
+import SourceLink from '../SourceLink.tsx'
 
 interface BridgeMainDrawerProps {
   event: Event
@@ -66,7 +68,7 @@ const EventDrawer: FC<BridgeMainDrawerProps> = ({ event, isOpen, onClose }) => {
                       <Text>{t('eventLog.table.header.created')}</Text>
                     </GridItem>
                     <GridItem data-testid={'event-value-created'}>
-                      <Text> {DateTime.fromISO(event?.created || '').toRelativeCalendar({ unit: 'minutes' })}</Text>
+                      <DateTimeRenderer date={DateTime.fromISO(event?.created || '')} />
                     </GridItem>
                     <GridItem data-testid={'event-title-source'}>
                       <Text>{t('eventLog.table.header.source')}</Text>

--- a/hivemq-edge/src/frontend/src/modules/EventLog/components/table/EventLogTable.tsx
+++ b/hivemq-edge/src/frontend/src/modules/EventLog/components/table/EventLogTable.tsx
@@ -14,6 +14,7 @@ import PaginatedTable from '@/components/PaginatedTable/PaginatedTable.tsx'
 import ErrorMessage from '@/components/ErrorMessage.tsx'
 
 import { compareSeverity } from '@/modules/ProtocolAdapters/utils/pagination-utils.ts'
+import DateTimeRenderer from '@/components/DateTime/DateTimeRenderer.tsx'
 
 import SourceLink from '../SourceLink.tsx'
 import SeverityBadge from '../SeverityBadge.tsx'
@@ -58,7 +59,7 @@ const EventLogTable: FC<EventLogTableProps> = ({ onOpen }) => {
         accessorFn: (row) => DateTime.fromISO(row.created).toMillis(),
         cell: (info) => (
           <Skeleton isLoaded={!isLoading} whiteSpace={'nowrap'}>
-            {DateTime.fromMillis(info.getValue() as number).toRelativeCalendar({ unit: 'minutes' })}
+            <DateTimeRenderer date={DateTime.fromMillis(info.getValue() as number)} isApprox />
           </Skeleton>
         ),
         header: t('eventLog.table.header.created') as string,

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/panels/ProtocolAdapters.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/panels/ProtocolAdapters.tsx
@@ -11,6 +11,7 @@ import { useDeleteProtocolAdapter } from '@/api/hooks/useProtocolAdapters/useDel
 import { useGetAdaptersStatus } from '@/api/hooks/useConnection/useGetAdaptersStatus.tsx'
 import { ProblemDetails } from '@/api/types/http-problem-details.ts'
 import { useGetAdapterTypes } from '@/api/hooks/useProtocolAdapters/useGetAdapterTypes.tsx'
+import { mockAdapter } from '@/api/hooks/useProtocolAdapters/__handlers__'
 
 import AdapterEmptyLogo from '@/assets/app/adaptor-empty.svg'
 
@@ -20,13 +21,14 @@ import { ConnectionStatusBadge } from '@/components/ConnectionStatusBadge'
 import ConfirmationDialog from '@/components/Modal/ConfirmationDialog.tsx'
 import PaginatedTable from '@/components/PaginatedTable/PaginatedTable.tsx'
 import WorkspaceIcon from '@/components/Icons/WorkspaceIcon.tsx'
+import DateTimeRenderer from '@/components/DateTime/DateTimeRenderer.tsx'
+
+import { AdapterNavigateState, ProtocolAdapterTabIndex } from '@/modules/ProtocolAdapters/types.ts'
 
 import { useEdgeToast } from '@/hooks/useEdgeToast/useEdgeToast.tsx'
 
-import { compareStatus } from '../../utils/pagination-utils.ts'
 import AdapterActionMenu from '../adapters/AdapterActionMenu.tsx'
-import { mockAdapter } from '@/api/hooks/useProtocolAdapters/__handlers__'
-import { AdapterNavigateState, ProtocolAdapterTabIndex } from '@/modules/ProtocolAdapters/types.ts'
+import { compareStatus } from '../../utils/pagination-utils.ts'
 
 const DEFAULT_PER_PAGE = 10
 
@@ -125,7 +127,7 @@ const ProtocolAdapters: FC = () => {
         id: 'lastStartedAttemptTime',
         cell: (info) => (
           <Skeleton isLoaded={!isLoading}>
-            {DateTime.fromISO(info.getValue() as string).toRelativeCalendar({ unit: 'minutes' })}
+            <DateTimeRenderer date={DateTime.fromISO(info.getValue() as string)} isApprox />
           </Skeleton>
         ),
         header: t('protocolAdapter.table.header.lastStarted') as string,


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/17327/details/

The PR is an attempt at fixing the unsatisfactory display of date and time in used in the in the system. 

It is the result of an endeavour to start defining design artefacts for consistency across the different apps in the company. A relevant, in-progress, topic has been created in the design system for that purpose, see https://zeroheight.com/9c4326648/p/5495a8-date-and-time

Every date/time element in the frontend has been replaced by the unified component (in the event log and in the adapter list). As such, the PR also closes 16679 (https://hivemq.kanbanize.com/ctrl_board/67/cards/16679/details/).
The PR also closes the original attempt to trigger an external contribution for a better relative date/time, https://github.com/hivemq/hivemq-edge/issues/63

### Design
- A single configurable Date/Time component has been designed, centralising all aspects of the rendering (localisation, approximation, format, tooltip, ...). It should be used for every date/time in the system, refactoring its props when needed 
- the date/time can be displayed either as a relative ("x minutes ago") or as a full date ("Wed, 23 November, ...")
- the relative "humanized" version of the date has been refactored to follow a "highest unit" approximation
- the full date is displayed as a localised string, using the browser-preferred language
- when displayed as a relative date, the component exposes a tooltip containing the full date

### out-of-scope
- the method used for "humanised" rendering doesn't yet match the proposal for the approximation. It will be updated in a different ticket once an agreement has been made on the proposal

### Before
![screenshot-localhost_3000-2023 11 14-13_37_33](https://github.com/hivemq/hivemq-edge/assets/2743481/e2a6b864-b155-4dc1-8e5a-6010a7d0b8ca)

### After
![screenshot-localhost_3000-2023 11 14-13_32_07](https://github.com/hivemq/hivemq-edge/assets/2743481/7ca346cb-05cd-4af2-bc84-94d391fdec40)

![screenshot-localhost_3000-2023 11 14-13_32_41](https://github.com/hivemq/hivemq-edge/assets/2743481/ce98e1fc-4844-413b-88de-7237a880d070)

![screenshot-localhost_3000-2023 11 14-13_33_05](https://github.com/hivemq/hivemq-edge/assets/2743481/e77bcfbd-8135-48a8-b621-7d17c8fae8f6)
