### PR TITLE
fix(17493): Fix the alignment of the column's headers in the pafinated table

### DIFF
--- a/hivemq-edge/src/frontend/src/components/PaginatedTable/PaginatedTable.tsx
+++ b/hivemq-edge/src/frontend/src/components/PaginatedTable/PaginatedTable.tsx
@@ -93,10 +93,11 @@ const PaginatedTable = <T,>({
                     verticalAlign={'top'}
                     aria-sort={getAriaSort(header.column.getCanSort(), header.column.getIsSorted())}
                   >
-                    <VStack>
+                    <VStack alignItems={'flex-start'}>
                       {header.isPlaceholder && null}
                       {!header.isPlaceholder && header.column.getCanSort() && (
                         <Button
+                          px={1}
                           onClick={header.column.getToggleSortingHandler()}
                           size={'sm'}
                           variant="ghost"


### PR DESCRIPTION
see https://hivemq.kanbanize.com/ctrl_board/57/cards/17493/details/

The PR corrects the expected left alignment of the column headers on all the tables

### Before
![screenshot-localhost_3000-2023 11 15-11_29_50](https://github.com/hivemq/hivemq-edge/assets/2743481/ae915365-a5e4-428d-b471-16ce4b159c10)

### After
![screenshot-localhost_3000-2023 11 15-11_28_09](https://github.com/hivemq/hivemq-edge/assets/2743481/fb60bc4c-db12-4977-905d-d8f95bf89012)
