### PR TITLE
fix(16319): Fix the colour of the links' border in the navigation panel

### DIFF
--- a/hivemq-edge/src/frontend/src/modules/Dashboard/components/NavLink.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Dashboard/components/NavLink.tsx
@@ -10,6 +10,7 @@ export const NavLink: FC<{ link: MainNavLinkType }> = ({ link }) => {
   const { href, icon, isExternal, isDisabled, isActive, label } = link
   const active = location.pathname === href || !!isActive
 
+  // TODO[NVL] Styling should be done in a proper theme's variant
   return (
     <Button
       justifyContent={'flex-start'}
@@ -20,12 +21,11 @@ export const NavLink: FC<{ link: MainNavLinkType }> = ({ link }) => {
       to={href}
       target={isExternal ? '_blank' : undefined}
       h={'40px'}
-      borderLeftColor={active ? '#FFC000' : 'white'}
-      borderLeftWidth={8}
+      borderLeftColor={active ? '#FFC000' : '#f5f5f5'}
+      borderLeftWidth={active ? 8 : 0}
       borderRadius={0}
-      // _hover={!isExternal ? { borderLeftColor: '#FFC000' } : {}}
     >
-      <HStack spacing="3" fontSize="sm" fontWeight={active ? 'semibold' : 'medium'}>
+      <HStack spacing="3" fontSize="sm" fontWeight={active ? 'semibold' : 'medium'} ml={active ? '-8px' : 0}>
         <Center w="6" h="6">
           {icon}
         </Center>

--- a/hivemq-edge/src/frontend/src/modules/Dashboard/components/NavLink.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Dashboard/components/NavLink.tsx
@@ -25,7 +25,7 @@ export const NavLink: FC<{ link: MainNavLinkType }> = ({ link }) => {
       borderLeftWidth={active ? 8 : 0}
       borderRadius={0}
     >
-      <HStack spacing="3" fontSize="sm" fontWeight={active ? 'semibold' : 'medium'} ml={active ? '-8px' : 0}>
+      <HStack spacing="3" fontSize="sm" fontWeight={active ? 'semibold' : 'medium'} ml={active ? 0 : 2}>
         <Center w="6" h="6">
           {icon}
         </Center>


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/16319/details/

The PR changes the colour of the left border in the navigation panel when hovered or actived

### Before
![screenshot-localhost_3000-2023 11 15-12_01_24](https://github.com/hivemq/hivemq-edge/assets/2743481/1d6ff9b7-7a09-4b17-9dea-134f655bd4a0).   ![screenshot-localhost_3000-2023 11 15-12_02_10](https://github.com/hivemq/hivemq-edge/assets/2743481/137d4114-2d01-4fb8-ac15-615e28f5093f)

### After
![screenshot-localhost_3000-2023 11 15-12_00_24](https://github.com/hivemq/hivemq-edge/assets/2743481/f978601f-41e9-4143-8dcd-42c5c88f3068).   ![screenshot-localhost_3000-2023 11 15-12_01_56](https://github.com/hivemq/hivemq-edge/assets/2743481/5aa50930-d285-46ce-8a43-e2f5dd21b277)
