### PR TITLE
feat(17448): Add a reduced version of the event log to the overview of entities in the workspace

### DIFF
--- a/hivemq-edge/src/frontend/src/components/DateTime/utils/duration.utils.spec.ts
+++ b/hivemq-edge/src/frontend/src/components/DateTime/utils/duration.utils.spec.ts
@@ -12,7 +12,7 @@ interface ToHumanTestSuite {
 const allTests: ToHumanTestSuite[] = [
   { date: MOCK_DATE_TIME_NOW.minus({ month: 2 }), expected: '2 months ago' },
   { date: MOCK_DATE_TIME_NOW.minus({ days: 9 }), expected: '9 days ago' },
-  { date: MOCK_DATE_TIME_NOW, expected: 'in 0 seconds' },
+  { date: MOCK_DATE_TIME_NOW.minus({ second: 1 }), expected: '1 second ago' },
   { date: MOCK_DATE_TIME_NOW.plus({ days: 1 }), expected: 'in 1 day' },
   { date: MOCK_DATE_TIME_NOW.plus({ days: 3 }), expected: 'in 3 days' },
   { date: MOCK_DATE_TIME_NOW.plus({ days: 3, hour: 19 }), expected: 'in 3 days' },

--- a/hivemq-edge/src/frontend/src/components/PaginatedTable/PaginatedTable.tsx
+++ b/hivemq-edge/src/frontend/src/components/PaginatedTable/PaginatedTable.tsx
@@ -40,6 +40,7 @@ interface PaginatedTableProps<T> {
   pageSizes?: number[]
   noDataText?: string
   enableColumnFilters?: boolean
+  enablePagination?: boolean
   /**
    * Define row styles
    */
@@ -55,6 +56,7 @@ const PaginatedTable = <T,>({
   noDataText,
   getRowStyles,
   enableColumnFilters = false,
+  enablePagination = true,
 }: PaginatedTableProps<T>) => {
   const { t } = useTranslation()
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([])
@@ -158,7 +160,7 @@ const PaginatedTable = <T,>({
           </Tbody>
         </TableUI>
       </TableContainer>
-      <PaginationBar table={table} pageSizes={pageSizes} />
+      {enablePagination && <PaginationBar table={table} pageSizes={pageSizes} />}
     </>
   )
 }

--- a/hivemq-edge/src/frontend/src/locales/en/translation.json
+++ b/hivemq-edge/src/frontend/src/locales/en/translation.json
@@ -614,6 +614,9 @@
       "adapter": {
         "header": "Adapter Observability",
         "modify": "Modify the adapter"
+      },
+      "eventLog": {
+        "showMore": "Show more"
       }
     }
   },

--- a/hivemq-edge/src/frontend/src/locales/en/translation.json
+++ b/hivemq-edge/src/frontend/src/locales/en/translation.json
@@ -600,6 +600,10 @@
       "gateway": "Node: Gateway",
       "group": "Node: Group"
     },
+    "device": {
+      "type_ADAPTER_NODE": "adapter",
+      "type_BRIDGE_NODE": "bridge"
+    },
     "layout": {
       "HORIZONTAL": "Horizontal",
       "CIRCLE_PACKING": "Circle Packing"
@@ -616,6 +620,7 @@
         "modify": "Modify the adapter"
       },
       "eventLog": {
+        "header": "The 5 most recent events for $t(workspace.device.type, {'context': '{{ type }}' }) {{ id }}",
         "showMore": "Show more"
       }
     }

--- a/hivemq-edge/src/frontend/src/locales/en/translation.json
+++ b/hivemq-edge/src/frontend/src/locales/en/translation.json
@@ -615,6 +615,7 @@
       "by_runtimeDuration": "By duration"
     },
     "observability": {
+      "header": "Properties",
       "adapter": {
         "header": "Adapter Observability",
         "modify": "Modify the adapter"

--- a/hivemq-edge/src/frontend/src/modules/App/routes.tsx
+++ b/hivemq-edge/src/frontend/src/modules/App/routes.tsx
@@ -13,8 +13,8 @@ import WelcomePage from '@/modules/Welcome/WelcomePage.tsx'
 import LoginPage from '@/modules/Login/LoginPage.tsx'
 import UnifiedNamespaceEditor from '@/modules/UnifiedNamespace/components/UnifiedNamespaceEditor.tsx'
 import EdgeFlowPage from '@/modules/EdgeVisualisation/EdgeFlowPage.tsx'
-import NodePropertyDrawer from '@/modules/EdgeVisualisation/components/drawers/NodePropertyDrawer.tsx'
 import EvenLogPage from '@/modules/EventLog/EvenLogPage.tsx'
+import NodePanelController from '@/modules/EdgeVisualisation/components/controls/NodePanelController.tsx'
 
 export const routes = createBrowserRouter(
   [
@@ -63,7 +63,7 @@ export const routes = createBrowserRouter(
           children: [
             {
               path: ':nodeType/:nodeId',
-              element: <NodePropertyDrawer />,
+              element: <NodePanelController />,
             },
           ],
         },

--- a/hivemq-edge/src/frontend/src/modules/EdgeVisualisation/components/controls/NodePanelController.tsx
+++ b/hivemq-edge/src/frontend/src/modules/EdgeVisualisation/components/controls/NodePanelController.tsx
@@ -1,0 +1,62 @@
+import { FC, useEffect } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+import { Node, useNodes } from 'reactflow'
+import { useDisclosure } from '@chakra-ui/react'
+
+import { Adapter, Bridge } from '@/api/__generated__'
+import { AdapterNavigateState, ProtocolAdapterTabIndex } from '@/modules/ProtocolAdapters/types.ts'
+
+import NodePropertyDrawer from '../drawers/NodePropertyDrawer.tsx'
+import { NodeTypes } from '../../types.ts'
+
+const NodePanelController: FC = () => {
+  const navigate = useNavigate()
+  const { isOpen, onOpen, onClose } = useDisclosure()
+
+  const nodes = useNodes()
+  const { nodeId } = useParams()
+  const selectedNode = nodes.find(
+    (e) => e.id === nodeId && (e.type === NodeTypes.BRIDGE_NODE || e.type === NodeTypes.ADAPTER_NODE)
+  ) as Node<Bridge | Adapter> | undefined
+
+  useEffect(() => {
+    if (!nodes.length) return
+    if (!selectedNode || !nodeId) {
+      navigate('/edge-flow', { replace: true })
+      return
+    }
+    onOpen()
+  }, [navigate, nodeId, nodes.length, onOpen, selectedNode])
+
+  const handleClose = () => {
+    onClose()
+    navigate('/edge-flow')
+  }
+
+  const handleEditEntity = () => {
+    const adapterNavigateState: AdapterNavigateState = {
+      protocolAdapterTabIndex: ProtocolAdapterTabIndex.adapters,
+      protocolAdapterType: (selectedNode?.data as Adapter).type,
+      selectedActiveAdapter: { isNew: false, isOpen: false, adapterId: (selectedNode?.data as Adapter).id },
+    }
+    navigate(`/protocol-adapters/${(selectedNode?.data as Adapter).id}`, {
+      state: adapterNavigateState,
+    })
+  }
+
+  if (!selectedNode || !selectedNode.type) {
+    navigate('/edge-flow', { replace: true })
+    return null
+  }
+
+  return (
+    <NodePropertyDrawer
+      selectedNode={selectedNode}
+      isOpen={isOpen}
+      onClose={handleClose}
+      onEditEntity={handleEditEntity}
+    />
+  )
+}
+
+export default NodePanelController

--- a/hivemq-edge/src/frontend/src/modules/EdgeVisualisation/components/drawers/NodePropertyDrawer.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/EdgeVisualisation/components/drawers/NodePropertyDrawer.spec.cy.tsx
@@ -1,0 +1,30 @@
+/// <reference types="cypress" />
+
+import NodePropertyDrawer from '@/modules/EdgeVisualisation/components/drawers/NodePropertyDrawer.tsx'
+import { MOCK_NODE_ADAPTER } from '@/__test-utils__/react-flow/nodes.ts'
+import { Node } from 'reactflow'
+import { Adapter, Bridge } from '@/api/__generated__'
+import { NodeTypes } from '@/modules/EdgeVisualisation/types.ts'
+
+const mockNode: Node<Bridge | Adapter> = {
+  position: { x: 0, y: 0 },
+  id: 'adapter@fgffgf',
+  type: NodeTypes.ADAPTER_NODE,
+  data: MOCK_NODE_ADAPTER,
+}
+
+describe('NodePropertyDrawer', () => {
+  beforeEach(() => {
+    cy.viewport(800, 800)
+  })
+
+  it('should be accessible', () => {
+    cy.injectAxe()
+    cy.mountWithProviders(
+      <NodePropertyDrawer selectedNode={mockNode} isOpen={true} onClose={cy.stub()} onEditEntity={cy.stub()} />
+    )
+
+    cy.checkAccessibility()
+    cy.percySnapshot('Component: NodePropertyDrawer')
+  })
+})

--- a/hivemq-edge/src/frontend/src/modules/EdgeVisualisation/components/drawers/NodePropertyDrawer.tsx
+++ b/hivemq-edge/src/frontend/src/modules/EdgeVisualisation/components/drawers/NodePropertyDrawer.tsx
@@ -8,6 +8,7 @@ import {
   Card,
   CardBody,
   CardFooter,
+  CardHeader,
   Drawer,
   DrawerBody,
   DrawerCloseButton,
@@ -75,7 +76,12 @@ const NodePropertyDrawer: FC = () => {
         <DrawerBody>
           <VStack gap={4} alignItems={'stretch'}>
             <Metrics initMetrics={getDefaultMetricsFor(selected)} />
-            <Card>
+            <Card size={'sm'}>
+              <CardHeader>
+                <Text>
+                  {t('workspace.observability.eventLog.header', { type: selected.type, id: selected.data.id })}
+                </Text>
+              </CardHeader>
               <CardBody>
                 <EventLogTable globalSourceFilter={(selected?.data as Adapter).id} variant={'summary'} />
               </CardBody>

--- a/hivemq-edge/src/frontend/src/modules/EdgeVisualisation/components/drawers/NodePropertyDrawer.tsx
+++ b/hivemq-edge/src/frontend/src/modules/EdgeVisualisation/components/drawers/NodePropertyDrawer.tsx
@@ -42,7 +42,7 @@ const NodePropertyDrawer: FC<NodePropertyDrawerProps> = ({ isOpen, selectedNode,
   return (
     <Drawer isOpen={isOpen} placement="right" size={'md'} onClose={onClose}>
       <DrawerOverlay />
-      <DrawerContent>
+      <DrawerContent aria-label={t('workspace.observability.header') as string}>
         <DrawerCloseButton />
         <DrawerHeader>
           <Text>{t('workspace.observability.adapter.header')}</Text>
@@ -61,6 +61,7 @@ const NodePropertyDrawer: FC<NodePropertyDrawerProps> = ({ isOpen, selectedNode,
               </CardBody>
               <CardFooter justifyContent={'flex-end'} pt={0}>
                 <Button
+                  data-testid={'navigate-eventLog-filtered'}
                   variant="link"
                   as={RouterLink}
                   // URL options not yet supported

--- a/hivemq-edge/src/frontend/src/modules/EdgeVisualisation/components/drawers/NodePropertyDrawer.tsx
+++ b/hivemq-edge/src/frontend/src/modules/EdgeVisualisation/components/drawers/NodePropertyDrawer.tsx
@@ -21,7 +21,7 @@ import {
   VStack,
 } from '@chakra-ui/react'
 import { EditIcon } from '@chakra-ui/icons'
-import { BiAbacus } from 'react-icons/bi'
+import { MdOutlineEventNote } from 'react-icons/md'
 
 import { Adapter, Bridge } from '@/api/__generated__'
 import { DeviceTypes } from '@/api/types/api-devices.ts'
@@ -79,16 +79,15 @@ const NodePropertyDrawer: FC = () => {
               <CardBody>
                 <EventLogTable globalSourceFilter={(selected?.data as Adapter).id} variant={'summary'} />
               </CardBody>
-              <CardFooter>
+              <CardFooter justifyContent={'flex-end'} pt={0}>
                 <Button
                   variant="link"
                   as={RouterLink}
-                  to={'/event-logs'}
-                  target={undefined}
-                  leftIcon={<BiAbacus />}
+                  to={`/event-logs?source=${selected.data.id}`}
+                  rightIcon={<MdOutlineEventNote />}
                   size="sm"
                 >
-                  {'Show more on the log'}
+                  {t('workspace.observability.eventLog.showMore')}
                 </Button>
               </CardFooter>
             </Card>

--- a/hivemq-edge/src/frontend/src/modules/EdgeVisualisation/components/drawers/NodePropertyDrawer.tsx
+++ b/hivemq-edge/src/frontend/src/modules/EdgeVisualisation/components/drawers/NodePropertyDrawer.tsx
@@ -1,9 +1,13 @@
 import { FC, useEffect } from 'react'
-import { useNavigate, useParams } from 'react-router-dom'
+import { Link as RouterLink, useNavigate, useParams } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { Node, useNodes } from 'reactflow'
+
 import {
   Button,
+  Card,
+  CardBody,
+  CardFooter,
   Drawer,
   DrawerBody,
   DrawerCloseButton,
@@ -17,17 +21,20 @@ import {
   VStack,
 } from '@chakra-ui/react'
 import { EditIcon } from '@chakra-ui/icons'
+import { BiAbacus } from 'react-icons/bi'
 
 import { Adapter, Bridge } from '@/api/__generated__'
 import { DeviceTypes } from '@/api/types/api-devices.ts'
 
 import ConnectionController from '@/components/ConnectionController/ConnectionController.tsx'
 
-import Metrics from '@/modules/Welcome/components/Metrics.tsx'
 import { AdapterNavigateState, ProtocolAdapterTabIndex } from '@/modules/ProtocolAdapters/types.ts'
-import { NodeTypes } from '@/modules/EdgeVisualisation/types.ts'
+import Metrics from '@/modules/Welcome/components/Metrics.tsx'
+import EventLogTable from '@/modules/EventLog/components/table/EventLogTable.tsx'
 
 import { getDefaultMetricsFor } from '../../utils/nodes-utils.ts'
+
+import { NodeTypes } from '../../types.ts'
 
 const NodePropertyDrawer: FC = () => {
   const { t } = useTranslation()
@@ -68,6 +75,23 @@ const NodePropertyDrawer: FC = () => {
         <DrawerBody>
           <VStack gap={4} alignItems={'stretch'}>
             <Metrics initMetrics={getDefaultMetricsFor(selected)} />
+            <Card>
+              <CardBody>
+                <EventLogTable globalSourceFilter={(selected?.data as Adapter).id} variant={'summary'} />
+              </CardBody>
+              <CardFooter>
+                <Button
+                  variant="link"
+                  as={RouterLink}
+                  to={'/event-logs'}
+                  target={undefined}
+                  leftIcon={<BiAbacus />}
+                  size="sm"
+                >
+                  {'Show more on the log'}
+                </Button>
+              </CardFooter>
+            </Card>
           </VStack>
         </DrawerBody>
         <DrawerFooter borderTopWidth="1px">

--- a/hivemq-edge/src/frontend/src/modules/EventLog/components/table/EventLogTable.tsx
+++ b/hivemq-edge/src/frontend/src/modules/EventLog/components/table/EventLogTable.tsx
@@ -29,12 +29,14 @@ const EventLogTable: FC<EventLogTableProps> = ({ onOpen, globalSourceFilter, var
   const { t } = useTranslation()
   const { data, isLoading, isFetching, error, refetch } = useGetEvents()
 
-  const safeData: Event[] =
-    data && data.items
-      ? data.items
-          .filter((e: Event) => (globalSourceFilter ? e.source?.identifier === globalSourceFilter : true))
-          .slice(0, 5)
-      : [...mockEdgeEvent(5)]
+  const safeData = useMemo<Event[]>(() => {
+    if (!data || !data?.items) return [...mockEdgeEvent(5)]
+    if (globalSourceFilter) {
+      return data.items.filter((e: Event) => e.source?.identifier === globalSourceFilter).slice(0, 5)
+    }
+
+    return data.items
+  }, [data, globalSourceFilter])
 
   const columns = useMemo<ColumnDef<Event>[]>(() => {
     return [

--- a/hivemq-edge/src/frontend/src/modules/EventLog/components/table/EventLogTable.tsx
+++ b/hivemq-edge/src/frontend/src/modules/EventLog/components/table/EventLogTable.tsx
@@ -20,14 +20,21 @@ import SourceLink from '../SourceLink.tsx'
 import SeverityBadge from '../SeverityBadge.tsx'
 
 interface EventLogTableProps {
-  onOpen: (t: Event) => void
+  onOpen?: (t: Event) => void
+  globalSourceFilter?: string
+  variant?: 'full' | 'summary'
 }
 
-const EventLogTable: FC<EventLogTableProps> = ({ onOpen }) => {
+const EventLogTable: FC<EventLogTableProps> = ({ onOpen, globalSourceFilter, variant = 'full' }) => {
   const { t } = useTranslation()
   const { data, isLoading, isFetching, error, refetch } = useGetEvents()
 
-  const safeData: Event[] = data && data.items ? data.items : [...mockEdgeEvent(5)]
+  const safeData: Event[] =
+    data && data.items
+      ? data.items
+          .filter((e: Event) => (globalSourceFilter ? e.source?.identifier === globalSourceFilter : true))
+          .slice(0, 5)
+      : [...mockEdgeEvent(5)]
 
   const columns = useMemo<ColumnDef<Event>[]>(() => {
     return [
@@ -44,7 +51,7 @@ const EventLogTable: FC<EventLogTableProps> = ({ onOpen }) => {
                 <IconButton
                   size={'sm'}
                   mr={2}
-                  onClick={() => onOpen(info.row.original)}
+                  onClick={() => onOpen?.(info.row.original)}
                   aria-label={t('eventLog.table.cta.open')}
                   icon={<MdOutlineEventNote />}
                 />
@@ -110,24 +117,30 @@ const EventLogTable: FC<EventLogTableProps> = ({ onOpen }) => {
     )
   }
 
+  // TODO[NVL] Not the best approach; destructure within memo
+  const [, a, b, , c] = columns
+
   return (
     <>
-      <Flex justifyContent={'flex-end'}>
-        <Button
-          isLoading={isFetching}
-          loadingText={t('eventLog.table.cta.refetch')}
-          variant={'outline'}
-          size={'sm'}
-          leftIcon={<Icon as={BiRefresh} fontSize={20} />}
-          onClick={() => refetch()}
-        >
-          {t('eventLog.table.cta.refetch')}
-        </Button>
-      </Flex>
+      {variant === 'full' && (
+        <Flex justifyContent={'flex-end'}>
+          <Button
+            isLoading={isFetching}
+            loadingText={t('eventLog.table.cta.refetch')}
+            variant={'outline'}
+            size={'sm'}
+            leftIcon={<Icon as={BiRefresh} fontSize={20} />}
+            onClick={() => refetch()}
+          >
+            {t('eventLog.table.cta.refetch')}
+          </Button>
+        </Flex>
+      )}
       <PaginatedTable<Event>
         data={safeData}
-        columns={columns}
-        enableColumnFilters
+        columns={variant === 'full' ? columns : [a, b, c]}
+        enablePagination={variant === 'full'}
+        enableColumnFilters={variant === 'full'}
         // getRowStyles={(row) => {
         //   return { backgroundColor: theme.colors.blue[50] }
         // }}

--- a/hivemq-edge/src/frontend/src/modules/Welcome/components/Metrics.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Welcome/components/Metrics.tsx
@@ -15,7 +15,7 @@ const Metrics: FC<MetricsProps> = ({ initMetrics }) => {
   const showSelector = config.features.METRICS_SELECT_PANEL
 
   return (
-    <Card flex={1}>
+    <Card flex={1} size={'sm'}>
       {showSelector && (
         <CardHeader>
           <MetricNameSelector


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/17448/details/

This PR extends the content of the overview available in the side panel when the user clicks on one of the entities (adapter or bridge) in the workspace 

It adds a limited version of the event log:
- only showing event for the selected entity (using the filter)
- only shows the 5 most recent events
- columns restricted to the most meaningful ones
- no access to the full payload
- no pagination 
- sorting still works (but might be turned off)

A CTA allows the user to directly access the full `Event Log`, with the filter pre-populated by the selected entity's name (id)

### Out-of-scope
- the payload of events is not available in the summary. The UX necessary to display it requires extended functionalities as used in the `Event Log`. 

### Before 
![screenshot-localhost_3000-2023 11 16-12_03_22](https://github.com/hivemq/hivemq-edge/assets/2743481/063c46f5-f4c1-420f-ad00-1cc6ac5d9e26)

### After 
![screenshot-localhost_3000-2023 11 16-12_02_52](https://github.com/hivemq/hivemq-edge/assets/2743481/0821a173-03d3-45d9-bd77-9a1afe6fb9e5)
