### PR TITLE
fix(17476): Add support for Bridge nodes in the workspace

### DIFF
--- a/hivemq-edge/src/frontend/src/locales/en/translation.json
+++ b/hivemq-edge/src/frontend/src/locales/en/translation.json
@@ -614,12 +614,11 @@
       "by_subscriptionCardinality": "By subscription count",
       "by_runtimeDuration": "By duration"
     },
-    "observability": {
-      "header": "Properties",
-      "adapter": {
-        "header": "Adapter Observability",
-        "modify": "Modify the adapter"
-      },
+    "property": {
+      "header_ADAPTER_NODE": "Adapter Observability",
+      "header_BRIDGE_NODE": "Bridge Observability",
+      "modify_ADAPTER_NODE": "Modify the adapter",
+      "modify_BRIDGE_NODE": "Modify the bridge",
       "eventLog": {
         "header": "The 5 most recent events for $t(workspace.device.type, {'context': '{{ type }}' }) {{ id }}",
         "showMore": "Show more"

--- a/hivemq-edge/src/frontend/src/modules/EdgeVisualisation/components/controls/NodePanelController.tsx
+++ b/hivemq-edge/src/frontend/src/modules/EdgeVisualisation/components/controls/NodePanelController.tsx
@@ -34,14 +34,18 @@ const NodePanelController: FC = () => {
   }
 
   const handleEditEntity = () => {
-    const adapterNavigateState: AdapterNavigateState = {
-      protocolAdapterTabIndex: ProtocolAdapterTabIndex.adapters,
-      protocolAdapterType: (selectedNode?.data as Adapter).type,
-      selectedActiveAdapter: { isNew: false, isOpen: false, adapterId: (selectedNode?.data as Adapter).id },
+    if (selectedNode?.type === NodeTypes.ADAPTER_NODE) {
+      const adapterNavigateState: AdapterNavigateState = {
+        protocolAdapterTabIndex: ProtocolAdapterTabIndex.adapters,
+        protocolAdapterType: (selectedNode?.data as Adapter).type,
+        selectedActiveAdapter: { isNew: false, isOpen: false, adapterId: (selectedNode?.data as Adapter).id },
+      }
+      navigate(`/protocol-adapters/${(selectedNode?.data as Adapter).id}`, {
+        state: adapterNavigateState,
+      })
+    } else if (selectedNode?.type === NodeTypes.BRIDGE_NODE) {
+      navigate(`/mqtt-bridges/${(selectedNode?.data as Bridge).id}`)
     }
-    navigate(`/protocol-adapters/${(selectedNode?.data as Adapter).id}`, {
-      state: adapterNavigateState,
-    })
   }
 
   if (!selectedNode || !selectedNode.type) {

--- a/hivemq-edge/src/frontend/src/modules/EdgeVisualisation/components/drawers/NodePropertyDrawer.tsx
+++ b/hivemq-edge/src/frontend/src/modules/EdgeVisualisation/components/drawers/NodePropertyDrawer.tsx
@@ -56,7 +56,7 @@ const NodePropertyDrawer: FC<NodePropertyDrawerProps> = ({ isOpen, selectedNode,
             <Card size={'sm'}>
               <CardHeader>
                 <Text>
-                  {t('workspace.observability.eventLog.header', { type: selectedNode.type, id: selectedNode.data.id })}
+                  {t('workspace.property.eventLog.header', { type: selectedNode.type, id: selectedNode.data.id })}
                 </Text>
               </CardHeader>
               <CardBody>
@@ -72,7 +72,7 @@ const NodePropertyDrawer: FC<NodePropertyDrawerProps> = ({ isOpen, selectedNode,
                   rightIcon={<MdOutlineEventNote />}
                   size="sm"
                 >
-                  {t('workspace.observability.eventLog.showMore')}
+                  {t('workspace.property.eventLog.showMore')}
                 </Button>
               </CardFooter>
             </Card>

--- a/hivemq-edge/src/frontend/src/modules/EdgeVisualisation/components/drawers/NodePropertyDrawer.tsx
+++ b/hivemq-edge/src/frontend/src/modules/EdgeVisualisation/components/drawers/NodePropertyDrawer.tsx
@@ -27,6 +27,7 @@ import { DeviceTypes } from '@/api/types/api-devices.ts'
 import ConnectionController from '@/components/ConnectionController/ConnectionController.tsx'
 import Metrics from '@/modules/Welcome/components/Metrics.tsx'
 import EventLogTable from '@/modules/EventLog/components/table/EventLogTable.tsx'
+import { NodeTypes } from '@/modules/EdgeVisualisation/types.ts'
 
 import { getDefaultMetricsFor } from '../../utils/nodes-utils.ts'
 import NodeNameCard from '../parts/NodeNameCard.tsx'
@@ -46,7 +47,7 @@ const NodePropertyDrawer: FC<NodePropertyDrawerProps> = ({ isOpen, selectedNode,
       <DrawerContent aria-label={t('workspace.observability.header') as string}>
         <DrawerCloseButton />
         <DrawerHeader>
-          <Text>{t('workspace.observability.adapter.header')}</Text>
+          <Text> {t('workspace.property.header', { context: selectedNode.type })}</Text>
         </DrawerHeader>
         <DrawerBody>
           <VStack gap={4} alignItems={'stretch'}>
@@ -86,10 +87,10 @@ const NodePropertyDrawer: FC<NodePropertyDrawerProps> = ({ isOpen, selectedNode,
               rightIcon={<EditIcon />}
               onClick={onEditEntity}
             >
-              {t('workspace.observability.adapter.modify')}
+              {t('workspace.property.modify', { context: selectedNode.type })}
             </Button>
             <ConnectionController
-              type={DeviceTypes.ADAPTER}
+              type={selectedNode.type === NodeTypes.ADAPTER_NODE ? DeviceTypes.ADAPTER : DeviceTypes.BRIDGE}
               id={selectedNode.data.id}
               status={selectedNode.data.status}
             />

--- a/hivemq-edge/src/frontend/src/modules/EdgeVisualisation/components/drawers/NodePropertyDrawer.tsx
+++ b/hivemq-edge/src/frontend/src/modules/EdgeVisualisation/components/drawers/NodePropertyDrawer.tsx
@@ -29,6 +29,7 @@ import Metrics from '@/modules/Welcome/components/Metrics.tsx'
 import EventLogTable from '@/modules/EventLog/components/table/EventLogTable.tsx'
 
 import { getDefaultMetricsFor } from '../../utils/nodes-utils.ts'
+import NodeNameCard from '../parts/NodeNameCard.tsx'
 
 interface NodePropertyDrawerProps {
   selectedNode: Node<Bridge | Adapter>
@@ -49,6 +50,7 @@ const NodePropertyDrawer: FC<NodePropertyDrawerProps> = ({ isOpen, selectedNode,
         </DrawerHeader>
         <DrawerBody>
           <VStack gap={4} alignItems={'stretch'}>
+            <NodeNameCard selectedNode={selectedNode} />
             <Metrics initMetrics={getDefaultMetricsFor(selectedNode)} />
             <Card size={'sm'}>
               <CardHeader>

--- a/hivemq-edge/src/frontend/src/modules/EdgeVisualisation/components/nodes/NodeAdapter.tsx
+++ b/hivemq-edge/src/frontend/src/modules/EdgeVisualisation/components/nodes/NodeAdapter.tsx
@@ -1,6 +1,6 @@
 import { FC, useMemo } from 'react'
 import { Handle, NodeProps, Position } from 'reactflow'
-import { Box, HStack, Image, Text, VStack, type BoxProps } from '@chakra-ui/react'
+import { Box, HStack, Image, Text, VStack } from '@chakra-ui/react'
 import { useNavigate } from 'react-router-dom'
 
 import { Adapter } from '@/api/__generated__'
@@ -12,7 +12,7 @@ import TopicsContainer from '../parts/TopicsContainer.tsx'
 import { discoverAdapterTopics } from '../../utils/topics-utils.ts'
 import { CONFIG_ADAPTER_WIDTH } from '../../utils/nodes-utils.ts'
 import { useEdgeFlowContext } from '../../hooks/useEdgeFlowContext.tsx'
-import { TopicFilter } from '@/modules/EdgeVisualisation/types.ts'
+import { TopicFilter } from '../../types.ts'
 
 const NodeAdapter: FC<NodeProps<Adapter>> = ({ id, data: adapter, selected }) => {
   const { data: protocols } = useGetAdapterTypes()
@@ -25,19 +25,13 @@ const NodeAdapter: FC<NodeProps<Adapter>> = ({ id, data: adapter, selected }) =>
     return discoverAdapterTopics(adapterProtocol, adapter.config).map((e) => ({ topic: e }))
   }, [adapter.config, adapterProtocol])
 
-  const selectedStyle: Partial<BoxProps> = {
-    boxShadow: 'dark-lg',
-    rounded: 'md',
-    bg: '#dddfe2',
-  }
-
   return (
     <>
       <NodeWrapper
-        p={2}
-        {...(selected ? { ...selectedStyle } : {})}
-        w={CONFIG_ADAPTER_WIDTH}
+        isSelected={selected}
         onDoubleClick={() => navigate(`/edge-flow/node/${id}`)}
+        w={CONFIG_ADAPTER_WIDTH}
+        p={2}
       >
         <VStack>
           <HStack w={'100%'}>

--- a/hivemq-edge/src/frontend/src/modules/EdgeVisualisation/components/nodes/NodeBridge.tsx
+++ b/hivemq-edge/src/frontend/src/modules/EdgeVisualisation/components/nodes/NodeBridge.tsx
@@ -2,6 +2,7 @@ import { FC } from 'react'
 import { Handle, Position, NodeProps } from 'reactflow'
 import { Box, HStack, Image, Text, VStack } from '@chakra-ui/react'
 import { useTranslation } from 'react-i18next'
+import { useNavigate } from 'react-router-dom'
 
 import { Bridge } from '@/api/__generated__'
 import { ConnectionStatusBadge } from '@/components/ConnectionStatusBadge'
@@ -12,14 +13,15 @@ import TopicsContainer from '../parts/TopicsContainer.tsx'
 import { getBridgeTopics } from '../../utils/topics-utils.ts'
 import { useEdgeFlowContext } from '../../hooks/useEdgeFlowContext.tsx'
 
-const NodeBridge: FC<NodeProps<Bridge>> = ({ data: bridge }) => {
+const NodeBridge: FC<NodeProps<Bridge>> = ({ id, data: bridge }) => {
   const { t } = useTranslation()
   const topics = getBridgeTopics(bridge)
   const { options } = useEdgeFlowContext()
+  const navigate = useNavigate()
 
   return (
     <>
-      <NodeWrapper p={3}>
+      <NodeWrapper p={3} onDoubleClick={() => navigate(`/edge-flow/node/${id}`)}>
         <VStack>
           {options.showTopics && <TopicsContainer topics={topics.remote} />}
 

--- a/hivemq-edge/src/frontend/src/modules/EdgeVisualisation/components/nodes/NodeBridge.tsx
+++ b/hivemq-edge/src/frontend/src/modules/EdgeVisualisation/components/nodes/NodeBridge.tsx
@@ -13,7 +13,7 @@ import TopicsContainer from '../parts/TopicsContainer.tsx'
 import { getBridgeTopics } from '../../utils/topics-utils.ts'
 import { useEdgeFlowContext } from '../../hooks/useEdgeFlowContext.tsx'
 
-const NodeBridge: FC<NodeProps<Bridge>> = ({ id, data: bridge }) => {
+const NodeBridge: FC<NodeProps<Bridge>> = ({ id, selected, data: bridge }) => {
   const { t } = useTranslation()
   const topics = getBridgeTopics(bridge)
   const { options } = useEdgeFlowContext()
@@ -21,7 +21,7 @@ const NodeBridge: FC<NodeProps<Bridge>> = ({ id, data: bridge }) => {
 
   return (
     <>
-      <NodeWrapper p={3} onDoubleClick={() => navigate(`/edge-flow/node/${id}`)}>
+      <NodeWrapper isSelected={selected} onDoubleClick={() => navigate(`/edge-flow/node/${id}`)} p={3}>
         <VStack>
           {options.showTopics && <TopicsContainer topics={topics.remote} />}
 

--- a/hivemq-edge/src/frontend/src/modules/EdgeVisualisation/components/nodes/NodeEdge.tsx
+++ b/hivemq-edge/src/frontend/src/modules/EdgeVisualisation/components/nodes/NodeEdge.tsx
@@ -12,7 +12,11 @@ const NodeEdge: FC<NodeProps> = (props) => {
 
   return (
     <>
-      <NodeWrapper backgroundColor={selected ? '#dddfe2' : undefined} alignContent={'center'}>
+      <NodeWrapper
+        isSelected={props.selected}
+        backgroundColor={selected ? '#dddfe2' : undefined}
+        alignContent={'center'}
+      >
         <Text data-testid={'edge-node-name'}>{data.label}</Text>
         <Image src={logo} alt={t('workspace.node.edge') as string} boxSize="48px" />
       </NodeWrapper>

--- a/hivemq-edge/src/frontend/src/modules/EdgeVisualisation/components/nodes/NodeListener.tsx
+++ b/hivemq-edge/src/frontend/src/modules/EdgeVisualisation/components/nodes/NodeListener.tsx
@@ -1,18 +1,17 @@
 import { FC } from 'react'
 import { Handle, Position, NodeProps } from 'reactflow'
 import { Image } from '@chakra-ui/react'
+import { useTranslation } from 'react-i18next'
 
 import logoTCP from '@/assets/app/gateway-tcp.svg'
 import logoUDP from '@/assets/app/gateway-udp.svg'
 import logoGateway from '@/assets/app/gateway.svg'
+import { Listener } from '@/api/__generated__'
 
 import NodeWrapper from '../parts/NodeWrapper.tsx'
-import { Listener } from '@/api/__generated__'
-import { useTranslation } from 'react-i18next'
 
-const NodeListener: FC<NodeProps<Listener>> = (props) => {
+const NodeListener: FC<NodeProps<Listener>> = ({ selected, data }) => {
   const { t } = useTranslation()
-  const { selected, data } = props
 
   const getLogo = () => {
     if (data.transport === Listener.transport.TCP) return logoTCP
@@ -22,7 +21,13 @@ const NodeListener: FC<NodeProps<Listener>> = (props) => {
 
   return (
     <>
-      <NodeWrapper p={2} borderRadius={60} backgroundColor={selected ? '#dddfe2' : 'white'} alignContent={'center'}>
+      <NodeWrapper
+        isSelected={selected}
+        p={2}
+        borderRadius={60}
+        backgroundColor={selected ? '#dddfe2' : 'white'}
+        alignContent={'center'}
+      >
         <Image src={getLogo()} alt={t('workspace.node.gateway') as string} boxSize="48px" />
       </NodeWrapper>
       <Handle type="target" position={Position.Right} id="Listeners" isConnectable={false} />

--- a/hivemq-edge/src/frontend/src/modules/EdgeVisualisation/components/parts/NodeNameCard.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/EdgeVisualisation/components/parts/NodeNameCard.spec.cy.tsx
@@ -1,0 +1,49 @@
+/// <reference types="cypress" />
+
+import { Node } from 'reactflow'
+
+import { MOCK_NODE_ADAPTER, MOCK_NODE_BRIDGE } from '@/__test-utils__/react-flow/nodes.ts'
+import { Adapter, Bridge } from '@/api/__generated__'
+import { NodeTypes } from '@/modules/EdgeVisualisation/types.ts'
+
+import NodeNameCard from './NodeNameCard.tsx'
+import { mockProtocolAdapter } from '@/api/hooks/useProtocolAdapters/__handlers__'
+
+const mockNodeAdapter: Node<Bridge | Adapter> = {
+  position: { x: 0, y: 0 },
+  id: 'adapter@fgffgf',
+  type: NodeTypes.ADAPTER_NODE,
+  data: MOCK_NODE_ADAPTER.data,
+}
+
+const mockNodeBridg: Node<Bridge | Adapter> = {
+  position: { x: 0, y: 0 },
+  id: 'adapter@fgffgf',
+  type: NodeTypes.BRIDGE_NODE,
+  data: MOCK_NODE_BRIDGE.data,
+}
+
+describe('NodeNameCard', () => {
+  beforeEach(() => {
+    cy.viewport(400, 400)
+    cy.intercept('/api/v1/management/protocol-adapters/types', { items: [mockProtocolAdapter] }).as('getConfig1')
+  })
+
+  it('should render adapter properly', () => {
+    cy.mountWithProviders(<NodeNameCard selectedNode={mockNodeAdapter} />)
+
+    cy.getByTestId('node-type-icon').should('exist').should('have.attr', 'data-nodeicon', NodeTypes.ADAPTER_NODE)
+    cy.getByTestId('node-type-text').should('contain.text', 'adapter')
+    cy.getByTestId('node-adapter-type').should('contain.text', 'Simulated Edge Device')
+    cy.getByTestId('node-name').should('contain.text', 'my-adapter')
+  })
+
+  it('should render bridge properly', () => {
+    cy.mountWithProviders(<NodeNameCard selectedNode={mockNodeBridg} />)
+
+    cy.getByTestId('node-type-icon').should('exist').should('have.attr', 'data-nodeicon', NodeTypes.BRIDGE_NODE)
+    cy.getByTestId('node-type-text').should('contain.text', 'bridge')
+    cy.getByTestId('node-adapter-type').should('not.exist')
+    cy.getByTestId('node-name').should('contain.text', 'bridge-id-01')
+  })
+})

--- a/hivemq-edge/src/frontend/src/modules/EdgeVisualisation/components/parts/NodeNameCard.tsx
+++ b/hivemq-edge/src/frontend/src/modules/EdgeVisualisation/components/parts/NodeNameCard.tsx
@@ -1,0 +1,45 @@
+import { FC, useMemo } from 'react'
+import { Node } from 'reactflow'
+import { Card, CardBody, HStack, Icon, StackDivider, Text } from '@chakra-ui/react'
+import { PiBridgeThin, PiPlugsConnectedFill } from 'react-icons/pi'
+
+import { Adapter, Bridge } from '@/api/__generated__'
+import { NodeTypes } from '@/modules/EdgeVisualisation/types.ts'
+import { useTranslation } from 'react-i18next'
+
+interface NodeNameCardProps {
+  selectedNode: Node<Bridge | Adapter>
+}
+
+const NodeNameCard: FC<NodeNameCardProps> = ({ selectedNode }) => {
+  const { t } = useTranslation()
+  const { type } = selectedNode
+
+  const EntityIcon = useMemo(() => {
+    if (type === NodeTypes.BRIDGE_NODE)
+      return (
+        <Icon
+          data-testid={'node-type-icon'}
+          data-nodeIcon={NodeTypes.BRIDGE_NODE}
+          as={PiBridgeThin}
+          fontSize={'20px'}
+        />
+      )
+    return <Icon data-testid={'node-type-icon'} data-nodeIcon={NodeTypes.BRIDGE_NODE} as={PiPlugsConnectedFill} />
+  }, [type])
+
+  return (
+    <Card size={'sm'} direction={'row'}>
+      <CardBody>
+        <HStack divider={<StackDivider />}>
+          {EntityIcon}
+          <Text>{t('workspace.device.type', { context: type })}</Text>
+          {type === NodeTypes.ADAPTER_NODE && <Text>{(selectedNode as Node<Adapter>).data.type}</Text>}
+          <Text noOfLines={1}>{selectedNode.data.id}</Text>
+        </HStack>
+      </CardBody>
+    </Card>
+  )
+}
+
+export default NodeNameCard

--- a/hivemq-edge/src/frontend/src/modules/EdgeVisualisation/components/parts/NodeNameCard.tsx
+++ b/hivemq-edge/src/frontend/src/modules/EdgeVisualisation/components/parts/NodeNameCard.tsx
@@ -1,11 +1,13 @@
 import { FC, useMemo } from 'react'
 import { Node } from 'reactflow'
-import { Card, CardBody, HStack, Icon, StackDivider, Text } from '@chakra-ui/react'
+import { Card, CardBody, HStack, Icon, StackDivider, Tag, Text, VStack } from '@chakra-ui/react'
 import { PiBridgeThin, PiPlugsConnectedFill } from 'react-icons/pi'
+import { useTranslation } from 'react-i18next'
 
 import { Adapter, Bridge } from '@/api/__generated__'
-import { NodeTypes } from '@/modules/EdgeVisualisation/types.ts'
-import { useTranslation } from 'react-i18next'
+import { useGetAdapterTypes } from '@/api/hooks/useProtocolAdapters/useGetAdapterTypes.tsx'
+
+import { NodeTypes } from '../../types.ts'
 
 interface NodeNameCardProps {
   selectedNode: Node<Bridge | Adapter>
@@ -13,29 +15,47 @@ interface NodeNameCardProps {
 
 const NodeNameCard: FC<NodeNameCardProps> = ({ selectedNode }) => {
   const { t } = useTranslation()
+  const { data } = useGetAdapterTypes()
   const { type } = selectedNode
+
+  const adapterType = useMemo(() => {
+    if (!data) return undefined
+    if (type === NodeTypes.BRIDGE_NODE) return undefined
+
+    const adapterType = (selectedNode as Node<Adapter>).data.type
+    return data?.items?.find((e) => e.id === adapterType)
+  }, [data, selectedNode, type])
 
   const EntityIcon = useMemo(() => {
     if (type === NodeTypes.BRIDGE_NODE)
       return (
         <Icon
           data-testid={'node-type-icon'}
-          data-nodeIcon={NodeTypes.BRIDGE_NODE}
+          data-nodeicon={NodeTypes.BRIDGE_NODE}
           as={PiBridgeThin}
-          fontSize={'20px'}
+          fontSize={'40px'}
         />
       )
-    return <Icon data-testid={'node-type-icon'} data-nodeIcon={NodeTypes.BRIDGE_NODE} as={PiPlugsConnectedFill} />
+    return <Icon data-testid={'node-type-icon'} data-nodeicon={NodeTypes.ADAPTER_NODE} as={PiPlugsConnectedFill} />
   }, [type])
 
   return (
     <Card size={'sm'} direction={'row'}>
       <CardBody>
         <HStack divider={<StackDivider />}>
-          {EntityIcon}
-          <Text>{t('workspace.device.type', { context: type })}</Text>
-          {type === NodeTypes.ADAPTER_NODE && <Text>{(selectedNode as Node<Adapter>).data.type}</Text>}
-          <Text noOfLines={1}>{selectedNode.data.id}</Text>
+          <VStack>
+            {EntityIcon}
+            <Tag data-testid={'node-type-text'} textTransform={'uppercase'}>
+              {t('workspace.device.type', { context: type })}{' '}
+            </Tag>
+          </VStack>
+
+          <VStack alignItems={'flex-start'}>
+            {adapterType && <Text data-testid={'node-adapter-type'}>{adapterType.name}</Text>}
+            <Text data-testid={'node-name'} noOfLines={1}>
+              {selectedNode.data.id}
+            </Text>
+          </VStack>
         </HStack>
       </CardBody>
     </Card>

--- a/hivemq-edge/src/frontend/src/modules/EdgeVisualisation/components/parts/NodeWrapper.tsx
+++ b/hivemq-edge/src/frontend/src/modules/EdgeVisualisation/components/parts/NodeWrapper.tsx
@@ -1,8 +1,18 @@
 import { FC } from 'react'
 import { type BoxProps, useTheme, VStack } from '@chakra-ui/react'
 
-const NodeWrapper: FC<BoxProps> = ({ children, ...rest }) => {
+interface NodeWrapperProps extends BoxProps {
+  isSelected?: boolean
+}
+
+const NodeWrapper: FC<NodeWrapperProps> = ({ children, isSelected = false, ...rest }) => {
   const { colors } = useTheme()
+
+  const selectedStyle: Partial<BoxProps> = {
+    boxShadow: 'dark-lg',
+    rounded: 'md',
+    bg: '#dddfe2',
+  }
 
   return (
     <VStack
@@ -20,6 +30,7 @@ const NodeWrapper: FC<BoxProps> = ({ children, ...rest }) => {
       _focus={{
         boxShadow: '0 0 10px 2px rgba(88, 144, 255, .75), 0 1px 1px rgba(0, 0, 0, .15)',
       }}
+      {...(isSelected ? { ...selectedStyle } : {})}
       {...rest}
     >
       {children}


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/17476/details/

The PR corrects a long-standing miss whereas only Adapters could be selected in the workspace and accessed the property side panel.

The PR extends the scheme to Bridges. 

Note that other entities like Edge itself or the listeners don't have any meaningful content to show in the properties so they are currently not selectable. 

The PR also fixes a few defects in the side panel: 
- improved name and type identification of the selected node
- improved layout

### Before 
![screenshot-localhost_3000-2023 11 17-11_56_22](https://github.com/hivemq/hivemq-edge/assets/2743481/ff65e306-4464-4b72-a9a1-be0aad4bf4b6)

### After 
![screenshot-localhost_3000-2023 11 17-11_54_44](https://github.com/hivemq/hivemq-edge/assets/2743481/4755b17f-f4fa-4f04-ba6c-2c80aa2c95e3)

![screenshot-localhost_3000-2023 11 17-11_55_12](https://github.com/hivemq/hivemq-edge/assets/2743481/d15cc414-74d4-4855-a13d-b8fc0ad81db3)
