### PR TITLE
feat(17781): Notification framework and new release notice

### DIFF
--- a/hivemq-edge/src/frontend/cypress/tsconfig.json
+++ b/hivemq-edge/src/frontend/cypress/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "target": "es5",
+    "types": ["cypress", "node", "@percy/cypress"]
+  },
+  "include": ["./**/*.ts", "../cypress.d.ts"]
+}

--- a/hivemq-edge/src/frontend/src/api/hooks/useFrontendServices/__handlers__/index.ts
+++ b/hivemq-edge/src/frontend/src/api/hooks/useFrontendServices/__handlers__/index.ts
@@ -1,4 +1,4 @@
-import { GatewayConfiguration } from '@/api/__generated__'
+import { GatewayConfiguration, Notification, NotificationList } from '@/api/__generated__'
 import { rest } from 'msw'
 
 const lorem =
@@ -102,8 +102,21 @@ export const mockGatewayConfiguration: GatewayConfiguration = {
   },
 }
 
+export const MOCK_NOTIFICATIONS: Array<Notification> = [
+  {
+    level: Notification.level.WARNING,
+    title: 'Default Credentials Need Changing!',
+    description:
+      'Your gateway access is configured to use the default username/password combination. This is a security risk. Please ensure you modify your access credentials in your configuration.xml file.',
+  },
+]
+
 export const handlers = [
   rest.get('**/frontend/configuration', (_, res, ctx) => {
     return res(ctx.json<GatewayConfiguration>(mockGatewayConfiguration), ctx.status(200))
+  }),
+
+  rest.get('**/frontend/notifications', (_, res, ctx) => {
+    return res(ctx.json<NotificationList>({ items: MOCK_NOTIFICATIONS }), ctx.status(200))
   }),
 ]

--- a/hivemq-edge/src/frontend/src/api/hooks/useFrontendServices/useGetNotifications.tsx
+++ b/hivemq-edge/src/frontend/src/api/hooks/useFrontendServices/useGetNotifications.tsx
@@ -1,0 +1,13 @@
+import { useQuery } from '@tanstack/react-query'
+import { useHttpClient } from '@/api/hooks/useHttpClient/useHttpClient.ts'
+import { QUERY_KEYS } from '@/api/utils.ts'
+import { ApiError, NotificationList } from '@/api/__generated__'
+
+export const useGetNotifications = () => {
+  const appClient = useHttpClient()
+
+  return useQuery<NotificationList, ApiError>([QUERY_KEYS.FRONTEND_NOTIFICATION], async () => {
+    const item = await appClient.frontend.getNotifications()
+    return item
+  })
+}

--- a/hivemq-edge/src/frontend/src/api/hooks/useGitHub/__handlers__/index.ts
+++ b/hivemq-edge/src/frontend/src/api/hooks/useGitHub/__handlers__/index.ts
@@ -1,8 +1,12 @@
 import { rest } from 'msw'
 import { GitHubReleases } from '../types.ts'
 
+export const MOCK_GITHUB_RELEASE: GitHubReleases = {
+  name: '2023.XXX',
+  html_url: 'http://localhost.com',
+}
 export const handlers = [
   rest.get('https://api.github.com/repos/hivemq/hivemq-edge/releases', (_, res, ctx) => {
-    return res(ctx.json<GitHubReleases[]>([]), ctx.status(200))
+    return res(ctx.json<GitHubReleases[]>([MOCK_GITHUB_RELEASE]), ctx.status(200))
   }),
 ]

--- a/hivemq-edge/src/frontend/src/api/hooks/useGitHub/__handlers__/index.ts
+++ b/hivemq-edge/src/frontend/src/api/hooks/useGitHub/__handlers__/index.ts
@@ -1,0 +1,8 @@
+import { rest } from 'msw'
+import { GitHubReleases } from '../types.ts'
+
+export const handlers = [
+  rest.get('https://api.github.com/repos/hivemq/hivemq-edge/releases', (_, res, ctx) => {
+    return res(ctx.json<GitHubReleases[]>([]), ctx.status(200))
+  }),
+]

--- a/hivemq-edge/src/frontend/src/api/hooks/useGitHub/types.ts
+++ b/hivemq-edge/src/frontend/src/api/hooks/useGitHub/types.ts
@@ -1,3 +1,4 @@
+// TODO[NVL] This is a manual extraction of the whole API payload. Can we do better?
 export interface GitHubReleases {
   name: string
   html_url: string

--- a/hivemq-edge/src/frontend/src/api/hooks/useGitHub/types.ts
+++ b/hivemq-edge/src/frontend/src/api/hooks/useGitHub/types.ts
@@ -1,0 +1,4 @@
+export interface GitHubReleases {
+  name: string
+  html_url: string
+}

--- a/hivemq-edge/src/frontend/src/api/hooks/useGitHub/useGetReleases.tsx
+++ b/hivemq-edge/src/frontend/src/api/hooks/useGitHub/useGetReleases.tsx
@@ -1,0 +1,17 @@
+import axios from 'axios'
+import { useQuery } from '@tanstack/react-query'
+
+import { ApiError } from '@/api/__generated__'
+import { GitHubReleases } from '@/api/hooks/useGitHub/types.ts'
+import { QUERY_KEYS } from '@/api/utils.ts'
+
+export const useGetReleases = () => {
+  return useQuery<GitHubReleases[], ApiError>([QUERY_KEYS.GITHUB_RELEASES], async () => {
+    const retrievePosts = async () => {
+      const response = await axios.get<GitHubReleases[]>('https://api.github.com/repos/hivemq/hivemq-edge/releases')
+      return response.data
+    }
+
+    return await retrievePosts()
+  })
+}

--- a/hivemq-edge/src/frontend/src/api/utils.ts
+++ b/hivemq-edge/src/frontend/src/api/utils.ts
@@ -12,6 +12,7 @@ export const QUERY_KEYS = {
   METRICS: 'metrics',
   METRICS_SAMPLE: 'sample',
   EVENTS: 'events',
+  GITHUB_RELEASES: 'github.releases',
 }
 
 export const parseJWT = (token: string): JWTPayload | null => {

--- a/hivemq-edge/src/frontend/src/api/utils.ts
+++ b/hivemq-edge/src/frontend/src/api/utils.ts
@@ -7,6 +7,7 @@ export const QUERY_KEYS = {
   ADAPTERS: 'adapters',
   UNIFIED_NAMESPACE: 'unified.namespace',
   FRONTEND_CONFIGURATION: 'frontend.configuration',
+  FRONTEND_NOTIFICATION: 'frontend.notification',
   LISTENERS: 'gateway.listeners',
   METRICS: 'metrics',
   METRICS_SAMPLE: 'sample',

--- a/hivemq-edge/src/frontend/src/components/Chakra/ButtonBadge.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/components/Chakra/ButtonBadge.spec.cy.tsx
@@ -1,0 +1,43 @@
+/// <reference types="cypress" />
+
+import ButtonBadge from './ButtonBadge.tsx'
+import { FiMail } from 'react-icons/fi'
+
+describe('ButtonBadge', () => {
+  beforeEach(() => {
+    cy.viewport(400, 150)
+  })
+
+  it('should render disabled badge', () => {
+    const onClick = cy.stub().as('onClick')
+    cy.mountWithProviders(
+      <ButtonBadge
+        aria-label={'You have no notification'}
+        badgeLabel={1}
+        icon={<FiMail />}
+        isDisabled
+        onClick={onClick}
+      />
+    )
+
+    cy.getByAriaLabel('You have no notification').click()
+    cy.get('@onClick').should('not.have.been.called')
+  })
+
+  it('should render properly', () => {
+    const onClick = cy.stub().as('onClick')
+    cy.mountWithProviders(
+      <ButtonBadge aria-label={'You have one notification'} badgeLabel={1} icon={<FiMail />} onClick={onClick} />
+    )
+
+    cy.getByAriaLabel('You have one notification').click()
+    cy.get('@onClick').should('have.been.called')
+  })
+
+  it('should be accessible', () => {
+    cy.injectAxe()
+    cy.mountWithProviders(<ButtonBadge aria-label={'You have one notification'} badgeLabel={1} icon={<FiMail />} />)
+    cy.checkAccessibility()
+    cy.percySnapshot('Component: Primary CTA Button')
+  })
+})

--- a/hivemq-edge/src/frontend/src/components/Chakra/ButtonBadge.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/components/Chakra/ButtonBadge.spec.cy.tsx
@@ -13,7 +13,7 @@ describe('ButtonBadge', () => {
     cy.mountWithProviders(
       <ButtonBadge
         aria-label={'You have no notification'}
-        badgeLabel={1}
+        badgeCount={1}
         icon={<FiMail />}
         isDisabled
         onClick={onClick}
@@ -27,7 +27,7 @@ describe('ButtonBadge', () => {
   it('should render properly', () => {
     const onClick = cy.stub().as('onClick')
     cy.mountWithProviders(
-      <ButtonBadge aria-label={'You have one notification'} badgeLabel={1} icon={<FiMail />} onClick={onClick} />
+      <ButtonBadge aria-label={'You have one notification'} badgeCount={1} icon={<FiMail />} onClick={onClick} />
     )
 
     cy.getByAriaLabel('You have one notification').click()
@@ -36,7 +36,7 @@ describe('ButtonBadge', () => {
 
   it('should be accessible', () => {
     cy.injectAxe()
-    cy.mountWithProviders(<ButtonBadge aria-label={'You have one notification'} badgeLabel={1} icon={<FiMail />} />)
+    cy.mountWithProviders(<ButtonBadge aria-label={'You have one notification'} badgeCount={1} icon={<FiMail />} />)
     cy.checkAccessibility()
     cy.percySnapshot('Component: Primary CTA Button')
   })

--- a/hivemq-edge/src/frontend/src/components/Chakra/ButtonBadge.tsx
+++ b/hivemq-edge/src/frontend/src/components/Chakra/ButtonBadge.tsx
@@ -2,14 +2,14 @@ import { FC } from 'react'
 import { Avatar, AvatarBadge, AvatarProps, IconButton, Text } from '@chakra-ui/react'
 
 interface ButtonBadgeProps extends Omit<AvatarProps, 'aria-label'> {
-  badgeLabel?: string | number
+  badgeCount?: number
   isDisabled?: boolean
   'aria-label': string
 }
 
 const ButtonBadge: FC<ButtonBadgeProps> = ({
   ['aria-label']: ariaLabel,
-  badgeLabel,
+  badgeCount,
   icon,
   isDisabled,
   onClick,
@@ -28,9 +28,9 @@ const ButtonBadge: FC<ButtonBadgeProps> = ({
 
   return (
     <Avatar aria-label={ariaLabel} isDisabled={isDisabled} icon={icon} bg="brand.400" {...activeProps} {...props}>
-      {badgeLabel && !isDisabled && (
+      {((badgeCount && !isDisabled) || !isDisabled) && (
         <AvatarBadge borderColor="yellow.50" bg="yellow.500" boxSize="1.25em">
-          <Text fontSize={'.95rem'}>{badgeLabel}</Text>
+          <Text fontSize={'.95rem'}>{badgeCount}</Text>
         </AvatarBadge>
       )}
     </Avatar>

--- a/hivemq-edge/src/frontend/src/components/Chakra/ButtonBadge.tsx
+++ b/hivemq-edge/src/frontend/src/components/Chakra/ButtonBadge.tsx
@@ -1,0 +1,40 @@
+import { FC } from 'react'
+import { Avatar, AvatarBadge, AvatarProps, IconButton, Text } from '@chakra-ui/react'
+
+interface ButtonBadgeProps extends Omit<AvatarProps, 'aria-label'> {
+  badgeLabel?: string | number
+  isDisabled?: boolean
+  'aria-label': string
+}
+
+const ButtonBadge: FC<ButtonBadgeProps> = ({
+  ['aria-label']: ariaLabel,
+  badgeLabel,
+  icon,
+  isDisabled,
+  onClick,
+  ...props
+}) => {
+  // TODO[NVL] Not a good idea. Keep the button but disabled ?
+  const activeProps: Partial<Omit<AvatarProps, 'aria-label'>> = isDisabled
+    ? { backgroundColor: 'brand.200' }
+    : {
+        backgroundColor: 'brand.500',
+        as: IconButton,
+        _hover: { backgroundColor: 'brand.500' },
+        _active: { backgroundColor: 'brand.600' },
+        onClick: onClick,
+      }
+
+  return (
+    <Avatar aria-label={ariaLabel} isDisabled={isDisabled} icon={icon} bg="brand.400" {...activeProps} {...props}>
+      {badgeLabel && !isDisabled && (
+        <AvatarBadge borderColor="yellow.50" bg="yellow.500" boxSize="1.25em">
+          <Text fontSize={'.95rem'}>{badgeLabel}</Text>
+        </AvatarBadge>
+      )}
+    </Avatar>
+  )
+}
+
+export default ButtonBadge

--- a/hivemq-edge/src/frontend/src/components/Chakra/ButtonBadge.tsx
+++ b/hivemq-edge/src/frontend/src/components/Chakra/ButtonBadge.tsx
@@ -29,7 +29,7 @@ const ButtonBadge: FC<ButtonBadgeProps> = ({
   return (
     <Avatar aria-label={ariaLabel} isDisabled={isDisabled} icon={icon} bg="brand.400" {...activeProps} {...props}>
       {((badgeCount && !isDisabled) || !isDisabled) && (
-        <AvatarBadge borderColor="yellow.50" bg="yellow.500" boxSize="1.25em">
+        <AvatarBadge borderColor="yellow.50" bg="yellow.500" boxSize="1.25em" data-testid={'buttonBadge-counter'}>
           <Text fontSize={'.95rem'}>{badgeCount}</Text>
         </AvatarBadge>
       )}

--- a/hivemq-edge/src/frontend/src/locales/en/translation.json
+++ b/hivemq-edge/src/frontend/src/locales/en/translation.json
@@ -728,5 +728,14 @@
     "error": {
       "loading": "We cannot load the events at this time. Please try again later"
     }
+  },
+  "notifications": {
+    "toast": {
+      "skipNotification": "Do not notify me again"
+    },
+    "releases": {
+      "title": "A new version of $t(branding.appName) is available",
+      "description": "Visit the GitHub repository to learn more about the latest version of $t(branding.appName)"
+    }
   }
 }

--- a/hivemq-edge/src/frontend/src/locales/en/translation.json
+++ b/hivemq-edge/src/frontend/src/locales/en/translation.json
@@ -730,6 +730,9 @@
     }
   },
   "notifications": {
+    "badge": {
+      "ariaLabel": "Notifications"
+    },
     "toast": {
       "skipNotification": "Do not notify me again"
     },

--- a/hivemq-edge/src/frontend/src/modules/Dashboard/components/SidePanel.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Dashboard/components/SidePanel.tsx
@@ -4,12 +4,12 @@ import { useNavigate } from 'react-router-dom'
 import { Box, Button, Flex, Image, Text } from '@chakra-ui/react'
 import { FiLogOut } from 'react-icons/fi'
 
-import NavLinksBlock from './NavLinksBlock.tsx'
-
-import { useGetConfiguration } from '@/api/hooks/useFrontendServices/useGetConfiguration.tsx'
 import logo from '@/assets/edge/03-hivemq-industrial-edge-vert.svg'
+import { useGetConfiguration } from '@/api/hooks/useFrontendServices/useGetConfiguration.tsx'
 import { useAuth } from '@/modules/Auth/hooks/useAuth.ts'
+import NotificationBadge from '@/modules/Notifications/NotificationBadge.tsx'
 
+import NavLinksBlock from './NavLinksBlock.tsx'
 import useGetNavItems from '../hooks/useGetNavItems.tsx'
 
 const SidePanel: FC = () => {
@@ -22,13 +22,17 @@ const SidePanel: FC = () => {
   return (
     <nav>
       <Flex flexDirection="column" w={256} h={'100%'} bgColor={'#f5f5f5'} overflow={'auto'}>
-        <Box p={4} m={'auto'} mb={10}>
+        <Box p={4} m={'auto'} mb={4}>
           <Image src={logo} alt={t('branding.company') as string} boxSize="200px" />
           {configuration && (
             <Text data-testid="edge-release" fontSize="xs" textAlign={'center'}>
               [ {configuration.environment?.properties?.version} ]
             </Text>
           )}
+        </Box>
+
+        <Box m={4} mb={8}>
+          <NotificationBadge />
         </Box>
 
         <Flex flexDirection="column" flex={1}>

--- a/hivemq-edge/src/frontend/src/modules/Notifications/NotificationBadge.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Notifications/NotificationBadge.spec.cy.tsx
@@ -1,0 +1,24 @@
+/// <reference types="cypress" />
+
+import NotificationBadge from '@/modules/Notifications/NotificationBadge.tsx'
+import { MOCK_NOTIFICATIONS } from '@/api/hooks/useFrontendServices/__handlers__'
+
+describe('NotificationBadge', () => {
+  beforeEach(() => {
+    cy.viewport(900, 500)
+    cy.intercept('https://api.github.com/repos/hivemq/hivemq-edge/releases', []).as('getReleases')
+    cy.intercept('/api/v1/frontend/notifications', { items: MOCK_NOTIFICATIONS }).as('getNotifications')
+  })
+
+  it('should render properly', () => {
+    cy.mountWithProviders(<NotificationBadge />)
+
+    cy.wait('@getReleases')
+    cy.wait('@getNotifications')
+
+    cy.getByTestId('buttonBadge-counter').should('contain.text', 1)
+    cy.getByAriaLabel('Notifications').click()
+
+    cy.get("[role='status']").should('be.visible').should('contain.text', 'Default Credentials Need Changing!')
+  })
+})

--- a/hivemq-edge/src/frontend/src/modules/Notifications/NotificationBadge.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Notifications/NotificationBadge.tsx
@@ -1,7 +1,7 @@
 import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
-import { FiMail } from 'react-icons/fi'
-import { useToast, UseToastOptions } from '@chakra-ui/react'
+import { IoNotifications } from 'react-icons/io5'
+import { Icon, useToast, UseToastOptions } from '@chakra-ui/react'
 
 import ButtonBadge from '@/components/Chakra/ButtonBadge.tsx'
 
@@ -35,7 +35,7 @@ const NotificationBadge: FC = () => {
       aria-label={t('notifications.badge.ariaLabel')}
       badgeCount={notifications.length}
       isDisabled={!notifications.length}
-      icon={<FiMail />}
+      icon={<Icon as={IoNotifications} fontSize={'2xl'} />}
       onClick={handleClick}
     />
   )

--- a/hivemq-edge/src/frontend/src/modules/Notifications/NotificationBadge.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Notifications/NotificationBadge.tsx
@@ -18,7 +18,7 @@ const NotificationBadge: FC = () => {
   return (
     <ButtonBadge
       aria-label={'dd'}
-      badgeLabel={notifications.length}
+      badgeCount={notifications.length}
       isDisabled={!notifications.length}
       icon={<FiMail />}
       onClick={handleClick}

--- a/hivemq-edge/src/frontend/src/modules/Notifications/NotificationBadge.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Notifications/NotificationBadge.tsx
@@ -1,4 +1,5 @@
 import { FC } from 'react'
+import { useTranslation } from 'react-i18next'
 import { FiMail } from 'react-icons/fi'
 import { useToast } from '@chakra-ui/react'
 
@@ -6,6 +7,7 @@ import ButtonBadge from '@/components/Chakra/ButtonBadge.tsx'
 import { useGetManagedNotifications } from './hooks/useGetManagedNotifications.tsx'
 
 const NotificationBadge: FC = () => {
+  const { t } = useTranslation()
   const toast = useToast()
   const { notifications } = useGetManagedNotifications()
 
@@ -17,7 +19,7 @@ const NotificationBadge: FC = () => {
 
   return (
     <ButtonBadge
-      aria-label={'dd'}
+      aria-label={t('notifications.badge.ariaLabel')}
       badgeCount={notifications.length}
       isDisabled={!notifications.length}
       icon={<FiMail />}

--- a/hivemq-edge/src/frontend/src/modules/Notifications/NotificationBadge.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Notifications/NotificationBadge.tsx
@@ -1,0 +1,29 @@
+import { FC } from 'react'
+import { FiMail } from 'react-icons/fi'
+import { useToast } from '@chakra-ui/react'
+
+import ButtonBadge from '@/components/Chakra/ButtonBadge.tsx'
+import { useGetManagedNotifications } from './hooks/useGetManagedNotifications.tsx'
+
+const NotificationBadge: FC = () => {
+  const toast = useToast()
+  const { notifications } = useGetManagedNotifications()
+
+  const handleClick = () => {
+    notifications.forEach((notification) => {
+      if (notification.id && !toast.isActive(notification.id)) toast(notification)
+    })
+  }
+
+  return (
+    <ButtonBadge
+      aria-label={'dd'}
+      badgeLabel={notifications.length}
+      isDisabled={!notifications.length}
+      icon={<FiMail />}
+      onClick={handleClick}
+    />
+  )
+}
+
+export default NotificationBadge

--- a/hivemq-edge/src/frontend/src/modules/Notifications/NotificationBadge.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Notifications/NotificationBadge.tsx
@@ -1,10 +1,12 @@
 import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
 import { FiMail } from 'react-icons/fi'
-import { useToast } from '@chakra-ui/react'
+import { useToast, UseToastOptions } from '@chakra-ui/react'
 
 import ButtonBadge from '@/components/Chakra/ButtonBadge.tsx'
+
 import { useGetManagedNotifications } from './hooks/useGetManagedNotifications.tsx'
+import { SkipNotification } from './components/SkipNotification.tsx'
 
 const NotificationBadge: FC = () => {
   const { t } = useTranslation()
@@ -13,7 +15,18 @@ const NotificationBadge: FC = () => {
 
   const handleClick = () => {
     notifications.forEach((notification) => {
-      if (notification.id && !toast.isActive(notification.id)) toast(notification)
+      if (notification.id && !toast.isActive(notification.id)) {
+        const notificationWithSkip: UseToastOptions = {
+          ...notification,
+          description: (
+            <>
+              {notification.description}
+              <SkipNotification id={notification.id.toString()} />
+            </>
+          ),
+        }
+        toast(notificationWithSkip)
+      }
     })
   }
 

--- a/hivemq-edge/src/frontend/src/modules/Notifications/components/SkipNotification.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Notifications/components/SkipNotification.spec.cy.tsx
@@ -1,0 +1,32 @@
+/// <reference types="cypress" />
+
+import { SkipNotification } from './SkipNotification.tsx'
+
+const mockNotificationId = 'mock-id'
+describe('SkipNotification', () => {
+  beforeEach(() => {
+    cy.viewport(300, 500)
+  })
+
+  it('should render properly', () => {
+    cy.mountWithProviders(<SkipNotification id={mockNotificationId} />)
+
+    cy.getByTestId('notification-skip').should('exist')
+    cy.getAllLocalStorage().then((e) => {
+      const g = Object.values(e)[0]['edge.notifications']
+      cy.wrap(g).should('equal', JSON.stringify([]))
+    })
+
+    cy.getByTestId('notification-skip').click()
+    cy.getAllLocalStorage().then((e) => {
+      const g = Object.values(e)[0]['edge.notifications']
+      cy.wrap(g).should('equal', JSON.stringify(['mock-id']))
+    })
+
+    cy.getByTestId('notification-skip').click()
+    cy.getAllLocalStorage().then((e) => {
+      const g = Object.values(e)[0]['edge.notifications']
+      cy.wrap(g).should('equal', JSON.stringify([]))
+    })
+  })
+})

--- a/hivemq-edge/src/frontend/src/modules/Notifications/components/SkipNotification.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Notifications/components/SkipNotification.tsx
@@ -1,16 +1,31 @@
 import { ChangeEvent, FC } from 'react'
 import { Checkbox, HStack } from '@chakra-ui/react'
 import { useTranslation } from 'react-i18next'
+import { useLocalStorage } from '@uidotdev/usehooks'
 
 interface SkipNotificationProps {
-  onChange: (event: ChangeEvent<HTMLInputElement>) => void
+  id: string
 }
-export const SkipNotification: FC<SkipNotificationProps> = ({ onChange }) => {
-  const { t } = useTranslation()
 
+export const SkipNotification: FC<SkipNotificationProps> = ({ id }) => {
+  const { t } = useTranslation()
+  const [, setSkip] = useLocalStorage<string[]>('edge.notifications', [])
+
+  const handleOnChange = (e: ChangeEvent<HTMLInputElement>) => {
+    if (e.target.checked) {
+      setSkip((old) => [...old, id])
+    } else {
+      setSkip((old) => old.filter((e) => e != id))
+    }
+  }
   return (
     <HStack justifyContent={'flex-end'}>
-      <Checkbox onChange={onChange} colorScheme="blackAlpha" borderColor={'blackAlpha.500'} isDisabled>
+      <Checkbox
+        onChange={handleOnChange}
+        colorScheme="blackAlpha"
+        borderColor={'blackAlpha.500'}
+        data-testid={'notification-skip'}
+      >
         {t('notifications.toast.skipNotification')}
       </Checkbox>
     </HStack>

--- a/hivemq-edge/src/frontend/src/modules/Notifications/components/SkipNotification.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Notifications/components/SkipNotification.tsx
@@ -1,0 +1,18 @@
+import { ChangeEvent, FC } from 'react'
+import { Checkbox, HStack } from '@chakra-ui/react'
+import { useTranslation } from 'react-i18next'
+
+interface SkipNotificationProps {
+  onChange: (event: ChangeEvent<HTMLInputElement>) => void
+}
+export const SkipNotification: FC<SkipNotificationProps> = ({ onChange }) => {
+  const { t } = useTranslation()
+
+  return (
+    <HStack justifyContent={'flex-end'}>
+      <Checkbox onChange={onChange} colorScheme="blackAlpha" borderColor={'blackAlpha.500'} isDisabled>
+        {t('notifications.toast.skipNotification')}
+      </Checkbox>
+    </HStack>
+  )
+}

--- a/hivemq-edge/src/frontend/src/modules/Notifications/hooks/useGetManagedNotifications.spec.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Notifications/hooks/useGetManagedNotifications.spec.tsx
@@ -1,0 +1,75 @@
+import { vi, expect, beforeEach } from 'vitest'
+import { MemoryRouter } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { act, renderHook, waitFor } from '@testing-library/react'
+
+import { server } from '@/__test-utils__/msw/mockServer.ts'
+import { handlers as frontendHandler } from '@/api/hooks/useFrontendServices/__handlers__'
+import { handlers as gitHubHandler } from '@/api/hooks/useGitHub/__handlers__'
+import { AuthProvider } from '@/modules/Auth/AuthProvider.tsx'
+
+import { useGetManagedNotifications } from './useGetManagedNotifications.tsx'
+
+import '@/config/i18n.config.ts'
+
+const wrapper: React.JSXElementConstructor<{ children: React.ReactElement }> = ({ children }) => (
+  <QueryClientProvider client={new QueryClient()}>
+    <AuthProvider>
+      <MemoryRouter>{children}</MemoryRouter>
+    </AuthProvider>
+  </QueryClientProvider>
+)
+
+describe('useGetManagedNotifications', () => {
+  beforeEach(() => {
+    server.use(...frontendHandler, ...gitHubHandler)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    server.resetHandlers()
+  })
+
+  it('should show a list of unread notifications', async () => {
+    const { result } = renderHook(useGetManagedNotifications, { wrapper })
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBeTruthy()
+    })
+
+    expect(result.current.notifications).toHaveLength(2)
+    expect(result.current.readNotifications).toHaveLength(0)
+  })
+
+  it('should handle reading a notification', async () => {
+    const { result } = renderHook(useGetManagedNotifications, { wrapper })
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBeTruthy()
+    })
+
+    expect(result.current.notifications).toHaveLength(2)
+    expect(result.current.readNotifications).toHaveLength(0)
+
+    // close the first notification
+    act(() => {
+      result.current.notifications[0].onCloseComplete?.()
+    })
+
+    expect(result.current.notifications).toHaveLength(1)
+    expect(result.current.readNotifications).toHaveLength(1)
+    expect(result.current.readNotifications).toContainEqual('Default Credentials Need Changing!')
+
+    // close the first notification
+    act(() => {
+      result.current.notifications[0].onCloseComplete?.()
+    })
+
+    expect(result.current.notifications).toHaveLength(0)
+    expect(result.current.readNotifications).toHaveLength(2)
+    expect(result.current.readNotifications).toContainEqual('Default Credentials Need Changing!')
+    expect(result.current.readNotifications).toContainEqual('2023.XXX')
+
+    console.log('XXXX', result.current)
+  })
+})

--- a/hivemq-edge/src/frontend/src/modules/Notifications/hooks/useGetManagedNotifications.spec.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Notifications/hooks/useGetManagedNotifications.spec.tsx
@@ -69,7 +69,5 @@ describe('useGetManagedNotifications', () => {
     expect(result.current.readNotifications).toHaveLength(2)
     expect(result.current.readNotifications).toContainEqual('Default Credentials Need Changing!')
     expect(result.current.readNotifications).toContainEqual('2023.XXX')
-
-    console.log('XXXX', result.current)
   })
 })

--- a/hivemq-edge/src/frontend/src/modules/Notifications/hooks/useGetManagedNotifications.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Notifications/hooks/useGetManagedNotifications.tsx
@@ -1,84 +1,90 @@
-import { ChangeEvent, useMemo } from 'react'
-import { Badge, Checkbox, HStack, Link, Text, UseToastOptions } from '@chakra-ui/react'
+import { ChangeEvent, useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Badge, Link, Text, UseToastOptions } from '@chakra-ui/react'
 import { ExternalLinkIcon } from '@chakra-ui/icons'
 
 import { useGetReleases } from '@/api/hooks/useGitHub/useGetReleases.tsx'
 import { useGetNotifications } from '@/api/hooks/useFrontendServices/useGetNotifications.tsx'
-import { useTranslation } from 'react-i18next'
+
+import { SkipNotification } from '../components/SkipNotification.tsx'
 
 // TODO[NVL] Need to check whether a "new release" notification might already be handled by BE
 export const useGetManagedNotifications = () => {
   const { t } = useTranslation()
   const { data: releases } = useGetReleases()
   const { data: notification } = useGetNotifications()
+  const [readNotifications, setReadNotifications] = useState<string[]>([])
 
   const notifications = useMemo<UseToastOptions[]>(() => {
     const list: UseToastOptions[] = []
 
     const handlePersistence = (event: ChangeEvent<HTMLInputElement>) => {
-      console.log('XXXX ss', event.target.checked)
+      console.log('XXXX handlePersistence', event.target.checked)
     }
 
-    const clock = (
-      <HStack justifyContent={'flex-end'}>
-        <Checkbox onChange={handlePersistence} colorScheme="blackAlpha" borderColor={'blackAlpha.500'}>
-          {t('notifications.toast.skipNotification')}
-        </Checkbox>
-      </HStack>
-    )
+    const handleReadNotification = (id: string) => {
+      console.log('XXXXX handleReadNotification', id)
+      setReadNotifications((old) => Array.from(new Set([...old, id])))
+    }
 
     const defaults: Partial<UseToastOptions> = {
-      duration: 30000,
+      // Should it be manual closing only?
+      duration: 30 * 1000,
       isClosable: true,
       variant: 'top-accent',
       position: 'top-right',
       status: 'info',
-      description: clock,
+      description: <SkipNotification onChange={handlePersistence} />,
     }
 
     if (notification?.items && notification.items.length > 0) {
-      const toasts: UseToastOptions[] = notification.items.map((e) => ({
-        ...defaults,
-        id: e.title,
-        status: e.level ? 'warning' : 'info',
-        title: <Text>{e.title}</Text>,
-        description: (
-          <>
-            <Text>{e.description}</Text>
-            {clock}
-          </>
-        ),
-      }))
+      const toasts: UseToastOptions[] = notification.items
+        .filter((e) => !readNotifications.includes(e.title as string))
+        .map((e) => ({
+          ...defaults,
+          id: e.title,
+          status: e.level ? 'warning' : 'info',
+          title: <Text>{e.title}</Text>,
+          description: (
+            <>
+              <Text>{e.description}</Text>
+              <SkipNotification onChange={handlePersistence} />
+            </>
+          ),
+          onCloseComplete: () => handleReadNotification(e.title as string),
+        }))
       list.push(...toasts)
     }
 
     if (releases && releases.length > 0) {
       const { name, html_url } = releases[0]
-      list.push({
-        ...defaults,
-        id: name,
-        title: (
-          <Text>
-            <Text as={'span'}>{t('notifications.releases.title')} </Text>
-            <Badge colorScheme={'yellow'}>{name}</Badge>
-          </Text>
-        ),
-        description: (
-          <>
+      if (!readNotifications.includes(name))
+        list.push({
+          ...defaults,
+          id: name,
+          title: (
             <Text>
-              {t('notifications.releases.description')}{' '}
-              <Link href={html_url} isExternal>
-                <ExternalLinkIcon mx="2px" mb={'4px'} /> hivemq/hivemq-edge
-              </Link>
+              <Text as={'span'}>{t('notifications.releases.title')} </Text>
+              <Badge colorScheme={'yellow'}>{name}</Badge>
             </Text>
-            {clock}
-          </>
-        ),
-      })
+          ),
+          description: (
+            <>
+              <Text>
+                {t('notifications.releases.description')}{' '}
+                <Link href={html_url} isExternal>
+                  <ExternalLinkIcon mx="2px" mb={'4px'} /> hivemq/hivemq-edge
+                </Link>
+              </Text>
+              <SkipNotification onChange={handlePersistence} />
+            </>
+          ),
+          onCloseComplete: () => handleReadNotification(name),
+        })
     }
 
     return list
-  }, [notification, releases, t])
+  }, [readNotifications, notification, releases, t])
 
   return { notifications }
 }

--- a/hivemq-edge/src/frontend/src/modules/Notifications/hooks/useGetManagedNotifications.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Notifications/hooks/useGetManagedNotifications.tsx
@@ -11,8 +11,8 @@ import { SkipNotification } from '../components/SkipNotification.tsx'
 // TODO[NVL] Need to check whether a "new release" notification might already be handled by BE
 export const useGetManagedNotifications = () => {
   const { t } = useTranslation()
-  const { data: releases } = useGetReleases()
-  const { data: notification } = useGetNotifications()
+  const { data: releases, isSuccess: isReleasesSuccess } = useGetReleases()
+  const { data: notification, isSuccess: isNotificationsSuccess } = useGetNotifications()
   const [readNotifications, setReadNotifications] = useState<string[]>([])
 
   const notifications = useMemo<UseToastOptions[]>(() => {
@@ -86,5 +86,5 @@ export const useGetManagedNotifications = () => {
     return list
   }, [readNotifications, notification, releases, t])
 
-  return { notifications }
+  return { notifications, isSuccess: isNotificationsSuccess && isReleasesSuccess, readNotifications }
 }

--- a/hivemq-edge/src/frontend/src/modules/Notifications/hooks/useGetManagedNotifications.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Notifications/hooks/useGetManagedNotifications.tsx
@@ -1,0 +1,84 @@
+import { ChangeEvent, useMemo } from 'react'
+import { Badge, Checkbox, HStack, Link, Text, UseToastOptions } from '@chakra-ui/react'
+import { ExternalLinkIcon } from '@chakra-ui/icons'
+
+import { useGetReleases } from '@/api/hooks/useGitHub/useGetReleases.tsx'
+import { useGetNotifications } from '@/api/hooks/useFrontendServices/useGetNotifications.tsx'
+import { useTranslation } from 'react-i18next'
+
+// TODO[NVL] Need to check whether a "new release" notification might already be handled by BE
+export const useGetManagedNotifications = () => {
+  const { t } = useTranslation()
+  const { data: releases } = useGetReleases()
+  const { data: notification } = useGetNotifications()
+
+  const notifications = useMemo<UseToastOptions[]>(() => {
+    const list: UseToastOptions[] = []
+
+    const handlePersistence = (event: ChangeEvent<HTMLInputElement>) => {
+      console.log('XXXX ss', event.target.checked)
+    }
+
+    const clock = (
+      <HStack justifyContent={'flex-end'}>
+        <Checkbox onChange={handlePersistence} colorScheme="blackAlpha" borderColor={'blackAlpha.500'}>
+          {t('notifications.toast.skipNotification')}
+        </Checkbox>
+      </HStack>
+    )
+
+    const defaults: Partial<UseToastOptions> = {
+      duration: 30000,
+      isClosable: true,
+      variant: 'top-accent',
+      position: 'top-right',
+      status: 'info',
+      description: clock,
+    }
+
+    if (notification?.items && notification.items.length > 0) {
+      const toasts: UseToastOptions[] = notification.items.map((e) => ({
+        ...defaults,
+        id: e.title,
+        status: e.level ? 'warning' : 'info',
+        title: <Text>{e.title}</Text>,
+        description: (
+          <>
+            <Text>{e.description}</Text>
+            {clock}
+          </>
+        ),
+      }))
+      list.push(...toasts)
+    }
+
+    if (releases && releases.length > 0) {
+      const { name, html_url } = releases[0]
+      list.push({
+        ...defaults,
+        id: name,
+        title: (
+          <Text>
+            <Text as={'span'}>{t('notifications.releases.title')} </Text>
+            <Badge colorScheme={'yellow'}>{name}</Badge>
+          </Text>
+        ),
+        description: (
+          <>
+            <Text>
+              {t('notifications.releases.description')}{' '}
+              <Link href={html_url} isExternal>
+                <ExternalLinkIcon mx="2px" mb={'4px'} /> hivemq/hivemq-edge
+              </Link>
+            </Text>
+            {clock}
+          </>
+        ),
+      })
+    }
+
+    return list
+  }, [notification, releases])
+
+  return { notifications }
+}

--- a/hivemq-edge/src/frontend/src/modules/Notifications/hooks/useGetManagedNotifications.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Notifications/hooks/useGetManagedNotifications.tsx
@@ -78,7 +78,7 @@ export const useGetManagedNotifications = () => {
     }
 
     return list
-  }, [notification, releases])
+  }, [notification, releases, t])
 
   return { notifications }
 }

--- a/hivemq-edge/src/frontend/src/modules/Notifications/hooks/useGetManagedNotifications.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Notifications/hooks/useGetManagedNotifications.tsx
@@ -1,64 +1,56 @@
-import { ChangeEvent, useMemo, useState } from 'react'
+import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useLocalStorage } from '@uidotdev/usehooks'
 import { Badge, Link, Text, UseToastOptions } from '@chakra-ui/react'
 import { ExternalLinkIcon } from '@chakra-ui/icons'
 
 import { useGetReleases } from '@/api/hooks/useGitHub/useGetReleases.tsx'
 import { useGetNotifications } from '@/api/hooks/useFrontendServices/useGetNotifications.tsx'
+import { useGetConfiguration } from '@/api/hooks/useFrontendServices/useGetConfiguration.tsx'
 
-import { SkipNotification } from '../components/SkipNotification.tsx'
-
-// TODO[NVL] Need to check whether a "new release" notification might already be handled by BE
 export const useGetManagedNotifications = () => {
   const { t } = useTranslation()
+  const { data: configuration } = useGetConfiguration()
   const { data: releases, isSuccess: isReleasesSuccess } = useGetReleases()
   const { data: notification, isSuccess: isNotificationsSuccess } = useGetNotifications()
   const [readNotifications, setReadNotifications] = useState<string[]>([])
+  const [skip] = useLocalStorage<string[]>('edge.notifications', [])
 
   const notifications = useMemo<UseToastOptions[]>(() => {
     const list: UseToastOptions[] = []
 
-    const handlePersistence = (event: ChangeEvent<HTMLInputElement>) => {
-      console.log('XXXX handlePersistence', event.target.checked)
-    }
-
     const handleReadNotification = (id: string) => {
-      console.log('XXXXX handleReadNotification', id)
       setReadNotifications((old) => Array.from(new Set([...old, id])))
     }
 
     const defaults: Partial<UseToastOptions> = {
       // Should it be manual closing only?
-      duration: 30 * 1000,
+      duration: 60 * 1000,
       isClosable: true,
       variant: 'top-accent',
       position: 'top-right',
       status: 'info',
-      description: <SkipNotification onChange={handlePersistence} />,
+      description: '',
     }
 
     if (notification?.items && notification.items.length > 0) {
       const toasts: UseToastOptions[] = notification.items
-        .filter((e) => !readNotifications.includes(e.title as string))
+        .filter((e) => !readNotifications.includes(e.title as string) && !skip.includes(e.title as string))
         .map((e) => ({
           ...defaults,
           id: e.title,
           status: e.level ? 'warning' : 'info',
           title: <Text>{e.title}</Text>,
-          description: (
-            <>
-              <Text>{e.description}</Text>
-              <SkipNotification onChange={handlePersistence} />
-            </>
-          ),
+          description: <Text>{e.description}</Text>,
           onCloseComplete: () => handleReadNotification(e.title as string),
         }))
       list.push(...toasts)
     }
 
-    if (releases && releases.length > 0) {
+    if (configuration && releases && releases.length > 0) {
       const { name, html_url } = releases[0]
-      if (!readNotifications.includes(name))
+      const currentVersion = configuration.environment?.properties?.version
+      if (currentVersion !== name && !readNotifications.includes(name) && !skip.includes(name))
         list.push({
           ...defaults,
           id: name,
@@ -69,22 +61,19 @@ export const useGetManagedNotifications = () => {
             </Text>
           ),
           description: (
-            <>
-              <Text>
-                {t('notifications.releases.description')}{' '}
-                <Link href={html_url} isExternal>
-                  <ExternalLinkIcon mx="2px" mb={'4px'} /> hivemq/hivemq-edge
-                </Link>
-              </Text>
-              <SkipNotification onChange={handlePersistence} />
-            </>
+            <Text>
+              {t('notifications.releases.description')}{' '}
+              <Link href={html_url} isExternal>
+                <ExternalLinkIcon mx="2px" mb={'4px'} /> hivemq/hivemq-edge
+              </Link>
+            </Text>
           ),
           onCloseComplete: () => handleReadNotification(name),
         })
     }
 
     return list
-  }, [readNotifications, notification, releases, t])
+  }, [notification?.items, configuration, releases, readNotifications, skip, t])
 
   return { notifications, isSuccess: isNotificationsSuccess && isReleasesSuccess, readNotifications }
 }


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/17781/details/

This PR introduces notice to the user for any new release of the system, for potential updating it.

The feature is introduced as part of the wider management of notifications in HiveMQ Edge. 

### Design
- a simple "notification" _button badge_ is added to the navigation panel, making the feature available from every point of the web application
- The _button badge_ contains a small badge indicating the number of unread notifications 
- The notifications are fetched dynamically; therefore the number displayed can change at any point in time.
- If there are no unread notifications, the _button badge_ is inactive
- When the user clicks on the _button badge_, the unread notifications are displayed as "toasts" on the right-hand side of the screen, consistent with any other toasts used in the web app.
- The design of the toasts is slightly different: light version, info or warning only, a "do not notify me again" check box, and a longer timeout. 
- Once displayed and then closed (manually or timed out), the notification will be considered as "unread", the _button badge_ being adapted accordingly
- The "unread" status is NOT persisted: reloading the page will renew the notifications
- Checking the "do not notify me again" option WILL persist the decision: the same notification (as identified by its name/ID, will not be listed again. The persistence is handled in `localStorage`, under the key `edge.notifications`

### Out-of-scope
- The use of toast for the notifications has the merit of consistency within the app but might create a visual overload when combined with other "overlay" components (other toasts or panels, see the last screenshot below). This will have to be looked at, using `Heap Analytics` and user journeys monitoring
- The notifications will be limited to 9 (single-digit badge on the _button badge_). This might create a discrepancy between data and UI.
- There is no mechanism in the UI (short of deleting the `localStorage` key) to cancel the "Do not notify me again". A user preference or settings might have to be implemented


### After
![screenshot-localhost_3000-2023 11 22-15_08_00](https://github.com/hivemq/hivemq-edge/assets/2743481/f446a6a9-2099-44e3-8830-5620e361646e)

![screenshot-localhost_3000-2023 11 22-15_08_10](https://github.com/hivemq/hivemq-edge/assets/2743481/f15e5297-93be-4358-b077-92b71e19c2cd)

![screenshot-localhost_3000-2023 11 22-15_08_17](https://github.com/hivemq/hivemq-edge/assets/2743481/b526b0f2-677d-4d02-8e7e-a5f9642671c7)

![screenshot-localhost_3000-2023 11 22-15_20_57](https://github.com/hivemq/hivemq-edge/assets/2743481/932dc8f0-19e6-415d-91e7-f634a17e3bf8)
