### PR TITLE
feat(17787): refactor copy-to-clipboard component

### DIFF
--- a/hivemq-edge/src/frontend/src/components/Chakra/ClipboardCopyIconButton.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/components/Chakra/ClipboardCopyIconButton.spec.cy.tsx
@@ -7,6 +7,10 @@ const MOCK_CONTENT = 'Text to copy to the clipboard'
 describe('ClipboardCopyIconButton', () => {
   beforeEach(() => {
     cy.viewport(400, 150)
+    cy.on('uncaught:exception', () => {
+      // should take care of unsupported browser permissions in headless mode
+      return false
+    })
     // Needed to test with the clipboard ss
     Cypress.automation('remote:debugger:protocol', {
       command: 'Browser.grantPermissions',

--- a/hivemq-edge/src/frontend/src/components/Chakra/ClipboardCopyIconButton.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/components/Chakra/ClipboardCopyIconButton.spec.cy.tsx
@@ -1,0 +1,58 @@
+/// <reference types="cypress" />
+
+import ClipboardCopyIconButton from './ClipboardCopyIconButton.tsx'
+
+const MOCK_CONTENT = 'Text to copy to the clipboard'
+
+describe('ClipboardCopyIconButton', () => {
+  beforeEach(() => {
+    cy.viewport(400, 150)
+    // Needed to test with the clipboard ss
+    Cypress.automation('remote:debugger:protocol', {
+      command: 'Browser.grantPermissions',
+      params: {
+        permissions: ['clipboardReadWrite', 'clipboardSanitizedWrite'],
+        origin: window.location.origin,
+      },
+    })
+  })
+
+  it('should render properly', () => {
+    cy.clock()
+    cy.mountWithProviders(<ClipboardCopyIconButton content={MOCK_CONTENT} />)
+
+    cy.get('button').should('have.attr', 'data-state', 'READY')
+    cy.get('button').click()
+
+    cy.get('button').should('have.attr', 'data-state', 'COPIED')
+    cy.get('[role="tooltip"]').should('contain.text', 'Copied!')
+
+    cy.window().then((win) => {
+      win.navigator.clipboard.readText().then((text) => {
+        expect(text).to.eq('Text to copy to the clipboard')
+      })
+    })
+
+    cy.tick(1500)
+
+    cy.get('button').should('have.attr', 'data-state', 'READY')
+  })
+
+  it('should be accessible', () => {
+    cy.injectAxe()
+    cy.mountWithProviders(<ClipboardCopyIconButton content={MOCK_CONTENT} />)
+    cy.checkAccessibility()
+
+    cy.get('button').focus()
+    cy.get('button').click()
+    cy.get('[role="tooltip"]').should('contain.text', 'Copied!')
+
+    cy.checkAccessibility(undefined, {
+      rules: {
+        // TODO[NVL] CTooltip seems to generate false positives
+        'color-contrast': { enabled: false },
+        region: { enabled: false },
+      },
+    })
+  })
+})

--- a/hivemq-edge/src/frontend/src/components/Chakra/ClipboardCopyIconButton.tsx
+++ b/hivemq-edge/src/frontend/src/components/Chakra/ClipboardCopyIconButton.tsx
@@ -1,0 +1,74 @@
+import { FC, useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Icon, IconButton, IconButtonProps, Tooltip, PlacementWithLogical } from '@chakra-ui/react'
+import { LuClipboardCopy } from 'react-icons/lu'
+import { VscCheck, VscError } from 'react-icons/vsc'
+
+enum CopyStatus {
+  READY = 'READY',
+  COPIED = 'COPIED',
+  ERROR = 'ERROR',
+}
+
+interface ClipboardCopyIconButtonProps extends Omit<IconButtonProps, 'aria-label'> {
+  content: string
+  placement?: PlacementWithLogical
+}
+
+const COPY_LATENCY = 1500
+
+const ClipboardCopyIconButton: FC<ClipboardCopyIconButtonProps> = ({ content, placement, ...props }) => {
+  const { t } = useTranslation('components')
+  const [state, setState] = useState<CopyStatus>(CopyStatus.READY)
+
+  useEffect(() => {
+    if (state === CopyStatus.READY) return
+
+    const interval = setInterval(() => {
+      setState(CopyStatus.READY)
+    }, COPY_LATENCY)
+    return () => clearInterval(interval)
+  }, [setState, state])
+
+  function handleClick() {
+    navigator.clipboard.writeText(content).then(
+      () => {
+        setState(CopyStatus.COPIED)
+      },
+      () => {
+        setState(CopyStatus.ERROR)
+      }
+    )
+    setState(CopyStatus.COPIED)
+  }
+
+  return (
+    <Tooltip
+      label={t('ClipboardCopyIconButton.action', { context: state })}
+      hasArrow
+      placement={placement || 'right'}
+      isOpen={state !== CopyStatus.READY}
+    >
+      <IconButton
+        isLoading={state != CopyStatus.READY}
+        data-state={state}
+        spinner={
+          state === CopyStatus.ERROR ? (
+            <Icon as={VscError} fontSize={'1rem'} color="red.500" />
+          ) : (
+            <Icon as={VscCheck} fontSize={'1rem'} color="green.500" />
+          )
+        }
+        data-testid="metrics-copy"
+        size={'xs'}
+        variant={'ghost'}
+        icon={<Icon as={LuClipboardCopy} fontSize={'1rem'} />}
+        onClick={handleClick}
+        aria-label={t('ClipboardCopyIconButton.ariaLabel')}
+        {...props}
+      />
+    </Tooltip>
+  )
+}
+
+export default ClipboardCopyIconButton

--- a/hivemq-edge/src/frontend/src/locales/en/components.json
+++ b/hivemq-edge/src/frontend/src/locales/en/components.json
@@ -44,5 +44,11 @@
         "seconds": "{{ value }}s"
       }
     }
+  },
+  "ClipboardCopyIconButton": {
+    "ariaLabel": "Copy to the clipboard",
+    "action_READY": "Ready!",
+    "action_COPIED": "Copied!",
+    "action_ERROR": "Error!"
   }
 }

--- a/hivemq-edge/src/frontend/src/modules/Metrics/Metrics.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Metrics/Metrics.tsx
@@ -1,5 +1,5 @@
 import { FC, useState } from 'react'
-import { Card, CardBody, CardHeader, Flex, IconButton, SimpleGrid, useDisclosure, useToast } from '@chakra-ui/react'
+import { Card, CardBody, CardHeader, Flex, IconButton, SimpleGrid, useDisclosure } from '@chakra-ui/react'
 import { TbLayoutNavbarExpand, TbLayoutNavbarCollapse } from 'react-icons/tb'
 import { useTranslation } from 'react-i18next'
 
@@ -20,16 +20,7 @@ const Metrics: FC<MetricsProps> = ({ id, initMetrics }) => {
   const [metrics, setMetrics] = useState<string[]>(initMetrics || [])
   const showSelector = config.features.METRICS_SELECT_PANEL
   const { isOpen, onOpen, onClose } = useDisclosure()
-  const toast = useToast()
   const { t } = useTranslation()
-
-  const handleCopyMetric = (metricName: string, timestamp: string) => {
-    const id = `${metricName}-${timestamp}`
-    navigator.clipboard.writeText(metricName).then(() => {
-      if (!toast.isActive(id))
-        toast({ id, duration: 3000, variant: 'subtle', description: t('metrics.command.copy.prompt') })
-    })
-  }
 
   return (
     <Card size={'sm'}>
@@ -62,12 +53,7 @@ const Metrics: FC<MetricsProps> = ({ id, initMetrics }) => {
       <CardBody>
         <SimpleGrid spacing={4} templateColumns="repeat(auto-fill, minmax(200px, 1fr))">
           {metrics.map((e) => (
-            <Sample
-              key={e}
-              metricName={e}
-              onClose={() => setMetrics((old) => old.filter((x) => x !== e))}
-              onClipboardCopy={handleCopyMetric}
-            />
+            <Sample key={e} metricName={e} onClose={() => setMetrics((old) => old.filter((x) => x !== e))} />
           ))}
         </SimpleGrid>
       </CardBody>

--- a/hivemq-edge/src/frontend/src/modules/Metrics/components/Sample.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Metrics/components/Sample.spec.cy.tsx
@@ -6,7 +6,7 @@ import Sample from './Sample.tsx'
 describe('Sample', () => {
   beforeEach(() => {
     cy.viewport(800, 800)
-    cy.intercept(`/api/v1/metrics/**`, MOCK_METRIC_SAMPLE).as('getSample')
+    cy.intercept(`/api/v1/metrics/**`, MOCK_METRIC_SAMPLE)
   })
 
   it('should render the bridge component', () => {

--- a/hivemq-edge/src/frontend/src/modules/Metrics/components/Sample.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Metrics/components/Sample.spec.cy.tsx
@@ -19,11 +19,5 @@ describe('Sample', () => {
     cy.get('@onClose').should('have.been.calledOnce')
 
     cy.getByTestId('metrics-copy').click()
-    cy.get('@onClipboardCopy').should(
-      'have.been.calledWith',
-      'com.hivemq.edge.bridge.bridge-id-01.forward.publish.count',
-      '2023-11-18T00:00:00Z',
-      50000
-    )
   })
 })

--- a/hivemq-edge/src/frontend/src/modules/Metrics/components/Sample.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Metrics/components/Sample.spec.cy.tsx
@@ -11,10 +11,7 @@ describe('Sample', () => {
 
   it('should render the bridge component', () => {
     const onClose = cy.stub().as('onClose')
-    const onClipboardCopy = cy.stub().as('onClipboardCopy')
-    cy.mountWithProviders(
-      <Sample metricName={MOCK_METRICS[0].name} onClose={onClose} onClipboardCopy={onClipboardCopy} />
-    )
+    cy.mountWithProviders(<Sample metricName={MOCK_METRICS[0].name} onClose={onClose} />)
 
     cy.get('dd').should('contain.text', '50,000')
 

--- a/hivemq-edge/src/frontend/src/modules/Metrics/components/Sample.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Metrics/components/Sample.tsx
@@ -1,6 +1,5 @@
 import { FC, useEffect, useState } from 'react'
-import { Box, CloseButton, Icon, IconButton, VStack } from '@chakra-ui/react'
-import { LuClipboardCopy } from 'react-icons/lu'
+import { Box, CloseButton, VStack } from '@chakra-ui/react'
 import { useTranslation } from 'react-i18next'
 
 import { useGetSample } from '@/api/hooks/useGetMetrics/useGetSample.tsx'
@@ -8,16 +7,16 @@ import { DataPoint } from '@/api/__generated__'
 
 import { extractMetricInfo } from '../utils/metrics-name.utils.ts'
 import SampleRenderer from '@/modules/Metrics/components/SampleRenderer.tsx'
+import ClipboardCopyIconButton from '@/components/Chakra/ClipboardCopyIconButton.tsx'
 
 interface SampleProps {
   metricName?: string
   onClose?: () => void
-  onClipboardCopy?: (metricName: string, timestamp: string, value: number) => void
 }
 
 const MAX_SERIES = 10
 
-const Sample: FC<SampleProps> = ({ metricName, onClose, onClipboardCopy }) => {
+const Sample: FC<SampleProps> = ({ metricName, onClose }) => {
   const { t } = useTranslation()
   const { data, isLoading, error } = useGetSample(metricName)
   const [series, setSeries] = useState<DataPoint[]>([])
@@ -47,7 +46,7 @@ const Sample: FC<SampleProps> = ({ metricName, onClose, onClipboardCopy }) => {
       series={series}
       {...(isMajor ? { gridColumn: '1 / span 2' } : {})}
     >
-      <VStack>
+      <VStack ml={1}>
         <Box flex={1}>
           <CloseButton
             data-testid="metrics-remove"
@@ -57,14 +56,7 @@ const Sample: FC<SampleProps> = ({ metricName, onClose, onClipboardCopy }) => {
           />
         </Box>
         <Box>
-          <IconButton
-            data-testid="metrics-copy"
-            size={'xs'}
-            variant={'ghost'}
-            icon={<Icon as={LuClipboardCopy} fontSize={'16px'} />}
-            aria-label={t('metrics.command.copy.ariaLabel')}
-            onClick={() => onClipboardCopy?.(metricName, series[0]?.sampleTime as string, series[0]?.value as number)}
-          />
+          <ClipboardCopyIconButton content={metricName} />
         </Box>
       </VStack>
     </SampleRenderer>


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/17787/details/

A small PR to improve the UX design of the copy button, which was wrongly relying on a toast to indicate success (or error) or the copy operation 

The new design follows the same pattern found in `GitHub` and other web apps. The button triggers a "loading" state to handle the asynchronous nature of the Clipboard API and display a time-limited tooltip ("Copied!").

### Before
![screenshot-localhost_3000-2023 11 23-09_27_14](https://github.com/hivemq/hivemq-edge/assets/2743481/bb5595f0-c8ac-49d3-bcb3-1429c120a48d)

### After
![screenshot-localhost_3000-2023 11 23-09_26_35](https://github.com/hivemq/hivemq-edge/assets/2743481/1554cba7-b434-465f-ae69-34d77a04673a)
