### PR TITLE
fix(17782): Fix duplicated keys in onboarding tasks

### DIFF
--- a/hivemq-edge/src/frontend/src/components/ConnectionController/ConnectionController.spec.tsx
+++ b/hivemq-edge/src/frontend/src/components/ConnectionController/ConnectionController.spec.tsx
@@ -65,7 +65,7 @@ describe('ConnectionController', () => {
       })
 
       expect(successToast).toHaveBeenCalledWith({
-        description: "We've successfully started the adapter. It might take up to 2 seconds to update the status.",
+        description: "We've successfully started the adapter. It might take a moment to update the status.",
         title: 'Connection updating',
       })
     })

--- a/hivemq-edge/src/frontend/src/components/ConnectionController/ConnectionController.tsx
+++ b/hivemq-edge/src/frontend/src/components/ConnectionController/ConnectionController.tsx
@@ -55,9 +55,8 @@ const ConnectionController: FC<ConnectionControllerProps> = ({ type, id, status,
         successToast({
           title: t('protocolAdapter.toast.status.title'),
           description: t('protocolAdapter.toast.status.description', {
-            action: status,
+            context: status,
             device: type,
-            callbackTimeoutMillis: callbackTimeoutMillis ? callbackTimeoutMillis / 1000 : 0,
           }),
         })
       })

--- a/hivemq-edge/src/frontend/src/locales/en/translation.json
+++ b/hivemq-edge/src/frontend/src/locales/en/translation.json
@@ -119,10 +119,10 @@
         }
       },
       "connectCloud": {
-        "header": "Connect To HiveMQ Cloud\n",
-        "bridge": {
-          "title": "Connect your HiveMQ Edge MQTT Broker to your Enterprise using MQTT Bridge connections.",
-          "label": "Use a Bridge"
+        "header": "Connect To HiveMQ Cloud",
+        "section": {
+          "title": "You should connect your HiveMQ Edge deployment with a HiveMQ Cloud MQTT Broker, which will be the source of truth for your business data",
+          "label": "Connect To HiveMQ Cloud"
         }
       }
     },

--- a/hivemq-edge/src/frontend/src/locales/en/translation.json
+++ b/hivemq-edge/src/frontend/src/locales/en/translation.json
@@ -442,16 +442,12 @@
     "toast": {
       "status": {
         "title": "Connection updating",
-        "action_STOP": "stopped",
-        "action_START": "started",
-        "action_RESTART": "restarted",
         "device": "the device",
         "device_BRIDGE": "the bridge",
         "device_ADAPTER": "the adapter",
-        "callbackTimeoutMillis_zero": "a little bit of time",
-        "callbackTimeoutMillis_one": "up to {{count}} second",
-        "callbackTimeoutMillis_other": "up to {{count}} seconds",
-        "description": "We've successfully $t(protocolAdapter.toast.status.action, {'context': '{{action}}' }) $t(protocolAdapter.toast.status.device, {'context': '{{device}}' }). It might take $t(protocolAdapter.toast.status.callbackTimeoutMillis, {'count': {{callbackTimeoutMillis}} }) to update the status.",
+        "description_STOP": "We've successfully stopped $t(protocolAdapter.toast.status.device, {'context': '{{device}}' }). It might take a moment to update the status.",
+        "description_START": "We've successfully started $t(protocolAdapter.toast.status.device, {'context': '{{device}}' }). It might take a moment to update the status.",
+        "description_RESTART": "We've successfully restarted $t(protocolAdapter.toast.status.device, {'context': '{{device}}' }). It might take a moment to update the status.",
         "error": "There was a problem trying to reconnect $t(protocolAdapter.toast.status.device, {'context': '{{device}}' })"
       },
       "delete": {

--- a/hivemq-edge/src/frontend/src/modules/Welcome/components/Onboarding.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Welcome/components/Onboarding.tsx
@@ -37,7 +37,9 @@ const Onboarding: FC<OnboardingProps> = ({ tasks, ...props }) => {
             <Card flex={1} key={e.header}>
               <CardHeader>
                 <Skeleton isLoaded={!e.isLoading}>
-                  <Heading size="md">{e.header}</Heading>
+                  <Heading as="h3" size="md">
+                    {e.header}
+                  </Heading>
                 </Skeleton>
               </CardHeader>
 
@@ -52,7 +54,7 @@ const Onboarding: FC<OnboardingProps> = ({ tasks, ...props }) => {
                       </Skeleton>
                       <Skeleton isLoaded={!e.isLoading}>
                         <Box>
-                          <Text fontSize="sm">{s.title}</Text>
+                          <Text>{s.title}</Text>
                           <Button
                             variant="link"
                             as={RouterLink}
@@ -60,7 +62,6 @@ const Onboarding: FC<OnboardingProps> = ({ tasks, ...props }) => {
                             target={s.isExternal ? '_blank' : undefined}
                             aria-label={s.label}
                             leftIcon={s.leftIcon}
-                            size="lg"
                           >
                             {s.label}
                           </Button>

--- a/hivemq-edge/src/frontend/src/modules/Welcome/hooks/useOnboarding.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Welcome/hooks/useOnboarding.tsx
@@ -17,11 +17,11 @@ export const useOnboarding = (): OnboardingFetchType => {
 
   const cloud: OnboardingTask = {
     isLoading: isLoading,
-    header: data?.cloudLink?.displayText || t('welcome.onboarding.connectCloud.header'),
+    header: t('welcome.onboarding.connectCloud.header'),
     sections: [
       {
-        title: data?.cloudLink?.description as string,
-        label: data?.cloudLink?.displayText as string,
+        title: t('welcome.onboarding.connectCloud.section.title'),
+        label: t('welcome.onboarding.connectCloud.section.label'),
         to: data?.cloudLink?.url as string,
         isExternal: true,
         leftIcon: <GoLinkExternal />,


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/17782/details/

This PR fixes a small bug with a duplicated key in a React list (error in log, unlikely to have effect in the page itself), arising from a yet unfetched string from the API.

It also fixes the basic typography for the tasks and sections.

### Before
![screenshot-localhost_3000-2023 11 24-10_32_11](https://github.com/hivemq/hivemq-edge/assets/2743481/fe9c7920-d2e5-43df-9f07-b82fdc4cac93)


### After 
![screenshot-localhost_3000-2023 11 24-10_31_48](https://github.com/hivemq/hivemq-edge/assets/2743481/47ed749a-94c9-403b-91f1-dc43d515604c)
