### PR TITLE
fix(17869): Improve date/time rendering for seconds

### DIFF
--- a/hivemq-edge/src/frontend/src/components/DateTime/DateTimeRenderer.tsx
+++ b/hivemq-edge/src/frontend/src/components/DateTime/DateTimeRenderer.tsx
@@ -1,6 +1,7 @@
 import { FC } from 'react'
 import { Text, Tooltip, type TextProps } from '@chakra-ui/react'
 import { DateTime } from 'luxon'
+import { useTranslation } from 'react-i18next'
 
 import { toHuman } from './utils/duration.utils.ts'
 
@@ -10,6 +11,7 @@ interface DateTimeRendererProps extends TextProps {
 }
 
 const DateTimeRenderer: FC<DateTimeRendererProps> = ({ date, isApprox = false, ...props }) => {
+  const { t } = useTranslation('components')
   const formatLongDate = new Intl.DateTimeFormat(navigator.language, {
     weekday: 'long',
     year: 'numeric',
@@ -21,7 +23,8 @@ const DateTimeRenderer: FC<DateTimeRendererProps> = ({ date, isApprox = false, .
     fractionalSecondDigits: 3,
   })
 
-  if (isApprox)
+  if (isApprox) {
+    const relative = toHuman(date)
     return (
       <Tooltip
         data-testid={'date-time-tooltip'}
@@ -31,10 +34,11 @@ const DateTimeRenderer: FC<DateTimeRendererProps> = ({ date, isApprox = false, .
         maxW={'200px'}
       >
         <Text data-testid={'date-time-approx'} width={'fit-content'} {...props}>
-          {toHuman(date)}
+          {relative || t('DateTimeRenderer.seconds', { context: 'minus' })}
         </Text>
       </Tooltip>
     )
+  }
 
   return (
     <Text data-testid={'date-time-full'} {...props}>

--- a/hivemq-edge/src/frontend/src/components/DateTime/utils/duration.utils.spec.ts
+++ b/hivemq-edge/src/frontend/src/components/DateTime/utils/duration.utils.spec.ts
@@ -6,16 +6,18 @@ import { MOCK_DATE_TIME_NOW } from './range-option.mocks.ts'
 
 interface ToHumanTestSuite {
   date: DateTime
-  expected: string
+  expected: string | null
 }
 
 const allTests: ToHumanTestSuite[] = [
   { date: MOCK_DATE_TIME_NOW.minus({ month: 2 }), expected: '2 months ago' },
   { date: MOCK_DATE_TIME_NOW.minus({ days: 9 }), expected: '9 days ago' },
-  { date: MOCK_DATE_TIME_NOW.minus({ second: 1 }), expected: '1 second ago' },
-  { date: MOCK_DATE_TIME_NOW.plus({ days: 1 }), expected: 'in 1 day' },
-  { date: MOCK_DATE_TIME_NOW.plus({ days: 3 }), expected: 'in 3 days' },
-  { date: MOCK_DATE_TIME_NOW.plus({ days: 3, hour: 19 }), expected: 'in 3 days' },
+  { date: MOCK_DATE_TIME_NOW.minus({ minutes: 3 }), expected: '3 minutes ago' },
+  { date: MOCK_DATE_TIME_NOW.minus({ minutes: 1 }), expected: '1 minute ago' },
+  { date: MOCK_DATE_TIME_NOW.minus({ seconds: 50 }), expected: '1 minute ago' },
+  { date: MOCK_DATE_TIME_NOW.minus({ seconds: 30 }), expected: '1 minute ago' },
+  { date: MOCK_DATE_TIME_NOW.minus({ seconds: 29 }), expected: null },
+  { date: MOCK_DATE_TIME_NOW.minus({ second: 1 }), expected: null },
 ]
 
 describe('toHuman', () => {

--- a/hivemq-edge/src/frontend/src/components/DateTime/utils/duration.utils.ts
+++ b/hivemq-edge/src/frontend/src/components/DateTime/utils/duration.utils.ts
@@ -1,7 +1,6 @@
 import { DateTime } from 'luxon'
 import { DurationUnits } from 'luxon/src/duration'
 
-// Better Duration.toHuman support https://github.com/moment/luxon/issues/1134
 export const toHuman = (timestamp: DateTime, alternativeNow?: DateTime) => {
   const units: DurationUnits = ['weeks', 'days', 'hours', 'minutes', 'seconds']
 
@@ -12,6 +11,12 @@ export const toHuman = (timestamp: DateTime, alternativeNow?: DateTime) => {
     .negate()
     .mapUnits((x) => Math.floor(x))
     .rescale()
+
+  if (rescaledDuration.valueOf() < 30 * 1000) return null
+  if (rescaledDuration.valueOf() < 60 * 1000)
+    return DateTime.local()
+      .minus(rescaledDuration.set({ minute: 1 }))
+      .toRelative()
 
   return DateTime.local().minus(rescaledDuration).toRelative()
 }

--- a/hivemq-edge/src/frontend/src/locales/en/components.json
+++ b/hivemq-edge/src/frontend/src/locales/en/components.json
@@ -28,6 +28,10 @@
       "createLabel": "Add the topic ... {{topic}}"
     }
   },
+  "DateTimeRenderer": {
+    "seconds_minus": "a few seconds ago",
+    "seconds_plus": "in a few seconds"
+  },
   "DateTimeRangeSelector": {
     "placeholder": "Select a date",
     "noOptionsMessage": "Not a valid date",


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/17869/details/

The PR fixes the rendering of relative date/time for seconds, using the proposed design system, see https://zeroheight.com/9c4326648/p/5495a8-date-and-time

To improve readability, it changes patterns like `10 seconds ago` to `a few seconds ago` and `45 seconds ago`  to `1 minute ago`. It also fixes a bug with `in 0 seconds` for a null duration

### Before
![screenshot-localhost_3000-2023 11 24-11_40_02](https://github.com/hivemq/hivemq-edge/assets/2743481/881db8f3-e9b2-4dac-8067-8bda93a081fb)

### After
![screenshot-localhost_3000-2023 11 24-11_38_23](https://github.com/hivemq/hivemq-edge/assets/2743481/65db1cff-5232-4bed-aac0-e1a781a97551)
