### PR TITLE
reactor(17951): Refactor the metrics editor to a better collapsible UX 

### DIFF
--- a/hivemq-edge/src/frontend/src/config/index.ts
+++ b/hivemq-edge/src/frontend/src/config/index.ts
@@ -17,8 +17,7 @@ interface configType {
     TOPIC_EDITOR_SHOW_BRANCHES: boolean
     WORKSPACE_FLOW_PANEL: boolean
     PROTOCOL_ADAPTER_FACET: boolean
-    METRICS_SELECT_PANEL: boolean
-    METRICS_DEFAULTS: string[]
+    METRICS_SHOW_EDITOR: boolean
   }
 
   documentation: {
@@ -65,16 +64,9 @@ const config: configType = {
      */
     PROTOCOL_ADAPTER_FACET: import.meta.env.VITE_FLAG_FACET_SEARCH === 'true',
     /**
-     * Show the metrics panel on the dashboard (conditional to first use flag)
+     * Show the metrics editor in the workspace panels
      */
-    METRICS_SELECT_PANEL: true,
-    /**
-     * The initial list of metrics
-     */
-    METRICS_DEFAULTS: [
-      'com.hivemq.edge.messages.incoming.connect.count',
-      'com.hivemq.edge.subscriptions.overall.current',
-    ],
+    METRICS_SHOW_EDITOR: true,
   },
 
   documentation: {

--- a/hivemq-edge/src/frontend/src/locales/en/translation.json
+++ b/hivemq-edge/src/frontend/src/locales/en/translation.json
@@ -653,16 +653,13 @@
     }
   },
   "metrics": {
+    "editor": {
+      "title": "Configure the metrics",
+      "select-metric": "Select a metric to display",
+      "select-chart": "Select a chart",
+      "add": "Add to panel"
+    },
     "command": {
-      "select-metric": {
-        "ariaLabel": "Select a metric to display"
-      },
-      "select-chart": {
-        "ariaLabel": "Select a chart"
-      },
-      "add": {
-        "ariaLabel": "Add to panel"
-      },
       "showSelector": {
         "ariaLabel": "Show/hide the metrics selector"
       },

--- a/hivemq-edge/src/frontend/src/modules/EdgeVisualisation/components/controls/NodePanelController.tsx
+++ b/hivemq-edge/src/frontend/src/modules/EdgeVisualisation/components/controls/NodePanelController.tsx
@@ -59,6 +59,8 @@ const NodePanelController: FC = () => {
     }
   }
 
+  if (!nodeId) return null
+
   return (
     <Suspense
       // TODO[NVL] Would be good to integrate the loader within the drawer
@@ -70,6 +72,7 @@ const NodePanelController: FC = () => {
     >
       {selectedLinkSource && (
         <LinkPropertyDrawer
+          nodeId={nodeId}
           selectedNode={selectedLinkSource}
           isOpen={isOpen}
           onClose={handleClose}
@@ -78,6 +81,7 @@ const NodePanelController: FC = () => {
       )}
       {selectedNode && (
         <NodePropertyDrawer
+          nodeId={nodeId}
           selectedNode={selectedNode}
           isOpen={isOpen}
           onClose={handleClose}

--- a/hivemq-edge/src/frontend/src/modules/EdgeVisualisation/components/drawers/LinkPropertyDrawer.tsx
+++ b/hivemq-edge/src/frontend/src/modules/EdgeVisualisation/components/drawers/LinkPropertyDrawer.tsx
@@ -10,12 +10,13 @@ import { getDefaultMetricsFor } from '../../utils/nodes-utils.ts'
 import { NodeTypes } from '../../types.ts'
 
 interface LinkPropertyDrawerProps {
+  nodeId: string
   selectedNode: Node<Bridge | Adapter>
   isOpen: boolean
   onClose: () => void
   onEditEntity: () => void
 }
-const LinkPropertyDrawer: FC<LinkPropertyDrawerProps> = ({ isOpen, selectedNode, onClose }) => {
+const LinkPropertyDrawer: FC<LinkPropertyDrawerProps> = ({ nodeId, isOpen, selectedNode, onClose }) => {
   const { t } = useTranslation()
 
   return (
@@ -34,6 +35,7 @@ const LinkPropertyDrawer: FC<LinkPropertyDrawerProps> = ({ isOpen, selectedNode,
         </DrawerHeader>
         <DrawerBody>
           <Metrics
+            nodeId={nodeId}
             type={selectedNode.type as NodeTypes}
             id={selectedNode.data.id}
             initMetrics={getDefaultMetricsFor(selectedNode)}

--- a/hivemq-edge/src/frontend/src/modules/EdgeVisualisation/components/drawers/NodePropertyDrawer.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/EdgeVisualisation/components/drawers/NodePropertyDrawer.spec.cy.tsx
@@ -25,7 +25,13 @@ describe('NodePropertyDrawer', () => {
     const onClose = cy.stub().as('onClose')
     const onEditEntity = cy.stub().as('onEditEntity')
     cy.mountWithProviders(
-      <NodePropertyDrawer selectedNode={mockNode} isOpen={true} onClose={onClose} onEditEntity={onEditEntity} />
+      <NodePropertyDrawer
+        nodeId="adapter@fgffgf"
+        selectedNode={mockNode}
+        isOpen={true}
+        onClose={onClose}
+        onEditEntity={onEditEntity}
+      />
     )
 
     // check the panel control
@@ -51,7 +57,13 @@ describe('NodePropertyDrawer', () => {
   it('should be accessible', () => {
     cy.injectAxe()
     cy.mountWithProviders(
-      <NodePropertyDrawer selectedNode={mockNode} isOpen={true} onClose={cy.stub()} onEditEntity={cy.stub()} />
+      <NodePropertyDrawer
+        nodeId={'adapter@fgffgf'}
+        selectedNode={mockNode}
+        isOpen={true}
+        onClose={cy.stub()}
+        onEditEntity={cy.stub()}
+      />
     )
 
     cy.checkAccessibility(undefined, {

--- a/hivemq-edge/src/frontend/src/modules/EdgeVisualisation/components/drawers/NodePropertyDrawer.tsx
+++ b/hivemq-edge/src/frontend/src/modules/EdgeVisualisation/components/drawers/NodePropertyDrawer.tsx
@@ -34,12 +34,13 @@ import { getDefaultMetricsFor } from '../../utils/nodes-utils.ts'
 import NodeNameCard from '../parts/NodeNameCard.tsx'
 
 interface NodePropertyDrawerProps {
+  nodeId: string
   selectedNode: Node<Bridge | Adapter>
   isOpen: boolean
   onClose: () => void
   onEditEntity: () => void
 }
-const NodePropertyDrawer: FC<NodePropertyDrawerProps> = ({ isOpen, selectedNode, onClose, onEditEntity }) => {
+const NodePropertyDrawer: FC<NodePropertyDrawerProps> = ({ nodeId, isOpen, selectedNode, onClose, onEditEntity }) => {
   const { t } = useTranslation()
 
   return (
@@ -54,6 +55,7 @@ const NodePropertyDrawer: FC<NodePropertyDrawerProps> = ({ isOpen, selectedNode,
           <VStack gap={4} alignItems={'stretch'}>
             <NodeNameCard selectedNode={selectedNode} />
             <Metrics
+              nodeId={nodeId}
               type={selectedNode.type as NodeTypes}
               id={selectedNode.data.id}
               initMetrics={getDefaultMetricsFor(selectedNode)}

--- a/hivemq-edge/src/frontend/src/modules/Metrics/Metrics.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Metrics/Metrics.spec.cy.tsx
@@ -14,7 +14,9 @@ describe('Metrics', () => {
   })
 
   it('should render the collapsible component', () => {
-    cy.mountWithProviders(<Metrics initMetrics={[]} id={mockBridgeId} type={NodeTypes.BRIDGE_NODE} />)
+    cy.mountWithProviders(
+      <Metrics nodeId={'bridge@bridge-id-01'} initMetrics={[]} id={mockBridgeId} type={NodeTypes.BRIDGE_NODE} />
+    )
 
     cy.getByTestId('metrics-toggle').should('have.attr', 'aria-expanded', 'false')
     cy.get('div#metrics-select-container').should('not.be.visible')

--- a/hivemq-edge/src/frontend/src/modules/Metrics/Metrics.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Metrics/Metrics.spec.cy.tsx
@@ -1,0 +1,28 @@
+/// <reference types="cypress" />
+
+import { MetricList } from '@/api/__generated__'
+import { MOCK_METRICS } from '@/api/hooks/useGetMetrics/__handlers__'
+
+import Metrics from '@/modules/Metrics/Metrics.tsx'
+import { NodeTypes } from '@/modules/EdgeVisualisation/types.ts'
+import { mockBridgeId } from '@/api/hooks/useGetBridges/__handlers__'
+
+describe('Metrics', () => {
+  beforeEach(() => {
+    cy.viewport(800, 800)
+    cy.intercept('/api/v1/metrics', { items: MOCK_METRICS } as MetricList).as('getMetrics')
+  })
+
+  it('should render the collapsible component', () => {
+    cy.mountWithProviders(<Metrics initMetrics={[]} id={mockBridgeId} type={NodeTypes.BRIDGE_NODE} />)
+
+    cy.getByTestId('metrics-toggle').should('have.attr', 'aria-expanded', 'false')
+    cy.get('div#metrics-select-container').should('not.be.visible')
+
+    cy.getByTestId('metrics-toggle').click()
+    cy.get('div#metrics-select-container').should('be.visible')
+
+    cy.getByTestId('metrics-toggle').click()
+    cy.get('div#metrics-select-container').should('not.be.visible')
+  })
+})

--- a/hivemq-edge/src/frontend/src/modules/Metrics/Metrics.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Metrics/Metrics.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react'
+import { FC, useState } from 'react'
 import {
   Accordion,
   AccordionButton,
@@ -59,7 +59,7 @@ const Metrics: FC<MetricsProps> = ({ id, initMetrics, defaultChartType }) => {
           }}
         >
           <AccordionItem>
-            <AccordionButton>
+            <AccordionButton data-testid="metrics-toggle">
               <Box as="span" flex="1" textAlign="left">
                 {t('metrics.editor.title')}
               </Box>

--- a/hivemq-edge/src/frontend/src/modules/Metrics/Metrics.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Metrics/Metrics.tsx
@@ -1,6 +1,16 @@
-import { FC, useState } from 'react'
-import { Card, CardBody, CardHeader, Flex, IconButton, SimpleGrid, useDisclosure } from '@chakra-ui/react'
-import { TbLayoutNavbarCollapse, TbLayoutNavbarExpand } from 'react-icons/tb'
+import { FC } from 'react'
+import {
+  Accordion,
+  AccordionButton,
+  AccordionIcon,
+  AccordionItem,
+  AccordionPanel,
+  Box,
+  Card,
+  CardBody,
+  SimpleGrid,
+  useDisclosure,
+} from '@chakra-ui/react'
 import { useTranslation } from 'react-i18next'
 
 import { NodeTypes } from '@/modules/EdgeVisualisation/types.ts'
@@ -40,30 +50,32 @@ const Metrics: FC<MetricsProps> = ({ id, initMetrics, defaultChartType }) => {
 
   return (
     <Card size={'sm'}>
-      {showSelector && (
-        <CardHeader>
-          <Flex justifyContent={'flex-end'}>
-            <IconButton
-              data-testid="metrics-toggle"
-              variant={'ghost'}
-              size={'sm'}
-              aria-label={t('metrics.command.showSelector.ariaLabel')}
-              fontSize={'20px'}
-              icon={!isOpen ? <TbLayoutNavbarExpand /> : <TbLayoutNavbarCollapse />}
-              onClick={() => (isOpen ? onClose() : onOpen())}
-            />
-          </Flex>
-          {isOpen && (
-            <>
+      {showEditor && (
+        <Accordion
+          allowToggle
+          onChange={(expandedIndex) => {
+            if (expandedIndex === -1) onClose()
+            else onOpen()
+          }}
+        >
+          <AccordionItem>
+            <AccordionButton>
+              <Box as="span" flex="1" textAlign="left">
+                {t('metrics.editor.title')}
+              </Box>
+              <AccordionIcon />
+            </AccordionButton>
+
+            <AccordionPanel pb={4}>
               <MetricEditor
                 filter={id}
                 selectedMetrics={metrics.map((e) => e.selectedTopic)}
                 selectedChart={defaultChartType}
                 onSubmit={handleCreateMetrics}
               />
-            </>
-          )}
-        </CardHeader>
+            </AccordionPanel>
+          </AccordionItem>
+        </Accordion>
       )}
 
       <CardBody>
@@ -74,7 +86,7 @@ const Metrics: FC<MetricsProps> = ({ id, initMetrics, defaultChartType }) => {
                 <Sample
                   key={e.selectedTopic}
                   metricName={e.selectedTopic}
-                  onClose={() => setMetrics((old) => old.filter((x) => x !== e))}
+                  onClose={() => setMetrics((old) => old.filter((x) => x.selectedTopic !== e.selectedTopic))}
                 />
               )
             else
@@ -83,7 +95,7 @@ const Metrics: FC<MetricsProps> = ({ id, initMetrics, defaultChartType }) => {
                   key={e.selectedTopic}
                   chartType={e.selectedChart}
                   metricName={e.selectedTopic}
-                  onClose={() => setMetrics((old) => old.filter((x) => x !== e))}
+                  onClose={() => setMetrics((old) => old.filter((x) => x.selectedTopic !== e.selectedTopic))}
                   canEdit={isOpen}
                 />
               )

--- a/hivemq-edge/src/frontend/src/modules/Metrics/Metrics.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Metrics/Metrics.tsx
@@ -1,4 +1,4 @@
-import { FC, useState } from 'react'
+import { FC } from 'react'
 import {
   Accordion,
   AccordionButton,
@@ -12,6 +12,7 @@ import {
   useDisclosure,
 } from '@chakra-ui/react'
 import { useTranslation } from 'react-i18next'
+import { useLocalStorage } from '@uidotdev/usehooks'
 
 import { NodeTypes } from '@/modules/EdgeVisualisation/types.ts'
 
@@ -23,6 +24,7 @@ import ChartContainer from './components/container/ChartContainer.tsx'
 import Sample from './components/container/Sample.tsx'
 
 interface MetricsProps {
+  nodeId: string
   type: NodeTypes
   id: string
   initMetrics?: string[]
@@ -34,9 +36,9 @@ export interface MetricSpecStorage {
   selectedChart?: ChartType
 }
 
-const Metrics: FC<MetricsProps> = ({ id, initMetrics, defaultChartType }) => {
-  // const [, saveReport] = useLocalStorage<MetricVisualisation[]>(`reports-${id}`, [])
-  const [metrics, setMetrics] = useState<MetricSpecStorage[]>(
+const Metrics: FC<MetricsProps> = ({ nodeId, id, initMetrics, defaultChartType }) => {
+  const [metrics, setMetrics] = useLocalStorage<MetricSpecStorage[]>(
+    `edge.reports-${nodeId}`,
     initMetrics ? initMetrics.map<MetricSpecStorage>((e) => ({ selectedTopic: e })) : []
   )
   const showEditor = config.features.METRICS_SHOW_EDITOR
@@ -46,6 +48,10 @@ const Metrics: FC<MetricsProps> = ({ id, initMetrics, defaultChartType }) => {
   const handleCreateMetrics = (value: MetricDefinition) => {
     const { selectedTopic, selectedChart } = value
     setMetrics((old) => [...old, { selectedTopic: selectedTopic?.value, selectedChart: selectedChart?.value }])
+  }
+
+  const handleRemoveMetrics = (selectedTopic: string) => {
+    setMetrics((old) => old.filter((x) => x.selectedTopic !== selectedTopic))
   }
 
   return (
@@ -86,7 +92,7 @@ const Metrics: FC<MetricsProps> = ({ id, initMetrics, defaultChartType }) => {
                 <Sample
                   key={e.selectedTopic}
                   metricName={e.selectedTopic}
-                  onClose={() => setMetrics((old) => old.filter((x) => x.selectedTopic !== e.selectedTopic))}
+                  onClose={() => handleRemoveMetrics(e.selectedTopic)}
                 />
               )
             else
@@ -95,7 +101,7 @@ const Metrics: FC<MetricsProps> = ({ id, initMetrics, defaultChartType }) => {
                   key={e.selectedTopic}
                   chartType={e.selectedChart}
                   metricName={e.selectedTopic}
-                  onClose={() => setMetrics((old) => old.filter((x) => x.selectedTopic !== e.selectedTopic))}
+                  onClose={() => handleRemoveMetrics(e.selectedTopic)}
                   canEdit={isOpen}
                 />
               )

--- a/hivemq-edge/src/frontend/src/modules/Metrics/Metrics.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Metrics/Metrics.tsx
@@ -29,7 +29,7 @@ const Metrics: FC<MetricsProps> = ({ id, initMetrics, defaultChartType }) => {
   const [metrics, setMetrics] = useState<MetricSpecStorage[]>(
     initMetrics ? initMetrics.map<MetricSpecStorage>((e) => ({ selectedTopic: e })) : []
   )
-  const showSelector = config.features.METRICS_SELECT_PANEL
+  const showEditor = config.features.METRICS_SHOW_EDITOR
   const { isOpen, onOpen, onClose } = useDisclosure()
   const { t } = useTranslation()
 

--- a/hivemq-edge/src/frontend/src/modules/Metrics/components/editor/MetricEditor.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Metrics/components/editor/MetricEditor.spec.cy.tsx
@@ -35,7 +35,6 @@ describe('MetricEditor', () => {
         .should('have.text', '[Forward] Publish success (count)')
         .should('have.attr', 'aria-disabled', 'true')
 
-      cy.get('div#metrics-select-container').should('contain.text', '[Local] Publish failed (count)')
       cy.get('div#react-select-2-listbox').find("[role='option']").eq(5).click()
       cy.get("button[type='submit']").should('not.be.disabled')
       cy.get("button[type='submit']").click()

--- a/hivemq-edge/src/frontend/src/modules/Metrics/components/editor/MetricEditor.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Metrics/components/editor/MetricEditor.tsx
@@ -65,7 +65,7 @@ const MetricEditor: FC<MetricEditorProps> = ({ onSubmit, filter, selectedMetrics
     >
       <VStack gap={2} alignItems={'flex-end'}>
         <FormControl>
-          <FormLabel htmlFor={'metrics-select'}>{t('metrics.command.select-metric.ariaLabel')}</FormLabel>
+          <FormLabel htmlFor={'metrics-select'}>{t('metrics.editor.select-metric')}</FormLabel>
 
           <Controller
             name={'selectedTopic'}
@@ -100,7 +100,7 @@ const MetricEditor: FC<MetricEditorProps> = ({ onSubmit, filter, selectedMetrics
         </FormControl>
         {!selectedChart && (
           <FormControl>
-            <FormLabel htmlFor={'chart-select'}>{t('metrics.command.select-chart.ariaLabel')}</FormLabel>
+            <FormLabel htmlFor={'chart-select'}>{t('metrics.editor.select-chart')}</FormLabel>
 
             <Controller
               name={'selectedChart'}
@@ -135,7 +135,7 @@ const MetricEditor: FC<MetricEditorProps> = ({ onSubmit, filter, selectedMetrics
           </FormControl>
         )}
         <Button isDisabled={!isValid} rightIcon={<BiAddToQueue />} type="submit" form="namespace-form">
-          {t('metrics.command.add.ariaLabel')}
+          {t('metrics.editor.add')}
         </Button>
       </VStack>
     </form>

--- a/hivemq-edge/src/frontend/src/modules/Metrics/components/editor/MetricEditor.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Metrics/components/editor/MetricEditor.tsx
@@ -78,6 +78,10 @@ const MetricEditor: FC<MetricEditorProps> = ({ onSubmit, filter, selectedMetrics
               return (
                 <Select
                   {...rest}
+                  menuPortalTarget={document.body}
+                  styles={{
+                    menuPortal: (provided) => ({ ...provided, zIndex: 1401 }),
+                  }}
                   id={'metrics-select-container'}
                   inputId={'metrics-select'}
                   value={value || null}
@@ -109,6 +113,10 @@ const MetricEditor: FC<MetricEditorProps> = ({ onSubmit, filter, selectedMetrics
                 return (
                   <Select
                     {...rest}
+                    menuPortalTarget={document.body}
+                    styles={{
+                      menuPortal: (provided) => ({ ...provided, zIndex: 1401 }),
+                    }}
                     id={'chart-select-container'}
                     inputId={'chart-select'}
                     value={value || null}


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/17951/details/

This PR is a follow-up to the main metrics initiative, see https://github.com/hivemq/hivemq-edge/pull/215. It fixes problems in the metrics editor with the "expand" UX. It redesigns the component with an internal `Accordion` component and fixes layout issues.

### Before
![screenshot-localhost_3000-2023 11 30-15_45_56](https://github.com/hivemq/hivemq-edge/assets/2743481/9189b9d9-7679-4148-a5fb-1f0f3e27031d)

### After
![screenshot-localhost_3000-2023 11 30-15_47_01](https://github.com/hivemq/hivemq-edge/assets/2743481/e3f30b7c-88b4-4098-88db-018024bda2cc)

![screenshot-localhost_3000-2023 11 30-15_47_27](https://github.com/hivemq/hivemq-edge/assets/2743481/9b90d2a0-4c9a-423b-bdd9-729ea1ba3da8)
