### PR TITLE
feat(18003): add localStorage for the configs of the metric panels

### DIFF
--- a/hivemq-edge/src/frontend/src/modules/EdgeVisualisation/components/controls/NodePanelController.tsx
+++ b/hivemq-edge/src/frontend/src/modules/EdgeVisualisation/components/controls/NodePanelController.tsx
@@ -59,6 +59,8 @@ const NodePanelController: FC = () => {
     }
   }
 
+  if (!nodeId) return null
+
   return (
     <Suspense
       // TODO[NVL] Would be good to integrate the loader within the drawer
@@ -70,6 +72,7 @@ const NodePanelController: FC = () => {
     >
       {selectedLinkSource && (
         <LinkPropertyDrawer
+          nodeId={nodeId}
           selectedNode={selectedLinkSource}
           isOpen={isOpen}
           onClose={handleClose}
@@ -78,6 +81,7 @@ const NodePanelController: FC = () => {
       )}
       {selectedNode && (
         <NodePropertyDrawer
+          nodeId={nodeId}
           selectedNode={selectedNode}
           isOpen={isOpen}
           onClose={handleClose}

--- a/hivemq-edge/src/frontend/src/modules/EdgeVisualisation/components/drawers/LinkPropertyDrawer.tsx
+++ b/hivemq-edge/src/frontend/src/modules/EdgeVisualisation/components/drawers/LinkPropertyDrawer.tsx
@@ -10,12 +10,13 @@ import { getDefaultMetricsFor } from '../../utils/nodes-utils.ts'
 import { NodeTypes } from '../../types.ts'
 
 interface LinkPropertyDrawerProps {
+  nodeId: string
   selectedNode: Node<Bridge | Adapter>
   isOpen: boolean
   onClose: () => void
   onEditEntity: () => void
 }
-const LinkPropertyDrawer: FC<LinkPropertyDrawerProps> = ({ isOpen, selectedNode, onClose }) => {
+const LinkPropertyDrawer: FC<LinkPropertyDrawerProps> = ({ nodeId, isOpen, selectedNode, onClose }) => {
   const { t } = useTranslation()
 
   return (
@@ -34,6 +35,7 @@ const LinkPropertyDrawer: FC<LinkPropertyDrawerProps> = ({ isOpen, selectedNode,
         </DrawerHeader>
         <DrawerBody>
           <Metrics
+            nodeId={nodeId}
             type={selectedNode.type as NodeTypes}
             id={selectedNode.data.id}
             initMetrics={getDefaultMetricsFor(selectedNode)}

--- a/hivemq-edge/src/frontend/src/modules/EdgeVisualisation/components/drawers/NodePropertyDrawer.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/EdgeVisualisation/components/drawers/NodePropertyDrawer.spec.cy.tsx
@@ -25,7 +25,13 @@ describe('NodePropertyDrawer', () => {
     const onClose = cy.stub().as('onClose')
     const onEditEntity = cy.stub().as('onEditEntity')
     cy.mountWithProviders(
-      <NodePropertyDrawer selectedNode={mockNode} isOpen={true} onClose={onClose} onEditEntity={onEditEntity} />
+      <NodePropertyDrawer
+        nodeId="adapter@fgffgf"
+        selectedNode={mockNode}
+        isOpen={true}
+        onClose={onClose}
+        onEditEntity={onEditEntity}
+      />
     )
 
     // check the panel control
@@ -51,7 +57,13 @@ describe('NodePropertyDrawer', () => {
   it('should be accessible', () => {
     cy.injectAxe()
     cy.mountWithProviders(
-      <NodePropertyDrawer selectedNode={mockNode} isOpen={true} onClose={cy.stub()} onEditEntity={cy.stub()} />
+      <NodePropertyDrawer
+        nodeId={'adapter@fgffgf'}
+        selectedNode={mockNode}
+        isOpen={true}
+        onClose={cy.stub()}
+        onEditEntity={cy.stub()}
+      />
     )
 
     cy.checkAccessibility(undefined, {

--- a/hivemq-edge/src/frontend/src/modules/EdgeVisualisation/components/drawers/NodePropertyDrawer.tsx
+++ b/hivemq-edge/src/frontend/src/modules/EdgeVisualisation/components/drawers/NodePropertyDrawer.tsx
@@ -34,12 +34,13 @@ import { getDefaultMetricsFor } from '../../utils/nodes-utils.ts'
 import NodeNameCard from '../parts/NodeNameCard.tsx'
 
 interface NodePropertyDrawerProps {
+  nodeId: string
   selectedNode: Node<Bridge | Adapter>
   isOpen: boolean
   onClose: () => void
   onEditEntity: () => void
 }
-const NodePropertyDrawer: FC<NodePropertyDrawerProps> = ({ isOpen, selectedNode, onClose, onEditEntity }) => {
+const NodePropertyDrawer: FC<NodePropertyDrawerProps> = ({ nodeId, isOpen, selectedNode, onClose, onEditEntity }) => {
   const { t } = useTranslation()
 
   return (
@@ -54,6 +55,7 @@ const NodePropertyDrawer: FC<NodePropertyDrawerProps> = ({ isOpen, selectedNode,
           <VStack gap={4} alignItems={'stretch'}>
             <NodeNameCard selectedNode={selectedNode} />
             <Metrics
+              nodeId={nodeId}
               type={selectedNode.type as NodeTypes}
               id={selectedNode.data.id}
               initMetrics={getDefaultMetricsFor(selectedNode)}

--- a/hivemq-edge/src/frontend/src/modules/Metrics/Metrics.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Metrics/Metrics.spec.cy.tsx
@@ -14,7 +14,9 @@ describe('Metrics', () => {
   })
 
   it('should render the collapsible component', () => {
-    cy.mountWithProviders(<Metrics initMetrics={[]} id={mockBridgeId} type={NodeTypes.BRIDGE_NODE} />)
+    cy.mountWithProviders(
+      <Metrics nodeId={'bridge@bridge-id-01'} initMetrics={[]} id={mockBridgeId} type={NodeTypes.BRIDGE_NODE} />
+    )
 
     cy.getByTestId('metrics-toggle').should('have.attr', 'aria-expanded', 'false')
     cy.get('div#metrics-select-container').should('not.be.visible')

--- a/hivemq-edge/src/frontend/src/modules/Metrics/Metrics.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Metrics/Metrics.tsx
@@ -23,6 +23,7 @@ import ChartContainer from './components/container/ChartContainer.tsx'
 import Sample from './components/container/Sample.tsx'
 
 interface MetricsProps {
+  nodeId: string
   type: NodeTypes
   id: string
   initMetrics?: string[]

--- a/hivemq-edge/src/frontend/src/modules/Metrics/Metrics.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Metrics/Metrics.tsx
@@ -12,6 +12,7 @@ import {
   useDisclosure,
 } from '@chakra-ui/react'
 import { useTranslation } from 'react-i18next'
+import { useLocalStorage } from '@uidotdev/usehooks'
 
 import { NodeTypes } from '@/modules/EdgeVisualisation/types.ts'
 
@@ -35,9 +36,9 @@ export interface MetricSpecStorage {
   selectedChart?: ChartType
 }
 
-const Metrics: FC<MetricsProps> = ({ id, initMetrics, defaultChartType }) => {
-  // const [, saveReport] = useLocalStorage<MetricVisualisation[]>(`reports-${id}`, [])
-  const [metrics, setMetrics] = useState<MetricSpecStorage[]>(
+const Metrics: FC<MetricsProps> = ({ nodeId, id, initMetrics, defaultChartType }) => {
+  const [metrics, setMetrics] = useLocalStorage<MetricSpecStorage[]>(
+    `edge.reports-${nodeId}`,
     initMetrics ? initMetrics.map<MetricSpecStorage>((e) => ({ selectedTopic: e })) : []
   )
   const showEditor = config.features.METRICS_SHOW_EDITOR

--- a/hivemq-edge/src/frontend/src/modules/Metrics/Metrics.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Metrics/Metrics.tsx
@@ -1,4 +1,4 @@
-import { FC, useState } from 'react'
+import { FC } from 'react'
 import {
   Accordion,
   AccordionButton,
@@ -50,6 +50,10 @@ const Metrics: FC<MetricsProps> = ({ nodeId, id, initMetrics, defaultChartType }
     setMetrics((old) => [...old, { selectedTopic: selectedTopic?.value, selectedChart: selectedChart?.value }])
   }
 
+  const handleRemoveMetrics = (selectedTopic: string) => {
+    setMetrics((old) => old.filter((x) => x.selectedTopic !== selectedTopic))
+  }
+
   return (
     <Card size={'sm'}>
       {showEditor && (
@@ -88,7 +92,7 @@ const Metrics: FC<MetricsProps> = ({ nodeId, id, initMetrics, defaultChartType }
                 <Sample
                   key={e.selectedTopic}
                   metricName={e.selectedTopic}
-                  onClose={() => setMetrics((old) => old.filter((x) => x.selectedTopic !== e.selectedTopic))}
+                  onClose={() => handleRemoveMetrics(e.selectedTopic)}
                 />
               )
             else
@@ -97,7 +101,7 @@ const Metrics: FC<MetricsProps> = ({ nodeId, id, initMetrics, defaultChartType }
                   key={e.selectedTopic}
                   chartType={e.selectedChart}
                   metricName={e.selectedTopic}
-                  onClose={() => setMetrics((old) => old.filter((x) => x.selectedTopic !== e.selectedTopic))}
+                  onClose={() => handleRemoveMetrics(e.selectedTopic)}
                   canEdit={isOpen}
                 />
               )


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/18003/details/

This PR is a follow-up to the main metrics initiative, see https://github.com/hivemq/hivemq-edge/pull/215. It adds persistence to the obervability panels created by the users, ensuring consistency across session. 

The persistency is done through `localStorage`, under individual keys (i.e. `edge.reports-#####`).

### Out-of-scope
- There is no UI-based mechanism to clear all the metric panels, especially the orphans.
