### PR TITLE
fix(18092): Fix the update of status for adapters and bridges in the wokspace

### DIFF
--- a/hivemq-edge/src/frontend/src/modules/EdgeVisualisation/components/controls/StatusListener.tsx
+++ b/hivemq-edge/src/frontend/src/modules/EdgeVisualisation/components/controls/StatusListener.tsx
@@ -1,22 +1,35 @@
 import { useEffect } from 'react'
 import { useReactFlow } from 'reactflow'
+import { useTheme } from '@chakra-ui/react'
 
 import { useGetAdaptersStatus } from '@/api/hooks/useConnection/useGetAdaptersStatus.tsx'
 import { useGetBridgesStatus } from '@/api/hooks/useConnection/useGetBridgesStatus.tsx'
+import { useGetAdapterTypes } from '@/api/hooks/useProtocolAdapters/useGetAdapterTypes.tsx'
 
-import { updateNodeStatus } from '../../utils/status-utils.ts'
+import { updateEdgesStatus, updateNodeStatus } from '../../utils/status-utils.ts'
 
 const StatusListener = () => {
   const { data: adapterConnections } = useGetAdaptersStatus()
   const { data: bridgeConnections } = useGetBridgesStatus()
-  const { setNodes } = useReactFlow()
+  const { data: adapterTypes } = useGetAdapterTypes()
+  const { setNodes, getNode, setEdges } = useReactFlow()
+  const theme = useTheme()
 
   useEffect(() => {
-    if (adapterConnections?.items && bridgeConnections?.items) {
-      const updates = [...adapterConnections.items, ...bridgeConnections.items]
-      setNodes((currentNodes) => updateNodeStatus(currentNodes, updates))
+    const { items } = adapterTypes || {}
+    if (adapterConnections?.items || bridgeConnections?.items) {
+      const updates = [...(adapterConnections?.items || []), ...(bridgeConnections?.items || [])]
+
+      setNodes((currentNodes) => {
+        return updateNodeStatus(currentNodes, updates)
+      })
+
+      if (items)
+        setEdges((currentEdges) => {
+          return updateEdgesStatus(items, currentEdges, updates, getNode, theme)
+        })
     }
-  }, [adapterConnections, bridgeConnections, setNodes])
+  }, [adapterConnections, adapterTypes, bridgeConnections, getNode, setEdges, setNodes, theme])
 
   return null
 }

--- a/hivemq-edge/src/frontend/src/modules/EdgeVisualisation/utils/status-utils.ts
+++ b/hivemq-edge/src/frontend/src/modules/EdgeVisualisation/utils/status-utils.ts
@@ -1,9 +1,12 @@
-import { Node } from 'reactflow'
+import { Edge, Instance, MarkerType, Node } from 'reactflow'
+import { GenericObjectType } from '@rjsf/utils'
 import { WithCSSVar } from '@chakra-ui/react'
 import { Dict } from '@chakra-ui/utils'
 
-import { Adapter, Bridge, Status } from '@/api/__generated__'
-import { NodeTypes } from '@/modules/EdgeVisualisation/types.ts'
+import { Adapter, Bridge, ProtocolAdapter, Status } from '@/api/__generated__'
+
+import { NodeTypes } from '../types.ts'
+import { discoverAdapterTopics, getBridgeTopics } from './topics-utils.ts'
 
 /**
  * @param theme
@@ -44,16 +47,64 @@ export const updateNodeStatus = (currentNodes: Node[], updates: Status[]) => {
       const newData = { ...n.data } as Adapter
       const newStatus = updates.find((s) => s.id === newData.id)
       if (!newStatus) return n
-      if (newStatus.connection === newData.status?.connection) return n
+      // if (newStatus.connection === newData.status?.connection) return n
 
       n.data = {
         ...newData,
-        status: {
-          connection: newStatus.connection,
-        },
+        status: { ...newStatus },
       }
       return n
     }
     return n
+  })
+}
+
+export type EdgeStyle = Pick<Edge, 'style' | 'animated' | 'markerEnd'>
+
+export const getEdgeStatus = (isConnected: boolean, hasTopics: boolean, themeForStatus: string): EdgeStyle => {
+  const edge: EdgeStyle = {}
+  edge.style = {
+    strokeWidth: isConnected ? 1.5 : 0.5,
+    stroke: themeForStatus,
+  }
+  edge.animated = isConnected && hasTopics
+  edge.markerEnd = {
+    type: MarkerType.ArrowClosed,
+    width: 20,
+    height: 20,
+    color: themeForStatus,
+  }
+  return edge
+}
+
+export const updateEdgesStatus = (
+  adapterTypes: ProtocolAdapter[],
+  currentEdges: Edge[],
+  updates: Status[],
+  getNode: Instance.GetNode<Partial<Bridge | Adapter>>,
+  theme: Partial<WithCSSVar<Dict>>
+): Edge[] => {
+  return currentEdges.map((edge) => {
+    const [a, b] = edge.source.split('@')
+    const status = updates.find((e) => e.id === b && e.type === a)
+    if (!status) return edge
+
+    const source = getNode(edge.source)
+    const isConnected =
+      status?.connection === Status.connection.CONNECTED ||
+      (status?.runtime === Status.runtime.STARTED && status?.connection === Status.connection.STATELESS)
+
+    if (source && source.type === NodeTypes.ADAPTER_NODE) {
+      const type = adapterTypes?.find((e) => e.id === (source.data as Adapter).type)
+      const topics = type ? discoverAdapterTopics(type, (source.data as Adapter).config as GenericObjectType) : []
+
+      return { ...edge, ...getEdgeStatus(isConnected, !!topics.length, getThemeForStatus(theme, status)) }
+    }
+
+    if (source && source.type === NodeTypes.BRIDGE_NODE) {
+      const { remote } = getBridgeTopics(source.data as Bridge)
+      return { ...edge, ...getEdgeStatus(isConnected, !!remote.length, getThemeForStatus(theme, status)) }
+    }
+    return edge
   })
 }


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/18092/details/

This PR changes the way statuses are updated in the `Workspace`. Up to now, any update is relying on the re-mounting of the component every time the users navigate to the page; the list of nodes (adapter and bridges) and edges (links!) would be regenerated with the newest status. 

With the `Workspace` persistence in the workflow, this will not work anymore. 

The PR correctly "listens" to changes in the status of all the entities in the workspace, dynamically changing the graph's nodes and edges as their internal data changes. 

Note: To experience the live update (since navigating between pages will recreate the `Workspace`), open two browsers with the `Workspace` in one and the adapters in the other. Stopping/starting adapters will immediately (give or take the pooling delay) the statuses on the `Worskapce`. 


### After

https://www.loom.com/share/036969c02ef84b679f420afd2665cb3e?sid=ac87304b-4cf8-4747-be29-1760e9dfae33