### PR TITLE
feat(18214): Add editor for the group metadata

### DIFF
--- a/hivemq-edge/src/frontend/src/components/Chakra/ColorPicker.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/components/Chakra/ColorPicker.spec.cy.tsx
@@ -1,0 +1,61 @@
+/// <reference types="cypress" />
+
+import { ColorPicker } from '@/components/Chakra/ColorPicker.tsx'
+
+const mockColorScheme = 'green'
+const mockDdefaultColorSchemes = [
+  'gray',
+  'red',
+  'orange',
+  'yellow',
+  'green',
+  'blue',
+  'cyan',
+  'purple',
+  'pink',
+  'whatsapp',
+]
+
+describe('ColorPicker', () => {
+  beforeEach(() => {
+    cy.viewport(300, 500)
+  })
+
+  it('should render properly', () => {
+    const onChange = cy.stub().as('onChange')
+    cy.mountWithProviders(
+      <ColorPicker
+        colorScheme={mockColorScheme}
+        onChange={onChange}
+        colorSchemes={mockDdefaultColorSchemes}
+        ml={'75px'}
+      />
+    )
+
+    cy.getByTestId('colorPicker-trigger').should('have.attr', 'data-colorScheme', mockColorScheme)
+    cy.getByTestId('colorPicker-trigger').click()
+    cy.getByTestId('colorPicker-popover').should('be.visible')
+    cy.getByTestId('colorPicker-sample').should('have.text', mockColorScheme)
+    cy.get("[data-testId^='colorPicker-selector']")
+      .should('have.length', 10)
+      .eq(5)
+      .should('have.attr', 'data-colorScheme', 'blue')
+      .click()
+
+    cy.get('@onChange').should('have.been.calledWith', 'blue')
+    cy.getByTestId('colorPicker-sample').should('have.text', 'blue')
+    cy.getByTestId('colorPicker-trigger').should('have.attr', 'data-colorScheme', 'blue')
+
+    // cy.getByTestId('colorPicker-trigger').click()
+    // cy.getByTestId('colorPicker-popover').should('not.be.visible')
+  })
+
+  // it('should be accessible', () => {
+  //   cy.injectAxe()
+  //   cy.mountWithProviders(<ColorPicker colorScheme={mockColorScheme} onChange={cy.stub()} ml={'75px'} />)
+  //
+  //   cy.getByTestId('colorPicker-trigger').click()
+  //   cy.checkAccessibility()
+  //   cy.percySnapshot('Component: ColorPicker')
+  // })
+})

--- a/hivemq-edge/src/frontend/src/components/Chakra/ColorPicker.tsx
+++ b/hivemq-edge/src/frontend/src/components/Chakra/ColorPicker.tsx
@@ -1,0 +1,117 @@
+import {
+  Button,
+  ButtonProps,
+  Popover,
+  PopoverArrow,
+  PopoverContent,
+  PopoverTrigger,
+  SimpleGrid,
+  PlacementWithLogical,
+  Box,
+  Flex,
+  Portal,
+} from '@chakra-ui/react'
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+// TODO[NVL] Verify that they are valid colorScheme from the theme
+const defaultColorSchemes = ['gray', 'red', 'orange', 'yellow', 'green', 'teal', 'blue', 'cyan', 'purple', 'pink']
+
+interface ColorPickerProps extends Omit<ButtonProps, 'onChange'> {
+  colorScheme: string | undefined
+  onChange: (value: string) => void
+  colorSchemes?: string[]
+  isDisabled?: boolean
+  placement?: PlacementWithLogical
+}
+
+export const ColorPicker = ({
+  onChange,
+  isDisabled,
+  colorScheme,
+  colorSchemes,
+  placement,
+  ...props
+}: ColorPickerProps) => {
+  const { t } = useTranslation('components')
+  const schemeOptions = colorSchemes || defaultColorSchemes
+  const [selectedColorScheme, setSelectedColorScheme] = useState<string>(colorScheme || schemeOptions[0])
+
+  return (
+    <Popover placement={placement || 'bottom'} isLazy>
+      <PopoverTrigger>
+        <Button
+          isDisabled={isDisabled}
+          data-testid={'colorPicker-trigger'}
+          data-colorScheme={selectedColorScheme}
+          aria-label={t('ColorPicker.trigger', { scheme: selectedColorScheme }) as string}
+          bg={`${selectedColorScheme}.500`}
+          _hover={{ bg: `${selectedColorScheme}.500` }}
+          _active={{ bg: `${selectedColorScheme}.700` }}
+          {...props}
+        ></Button>
+      </PopoverTrigger>
+
+      <Portal>
+        <Box
+          // Fix for the portal's zIndex
+          sx={{
+            '& .chakra-popover__popper': {
+              zIndex: 'popover',
+            },
+          }}
+        >
+          <PopoverContent
+            w="auto"
+            boxShadow="md"
+            data-testid={'colorPicker-popover'}
+            aria-label={'ColorPicker.popover'}
+          >
+            <PopoverArrow backgroundColor={`${selectedColorScheme}.500`} />
+            <SimpleGrid columns={1}>
+              <Flex
+                data-testid={'colorPicker-sample'}
+                alignItems={'center'}
+                justifyContent={'center'}
+                borderWidth={0}
+                borderTopRadius={'sm'}
+                h={10}
+                w="100%"
+                p={0}
+                fontSize={'lg'}
+                bg={`${selectedColorScheme}.500`}
+                color={'black'}
+              >
+                {selectedColorScheme}
+              </Flex>
+            </SimpleGrid>
+            <SimpleGrid columns={5} p={1} spacing={1}>
+              {schemeOptions.map((color, index) => {
+                // const [a] = color.split('.')
+                // const g = `${a}.${selectedColorScheme || 50}`
+                return (
+                  <Button
+                    key={`color-picker-${color}-${index}`}
+                    data-testid={`colorPicker-selector-${index}`}
+                    data-colorScheme={color}
+                    aria-label={t('ColorPicker.option', { scheme: color }) as string}
+                    onClick={() => {
+                      setSelectedColorScheme(color)
+                      onChange(color)
+                    }}
+                    h={6}
+                    w={6}
+                    minW={6}
+                    bg={`${color}.500`}
+                    _hover={{ bg: `${color}.500`, transform: 'scale(1.1)' }}
+                    _active={{ bg: `${color}.500` }}
+                  />
+                )
+              })}
+            </SimpleGrid>
+          </PopoverContent>
+        </Box>
+      </Portal>
+    </Popover>
+  )
+}

--- a/hivemq-edge/src/frontend/src/locales/en/components.json
+++ b/hivemq-edge/src/frontend/src/locales/en/components.json
@@ -33,6 +33,11 @@
     "seconds_minus": "a few seconds ago",
     "seconds_plus": "in a few seconds"
   },
+  "ColorPicker": {
+    "trigger": "Selected color scheme: {{ scheme }}",
+    "popover": "Select one of the options",
+    "option": "Select {{ scheme }}"
+  },
   "DateTimeRangeSelector": {
     "placeholder": "Select a date",
     "noOptionsMessage": "Not a valid date",

--- a/hivemq-edge/src/frontend/src/locales/en/translation.json
+++ b/hivemq-edge/src/frontend/src/locales/en/translation.json
@@ -616,6 +616,12 @@
         "collapse": "Collapse group",
         "ungroup": "Ungroup"
       },
+      "editor": {
+        "title": "Configure the group",
+        "input-title": "Title",
+        "input-color": "Group colour",
+        "save": "Save changes"
+      },
       "create": "Create group",
       "untitled": "Untitled group",
       "title": "Grouping",

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/controls/GroupNodesControl.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/controls/GroupNodesControl.tsx
@@ -31,7 +31,7 @@ const GroupNodesControl: FC = () => {
     const newGroupNode: Node<Group, NodeTypes.CLUSTER_NODE> = {
       id: groupId,
       type: NodeTypes.CLUSTER_NODE,
-      data: { childrenNodeIds: currentSelection.map((e) => e.id), title: groupTitle, isOpen: true },
+      data: { childrenNodeIds: currentSelection.map((e) => e.id), title: groupTitle, isOpen: true, colorScheme: 'red' },
       style: {
         width: rect.width,
         height: rect.height,

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/drawers/GroupPropertyDrawer.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/drawers/GroupPropertyDrawer.tsx
@@ -1,12 +1,23 @@
 import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Node } from 'reactflow'
-import { Box, Drawer, DrawerBody, DrawerCloseButton, DrawerContent, DrawerHeader, Text } from '@chakra-ui/react'
+import {
+  Box,
+  Drawer,
+  DrawerBody,
+  DrawerCloseButton,
+  DrawerContent,
+  DrawerHeader,
+  DrawerOverlay,
+  Text,
+} from '@chakra-ui/react'
 
 import Metrics from '@/modules/Metrics/Metrics.tsx'
 
-import { getDefaultMetricsFor } from '../../utils/nodes-utils.ts'
 import { Group, NodeTypes } from '../../types.ts'
+import useWorkspaceStore from '../../hooks/useWorkspaceStore.ts'
+import { getDefaultMetricsFor } from '../../utils/nodes-utils.ts'
+import GroupMetadataEditor from '../parts/GroupMetadataEditor.tsx'
 
 interface LinkPropertyDrawerProps {
   nodeId: string
@@ -19,13 +30,14 @@ interface LinkPropertyDrawerProps {
 
 const GroupPropertyDrawer: FC<LinkPropertyDrawerProps> = ({ nodeId, isOpen, selectedNode, nodes, onClose }) => {
   const { t } = useTranslation()
+  const { onGroupSetData } = useWorkspaceStore()
 
   const adapterIDs = selectedNode.data.childrenNodeIds.map<Node | undefined>((e) => nodes.find((x) => x.id === e))
   const metrics = adapterIDs.map((x) => (x ? getDefaultMetricsFor(x) : [])).flat()
 
   return (
     <Drawer isOpen={isOpen} placement="right" size={'lg'} onClose={onClose}>
-      {/*<DrawerOverlay />*/}
+      <DrawerOverlay />
       <DrawerContent aria-label={t('workspace.observability.header', { context: selectedNode.type }) as string}>
         <DrawerCloseButton />
 
@@ -42,7 +54,13 @@ const GroupPropertyDrawer: FC<LinkPropertyDrawerProps> = ({ nodeId, isOpen, sele
             ))}
           </Box>
         </DrawerHeader>
-        <DrawerBody>
+        <DrawerBody display={'flex'} flexDirection={'column'} gap={6}>
+          <GroupMetadataEditor
+            group={selectedNode}
+            onSubmit={(group) => {
+              onGroupSetData(nodeId, group)
+            }}
+          />
           <Metrics
             nodeId={nodeId}
             type={selectedNode.type as NodeTypes}

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeGroup.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeGroup.tsx
@@ -56,6 +56,7 @@ const NodeGroup: FC<NodeProps<Group>> = ({ id, data, selected, ...props }) => {
     onEdgesChange(edges.filter((e) => e.source === id).map((e) => ({ id: e.id, type: 'remove' } as EdgeRemoveChange)))
   }
 
+  console.log('XXXXXXX data', data)
   return (
     <>
       <NodeToolbar isVisible={selected} position={Position.Top}>
@@ -93,14 +94,8 @@ const NodeGroup: FC<NodeProps<Group>> = ({ id, data, selected, ...props }) => {
         h={'100%'}
         backgroundColor={data.isOpen ? undefined : data.colorScheme ? colors[data.colorScheme][50] : colors.red[50]}
         borderColor={data.colorScheme ? colors[data.colorScheme][500] : colors.red[50]}
-        style={{
-          backgroundColor: data.isOpen ? undefined : colors.red[50],
-          // borderRadius: '100%',
-          // opacity: 0.05,
-          borderColor: colors.red[100],
-          borderWidth: 3,
-          borderStyle: 'solid',
-        }}
+        borderWidth={1}
+        borderStyle={'solid'}
         onDoubleClick={() => navigate(`/edge-flow/group/${id}`)}
       >
         <Text m={2} color={'blackAlpha.900'}>

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeGroup.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeGroup.tsx
@@ -91,6 +91,8 @@ const NodeGroup: FC<NodeProps<Group>> = ({ id, data, selected, ...props }) => {
         id={`node-group-${id}`}
         w={'100%'}
         h={'100%'}
+        backgroundColor={data.isOpen ? undefined : data.colorScheme ? colors[data.colorScheme][50] : colors.red[50]}
+        borderColor={data.colorScheme ? colors[data.colorScheme][500] : colors.red[50]}
         style={{
           backgroundColor: data.isOpen ? undefined : colors.red[50],
           // borderRadius: '100%',

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/parts/GroupMetadataEditor.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/parts/GroupMetadataEditor.tsx
@@ -1,0 +1,95 @@
+import { FC } from 'react'
+import { Node } from 'reactflow'
+import {
+  Accordion,
+  AccordionButton,
+  AccordionIcon,
+  AccordionItem,
+  AccordionPanel,
+  Box,
+  Button,
+  Card,
+  FormControl,
+  FormLabel,
+  Input,
+  VStack,
+} from '@chakra-ui/react'
+import { useTranslation } from 'react-i18next'
+import { Controller, useForm } from 'react-hook-form'
+import { Group } from '@/modules/Workspace/types.ts'
+import { ColorPicker } from '@/components/Chakra/ColorPicker.tsx'
+
+interface GroupMetadataEditorProps {
+  id?: string
+  group: Node<Group>
+  onSubmit: (data: Group) => void
+}
+
+const GroupMetadataEditor: FC<GroupMetadataEditorProps> = ({ group, onSubmit }) => {
+  const { t } = useTranslation()
+  const { register, control, reset, formState, handleSubmit } = useForm<Group>({
+    mode: 'all',
+    criteriaMode: 'all',
+    defaultValues: group.data,
+  })
+
+  const handleFormSubmit = (data: Group) => {
+    onSubmit(data)
+    reset(data)
+  }
+
+  return (
+    <Card size={'sm'}>
+      <Accordion allowToggle defaultIndex={0}>
+        <AccordionItem>
+          <AccordionButton data-testid="metrics-toggle">
+            <Box as="span" flex="1" textAlign="left">
+              {t('workspace.grouping.editor.title')}
+            </Box>
+            <AccordionIcon />
+          </AccordionButton>
+
+          <AccordionPanel pb={4}>
+            <VStack gap={2} alignItems={'stretch'}>
+              <form
+                id="group-form"
+                onSubmit={handleSubmit(handleFormSubmit)}
+                style={{ display: 'flex', flexDirection: 'row', gap: '18px' }}
+              >
+                <FormControl>
+                  <FormLabel htmlFor={'group-title'}>{t('workspace.grouping.editor.input-title')}</FormLabel>
+                  <Input id={'group-title'} {...register('title')} />
+                </FormControl>
+
+                <FormControl as="fieldset">
+                  <FormLabel as="legend">{t('workspace.grouping.editor.input-color')}</FormLabel>
+                  <Controller
+                    name={`colorScheme`}
+                    render={({ field }) => {
+                      const { value, onChange, ...rest } = field
+                      return <ColorPicker colorScheme={value} onChange={(value) => onChange(value)} {...rest} />
+                    }}
+                    control={control}
+                  />
+                </FormControl>
+              </form>
+              <VStack alignItems={'end'}>
+                <Button
+                  isDisabled={!formState.isDirty}
+                  type={'submit'}
+                  form="group-form"
+                  data-testid={'form-submit'}
+                  mt={8}
+                >
+                  {t('workspace.grouping.editor.save')}
+                </Button>
+              </VStack>
+            </VStack>
+          </AccordionPanel>
+        </AccordionItem>
+      </Accordion>
+    </Card>
+  )
+}
+
+export default GroupMetadataEditor

--- a/hivemq-edge/src/frontend/src/modules/Workspace/hooks/useWorkspaceStore.ts
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/hooks/useWorkspaceStore.ts
@@ -95,6 +95,22 @@ const useWorkspaceStore = create<WorkspaceState & WorkspaceAction>()(
           }),
         })
       },
+      onGroupSetData: (id: string, group: Pick<Group, 'title' | 'colorScheme'>) => {
+        set({
+          nodes: get().nodes.map((n) => {
+            if (id === n.id) {
+              return {
+                ...n,
+                data: {
+                  ...n.data,
+                  ...group,
+                },
+              }
+            }
+            return n
+          }),
+        })
+      },
     }),
     {
       name: 'edge.workspace',

--- a/hivemq-edge/src/frontend/src/modules/Workspace/types.ts
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/types.ts
@@ -50,6 +50,7 @@ export interface Group {
   childrenNodeIds: string[]
   title: string
   isOpen: boolean
+  colorScheme?: string
 }
 
 export interface WorkspaceState {
@@ -65,4 +66,5 @@ export interface WorkspaceAction {
   onInsertGroupNode: (node: Node<Group, NodeTypes.CLUSTER_NODE>, edge: Edge, rect: Rect) => void
   onDeleteNode: (type: NodeTypes, adapterId: string) => void
   onToggleGroup: (node: Pick<Node<Group, NodeTypes.CLUSTER_NODE>, 'id' | 'data'>, show: boolean) => void
+  onGroupSetData: (id: string, node: Pick<Group, 'title' | 'colorScheme'>) => void
 }


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/18214/details/

This PR adds a simple editor to the group's side panel, allowing users to change the two pieces of information defined by its creation: title and colour scheme.

The editor follows the same pattern as the metrics editor, with a simple collapsible panel with the form.

The colour scheme input is a `Colour Picker` designed to work with the default schemes defined within the `Chakra UI` theme. The number of colours added to the pickers is customisable. 

As with defining a `colourScheme` for other components, the scheme selected for the group will use the two hues `.100` and `.500` for the background and the border respectively

### Before 
![screenshot-localhost_3000-2023 12 11-08_59_16](https://github.com/hivemq/hivemq-edge/assets/2743481/76f6479b-e809-48c1-922e-80b6af084897)

### After 
![screenshot-localhost_3000-2023 12 11-08_58_47](https://github.com/hivemq/hivemq-edge/assets/2743481/532cee3d-8834-473e-82e1-643366076c6f)
