### PR TITLE
fix(18204): Refactor the location of a group and its nodes

### DIFF
--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/ReactFlowWrapper.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/ReactFlowWrapper.tsx
@@ -48,15 +48,16 @@ const ReactFlowWrapper = () => {
   return (
     <ReactFlow
       id={'edge-workspace-canvas'}
-      deleteKeyCode={null}
-      snapToGrid={true}
       nodes={nodes}
+      edges={edges}
       nodeTypes={nodeTypes}
       edgeTypes={edgeTypes}
       onNodesChange={onNodesChange}
-      edges={edges}
       onEdgesChange={onEdgesChange}
       fitView
+      snapToGrid={true}
+      nodesConnectable={false}
+      deleteKeyCode={null}
     >
       <Box
         role={'toolbar'}

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/controls/GroupNodesControl.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/controls/GroupNodesControl.tsx
@@ -4,10 +4,11 @@ import { useTranslation } from 'react-i18next'
 import { IconButton, useTheme } from '@chakra-ui/react'
 import { GrObjectGroup } from 'react-icons/gr'
 
-import { Status } from '@/api/__generated__'
+import { Adapter, Status } from '@/api/__generated__'
 import { EdgeTypes, Group, IdStubs, NodeTypes } from '../../types.ts'
 import useWorkspaceStore from '../../hooks/useWorkspaceStore.ts'
 import { getThemeForStatus } from '../../utils/status-utils.ts'
+import { getGroupLayout } from '../../utils/group.utils.ts'
 
 const GroupNodesControl: FC = () => {
   const { t } = useTranslation()
@@ -26,16 +27,27 @@ const GroupNodesControl: FC = () => {
   const onCreateGroup = () => {
     const groupId = `${IdStubs.GROUP_NODE}@${currentSelection.map((e) => e.data.id).join('+')}`
     const groupTitle = t('workspace.grouping.untitled')
+    const rect = getGroupLayout(currentSelection)
     const newGroupNode: Node<Group, NodeTypes.CLUSTER_NODE> = {
       id: groupId,
       type: NodeTypes.CLUSTER_NODE,
       data: { childrenNodeIds: currentSelection.map((e) => e.id), title: groupTitle, isOpen: true },
-      // TODO[NVL] Position/size needs to be more elegant, including adjustment of children nodes
-      position: { x: 20, y: 20 },
       style: {
-        width: 500,
-        height: 140,
+        width: rect.width,
+        height: rect.height,
       },
+      position: { x: rect.x, y: rect.y },
+    }
+
+    const groupStatus: Status = {
+      runtime: currentSelection.every((e: Node<Adapter>) => e.data.status?.runtime === Status.runtime.STARTED)
+        ? Status.runtime.STARTED
+        : Status.runtime.STOPPED,
+      connection: currentSelection.every(
+        (e: Node<Adapter>) => e.data.status?.connection !== Status.connection.CONNECTED
+      )
+        ? Status.connection.CONNECTED
+        : Status.connection.DISCONNECTED,
     }
 
     const newAEdge: Edge = {
@@ -50,20 +62,20 @@ const GroupNodesControl: FC = () => {
         type: MarkerType.ArrowClosed,
         width: 20,
         height: 20,
-        color: getThemeForStatus(theme, { connection: Status.connection.CONNECTED, runtime: Status.runtime.STARTED }),
+        color: getThemeForStatus(theme, groupStatus),
       },
-      animated: true,
+      animated: groupStatus.connection === Status.connection.CONNECTED,
       style: {
         strokeWidth: 1.5,
-        stroke: getThemeForStatus(theme, { connection: Status.connection.CONNECTED, runtime: Status.runtime.STARTED }),
+        stroke: getThemeForStatus(theme, groupStatus),
       },
     }
 
-    onInsertGroupNode(newGroupNode, newAEdge)
+    onInsertGroupNode(newGroupNode, newAEdge, rect)
     setCurrentSelection([])
   }
 
-  if (currentSelection.length < 2) return null
+  // if (currentSelection.length < 2) return null
   return (
     <Panel position="top-left">
       <IconButton

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeAdapter.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeAdapter.tsx
@@ -48,7 +48,7 @@ const NodeAdapter: FC<NodeProps<Adapter>> = ({ id, data: adapter, selected }) =>
           {options.showTopics && <TopicsContainer topics={topics} />}
         </VStack>
       </NodeWrapper>
-      <Handle type="source" position={Position.Bottom} id="Bottom" isConnectable={true} />
+      <Handle type="source" position={Position.Bottom} id="Bottom" isConnectable={false} />
     </>
   )
 }

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeBridge.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeBridge.tsx
@@ -39,8 +39,8 @@ const NodeBridge: FC<NodeProps<Bridge>> = ({ id, selected, data: bridge }) => {
           {options.showTopics && <TopicsContainer topics={topics.local} />}
         </VStack>
       </NodeWrapper>
-      <Handle type="source" position={Position.Top} id="Top" isConnectable={true} />
-      {options.showHosts && <Handle type="source" position={Position.Bottom} id="Bottom" isConnectable={true} />}
+      <Handle type="source" position={Position.Top} id="Top" isConnectable={false} />
+      {options.showHosts && <Handle type="source" position={Position.Bottom} id="Bottom" isConnectable={false} />}
     </>
   )
 }

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeEdge.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeEdge.tsx
@@ -22,7 +22,7 @@ const NodeEdge: FC<NodeProps> = (props) => {
       </NodeWrapper>
       <Handle type="target" position={Position.Bottom} id="Bottom" isConnectable={false} />
       <Handle type="target" position={Position.Top} id="Top" isConnectable={false} />
-      <Handle type="source" position={Position.Left} id="SRight" isConnectable={true} />
+      <Handle type="source" position={Position.Left} id="SRight" isConnectable={false} />
     </>
   )
 }

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeGroup.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeGroup.tsx
@@ -97,7 +97,7 @@ const NodeGroup: FC<NodeProps<Group>> = ({ id, data, selected, ...props }) => {
           {data.title}
         </Text>
       </Box>
-      <Handle type="source" position={Position.Bottom} id="a" />
+      <Handle type="source" position={Position.Bottom} id="a" isConnectable={false} />
       <ConfirmationDialog
         isOpen={isConfirmUngroupOpen}
         onClose={onConfirmUngroupClose}

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeGroup.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeGroup.tsx
@@ -19,7 +19,7 @@ import ConfirmationDialog from '@/components/Modal/ConfirmationDialog.tsx'
 import { Group } from '../../types.ts'
 import useWorkspaceStore from '../../hooks/useWorkspaceStore.ts'
 
-const NodeGroup: FC<NodeProps<Group>> = ({ id, data, selected }) => {
+const NodeGroup: FC<NodeProps<Group>> = ({ id, data, selected, ...props }) => {
   const { t } = useTranslation()
   const navigate = useNavigate()
   const { colors } = useTheme()
@@ -41,8 +41,14 @@ const NodeGroup: FC<NodeProps<Group>> = ({ id, data, selected }) => {
     onNodesChange(
       nodes.map((e) => {
         if (data.childrenNodeIds.includes(e.id)) {
-          // TODO[NVL] Compute position so that nodes don't move on the screen
-          return { item: { ...e, parentNode: undefined }, type: 'reset' } as NodeResetChange
+          return {
+            item: {
+              ...e,
+              parentNode: undefined,
+              position: { x: e.position.x + props.xPos, y: e.position.y + props.yPos },
+            },
+            type: 'reset',
+          } as NodeResetChange
         } else return { item: e, type: 'reset' } as NodeResetChange
       })
     )

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeGroup.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeGroup.tsx
@@ -77,7 +77,15 @@ const NodeGroup: FC<NodeProps<Group>> = ({ id, data, selected, ...props }) => {
           />
         </ButtonGroup>
       </NodeToolbar>
-      {selected && <NodeResizer isVisible={true} minWidth={180} minHeight={100} />}
+      {selected && (
+        <NodeResizer
+          isVisible={true}
+          minWidth={180}
+          minHeight={100}
+          handleStyle={{ width: '8px', height: '8px', backgroundColor: 'transparent', borderColor: 'gray' }}
+          lineStyle={{ borderWidth: 5, borderColor: 'transparent' }}
+        />
+      )}
 
       <Box
         id={`node-group-${id}`}
@@ -87,7 +95,7 @@ const NodeGroup: FC<NodeProps<Group>> = ({ id, data, selected, ...props }) => {
           backgroundColor: data.isOpen ? undefined : colors.red[50],
           // borderRadius: '100%',
           // opacity: 0.05,
-          // borderColor: 'red',
+          borderColor: colors.red[100],
           borderWidth: 3,
           borderStyle: 'solid',
         }}

--- a/hivemq-edge/src/frontend/src/modules/Workspace/hooks/useWorkspaceStore.spec.ts
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/hooks/useWorkspaceStore.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'vitest'
 import { act, renderHook } from '@testing-library/react'
-import { NodeAddChange, EdgeAddChange, Node, Edge } from 'reactflow'
+import { NodeAddChange, EdgeAddChange, Node, Edge, Rect } from 'reactflow'
 
 import { Group, IdStubs, NodeTypes, WorkspaceAction, WorkspaceState } from '../types.ts'
 import useWorkspaceStore from './useWorkspaceStore.ts'
@@ -82,10 +82,11 @@ describe('useWorkspaceStore', () => {
         position: { x: 0, y: 0 },
         data: { childrenNodeIds: ['idAdapter', 'idBridge'], title: 'my title', isOpen: true },
       }
+      const rect: Rect = { x: 0, y: 0, width: 250, height: 250 }
 
       const groupEdge: Edge = { id: '1-233', source: '1', target: IdStubs.EDGE_NODE }
 
-      onInsertGroupNode(group, groupEdge)
+      onInsertGroupNode(group, groupEdge, rect)
     })
 
     expect(result.current.nodes).toHaveLength(4)

--- a/hivemq-edge/src/frontend/src/modules/Workspace/hooks/useWorkspaceStore.ts
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/hooks/useWorkspaceStore.ts
@@ -8,7 +8,6 @@ import {
   addEdge,
   applyNodeChanges,
   applyEdgeChanges,
-  Edge,
 } from 'reactflow'
 import { Group, NodeTypes, WorkspaceState, WorkspaceAction } from '@/modules/Workspace/types.ts'
 import { persist, createJSONStorage } from 'zustand/middleware'
@@ -37,18 +36,17 @@ const useWorkspaceStore = create<WorkspaceState & WorkspaceAction>()(
           edges: applyEdgeChanges(changes, get().edges),
         })
       },
-      onInsertGroupNode: (parentNode: Node<Group, NodeTypes.CLUSTER_NODE>, edge: Edge) => {
+      onInsertGroupNode: (parentNode, edge, rect) => {
         const nodeIds = parentNode.data.childrenNodeIds
-        let pos = 0
+        // let pos = 0
         set({
           nodes: [
             parentNode,
             ...get().nodes.map((node) => {
               if (nodeIds.includes(node.id)) {
-                pos += 25
                 return {
                   ...node,
-                  position: { x: pos, y: pos },
+                  position: { x: node.position.x - rect.x, y: node.position.y - rect.y },
                   parentNode: parentNode.id,
                   expandParent: true,
                   selected: false,
@@ -61,24 +59,6 @@ const useWorkspaceStore = create<WorkspaceState & WorkspaceAction>()(
 
         set({
           edges: addEdge(edge, get().edges),
-        })
-      },
-      updateNodeParent: (nodeIds: string[], parentNode: string | undefined) => {
-        set({
-          nodes: get().nodes.map((node) => {
-            let pos = 0
-            if (nodeIds.includes(node.id)) {
-              pos += 10
-              // it's important to create a new object here, to inform React Flow about the changes
-              return {
-                ...node,
-                position: { x: pos, y: pos },
-                parentNode,
-                expandParent: true,
-              }
-            }
-            return node
-          }),
         })
       },
       onAddNodes: (changes: NodeAddChange[]) => {

--- a/hivemq-edge/src/frontend/src/modules/Workspace/types.ts
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/types.ts
@@ -1,4 +1,4 @@
-import { Edge, Node, OnEdgesChange, OnNodesChange, NodeAddChange, EdgeAddChange } from 'reactflow'
+import { Edge, Node, OnEdgesChange, OnNodesChange, NodeAddChange, EdgeAddChange, Rect } from 'reactflow'
 
 export interface EdgeFlowOptions {
   showTopics: boolean
@@ -62,7 +62,7 @@ export interface WorkspaceAction {
   onEdgesChange: OnEdgesChange
   onAddNodes: (changes: NodeAddChange[]) => void
   onAddEdges: (changes: EdgeAddChange[]) => void
-  onInsertGroupNode: (node: Node<Group, NodeTypes.CLUSTER_NODE>, edge: Edge) => void
+  onInsertGroupNode: (node: Node<Group, NodeTypes.CLUSTER_NODE>, edge: Edge, rect: Rect) => void
   onDeleteNode: (type: NodeTypes, adapterId: string) => void
   onToggleGroup: (node: Pick<Node<Group, NodeTypes.CLUSTER_NODE>, 'id' | 'data'>, show: boolean) => void
 }

--- a/hivemq-edge/src/frontend/src/modules/Workspace/utils/group.utils.spec.ts
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/utils/group.utils.spec.ts
@@ -1,0 +1,17 @@
+import { expect } from 'vitest'
+import { getGroupLayout } from './group.utils.ts'
+import { Rect } from 'reactflow'
+import { MOCK_NODE_ADAPTER } from '@/__test-utils__/react-flow/nodes.ts'
+
+describe('getGroupLayout', () => {
+  it('should return the layout characteristics of a group', async () => {
+    expect(
+      getGroupLayout([{ ...MOCK_NODE_ADAPTER, position: { x: 0, y: 0 }, width: 50, height: 100 }])
+    ).toStrictEqual<Rect>({
+      height: 164,
+      width: 90,
+      x: -20,
+      y: -44,
+    })
+  })
+})

--- a/hivemq-edge/src/frontend/src/modules/Workspace/utils/group.utils.ts
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/utils/group.utils.ts
@@ -1,0 +1,15 @@
+import { getRectOfNodes, Node, Rect } from 'reactflow'
+
+const GROUP_MARGIN = 20
+const GROUP_TITLE_MARGIN = 24
+
+export const getGroupLayout = (nodes: Node[]): Rect => {
+  const rect = getRectOfNodes(nodes.filter((e) => e !== undefined))
+
+  return {
+    x: rect.x - GROUP_MARGIN,
+    y: rect.y - GROUP_MARGIN - GROUP_TITLE_MARGIN,
+    width: rect.width + 2 * GROUP_MARGIN,
+    height: rect.height + 2 * GROUP_MARGIN + GROUP_TITLE_MARGIN,
+  }
+}


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/18204/details/

This PR improves the computation of the initial location of a group and, at its deletion, of its nodes.

The changes guarantee that, when a group is created, the selected nodes remain at the same visual position on the canvas. Similarly, when the nodes are ungrouped, their visual positions remain the same on the canvas. when the group is deleted. 

The new implementation ensures that repetitive grouping and ungrouping don't introduce any "drift" on the visual canvas.

The PR also fixes two visual aspects of nodes on the graph:
- the "edge handles" (used to connect nodes by an edge) are now properly "not manually connectable" and prevent the rendering of a "preview" of an edge when clicking and dragging
- the rendering of a "resizable" group has been improved (bigger resize handles, wider grabbing area on the borders)

### Before 
![screenshot-localhost_3000-2023 12 11-09_11_49](https://github.com/hivemq/hivemq-edge/assets/2743481/5e67937f-a0b7-4ee9-908d-9b521c8deb2d)

### After
![screenshot-localhost_3000-2023 12 11-09_11_19](https://github.com/hivemq/hivemq-edge/assets/2743481/12f3e42f-4f4f-45c9-9568-a53ef71eeabb)
