### PR TITLE
fix(18218): Fix the availability of the "remove metrics" button for Stats

### DIFF
--- a/hivemq-edge/src/frontend/src/modules/Metrics/Metrics.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Metrics/Metrics.tsx
@@ -93,6 +93,7 @@ const Metrics: FC<MetricsProps> = ({ nodeId, adapterIDs, initMetrics, defaultCha
                   key={e.selectedTopic}
                   metricName={e.selectedTopic}
                   onClose={() => handleRemoveMetrics(e.selectedTopic)}
+                  canEdit={isOpen}
                 />
               )
             else

--- a/hivemq-edge/src/frontend/src/modules/Metrics/components/container/ChartContainer.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Metrics/components/container/ChartContainer.spec.cy.tsx
@@ -33,4 +33,18 @@ describe('ChartContainer', () => {
     //
     // cy.getByTestId('metrics-copy').click()
   })
+
+  it('should not allow editing', () => {
+    const onClose = cy.stub().as('onClose')
+    cy.mountWithProviders(
+      <ChartContainer
+        chartType={ChartType.LINE_CHART}
+        onClose={onClose}
+        metricName={MOCK_METRICS[0].name}
+        canEdit={false}
+      />
+    )
+
+    cy.getByTestId('metrics-remove').should('not.exist')
+  })
 })

--- a/hivemq-edge/src/frontend/src/modules/Metrics/components/container/Sample.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Metrics/components/container/Sample.spec.cy.tsx
@@ -11,7 +11,7 @@ describe('Sample', () => {
 
   it('should render the bridge component', () => {
     const onClose = cy.stub().as('onClose')
-    cy.mountWithProviders(<Sample metricName={MOCK_METRICS[0].name} onClose={onClose} />)
+    cy.mountWithProviders(<Sample metricName={MOCK_METRICS[0].name} onClose={onClose} canEdit={true} />)
 
     cy.get('dd').should('contain.text', '50,000')
 
@@ -19,5 +19,11 @@ describe('Sample', () => {
     cy.get('@onClose').should('have.been.calledOnce')
 
     cy.getByTestId('metrics-copy').click()
+  })
+
+  it('should not allow editing', () => {
+    cy.mountWithProviders(<Sample metricName={MOCK_METRICS[0].name} onClose={cy.stub()} canEdit={false} />)
+
+    cy.getByTestId('metrics-remove').should('not.exist')
   })
 })

--- a/hivemq-edge/src/frontend/src/modules/Metrics/components/container/Sample.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Metrics/components/container/Sample.tsx
@@ -12,11 +12,12 @@ import SampleRenderer from '../charts/SampleRenderer.tsx'
 interface SampleProps {
   metricName?: string
   onClose?: () => void
+  canEdit?: boolean
 }
 
 const MAX_SERIES = 10
 
-const Sample: FC<SampleProps> = ({ metricName, onClose }) => {
+const Sample: FC<SampleProps> = ({ metricName, onClose, canEdit = true }) => {
   const { t } = useTranslation()
   const { data, isLoading, error } = useGetSample(metricName)
   const [series, setSeries] = useState<DataPoint[]>([])
@@ -47,14 +48,16 @@ const Sample: FC<SampleProps> = ({ metricName, onClose }) => {
       {...(isMajor ? { gridColumn: '1 / span 2' } : {})}
     >
       <VStack ml={1}>
-        <Box flex={1}>
-          <CloseButton
-            data-testid="metrics-remove"
-            aria-label={t('metrics.command.remove.ariaLabel') as string}
-            size={'sm'}
-            onClick={onClose}
-          />
-        </Box>
+        {canEdit && (
+          <Box flex={1}>
+            <CloseButton
+              data-testid="metrics-remove"
+              aria-label={t('metrics.command.remove.ariaLabel') as string}
+              size={'sm'}
+              onClick={onClose}
+            />
+          </Box>
+        )}
         <Box>
           <ClipboardCopyIconButton content={metricName} />
         </Box>


### PR DESCRIPTION
fix(18218): Fix the availability of the "remove metrics" button for Stats

See https://hivemq.kanbanize.com/ctrl_board/57/cards/18218/details/

This PR fixes a small oversight: a `Stat` chart (the simple value and increase/decrease indicators) could still be removed from a panel even if the editor was "collapsed".

This was a breach of the design pattern applied to the other charts. Charts cannot be edited or removed from the panel unless the editor is "expanded" and ready for usage.

### Before
![screenshot-localhost_3000-2023 12 11-09_18_55](https://github.com/hivemq/hivemq-edge/assets/2743481/f4f39124-0f3d-4edf-9e16-817d08bb9026)

### After 
![screenshot-localhost_3000-2023 12 11-09_18_11](https://github.com/hivemq/hivemq-edge/assets/2743481/2d22c40b-50fe-405c-b500-14d30b693ac0)
