### PR TITLE
fix(18216): Fix the propagation of status to a collapsed group's edge

### DIFF
--- a/hivemq-edge/src/frontend/src/modules/Workspace/utils/status-utils.spec.ts
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/utils/status-utils.spec.ts
@@ -167,6 +167,11 @@ interface StatusStyleSuite {
 describe('getEdgeStatus', () => {
   const color = MOCK_THEME.colors.status.connected[500]
   const edge: EdgeStyle = {}
+
+  edge.data = {
+    hasTopics: true,
+    isConnected: true,
+  }
   edge.style = {
     strokeWidth: 0.5,
     stroke: color,
@@ -196,6 +201,10 @@ describe('getEdgeStatus', () => {
       hasTopics: true,
       expected: {
         ...edge,
+        data: {
+          hasTopics: true,
+          isConnected: false,
+        },
         animated: false,
       },
     },
@@ -204,6 +213,10 @@ describe('getEdgeStatus', () => {
       hasTopics: false,
       expected: {
         ...edge,
+        data: {
+          hasTopics: false,
+          isConnected: true,
+        },
         animated: false,
         style: {
           ...edge.style,
@@ -216,6 +229,10 @@ describe('getEdgeStatus', () => {
       hasTopics: false,
       expected: {
         ...edge,
+        data: {
+          hasTopics: false,
+          isConnected: false,
+        },
         animated: false,
       },
     },


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/18216/details/

This PR fixes the computation of the summarised status as displayed on the single edge when the group is collapsed 

In an "expanded" view, each one of the grouped nodes still shows its own edge to the `Edge` node. When collapsed, the group node summarises all the edges into a single one connecting it to the `Edge`. 


Its status is based on the union of all the included nodes:
- if one of the nodes is `STOPPED` then the group's status will be `STOPPED`
- if one of the nodes is `DISCONNECTED` then the group's status will be `DISCONNECTED`
- if one of the nodes has no topic, then the group's edge will be shown as `DATA NOT FLOWING`

The purpose is to convey a summary of the group of nodes by singling out the `DISCONNECTED` and `NOT FLOWING` aspects of the group.

### Before
![screenshot-localhost_3000-2023 12 11-09_25_53](https://github.com/hivemq/hivemq-edge/assets/2743481/8fec6380-c12c-4ab9-bd7b-0dc238254362)

### After
![screenshot-localhost_3000-2023 12 11-09_25_26](https://github.com/hivemq/hivemq-edge/assets/2743481/13c0ecf4-4bd0-44c9-ae91-7c8f19ac1be6)
