### PR TITLE
fix(18246): fix focus/selected status of nodes in workspace

### DIFF
--- a/hivemq-edge/src/frontend/package.json
+++ b/hivemq-edge/src/frontend/package.json
@@ -9,7 +9,7 @@
     "lint:eslint": "eslint src --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "lint:prettier": "prettier --check .",
     "lint:prettier:write": "prettier --write .",
-    "lint:stylelint": "stylelint '{src}/**/*.{css}'",
+    "lint:stylelint": "stylelint './src/**/*.css'",
     "lint:all": "eslint src --ext ts,tsx --report-unused-disable-directives --max-warnings 0 && prettier --check .",
     "dev:openAPI": "openapi --input '../../../../hivemq-edge/ext/hivemq-edge-openapi-2023.8.yaml' -o ./src/api/__generated__ -c axios --name HiveMqClient --exportSchemas true",
     "cypress:open": "cypress open",

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/ReactFlowWrapper.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/ReactFlowWrapper.tsx
@@ -5,6 +5,7 @@ import { Outlet } from 'react-router-dom'
 import { Box } from '@chakra-ui/react'
 
 import 'reactflow/dist/style.css'
+import './reactflow-chakra.fix.css'
 
 import { EdgeTypes, NodeTypes } from '../types.ts'
 import useGetFlowElements from '../hooks/useGetFlowElements.tsx'

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/parts/NodeWrapper.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/parts/NodeWrapper.tsx
@@ -10,26 +10,17 @@ const NodeWrapper: FC<NodeWrapperProps> = ({ children, isSelected = false, ...re
 
   const selectedStyle: Partial<BoxProps> = {
     boxShadow: 'dark-lg',
-    rounded: 'md',
     bg: '#dddfe2',
   }
 
   return (
     <VStack
-      p={'24px'}
+      p={6}
+      rounded={'md'}
       borderColor={'#bec3c9'}
       backgroundColor={colors.white}
-      border={'1px'}
+      border={`1px`}
       _hover={{ bg: '#ebedf0' }}
-      _active={{
-        border: '2px',
-        bg: '#dddfe2',
-        transform: 'scale(0.98)',
-        borderColor: '#bec3c9',
-      }}
-      _focus={{
-        boxShadow: '0 0 10px 2px rgba(88, 144, 255, .75), 0 1px 1px rgba(0, 0, 0, .15)',
-      }}
       {...(isSelected ? { ...selectedStyle } : {})}
       {...rest}
     >

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/reactflow-chakra.fix.css
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/reactflow-chakra.fix.css
@@ -2,5 +2,5 @@
 
 /* .react-flow__node.selectable:focus, */
 .react-flow__node.selectable:focus-visible {
-    box-shadow: 0 0 10px 2px rgb(88 144 255 / 75%), 0 1px 1px rgb(0 0 0 / 15%);
+  box-shadow: 0 0 10px 2px rgb(88 144 255 / 75%), 0 1px 1px rgb(0 0 0 / 15%);
 }

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/reactflow-chakra.fix.css
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/reactflow-chakra.fix.css
@@ -1,0 +1,6 @@
+/* stylelint-disable selector-class-pattern */
+
+/* .react-flow__node.selectable:focus, */
+.react-flow__node.selectable:focus-visible {
+    box-shadow: 0 0 10px 2px rgb(88 144 255 / 75%), 0 1px 1px rgb(0 0 0 / 15%);
+}


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/18246/details/

This PR fixes a long-standing accessibility issue with the custom nodes in the graph. 

Their `selected` and `focus-visible` statuses are now properly materialised by the similar blue shadow box used for all the other widgets in the UI.

In the graph, it means that nodes (`HiveMQ Edge`, `Adapter`, `Bridge` and `Group`) and the edge's observability button are now properly rendered and responding to keyboard navigation.

### Out-of-scope
- the side panel for the interactive elements is still based on a double-click, which is not keyboard-friendly. It will be fixed in a separate PR.

### Before 
![screenshot-localhost_3000-2023 12 11-11_13_35](https://github.com/hivemq/hivemq-edge/assets/2743481/8ebea83f-55b2-4294-9615-353ab4f10b81)

### After
![screenshot-localhost_3000-2023 12 11-11_12_57](https://github.com/hivemq/hivemq-edge/assets/2743481/bf44120a-fe09-4d8a-97e4-bdde956d7c2b)
