### PR TITLE
feat(17823): Add form field for the limit of persisted queue message

### DIFF
--- a/hivemq-edge/src/frontend/package.json
+++ b/hivemq-edge/src/frontend/package.json
@@ -11,7 +11,7 @@
     "lint:prettier:write": "prettier --write .",
     "lint:stylelint": "stylelint '{src}/**/*.{css}'",
     "lint:all": "eslint src --ext ts,tsx --report-unused-disable-directives --max-warnings 0 && prettier --check .",
-    "dev:openAPI": "openapi --input '../../../../hivemq-edge/ext/hivemq-edge-openapi-2023.8.yaml' -o ./src/api/__generated__ -c axios --name HiveMqClient --exportSchemas true",
+    "dev:openAPI": "openapi --input '../../../../hivemq-edge/ext/hivemq-edge-openapi-2023.10.yaml' -o ./src/api/__generated__ -c axios --name HiveMqClient --exportSchemas true",
     "cypress:open": "cypress open",
     "cypress:open:component": "cypress open --component --browser chrome",
     "cypress:open:e2e": "cypress open --e2e --browser chrome",

--- a/hivemq-edge/src/frontend/src/api/__generated__/models/LocalBridgeSubscription.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/models/LocalBridgeSubscription.ts
@@ -33,6 +33,10 @@ export type LocalBridgeSubscription = {
      * The preserveRetain for this subscription
      */
     preserveRetain?: boolean;
+    /**
+     * The limit of this bridge for QoS-1 and QoS-2 messages.
+     */
+    queueLimit?: number | null;
 };
 
 export namespace LocalBridgeSubscription {

--- a/hivemq-edge/src/frontend/src/api/__generated__/schemas/$LocalBridgeSubscription.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/schemas/$LocalBridgeSubscription.ts
@@ -41,5 +41,11 @@ export const $LocalBridgeSubscription = {
             type: 'boolean',
             description: `The preserveRetain for this subscription`,
         },
+        queueLimit: {
+            type: 'number',
+            description: `The limit of this bridge for QoS-1 and QoS-2 messages.`,
+            isNullable: true,
+            format: 'int64',
+        },
     },
 } as const;

--- a/hivemq-edge/src/frontend/src/locales/en/translation.json
+++ b/hivemq-edge/src/frontend/src/locales/en/translation.json
@@ -204,9 +204,9 @@
         "label": "Max QoS",
         "helper": "Maximum Quality of Service",
         "values": {
-          "0": "At most once",
-          "1": "At least once",
-          "2": "Exactly once"
+          "0": "0 - At most once",
+          "1": "1 - At least once",
+          "2": "2 - Exactly once"
         }
       },
       "queueLimit": {

--- a/hivemq-edge/src/frontend/src/locales/en/translation.json
+++ b/hivemq-edge/src/frontend/src/locales/en/translation.json
@@ -209,6 +209,10 @@
           "2": "Exactly once"
         }
       },
+      "queueLimit": {
+        "label": "Message Queue Limit",
+        "helper": "The maximum number of messages persisted for QoS-1 and QoS-2."
+      },
       "preserveRetain": {
         "label": "Preserve Retain",
         "helper": "Description of the Preserve Retain"

--- a/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/SubscriptionsPanel.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/SubscriptionsPanel.spec.cy.tsx
@@ -40,9 +40,9 @@ describe('SubscriptionsPanel', () => {
   beforeEach(() => {
     cy.viewport(800, 800)
 
-    cy.intercept('/api/v1/management/protocol-adapters/types', { items: [] }).as('getConfig1')
-    cy.intercept('/api/v1/management/protocol-adapters/adapters', { items: [] }).as('getConfig2')
-    cy.intercept('/api/v1/management/bridges', { items: [] }).as('getConfig3')
+    cy.intercept('/api/v1/management/protocol-adapters/types', { items: [] })
+    cy.intercept('/api/v1/management/protocol-adapters/adapters', { items: [] })
+    cy.intercept('/api/v1/management/bridges', { items: [] })
   })
 
   it('should be accessible', () => {
@@ -78,7 +78,7 @@ describe('SubscriptionsPanel', () => {
 
   describe('mqtt-persistence capability', () => {
     it('should render properly the persist options', () => {
-      cy.intercept('/api/v1/frontend/capabilities', MOCK_CAPABILITIES).as('getCapabilities')
+      cy.intercept('/api/v1/frontend/capabilities', MOCK_CAPABILITIES)
       cy.mountWithProviders(
         <TestingComponent
           onSubmit={cy.stub}
@@ -94,7 +94,7 @@ describe('SubscriptionsPanel', () => {
     })
 
     it('should disable the persist options if the flag is not activated', () => {
-      cy.intercept('/api/v1/frontend/capabilities', MOCK_CAPABILITIES).as('getCapabilities')
+      cy.intercept('/api/v1/frontend/capabilities', MOCK_CAPABILITIES)
       cy.mountWithProviders(
         <TestingComponent
           onSubmit={cy.stub}
@@ -110,7 +110,7 @@ describe('SubscriptionsPanel', () => {
     })
 
     it('should not render the persist options if mqtt-persistence is not in the capabilities', () => {
-      cy.intercept('/api/v1/frontend/capabilities', { items: [] }).as('getCapabilities')
+      cy.intercept('/api/v1/frontend/capabilities', { items: [] })
       cy.mountWithProviders(
         <TestingComponent
           onSubmit={cy.stub}

--- a/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/SubscriptionsPanel.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/SubscriptionsPanel.spec.cy.tsx
@@ -8,15 +8,17 @@ import ButtonCTA from '@/components/Chakra/ButtonCTA.tsx'
 
 import SubscriptionsPanel from './SubscriptionsPanel.tsx'
 import { SubscriptionType } from '@/modules/Bridges/types.ts'
+import { MOCK_CAPABILITIES } from '@/api/hooks/useFrontendServices/__handlers__'
 
 interface TestingComponentProps {
   onSubmit: (data: Bridge) => void
   defaultValues: Bridge
+  type?: SubscriptionType
 }
 
 const MOCK_TYPE: SubscriptionType = 'remoteSubscriptions'
 
-const TestingComponent: FC<TestingComponentProps> = ({ onSubmit, defaultValues }) => {
+const TestingComponent: FC<TestingComponentProps> = ({ onSubmit, defaultValues, type = MOCK_TYPE }) => {
   const form = useForm<Bridge>({
     mode: 'all',
     criteriaMode: 'all',
@@ -25,7 +27,7 @@ const TestingComponent: FC<TestingComponentProps> = ({ onSubmit, defaultValues }
   return (
     <div>
       <form id="bridge-form" onSubmit={form.handleSubmit(onSubmit)}>
-        <SubscriptionsPanel form={form} type={MOCK_TYPE} />
+        <SubscriptionsPanel form={form} type={type} />
       </form>
       <ButtonCTA type={'submit'} form="bridge-form" data-testid={'form-submit'} mt={8}>
         Submit
@@ -68,9 +70,57 @@ describe('SubscriptionsPanel', () => {
 
     cy.getByTestId(`${MOCK_TYPE}.0.filters`).should('be.visible').find('label').should('not.have.attr', 'data-invalid')
 
-    cy.get('input[id="remoteSubscriptions.0.filters"').type('my topic{Enter}')
+    cy.get('input[id="remoteSubscriptions.0.filters"]').type('my topic{Enter}')
     // force validation to trigger error messages. Better alternative?
     cy.getByTestId(`form-submit`).click()
     cy.getByTestId(`${MOCK_TYPE}.0.destination`).should('be.visible').find('label').should('have.attr', 'data-invalid')
+  })
+
+  describe('mqtt-persistence capability', () => {
+    it('should render properly the persist options', () => {
+      cy.intercept('/api/v1/frontend/capabilities', MOCK_CAPABILITIES).as('getCapabilities')
+      cy.mountWithProviders(
+        <TestingComponent
+          onSubmit={cy.stub}
+          defaultValues={{ ...mockBridge, persist: true }}
+          type={'localSubscriptions'}
+        />
+      )
+
+      cy.getByTestId('localSubscriptions.0.advanced').click()
+      cy.getByTestId('localSubscriptions.0.queueLimit').find('input').should('be.disabled')
+      cy.getByTestId('localSubscriptions.0.maxQoS.options').find('label').eq(2).click()
+      cy.getByTestId('localSubscriptions.0.queueLimit').find('input').should('not.be.disabled')
+    })
+
+    it('should disable the persist options if the flag is not activated', () => {
+      cy.intercept('/api/v1/frontend/capabilities', MOCK_CAPABILITIES).as('getCapabilities')
+      cy.mountWithProviders(
+        <TestingComponent
+          onSubmit={cy.stub}
+          defaultValues={{ ...mockBridge, persist: false }}
+          type={'localSubscriptions'}
+        />
+      )
+
+      cy.getByTestId('localSubscriptions.0.advanced').click()
+      cy.getByTestId('localSubscriptions.0.queueLimit').find('input').should('be.disabled')
+      cy.getByTestId('localSubscriptions.0.maxQoS.options').find('label').eq(2).click()
+      cy.getByTestId('localSubscriptions.0.queueLimit').find('input').should('be.disabled')
+    })
+
+    it('should not render the persist options if mqtt-persistence is not in the capabilities', () => {
+      cy.intercept('/api/v1/frontend/capabilities', { items: [] }).as('getCapabilities')
+      cy.mountWithProviders(
+        <TestingComponent
+          onSubmit={cy.stub}
+          defaultValues={{ ...mockBridge, persist: false }}
+          type={'localSubscriptions'}
+        />
+      )
+
+      cy.getByTestId('localSubscriptions.0.advanced').click()
+      cy.getByTestId('localSubscriptions.0.queueLimit').should('not.exist')
+    })
   })
 })

--- a/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/SubscriptionsPanel.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/SubscriptionsPanel.tsx
@@ -187,7 +187,7 @@ const SubscriptionsPanel: FC<BridgeSubscriptionsProps> = ({ form, type }) => {
                       {hasPersistence && type === 'localSubscriptions' && (
                         <FormControl isDisabled={!isPersistEnabled || !isQoSValidForPersistence}>
                           <FormLabel htmlFor="queueLimit">{t('bridge.subscription.queueLimit.label')}</FormLabel>
-                          <NumberInput id="queueLimit" min={100}>
+                          <NumberInput id="queueLimit" min={0}>
                             <NumberInputField
                               {...register(`${type}.${index}.queueLimit`, {
                                 ...getRulesForProperty($LocalBridgeSubscription.properties.queueLimit),

--- a/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/SubscriptionsPanel.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/SubscriptionsPanel.tsx
@@ -25,11 +25,17 @@ import {
   RadioGroup,
   Radio,
   Switch,
+  NumberInput,
+  NumberInputField,
+  NumberInputStepper,
+  NumberIncrementStepper,
+  NumberDecrementStepper,
 } from '@chakra-ui/react'
 import { AddIcon, DeleteIcon } from '@chakra-ui/icons'
 
-import { $BridgeSubscription } from '@/api/__generated__'
+import { $BridgeSubscription, $LocalBridgeSubscription } from '@/api/__generated__'
 import { useValidationRules } from '@/api/hooks/useValidationRules/useValidationRules.ts'
+import { useGetCapability } from '@/api/hooks/useFrontendServices/useGetCapability.tsx'
 import { MultiTopicsCreatableSelect } from '@/components/MQTT/TopicCreatableSelect.tsx'
 
 import CustomUserProperties from './CustomUserProperties.tsx'
@@ -42,6 +48,8 @@ const SubscriptionsPanel: FC<BridgeSubscriptionsProps> = ({ form, type }) => {
     name: type, // unique name for your Field Array
   })
   const getRulesForProperty = useValidationRules()
+  const hasPersistence = useGetCapability('mqtt-persistence')
+  const isPersistEnabled = form.watch('persist')
 
   const {
     register,
@@ -52,6 +60,8 @@ const SubscriptionsPanel: FC<BridgeSubscriptionsProps> = ({ form, type }) => {
     <>
       <VStack spacing={4} align="stretch" mt={4}>
         {fields.map((field, index) => {
+          const maxQoS = form.watch(`${type}.${index}.maxQoS`)
+          const isQoSValidForPersistence = maxQoS.toString() === '1' || maxQoS.toString() == '2'
           return (
             <Card shadow="xs" flexDirection={'column'} key={field.id}>
               <HStack>
@@ -151,7 +161,7 @@ const SubscriptionsPanel: FC<BridgeSubscriptionsProps> = ({ form, type }) => {
                       </Box>
                     </AccordionButton>
 
-                    <AccordionPanel m={1}>
+                    <AccordionPanel m={1} as={VStack} gap={4}>
                       <FormControl>
                         <FormLabel htmlFor={`${type}.${index}.maxQoS`} data-testid={`${type}.${index}.maxQoS`}>
                           {t('bridge.subscription.maxQoS.label')}
@@ -173,6 +183,24 @@ const SubscriptionsPanel: FC<BridgeSubscriptionsProps> = ({ form, type }) => {
                           }}
                         />
                       </FormControl>
+
+                      {hasPersistence && type === 'localSubscriptions' && (
+                        <FormControl isDisabled={!isPersistEnabled || !isQoSValidForPersistence}>
+                          <FormLabel htmlFor="queueLimit">{t('bridge.subscription.queueLimit.label')}</FormLabel>
+                          <NumberInput id="queueLimit" min={100}>
+                            <NumberInputField
+                              {...register(`${type}.${index}.queueLimit`, {
+                                ...getRulesForProperty($LocalBridgeSubscription.properties.queueLimit),
+                              })}
+                            />
+                            <NumberInputStepper>
+                              <NumberIncrementStepper />
+                              <NumberDecrementStepper />
+                            </NumberInputStepper>
+                          </NumberInput>
+                          <FormHelperText> {t('bridge.subscription.queueLimit.helper')}</FormHelperText>
+                        </FormControl>
+                      )}
 
                       {type === 'localSubscriptions' && (
                         <FormControl>

--- a/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/SubscriptionsPanel.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/SubscriptionsPanel.tsx
@@ -170,7 +170,12 @@ const SubscriptionsPanel: FC<BridgeSubscriptionsProps> = ({ form, type }) => {
                           name={`${type}.${index}.maxQoS`}
                           control={form.control}
                           render={({ field: { value, ...rest } }) => (
-                            <RadioGroup {...rest} value={value.toString()} id={`${type}.${index}.maxQoS`}>
+                            <RadioGroup
+                              {...rest}
+                              value={value.toString()}
+                              id={`${type}.${index}.maxQoS`}
+                              data-testid={`${type}.${index}.maxQoS.options`}
+                            >
                               <Stack direction="row">
                                 <Radio value="0">{t('bridge.subscription.maxQoS.values.0')}</Radio>
                                 <Radio value="1">{t('bridge.subscription.maxQoS.values.1')}</Radio>
@@ -185,7 +190,10 @@ const SubscriptionsPanel: FC<BridgeSubscriptionsProps> = ({ form, type }) => {
                       </FormControl>
 
                       {hasPersistence && type === 'localSubscriptions' && (
-                        <FormControl isDisabled={!isPersistEnabled || !isQoSValidForPersistence}>
+                        <FormControl
+                          isDisabled={!isPersistEnabled || !isQoSValidForPersistence}
+                          data-testid={`${type}.${index}.queueLimit`}
+                        >
                           <FormLabel htmlFor="queueLimit">{t('bridge.subscription.queueLimit.label')}</FormLabel>
                           <NumberInput id="queueLimit" min={0}>
                             <NumberInputField


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/17823/details/

This PR adds a new "queue limit" field to the local subscription form. 

It is part of the persistence feature and the field has conditions:
- if `mqtt-persistence` is not part of the Edge capabilities, the field is no shown
- if the `persist` flag is not turned on, the field is disabled
- if the `maxQoS` for the subscription is set at 0, the field is disabled 

### Out-of-scope
- The range of valid numbers for the limit is undefined. Users could set any number from 10s to millions of messages. With no default, the initial value will be treated at 0. Using the UI "helpers" for number fields (spinners and mouse wheel) cannot deliver supportive behaviour unless an appropriate "step" is defined (e.g. increment by 1000s). The default increment is 1.

### Before
![screenshot-localhost_3000-2023 12 12-13_27_55](https://github.com/hivemq/hivemq-edge/assets/2743481/d07983d0-7667-4446-9b87-e2e53ed4ad90)

### After 
![screenshot-localhost_3000-2023 12 12-13_26_36](https://github.com/hivemq/hivemq-edge/assets/2743481/e876b526-f7c5-4e41-a2b6-c0eb24d96c49)

![screenshot-localhost_3000-2023 12 12-13_29_42](https://github.com/hivemq/hivemq-edge/assets/2743481/341703e4-dbb6-4ffa-88b1-a5db25c82f1c)

