### PR TITLE
fix(18293): Change mouse and keyboard interactions with nodes

### DIFF
--- a/hivemq-edge/src/frontend/src/locales/en/translation.json
+++ b/hivemq-edge/src/frontend/src/locales/en/translation.json
@@ -612,6 +612,7 @@
         "description": "Are you sure you want to delete this group? The adapters inside the group will revert to their original state."
       },
       "command": {
+        "overview": "Open the overview panel",
         "expand": "Expand group",
         "collapse": "Collapse group",
         "ungroup": "Ungroup"

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/edges/MonitoringEdge.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/edges/MonitoringEdge.tsx
@@ -54,7 +54,7 @@ const MonitoringEdge: FC<EdgeProps> = ({
               icon={<BiBarChartSquare />}
               backgroundColor={'white'}
               color={style?.stroke}
-              onDoubleClick={() => navigate(`/edge-flow/link/${id}`)}
+              onClick={() => navigate(`/edge-flow/link/${id}`)}
               borderRadius={25}
             />
           </div>

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeAdapter.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeAdapter.tsx
@@ -1,7 +1,6 @@
 import { FC, useMemo } from 'react'
 import { Handle, NodeProps, Position } from 'reactflow'
 import { Box, HStack, Image, Text, VStack } from '@chakra-ui/react'
-import { useNavigate } from 'react-router-dom'
 
 import { Adapter } from '@/api/__generated__'
 import { useGetAdapterTypes } from '@/api/hooks/useProtocolAdapters/useGetAdapterTypes.tsx'
@@ -12,24 +11,26 @@ import TopicsContainer from '../parts/TopicsContainer.tsx'
 import { discoverAdapterTopics } from '../../utils/topics-utils.ts'
 import { CONFIG_ADAPTER_WIDTH } from '../../utils/nodes-utils.ts'
 import { useEdgeFlowContext } from '../../hooks/useEdgeFlowContext.tsx'
+import { useContextMenu } from '../../hooks/useContextMenu.tsx'
 import { TopicFilter } from '../../types.ts'
 
 const NodeAdapter: FC<NodeProps<Adapter>> = ({ id, data: adapter, selected }) => {
   const { data: protocols } = useGetAdapterTypes()
   const adapterProtocol = protocols?.items?.find((e) => e.id === adapter.type)
   const { options } = useEdgeFlowContext()
-  const navigate = useNavigate()
   const topics = useMemo<TopicFilter[]>(() => {
     if (!adapterProtocol) return []
     if (!adapter.config) return []
     return discoverAdapterTopics(adapterProtocol, adapter.config).map((e) => ({ topic: e }))
   }, [adapter.config, adapterProtocol])
+  const { onContextMenu } = useContextMenu(id, selected, '/edge-flow/node')
 
   return (
     <>
       <NodeWrapper
         isSelected={selected}
-        onDoubleClick={() => navigate(`/edge-flow/node/${id}`)}
+        onDoubleClick={onContextMenu}
+        onContextMenu={onContextMenu}
         w={CONFIG_ADAPTER_WIDTH}
         p={2}
       >

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeBridge.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeBridge.tsx
@@ -2,7 +2,6 @@ import { FC } from 'react'
 import { Handle, Position, NodeProps } from 'reactflow'
 import { Box, HStack, Image, Text, VStack } from '@chakra-ui/react'
 import { useTranslation } from 'react-i18next'
-import { useNavigate } from 'react-router-dom'
 
 import { Bridge } from '@/api/__generated__'
 import { ConnectionStatusBadge } from '@/components/ConnectionStatusBadge'
@@ -12,16 +11,17 @@ import NodeWrapper from '../parts/NodeWrapper.tsx'
 import TopicsContainer from '../parts/TopicsContainer.tsx'
 import { getBridgeTopics } from '../../utils/topics-utils.ts'
 import { useEdgeFlowContext } from '../../hooks/useEdgeFlowContext.tsx'
+import { useContextMenu } from '../../hooks/useContextMenu.tsx'
 
 const NodeBridge: FC<NodeProps<Bridge>> = ({ id, selected, data: bridge }) => {
   const { t } = useTranslation()
   const topics = getBridgeTopics(bridge)
   const { options } = useEdgeFlowContext()
-  const navigate = useNavigate()
+  const { onContextMenu } = useContextMenu(id, selected, '/edge-flow/node')
 
   return (
     <>
-      <NodeWrapper isSelected={selected} onDoubleClick={() => navigate(`/edge-flow/node/${id}`)} p={3}>
+      <NodeWrapper isSelected={selected} onDoubleClick={onContextMenu} onContextMenu={onContextMenu} p={3}>
         <VStack>
           {options.showTopics && <TopicsContainer topics={topics.remote} />}
 

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeGroup.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeGroup.spec.cy.tsx
@@ -22,6 +22,11 @@ describe('NodeGroup', () => {
 
     cy.get("[role='button']").should('contain.text', 'The group title')
     cy.get("[role='button']").click({ force: true })
+
+    cy.getByTestId('node-group-toolbar-panel')
+      .should('exist')
+      .should('have.attr', 'aria-label', 'Open the overview panel')
+
     cy.getByTestId('node-group-toolbar-expand').should('exist').should('have.text', 'Collapse group')
 
     cy.getByTestId('node-group-toolbar-expand').click()

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeGroup.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeGroup.tsx
@@ -10,21 +10,21 @@ import {
   NodeResetChange,
   EdgeRemoveChange,
 } from 'reactflow'
-import { useNavigate } from 'react-router-dom'
 import { Box, Button, ButtonGroup, Icon, IconButton, Text, useDisclosure, useTheme } from '@chakra-ui/react'
-import { GrObjectUngroup } from 'react-icons/gr'
+import { GrDocumentConfig, GrObjectUngroup } from 'react-icons/gr'
 
 import ConfirmationDialog from '@/components/Modal/ConfirmationDialog.tsx'
 
 import { Group } from '../../types.ts'
 import useWorkspaceStore from '../../hooks/useWorkspaceStore.ts'
+import { useContextMenu } from '../../hooks/useContextMenu.tsx'
 
 const NodeGroup: FC<NodeProps<Group>> = ({ id, data, selected, ...props }) => {
   const { t } = useTranslation()
-  const navigate = useNavigate()
   const { colors } = useTheme()
   const { onToggleGroup, onNodesChange, onEdgesChange, nodes, edges } = useWorkspaceStore()
   const { isOpen: isConfirmUngroupOpen, onOpen: onConfirmUngroupOpen, onClose: onConfirmUngroupClose } = useDisclosure()
+  const { onContextMenu } = useContextMenu(id, selected, '/edge-flow/group')
 
   const onConfirmUngroup = () => {
     onConfirmUngroupOpen()
@@ -59,14 +59,23 @@ const NodeGroup: FC<NodeProps<Group>> = ({ id, data, selected, ...props }) => {
   console.log('XXXXXXX data', data)
   return (
     <>
-      <NodeToolbar isVisible={selected} position={Position.Top}>
-        <ButtonGroup
+      <NodeToolbar
+        isVisible={selected}
+        position={Position.Top}
+        role={'toolbar'}
+        aria-controls={`node-group-${id}`}
+        aria-label={t('workspace.grouping.toolbar.aria-label', { id }) as string}
+        style={{ display: 'flex', gap: '12px' }}
+      >
+        <IconButton
           size="sm"
-          isAttached
           variant="outline"
-          aria-controls={`node-group-${id}`}
-          aria-label={t('workspace.grouping.toolbar.aria-label', { id }) as string}
-        >
+          data-testid={'node-group-toolbar-panel'}
+          icon={<Icon as={GrDocumentConfig} />}
+          aria-label={t('workspace.grouping.command.overview')}
+          onClick={onContextMenu}
+        />
+        <ButtonGroup size="sm" isAttached variant="outline">
           <Button data-testid={'node-group-toolbar-expand'} onClick={handleToggle}>
             {!data.isOpen ? t('workspace.grouping.command.expand') : t('workspace.grouping.command.collapse')}
           </Button>
@@ -96,8 +105,8 @@ const NodeGroup: FC<NodeProps<Group>> = ({ id, data, selected, ...props }) => {
         borderColor={data.colorScheme ? colors[data.colorScheme][500] : colors.red[50]}
         borderWidth={1}
         borderStyle={'solid'}
-        onDoubleClick={() => navigate(`/edge-flow/group/${id}`)}
         onDoubleClick={onContextMenu}
+        onContextMenu={onContextMenu}
       >
         <Text m={2} color={'blackAlpha.900'}>
           {data.title}

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeGroup.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeGroup.tsx
@@ -97,6 +97,7 @@ const NodeGroup: FC<NodeProps<Group>> = ({ id, data, selected, ...props }) => {
         borderWidth={1}
         borderStyle={'solid'}
         onDoubleClick={() => navigate(`/edge-flow/group/${id}`)}
+        onDoubleClick={onContextMenu}
       >
         <Text m={2} color={'blackAlpha.900'}>
           {data.title}

--- a/hivemq-edge/src/frontend/src/modules/Workspace/hooks/useContextMenu.spec.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/hooks/useContextMenu.spec.tsx
@@ -1,0 +1,64 @@
+import { renderHook, act } from '@testing-library/react'
+import { describe, expect, vi } from 'vitest'
+import { MouseEvent, ReactElement } from 'react'
+import { MemoryRouter } from 'react-router-dom'
+
+import { useContextMenu } from './useContextMenu.tsx'
+
+const wrapper: React.JSXElementConstructor<{ children: ReactElement }> = ({ children }) => (
+  <MemoryRouter>{children}</MemoryRouter>
+)
+
+const mocks = vi.hoisted(() => {
+  return {
+    navigate: vi.fn(() => undefined),
+  }
+})
+
+describe('useContextMenu', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+
+    vi.mock('react-router-dom', async () => {
+      const actual = await vi.importActual<object>('react-router-dom')
+      return {
+        ...actual,
+        useNavigate() {
+          return mocks.navigate
+        },
+      }
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('should navigate to the proper route', () => {
+    const preventDefault = vi.fn()
+
+    const { result } = renderHook(() => useContextMenu('id', true, 'route'), { wrapper })
+
+    act(() => {
+      const mockEvent = { preventDefault: preventDefault } as unknown as MouseEvent<HTMLElement>
+      result.current.onContextMenu(mockEvent)
+    })
+
+    expect(preventDefault).toHaveBeenCalled()
+    expect(mocks.navigate).toHaveBeenCalledWith('route/id')
+  })
+
+  it('should not navigate if not selected', () => {
+    const preventDefault = vi.fn()
+
+    const { result } = renderHook(() => useContextMenu('id', false, 'route'), { wrapper })
+
+    act(() => {
+      const mockEvent = { preventDefault: preventDefault } as unknown as MouseEvent<HTMLElement>
+      result.current.onContextMenu(mockEvent)
+    })
+
+    expect(preventDefault).not.toHaveBeenCalled()
+    expect(mocks.navigate).not.toHaveBeenCalled()
+  })
+})

--- a/hivemq-edge/src/frontend/src/modules/Workspace/hooks/useContextMenu.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/hooks/useContextMenu.tsx
@@ -1,0 +1,25 @@
+import { MouseEvent } from 'react'
+// import { useKeyPress } from 'reactflow'
+import { useNavigate } from 'react-router-dom'
+
+export const useContextMenu = (id: string, selected: boolean, route: string) => {
+  const navigate = useNavigate()
+  // TODO[NVL] keyboard unsupported until accessibility can be fixed (see #18293)
+  // const spacePressed = useKeyPress('Enter', { target: document.querySelector<HTMLElement>(`[data-id="${id}"]`) })
+  //
+  // useEffect(() => {
+  //   console.log('XXXXXXXX', spacePressed, selected, document.querySelector<HTMLElement>(`[data-id="${id}"]`))
+  //   if (selected && spacePressed) {
+  //     navigate(`${route}/${id}`)
+  //   }
+  // }, [id, navigate, route, selected, spacePressed])
+
+  const onContextMenu = (event: MouseEvent<HTMLElement>) => {
+    if (selected) {
+      navigate(`${route}/${id}`)
+      event.preventDefault()
+    }
+  }
+
+  return { onContextMenu }
+}

--- a/hivemq-edge/src/frontend/src/modules/Workspace/hooks/useContextMenu.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/hooks/useContextMenu.tsx
@@ -1,18 +1,19 @@
-import { MouseEvent } from 'react'
-// import { useKeyPress } from 'reactflow'
+import { MouseEvent, useEffect } from 'react'
+import { useKeyPress } from 'reactflow'
 import { useNavigate } from 'react-router-dom'
 
 export const useContextMenu = (id: string, selected: boolean, route: string) => {
   const navigate = useNavigate()
   // TODO[NVL] keyboard unsupported until accessibility can be fixed (see #18293)
-  // const spacePressed = useKeyPress('Enter', { target: document.querySelector<HTMLElement>(`[data-id="${id}"]`) })
-  //
-  // useEffect(() => {
-  //   console.log('XXXXXXXX', spacePressed, selected, document.querySelector<HTMLElement>(`[data-id="${id}"]`))
-  //   if (selected && spacePressed) {
-  //     navigate(`${route}/${id}`)
-  //   }
-  // }, [id, navigate, route, selected, spacePressed])
+  const spacePressed = useKeyPress(['Meta+Enter', 'Shift+Enter'], {
+    target: document.querySelector<HTMLElement>(`[data-id="${id}"]`),
+  })
+
+  useEffect(() => {
+    if (selected && spacePressed) {
+      navigate(`${route}/${id}`)
+    }
+  }, [id, navigate, route, selected, spacePressed])
 
   const onContextMenu = (event: MouseEvent<HTMLElement>) => {
     if (selected) {


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/18293/details/

This PR changes the keyboard and mouse interaction with the nodes (adapters, bridges and groups) on the workspace. 

- a double click on a node opens the `Overview` side panel (before/after)
- a right-click on a node opens the `Overview` side panel  (after)
- a click on the icon on a link opens the `Observability` side panel of the source node (before was double-click)

- `Meta + Enter` with a node selected opens its `Overview` side panel
- `Shift + Enter` with a node selected opens its `Overview` side panel

The default keys and mouse events from `ReactFlow`  for manipulating nodes and the canvas are still in operation.

The PR also adds a link to the panel in the group's toolbar.

### Before
![screenshot-localhost_3000-2023 12 13-14_10_42](https://github.com/hivemq/hivemq-edge/assets/2743481/fb060ace-f059-4322-a981-4d0860a0dd24)

### After
![screenshot-localhost_3000-2023 12 13-14_10_13](https://github.com/hivemq/hivemq-edge/assets/2743481/ba85cfa4-b5fd-4d94-abc7-e7285d203a31)
