### PR TITLE
refactor(18161): Change the persistence of the metrics to a local store

### DIFF
--- a/hivemq-edge/src/frontend/src/modules/Metrics/hooks/useMetricsStore.spec.ts
+++ b/hivemq-edge/src/frontend/src/modules/Metrics/hooks/useMetricsStore.spec.ts
@@ -1,0 +1,128 @@
+import { expect } from 'vitest'
+import { act, renderHook } from '@testing-library/react'
+
+import useMetricsStore, {
+  MetricDefinitionSpec,
+  MetricDefinitionStore,
+} from '@/modules/Metrics/hooks/useMetricsStore.ts'
+import { ChartType } from '@/modules/Metrics/types.ts'
+
+describe('useMetricsStore', () => {
+  beforeEach(() => {
+    const { result } = renderHook<MetricDefinitionStore, unknown>(useMetricsStore)
+    act(() => {
+      result.current.reset()
+    })
+  })
+
+  it('should start with an empty store', async () => {
+    const { result } = renderHook<MetricDefinitionStore, unknown>(useMetricsStore)
+    const { metrics } = result.current
+
+    expect(metrics).toHaveLength(0)
+  })
+
+  it('should add a metric to the store', async () => {
+    const { result } = renderHook<MetricDefinitionStore, unknown>(useMetricsStore)
+    const { metrics } = result.current
+
+    expect(metrics).toHaveLength(0)
+
+    act(() => {
+      const { addMetrics } = result.current
+      addMetrics('nodeId', 'metricNAme', ChartType.SAMPLE)
+    })
+
+    expect(result.current.metrics).toHaveLength(1)
+  })
+
+  it('should remove a metric to the store', async () => {
+    const { result } = renderHook<MetricDefinitionStore, unknown>(useMetricsStore)
+    const { metrics } = result.current
+
+    expect(metrics).toHaveLength(0)
+
+    act(() => {
+      const { addMetrics } = result.current
+      addMetrics('nodeId', 'metricName1', ChartType.SAMPLE)
+      addMetrics('nodeId', 'metricName2', ChartType.SAMPLE)
+      addMetrics('anotherNodeId', 'metricName1', ChartType.SAMPLE)
+    })
+
+    expect(result.current.metrics).toHaveLength(3)
+
+    act(() => {
+      const { removeMetrics } = result.current
+      removeMetrics('nodeId', 'metricName1')
+    })
+
+    expect(result.current.metrics).toStrictEqual<MetricDefinitionSpec[]>([
+      {
+        chart: ChartType.SAMPLE,
+        metrics: 'metricName2',
+        source: 'nodeId',
+      },
+      {
+        chart: ChartType.SAMPLE,
+        metrics: 'metricName1',
+        source: 'anotherNodeId',
+      },
+    ])
+  })
+
+  it('should return all the metrics for a node', async () => {
+    const { result } = renderHook<MetricDefinitionStore, unknown>(useMetricsStore)
+    const { metrics } = result.current
+
+    expect(metrics).toHaveLength(0)
+
+    act(() => {
+      const { addMetrics } = result.current
+      addMetrics('nodeId', 'metricName1', ChartType.SAMPLE)
+      addMetrics('nodeId', 'metricName2', ChartType.SAMPLE)
+      addMetrics('anotherNodeId', 'metricName1', ChartType.SAMPLE)
+    })
+
+    expect(result.current.metrics).toHaveLength(3)
+
+    act(() => {
+      const { getMetricsFor } = result.current
+      const res = getMetricsFor('nodeId')
+      expect(res).toStrictEqual<MetricDefinitionSpec[]>([
+        {
+          chart: ChartType.SAMPLE,
+          metrics: 'metricName1',
+          source: 'nodeId',
+        },
+        {
+          chart: ChartType.SAMPLE,
+          metrics: 'metricName2',
+          source: 'nodeId',
+        },
+      ])
+    })
+  })
+
+  it('should reset the store', async () => {
+    const { result } = renderHook<MetricDefinitionStore, unknown>(useMetricsStore)
+    const { metrics } = result.current
+
+    expect(metrics).toHaveLength(0)
+
+    act(() => {
+      const { addMetrics } = result.current
+      addMetrics('nodeId', 'metricName1', ChartType.SAMPLE)
+      addMetrics('nodeId', 'metricName2', ChartType.SAMPLE)
+      addMetrics('anotherNodeId', 'metricName1', ChartType.SAMPLE)
+    })
+
+    expect(result.current.metrics).toHaveLength(3)
+
+    act(() => {
+      const { reset } = result.current
+      reset()
+    })
+
+    expect(result.current.metrics).toHaveLength(0)
+  })
+})

--- a/hivemq-edge/src/frontend/src/modules/Metrics/hooks/useMetricsStore.ts
+++ b/hivemq-edge/src/frontend/src/modules/Metrics/hooks/useMetricsStore.ts
@@ -1,0 +1,48 @@
+import { create } from 'zustand'
+import { persist, createJSONStorage } from 'zustand/middleware'
+
+import { ChartType } from '../types.ts'
+
+export interface MetricDefinitionSpec {
+  source: string
+  metrics: string
+  chart?: ChartType
+}
+
+export interface MetricDefinitionStore {
+  metrics: MetricDefinitionSpec[]
+  reset: () => void
+  addMetrics: (source: string, metrics: string, chart?: ChartType) => void
+  removeMetrics: (source: string, metrics: string) => void
+  getMetricsFor: (source: string) => MetricDefinitionSpec[]
+}
+
+const useMetricsStore = create<MetricDefinitionStore>()(
+  persist(
+    (set, get) => ({
+      metrics: [],
+      reset: () => {
+        set({ metrics: [] })
+      },
+      addMetrics: (source: string, metrics, chart) => {
+        set({
+          metrics: [...get().metrics, { source: source, metrics: metrics, chart: chart }],
+        })
+      },
+      removeMetrics: (source: string, metrics: string) => {
+        set({
+          metrics: get().metrics.filter((e) => e.source !== source || e.metrics !== metrics),
+        })
+      },
+      getMetricsFor: (source: string) => {
+        return get().metrics.filter((m) => m.source === source)
+      },
+    }),
+    {
+      name: 'edge.observability',
+      storage: createJSONStorage(() => localStorage),
+    }
+  )
+)
+
+export default useMetricsStore

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeGroup.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeGroup.tsx
@@ -56,7 +56,6 @@ const NodeGroup: FC<NodeProps<Group>> = ({ id, data, selected, ...props }) => {
     onEdgesChange(edges.filter((e) => e.source === id).map((e) => ({ id: e.id, type: 'remove' } as EdgeRemoveChange)))
   }
 
-  console.log('XXXXXXX data', data)
   return (
     <>
       <NodeToolbar


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/18161/details/

This simple PR is removing the direct use of the `localStorage` to a cleaner and more versatile state-management solution (`Zustand`).vanch