### PR TITLE
refactor(18077): Align the design of the charts with the Edge theme

### DIFF
--- a/hivemq-edge/src/frontend/src/locales/en/translation.json
+++ b/hivemq-edge/src/frontend/src/locales/en/translation.json
@@ -633,6 +633,7 @@
     "property": {
       "header_ADAPTER_NODE": "Adapter Overview",
       "header_BRIDGE_NODE": "Bridge Overview",
+      "header_CLUSTER_NODE": "Group Overview",
       "modify_ADAPTER_NODE": "Modify the adapter",
       "modify_BRIDGE_NODE": "Modify the bridge",
       "eventLog": {
@@ -703,7 +704,7 @@
     "charts": {
       "LineChart": {
         "ariaLabel": {
-          "legend": "timestamp (s)"
+          "legend": "timestamp (seconds ago)"
         }
       }
     },

--- a/hivemq-edge/src/frontend/src/modules/Metrics/Metrics.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Metrics/Metrics.tsx
@@ -10,6 +10,7 @@ import {
   CardBody,
   SimpleGrid,
   useDisclosure,
+  useTheme,
 } from '@chakra-ui/react'
 import { useTranslation } from 'react-i18next'
 
@@ -19,6 +20,7 @@ import config from '@/config'
 
 import { ChartType, MetricDefinition } from './types.ts'
 import useMetricsStore from './hooks/useMetricsStore.ts'
+import { extractMetricInfo } from './utils/metrics-name.utils.ts'
 import MetricEditor from './components/editor/MetricEditor.tsx'
 import ChartContainer from './components/container/ChartContainer.tsx'
 import Sample from './components/container/Sample.tsx'
@@ -36,11 +38,20 @@ export interface MetricSpecStorage {
   selectedChart?: ChartType
 }
 
+// TODO[NVL] Should go to some kind of reusable routine, with verification
+const defaultColorSchemes = ['blue', 'green', 'orange', 'pink', 'purple', 'red', 'teal', 'yellow', 'cyan']
+
 const Metrics: FC<MetricsProps> = ({ nodeId, adapterIDs, initMetrics, defaultChartType }) => {
   const { t } = useTranslation()
   const { isOpen, onOpen, onClose } = useDisclosure()
   const { addMetrics, getMetricsFor, removeMetrics } = useMetricsStore()
+  const { colors } = useTheme()
+
   const showEditor = config.features.METRICS_SHOW_EDITOR
+
+  // TODO[NVL] Should go to some kind of reusable routine, with verification
+  const colorKeys = Object.keys(colors)
+  const chartTheme = defaultColorSchemes.filter((c) => colorKeys.includes(c))
 
   const handleCreateMetrics = (value: MetricDefinition) => {
     const { selectedTopic, selectedChart } = value
@@ -96,11 +107,15 @@ const Metrics: FC<MetricsProps> = ({ nodeId, adapterIDs, initMetrics, defaultCha
       <CardBody>
         <SimpleGrid spacing={4} templateColumns="repeat(auto-fill, minmax(200px, 1fr))">
           {metrics.map((e) => {
+            const { id } = extractMetricInfo(e.metrics)
+            const colorSchemeIndex = adapterIDs.indexOf(id as string)
+
             if (!e.chart || e.chart === ChartType.SAMPLE)
               return (
                 <Sample
                   key={e.metrics}
                   metricName={e.metrics}
+                  chartTheme={{ colourScheme: chartTheme[colorSchemeIndex] }}
                   onClose={() => handleRemoveMetrics(e.metrics)}
                   canEdit={isOpen}
                 />
@@ -111,6 +126,7 @@ const Metrics: FC<MetricsProps> = ({ nodeId, adapterIDs, initMetrics, defaultCha
                   key={e.metrics}
                   chartType={e.chart}
                   metricName={e.metrics}
+                  chartTheme={{ colourScheme: chartTheme[colorSchemeIndex] }}
                   onClose={() => handleRemoveMetrics(e.metrics)}
                   canEdit={isOpen}
                 />

--- a/hivemq-edge/src/frontend/src/modules/Metrics/components/charts/BarChart.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Metrics/components/charts/BarChart.spec.cy.tsx
@@ -5,7 +5,6 @@ import { Box } from '@chakra-ui/react'
 
 import { MOCK_METRIC_SAMPLE_ARRAY, MOCK_METRICS } from '@/api/hooks/useGetMetrics/__handlers__'
 import BarChart from './BarChart.tsx'
-import { DateTime } from 'luxon'
 
 const mockAriaLabel = 'aria-label'
 const Wrapper: FC<PropsWithChildren> = ({ children }) => (
@@ -33,24 +32,10 @@ describe('BarChart', () => {
       </Wrapper>
     )
 
-    const formatShortDate = new Intl.DateTimeFormat(navigator.language, {
-      month: 'short',
-      day: 'numeric',
-      hour: 'numeric',
-      minute: 'numeric',
-      second: 'numeric',
-    })
-
     cy.get("[role='application']").should('have.attr', 'aria-label', mockAriaLabel)
-    cy.get('text').should('contain.text', 'timestamp (s)')
+    cy.get('text').should('contain.text', 'timestamp (seconds ago)')
     cy.get('svg > g > g > rect').eq(4).click()
-    cy.getByTestId('bar-chart-tooltip')
-      .should('contain.text', '[Forward] Publish success (count)')
-      .should(
-        'contain.text',
-        formatShortDate.format(DateTime.fromISO(MOCK_METRIC_SAMPLE_ARRAY[5].sampleTime as string).toJSDate())
-      )
-      .should('contain.text', '55000')
+
     cy.checkAccessibility()
     cy.percySnapshot('Component: BarChart')
   })

--- a/hivemq-edge/src/frontend/src/modules/Metrics/components/charts/BarChart.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Metrics/components/charts/BarChart.tsx
@@ -2,18 +2,20 @@ import { FC } from 'react'
 import { BarDatum, ResponsiveBar } from '@nivo/bar'
 import { DateTime } from 'luxon'
 import { useTranslation } from 'react-i18next'
-import { Badge, Box, Card, Text } from '@chakra-ui/react'
+import { Badge, Box, Card, Text, useTheme } from '@chakra-ui/react'
+
+import DateTimeRenderer from '@/components/DateTime/DateTimeRenderer.tsx'
 
 import { ChartProps } from '../../types.ts'
-import DateTimeRenderer from '@/components/DateTime/DateTimeRenderer.tsx'
-import { extractMetricInfo } from '@/modules/Metrics/utils/metrics-name.utils.ts'
+import { extractMetricInfo } from '../../utils/metrics-name.utils.ts'
 
 interface Datum extends BarDatum {
   sampleTime: string
 }
 
-const BarChart: FC<ChartProps> = ({ data, metricName, 'aria-label': ariaLabel, ...props }) => {
+const BarChart: FC<ChartProps> = ({ data, metricName, 'aria-label': ariaLabel, chartTheme, ...props }) => {
   const { t } = useTranslation()
+  const { colors } = useTheme()
 
   if (!metricName) return null
 
@@ -24,20 +26,23 @@ const BarChart: FC<ChartProps> = ({ data, metricName, 'aria-label': ariaLabel, .
     .reverse()
     .map((e) => ({ sampleTime: e.sampleTime as string, [seriesName]: e.value as number }))
 
+  const colorScheme = chartTheme?.colourScheme || 'red'
+  const colorElement = colors[colorScheme][500]
+
   return (
     <Box w={'100%'} {...props}>
       <ResponsiveBar
         data={barSeries}
         keys={[seriesName]}
         indexBy="sampleTime"
-        margin={{ top: 10, right: 80, bottom: 40, left: 40 }}
-        padding={0.3}
         valueScale={{ type: 'linear' }}
         indexScale={{ type: 'band', round: true }}
-        colors={{ scheme: 'nivo' }}
+        colors={[colorElement]}
         tooltip={(d) => (
           <Card p={1} data-testid={'bar-chart-tooltip'}>
-            <Badge backgroundColor={d.color}>{d.id}</Badge>
+            <Badge backgroundColor={d.color} color={'white'}>
+              {d.id}
+            </Badge>
             <DateTimeRenderer date={DateTime.fromISO(d.indexValue as string)} isShort />
             <Text fontWeight={'bold'}>{d.formattedValue}</Text>
           </Card>

--- a/hivemq-edge/src/frontend/src/modules/Metrics/components/charts/BarChart.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Metrics/components/charts/BarChart.tsx
@@ -2,12 +2,11 @@ import { FC } from 'react'
 import { BarDatum, ResponsiveBar } from '@nivo/bar'
 import { DateTime } from 'luxon'
 import { useTranslation } from 'react-i18next'
-import { Badge, Box, Card, Text, useTheme } from '@chakra-ui/react'
-
-import DateTimeRenderer from '@/components/DateTime/DateTimeRenderer.tsx'
+import { Box, useTheme } from '@chakra-ui/react'
 
 import { ChartProps } from '../../types.ts'
 import { extractMetricInfo } from '../../utils/metrics-name.utils.ts'
+import ChartTooltip from '../parts/ChartTooltip.tsx'
 
 interface Datum extends BarDatum {
   sampleTime: string
@@ -38,49 +37,15 @@ const BarChart: FC<ChartProps> = ({ data, metricName, 'aria-label': ariaLabel, c
         valueScale={{ type: 'linear' }}
         indexScale={{ type: 'band', round: true }}
         colors={[colorElement]}
-        tooltip={(d) => (
-          <Card p={1} data-testid={'bar-chart-tooltip'}>
-            <Badge backgroundColor={d.color} color={'white'}>
-              {d.id}
-            </Badge>
-            <DateTimeRenderer date={DateTime.fromISO(d.indexValue as string)} isShort />
-            <Text fontWeight={'bold'}>{d.formattedValue}</Text>
-          </Card>
-        )}
-        // defs={[
-        //   {
-        //     id: 'dots',
-        //     type: 'patternDots',
-        //     background: 'inherit',
-        //     color: '#38bcb2',
-        //     size: 4,
-        //     padding: 1,
-        //     stagger: true,
-        //   },
-        //   {
-        //     id: 'lines',
-        //     type: 'patternLines',
-        //     background: 'inherit',
-        //     color: '#eed312',
-        //     rotation: -45,
-        //     lineWidth: 6,
-        //     spacing: 10,
-        //   },
-        // ]}
-        // fill={[
-        //   {
-        //     match: {
-        //       id: 'fries',
-        //     },
-        //     id: 'dots',
-        //   },
-        //   {
-        //     match: {
-        //       id: 'sandwich',
-        //     },
-        //     id: 'lines',
-        //   },
-        // ]}
+        // tooltip={(d) => (
+        //   <Card p={1} data-testid={'bar-chart-tooltip'}>
+        //     <Badge backgroundColor={d.color} color={'white'}>
+        //       {d.id}
+        //     </Badge>
+        //     <DateTimeRenderer date={DateTime.fromISO(d.indexValue as string)} isShort />
+        //     <Text fontWeight={'bold'}>{d.formattedValue}</Text>
+        //   </Card>
+        // )}
         borderColor={{
           from: 'color',
           modifiers: [['darker', 1.6]],
@@ -119,6 +84,16 @@ const BarChart: FC<ChartProps> = ({ data, metricName, 'aria-label': ariaLabel, c
           from: 'color',
           modifiers: [['darker', 1.6]],
         }}
+        margin={{ top: 5, right: 0, bottom: 70, left: 40 }}
+        padding={0.3}
+        tooltip={(d) => (
+          <ChartTooltip
+            color={d.color}
+            id={d.id}
+            date={DateTime.fromISO(d.indexValue as string)}
+            formattedValue={d.formattedValue.toString()}
+          />
+        )}
         legends={[
           {
             direction: 'row',

--- a/hivemq-edge/src/frontend/src/modules/Metrics/components/charts/BarChart.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Metrics/components/charts/BarChart.tsx
@@ -96,7 +96,12 @@ const BarChart: FC<ChartProps> = ({ data, metricName, 'aria-label': ariaLabel, c
           legendOffset: 32,
           truncateTickAt: 0,
           format: (value) => {
-            return '+' + DateTime.fromISO(value).second
+            const duration = DateTime.fromISO(value).diffNow(['second'])
+            const rescaledDuration = duration
+              .negate()
+              .mapUnits((x) => Math.floor(x))
+              .rescale()
+            return rescaledDuration.as('seconds')
           },
         }}
         axisLeft={{

--- a/hivemq-edge/src/frontend/src/modules/Metrics/components/charts/BarChart.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Metrics/components/charts/BarChart.tsx
@@ -18,8 +18,9 @@ const BarChart: FC<ChartProps> = ({ data, metricName, 'aria-label': ariaLabel, c
 
   if (!metricName) return null
 
-  const { suffix, device } = extractMetricInfo(metricName)
-  const seriesName = t(`metrics.${device}.${suffix}`).replaceAll('.', ' ')
+  const { suffix, device, id } = extractMetricInfo(metricName)
+  let seriesName = t(`metrics.${device}.${suffix}`).replaceAll('.', ' ')
+  seriesName = `${seriesName} - ${id}`
 
   const barSeries: Datum[] = [...data]
     .reverse()

--- a/hivemq-edge/src/frontend/src/modules/Metrics/components/charts/BarChart.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Metrics/components/charts/BarChart.tsx
@@ -82,7 +82,7 @@ const BarChart: FC<ChartProps> = ({ data, metricName, 'aria-label': ariaLabel, c
         labelSkipHeight={12}
         labelTextColor={{
           from: 'color',
-          modifiers: [['darker', 1.6]],
+          modifiers: [['darker', 0]],
         }}
         margin={{ top: 5, right: 0, bottom: 70, left: 40 }}
         padding={0.3}

--- a/hivemq-edge/src/frontend/src/modules/Metrics/components/charts/BarChart.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Metrics/components/charts/BarChart.tsx
@@ -116,18 +116,16 @@ const BarChart: FC<ChartProps> = ({ data, metricName, 'aria-label': ariaLabel, c
         }}
         legends={[
           {
-            dataFrom: 'keys',
+            direction: 'row',
             anchor: 'bottom-right',
-            direction: 'column',
-            justify: false,
-            translateX: 120,
-            translateY: 0,
-            itemsSpacing: 2,
-            itemWidth: 100,
+            dataFrom: 'keys',
+            itemDirection: 'right-to-left',
+            translateY: 70,
+
+            itemWidth: 0,
             itemHeight: 20,
-            itemDirection: 'left-to-right',
-            itemOpacity: 0.85,
-            symbolSize: 20,
+            // itemOpacity: 0.85,
+            // symbolSize: 20,
             effects: [
               {
                 on: 'hover',

--- a/hivemq-edge/src/frontend/src/modules/Metrics/components/charts/LineChart.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Metrics/components/charts/LineChart.spec.cy.tsx
@@ -33,7 +33,7 @@ describe('LineChart', () => {
     )
 
     cy.get("[role='application']").should('have.attr', 'aria-label', mockAriaLabel)
-    cy.get('text').should('contain.text', 'timestamp (s)')
+    cy.get('text').should('contain.text', 'timestamp (seconds ago)')
 
     cy.checkAccessibility()
     cy.percySnapshot('Component: LineChart')

--- a/hivemq-edge/src/frontend/src/modules/Metrics/components/charts/LineChart.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Metrics/components/charts/LineChart.tsx
@@ -2,14 +2,15 @@ import { FC } from 'react'
 import { ResponsiveLine } from '@nivo/line'
 import { DateTime } from 'luxon'
 import { useTranslation } from 'react-i18next'
-import { Badge, Box, Card, Text } from '@chakra-ui/react'
+import { Box, useTheme } from '@chakra-ui/react'
 
+import ChartTooltip from '../parts/ChartTooltip.tsx'
 import { ChartProps } from '../../types.ts'
-import DateTimeRenderer from '@/components/DateTime/DateTimeRenderer.tsx'
-import { extractMetricInfo } from '@/modules/Metrics/utils/metrics-name.utils.ts'
+import { extractMetricInfo } from '../../utils/metrics-name.utils.ts'
 
-const LineChart: FC<ChartProps> = ({ data, metricName, 'aria-label': ariaLabel, ...props }) => {
+const LineChart: FC<ChartProps> = ({ data, metricName, 'aria-label': ariaLabel, chartTheme, ...props }) => {
   const { t } = useTranslation()
+  const { colors } = useTheme()
 
   if (!metricName) return null
 
@@ -20,6 +21,9 @@ const LineChart: FC<ChartProps> = ({ data, metricName, 'aria-label': ariaLabel, 
 
   const { suffix, device } = extractMetricInfo(metricName)
   const seriesName = t(`metrics.${device}.${suffix}`).replaceAll('.', ' ')
+
+  const colorScheme = chartTheme?.colourScheme || 'red'
+  const colorElement = colors[colorScheme][500]
 
   return (
     <Box w={'100%'} {...props} role={'application'} aria-label={ariaLabel}>
@@ -36,15 +40,9 @@ const LineChart: FC<ChartProps> = ({ data, metricName, 'aria-label': ariaLabel, 
               .map((e) => ({ x: DateTime.fromISO(e.sampleTime as string).toMillis(), y: e.value })),
           },
         ]}
-        colors={{ scheme: 'nivo' }}
-        tooltip={(d) => (
-          <Card p={1} data-testid={'line-chart-tooltip'}>
-            <Badge backgroundColor={d.point.serieColor}>{d.point.serieId}</Badge>
-            <DateTimeRenderer date={DateTime.fromMillis(d.point.data.x as number)} isShort />
-            <Text fontWeight={'bold'}>{d.point.data.yFormatted}</Text>
-          </Card>
-        )}
-        margin={{ top: 0, right: 10, bottom: 50, left: 50 }}
+        // colors={{ scheme: 'nivo' }}
+        colors={[colorElement]}
+        margin={{ top: 0, right: 10, bottom: 70, left: 50 }}
         yScale={{ type: 'linear', min: boundaries.x, max: boundaries.y, stacked: true }}
         // xScale={{ type: 'linear' }}
         // yScale={{ type: 'linear', stacked: true, min: 0, max: 2500 }}

--- a/hivemq-edge/src/frontend/src/modules/Metrics/components/charts/LineChart.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Metrics/components/charts/LineChart.tsx
@@ -19,8 +19,9 @@ const LineChart: FC<ChartProps> = ({ data, metricName, 'aria-label': ariaLabel, 
     y: Math.max(...data.map((e) => e.value as number)),
   }
 
-  const { suffix, device } = extractMetricInfo(metricName)
-  const seriesName = t(`metrics.${device}.${suffix}`).replaceAll('.', ' ')
+  const { suffix, device, id } = extractMetricInfo(metricName)
+  let seriesName = t(`metrics.${device}.${suffix}`).replaceAll('.', ' ')
+  seriesName = `${seriesName} - ${id}`
 
   const colorScheme = chartTheme?.colourScheme || 'red'
   const colorElement = colors[colorScheme][500]

--- a/hivemq-edge/src/frontend/src/modules/Metrics/components/charts/LineChart.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Metrics/components/charts/LineChart.tsx
@@ -118,6 +118,27 @@ const LineChart: FC<ChartProps> = ({ data, metricName, 'aria-label': ariaLabel, 
         //     ],
         //   },
         // ]}
+        legends={[
+          {
+            direction: 'row',
+            anchor: 'bottom-right',
+            itemDirection: 'right-to-left',
+            translateY: 70,
+
+            itemWidth: 0,
+            itemHeight: 20,
+            // itemOpacity: 0.85,
+            // symbolSize: 20,
+            effects: [
+              {
+                on: 'hover',
+                style: {
+                  itemOpacity: 1,
+                },
+              },
+            ],
+          },
+        ]}
       />
     </Box>
   )

--- a/hivemq-edge/src/frontend/src/modules/Metrics/components/charts/LineChart.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Metrics/components/charts/LineChart.tsx
@@ -4,9 +4,9 @@ import { DateTime } from 'luxon'
 import { useTranslation } from 'react-i18next'
 import { Box, useTheme } from '@chakra-ui/react'
 
-import ChartTooltip from '../parts/ChartTooltip.tsx'
 import { ChartProps } from '../../types.ts'
 import { extractMetricInfo } from '../../utils/metrics-name.utils.ts'
+import ChartTooltip from '../parts/ChartTooltip.tsx'
 
 const LineChart: FC<ChartProps> = ({ data, metricName, 'aria-label': ariaLabel, chartTheme, ...props }) => {
   const { t } = useTranslation()
@@ -123,6 +123,15 @@ const LineChart: FC<ChartProps> = ({ data, metricName, 'aria-label': ariaLabel, 
         //     ],
         //   },
         // ]}
+
+        tooltip={(d) => (
+          <ChartTooltip
+            color={d.point.serieColor}
+            id={d.point.serieId}
+            date={DateTime.fromMillis(d.point.data.x as number)}
+            formattedValue={d.point.data.yFormatted.toString()}
+          />
+        )}
         legends={[
           {
             direction: 'row',

--- a/hivemq-edge/src/frontend/src/modules/Metrics/components/charts/LineChart.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Metrics/components/charts/LineChart.tsx
@@ -65,7 +65,12 @@ const LineChart: FC<ChartProps> = ({ data, metricName, 'aria-label': ariaLabel, 
           // tickRotation: 0,
           // // format: '.2f',
           format: (value) => {
-            return '+' + DateTime.fromMillis(value).second
+            const duration = DateTime.fromMillis(value).diffNow(['second'])
+            const rescaledDuration = duration
+              .negate()
+              .mapUnits((x) => Math.floor(x))
+              .rescale()
+            return rescaledDuration.as('seconds')
           },
           legend: t('metrics.charts.LineChart.ariaLabel.legend'),
           legendOffset: 36,

--- a/hivemq-edge/src/frontend/src/modules/Metrics/components/charts/SampleRenderer.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Metrics/components/charts/SampleRenderer.tsx
@@ -10,12 +10,14 @@ import {
   StatProps,
   Text,
   Tooltip,
+  useTheme,
 } from '@chakra-ui/react'
 import { NotAllowedIcon } from '@chakra-ui/icons'
 import { useTranslation } from 'react-i18next'
 
 import { ApiError, DataPoint } from '@/api/__generated__'
 import { MetricInfo } from '../../utils/metrics-name.utils.ts'
+import { ChartTheme } from '@/modules/Metrics/types.ts'
 
 interface SampleRendererProps extends StatProps {
   metricInfo: MetricInfo
@@ -23,12 +25,22 @@ interface SampleRendererProps extends StatProps {
   isLoading: boolean
   error?: ApiError | null
   children?: ReactNode
+  chartTheme?: ChartTheme
 }
 
-const SampleRenderer: FC<SampleRendererProps> = ({ metricInfo, series, isLoading, error, children, ...props }) => {
+const SampleRenderer: FC<SampleRendererProps> = ({
+  metricInfo,
+  series,
+  chartTheme,
+  isLoading,
+  error,
+  children,
+  ...props
+}) => {
   const { t } = useTranslation()
   const { device, suffix, id } = metricInfo
   const formatNumber = Intl.NumberFormat(navigator.language)
+  const { colors } = useTheme()
 
   const diff = (current: number, previous: number) => current - previous
 
@@ -40,9 +52,23 @@ const SampleRenderer: FC<SampleRendererProps> = ({ metricInfo, series, isLoading
 
   const n = series[0]?.value as number
 
+  const colorScheme = chartTheme?.colourScheme || 'red'
+  const colorElement = colors[colorScheme][500]
+
   return (
     <HStack alignItems={'flex-start'} gap={0}>
-      <Stat variant="hivemq" {...props} overflowX={'hidden'} h={'100%'}>
+      <Stat
+        variant="hivemq"
+        {...props}
+        overflowX={'hidden'}
+        h={'100%'}
+        sx={{
+          borderColor: colorElement,
+          "dd[data-testid='metric-value']": {
+            color: colorElement,
+          },
+        }}
+      >
         <StatLabel isTruncated h={'100%'}>
           <Tooltip label={t(`metrics.${device}.${suffix}`).replaceAll('.', ' ')} placement={'top'}>
             <Text textOverflow={'ellipsis'}>{t(`metrics.${device}.${suffix}`).replaceAll('.', ' ')}</Text>

--- a/hivemq-edge/src/frontend/src/modules/Metrics/components/container/ChartContainer.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Metrics/components/container/ChartContainer.tsx
@@ -7,13 +7,14 @@ import { DataPoint } from '@/api/__generated__'
 import { useGetSample } from '@/api/hooks/useGetMetrics/useGetSample.tsx'
 import ClipboardCopyIconButton from '@/components/Chakra/ClipboardCopyIconButton.tsx'
 
-import { ChartType } from '../../types.ts'
+import { ChartTheme, ChartType } from '../../types.ts'
 import { extractMetricInfo } from '../../utils/metrics-name.utils.ts'
 import LineChart from '../charts/LineChart.tsx'
 import BarChart from '../charts/BarChart.tsx'
 
 interface ChartContainerProps extends StackProps {
   chartType: ChartType
+  chartTheme?: ChartTheme
   metricName?: string
   onClose?: () => void
   canEdit?: boolean
@@ -21,7 +22,14 @@ interface ChartContainerProps extends StackProps {
 
 const MAX_SERIES = 10
 
-const ChartContainer: FC<ChartContainerProps> = ({ chartType, metricName, onClose, canEdit = true, ...props }) => {
+const ChartContainer: FC<ChartContainerProps> = ({
+  chartType,
+  chartTheme,
+  metricName,
+  onClose,
+  canEdit = true,
+  ...props
+}) => {
   const { t } = useTranslation()
   const { data } = useGetSample(metricName)
   const [series, setSeries] = useState<DataPoint[]>([])
@@ -56,6 +64,7 @@ const ChartContainer: FC<ChartContainerProps> = ({ chartType, metricName, onClos
             data={series}
             metricName={metricName}
             aria-label={t(`metrics.${device}.${suffix}`).replaceAll('.', ' ')}
+            chartTheme={chartTheme}
           />
         </CardBody>
       </Card>

--- a/hivemq-edge/src/frontend/src/modules/Metrics/components/container/Sample.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Metrics/components/container/Sample.tsx
@@ -8,16 +8,18 @@ import { DataPoint } from '@/api/__generated__'
 import ClipboardCopyIconButton from '@/components/Chakra/ClipboardCopyIconButton.tsx'
 import { extractMetricInfo } from '../../utils/metrics-name.utils.ts'
 import SampleRenderer from '../charts/SampleRenderer.tsx'
+import { ChartTheme } from '@/modules/Metrics/types.ts'
 
 interface SampleProps {
   metricName?: string
+  chartTheme?: ChartTheme
   onClose?: () => void
   canEdit?: boolean
 }
 
 const MAX_SERIES = 10
 
-const Sample: FC<SampleProps> = ({ metricName, onClose, canEdit = true }) => {
+const Sample: FC<SampleProps> = ({ metricName, chartTheme, onClose, canEdit = true }) => {
   const { t } = useTranslation()
   const { data, isLoading, error } = useGetSample(metricName)
   const [series, setSeries] = useState<DataPoint[]>([])
@@ -45,6 +47,7 @@ const Sample: FC<SampleProps> = ({ metricName, onClose, canEdit = true }) => {
       isLoading={isLoading}
       error={error}
       series={series}
+      chartTheme={chartTheme}
       {...(isMajor ? { gridColumn: '1 / span 2' } : {})}
     >
       <VStack ml={1}>

--- a/hivemq-edge/src/frontend/src/modules/Metrics/components/parts/ChartTooltip.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Metrics/components/parts/ChartTooltip.spec.cy.tsx
@@ -1,0 +1,25 @@
+/// <reference types="cypress" />
+
+import { DateTime } from 'luxon'
+import ChartTooltip from './ChartTooltip.tsx'
+
+describe('ChartTooltip', () => {
+  beforeEach(() => {
+    cy.viewport(800, 800)
+  })
+
+  it('should be accessible', () => {
+    cy.injectAxe()
+
+    cy.mountWithProviders(
+      <ChartTooltip formattedValue={'the value'} color={'red.300'} date={DateTime.fromMillis(1000)} id={'the task'} />
+    )
+
+    cy.getByTestId('chart-tooltip-id').should('contain.text', 'the task')
+    cy.getByTestId('date-time-full').should('contain.text', '1 Jan, 01:00:01')
+    cy.getByTestId('chart-tooltip-value').should('contain.text', 'the value')
+
+    cy.checkAccessibility()
+    cy.percySnapshot('Component: ChartTooltip')
+  })
+})

--- a/hivemq-edge/src/frontend/src/modules/Metrics/components/parts/ChartTooltip.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Metrics/components/parts/ChartTooltip.spec.cy.tsx
@@ -9,14 +9,23 @@ describe('ChartTooltip', () => {
   })
 
   it('should be accessible', () => {
+    const mockTime = DateTime.fromMillis(1000)
     cy.injectAxe()
-
     cy.mountWithProviders(
-      <ChartTooltip formattedValue={'the value'} color={'red.300'} date={DateTime.fromMillis(1000)} id={'the task'} />
+      <ChartTooltip formattedValue={'the value'} color={'red.300'} date={mockTime} id={'the task'} />
     )
 
+    const formatShortDate = new Intl.DateTimeFormat(navigator.language, {
+      month: 'short',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: 'numeric',
+      second: 'numeric',
+    })
+    const shortDate = formatShortDate.format(mockTime.toJSDate())
+
     cy.getByTestId('chart-tooltip-id').should('contain.text', 'the task')
-    cy.getByTestId('date-time-full').should('contain.text', '1 Jan, 01:00:01')
+    cy.getByTestId('date-time-full').should('contain.text', shortDate)
     cy.getByTestId('chart-tooltip-value').should('contain.text', 'the value')
 
     cy.checkAccessibility()

--- a/hivemq-edge/src/frontend/src/modules/Metrics/components/parts/ChartTooltip.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Metrics/components/parts/ChartTooltip.tsx
@@ -1,0 +1,30 @@
+import { FC } from 'react'
+import { Badge, Card, Text } from '@chakra-ui/react'
+import DateTimeRenderer from '@/components/DateTime/DateTimeRenderer.tsx'
+import { DateTime } from 'luxon'
+import { PointTooltipProps } from '@nivo/line'
+import { BarTooltipProps } from '@nivo/bar'
+
+interface TooltipProps {
+  d?: PointTooltipProps
+  f?: BarTooltipProps<unknown>
+
+  color: string
+  id: string | number
+  date: DateTime
+  formattedValue: string
+}
+
+const ChartTooltip: FC<TooltipProps> = ({ formattedValue, color, date, id }) => {
+  return (
+    <Card p={1} data-testid={'chart-tooltip'}>
+      <Badge backgroundColor={color} color={'white'}>
+        {id}
+      </Badge>
+      <DateTimeRenderer date={date} isShort />
+      <Text fontWeight={'bold'}>{formattedValue}</Text>
+    </Card>
+  )
+}
+
+export default ChartTooltip

--- a/hivemq-edge/src/frontend/src/modules/Metrics/components/parts/ChartTooltip.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Metrics/components/parts/ChartTooltip.tsx
@@ -1,14 +1,9 @@
 import { FC } from 'react'
-import { Badge, Card, Text } from '@chakra-ui/react'
+import { Card, HStack, Square, Text } from '@chakra-ui/react'
 import DateTimeRenderer from '@/components/DateTime/DateTimeRenderer.tsx'
 import { DateTime } from 'luxon'
-import { PointTooltipProps } from '@nivo/line'
-import { BarTooltipProps } from '@nivo/bar'
 
 interface TooltipProps {
-  d?: PointTooltipProps
-  f?: BarTooltipProps<unknown>
-
   color: string
   id: string | number
   date: DateTime
@@ -18,11 +13,15 @@ interface TooltipProps {
 const ChartTooltip: FC<TooltipProps> = ({ formattedValue, color, date, id }) => {
   return (
     <Card p={1} data-testid={'chart-tooltip'}>
-      <Badge backgroundColor={color} color={'white'}>
-        {id}
-      </Badge>
+      <HStack data-testid={'chart-tooltip-id'}>
+        <Square size={4} bg={color} />
+        <Text>{id}</Text>
+      </HStack>
+
       <DateTimeRenderer date={date} isShort />
-      <Text fontWeight={'bold'}>{formattedValue}</Text>
+      <Text fontWeight={'bold'} data-testid={'chart-tooltip-value'}>
+        {formattedValue}
+      </Text>
     </Card>
   )
 }

--- a/hivemq-edge/src/frontend/src/modules/Metrics/types.ts
+++ b/hivemq-edge/src/frontend/src/modules/Metrics/types.ts
@@ -34,4 +34,10 @@ export interface ChartProps extends BoxProps {
   metricName: string
   'aria-label': string
   data: DataPoint[]
+  chartTheme?: ChartTheme
+}
+
+export interface ChartTheme {
+  colourScheme: string
+  deviceId?: string
 }

--- a/hivemq-edge/src/frontend/src/modules/Theme/styles/Stat.ts
+++ b/hivemq-edge/src/frontend/src/modules/Theme/styles/Stat.ts
@@ -6,7 +6,7 @@ const { definePartsStyle, defineMultiStyleConfig } = createMultiStyleConfigHelpe
 const hivemq = definePartsStyle({
   container: {
     borderRadius: 'lg',
-    border: '2px solid',
+    border: '4px solid',
     borderColor: 'blue.500',
     p: 1,
   },

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/controls/NodePanelController.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/controls/NodePanelController.tsx
@@ -106,6 +106,7 @@ const NodePanelController: FC = () => {
       )}
       {selectedGroup && (
         <GroupPropertyDrawer
+          showConfig
           nodeId={nodeId}
           nodes={nodes}
           selectedNode={selectedGroup}

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/drawers/GroupPropertyDrawer.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/drawers/GroupPropertyDrawer.tsx
@@ -18,33 +18,44 @@ import { Group, NodeTypes } from '../../types.ts'
 import useWorkspaceStore from '../../hooks/useWorkspaceStore.ts'
 import { getDefaultMetricsFor } from '../../utils/nodes-utils.ts'
 import GroupMetadataEditor from '../parts/GroupMetadataEditor.tsx'
+import { ChartType } from '@/modules/Metrics/types.ts'
 
-interface LinkPropertyDrawerProps {
+interface GroupPropertyDrawerProps {
   nodeId: string
   selectedNode: Node<Group>
   nodes: Node[]
   isOpen: boolean
+  showConfig?: boolean
   onClose: () => void
   onEditEntity: () => void
 }
 
-const GroupPropertyDrawer: FC<LinkPropertyDrawerProps> = ({ nodeId, isOpen, selectedNode, nodes, onClose }) => {
+const GroupPropertyDrawer: FC<GroupPropertyDrawerProps> = ({
+  nodeId,
+  isOpen,
+  showConfig = false,
+  selectedNode,
+  nodes,
+  onClose,
+}) => {
   const { t } = useTranslation()
   const { onGroupSetData } = useWorkspaceStore()
 
   const adapterIDs = selectedNode.data.childrenNodeIds.map<Node | undefined>((e) => nodes.find((x) => x.id === e))
   const metrics = adapterIDs.map((x) => (x ? getDefaultMetricsFor(x) : [])).flat()
 
+  const panelTitle = showConfig
+    ? (t('workspace.property.header', { context: selectedNode.type }) as string)
+    : (t('workspace.observability.header', { context: selectedNode.type }) as string)
+
   return (
     <Drawer isOpen={isOpen} placement="right" size={'lg'} onClose={onClose}>
       <DrawerOverlay />
-      <DrawerContent aria-label={t('workspace.observability.header', { context: selectedNode.type }) as string}>
+      <DrawerContent aria-label={panelTitle}>
         <DrawerCloseButton />
 
         <DrawerHeader>
-          <Text data-testid={'group-panel-title'}>
-            {t('workspace.observability.header', { context: selectedNode.type })}
-          </Text>
+          <Text data-testid={'group-panel-title'}>{panelTitle}</Text>
           <Box data-testid={'group-panel-keys'}>
             {selectedNode.data.childrenNodeIds.map((e) => (
               <Text key={e}>
@@ -55,17 +66,20 @@ const GroupPropertyDrawer: FC<LinkPropertyDrawerProps> = ({ nodeId, isOpen, sele
           </Box>
         </DrawerHeader>
         <DrawerBody display={'flex'} flexDirection={'column'} gap={6}>
-          <GroupMetadataEditor
-            group={selectedNode}
-            onSubmit={(group) => {
-              onGroupSetData(nodeId, group)
-            }}
-          />
+          {showConfig && (
+            <GroupMetadataEditor
+              group={selectedNode}
+              onSubmit={(group) => {
+                onGroupSetData(nodeId, group)
+              }}
+            />
+          )}
           <Metrics
             nodeId={nodeId}
             type={selectedNode.type as NodeTypes}
             adapterIDs={adapterIDs.map((e) => e?.data.id)}
             initMetrics={metrics}
+            defaultChartType={showConfig ? ChartType.SAMPLE : undefined}
           />
         </DrawerBody>
       </DrawerContent>


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/18077/details/

The PR refactors the charts in the Observability panel, in order to alig ntheir design with the theme used for the Edge application. 

- The color schemes for the "series" are now based on the `ChakraUI` theme
- each data series in a chart is assign one of the available color scheme
- the tooltip is now consistent across the line and bar charts 
- the legend of the line and barcharts are now properly disaplyed
- the x-axis of the line and chart is now using a proper timestamp formatttng 

The PR also fixes the nature of the group side panel, properly differentiating between "Overview" and "Observability", as for the other nodes.

### Out-of-scope
- The display of multiple series within a chart will be dealt with in another ticket. See https://hivemq.kanbanize.com/ctrl_board/57/cards/18215/details/
- The handling of persisted data is limited to the last 10 samples, and are not persisted in any way. Changing this behaviour, if required, will be dealt with in another ticket. See https://hivemq.kanbanize.com/ctrl_board/57/cards/17964/details/

### Before
![screenshot-localhost_3000-2023 12 14-18_16_34](https://github.com/hivemq/hivemq-edge/assets/2743481/85de4749-a5c8-4efd-b2aa-6f62f8939025)

![screenshot-localhost_3000-2023 12 14-18_19_41](https://github.com/hivemq/hivemq-edge/assets/2743481/a7f4a3ab-7ce8-4d65-9279-15ddfd527556)


### After
![screenshot-localhost_3000-2023 12 14-18_15_55](https://github.com/hivemq/hivemq-edge/assets/2743481/92e10080-719d-44d3-8c4b-884d4c18c924)

![screenshot-localhost_3000-2023 12 14-14_55_33](https://github.com/hivemq/hivemq-edge/assets/2743481/7c02c3bc-1181-4c73-9ed0-868a2c9c0117)


![screenshot-localhost_3000-2023 12 15-10_12_38](https://github.com/hivemq/hivemq-edge/assets/2743481/6723653d-9425-4545-b1bb-aa626ace6dcb)

