### PR TITLE
fix(17823): Change persist default and remove warning

### DIFF
--- a/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/PersistencePanel.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/PersistencePanel.spec.cy.tsx
@@ -47,11 +47,6 @@ describe('PersistencePanel', () => {
       .should('contain.text', 'Select to store MQTT Traffic greater than QoS 0 on disk.')
     cy.get('label').should('contain.text', 'MQTT Persistence')
 
-    cy.get('label').click()
-    cy.get('[role="alert"]')
-      .should('have.attr', 'data-status', 'info')
-      .should('contain.text', 'Change will only be applied after a persisted restart of HIveMQ Edge')
-
     cy.checkAccessibility()
     cy.percySnapshot('Component: PersistencePanel')
   })

--- a/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/PersistencePanel.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/PersistencePanel.tsx
@@ -1,6 +1,6 @@
 import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Alert, AlertIcon, Checkbox, FormControl, FormErrorMessage, FormHelperText } from '@chakra-ui/react'
+import { Checkbox, FormControl, FormErrorMessage, FormHelperText } from '@chakra-ui/react'
 
 import { Capability } from '@/api/__generated__'
 import { BridgePanelType } from '../../types.ts'
@@ -13,25 +13,17 @@ const PersistencePanel: FC<PersistencePanelType> = ({ form }) => {
   const { t } = useTranslation()
   const {
     register,
-    formState: { errors, dirtyFields },
+    formState: { errors },
   } = form
 
   return (
-    <>
-      {dirtyFields.persist && (
-        <Alert status="info" mb={4}>
-          <AlertIcon />
-          {t('bridge.persistence.restartWarning')}
-        </Alert>
-      )}
-      <FormControl variant={'hivemq'} flexGrow={1} display={'flex'} flexDirection={'column'} gap={4} as={'fieldset'}>
-        <FormControl isInvalid={!!errors.persist}>
-          <Checkbox {...register('persist')}>{t('bridge.persistence.persist.label')}</Checkbox>
-          <FormHelperText>{t('bridge.persistence.persist.helper')}</FormHelperText>
-          <FormErrorMessage>{errors.persist && errors.persist.message}</FormErrorMessage>
-        </FormControl>
+    <FormControl variant={'hivemq'} flexGrow={1} display={'flex'} flexDirection={'column'} gap={4} as={'fieldset'}>
+      <FormControl isInvalid={!!errors.persist}>
+        <Checkbox {...register('persist')}>{t('bridge.persistence.persist.label')}</Checkbox>
+        <FormHelperText>{t('bridge.persistence.persist.helper')}</FormHelperText>
+        <FormErrorMessage>{errors.persist && errors.persist.message}</FormErrorMessage>
       </FormControl>
-    </>
+    </FormControl>
   )
 }
 

--- a/hivemq-edge/src/frontend/src/modules/Bridges/hooks/useBridgeConfig.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Bridges/hooks/useBridgeConfig.tsx
@@ -25,6 +25,7 @@ export const bridgeInitialState: Bridge = {
   id: '',
   port: 1883,
   sessionExpiry: 3600,
+  persist: true,
 }
 
 export const BridgeProvider: FunctionComponent<PropsWithChildren> = ({ children }) => {


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/17823/details/

Small PR to fix the following issue
- default `persist` option set to checked on creation
- restart warning message removed from the UI  