### PR TITLE
fix(17211) - Cascase bridge and adapter metrics on delete / stop

### DIFF
--- a/hivemq-edge/src/main/java/com/hivemq/bridge/metrics/PerBridgeMetrics.java
+++ b/hivemq-edge/src/main/java/com/hivemq/bridge/metrics/PerBridgeMetrics.java
@@ -40,6 +40,7 @@ public class PerBridgeMetrics {
     private final @NotNull Counter loopPreventionForwardDropCounter;
     private final @NotNull Counter loopPreventionRemoteDropCounter;
     private final @NotNull Set<String> metricNames = new HashSet<>();
+    private final @NotNull Object mutex = new Object();
 
     public PerBridgeMetrics(final @NotNull String bridgeName, final @NotNull MetricRegistry metricRegistry) {
 
@@ -96,7 +97,9 @@ public class PerBridgeMetrics {
 
     private Counter createBridgeCounter(final @NotNull MetricRegistry metricRegistry, @NotNull final String... names){
         final String metricName = MetricRegistry.name(BRIDGE_PREFIX, names);
-        metricNames.add(metricName);
+        synchronized (mutex){
+            metricNames.add(metricName);
+        }
         return metricRegistry.counter(metricName);
     }
 
@@ -142,7 +145,9 @@ public class PerBridgeMetrics {
 
     public void clearAll(final @NotNull MetricRegistry metricRegistry){
         Preconditions.checkNotNull(metricRegistry);
-        metricNames.forEach(metricRegistry::remove);
-        metricNames.clear();
+        synchronized (mutex){
+            metricNames.forEach(metricRegistry::remove);
+            metricNames.clear();
+        }
     }
 }

--- a/hivemq-edge/src/main/java/com/hivemq/bridge/metrics/PerBridgeMetrics.java
+++ b/hivemq-edge/src/main/java/com/hivemq/bridge/metrics/PerBridgeMetrics.java
@@ -19,6 +19,7 @@ import com.codahale.metrics.Counter;
 import com.codahale.metrics.MetricRegistry;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
 import com.hivemq.metrics.HiveMQMetrics;
+import dagger.internal.Preconditions;
 import javassist.convert.TransformNew;
 
 import javax.sound.midi.VoiceStatus;
@@ -140,6 +141,7 @@ public class PerBridgeMetrics {
     }
 
     public void clearAll(final @NotNull MetricRegistry metricRegistry){
+        Preconditions.checkNotNull(metricRegistry);
         metricNames.forEach(metricRegistry::remove);
         metricNames.clear();
     }

--- a/hivemq-edge/src/main/java/com/hivemq/edge/modules/adapters/impl/AbstractProtocolAdapter.java
+++ b/hivemq-edge/src/main/java/com/hivemq/edge/modules/adapters/impl/AbstractProtocolAdapter.java
@@ -297,6 +297,11 @@ public abstract class AbstractProtocolAdapter<T extends AbstractProtocolAdapterC
         this.runtimeStatus.set(runtimeStatus);
     }
 
+    @Override
+    public void destroy() {
+        protocolAdapterMetricsHelper.clearAll();
+    }
+
     protected boolean running(){
         return runtimeStatus.get() == RuntimeStatus.STARTED;
     }

--- a/hivemq-edge/src/main/java/com/hivemq/edge/modules/adapters/metrics/ProtocolAdapterMetricsHelper.java
+++ b/hivemq-edge/src/main/java/com/hivemq/edge/modules/adapters/metrics/ProtocolAdapterMetricsHelper.java
@@ -18,8 +18,14 @@ package com.hivemq.edge.modules.adapters.metrics;
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.base.Preconditions;
+import com.hivemq.bootstrap.LoggingBootstrap;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
 import com.hivemq.metrics.HiveMQMetrics;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.logging.Logger;
 
 /**
  * Ensures the adapters use consistent namespaces for the metrics so they can be derived
@@ -32,6 +38,7 @@ public class ProtocolAdapterMetricsHelper {
     private @NotNull String protocolAdapterType;
     private @NotNull String protocolAdapterId;
     private @NotNull MetricRegistry metricRegistry;
+    private final @NotNull Set<String> metricNames = new HashSet<>();
     static final String SUCCESS_COUNT = "success.count";
     static final String FAILED_COUNT = "failed.count";
     static final String PERIOD = ".";
@@ -98,6 +105,13 @@ public class ProtocolAdapterMetricsHelper {
         metricRegistry.counter(createAdapterMetricsNamespace(metricName, false)).inc();
     }
 
+    public void clearAll(){
+        Preconditions.checkNotNull(metricRegistry);
+        LoggerFactory.getLogger(ProtocolAdapterMetricsHelper.class).info("Clearing all protocol adapter metrics");
+        metricNames.forEach(metricRegistry::remove);
+        metricNames.clear();
+    }
+
     /**
      * Create a deterministic prefix for use in the metrics registry.
      *
@@ -118,6 +132,8 @@ public class ProtocolAdapterMetricsHelper {
         if(trailingPeriod){
             stringBuilder.append(PERIOD);
         }
-        return stringBuilder.toString();
+        String metricName = stringBuilder.toString();
+        metricNames.add(metricName);
+        return metricName;
     }
 }

--- a/hivemq-edge/src/main/java/com/hivemq/edge/modules/adapters/metrics/ProtocolAdapterMetricsHelper.java
+++ b/hivemq-edge/src/main/java/com/hivemq/edge/modules/adapters/metrics/ProtocolAdapterMetricsHelper.java
@@ -62,10 +62,10 @@ public class ProtocolAdapterMetricsHelper {
     }
 
     protected void initRegistry(){
-        publishSuccessCounter = metricRegistry.counter(createAdapterMetricsNamespace("read.publish" + SUCCESS_COUNT));
-        publishFailedCounter = metricRegistry.counter(createAdapterMetricsNamespace("read.publish" + FAILED_COUNT) );
-        connectionSuccessCounter = metricRegistry.counter(createAdapterMetricsNamespace("connection" + SUCCESS_COUNT));
-        connectionFailedCounter = metricRegistry.counter(createAdapterMetricsNamespace("connection" + FAILED_COUNT));
+        publishSuccessCounter = metricRegistry.counter(createAdapterMetricsNamespace("read.publish." + SUCCESS_COUNT));
+        publishFailedCounter = metricRegistry.counter(createAdapterMetricsNamespace("read.publish." + FAILED_COUNT) );
+        connectionSuccessCounter = metricRegistry.counter(createAdapterMetricsNamespace("connection." + SUCCESS_COUNT));
+        connectionFailedCounter = metricRegistry.counter(createAdapterMetricsNamespace("connection." + FAILED_COUNT));
     }
 
     /**

--- a/hivemq-edge/src/main/java/com/hivemq/edge/modules/api/adapters/ProtocolAdapter.java
+++ b/hivemq-edge/src/main/java/com/hivemq/edge/modules/api/adapters/ProtocolAdapter.java
@@ -77,6 +77,13 @@ public interface ProtocolAdapter {
 
     @Nullable String getErrorMessage();
 
+    /**
+     *  Called by the framework when the instance will be discarded
+     */
+    default void destroy() {
+
+    }
+
 
     enum RuntimeStatus {
         STARTED,

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/ProtocolAdapterManager.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/ProtocolAdapterManager.java
@@ -293,6 +293,8 @@ public class ProtocolAdapterManager {
             if (protocolAdapters.remove(id) != null) {
                 try {
                     synchronized(lock){
+                        //ensure the instance releases any hard state
+                        adapterInstance.get().getAdapter().destroy();
                         Map<String, Object> mainMap =
                                 configurationService.protocolAdapterConfigurationService().getAllConfigs();
                         List<Map> adapterList = getAdapterListForType(adapterInstance.get().getAdapterInformation().getProtocolId());

--- a/hivemq-edge/src/test/java/com/hivemq/adapter/ProtocolMetricsHelperTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/adapter/ProtocolMetricsHelperTest.java
@@ -26,6 +26,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  */
 public class ProtocolMetricsHelperTest {
 
+    static final String ARBITRARY_METRIC = "arbitrary-metric";
+
     @Test
     void testMetricsAdapterWrapperUpdatesRegistry() {
 
@@ -38,8 +40,29 @@ public class ProtocolMetricsHelperTest {
         assertEquals(1, registry.getCounters().get("com.hivemq.edge.protocol-adapters.test-adapter-name.test-adapter-id.read.publish.failed.count").getCount(), "Matching failed data point should be incremented");
         assertEquals(1, registry.getCounters().get("com.hivemq.edge.protocol-adapters.test-adapter-name.test-adapter-id.read.publish.success.count").getCount(), "Matching success data point should be incremented");
 
-        helper.increment("arbitrary-metric");
+        helper.increment(ARBITRARY_METRIC);
         assertEquals(1, registry.getCounters().get("com.hivemq.edge.protocol-adapters.test-adapter-name.test-adapter-id.arbitrary-metric").getCount(), "Matching arbitrary data point should be incremented");
+
+    }
+
+    @Test
+    void testTearDownMetrics() {
+
+        MetricRegistry registry = new MetricRegistry();
+
+        //adapter helper creates 4 metrics
+        ProtocolAdapterMetricsHelper helper1 =
+                new ProtocolAdapterMetricsHelper("tear-down-name1","test-adapter-id", registry);
+
+        //add an arbitrary fifth
+        registry.counter(ARBITRARY_METRIC).inc();
+
+        assertEquals(5, registry.getMetrics().size(), "Number of metrics should match");
+
+        helper1.clearAll();
+
+        assertEquals(1, registry.getMetrics().size(), "Number of metrics should match");
+        assertEquals(1, registry.getCounters().get(ARBITRARY_METRIC).getCount(), "Matching success data point should be incremented");
 
     }
 }

--- a/hivemq-edge/src/test/java/com/hivemq/bridge/BridgeMetricsTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/bridge/BridgeMetricsTest.java
@@ -1,0 +1,46 @@
+package com.hivemq.bridge;
+
+import com.codahale.metrics.MetricRegistry;
+import com.hivemq.bridge.metrics.PerBridgeMetrics;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * @author Simon L Johnson
+ */
+public class BridgeMetricsTest {
+
+    static final String ARBITRARY_METRIC = "arbitrary-metric";
+    @Test
+    void testTearDownMetrics() {
+
+        MetricRegistry registry = new MetricRegistry();
+
+        //adapter helper creates 10 metrics
+        PerBridgeMetrics perBridgeMetrics = new PerBridgeMetrics("bridge-name", registry);
+
+        assertEquals(10, registry.getMetrics().size(), "Number of metrics should match");
+
+        PerBridgeMetrics perBridgeMetrics2 = new PerBridgeMetrics("bridge-name2", registry);
+
+        assertEquals(20, registry.getMetrics().size(), "Number of metrics should match");
+
+        //add an arbitrary fifth
+        registry.counter(ARBITRARY_METRIC).inc();
+
+        assertEquals(21, registry.getMetrics().size(), "Number of metrics should match");
+
+        perBridgeMetrics.clearAll(registry);
+
+        assertEquals(11, registry.getMetrics().size(), "Number of metrics should match");
+
+        perBridgeMetrics2.clearAll(registry);
+
+        assertEquals(1, registry.getMetrics().size(), "Number of metrics should match");
+
+        assertEquals(1, registry.getCounters().get(ARBITRARY_METRIC).getCount(), "Matching success data point should be incremented");
+
+    }
+
+}


### PR DESCRIPTION
**Motivation**

**Changes**

When a bridge is stopped / deleted, the associated metrics are removed.
When an adaper is updated / deletedthe associated metrics are removed.
