### PR TITLE
remove .browserslistrc file ref from build.gradle fe script

### DIFF
--- a/hivemq-edge/src/frontend/build.gradle.kts
+++ b/hivemq-edge/src/frontend/build.gradle.kts
@@ -13,7 +13,7 @@ val buildFrontend by tasks.registering(PnpmTask::class) {
   inputs.dir(project.fileTree("src"))
   inputs.dir(project.fileTree("public"))
   inputs.dir("node_modules")
-  inputs.files("index.html", ".env", "vite.config.ts", ".browserslistrc", "tsconfig.json", "tsconfig.node.json")
+  inputs.files("index.html", ".env", "vite.config.ts", "tsconfig.json", "tsconfig.node.json")
   outputs.dir("${project.projectDir}/dist")
 }
 


### PR DESCRIPTION
**Motivation**

I think this file doesn't exists in the project, so it is safe to remove.

**Changes**

- removed .browserslistrc file ref from build.gradle fe script