### PR TITLE
feat(18687): Add navigation and basic flow architecture

### DIFF
--- a/hivemq-edge/src/frontend/src/__test-utils__/msw/handlers.ts
+++ b/hivemq-edge/src/frontend/src/__test-utils__/msw/handlers.ts
@@ -1,13 +1,25 @@
-import { handlers as AuthHandlers } from '../../api/hooks/usePostAuthentication/__handlers__'
-import { handlers as ConnectionStatusHandlers } from '../../api/hooks/useConnection/__handlers__'
-import { handlers as BridgeHandlers } from '../../api/hooks/useGetBridges/__handlers__'
-import { handlers as ProtocolAdapterHandlers } from '../../api/hooks/useProtocolAdapters/__handlers__'
-import { handlers as ListenerHandlers } from '../../api/hooks/useGateway/__handlers__'
+import { handlers as useFrontendServices } from '@/api/hooks/useFrontendServices/__handlers__'
+import { handlers as AuthHandlers } from '@/api/hooks/usePostAuthentication/__handlers__'
+import { handlers as ConnectionStatusHandlers } from '@/api/hooks/useConnection/__handlers__'
+import { handlers as BridgeHandlers } from '@/api/hooks/useGetBridges/__handlers__'
+import { handlers as ProtocolAdapterHandlers } from '@/api/hooks/useProtocolAdapters/__handlers__'
+import { handlers as ListenerHandlers } from '@/api/hooks/useGateway/__handlers__'
+
+import { handlers as DataHubDataPoliciesService } from '@/extensions/datahub/api/hooks/DataHubDataPoliciesService/__handlers__'
+import { handlers as DataHubBehaviorPoliciesService } from '@/extensions/datahub/api/hooks/DataHubBehaviorPoliciesService/__handlers__'
+import { handlers as DataHubSchemasService } from '@/extensions/datahub/api/hooks/DataHubSchemasService/__handlers__'
+import { handlers as DataHubScriptsService } from '@/extensions/datahub/api/hooks/DataHubScriptsService/__handlers__'
 
 export const handlers = [
+  ...useFrontendServices,
   ...ListenerHandlers,
   ...AuthHandlers,
   ...ConnectionStatusHandlers,
   ...BridgeHandlers,
   ...ProtocolAdapterHandlers,
+  // Datahub extension
+  ...DataHubDataPoliciesService,
+  ...DataHubBehaviorPoliciesService,
+  ...DataHubSchemasService,
+  ...DataHubScriptsService,
 ]

--- a/hivemq-edge/src/frontend/src/__test-utils__/react-flow/nodes.ts
+++ b/hivemq-edge/src/frontend/src/__test-utils__/react-flow/nodes.ts
@@ -5,7 +5,7 @@ import { Listener } from '@/api/__generated__'
 import { mockMqttListener } from '@/api/hooks/useGateway/__handlers__'
 import { Group, NodeTypes } from '@/modules/Workspace/types.ts'
 
-const DEFAULT_NODE = {
+export const MOCK_DEFAULT_NODE = {
   selected: false,
   zIndex: 1000,
   isConnectable: true,
@@ -19,7 +19,7 @@ export const MOCK_NODE_ADAPTER: NodeProps = {
   type: NodeTypes.ADAPTER_NODE,
   sourcePosition: Position.Bottom,
   data: mockAdapter,
-  ...DEFAULT_NODE,
+  ...MOCK_DEFAULT_NODE,
 }
 
 export const MOCK_NODE_BRIDGE: NodeProps = {
@@ -27,7 +27,7 @@ export const MOCK_NODE_BRIDGE: NodeProps = {
   type: NodeTypes.BRIDGE_NODE,
   sourcePosition: Position.Bottom,
   data: mockBridge,
-  ...DEFAULT_NODE,
+  ...MOCK_DEFAULT_NODE,
 }
 
 export const MOCK_NODE_EDGE: NodeProps = {
@@ -35,7 +35,7 @@ export const MOCK_NODE_EDGE: NodeProps = {
   type: NodeTypes.EDGE_NODE,
   sourcePosition: Position.Bottom,
   data: { label: 'HiveMQ Edge' },
-  ...DEFAULT_NODE,
+  ...MOCK_DEFAULT_NODE,
 }
 
 export const MOCK_NODE_LISTENER: NodeProps<Listener> = {
@@ -43,7 +43,7 @@ export const MOCK_NODE_LISTENER: NodeProps<Listener> = {
   type: NodeTypes.LISTENER_NODE,
   sourcePosition: Position.Bottom,
   data: mockMqttListener,
-  ...DEFAULT_NODE,
+  ...MOCK_DEFAULT_NODE,
 }
 
 export const MOCK_NODE_GROUP: NodeProps<Group> = {
@@ -51,5 +51,5 @@ export const MOCK_NODE_GROUP: NodeProps<Group> = {
   type: NodeTypes.CLUSTER_NODE,
   sourcePosition: Position.Bottom,
   data: { childrenNodeIds: ['idAdapter', 'idBridge'], title: 'The group title', isOpen: true },
-  ...DEFAULT_NODE,
+  ...MOCK_DEFAULT_NODE,
 }

--- a/hivemq-edge/src/frontend/src/api/hooks/useFrontendServices/useGetCapability.tsx
+++ b/hivemq-edge/src/frontend/src/api/hooks/useFrontendServices/useGetCapability.tsx
@@ -3,6 +3,11 @@ import { Capability } from '@/api/__generated__'
 
 import { useGetCapabilities } from './useGetCapabilities.tsx'
 
+export enum CAPABILITY {
+  PERSISTENCE = 'mqtt-persistence',
+  DATAHUB = 'mqtt-datahub',
+}
+
 export const useGetCapability = (id: string) => {
   const { data, isSuccess } = useGetCapabilities()
 

--- a/hivemq-edge/src/frontend/src/config/i18n.config.ts
+++ b/hivemq-edge/src/frontend/src/config/i18n.config.ts
@@ -2,13 +2,15 @@ import { initReactI18next } from 'react-i18next'
 import i18n from 'i18next'
 import Pseudo from 'i18next-pseudo'
 
-import main_en from '../locales/en/translation.json'
-import component_en from '../locales/en/components.json'
+import main_en from '@/locales/en/translation.json'
+import component_en from '@/locales/en/components.json'
+import datahub_en from '@/extensions/datahub/locales/en/datahub.json'
 
 const resources = {
   en: {
     translation: { ...main_en },
     components: { ...component_en },
+    datahub: { ...datahub_en },
   },
 }
 

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/DataHubPage.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/DataHubPage.tsx
@@ -1,0 +1,34 @@
+import { FC } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Outlet } from 'react-router-dom'
+
+import PageContainer from '@/components/PageContainer.tsx'
+import { CAPABILITY, useGetCapability } from '@/api/hooks/useFrontendServices/useGetCapability.tsx'
+import { Box } from '@chakra-ui/react'
+import WarningMessage from '@/components/WarningMessage.tsx'
+import AdapterEmptyLogo from '@/assets/app/adaptor-empty.svg'
+
+const DataHubPage: FC = () => {
+  const { t } = useTranslation('datahub')
+  const hasDataHub = useGetCapability(CAPABILITY.DATAHUB)
+  // const navigate = useNavigate()
+
+  return (
+    <PageContainer title={t('page.title') as string} subtitle={t('page.description') as string}>
+      {hasDataHub && <Outlet />}
+      {!hasDataHub && (
+        <Box width={'100%'}>
+          <WarningMessage
+            image={AdapterEmptyLogo}
+            title={t('error.notActivated.title') as string}
+            prompt={t('error.notActivated.description') as string}
+            alt={t('brand.extension')}
+            mt={10}
+          />
+        </Box>
+      )}
+    </PageContainer>
+  )
+}
+
+export default DataHubPage

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/CanvasControls.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/CanvasControls.spec.cy.tsx
@@ -1,0 +1,23 @@
+/// <reference types="cypress" />
+
+import { ReactFlowProvider } from 'reactflow'
+import CanvasControls from './CanvasControls.tsx'
+
+describe('CanvasControls', () => {
+  beforeEach(() => {
+    cy.viewport(800, 250)
+  })
+
+  it('should renders properly', () => {
+    cy.mountWithProviders(
+      <ReactFlowProvider>
+        <CanvasControls />
+      </ReactFlowProvider>
+    )
+    cy.get("[role='group']").find('button').should('have.length', 4)
+    cy.get("[role='group']").find('button').eq(0).should('have.attr', 'aria-label', 'Zoom in')
+    cy.get("[role='group']").find('button').eq(1).should('have.attr', 'aria-label', 'Zoom out')
+    cy.get("[role='group']").find('button').eq(2).should('have.attr', 'aria-label', 'Fit to the canvas')
+    cy.get("[role='group']").find('button').eq(3).should('have.attr', 'aria-label', 'Lock the canvas')
+  })
+})

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/CanvasControls.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/CanvasControls.tsx
@@ -1,0 +1,55 @@
+import { FC } from 'react'
+import { ControlProps, Panel, ReactFlowState, useReactFlow, useStore, useStoreApi } from 'reactflow'
+
+import { ButtonGroup } from '@chakra-ui/react'
+import { FaLock, FaLockOpen, FaMinus, FaPlus } from 'react-icons/fa6'
+import { LuBoxSelect } from 'react-icons/lu'
+import { useTranslation } from 'react-i18next'
+
+import IconButton from '@/components/Chakra/IconButton.tsx'
+
+import 'reactflow/dist/style.css'
+
+const CanvasControls: FC<ControlProps> = ({ onInteractiveChange }) => {
+  const { t } = useTranslation('datahub')
+  const store = useStoreApi()
+  const { zoomIn, zoomOut, fitView } = useReactFlow()
+  const { isInteractive } = useStore((s: ReactFlowState) => ({
+    isInteractive: s.nodesDraggable || s.nodesConnectable || s.elementsSelectable,
+  }))
+
+  const onToggleInteractivity = () => {
+    store.setState({
+      nodesDraggable: !isInteractive,
+      nodesConnectable: !isInteractive,
+      elementsSelectable: !isInteractive,
+    })
+
+    onInteractiveChange?.(!isInteractive)
+  }
+
+  return (
+    <Panel position={'bottom-left'}>
+      <ButtonGroup variant="outline" isAttached size={'sm'}>
+        <IconButton icon={<FaPlus />} onClick={() => zoomIn()} aria-label={t('workspace.controls.zoomIn') as string} />
+        <IconButton
+          icon={<FaMinus />}
+          onClick={() => zoomOut()}
+          aria-label={t('workspace.controls.zoomIOut') as string}
+        />
+        <IconButton
+          icon={<LuBoxSelect />}
+          onClick={() => fitView()}
+          aria-label={t('workspace.controls.fitView') as string}
+        />
+        <IconButton
+          icon={isInteractive ? <FaLock /> : <FaLockOpen />}
+          onClick={onToggleInteractivity}
+          aria-label={t('workspace.controls.toggleInteractivity') as string}
+        />
+      </ButtonGroup>
+    </Panel>
+  )
+}
+
+export default CanvasControls

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/Minimap.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/Minimap.spec.cy.tsx
@@ -1,0 +1,18 @@
+/// <reference types="cypress" />
+
+import { ReactFlowProvider } from 'reactflow'
+import Minimap from './Minimap.tsx'
+
+describe('Minimap', () => {
+  beforeEach(() => {
+    cy.viewport(800, 250)
+  })
+
+  it('should renders properly', () => {
+    cy.mountWithProviders(
+      <ReactFlowProvider>
+        <Minimap position={'top-left'} />
+      </ReactFlowProvider>
+    )
+  })
+})

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/Minimap.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/Minimap.tsx
@@ -1,13 +1,14 @@
 import { FC } from 'react'
-import { MiniMap as ReactFlowMinimap } from 'reactflow'
+import { MiniMap as ReactFlowMinimap, MiniMapProps } from 'reactflow'
 import { useTheme, useColorMode } from '@chakra-ui/react'
 
-const Minimap: FC = () => {
+const Minimap: FC<MiniMapProps> = (props) => {
   const { colors } = useTheme()
   const { colorMode } = useColorMode()
 
   return (
     <ReactFlowMinimap
+      {...props}
       nodeStrokeWidth={1}
       nodeColor={colorMode === 'light' ? colors.gray[300] : colors.gray[700]}
       maskColor={colorMode === 'light' ? colors.gray[200] : colors.gray[700]}

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/Minimap.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/Minimap.tsx
@@ -1,0 +1,19 @@
+import { FC } from 'react'
+import { MiniMap as ReactFlowMinimap } from 'reactflow'
+import { useTheme, useColorMode } from '@chakra-ui/react'
+
+const Minimap: FC = () => {
+  const { colors } = useTheme()
+  const { colorMode } = useColorMode()
+
+  return (
+    <ReactFlowMinimap
+      nodeStrokeWidth={1}
+      nodeColor={colorMode === 'light' ? colors.gray[300] : colors.gray[700]}
+      maskColor={colorMode === 'light' ? colors.gray[200] : colors.gray[700]}
+      style={{ backgroundColor: colorMode === 'light' ? colors['white'] : colors.gray[500] }}
+    />
+  )
+}
+
+export default Minimap

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/PropertyPanelController.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/PropertyPanelController.spec.cy.tsx
@@ -1,0 +1,28 @@
+/// <reference types="cypress" />
+
+import { ReactFlowProvider } from 'reactflow'
+import PropertyPanelController from '@/extensions/datahub/components/controls/PropertyPanelController.tsx'
+import { Route, Routes } from 'react-router-dom'
+
+describe('PropertyPanelController', () => {
+  beforeEach(() => {
+    cy.viewport(800, 600)
+  })
+
+  it('should renders properly the side panel', () => {
+    cy.mountWithProviders(
+      <ReactFlowProvider>
+        <Routes>
+          <Route path="/node/:type/:nodeId" element={<PropertyPanelController />}></Route>
+        </Routes>
+      </ReactFlowProvider>,
+      { routerProps: { initialEntries: ['/node/TOPIC_FILTER/1'] } }
+    )
+
+    cy.getByTestId('node-editor-content').should('be.visible')
+    cy.getByTestId('node-editor-name').should('contain.text', 'Topic Filter')
+    cy.getByTestId('node-editor-icon').find('svg').should('have.attr', 'aria-label', 'Topic Filter')
+    cy.getByTestId('node-editor-id').should('contain.text', '1')
+    cy.getByTestId('node-editor-under-construction').should('be.visible')
+  })
+})

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/PropertyPanelController.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/PropertyPanelController.tsx
@@ -48,20 +48,24 @@ const PropertyPanelController = () => {
       // finalFocusRef={btnRef}
     >
       <DrawerOverlay />
-      <DrawerContent>
+      <DrawerContent data-testid={'node-editor-content'}>
         <DrawerCloseButton />
         <DrawerHeader>
           <Flex>
-            <Avatar icon={<NodeIcon type={'type'} />} bg="gray.200" />
+            <Avatar icon={<NodeIcon type={type} />} bg="gray.200" data-testid={'node-editor-icon'} />
             <Box ml="3">
-              <Text fontWeight="bold">{t('workspace.nodes.type', { context: type })}</Text>
-              <Text fontSize="sm">id: {nodeId}</Text>
+              <Text fontWeight="bold" data-testid={'node-editor-name'}>
+                {t('workspace.nodes.type', { context: type })}
+              </Text>
+              <Text fontSize="sm" data-testid={'node-editor-id'}>
+                id: {nodeId}
+              </Text>
             </Box>
           </Flex>
         </DrawerHeader>
 
         <DrawerBody>
-          <AbsoluteCenter axis="both">
+          <AbsoluteCenter axis="both" data-testid={'node-editor-under-construction'}>
             <Icon as={LuConstruction} boxSize={100} />
           </AbsoluteCenter>
         </DrawerBody>

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/PropertyPanelController.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/PropertyPanelController.tsx
@@ -1,0 +1,73 @@
+import { useCallback, useEffect } from 'react'
+import { useLocation, useNavigate, useParams } from 'react-router-dom'
+
+import {
+  AbsoluteCenter,
+  Avatar,
+  Box,
+  Drawer,
+  DrawerBody,
+  DrawerCloseButton,
+  DrawerContent,
+  DrawerHeader,
+  DrawerOverlay,
+  Flex,
+  Icon,
+  Text,
+  useDisclosure,
+} from '@chakra-ui/react'
+import { useTranslation } from 'react-i18next'
+import { LuConstruction } from 'react-icons/lu'
+
+import NodeIcon from '../helpers/NodeIcon.tsx'
+
+const PropertyPanelController = () => {
+  const { t } = useTranslation('datahub')
+  const { type, nodeId } = useParams()
+  const { state } = useLocation()
+  const navigate = useNavigate()
+  const { isOpen, onOpen, onClose } = useDisclosure()
+
+  useEffect(() => {
+    if (type && nodeId) {
+      onOpen()
+    }
+  }, [onOpen, type, nodeId])
+
+  const onDrawerClose = useCallback(() => {
+    onClose()
+    navigate(state?.origin || '/datahub')
+  }, [onClose, navigate, state?.origin])
+
+  return (
+    <Drawer
+      size={'lg'}
+      isOpen={isOpen}
+      placement="right"
+      onClose={onDrawerClose}
+      // finalFocusRef={btnRef}
+    >
+      <DrawerOverlay />
+      <DrawerContent>
+        <DrawerCloseButton />
+        <DrawerHeader>
+          <Flex>
+            <Avatar icon={<NodeIcon type={'type'} />} bg="gray.200" />
+            <Box ml="3">
+              <Text fontWeight="bold">{t('workspace.nodes.type', { context: type })}</Text>
+              <Text fontSize="sm">id: {nodeId}</Text>
+            </Box>
+          </Flex>
+        </DrawerHeader>
+
+        <DrawerBody>
+          <AbsoluteCenter axis="both">
+            <Icon as={LuConstruction} boxSize={100} />
+          </AbsoluteCenter>
+        </DrawerBody>
+      </DrawerContent>
+    </Drawer>
+  )
+}
+
+export default PropertyPanelController

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/helpers/NodeIcon.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/helpers/NodeIcon.spec.cy.tsx
@@ -1,0 +1,20 @@
+/// <reference types="cypress" />
+
+import NodeIcon from '@/extensions/datahub/components/helpers/NodeIcon.tsx'
+import { DataHubNodeType } from '@/extensions/datahub/types.ts'
+
+describe('NodeIcon', () => {
+  beforeEach(() => {
+    cy.viewport(800, 250)
+  })
+
+  it('should renders properly', () => {
+    cy.mountWithProviders(<NodeIcon type={DataHubNodeType.DATA_POLICY} />)
+    cy.get('svg').should('have.attr', 'aria-label', 'Data Policy')
+  })
+
+  it('should renders even an unknown type ', () => {
+    cy.mountWithProviders(<NodeIcon type={undefined} />)
+    cy.get('svg').should('have.attr', 'aria-label', 'Unknown type')
+  })
+})

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/helpers/NodeIcon.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/helpers/NodeIcon.tsx
@@ -1,0 +1,49 @@
+import { Icon } from '@chakra-ui/react'
+import { FC } from 'react'
+
+import { GrConnect, GrStatusUnknown, GrValidate } from 'react-icons/gr'
+import { LuFunctionSquare } from 'react-icons/lu'
+import { MdPolicy, MdSchema } from 'react-icons/md'
+import { TbTransitionRight } from 'react-icons/tb'
+import { AiOutlineCloudServer } from 'react-icons/ai'
+import { SiMqtt } from 'react-icons/si'
+
+import { DataHubNodeType } from '../../types.ts'
+import { useTranslation } from 'react-i18next'
+
+const iconMapping: Record<string, (label: string) => JSX.Element> = {
+  [DataHubNodeType.ADAPTOR]: (label) => <Icon as={GrConnect} color={'black'} boxSize={'24px'} aria-label={label} />,
+  [DataHubNodeType.TOPIC_FILTER]: (label) => <Icon as={SiMqtt} color={'black'} boxSize={'16px'} aria-label={label} />,
+  [DataHubNodeType.CLIENT_FILTER]: (label) => (
+    <Icon as={AiOutlineCloudServer} color={'black'} boxSize={'24px'} aria-label={label} />
+  ),
+  [DataHubNodeType.DATA_POLICY]: (label) => <Icon as={MdPolicy} color={'black'} boxSize={'24px'} aria-label={label} />,
+  [DataHubNodeType.BEHAVIOR_POLICY]: (label) => (
+    <Icon as={MdPolicy} color={'black'} boxSize={'24px'} aria-label={label} />
+  ),
+  [DataHubNodeType.VALIDATOR]: (label) => <Icon as={GrValidate} color={'black'} boxSize={'24px'} aria-label={label} />,
+  [DataHubNodeType.SCHEMA]: (label) => <Icon as={MdSchema} color={'black'} boxSize={'24px'} aria-label={label} />,
+  [DataHubNodeType.ACTION]: (label) => (
+    <Icon as={LuFunctionSquare} color={'black'} boxSize={'24px'} aria-label={label} />
+  ),
+  [DataHubNodeType.TRANSITION]: (label) => (
+    <Icon as={TbTransitionRight} color={'black'} boxSize={'24px'} aria-label={label} />
+  ),
+}
+
+interface NodeIconProps {
+  type: DataHubNodeType | string | undefined
+}
+
+const NodeIcon: FC<NodeIconProps> = ({ type }) => {
+  const { t } = useTranslation('datahub')
+
+  if (!type || !iconMapping[type]) {
+    return (
+      <Icon as={GrStatusUnknown} color={'black'} boxSize={'24px'} aria-label={t('workspace.nodes.type') as string} />
+    )
+  }
+  return iconMapping[type](t('workspace.nodes.type', { context: type }))
+}
+
+export default NodeIcon

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/BaseNode.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/BaseNode.spec.cy.tsx
@@ -1,0 +1,33 @@
+/// <reference types="cypress" />
+
+import { NodeProps } from 'reactflow'
+
+import { mockReactFlow } from '@/__test-utils__/react-flow/providers.tsx'
+import { MOCK_DEFAULT_NODE } from '@/__test-utils__/react-flow/nodes.ts'
+
+import { DataHubNodeType } from '../../types.ts'
+import { BaseNode } from './BaseNode.tsx'
+
+export const MOCK_NODE_ADAPTER: NodeProps<{ label: string }> = {
+  id: 'idAdapter',
+  type: DataHubNodeType.TOPIC_FILTER,
+  data: { label: 'Hello1' },
+  ...MOCK_DEFAULT_NODE,
+}
+
+describe('BaseNode', () => {
+  beforeEach(() => {
+    cy.viewport(400, 400)
+  })
+
+  it('should render properly', () => {
+    cy.mountWithProviders(mockReactFlow(<BaseNode {...MOCK_NODE_ADAPTER} selected={true} />))
+  })
+
+  it('should be accessible', () => {
+    cy.injectAxe()
+    cy.mountWithProviders(mockReactFlow(<BaseNode {...MOCK_NODE_ADAPTER} />))
+    cy.checkAccessibility()
+    cy.percySnapshot('Component: DataHub - BaseNode')
+  })
+})

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/BaseNode.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/BaseNode.tsx
@@ -1,0 +1,19 @@
+import { FC } from 'react'
+import { Handle, NodeProps, Position } from 'reactflow'
+
+import { NodeWrapper } from './NodeWrapper.tsx'
+import { Text } from '@chakra-ui/react'
+
+export const BaseNode: FC<NodeProps> = (props) => {
+  const { id, data, type } = props
+
+  return (
+    <>
+      <NodeWrapper route={`node/${type}/${id}`} {...props}>
+        <Text>{data.label}</Text>
+      </NodeWrapper>
+      <Handle type="target" position={Position.Left} />
+      <Handle type="source" position={Position.Right} />
+    </>
+  )
+}

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/NodeWrapper.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/NodeWrapper.tsx
@@ -1,0 +1,41 @@
+import { FC, ReactNode, useEffect, useState } from 'react'
+import { useLocation, useNavigate } from 'react-router-dom'
+import { NodeProps } from 'reactflow'
+import { BoxProps, Card, CardBody, HStack } from '@chakra-ui/react'
+
+interface NodeWrapperProps extends NodeProps {
+  children: ReactNode
+  route: string
+}
+
+export const NodeWrapper: FC<NodeWrapperProps> = ({ selected, children, route }) => {
+  const [internalSelection, setInternalSelection] = useState(false)
+  const navigate = useNavigate()
+  const { pathname } = useLocation()
+
+  useEffect(() => {
+    if (!selected) setInternalSelection(false)
+  }, [selected])
+
+  const selectedStyle: Partial<BoxProps> = {
+    boxShadow: 'var(--chakra-shadows-outline)',
+  }
+
+  return (
+    <Card
+      variant={'elevated'}
+      {...(selected ? { ...selectedStyle } : {})}
+      size={'sm'}
+      onClick={(event) => {
+        if (internalSelection) {
+          navigate(route, { state: { origin: pathname } })
+          event.preventDefault()
+          event.stopPropagation()
+        }
+        setInternalSelection(true)
+      }}
+    >
+      <CardBody as={HStack}>{children}</CardBody>
+    </Card>
+  )
+}

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/PolicyEditor.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/PolicyEditor.tsx
@@ -15,9 +15,9 @@ import { Box } from '@chakra-ui/react'
 const PolicyEditor: FC = () => {
   const { t } = useTranslation('datahub')
   const reactFlowWrapper = useRef(null)
-  const [reactFlowInstance, setReactFlowInstance] = useState<ReactFlowInstance | null>(null)
+  const [, /*reactFlowInstance */ setReactFlowInstance] = useState<ReactFlowInstance | null>(null)
   const { nodes, edges, onNodesChange, onEdgesChange, onConnect } = useDataHubDraftStore()
-  const { policyType, policyId } = useParams()
+  const { policyType /*, policyId */ } = useParams()
 
   const nodeTypes = useMemo(
     () => ({

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/PolicyEditor.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/PolicyEditor.tsx
@@ -1,0 +1,77 @@
+import { FC, useMemo, useRef, useState } from 'react'
+import ReactFlow, { Background, ReactFlowInstance, ReactFlowProvider } from 'reactflow'
+import { Outlet, useParams } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+
+import ErrorMessage from '@/components/ErrorMessage.tsx'
+
+import { DataHubNodeType, PolicyType } from '../../types.ts'
+import useDataHubDraftStore from '../../hooks/useDataHubDraftStore.ts'
+import CanvasControls from '../controls/CanvasControls.tsx'
+import Minimap from '../controls/Minimap.tsx'
+import { BaseNode } from '../nodes/BaseNode.tsx'
+import { Box } from '@chakra-ui/react'
+
+const PolicyEditor: FC = () => {
+  const { t } = useTranslation('datahub')
+  const reactFlowWrapper = useRef(null)
+  const [reactFlowInstance, setReactFlowInstance] = useState<ReactFlowInstance | null>(null)
+  const { nodes, edges, onNodesChange, onEdgesChange, onConnect } = useDataHubDraftStore()
+  const { policyType, policyId } = useParams()
+
+  const nodeTypes = useMemo(
+    () => ({
+      [DataHubNodeType.TOPIC_FILTER]: BaseNode,
+      [DataHubNodeType.CLIENT_FILTER]: BaseNode,
+    }),
+    []
+  )
+
+  if (!policyType || !(policyType in PolicyType))
+    return (
+      <ErrorMessage
+        type={t('error.notDefined.title') as string}
+        message={t('error.notDefined.description') as string}
+      />
+    )
+
+  return (
+    <>
+      <ReactFlowProvider>
+        <ReactFlow
+          ref={reactFlowWrapper}
+          id={'edge-workspace-canvas'}
+          nodes={nodes}
+          edges={edges}
+          nodeTypes={nodeTypes}
+          onNodesChange={onNodesChange}
+          onEdgesChange={onEdgesChange}
+          // onEdgeUpdate={onEdgeUpdate}
+          // onConnectStart={onConnectStart}
+          // onConnectEnd={onConnectEnd}
+          onConnect={onConnect}
+          onInit={setReactFlowInstance}
+          fitView
+          snapToGrid
+          // nodesConnectable
+          // onDrop={onDrop}
+          // onDragOver={onDragOver}
+          // isValidConnection={isValidConnection}
+        >
+          <Background />
+          <Box
+            role={'toolbar'}
+            aria-label={t('workspace.controls.aria-label') as string}
+            aria-controls={'edge-workspace-canvas'}
+          >
+            <CanvasControls />
+            <Minimap />
+          </Box>
+        </ReactFlow>
+      </ReactFlowProvider>
+      <Outlet />
+    </>
+  )
+}
+
+export default PolicyEditor

--- a/hivemq-edge/src/frontend/src/extensions/datahub/hooks/useDataHubDraftStore.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/hooks/useDataHubDraftStore.ts
@@ -1,0 +1,76 @@
+import {
+  Connection,
+  EdgeAddChange,
+  EdgeChange,
+  NodeAddChange,
+  NodeChange,
+  addEdge,
+  applyEdgeChanges,
+  applyNodeChanges,
+} from 'reactflow'
+import { create } from 'zustand'
+import { createJSONStorage, persist } from 'zustand/middleware'
+import { WorkspaceAction, WorkspaceState } from '../types.ts'
+import { initialFlow } from '../utils/node.utils.ts'
+
+const useDataHubDraftStore = create<WorkspaceState & WorkspaceAction>()(
+  persist(
+    (set, get) => ({
+      ...initialFlow(),
+      reset: () => {
+        set(initialFlow())
+      },
+      onNodesChange: (changes: NodeChange[]) => {
+        set({
+          nodes: applyNodeChanges(changes, get().nodes),
+        })
+      },
+      onEdgesChange: (changes: EdgeChange[]) => {
+        set({
+          edges: applyEdgeChanges(changes, get().edges),
+        })
+      },
+      onConnect: (connection: Connection) => {
+        set({
+          edges: addEdge(connection, get().edges),
+        })
+      },
+      onAddNodes: (changes: NodeAddChange[]) => {
+        const nodeIDs = get().nodes.map((e) => e.id)
+
+        const addChanges: NodeChange[] = changes.filter((e) => !nodeIDs.includes(e.item.id))
+        if (addChanges.length) {
+          set({
+            nodes: applyNodeChanges(addChanges, get().nodes),
+          })
+        }
+      },
+      onAddEdges: (changes: EdgeAddChange[]) => {
+        const ndID = get().edges.map((e) => e.id)
+
+        const addChanges: EdgeChange[] = changes.filter((e) => !ndID.includes(e.item.id))
+        if (addChanges.length) {
+          set({
+            edges: applyEdgeChanges(addChanges, get().edges),
+          })
+        }
+      },
+      onUpdateNodes: <T>(item: string, data: T) => {
+        set({
+          nodes: get().nodes.map((node) => {
+            if (node.id === item) {
+              node.data = data
+            }
+            return node
+          }),
+        })
+      },
+    }),
+    {
+      name: 'datahub.workspace',
+      storage: createJSONStorage(() => localStorage),
+    }
+  )
+)
+
+export default useDataHubDraftStore

--- a/hivemq-edge/src/frontend/src/extensions/datahub/locales/en/datahub.json
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/locales/en/datahub.json
@@ -25,7 +25,27 @@
       "edit": "Edit"
     }
   },
+  "workspace": {
+    "controls": {
+      "aria-label": "Workspace toolbar",
+      "zoomIn": "Zoom in",
+      "zoomIOut": "Zoom out",
+      "fitView": "Fit to the canvas",
+      "toggleInteractivity": "Lock the canvas",
+      "group": "Group the selected entities"
+    },
+    "nodes": {
+      "type": "Unknown type",
+      "type_DATA_POLICY": "Data Policy",
+      "type_TOPIC_FILTER": "Topic Filter",
+      "type_CLIENT_FILTER": "Client Filter"
+    }
+  },
   "error": {
+    "notActivated": {
+      "title": "Datahub is now available to commercial licenses",
+      "description": "Please contact our sales team to gain access"
+    },
     "notDefined": {
       "title": "Not identified",
       "description": "The policy is not a valid document"

--- a/hivemq-edge/src/frontend/src/extensions/datahub/locales/en/datahub.json
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/locales/en/datahub.json
@@ -31,14 +31,21 @@
       "zoomIn": "Zoom in",
       "zoomIOut": "Zoom out",
       "fitView": "Fit to the canvas",
-      "toggleInteractivity": "Lock the canvas",
-      "group": "Group the selected entities"
+      "toggleInteractivity": "Lock the canvas"
     },
     "nodes": {
       "type": "Unknown type",
-      "type_DATA_POLICY": "Data Policy",
       "type_TOPIC_FILTER": "Topic Filter",
-      "type_CLIENT_FILTER": "Client Filter"
+      "type_CLIENT_FILTER": "Client Filter",
+      "type_ADAPTOR": "Adaptor Filter",
+      "type_BRIDGE": "Broker Filter",
+      "type_DATA_POLICY": "Data Policy",
+      "type_BEHAVIOR_POLICY": "Behavior Policy",
+      "type_VALIDATOR": "Policy Validator",
+      "type_SCHEMA": "Schema",
+      "type_ACTION": "Action",
+      "type_TRANSITION": "Transition",
+      "type_EVENT": "Event"
     }
   },
   "error": {

--- a/hivemq-edge/src/frontend/src/extensions/datahub/locales/en/datahub.json
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/locales/en/datahub.json
@@ -1,0 +1,34 @@
+{
+  "brand": {
+    "extension": "DataHub"
+  },
+  "navigation": {
+    "mainPage": "Datahub"
+  },
+  "page": {
+    "title": "Edge-Datahub Integration",
+    "description": "Welcome to HiveMQ Edge - DataHub integration"
+  },
+  "policy": {
+    "type_DATA": "Data Policy",
+    "type_BEHAVIOR": "Behavior Policy"
+  },
+  "policyTable": {
+    "title": "List of policies",
+    "header": {
+      "created": "Created",
+      "type": "Type",
+      "matching": "Matching",
+      "actions": "Actions"
+    },
+    "action": {
+      "edit": "Edit"
+    }
+  },
+  "error": {
+    "notDefined": {
+      "title": "Not identified",
+      "description": "The policy is not a valid document"
+    }
+  }
+}

--- a/hivemq-edge/src/frontend/src/extensions/datahub/routes.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/routes.tsx
@@ -1,0 +1,29 @@
+/* eslint-disable react-refresh/only-export-components */
+import { RouteObject } from 'react-router-dom'
+
+import DataHubPage from './components/DataHubPage.tsx'
+import PolicyTable from './components/pages/PolicyTable.tsx'
+import PolicyEditor from './components/pages/PolicyEditor.tsx'
+import PropertyPanelController from './components/controls/PropertyPanelController.tsx'
+
+export const dataHubRoutes: RouteObject = {
+  path: 'datahub/',
+  element: <DataHubPage />,
+  children: [
+    {
+      path: '',
+      index: true,
+      element: <PolicyTable />,
+    },
+    {
+      path: ':policyType/:policyId',
+      element: <PolicyEditor />,
+      children: [
+        {
+          path: 'node/:type/:nodeId',
+          element: <PropertyPanelController />,
+        },
+      ],
+    },
+  ],
+}

--- a/hivemq-edge/src/frontend/src/extensions/datahub/routes.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/routes.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react-refresh/only-export-components */
 import { RouteObject } from 'react-router-dom'
 
 import DataHubPage from './components/DataHubPage.tsx'

--- a/hivemq-edge/src/frontend/src/extensions/datahub/types.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/types.ts
@@ -1,0 +1,36 @@
+import { Connection, Edge, EdgeAddChange, Node, NodeAddChange, OnEdgesChange, OnNodesChange } from 'reactflow'
+
+export interface WorkspaceState {
+  nodes: Node[]
+  edges: Edge[]
+}
+
+export interface WorkspaceAction {
+  reset: () => void
+  onNodesChange: OnNodesChange
+  onEdgesChange: OnEdgesChange
+  onConnect: (connection: Connection) => void
+  onAddNodes: (changes: NodeAddChange[]) => void
+  onAddEdges: (changes: EdgeAddChange[]) => void
+  onUpdateNodes: <T>(item: string, data: T) => void
+}
+
+export enum PolicyType {
+  DATA = 'DATA',
+  BEHAVIOR = 'BEHAVIOR',
+}
+
+export enum DataHubNodeType {
+  ADAPTOR = 'ADAPTOR',
+  EDGE = 'EDGE',
+  BRIDGE = 'BRIDGE',
+  TOPIC_FILTER = 'TOPIC_FILTER',
+  CLIENT_FILTER = 'CLIENT_FILTER',
+  DATA_POLICY = 'DATA_POLICY',
+  BEHAVIOR_POLICY = 'BEHAVIOR_POLICY',
+  VALIDATOR = 'VALIDATOR',
+  SCHEMA = 'SCHEMA',
+  ACTION = 'ACTION',
+  TRANSITION = 'TRANSITION',
+  EVENT = 'EVENT',
+}

--- a/hivemq-edge/src/frontend/src/extensions/datahub/utils/node.utils.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/utils/node.utils.ts
@@ -1,0 +1,8 @@
+import { Edge, Node } from 'reactflow'
+
+export const initialFlow = () => {
+  const nodes: Node[] = []
+  const edges: Edge[] = []
+
+  return { nodes, edges }
+}

--- a/hivemq-edge/src/frontend/src/modules/App/routes.spec.tsx
+++ b/hivemq-edge/src/frontend/src/modules/App/routes.spec.tsx
@@ -15,6 +15,7 @@ describe('createBrowserRouter', () => {
             expect.objectContaining({ path: 'edge-flow/' }),
             expect.objectContaining({ path: 'event-logs/' }),
             expect.objectContaining({ path: 'namespace/' }),
+            expect.objectContaining({ path: 'datahub/' }),
           ]),
         }),
         expect.objectContaining({ path: '/login' }),

--- a/hivemq-edge/src/frontend/src/modules/App/routes.tsx
+++ b/hivemq-edge/src/frontend/src/modules/App/routes.tsx
@@ -15,6 +15,11 @@ const EdgeFlowPage = lazy(() => import('@/modules/Workspace/EdgeFlowPage.tsx'))
 const NodePanelController = lazy(() => import('@/modules/Workspace/components/controls/NodePanelController.tsx'))
 const EvenLogPage = lazy(() => import('@/modules/EventLog/EvenLogPage.tsx'))
 
+// const DataHubPage = lazy(() => import('@/extensions/datahub/components/DataHubPage.tsx'))
+// const PolicyTable = lazy(() => import('@/extensions/datahub/components/PolicyTable.tsx'))
+
+import { dataHubRoutes } from '@/extensions/datahub/routes.tsx'
+
 import Dashboard from '../Dashboard/Dashboard.tsx'
 import ErrorPage from './components/ErrorPage.tsx'
 
@@ -83,6 +88,18 @@ export const routes = createBrowserRouter(
             },
           ],
         },
+        { ...dataHubRoutes },
+        // {
+        //   path: 'datahub/',
+        //   element: <DataHubPage />,
+        //   children: [
+        //     {
+        //       path: '',
+        //       index: true,
+        //       element: <PolicyTable />,
+        //     },
+        //   ],
+        // },
       ],
     },
     {

--- a/hivemq-edge/src/frontend/src/modules/Dashboard/hooks/useGetNavItems.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Dashboard/hooks/useGetNavItems.tsx
@@ -6,7 +6,7 @@ import { PiBridgeThin, PiPlugsConnectedFill } from 'react-icons/pi'
 import { BsIntersect } from 'react-icons/bs'
 import { HiOutlinePuzzle } from 'react-icons/hi'
 import { GoLinkExternal } from 'react-icons/go'
-import { MdOutlineEventNote } from 'react-icons/md'
+import { MdOutlineEventNote, MdPolicy } from 'react-icons/md'
 
 import { useGetConfiguration } from '@/api/hooks/useFrontendServices/useGetConfiguration.tsx'
 import WorkspaceIcon from '@/components/Icons/WorkspaceIcon.tsx'
@@ -69,6 +69,11 @@ const useGetNavItems = (): { data: NavLinksBlockType[]; isSuccess: boolean } => 
           icon: <BsIntersect />,
           href: '/namespace',
           label: t('translation:navigation.extensions.routes.namespace') as string,
+        },
+        {
+          icon: <Icon as={MdPolicy} fontSize={'16px'} />,
+          href: '/datahub',
+          label: t('datahub:navigation.mainPage') as string,
         },
       ],
     },


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/18687/details/

This PR is part of the `DataHub` frontend initiatives and creates the basic elements for the integration with Edge: 
- in-app navigation and menus to enable the feature at the interface
- landing page
- initial flow canvas with basic node and side editor for the nodes in the canvas

The design reuses many of the principles in place in the `Workspace`:
- canvas showing a graph composed of nodes and edges
- user interactions on the canvas (pan, scroll, ...)
- user interactions on the graph elements
- custom rendering of the graph elements 

### Out-of-scope
- When `datahub` is not activated, a simple warning message is displayed. A better UX will be added at a later stage
- The content (nodes) and flow (layout) of the policies will be added in a subsequent PR

### After
![screenshot-localhost_3000-2024 01 16-10_52_49](https://github.com/hivemq/hivemq-edge/assets/2743481/72078080-5318-4d4c-9cc8-69c1353e8358)

![screenshot-localhost_3000-2024 01 15-20_58_37](https://github.com/hivemq/hivemq-edge/assets/2743481/380e6b95-70a4-4804-a853-2289baa9dd23)

![screenshot-localhost_3000-2024 01 15-21_05_37](https://github.com/hivemq/hivemq-edge/assets/2743481/ddd2a249-8843-441f-a747-414deaaa169f)

![screenshot-localhost_3000-2024 01 15-21_08_05](https://github.com/hivemq/hivemq-edge/assets/2743481/926c2c69-6649-4674-9ff4-91f56528753e)
