### PR TITLE
refactor(18855): Relocate the submit button to the footer of the panel

### DIFF
--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/PropertyPanelController.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/PropertyPanelController.spec.cy.tsx
@@ -9,7 +9,7 @@ describe('PropertyPanelController', () => {
     cy.viewport(800, 600)
   })
 
-  it('should indicate an incorrect panel', () => {
+  it('should display an error panel without an action', () => {
     cy.mountWithProviders(
       <ReactFlowProvider>
         <Routes>

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/PropertyPanelController.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/PropertyPanelController.spec.cy.tsx
@@ -9,7 +9,7 @@ describe('PropertyPanelController', () => {
     cy.viewport(800, 600)
   })
 
-  it('should renders properly the side panel', () => {
+  it('should indicate an incorrect panel', () => {
     cy.mountWithProviders(
       <ReactFlowProvider>
         <Routes>
@@ -23,6 +23,22 @@ describe('PropertyPanelController', () => {
     cy.getByTestId('node-editor-name').should('contain.text', 'Unknown type')
     cy.getByTestId('node-editor-icon').find('svg').should('have.attr', 'aria-label', 'Unknown type')
     cy.getByTestId('node-editor-id').should('contain.text', '1')
+
     cy.getByTestId('node-editor-under-construction').should('be.visible')
+    cy.get('button[type="submit"]').should('not.exist')
+  })
+
+  it('should render a proper panel with a submit button', () => {
+    cy.mountWithProviders(
+      <ReactFlowProvider>
+        <Routes>
+          <Route path="/node/:type/:nodeId" element={<PropertyPanelController />}></Route>
+        </Routes>
+      </ReactFlowProvider>,
+      { routerProps: { initialEntries: ['/node/TOPIC_FILTER/1'] } }
+    )
+
+    cy.getByTestId('node-editor-under-construction').should('not.exist')
+    cy.get('button[type="submit"]').should('be.visible')
   })
 })

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/PropertyPanelController.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/PropertyPanelController.spec.cy.tsx
@@ -28,7 +28,7 @@ describe('PropertyPanelController', () => {
     cy.get('button[type="submit"]').should('not.exist')
   })
 
-  it('should render a proper panel with a submit button', () => {
+  it('should render a panel with a submit button', () => {
     cy.mountWithProviders(
       <ReactFlowProvider>
         <Routes>

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/PropertyPanelController.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/PropertyPanelController.tsx
@@ -7,10 +7,12 @@ import {
   AbsoluteCenter,
   Avatar,
   Box,
+  Button,
   Drawer,
   DrawerBody,
   DrawerCloseButton,
   DrawerContent,
+  DrawerFooter,
   DrawerHeader,
   DrawerOverlay,
   Flex,
@@ -109,6 +111,15 @@ const PropertyPanelController = () => {
             </AbsoluteCenter>
           )}
         </DrawerBody>
+        <DrawerFooter borderTopWidth="1px">
+          {isEditorValid && (
+            <Flex flexGrow={1} justifyContent={'flex-end'}>
+              <Button variant={'primary'} type="submit" form="datahub-node-form">
+                {t('workspace.panel.submit')}
+              </Button>
+            </Flex>
+          )}
+        </DrawerFooter>
       </DrawerContent>
     </Drawer>
   )

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/helpers/ReactFlowSchemaForm.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/helpers/ReactFlowSchemaForm.tsx
@@ -130,14 +130,22 @@ export function FieldTemplate<
 export const ReactFlowSchemaForm: FC<Omit<FormProps, 'validator' | 'templates' | 'liveValidate' | 'omitExtraData'>> = (
   props
 ) => {
+  const { uiSchema, ...rest } = props
   return (
     <Form
+      id="datahub-node-form"
       showErrorList="bottom"
       templates={{ DescriptionFieldTemplate, FieldTemplate, ErrorListTemplate }}
       validator={validator}
+      uiSchema={{
+        ...uiSchema,
+        'ui:submitButtonOptions': {
+          norender: true,
+        },
+      }}
       liveValidate
       omitExtraData
-      {...props}
+      {...rest}
     />
   )
 }

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/helpers/ReactFlowSchemaForm.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/helpers/ReactFlowSchemaForm.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react'
+import { FC, PropsWithChildren } from 'react'
 import Form from '@rjsf/chakra-ui'
 import { FormProps } from '@rjsf/core'
 import {
@@ -98,22 +98,35 @@ export function FieldTemplate<
     return <div style={{ display: 'none' }}>{children}</div>
   }
 
+  // Change the type of wrapper based on existence of a label (indicating a field)
+  const Wrapper: FC<PropsWithChildren> = ({ children }) => {
+    return props.displayLabel ? (
+      <WrapIfAdditionalTemplate
+        classNames={classNames}
+        style={style}
+        disabled={disabled}
+        id={id}
+        label={label}
+        onDropPropertyClick={onDropPropertyClick}
+        onKeyChange={onKeyChange}
+        readonly={readonly}
+        required={required}
+        schema={schema}
+        uiSchema={uiSchema}
+        registry={registry}
+      >
+        <FormControl variant={'hivemq'} isRequired={required} isInvalid={rawErrors && rawErrors.length > 0} mb={4}>
+          {children}
+        </FormControl>
+      </WrapIfAdditionalTemplate>
+    ) : (
+      <Box>{children}</Box>
+    )
+  }
+
   return (
-    <WrapIfAdditionalTemplate
-      classNames={classNames}
-      style={style}
-      disabled={disabled}
-      id={id}
-      label={label}
-      onDropPropertyClick={onDropPropertyClick}
-      onKeyChange={onKeyChange}
-      readonly={readonly}
-      required={required}
-      schema={schema}
-      uiSchema={uiSchema}
-      registry={registry}
-    >
-      <FormControl variant={'hivemq'} isRequired={required} isInvalid={rawErrors && rawErrors.length > 0} mb={4}>
+    <Wrapper>
+      <>
         {children}
         {displayLabel && rawDescription && !rawErrors.length ? (
           <Box mt={2} mb={4}>
@@ -122,8 +135,8 @@ export function FieldTemplate<
         ) : null}
         {!!rawErrors.length && errors}
         {help}
-      </FormControl>
-    </WrapIfAdditionalTemplate>
+      </>
+    </Wrapper>
   )
 }
 

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/helpers/ReactFlowSchemaForm.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/helpers/ReactFlowSchemaForm.tsx
@@ -116,28 +116,29 @@ function FieldTemplate<
 
   // Change the type of wrapper based on existence of a label (indicating a field)
   const Wrapper: FC<PropsWithChildren> = ({ children }) => {
-    return props.displayLabel ? (
-      <WrapIfAdditionalTemplate
-        classNames={classNames}
-        style={style}
-        disabled={disabled}
-        id={id}
-        label={label}
-        onDropPropertyClick={onDropPropertyClick}
-        onKeyChange={onKeyChange}
-        readonly={readonly}
-        required={required}
-        schema={schema}
-        uiSchema={uiSchema}
-        registry={registry}
-      >
-        <FormControl variant={'hivemq'} isRequired={required} isInvalid={rawErrors && rawErrors.length > 0} mb={4}>
-          {children}
-        </FormControl>
-      </WrapIfAdditionalTemplate>
-    ) : (
-      <Box>{children}</Box>
-    )
+    if (props.displayLabel)
+      return (
+        <WrapIfAdditionalTemplate
+          classNames={classNames}
+          style={style}
+          disabled={disabled}
+          id={id}
+          label={label}
+          onDropPropertyClick={onDropPropertyClick}
+          onKeyChange={onKeyChange}
+          readonly={readonly}
+          required={required}
+          schema={schema}
+          uiSchema={uiSchema}
+          registry={registry}
+        >
+          <FormControl variant={'hivemq'} isRequired={required} isInvalid={rawErrors && rawErrors.length > 0} mb={4}>
+            {children}
+          </FormControl>
+        </WrapIfAdditionalTemplate>
+      )
+
+    return <Box>{children}</Box>
   }
 
   return (

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/helpers/ReactFlowSchemaForm.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/helpers/ReactFlowSchemaForm.tsx
@@ -38,7 +38,7 @@ function ErrorListTemplate<T = unknown, S extends StrictRJSFSchema = RJSFSchema>
 }
 
 // Override to fix bug with nested p
-export function DescriptionFieldTemplate<
+function DescriptionFieldTemplate<
   T = unknown,
   S extends StrictRJSFSchema = RJSFSchema,
   F extends FormContextType = GenericObjectType
@@ -60,7 +60,7 @@ export function DescriptionFieldTemplate<
 
 // Override to fix bug with nested p
 // Override to fix conditional rendering of either error or description
-export function FieldTemplate<
+function FieldTemplate<
   T = unknown,
   S extends StrictRJSFSchema = RJSFSchema,
   F extends FormContextType = GenericObjectType

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/helpers/ReactFlowSchemaForm.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/helpers/ReactFlowSchemaForm.tsx
@@ -11,11 +11,27 @@ import {
   getUiOptions,
   ErrorListProps,
   TranslatableString,
+  TitleFieldProps,
 } from '@rjsf/utils'
 import { GenericObjectType } from '@rjsf/utils/src/types.ts'
 import validator from '@rjsf/validator-ajv8'
-import { Alert, AlertTitle, Box, FormControl, List, ListIcon, ListItem, Text } from '@chakra-ui/react'
+import { Alert, AlertTitle, Box, Divider, FormControl, Heading, List, ListIcon, ListItem, Text } from '@chakra-ui/react'
 import { WarningIcon } from '@chakra-ui/icons'
+
+// overriding the heading definition
+function TitleFieldTemplate<T = unknown, S extends StrictRJSFSchema = RJSFSchema>({
+  id,
+  title,
+}: TitleFieldProps<T, S>) {
+  return (
+    <Box id={id} mt={1} mb={4}>
+      <Heading as={'h2'} size={'lg'}>
+        {title}
+      </Heading>
+      <Divider />
+    </Box>
+  )
+}
 
 function ErrorListTemplate<T = unknown, S extends StrictRJSFSchema = RJSFSchema>({
   errors,
@@ -148,7 +164,12 @@ export const ReactFlowSchemaForm: FC<Omit<FormProps, 'validator' | 'templates' |
     <Form
       id="datahub-node-form"
       showErrorList="bottom"
-      templates={{ DescriptionFieldTemplate, FieldTemplate, ErrorListTemplate }}
+      templates={{
+        DescriptionFieldTemplate,
+        FieldTemplate,
+        ErrorListTemplate,
+        TitleFieldTemplate,
+      }}
       validator={validator}
       uiSchema={{
         ...uiSchema,

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/panels/BehaviorPolicyPanel.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/panels/BehaviorPolicyPanel.spec.cy.tsx
@@ -54,7 +54,7 @@ describe('BehaviorPolicyPanel', () => {
       .should('contain.text', 'Publish.quota')
     cy.get('label#root_type-label + div').find("[role='listbox']").find("[role='option']").eq(2).click()
 
-    cy.get('h5').eq(0).should('contain.text', 'Publish')
+    cy.get('h2').eq(0).should('contain.text', 'Publish')
     // first item
     cy.get('label#root_arguments_minPublishes-label').should('contain.text', 'Minimum number of messages')
     cy.get('label#root_arguments_minPublishes-label + input').should('have.value', '0')

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/panels/BehaviorPolicyPanel.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/panels/BehaviorPolicyPanel.spec.cy.tsx
@@ -4,6 +4,7 @@ import { MockStoreWrapper } from '../../__test-utils__/MockStoreWrapper.tsx'
 import { DataHubNodeType } from '../../types.ts'
 import { getNodePayload } from '../../utils/node.utils.ts'
 import { BehaviorPolicyPanel } from '../panels/BehaviorPolicyPanel.tsx'
+import { Button } from '@chakra-ui/react'
 
 const wrapper: React.JSXElementConstructor<{ children: React.ReactNode }> = ({ children }) => (
   <MockStoreWrapper
@@ -21,6 +22,9 @@ const wrapper: React.JSXElementConstructor<{ children: React.ReactNode }> = ({ c
     }}
   >
     {children}
+    <Button variant={'primary'} type="submit" form="datahub-node-form">
+      SUBMIT{' '}
+    </Button>
   </MockStoreWrapper>
 )
 

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/panels/ClientFilterPanel.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/panels/ClientFilterPanel.spec.cy.tsx
@@ -4,6 +4,7 @@ import { MockStoreWrapper } from '../../__test-utils__/MockStoreWrapper.tsx'
 import { DataHubNodeType } from '../../types.ts'
 import { getNodePayload } from '../../utils/node.utils.ts'
 import { ClientFilterPanel } from '../panels/ClientFilterPanel.tsx'
+import { Button } from '@chakra-ui/react'
 
 const wrapper: React.JSXElementConstructor<{ children: React.ReactNode }> = ({ children }) => (
   <MockStoreWrapper
@@ -21,6 +22,9 @@ const wrapper: React.JSXElementConstructor<{ children: React.ReactNode }> = ({ c
     }}
   >
     {children}
+    <Button variant={'primary'} type="submit" form="datahub-node-form">
+      SUBMIT{' '}
+    </Button>
   </MockStoreWrapper>
 )
 

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/panels/ClientFilterPanel.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/panels/ClientFilterPanel.spec.cy.tsx
@@ -38,7 +38,7 @@ describe('ClientFilterPanel', () => {
 
     cy.mountWithProviders(<ClientFilterPanel selectedNode={'3'} onFormSubmit={onSubmit} />, { wrapper })
 
-    cy.get('h5').eq(0).should('contain.text', 'Client Filters')
+    cy.get('h2').eq(0).should('contain.text', 'Client Filters')
     // first item
     cy.get('label#root_clients_0-label').should('contain.text', 'clients-0')
     cy.get('label#root_clients_0-label + input').should('have.value', 'client10')
@@ -63,13 +63,7 @@ describe('ClientFilterPanel', () => {
     cy.injectAxe()
     cy.mountWithProviders(<ClientFilterPanel selectedNode={'3'} />, { wrapper })
 
-    cy.checkAccessibility(undefined, {
-      rules: {
-        // TODO[18840] Need to change the heading wrapper in the RJSF template
-        'heading-order': { enabled: false },
-        region: { enabled: false },
-      },
-    })
+    cy.checkAccessibility()
     cy.percySnapshot('Component: ClientFilterPanel')
   })
 })

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/panels/OperationPanel.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/panels/OperationPanel.spec.cy.tsx
@@ -4,6 +4,7 @@ import { MockStoreWrapper } from '../../__test-utils__/MockStoreWrapper.tsx'
 import { DataHubNodeType } from '../../types.ts'
 import { getNodePayload } from '../../utils/node.utils.ts'
 import { OperationPanel } from '../panels/OperationPanel.tsx'
+import { Button } from '@chakra-ui/react'
 
 const wrapper: React.JSXElementConstructor<{ children: React.ReactNode }> = ({ children }) => (
   <MockStoreWrapper
@@ -21,6 +22,9 @@ const wrapper: React.JSXElementConstructor<{ children: React.ReactNode }> = ({ c
     }}
   >
     {children}
+    <Button variant={'primary'} type="submit" form="datahub-node-form">
+      SUBMIT{' '}
+    </Button>
   </MockStoreWrapper>
 )
 

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/panels/SchemaPanel.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/panels/SchemaPanel.spec.cy.tsx
@@ -4,6 +4,7 @@ import { MockStoreWrapper } from '../../__test-utils__/MockStoreWrapper.tsx'
 import { DataHubNodeType } from '../../types.ts'
 import { getNodePayload } from '../../utils/node.utils.ts'
 import { SchemaPanel } from '../panels/SchemaPanel.tsx'
+import { Button } from '@chakra-ui/react'
 
 const wrapper: React.JSXElementConstructor<{ children: React.ReactNode }> = ({ children }) => (
   <MockStoreWrapper
@@ -21,6 +22,9 @@ const wrapper: React.JSXElementConstructor<{ children: React.ReactNode }> = ({ c
     }}
   >
     {children}
+    <Button variant={'primary'} type="submit" form="datahub-node-form">
+      SUBMIT{' '}
+    </Button>
   </MockStoreWrapper>
 )
 

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/panels/TopicFilterPanel.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/panels/TopicFilterPanel.spec.cy.tsx
@@ -4,6 +4,7 @@ import { MockStoreWrapper } from '../../__test-utils__/MockStoreWrapper.tsx'
 import { DataHubNodeType } from '../../types.ts'
 import { getNodePayload } from '../../utils/node.utils.ts'
 import { TopicFilterPanel } from '../panels/TopicFilterPanel.tsx'
+import { Button } from '@chakra-ui/react'
 
 const wrapper: React.JSXElementConstructor<{ children: React.ReactNode }> = ({ children }) => (
   <MockStoreWrapper
@@ -21,6 +22,9 @@ const wrapper: React.JSXElementConstructor<{ children: React.ReactNode }> = ({ c
     }}
   >
     {children}
+    <Button variant={'primary'} type="submit" form="datahub-node-form">
+      SUBMIT{' '}
+    </Button>
   </MockStoreWrapper>
 )
 

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/panels/TopicFilterPanel.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/panels/TopicFilterPanel.spec.cy.tsx
@@ -36,7 +36,7 @@ describe('TopicFilterPanel', () => {
   it('should render the fields for a Validator', () => {
     cy.mountWithProviders(<TopicFilterPanel selectedNode={'3'} />, { wrapper })
 
-    cy.get('h5').eq(0).should('contain.text', 'Topic Filters')
+    cy.get('h2').eq(0).should('contain.text', 'Topic Filters')
     // first item
     cy.get('label#root_topics_0-label').should('contain.text', 'topics-0')
     cy.get('label#root_topics_0-label + input').should('have.value', 'root/test1')
@@ -49,13 +49,7 @@ describe('TopicFilterPanel', () => {
     cy.injectAxe()
     cy.mountWithProviders(<TopicFilterPanel selectedNode={'3'} />, { wrapper })
 
-    cy.checkAccessibility(undefined, {
-      rules: {
-        // TODO[18840] Need to change the heading wrapper in the RJSF template
-        'heading-order': { enabled: false },
-        region: { enabled: false },
-      },
-    })
+    cy.checkAccessibility()
     cy.percySnapshot('Component: TopicFilterPanel')
   })
 })

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/panels/TransitionPanel.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/panels/TransitionPanel.spec.cy.tsx
@@ -4,6 +4,7 @@ import { MockStoreWrapper } from '../../__test-utils__/MockStoreWrapper.tsx'
 import { DataHubNodeType } from '../../types.ts'
 import { getNodePayload } from '../../utils/node.utils.ts'
 import { TransitionPanel } from '../panels/TransitionPanel.tsx'
+import { Button } from '@chakra-ui/react'
 
 const wrapper: React.JSXElementConstructor<{ children: React.ReactNode }> = ({ children }) => (
   <MockStoreWrapper
@@ -21,6 +22,9 @@ const wrapper: React.JSXElementConstructor<{ children: React.ReactNode }> = ({ c
     }}
   >
     {children}
+    <Button variant={'primary'} type="submit" form="datahub-node-form">
+      SUBMIT{' '}
+    </Button>
   </MockStoreWrapper>
 )
 

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/panels/ValidatorPanel.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/panels/ValidatorPanel.spec.cy.tsx
@@ -4,6 +4,7 @@ import { MockStoreWrapper } from '../../__test-utils__/MockStoreWrapper.tsx'
 import { DataHubNodeType } from '../../types.ts'
 import { getNodePayload } from '../../utils/node.utils.ts'
 import { ValidatorPanel } from '../panels/ValidatorPanel.tsx'
+import { Button } from '@chakra-ui/react'
 
 const wrapper: React.JSXElementConstructor<{ children: React.ReactNode }> = ({ children }) => (
   <MockStoreWrapper
@@ -21,6 +22,9 @@ const wrapper: React.JSXElementConstructor<{ children: React.ReactNode }> = ({ c
     }}
   >
     {children}
+    <Button variant={'primary'} type="submit" form="datahub-node-form">
+      SUBMIT{' '}
+    </Button>
   </MockStoreWrapper>
 )
 

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/panels/ValidatorPanel.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/panels/ValidatorPanel.spec.cy.tsx
@@ -58,9 +58,9 @@ describe('ValidatorPanel', () => {
       .should('contain.text', 'ANY_OF')
     cy.get('label#root_strategy-label + div').click()
 
-    cy.get('h5').eq(0).should('contain.text', 'schemas')
+    cy.get('h2').eq(0).should('contain.text', 'schemas')
     // first item
-    cy.get('h5').eq(1).should('contain.text', 'schemas-0')
+    cy.get('h2').eq(1).should('contain.text', 'schemas-0')
     // first item property
     cy.get('label#root_schemas_0_schemaId-label').should('contain.text', 'ID of the schema')
     cy.get('label#root_schemas_0_schemaId-label + input').should('have.value', 'first mock schema')
@@ -84,13 +84,7 @@ describe('ValidatorPanel', () => {
     cy.injectAxe()
     cy.mountWithProviders(<ValidatorPanel selectedNode={'3'} />, { wrapper })
 
-    cy.checkAccessibility(undefined, {
-      rules: {
-        // TODO[18840] Need to change the heading wrapper in the RJSF template
-        'heading-order': { enabled: false },
-        region: { enabled: false },
-      },
-    })
+    cy.checkAccessibility()
     cy.percySnapshot('Component: ValidatorPanel')
   })
 })

--- a/hivemq-edge/src/frontend/src/extensions/datahub/locales/en/datahub.json
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/locales/en/datahub.json
@@ -64,6 +64,9 @@
       "validation_onError": "onError",
       "behavior_serial.will": "onWill",
       "behavior_serial.publish": "onPublish"
+    },
+    "panel": {
+      "submit": "Submit"
     }
   },
   "error": {


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/18855/details/

This PR fixes a usability problem whereas a scrolling form would hide the `submit` button at the bottom of it. It is now located on the "sticky" footer of the side panel, always visible to the user. This new behaviour is the same for the adapter forms.

The PR also slightly improves the layout of the generated JSONSchema form, reducing the amount of unnecessary nesting of "group". 

### Before
![screenshot-localhost_3000-2024 01 23-10_34_06](https://github.com/hivemq/hivemq-edge/assets/2743481/672e19db-182e-4db4-b7c0-525e73395fd1)


### After
![screenshot-localhost_3000-2024 01 23-10_33_05](https://github.com/hivemq/hivemq-edge/assets/2743481/f4299adc-0f31-4f68-9afc-ba900a4762d2)
