### PR TITLE
refactor(18840): Change the heading for titles in the node forms

### DIFF
--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/helpers/ReactFlowSchemaForm.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/helpers/ReactFlowSchemaForm.tsx
@@ -11,11 +11,27 @@ import {
   getUiOptions,
   ErrorListProps,
   TranslatableString,
+  TitleFieldProps,
 } from '@rjsf/utils'
 import { GenericObjectType } from '@rjsf/utils/src/types.ts'
 import validator from '@rjsf/validator-ajv8'
-import { Alert, AlertTitle, Box, FormControl, List, ListIcon, ListItem, Text } from '@chakra-ui/react'
+import { Alert, AlertTitle, Box, Divider, FormControl, Heading, List, ListIcon, ListItem, Text } from '@chakra-ui/react'
 import { WarningIcon } from '@chakra-ui/icons'
+
+// overriding the heading definition
+function TitleFieldTemplate<T = unknown, S extends StrictRJSFSchema = RJSFSchema>({
+  id,
+  title,
+}: TitleFieldProps<T, S>) {
+  return (
+    <Box id={id} mt={1} mb={4}>
+      <Heading as={'h2'} size={'lg'}>
+        {title}
+      </Heading>
+      <Divider />
+    </Box>
+  )
+}
 
 function ErrorListTemplate<T = unknown, S extends StrictRJSFSchema = RJSFSchema>({
   errors,
@@ -148,7 +164,12 @@ export const ReactFlowSchemaForm: FC<Omit<FormProps, 'validator' | 'templates' |
     <Form
       id="datahub-node-form"
       showErrorList="bottom"
-      templates={{ DescriptionFieldTemplate, FieldTemplate, ErrorListTemplate }}
+      templates={{
+        DescriptionFieldTemplate,
+        FieldTemplate,
+        ErrorListTemplate,
+        TitleFieldTemplate,
+      }}
       validator={validator}
       uiSchema={{
         ...uiSchema,

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/panels/BehaviorPolicyPanel.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/panels/BehaviorPolicyPanel.spec.cy.tsx
@@ -54,7 +54,7 @@ describe('BehaviorPolicyPanel', () => {
       .should('contain.text', 'Publish.quota')
     cy.get('label#root_type-label + div').find("[role='listbox']").find("[role='option']").eq(2).click()
 
-    cy.get('h5').eq(0).should('contain.text', 'Publish')
+    cy.get('h2').eq(0).should('contain.text', 'Publish')
     // first item
     cy.get('label#root_arguments_minPublishes-label').should('contain.text', 'Minimum number of messages')
     cy.get('label#root_arguments_minPublishes-label + input').should('have.value', '0')

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/panels/ClientFilterPanel.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/panels/ClientFilterPanel.spec.cy.tsx
@@ -38,7 +38,7 @@ describe('ClientFilterPanel', () => {
 
     cy.mountWithProviders(<ClientFilterPanel selectedNode={'3'} onFormSubmit={onSubmit} />, { wrapper })
 
-    cy.get('h5').eq(0).should('contain.text', 'Client Filters')
+    cy.get('h2').eq(0).should('contain.text', 'Client Filters')
     // first item
     cy.get('label#root_clients_0-label').should('contain.text', 'clients-0')
     cy.get('label#root_clients_0-label + input').should('have.value', 'client10')
@@ -63,13 +63,7 @@ describe('ClientFilterPanel', () => {
     cy.injectAxe()
     cy.mountWithProviders(<ClientFilterPanel selectedNode={'3'} />, { wrapper })
 
-    cy.checkAccessibility(undefined, {
-      rules: {
-        // TODO[18840] Need to change the heading wrapper in the RJSF template
-        'heading-order': { enabled: false },
-        region: { enabled: false },
-      },
-    })
+    cy.checkAccessibility()
     cy.percySnapshot('Component: ClientFilterPanel')
   })
 })

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/panels/TopicFilterPanel.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/panels/TopicFilterPanel.spec.cy.tsx
@@ -36,7 +36,7 @@ describe('TopicFilterPanel', () => {
   it('should render the fields for a Validator', () => {
     cy.mountWithProviders(<TopicFilterPanel selectedNode={'3'} />, { wrapper })
 
-    cy.get('h5').eq(0).should('contain.text', 'Topic Filters')
+    cy.get('h2').eq(0).should('contain.text', 'Topic Filters')
     // first item
     cy.get('label#root_topics_0-label').should('contain.text', 'topics-0')
     cy.get('label#root_topics_0-label + input').should('have.value', 'root/test1')
@@ -49,13 +49,7 @@ describe('TopicFilterPanel', () => {
     cy.injectAxe()
     cy.mountWithProviders(<TopicFilterPanel selectedNode={'3'} />, { wrapper })
 
-    cy.checkAccessibility(undefined, {
-      rules: {
-        // TODO[18840] Need to change the heading wrapper in the RJSF template
-        'heading-order': { enabled: false },
-        region: { enabled: false },
-      },
-    })
+    cy.checkAccessibility()
     cy.percySnapshot('Component: TopicFilterPanel')
   })
 })

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/panels/ValidatorPanel.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/panels/ValidatorPanel.spec.cy.tsx
@@ -58,9 +58,9 @@ describe('ValidatorPanel', () => {
       .should('contain.text', 'ANY_OF')
     cy.get('label#root_strategy-label + div').click()
 
-    cy.get('h5').eq(0).should('contain.text', 'schemas')
+    cy.get('h2').eq(0).should('contain.text', 'schemas')
     // first item
-    cy.get('h5').eq(1).should('contain.text', 'schemas-0')
+    cy.get('h2').eq(1).should('contain.text', 'schemas-0')
     // first item property
     cy.get('label#root_schemas_0_schemaId-label').should('contain.text', 'ID of the schema')
     cy.get('label#root_schemas_0_schemaId-label + input').should('have.value', 'first mock schema')
@@ -84,13 +84,7 @@ describe('ValidatorPanel', () => {
     cy.injectAxe()
     cy.mountWithProviders(<ValidatorPanel selectedNode={'3'} />, { wrapper })
 
-    cy.checkAccessibility(undefined, {
-      rules: {
-        // TODO[18840] Need to change the heading wrapper in the RJSF template
-        'heading-order': { enabled: false },
-        region: { enabled: false },
-      },
-    })
+    cy.checkAccessibility()
     cy.percySnapshot('Component: ValidatorPanel')
   })
 })


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/18840/details/

The PR changes the default heading used for titles in the JSONSchema form to `h2`.

It fixes an accessibility issue with the heading preferred to be incremented by 1 on nesting (the previous value was `h5`). 

### Before
![screenshot-localhost_3000-2024 01 23-10_40_57](https://github.com/hivemq/hivemq-edge/assets/2743481/f930722c-5a4f-44f4-80c0-4a83ccd0e667)

### After
![screenshot-localhost_3000-2024 01 23-10_43_36](https://github.com/hivemq/hivemq-edge/assets/2743481/1392f4cf-02fc-48b9-ac65-0791aeebf6f4)
