### PR TITLE
feat(18842): Implement connectivity controls between the different types of node

### DIFF
--- a/hivemq-edge/src/frontend/package.json
+++ b/hivemq-edge/src/frontend/package.json
@@ -97,6 +97,7 @@
     "msw": "^1.2.1",
     "openapi-typescript-codegen": "^0.25.0",
     "prettier": "2.8.8",
+    "sass": "^1.70.0",
     "stylelint": "^15.6.2",
     "stylelint-config-standard": "^33.0.0",
     "stylelint-config-standard-scss": "^9.0.0",

--- a/hivemq-edge/src/frontend/pnpm-lock.yaml
+++ b/hivemq-edge/src/frontend/pnpm-lock.yaml
@@ -210,6 +210,9 @@ devDependencies:
   prettier:
     specifier: 2.8.8
     version: 2.8.8
+  sass:
+    specifier: ^1.70.0
+    version: 1.70.0
   stylelint:
     specifier: ^15.6.2
     version: 15.6.2
@@ -224,10 +227,10 @@ devDependencies:
     version: 5.0.4
   vite:
     specifier: ^4.3.9
-    version: 4.3.9(@types/node@20.4.2)
+    version: 4.3.9(@types/node@20.4.2)(sass@1.70.0)
   vitest:
     specifier: ^0.33.0
-    version: 0.33.0(@vitest/ui@0.31.1)(jsdom@22.0.0)
+    version: 0.33.0(@vitest/ui@0.31.1)(jsdom@22.0.0)(sass@1.70.0)
 
 packages:
 
@@ -3492,7 +3495,7 @@ packages:
       '@babel/plugin-transform-react-jsx-self': 7.22.5(@babel/core@7.22.9)
       '@babel/plugin-transform-react-jsx-source': 7.22.5(@babel/core@7.22.9)
       react-refresh: 0.14.0
-      vite: 4.3.9(@types/node@20.4.2)
+      vite: 4.3.9(@types/node@20.4.2)(sass@1.70.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -3507,7 +3510,7 @@ packages:
       magic-string: 0.30.1
       picocolors: 1.0.0
       std-env: 3.3.3
-      vitest: 0.33.0(@vitest/ui@0.31.1)(jsdom@22.0.0)
+      vitest: 0.33.0(@vitest/ui@0.31.1)(jsdom@22.0.0)(sass@1.70.0)
     dev: true
 
   /@vitest/coverage-istanbul@0.32.4(vitest@0.33.0):
@@ -3521,7 +3524,7 @@ packages:
       istanbul-lib-source-maps: 4.0.1
       istanbul-reports: 3.1.5
       test-exclude: 6.0.0
-      vitest: 0.33.0(@vitest/ui@0.31.1)(jsdom@22.0.0)
+      vitest: 0.33.0(@vitest/ui@0.31.1)(jsdom@22.0.0)(sass@1.70.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -3568,7 +3571,7 @@ packages:
       pathe: 1.1.1
       picocolors: 1.0.0
       sirv: 2.0.3
-      vitest: 0.33.0(@vitest/ui@0.31.1)(jsdom@22.0.0)
+      vitest: 0.33.0(@vitest/ui@0.31.1)(jsdom@22.0.0)(sass@1.70.0)
     dev: true
 
   /@vitest/utils@0.31.1:
@@ -5648,6 +5651,10 @@ packages:
       queue: 6.0.2
     dev: true
 
+  /immutable@4.3.4:
+    resolution: {integrity: sha512-fsXeu4J4i6WNWSikpI88v/PcVflZz+6kMhUfIwc5SY+poQRPnaf5V7qds6SUyUN3cVxEzuCab7QIoLOQ+DQ1wA==}
+    dev: true
+
   /import-fresh@3.3.0:
     resolution: {integrity: sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==}
     engines: {node: '>=6'}
@@ -7370,6 +7377,16 @@ packages:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
     dev: true
 
+  /sass@1.70.0:
+    resolution: {integrity: sha512-uUxNQ3zAHeAx5nRFskBnrWzDUJrrvpCPD5FNAoRvTi0WwremlheES3tg+56PaVtCs5QDRX5CBLxxKMDJMEa1WQ==}
+    engines: {node: '>=14.0.0'}
+    hasBin: true
+    dependencies:
+      chokidar: 3.5.3
+      immutable: 4.3.4
+      source-map-js: 1.0.2
+    dev: true
+
   /saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
     engines: {node: '>=v12.22.7'}
@@ -8151,7 +8168,7 @@ packages:
       extsprintf: 1.3.0
     dev: true
 
-  /vite-node@0.33.0(@types/node@20.4.2):
+  /vite-node@0.33.0(@types/node@20.4.2)(sass@1.70.0):
     resolution: {integrity: sha512-19FpHYbwWWxDr73ruNahC+vtEdza52kA90Qb3La98yZ0xULqV8A5JLNPUff0f5zID4984tW7l3DH2przTJUZSw==}
     engines: {node: '>=v14.18.0'}
     hasBin: true
@@ -8161,7 +8178,7 @@ packages:
       mlly: 1.4.0
       pathe: 1.1.1
       picocolors: 1.0.0
-      vite: 4.3.9(@types/node@20.4.2)
+      vite: 4.3.9(@types/node@20.4.2)(sass@1.70.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -8172,7 +8189,7 @@ packages:
       - terser
     dev: true
 
-  /vite@4.3.9(@types/node@20.4.2):
+  /vite@4.3.9(@types/node@20.4.2)(sass@1.70.0):
     resolution: {integrity: sha512-qsTNZjO9NoJNW7KnOrgYwczm0WctJ8m/yqYAMAK9Lxt4SoySUfS5S8ia9K7JHpa3KEeMfyF8LoJ3c5NeBJy6pg==}
     engines: {node: ^14.18.0 || >=16.0.0}
     hasBin: true
@@ -8201,11 +8218,12 @@ packages:
       esbuild: 0.17.19
       postcss: 8.4.26
       rollup: 3.26.2
+      sass: 1.70.0
     optionalDependencies:
       fsevents: 2.3.2
     dev: true
 
-  /vitest@0.33.0(@vitest/ui@0.31.1)(jsdom@22.0.0):
+  /vitest@0.33.0(@vitest/ui@0.31.1)(jsdom@22.0.0)(sass@1.70.0):
     resolution: {integrity: sha512-1CxaugJ50xskkQ0e969R/hW47za4YXDUfWJDxip1hwbnhUjYolpfUn2AMOulqG/Dtd9WYAtkHmM/m3yKVrEejQ==}
     engines: {node: '>=v14.18.0'}
     hasBin: true
@@ -8259,8 +8277,8 @@ packages:
       strip-literal: 1.0.1
       tinybench: 2.5.0
       tinypool: 0.6.0
-      vite: 4.3.9(@types/node@20.4.2)
-      vite-node: 0.33.0(@types/node@20.4.2)
+      vite: 4.3.9(@types/node@20.4.2)(sass@1.70.0)
+      vite-node: 0.33.0(@types/node@20.4.2)(sass@1.70.0)
       why-is-node-running: 2.2.2
     transitivePeerDependencies:
       - less

--- a/hivemq-edge/src/frontend/src/extensions/datahub/api/specs/DataPolicyValidator.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/api/specs/DataPolicyValidator.ts
@@ -29,6 +29,7 @@ export const MOCK_VALIDATOR_SCHEMA: PanelSpecs = {
       strategy: {
         title: 'Validation Strategy',
         enum: [StrategyType.ANY_OF, StrategyType.ALL_OF],
+        default: StrategyType.ALL_OF,
       },
       schemas: {
         type: 'array',

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/BaseNode.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/BaseNode.tsx
@@ -1,9 +1,9 @@
 import { FC } from 'react'
-import { Handle, NodeProps, Position } from 'reactflow'
+import { NodeProps, Position } from 'reactflow'
 import { Text } from '@chakra-ui/react'
 
-import { styleSourceHandle } from '../../utils/node.utils.ts'
 import { NodeWrapper } from './NodeWrapper.tsx'
+import { CustomHandle } from './CustomHandle.tsx'
 
 export const BaseNode: FC<NodeProps> = (props) => {
   const { id, data, type } = props
@@ -13,8 +13,8 @@ export const BaseNode: FC<NodeProps> = (props) => {
       <NodeWrapper route={`node/${type}/${id}`} {...props}>
         <Text>{data.label}</Text>
       </NodeWrapper>
-      <Handle type="target" position={Position.Left} />
-      <Handle type="source" position={Position.Right} style={styleSourceHandle} />
+      <CustomHandle type="target" position={Position.Left} />
+      <CustomHandle type="source" position={Position.Right} />
     </>
   )
 }

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/BehaviorPolicyNode.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/BehaviorPolicyNode.spec.cy.tsx
@@ -1,0 +1,53 @@
+/// <reference types="cypress" />
+
+import { NodeProps } from 'reactflow'
+
+import { mockReactFlow } from '@/__test-utils__/react-flow/providers.tsx'
+import { MOCK_DEFAULT_NODE } from '@/__test-utils__/react-flow/nodes.ts'
+
+import { BehaviorPolicyData, BehaviorPolicyType, DataHubNodeType } from '../../types.ts'
+import { BehaviorPolicyNode } from '../nodes/BehaviorPolicyNode.tsx'
+
+const MOCK_NODE_BEHAVIOR_POLICY: NodeProps<BehaviorPolicyData> = {
+  id: 'node-id',
+  type: DataHubNodeType.BEHAVIOR_POLICY,
+  data: { model: BehaviorPolicyType.MQTT_EVENT },
+  ...MOCK_DEFAULT_NODE,
+}
+
+describe('BehaviorPolicyNode', () => {
+  beforeEach(() => {
+    cy.viewport(400, 400)
+  })
+
+  it('should render properly', () => {
+    cy.mountWithProviders(mockReactFlow(<BehaviorPolicyNode {...MOCK_NODE_BEHAVIOR_POLICY} selected={true} />))
+    cy.getByTestId(`node-title`).should('contain.text', 'Behavior Policy')
+    cy.getByTestId(`node-model`).should('contain.text', 'Mqtt.events')
+
+    // TODO[NVL] Create a PageObject and generalise the selectors
+    cy.get('div[data-handleid]').should('have.length', 2)
+    cy.get('div[data-handleid]')
+      .eq(0)
+      .should('have.attr', 'data-handlepos', 'left')
+      .should('have.attr', 'data-id')
+      .then((attr) => {
+        expect((attr as unknown as string).endsWith('target')).to.be.true
+      })
+
+    cy.get('div[data-handleid]')
+      .eq(1)
+      .should('have.attr', 'data-handlepos', 'right')
+      .should('have.attr', 'data-id')
+      .then((attr) => {
+        expect((attr as unknown as string).endsWith('source')).to.be.true
+      })
+  })
+
+  it('should be accessible', () => {
+    cy.injectAxe()
+    cy.mountWithProviders(mockReactFlow(<BehaviorPolicyNode {...MOCK_NODE_BEHAVIOR_POLICY} />))
+    cy.checkAccessibility()
+    cy.percySnapshot('Component: DataHub - BehaviorPolicyNode')
+  })
+})

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/BehaviorPolicyNode.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/BehaviorPolicyNode.tsx
@@ -1,12 +1,12 @@
 import { FC } from 'react'
-import { Handle, NodeProps, Position } from 'reactflow'
+import { NodeProps, Position } from 'reactflow'
 import { useTranslation } from 'react-i18next'
 import { HStack, Text, VStack } from '@chakra-ui/react'
 
 import { BehaviorPolicyData, DataHubNodeType } from '../../types.ts'
-import { styleSourceHandle } from '../../utils/node.utils.ts'
 import NodeIcon from '../helpers/NodeIcon.tsx'
 import { NodeWrapper } from './NodeWrapper.tsx'
+import { CustomHandle } from './CustomHandle.tsx'
 
 export const BehaviorPolicyNode: FC<NodeProps<BehaviorPolicyData>> = (props) => {
   const { t } = useTranslation('datahub')
@@ -25,8 +25,8 @@ export const BehaviorPolicyNode: FC<NodeProps<BehaviorPolicyData>> = (props) => 
           </HStack>
         </VStack>
       </NodeWrapper>
-      <Handle type="target" position={Position.Left} id={BehaviorPolicyData.Handle.CLIENT_FILTER} />
-      <Handle type="source" position={Position.Right} id="transitions" style={styleSourceHandle} />
+      <CustomHandle type="target" position={Position.Left} id={BehaviorPolicyData.Handle.CLIENT_FILTER} />
+      <CustomHandle type="source" position={Position.Right} id="transitions" />
     </>
   )
 }

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/BehaviorPolicyNode.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/BehaviorPolicyNode.tsx
@@ -18,9 +18,11 @@ export const BehaviorPolicyNode: FC<NodeProps<BehaviorPolicyData>> = (props) => 
         <VStack>
           <HStack>
             <NodeIcon type={DataHubNodeType.BEHAVIOR_POLICY} />
-            <Text w={'45%'}> {t('workspace.nodes.type', { context: type })}</Text>
+            <Text data-testid={'node-title'} w={'45%'}>
+              {t('workspace.nodes.type', { context: type })}
+            </Text>
             <VStack>
-              <Text>{data.model || '< none >'}</Text>
+              <Text data-testid={`node-model`}>{data.model || t('error.noSet.select')}</Text>
             </VStack>
           </HStack>
         </VStack>

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/ClientFilterNode.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/ClientFilterNode.spec.cy.tsx
@@ -1,0 +1,46 @@
+/// <reference types="cypress" />
+
+import { NodeProps } from 'reactflow'
+
+import { mockReactFlow } from '@/__test-utils__/react-flow/providers.tsx'
+import { MOCK_DEFAULT_NODE } from '@/__test-utils__/react-flow/nodes.ts'
+
+import { ClientFilterData, DataHubNodeType } from '../../types.ts'
+import { ClientFilterNode } from './ClientFilterNode.tsx'
+
+const MOCK_NODE_CLIENT_FILTER: NodeProps<ClientFilterData> = {
+  id: 'node-id',
+  type: DataHubNodeType.CLIENT_FILTER,
+  data: { clients: ['client1', 'client2'] },
+  ...MOCK_DEFAULT_NODE,
+}
+
+describe('ClientFilterNode', () => {
+  beforeEach(() => {
+    cy.viewport(400, 400)
+  })
+
+  it('should render properly', () => {
+    cy.mountWithProviders(mockReactFlow(<ClientFilterNode {...MOCK_NODE_CLIENT_FILTER} selected={true} />))
+    cy.getByTestId(`node-title`).should('contain.text', 'Client Filter')
+    cy.getByTestId('client-wrapper').should('have.length', 2)
+    cy.getByTestId('client-wrapper').eq(0).should('contain.text', 'client1')
+    cy.getByTestId('client-wrapper').eq(1).should('contain.text', 'client2')
+
+    // TODO[NVL] Create a PageObject and generalise the selectors
+    cy.get('div[data-handleid]').should('have.length', 2)
+    cy.get('div[data-handleid]')
+      .eq(0)
+      .should('have.attr', 'data-id')
+      .then((attr) => {
+        expect((attr as unknown as string).endsWith('source')).to.be.true
+      })
+  })
+
+  it('should be accessible', () => {
+    cy.injectAxe()
+    cy.mountWithProviders(mockReactFlow(<ClientFilterNode {...MOCK_NODE_CLIENT_FILTER} />))
+    cy.checkAccessibility()
+    cy.percySnapshot('Component: DataHub - ClientFilterNode')
+  })
+})

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/ClientFilterNode.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/ClientFilterNode.tsx
@@ -18,10 +18,10 @@ export const ClientFilterNode: FC<NodeProps<ClientFilterData>> = (props) => {
       <NodeWrapper route={`node/${type}/${id}`} {...props}>
         <HStack>
           <VStack>
-            <Text> {t('workspace.nodes.type', { context: type })}</Text>
+            <Text data-testid={'node-title'}> {t('workspace.nodes.type', { context: type })}</Text>
           </VStack>
         </HStack>
-        <VStack ml={6}>
+        <VStack ml={6} data-testid={'node-model'}>
           {data.clients?.map((t) => (
             <Client client={t} key={t} />
           ))}

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/ClientFilterNode.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/ClientFilterNode.tsx
@@ -1,13 +1,13 @@
 import { FC } from 'react'
-import { Handle, NodeProps, Position } from 'reactflow'
+import { NodeProps, Position } from 'reactflow'
 import { useTranslation } from 'react-i18next'
 import { HStack, Text, VStack } from '@chakra-ui/react'
 
 import Client from '@/components/MQTT/Client.tsx'
 
 import { ClientFilterData } from '../../types.ts'
-import { styleSourceHandle } from '../../utils/node.utils.ts'
 import { NodeWrapper } from './NodeWrapper.tsx'
+import { CustomHandle } from './CustomHandle.tsx'
 
 export const ClientFilterNode: FC<NodeProps<ClientFilterData>> = (props) => {
   const { t } = useTranslation('datahub')
@@ -28,15 +28,13 @@ export const ClientFilterNode: FC<NodeProps<ClientFilterData>> = (props) => {
         </VStack>
       </NodeWrapper>
       {data.clients?.map((t, index) => (
-        <Handle
+        <CustomHandle
           type="source"
           position={Position.Right}
           id={`${id}-${index}`}
           key={`${id}-${t}-${index}`}
-          // aria-label={t}
           style={{
             top: `calc(var(--chakra-space-3) + 12px + ${index * 24}px + ${0.5 * index}rem)`,
-            ...styleSourceHandle,
           }}
         />
       ))}

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/CustomHandle.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/CustomHandle.spec.cy.tsx
@@ -1,0 +1,21 @@
+/// <reference types="cypress" />
+
+import { Position } from 'reactflow'
+
+import { mockReactFlow } from '@/__test-utils__/react-flow/providers.tsx'
+
+import { CustomHandle } from './CustomHandle.tsx'
+
+describe('CustomHandle', () => {
+  beforeEach(() => {
+    cy.viewport(400, 400)
+  })
+
+  it('should render properly', () => {
+    cy.mountWithProviders(mockReactFlow(<CustomHandle type="target" position={Position.Bottom} />))
+  })
+
+  it('should render properly', () => {
+    cy.mountWithProviders(mockReactFlow(<CustomHandle type="source" position={Position.Bottom} />))
+  })
+})

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/CustomHandle.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/CustomHandle.tsx
@@ -1,0 +1,52 @@
+import { CSSProperties, FC, HTMLAttributes, useMemo } from 'react'
+import { getConnectedEdges, Handle, HandleProps, useNodeId } from 'reactflow'
+
+import useDataHubDraftStore from '../../hooks/useDataHubDraftStore.ts'
+
+interface CustomHandleProps extends Omit<HandleProps & Omit<HTMLAttributes<HTMLDivElement>, 'id'>, 'isConnectable'> {
+  isConnectable?: boolean | number
+}
+
+export const CustomHandle: FC<CustomHandleProps> = (props) => {
+  const { nodes, edges } = useDataHubDraftStore()
+  const nodeId = useNodeId()
+
+  const isHandleConnectable = useMemo(() => {
+    if (typeof props.isConnectable === 'number') {
+      const node = nodes.find((e) => e.id === nodeId)
+      if (node) {
+        const connectedEdges = getConnectedEdges([node], edges)
+
+        const toHandle = connectedEdges.filter((e) => {
+          const otherEnd = props.type === 'source' ? e.sourceHandle : e.targetHandle
+          return otherEnd === props.id
+        })
+
+        return toHandle.length < props.isConnectable
+      }
+      return false
+    }
+    return true
+  }, [edges, nodeId, nodes, props.id, props.isConnectable, props.type])
+
+  let transform: CSSProperties = {
+    width: '12px',
+    height: '12px',
+  }
+  if (props.type === 'source') transform = { ...transform, borderRadius: 0 }
+  if (props.position === 'left') transform = { ...transform, left: '-7px' }
+  if (props.position === 'right') transform = { ...transform, right: '-7px' }
+  if (props.position === 'top') transform = { ...transform, top: '-7px' }
+  if (props.position === 'bottom') transform = { ...transform, bottom: '-7px' }
+
+  return (
+    <Handle
+      {...props}
+      isConnectable={isHandleConnectable}
+      style={{
+        ...transform,
+        ...props.style,
+      }}
+    ></Handle>
+  )
+}

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/CustomHandle.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/CustomHandle.tsx
@@ -17,8 +17,8 @@ export const CustomHandle: FC<CustomHandleProps> = (props) => {
       if (node) {
         const connectedEdges = getConnectedEdges([node], edges)
 
-        const toHandle = connectedEdges.filter((e) => {
-          const otherEnd = props.type === 'source' ? e.sourceHandle : e.targetHandle
+        const toHandle = connectedEdges.filter((edge) => {
+          const otherEnd = props.type === 'source' ? edge.sourceHandle : edge.targetHandle
           return otherEnd === props.id
         })
 

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/CustomHandle.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/CustomHandle.tsx
@@ -13,7 +13,7 @@ export const CustomHandle: FC<CustomHandleProps> = (props) => {
 
   const isHandleConnectable = useMemo(() => {
     if (typeof props.isConnectable === 'number') {
-      const node = nodes.find((e) => e.id === nodeId)
+      const node = nodes.find((node) => node.id === nodeId)
       if (node) {
         const connectedEdges = getConnectedEdges([node], edges)
 

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/DataPolicyNode.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/DataPolicyNode.spec.cy.tsx
@@ -1,0 +1,71 @@
+/// <reference types="cypress" />
+
+import { NodeProps } from 'reactflow'
+
+import { mockReactFlow } from '@/__test-utils__/react-flow/providers.tsx'
+import { MOCK_DEFAULT_NODE } from '@/__test-utils__/react-flow/nodes.ts'
+
+import { DataHubNodeType, DataPolicyData } from '../../types.ts'
+import { DataPolicyNode } from './DataPolicyNode.tsx'
+
+const MOCK_NODE_DATA_POLICY: NodeProps<DataPolicyData> = {
+  id: 'node-id',
+  type: DataHubNodeType.DATA_POLICY,
+  data: {},
+  ...MOCK_DEFAULT_NODE,
+}
+
+describe('DataPolicyNode', () => {
+  beforeEach(() => {
+    cy.viewport(400, 400)
+  })
+
+  it('should render properly', () => {
+    cy.mountWithProviders(mockReactFlow(<DataPolicyNode {...MOCK_NODE_DATA_POLICY} selected={true} />))
+    cy.getByTestId(`node-title`).should('contain.text', 'Data Policy')
+    cy.getByTestId(`node-model`).find('p').eq(0).should('contain.text', 'onSuccess')
+    cy.getByTestId(`node-model`).find('p').eq(1).should('contain.text', 'onError')
+
+    // TODO[NVL] Create a PageObject and generalise the selectors
+    cy.get('div[data-handleid]').should('have.length', 4)
+    cy.get('div[data-handleid]')
+      .eq(0)
+      .should('have.attr', 'data-handlepos', 'left')
+      .should('have.attr', 'data-id')
+      .then((attr) => {
+        expect((attr as unknown as string).endsWith('target')).to.be.true
+      })
+    cy.get('div[data-handleid]')
+      .eq(1)
+      .should('have.attr', 'data-handlepos', 'top')
+      .should('have.attr', 'data-id')
+      .then((attr) => {
+        expect((attr as unknown as string).endsWith('target')).to.be.true
+      })
+
+    cy.get('div[data-handleid]')
+      .eq(2)
+      .should('have.attr', 'data-handlepos', 'right')
+      .should('have.attr', 'data-handleid', 'onSuccess')
+      .should('have.attr', 'data-id')
+      .then((attr) => {
+        expect((attr as unknown as string).endsWith('source')).to.be.true
+      })
+
+    cy.get('div[data-handleid]')
+      .eq(3)
+      .should('have.attr', 'data-handlepos', 'right')
+      .should('have.attr', 'data-handleid', 'onError')
+      .should('have.attr', 'data-id')
+      .then((attr) => {
+        expect((attr as unknown as string).endsWith('source')).to.be.true
+      })
+  })
+
+  it('should be accessible', () => {
+    cy.injectAxe()
+    cy.mountWithProviders(mockReactFlow(<DataPolicyNode {...MOCK_NODE_DATA_POLICY} />))
+    cy.checkAccessibility()
+    cy.percySnapshot('Component: DataHub - BehaviorPolicyNode')
+  })
+})

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/DataPolicyNode.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/DataPolicyNode.tsx
@@ -17,9 +17,9 @@ export const DataPolicyNode: FC<NodeProps<DataPolicyData>> = (props) => {
       <NodeWrapper route={`node/${DataHubNodeType.DATA_POLICY}/${id}`} {...props}>
         <HStack>
           <NodeIcon type={DataHubNodeType.DATA_POLICY} />
-          <Text> {t('workspace.nodes.type', { context: type })}</Text>
+          <Text data-testid={'node-title'}> {t('workspace.nodes.type', { context: type })}</Text>
         </HStack>
-        <VStack ml={6} alignItems={'flex-end'}>
+        <VStack ml={6} alignItems={'flex-end'} data-testid={'node-model'}>
           <Text fontSize={'xs'}>
             {t('workspace.handles.validation', { context: DataPolicyData.Handle.ON_SUCCESS })}
           </Text>

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/DataPolicyNode.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/DataPolicyNode.tsx
@@ -37,6 +37,7 @@ export const DataPolicyNode: FC<NodeProps<DataPolicyData>> = (props) => {
           top: `calc(var(--chakra-space-3) + 10px)`,
           // background: 'green',
         }}
+        isConnectable={1}
       />
       <CustomHandle
         type="source"
@@ -46,6 +47,7 @@ export const DataPolicyNode: FC<NodeProps<DataPolicyData>> = (props) => {
         style={{
           top: `calc(var(--chakra-space-3) + 10px + 16px + 0.5rem)`,
         }}
+        isConnectable={1}
       />
     </>
   )

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/DataPolicyNode.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/DataPolicyNode.tsx
@@ -1,12 +1,12 @@
 import { FC } from 'react'
-import { Handle, NodeProps, Position } from 'reactflow'
+import { NodeProps, Position } from 'reactflow'
 import { useTranslation } from 'react-i18next'
 import { HStack, Text, VStack } from '@chakra-ui/react'
 
 import { DataHubNodeType, DataPolicyData } from '../../types.ts'
-import { styleSourceHandle } from '../../utils/node.utils.ts'
 import NodeIcon from '../helpers/NodeIcon.tsx'
 import { NodeWrapper } from './NodeWrapper.tsx'
+import { CustomHandle } from './CustomHandle.tsx'
 
 export const DataPolicyNode: FC<NodeProps<DataPolicyData>> = (props) => {
   const { t } = useTranslation('datahub')
@@ -26,29 +26,27 @@ export const DataPolicyNode: FC<NodeProps<DataPolicyData>> = (props) => {
           <Text fontSize={'xs'}>{t('workspace.handles.validation', { context: DataPolicyData.Handle.ON_ERROR })}</Text>
         </VStack>
       </NodeWrapper>
-      <Handle type="target" position={Position.Left} id={DataPolicyData.Handle.TOPIC_FILTER} />
-      <Handle type="target" position={Position.Top} id={DataPolicyData.Handle.VALIDATION} />
-      <Handle
+      <CustomHandle type="target" position={Position.Left} id={DataPolicyData.Handle.TOPIC_FILTER} />
+      <CustomHandle type="target" position={Position.Top} id={DataPolicyData.Handle.VALIDATION} />
+      <CustomHandle
         type="source"
         position={Position.Right}
         id={DataPolicyData.Handle.ON_SUCCESS}
+        className={DataPolicyData.Handle.ON_SUCCESS}
         style={{
           top: `calc(var(--chakra-space-3) + 10px)`,
-          background: 'green',
-          ...styleSourceHandle,
+          // background: 'green',
         }}
       />
-      <Handle
+      <CustomHandle
         type="source"
         position={Position.Right}
         id={DataPolicyData.Handle.ON_ERROR}
+        className={DataPolicyData.Handle.ON_ERROR}
         style={{
           top: `calc(var(--chakra-space-3) + 10px + 16px + 0.5rem)`,
-          background: 'red',
-          ...styleSourceHandle,
         }}
       />
-      {/*<Handle type="source" position={Position.Right} id="finally" />*/}
     </>
   )
 }

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/OperationNode.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/OperationNode.spec.cy.tsx
@@ -1,0 +1,95 @@
+/// <reference types="cypress" />
+
+import { NodeProps } from 'reactflow'
+
+import { mockReactFlow } from '@/__test-utils__/react-flow/providers.tsx'
+import { MOCK_DEFAULT_NODE } from '@/__test-utils__/react-flow/nodes.ts'
+
+import { DataHubNodeType, OperationData } from '../../types.ts'
+import { OperationNode } from '@/extensions/datahub/components/nodes/OperationNode.tsx'
+
+const MOCK_NODE_OPERATION: NodeProps<OperationData> = {
+  id: 'node-id',
+  type: DataHubNodeType.OPERATION,
+  data: {},
+  ...MOCK_DEFAULT_NODE,
+}
+
+describe('OperationNode', () => {
+  beforeEach(() => {
+    cy.viewport(400, 400)
+  })
+
+  it('should render properly', () => {
+    cy.mountWithProviders(mockReactFlow(<OperationNode {...MOCK_NODE_OPERATION} selected={true} />))
+    cy.getByTestId(`node-title`).should('contain.text', 'Operation')
+    cy.getByTestId(`node-model`).should('contain.text', '< not set >')
+
+    // TODO[NVL] Create a PageObject and generalise the selectors
+    cy.get('div[data-handleid]').should('have.length', 2)
+    cy.get('div[data-handleid]')
+      .eq(0)
+      .should('have.attr', 'data-handlepos', 'left')
+      .should('have.attr', 'data-id')
+      .then((attr) => {
+        expect((attr as unknown as string).endsWith('target')).to.be.true
+      })
+
+    cy.get('div[data-handleid]')
+      .eq(1)
+      .should('have.attr', 'data-handlepos', 'right')
+      .should('have.attr', 'data-handleid', 'output')
+      .should('have.attr', 'data-id')
+      .then((attr) => {
+        expect((attr as unknown as string).endsWith('source')).to.be.true
+      })
+  })
+
+  it('should render properly with arguments', () => {
+    const data: NodeProps<OperationData> = {
+      ...MOCK_NODE_OPERATION,
+      data: { action: { functionId: 'test', hasArguments: true } },
+    }
+    cy.mountWithProviders(mockReactFlow(<OperationNode {...data} selected={true} />))
+    cy.getByTestId(`node-title`).should('contain.text', 'Operation')
+    cy.getByTestId(`node-model`).should('contain.text', 'test')
+
+    // TODO[NVL] Create a PageObject and generalise the selectors
+    cy.get('div[data-handleid]').should('have.length', 3)
+    cy.get('div[data-handleid]')
+      .eq(2)
+      .should('have.attr', 'data-handlepos', 'top')
+      .should('have.attr', 'data-handleid', 'schema')
+      .should('have.attr', 'data-id')
+      .then((attr) => {
+        expect((attr as unknown as string).endsWith('target')).to.be.true
+      })
+  })
+
+  it('should render properly with terminal', () => {
+    const data: NodeProps<OperationData> = {
+      ...MOCK_NODE_OPERATION,
+      data: { action: { functionId: 'test', isTerminal: true } },
+    }
+    cy.mountWithProviders(mockReactFlow(<OperationNode {...data} selected={true} />))
+    cy.getByTestId(`node-title`).should('contain.text', 'Operation')
+    cy.getByTestId(`node-model`).should('contain.text', 'test')
+
+    // TODO[NVL] Create a PageObject and generalise the selectors
+    cy.get('div[data-handleid]').should('have.length', 1)
+    cy.get('div[data-handleid]')
+      .eq(0)
+      .should('have.attr', 'data-handlepos', 'left')
+      .should('have.attr', 'data-id')
+      .then((attr) => {
+        expect((attr as unknown as string).endsWith('target')).to.be.true
+      })
+  })
+
+  // it('should be accessible', () => {
+  //   cy.injectAxe()
+  //   cy.mountWithProviders(mockReactFlow(<OperationNode {...MOCK_NODE_OPERATION} />))
+  //   cy.checkAccessibility()
+  //   cy.percySnapshot('Component: DataHub - OperationNode')
+  // })
+})

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/OperationNode.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/OperationNode.tsx
@@ -1,9 +1,9 @@
-import { FC } from 'react'
+import { FC, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { NodeProps, Position } from 'reactflow'
 import { HStack, Text, VStack } from '@chakra-ui/react'
 
-import { DataHubNodeType, OperationData } from '../../types.ts'
+import { DataHubNodeType, FunctionDefinition, OperationData } from '../../types.ts'
 import NodeIcon from '../helpers/NodeIcon.tsx'
 import { NodeWrapper } from './NodeWrapper.tsx'
 import { CustomHandle } from '@/extensions/datahub/components/nodes/CustomHandle.tsx'
@@ -13,6 +13,16 @@ export const OperationNode: FC<NodeProps<OperationData>> = (props) => {
   const { data, id, type } = props
   const { action } = data
 
+  const model = useMemo(() => {
+    if (!action) return undefined
+
+    return typeof action === 'string'
+      ? ({
+          functionId: action,
+        } as FunctionDefinition)
+      : action
+  }, [action])
+
   return (
     <>
       <NodeWrapper route={`node/${DataHubNodeType.OPERATION}/${id}`} {...props}>
@@ -20,15 +30,15 @@ export const OperationNode: FC<NodeProps<OperationData>> = (props) => {
           <NodeIcon type={DataHubNodeType.OPERATION} />
           <Text data-testid={'node-title'}> {t('workspace.nodes.type', { context: type })}</Text>
           <VStack>
-            <Text data-testid={'node-model'}>{action?.functionId || t('error.noSet.select')}</Text>
+            <Text data-testid={'node-model'}>{model?.functionId || t('error.noSet.select')}</Text>
           </VStack>
         </HStack>
       </NodeWrapper>
       <CustomHandle type="target" position={Position.Left} id={OperationData.Handle.INPUT} />
-      {!action?.isTerminal && (
+      {!model?.isTerminal && (
         <CustomHandle type="source" position={Position.Right} id={OperationData.Handle.OUTPUT} isConnectable={1} />
       )}
-      {action?.hasArguments && <CustomHandle type="target" position={Position.Top} id={OperationData.Handle.SCHEMA} />}
+      {model?.hasArguments && <CustomHandle type="target" position={Position.Top} id={OperationData.Handle.SCHEMA} />}
     </>
   )
 }

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/OperationNode.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/OperationNode.tsx
@@ -1,12 +1,12 @@
 import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Handle, NodeProps, Position } from 'reactflow'
+import { NodeProps, Position } from 'reactflow'
 import { HStack, Text, VStack } from '@chakra-ui/react'
 
 import { DataHubNodeType, OperationData } from '../../types.ts'
-import { styleSourceHandle } from '../../utils/node.utils.ts'
 import NodeIcon from '../helpers/NodeIcon.tsx'
 import { NodeWrapper } from './NodeWrapper.tsx'
+import { CustomHandle } from '@/extensions/datahub/components/nodes/CustomHandle.tsx'
 
 export const OperationNode: FC<NodeProps<OperationData>> = (props) => {
   const { t } = useTranslation('datahub')
@@ -24,11 +24,11 @@ export const OperationNode: FC<NodeProps<OperationData>> = (props) => {
           </VStack>
         </HStack>
       </NodeWrapper>
-      <Handle type="target" position={Position.Left} id={OperationData.Handle.INPUT} />
+      <CustomHandle type="target" position={Position.Left} id={OperationData.Handle.INPUT} />
       {!action?.isTerminal && (
-        <Handle type="source" position={Position.Right} id={OperationData.Handle.OUTPUT} style={styleSourceHandle} />
+        <CustomHandle type="source" position={Position.Right} id={OperationData.Handle.OUTPUT} isConnectable={1} />
       )}
-      {action?.hasArguments && <Handle type="target" position={Position.Top} id={OperationData.Handle.SCHEMA} />}
+      {action?.hasArguments && <CustomHandle type="target" position={Position.Top} id={OperationData.Handle.SCHEMA} />}
     </>
   )
 }

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/OperationNode.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/OperationNode.tsx
@@ -18,9 +18,9 @@ export const OperationNode: FC<NodeProps<OperationData>> = (props) => {
       <NodeWrapper route={`node/${DataHubNodeType.OPERATION}/${id}`} {...props}>
         <HStack>
           <NodeIcon type={DataHubNodeType.OPERATION} />
-          <Text> {t('workspace.nodes.type', { context: type })}</Text>
+          <Text data-testid={'node-title'}> {t('workspace.nodes.type', { context: type })}</Text>
           <VStack>
-            <Text>{action?.functionId || '< none >'}</Text>
+            <Text data-testid={'node-model'}>{action?.functionId || t('error.noSet.select')}</Text>
           </VStack>
         </HStack>
       </NodeWrapper>

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/SchemaNode.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/SchemaNode.spec.cy.tsx
@@ -1,0 +1,45 @@
+/// <reference types="cypress" />
+
+import { NodeProps } from 'reactflow'
+
+import { mockReactFlow } from '@/__test-utils__/react-flow/providers.tsx'
+import { MOCK_DEFAULT_NODE } from '@/__test-utils__/react-flow/nodes.ts'
+
+import { DataHubNodeType, SchemaData, SchemaType } from '../../types.ts'
+import { SchemaNode } from './SchemaNode.tsx'
+
+const MOCK_NODE_SCHEMA: NodeProps<SchemaData> = {
+  id: 'node-id',
+  type: DataHubNodeType.SCHEMA,
+  data: { type: SchemaType.JSON, version: '1' },
+  ...MOCK_DEFAULT_NODE,
+}
+
+describe('OperationNode', () => {
+  beforeEach(() => {
+    cy.viewport(400, 400)
+  })
+
+  it('should render properly', () => {
+    cy.mountWithProviders(mockReactFlow(<SchemaNode {...MOCK_NODE_SCHEMA} selected={true} />))
+    cy.getByTestId(`node-title`).should('contain.text', 'Schema')
+    cy.getByTestId(`node-model`).should('contain.text', 'JSON')
+
+    // TODO[NVL] Create a PageObject and generalise the selectors
+    cy.get('div[data-handleid]').should('have.length', 1)
+    cy.get('div[data-handleid]')
+      .eq(0)
+      .should('have.attr', 'data-handlepos', 'bottom')
+      .should('have.attr', 'data-id')
+      .then((attr) => {
+        expect((attr as unknown as string).endsWith('source')).to.be.true
+      })
+  })
+
+  it('should be accessible', () => {
+    cy.injectAxe()
+    cy.mountWithProviders(mockReactFlow(<SchemaNode {...MOCK_NODE_SCHEMA} />))
+    cy.checkAccessibility()
+    cy.percySnapshot('Component: DataHub - SchemaNode')
+  })
+})

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/SchemaNode.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/SchemaNode.tsx
@@ -6,23 +6,24 @@ import { DataHubNodeType, SchemaData } from '../../types.ts'
 import NodeIcon from '../helpers/NodeIcon.tsx'
 import { NodeWrapper } from './NodeWrapper.tsx'
 import { CustomHandle } from './CustomHandle.tsx'
+import { useTranslation } from 'react-i18next'
 
 export const SchemaNode: FC<NodeProps<SchemaData>> = (props) => {
-  const { id, data } = props
+  const { t } = useTranslation('datahub')
+  const { id, data, type } = props
 
   return (
     <>
       <NodeWrapper route={`node/${DataHubNodeType.SCHEMA}/${id}`} {...props}>
         <HStack>
           <NodeIcon type={DataHubNodeType.SCHEMA} />
-          <Text>Schema</Text>
+          <Text data-testid={'node-title'}> {t('workspace.nodes.type', { context: type })}</Text>
           <VStack>
-            <Text>{data?.type}</Text>
-            {/*<Text>{data?.schemaSource?.title || '< not defined>'}</Text>*/}
+            <Text data-testid={'node-model'}>{data?.type || t('error.noSet.select')}</Text>
           </VStack>
         </HStack>
       </NodeWrapper>
-      <CustomHandle type="source" position={Position.Bottom} />
+      <CustomHandle type="source" position={Position.Bottom} id="source" />
     </>
   )
 }

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/SchemaNode.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/SchemaNode.tsx
@@ -1,11 +1,11 @@
 import { HStack, Text, VStack } from '@chakra-ui/react'
 import { FC } from 'react'
-import { Handle, NodeProps, Position } from 'reactflow'
+import { NodeProps, Position } from 'reactflow'
 
 import { DataHubNodeType, SchemaData } from '../../types.ts'
-import { styleSourceHandle } from '../../utils/node.utils.ts'
 import NodeIcon from '../helpers/NodeIcon.tsx'
 import { NodeWrapper } from './NodeWrapper.tsx'
+import { CustomHandle } from './CustomHandle.tsx'
 
 export const SchemaNode: FC<NodeProps<SchemaData>> = (props) => {
   const { id, data } = props
@@ -22,7 +22,7 @@ export const SchemaNode: FC<NodeProps<SchemaData>> = (props) => {
           </VStack>
         </HStack>
       </NodeWrapper>
-      <Handle type="source" position={Position.Bottom} style={styleSourceHandle} />
+      <CustomHandle type="source" position={Position.Bottom} />
     </>
   )
 }

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/TopicFilterNode.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/TopicFilterNode.tsx
@@ -1,13 +1,13 @@
 import { FC } from 'react'
-import { Handle, NodeProps, Position } from 'reactflow'
+import { NodeProps, Position } from 'reactflow'
 import { useTranslation } from 'react-i18next'
 import { HStack, Text, VStack } from '@chakra-ui/react'
 
 import Topic from '@/components/MQTT/Topic.tsx'
 
 import { TopicFilterData } from '../../types.ts'
-import { styleSourceHandle } from '../../utils/node.utils.ts'
 import { NodeWrapper } from './NodeWrapper.tsx'
+import { CustomHandle } from './CustomHandle.tsx'
 
 export const TopicFilterNode: FC<NodeProps<TopicFilterData>> = (props) => {
   const { t } = useTranslation('datahub')
@@ -29,15 +29,13 @@ export const TopicFilterNode: FC<NodeProps<TopicFilterData>> = (props) => {
         </VStack>
       </NodeWrapper>
       {data.topics?.map((t, index) => (
-        <Handle
+        <CustomHandle
           type="source"
           position={Position.Right}
           id={`${t}-${index}`}
           key={`${id}-${t}-${index}`}
-          // aria-label={t}
           style={{
             top: `calc(var(--chakra-space-3) + 12px + ${index * 24}px + ${0.5 * index}rem)`,
-            ...styleSourceHandle,
           }}
         />
       ))}

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/TransitionNode.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/TransitionNode.spec.cy.tsx
@@ -1,0 +1,53 @@
+/// <reference types="cypress" />
+
+import { NodeProps } from 'reactflow'
+
+import { mockReactFlow } from '@/__test-utils__/react-flow/providers.tsx'
+import { MOCK_DEFAULT_NODE } from '@/__test-utils__/react-flow/nodes.ts'
+
+import { DataHubNodeType, TransitionData } from '../../types.ts'
+import { TransitionNode } from './TransitionNode.tsx'
+
+const MOCK_NODE_TRANSITION: NodeProps<TransitionData> = {
+  id: 'node-id',
+  type: DataHubNodeType.TRANSITION,
+  data: {},
+  ...MOCK_DEFAULT_NODE,
+}
+
+describe('TransitionNode', () => {
+  beforeEach(() => {
+    cy.viewport(400, 400)
+  })
+
+  it('should render properly', () => {
+    cy.mountWithProviders(mockReactFlow(<TransitionNode {...MOCK_NODE_TRANSITION} selected={true} />))
+    cy.getByTestId(`node-title`).should('contain.text', 'Transition')
+    cy.getByTestId(`node-model`).should('contain.text', '< not set >')
+
+    // TODO[NVL] Create a PageObject and generalise the selectors
+    cy.get('div[data-handleid]').should('have.length', 2)
+    cy.get('div[data-handleid]')
+      .eq(0)
+      .should('have.attr', 'data-handlepos', 'left')
+      .should('have.attr', 'data-id')
+      .then((attr) => {
+        expect((attr as unknown as string).endsWith('target')).to.be.true
+      })
+
+    cy.get('div[data-handleid]')
+      .eq(1)
+      .should('have.attr', 'data-handlepos', 'right')
+      .should('have.attr', 'data-id')
+      .then((attr) => {
+        expect((attr as unknown as string).endsWith('source')).to.be.true
+      })
+  })
+
+  it('should be accessible', () => {
+    cy.injectAxe()
+    cy.mountWithProviders(mockReactFlow(<TransitionNode {...MOCK_NODE_TRANSITION} />))
+    cy.checkAccessibility()
+    cy.percySnapshot('Component: DataHub - TransitionNode')
+  })
+})

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/TransitionNode.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/TransitionNode.tsx
@@ -1,12 +1,12 @@
 import { FC } from 'react'
 import { HStack, Text, VStack } from '@chakra-ui/react'
 import { useTranslation } from 'react-i18next'
-import { Handle, NodeProps, Position } from 'reactflow'
+import { NodeProps, Position } from 'reactflow'
 
 import { DataHubNodeType, TransitionData } from '../../types.ts'
-import { styleSourceHandle } from '../../utils/node.utils.ts'
 import NodeIcon from '../helpers/NodeIcon.tsx'
 import { NodeWrapper } from './NodeWrapper.tsx'
+import { CustomHandle } from './CustomHandle.tsx'
 
 export const TransitionNode: FC<NodeProps<TransitionData>> = (props) => {
   const { t } = useTranslation('datahub')
@@ -23,8 +23,8 @@ export const TransitionNode: FC<NodeProps<TransitionData>> = (props) => {
           </VStack>
         </HStack>
       </NodeWrapper>
-      <Handle type="target" position={Position.Left} />
-      <Handle type="source" position={Position.Right} style={styleSourceHandle} />
+      <CustomHandle type="target" position={Position.Left} id="target" />
+      <CustomHandle type="source" id="source" position={Position.Right} isConnectable={1} />
     </>
   )
 }

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/TransitionNode.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/TransitionNode.tsx
@@ -17,9 +17,9 @@ export const TransitionNode: FC<NodeProps<TransitionData>> = (props) => {
       <NodeWrapper route={`node/${DataHubNodeType.TRANSITION}/${id}`} {...props}>
         <HStack>
           <NodeIcon type={DataHubNodeType.TRANSITION} />
-          <Text> {t('workspace.nodes.type', { context: type })}</Text>
+          <Text data-testid={'node-title'}> {t('workspace.nodes.type', { context: type })}</Text>
           <VStack>
-            <Text>{data.type || '< none >'}</Text>
+            <Text data-testid={'node-model'}>{data.type || t('error.noSet.select')}</Text>
           </VStack>
         </HStack>
       </NodeWrapper>

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/ValidatorNode.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/ValidatorNode.spec.cy.tsx
@@ -1,0 +1,55 @@
+/// <reference types="cypress" />
+
+import { NodeProps } from 'reactflow'
+
+import { mockReactFlow } from '@/__test-utils__/react-flow/providers.tsx'
+import { MOCK_DEFAULT_NODE } from '@/__test-utils__/react-flow/nodes.ts'
+
+import { DataHubNodeType, StrategyType, ValidatorData, ValidatorType } from '../../types.ts'
+import { ValidatorNode } from './ValidatorNode.tsx'
+
+const MOCK_NODE_VALIDATOR: NodeProps<ValidatorData> = {
+  id: 'node-id',
+  type: DataHubNodeType.VALIDATOR,
+  data: { type: ValidatorType.SCHEMA, strategy: StrategyType.ALL_OF, schemas: [] },
+  ...MOCK_DEFAULT_NODE,
+}
+
+describe('ValidatorNode', () => {
+  beforeEach(() => {
+    cy.viewport(400, 400)
+  })
+
+  it('should render properly', () => {
+    cy.mountWithProviders(mockReactFlow(<ValidatorNode {...MOCK_NODE_VALIDATOR} selected={true} />))
+    cy.getByTestId(`node-title`).should('contain.text', 'Policy Validator')
+    cy.getByTestId(`node-model`).find('p').should('have.length', 2)
+    cy.getByTestId(`node-model`).find('p').eq(0).should('contain.text', 'schema')
+    cy.getByTestId(`node-model`).find('p').eq(1).should('contain.text', 'ALL_OF')
+
+    // TODO[NVL] Create a PageObject and generalise the selectors
+    cy.get('div[data-handleid]').should('have.length', 2)
+    cy.get('div[data-handleid]')
+      .eq(0)
+      .should('have.attr', 'data-handlepos', 'top')
+      .should('have.attr', 'data-id')
+      .then((attr) => {
+        expect((attr as unknown as string).endsWith('target')).to.be.true
+      })
+
+    cy.get('div[data-handleid]')
+      .eq(1)
+      .should('have.attr', 'data-handlepos', 'bottom')
+      .should('have.attr', 'data-id')
+      .then((attr) => {
+        expect((attr as unknown as string).endsWith('source')).to.be.true
+      })
+  })
+
+  it('should be accessible', () => {
+    cy.injectAxe()
+    cy.mountWithProviders(mockReactFlow(<ValidatorNode {...MOCK_NODE_VALIDATOR} />))
+    cy.checkAccessibility()
+    cy.percySnapshot('Component: DataHub - ValidatorNode')
+  })
+})

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/ValidatorNode.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/ValidatorNode.tsx
@@ -1,12 +1,12 @@
 import { FC } from 'react'
 import { HStack, Text, VStack } from '@chakra-ui/react'
 import { useTranslation } from 'react-i18next'
-import { Handle, NodeProps, Position } from 'reactflow'
+import { NodeProps, Position } from 'reactflow'
 
 import { DataHubNodeType, ValidatorData } from '../../types.ts'
-import { styleSourceHandle } from '../../utils/node.utils.ts'
 import NodeIcon from '../helpers/NodeIcon.tsx'
 import { NodeWrapper } from './NodeWrapper.tsx'
+import { CustomHandle } from './CustomHandle.tsx'
 
 export const ValidatorNode: FC<NodeProps<ValidatorData>> = (props) => {
   const { t } = useTranslation('datahub')
@@ -23,9 +23,8 @@ export const ValidatorNode: FC<NodeProps<ValidatorData>> = (props) => {
           </VStack>
         </HStack>
       </NodeWrapper>
-
-      <Handle type="target" position={Position.Top} />
-      <Handle type="source" position={Position.Bottom} style={styleSourceHandle} />
+      <CustomHandle type="target" position={Position.Top} />
+      <CustomHandle type="source" position={Position.Bottom} />
     </>
   )
 }

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/ValidatorNode.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/ValidatorNode.tsx
@@ -16,15 +16,17 @@ export const ValidatorNode: FC<NodeProps<ValidatorData>> = (props) => {
       <NodeWrapper route={`node/${DataHubNodeType.VALIDATOR}/${id}`} {...props}>
         <HStack>
           <NodeIcon type={DataHubNodeType.VALIDATOR} />
-          <Text w={'50%'}> {t('workspace.nodes.type', { context: type })}</Text>
-          <VStack>
-            <Text>{data.strategy}</Text>
+          <Text data-testid={'node-title'} w={'50%'}>
+            {t('workspace.nodes.type', { context: type })}
+          </Text>
+          <VStack data-testid={'node-model'}>
             <Text>{data.type}</Text>
+            <Text>{data.strategy}</Text>
           </VStack>
         </HStack>
       </NodeWrapper>
-      <CustomHandle type="target" position={Position.Top} />
-      <CustomHandle type="source" position={Position.Bottom} />
+      <CustomHandle type="target" position={Position.Top} id="target" />
+      <CustomHandle type="source" position={Position.Bottom} id="source" />
     </>
   )
 }

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/PolicyEditor.module.scss
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/PolicyEditor.module.scss
@@ -18,9 +18,15 @@
     &.react-flow__handle-valid {
       box-shadow: 0 0 10px 2px rgb(88 144 255 / 75%), 0 1px 1px rgb(0 0 0 / 15%);
     }
-    // Add notConnectable
     &:not(.react-flow__handle-valid) {
       cursor: no-drop;
+      box-shadow: 0 0 10px 2px rgba(226, 85, 85, 0.75), 0 1px 1px rgb(0 0 0 / 15%);
+
+    }
+    &:not(.connectable) {
+      cursor: no-drop;
+      box-shadow: 0 0 10px 2px rgba(226, 85, 85, 0.75), 0 1px 1px rgb(0 0 0 / 15%);
+
     }
   }
 }

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/PolicyEditor.module.scss
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/PolicyEditor.module.scss
@@ -21,12 +21,10 @@
     &:not(.react-flow__handle-valid) {
       cursor: no-drop;
       box-shadow: 0 0 10px 2px rgba(226, 85, 85, 0.75), 0 1px 1px rgb(0 0 0 / 15%);
-
     }
     &:not(.connectable) {
       cursor: no-drop;
       box-shadow: 0 0 10px 2px rgba(226, 85, 85, 0.75), 0 1px 1px rgb(0 0 0 / 15%);
-
     }
   }
 }

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/PolicyEditor.module.scss
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/PolicyEditor.module.scss
@@ -1,0 +1,26 @@
+.dataHubFlow {
+  :global .react-flow__node.selectable {
+    &:focus-visible {
+      box-shadow: 0 0 10px 2px rgb(88 144 255 / 75%), 0 1px 1px rgb(0 0 0 / 15%);
+    }
+  }
+
+  :global .react-flow__node {
+    .react-flow__handle.onSuccess {
+      background: var(--chakra-colors-green-400);
+    }
+    .react-flow__handle.onError {
+      background: var(--chakra-colors-red-400);
+    }
+  }
+
+  :global .react-flow__handle-connecting {
+    &.react-flow__handle-valid {
+      box-shadow: 0 0 10px 2px rgb(88 144 255 / 75%), 0 1px 1px rgb(0 0 0 / 15%);
+    }
+    // Add notConnectable
+    &:not(.react-flow__handle-valid) {
+      cursor: no-drop;
+    }
+  }
+}

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/PolicyEditor.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/PolicyEditor.tsx
@@ -1,5 +1,5 @@
 import React, { FC, useCallback, useMemo, useRef, useState } from 'react'
-import ReactFlow, { Node, ReactFlowInstance, ReactFlowProvider, XYPosition } from 'reactflow'
+import ReactFlow, { Connection, Node, ReactFlowInstance, ReactFlowProvider, XYPosition } from 'reactflow'
 import { Outlet, useParams } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { Box } from '@chakra-ui/react'
@@ -22,7 +22,7 @@ import {
   BehaviorPolicyNode,
   TransitionNode,
 } from '../../components/nodes/'
-import { getNodeId, getNodePayload } from '@/extensions/datahub/utils/node.utils.ts'
+import { getNodeId, getNodePayload, isValidPolicyConnection } from '../../utils/node.utils.ts'
 
 const PolicyEditor: FC = () => {
   const { t } = useTranslation('datahub')
@@ -45,6 +45,8 @@ const PolicyEditor: FC = () => {
     }),
     []
   )
+
+  const checkValidity = useCallback((connection: Connection) => isValidPolicyConnection(connection, nodes), [nodes])
 
   const onDragOver = useCallback((event: React.DragEvent<HTMLElement> | undefined) => {
     if (event) {
@@ -110,7 +112,7 @@ const PolicyEditor: FC = () => {
           // nodesConnectable
           onDragOver={onDragOver}
           onDrop={onDrop}
-          // isValidConnection={isValidConnection}
+          isValidConnection={checkValidity}
         >
           <Box
             role={'toolbar'}

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/PolicyEditor.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/PolicyEditor.tsx
@@ -11,7 +11,9 @@ import useDataHubDraftStore from '../../hooks/useDataHubDraftStore.ts'
 import CanvasControls from '../controls/CanvasControls.tsx'
 import { Toolbox } from '../controls/Toolbox.tsx'
 import Minimap from '../controls/Minimap.tsx'
-import { BaseNode } from '../nodes/BaseNode.tsx'
+
+import styles from './PolicyEditor.module.scss'
+
 import {
   TopicFilterNode,
   ClientFilterNode,
@@ -109,6 +111,7 @@ const PolicyEditor: FC = () => {
           onInit={setReactFlowInstance}
           fitView
           snapToGrid
+          className={styles.dataHubFlow}
           // nodesConnectable
           onDragOver={onDragOver}
           onDrop={onDrop}

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/PolicyEditor.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/PolicyEditor.tsx
@@ -35,7 +35,6 @@ const PolicyEditor: FC = () => {
 
   const nodeTypes = useMemo(
     () => ({
-      baseNode: BaseNode,
       [DataHubNodeType.TOPIC_FILTER]: TopicFilterNode,
       [DataHubNodeType.CLIENT_FILTER]: ClientFilterNode,
       [DataHubNodeType.DATA_POLICY]: DataPolicyNode,

--- a/hivemq-edge/src/frontend/src/extensions/datahub/locales/en/datahub.json
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/locales/en/datahub.json
@@ -70,6 +70,9 @@
     }
   },
   "error": {
+    "noSet": {
+      "select": "< not set >"
+    },
     "notActivated": {
       "title": "Datahub is now available to commercial licenses",
       "description": "Please contact our sales team to gain access"

--- a/hivemq-edge/src/frontend/src/extensions/datahub/types.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/types.ts
@@ -127,7 +127,8 @@ export interface FunctionSpecs extends FunctionDefinition {
 }
 
 export interface OperationData extends DataHubNodeData {
-  action?: FunctionDefinition
+  // TODO[18841] Temporary definition until functions' JSONSchema are properly defined
+  action?: FunctionDefinition | string
   formData?: Record<string, string | number>
   core?: PolicyOperation
 }

--- a/hivemq-edge/src/frontend/src/extensions/datahub/utils/node.utils.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/utils/node.utils.ts
@@ -1,5 +1,4 @@
 import { Connection, Edge, Node } from 'reactflow'
-import { CSSProperties } from 'react'
 import { MOCK_JSONSCHEMA_SCHEMA } from '../__test-utils__/schema-mocks.ts'
 
 import {
@@ -16,13 +15,6 @@ import {
   ValidatorData,
   ValidatorType,
 } from '../types.ts'
-
-export const styleSourceHandle: CSSProperties = {
-  width: '12px',
-  right: '-6px',
-  borderRadius: 0,
-  height: '12px',
-}
 
 export const initialFlow = () => {
   const nodes: Node[] = []

--- a/hivemq-edge/src/frontend/src/extensions/datahub/utils/node.utils.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/utils/node.utils.ts
@@ -1,11 +1,13 @@
-import { Edge, Node } from 'reactflow'
+import { Connection, Edge, Node } from 'reactflow'
 import { CSSProperties } from 'react'
 import { MOCK_JSONSCHEMA_SCHEMA } from '../__test-utils__/schema-mocks.ts'
 
 import {
+  BehaviorPolicyData,
   ClientFilterData,
   DataHubNodeData,
   DataHubNodeType,
+  DataPolicyData,
   OperationData,
   SchemaData,
   SchemaType,
@@ -68,4 +70,42 @@ export const getNodePayload = (type: string): DataHubNodeData => {
     return payload
   }
   return { label: `${type} node` }
+}
+
+type ConnectionValidity = Record<string, (DataHubNodeType | [DataHubNodeType, string])[]>
+
+// TODO[NVL} worth moving as property to individual node?
+export const validConnections: ConnectionValidity = {
+  [DataHubNodeType.TOPIC_FILTER]: [[DataHubNodeType.DATA_POLICY, DataPolicyData.Handle.TOPIC_FILTER]],
+  [DataHubNodeType.VALIDATOR]: [[DataHubNodeType.DATA_POLICY, DataPolicyData.Handle.VALIDATION]],
+  [DataHubNodeType.DATA_POLICY]: [DataHubNodeType.OPERATION],
+  [DataHubNodeType.OPERATION]: [DataHubNodeType.OPERATION],
+  [DataHubNodeType.SCHEMA]: [DataHubNodeType.VALIDATOR, [DataHubNodeType.OPERATION, OperationData.Handle.SCHEMA]],
+  [DataHubNodeType.CLIENT_FILTER]: [[DataHubNodeType.BEHAVIOR_POLICY, BehaviorPolicyData.Handle.CLIENT_FILTER]],
+  [DataHubNodeType.BEHAVIOR_POLICY]: [DataHubNodeType.TRANSITION],
+  [DataHubNodeType.TRANSITION]: [DataHubNodeType.OPERATION],
+}
+
+export const isValidPolicyConnection = (connection: Connection, nodes: Node[]) => {
+  const source = nodes.find((e) => e.id === connection.source)
+  const destination = nodes.find((e) => e.id === connection.target)
+
+  if (!source) {
+    return false
+  }
+  const { type } = source
+  if (!type) {
+    return false
+  }
+  const connectionValidators = validConnections[type]
+  if (!connectionValidators) {
+    return false
+  }
+  return connectionValidators.some((elt) => {
+    if (Array.isArray(elt)) {
+      return destination?.type === elt[0] && connection.targetHandle === elt[1]
+    }
+
+    return destination?.type === elt
+  })
 }


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/18842/details/

This PR complements the work done on the new visual language for policies by adding and visualising constraints between elements on the canvas.

The PR also fixes a few styling issues with the nodes.

### Design
- The two types of handles on nodes have been made more visible to highlight `target` (circle) and `source` (square) 
- Connecting two nodes can only be done between a source and a target. Drag-and-drop can be used from any direction but the created link will be directional.
- A source node can only be connected to a valid target. Each node defined its own validity (e.g. `Topic Filter` connected to `Data Policy` only)
- Some nodes (e.g. `Data Policy` or `Operation`) also have cardinality constraints and only allow one link to another destination. Each handle (e.g. `onSuccess` or `onError`) has its constraints. 
- When dragging a link from one node to another, the validity of the targetted handle will be shown; if invalid, the connection cannot be established 

### Before
Any node could be connected to any other node

![screenshot-localhost_3000-2024 01 24-13_24_05](https://github.com/hivemq/hivemq-edge/assets/2743481/7ad5de38-12b2-4f8c-b24a-645df74e149f)

### After
Only valid connections can be established

![screenshot-localhost_3000-2024 01 24-13_26_40](https://github.com/hivemq/hivemq-edge/assets/2743481/b84e8580-3bea-411b-8aaa-4802d2ba5b9d)

Visual feedback for the validity of an attempted connection is now provided 

![screenshot-localhost_3000-2024 01 24-11_39_27](https://github.com/hivemq/hivemq-edge/assets/2743481/691e9798-e1f0-4b4c-9558-28514a626204)

![screenshot-localhost_3000-2024 01 24-11_39_42](https://github.com/hivemq/hivemq-edge/assets/2743481/ffcf2cc9-70dd-4191-af9b-38af25cf82e7)

![screenshot-localhost_3000-2024 01 24-11_39_58](https://github.com/hivemq/hivemq-edge/assets/2743481/f3db02ac-cd6b-43ad-97d6-0e02ce2a3833)


