### PR TITLE
chore(18908): update eslint rules and reformat code

### DIFF
--- a/hivemq-edge/src/frontend/.eslintrc.cjs
+++ b/hivemq-edge/src/frontend/.eslintrc.cjs
@@ -3,6 +3,7 @@ module.exports = {
   extends: [
     'eslint:recommended',
     'plugin:@typescript-eslint/recommended',
+    'plugin:react/recommended',
     'plugin:react-hooks/recommended',
     'plugin:cypress/recommended',
   ],
@@ -10,6 +11,9 @@ module.exports = {
   parserOptions: { ecmaVersion: 'latest', sourceType: 'module' },
   plugins: ['react-refresh', 'cypress'],
   rules: {
+    'react/react-in-jsx-scope': 0,
+    'react/prop-types': 0,
+    'react/jsx-curly-brace-presence': ['error', { props: 'never', children: 'never' }],
     'react-refresh/only-export-components': 'warn',
     '@typescript-eslint/ban-ts-comment': 0,
     '@typescript-eslint/no-unused-vars': ['error', { ignoreRestSiblings: true }],

--- a/hivemq-edge/src/frontend/package.json
+++ b/hivemq-edge/src/frontend/package.json
@@ -90,6 +90,7 @@
     "cypress-terminal-report": "^5.1.1",
     "eslint": "^8.38.0",
     "eslint-plugin-cypress": "^2.13.3",
+    "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.3.4",
     "i18next-pseudo": "^2.2.1",

--- a/hivemq-edge/src/frontend/pnpm-lock.yaml
+++ b/hivemq-edge/src/frontend/pnpm-lock.yaml
@@ -189,6 +189,9 @@ devDependencies:
   eslint-plugin-cypress:
     specifier: ^2.13.3
     version: 2.13.3(eslint@8.38.0)
+  eslint-plugin-react:
+    specifier: ^7.33.2
+    version: 7.33.2(eslint@8.38.0)
   eslint-plugin-react-hooks:
     specifier: ^4.6.0
     version: 4.6.0(eslint@8.38.0)
@@ -3750,13 +3753,67 @@ packages:
   /array-buffer-byte-length@1.0.0:
     resolution: {integrity: sha512-LPuwb2P+NrQw3XhxGc36+XSvuBPopovXYTR9Ew++Du9Yb/bx5AzBfrIsBoj0EZUifjQU+sHL21sseZ3jerWO/A==}
     dependencies:
-      call-bind: 1.0.2
+      call-bind: 1.0.5
       is-array-buffer: 3.0.2
+    dev: true
+
+  /array-includes@3.1.7:
+    resolution: {integrity: sha512-dlcsNBIiWhPkHdOEEKnehA+RNUWDc4UqFtnIXU4uuYDPtA4LDkr7qip2p0VvFAEXNDr0yWZ9PJyIRiGjRLQzwQ==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind: 1.0.2
+      define-properties: 1.2.0
+      es-abstract: 1.22.3
+      get-intrinsic: 1.2.1
+      is-string: 1.0.7
     dev: true
 
   /array-union@2.1.0:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
     engines: {node: '>=8'}
+    dev: true
+
+  /array.prototype.flat@1.3.2:
+    resolution: {integrity: sha512-djYB+Zx2vLewY8RWlNCUdHjDXs2XOgm602S9E7P/UpHgfeHL00cRiIF+IN/G/aUJ7kGPb6yO/ErDI5V2s8iycA==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind: 1.0.2
+      define-properties: 1.2.1
+      es-abstract: 1.22.3
+      es-shim-unscopables: 1.0.2
+    dev: true
+
+  /array.prototype.flatmap@1.3.2:
+    resolution: {integrity: sha512-Ewyx0c9PmpcsByhSW4r+9zDU7sGjFc86qf/kKtuSCRdhfbk0SNLLkaT5qvcHnRGgc5NP/ly/y+qkXkqONX54CQ==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind: 1.0.2
+      define-properties: 1.2.0
+      es-abstract: 1.22.3
+      es-shim-unscopables: 1.0.2
+    dev: true
+
+  /array.prototype.tosorted@1.1.2:
+    resolution: {integrity: sha512-HuQCHOlk1Weat5jzStICBCd83NxiIMwqDg/dHEsoefabn/hJRj5pVdWcPUSpRrwhwxZOsQassMpgN/xRYFBMIg==}
+    dependencies:
+      call-bind: 1.0.2
+      define-properties: 1.2.0
+      es-abstract: 1.22.3
+      es-shim-unscopables: 1.0.2
+      get-intrinsic: 1.2.1
+    dev: true
+
+  /arraybuffer.prototype.slice@1.0.2:
+    resolution: {integrity: sha512-yMBKppFur/fbHu9/6USUe03bZ4knMYiwFBcyiaXB8Go0qNehwX6inYPzK9U0NeQvGxKthcmHcaR8P5MStSRBAw==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      array-buffer-byte-length: 1.0.0
+      call-bind: 1.0.5
+      define-properties: 1.2.1
+      es-abstract: 1.22.3
+      get-intrinsic: 1.2.2
+      is-array-buffer: 3.0.2
+      is-shared-array-buffer: 1.0.2
     dev: true
 
   /arrify@1.0.1:
@@ -3786,6 +3843,12 @@ packages:
 
   /async@3.2.4:
     resolution: {integrity: sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==}
+    dev: true
+
+  /asynciterator.prototype@1.0.0:
+    resolution: {integrity: sha512-wwHYEIS0Q80f5mosx3L/dfG5t5rjEa9Ft51GTaNt862EnpyGHpgz2RkZvLPp1oF5TnAiTohkEKVEu8pQPJI7Vg==}
+    dependencies:
+      has-symbols: 1.0.3
     dev: true
 
   /asynckit@0.4.0:
@@ -3946,6 +4009,14 @@ packages:
     dependencies:
       function-bind: 1.1.1
       get-intrinsic: 1.2.1
+    dev: true
+
+  /call-bind@1.0.5:
+    resolution: {integrity: sha512-C3nQxfFZxFRVoJoGKKI8y3MOEo129NQ+FgQ08iye+Mk4zNZZGdjfs06bVTr+DBSlA66Q2VEcMki/cUCP4SercQ==}
+    dependencies:
+      function-bind: 1.1.2
+      get-intrinsic: 1.2.2
+      set-function-length: 1.2.0
     dev: true
 
   /call-me-maybe@1.0.2:
@@ -4699,9 +4770,9 @@ packages:
     resolution: {integrity: sha512-xjVyBf0w5vH0I42jdAZzOKVldmPgSulmiyPRywoyq7HXC9qdgo17kxJE+rdnif5Tz6+pIrpJI8dCpMNLIGkUiA==}
     dependencies:
       array-buffer-byte-length: 1.0.0
-      call-bind: 1.0.2
+      call-bind: 1.0.5
       es-get-iterator: 1.1.3
-      get-intrinsic: 1.2.1
+      get-intrinsic: 1.2.2
       is-arguments: 1.1.1
       is-array-buffer: 3.0.2
       is-date-object: 1.0.5
@@ -4711,11 +4782,11 @@ packages:
       object-is: 1.1.5
       object-keys: 1.1.1
       object.assign: 4.1.4
-      regexp.prototype.flags: 1.5.0
+      regexp.prototype.flags: 1.5.1
       side-channel: 1.0.4
       which-boxed-primitive: 1.0.2
       which-collection: 1.0.1
-      which-typed-array: 1.1.10
+      which-typed-array: 1.1.13
     dev: true
 
   /deep-is@0.1.4:
@@ -4728,10 +4799,28 @@ packages:
       clone: 1.0.4
     dev: true
 
+  /define-data-property@1.1.1:
+    resolution: {integrity: sha512-E7uGkTzkk1d0ByLeSc6ZsFS79Axg+m1P/VsgYsxHgiuc3tFSj+MjMIwe90FC4lOAZzNBdY7kkO2P2wKdsQ1vgQ==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      get-intrinsic: 1.2.2
+      gopd: 1.0.1
+      has-property-descriptors: 1.0.0
+    dev: true
+
   /define-properties@1.2.0:
     resolution: {integrity: sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==}
     engines: {node: '>= 0.4'}
     dependencies:
+      has-property-descriptors: 1.0.0
+      object-keys: 1.1.1
+    dev: true
+
+  /define-properties@1.2.1:
+    resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      define-data-property: 1.1.1
       has-property-descriptors: 1.0.0
       object-keys: 1.1.1
     dev: true
@@ -4763,6 +4852,13 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       path-type: 4.0.0
+    dev: true
+
+  /doctrine@2.1.0:
+    resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      esutils: 2.0.3
     dev: true
 
   /doctrine@3.0.0:
@@ -4828,11 +4924,56 @@ packages:
     dependencies:
       is-arrayish: 0.2.1
 
+  /es-abstract@1.22.3:
+    resolution: {integrity: sha512-eiiY8HQeYfYH2Con2berK+To6GrK2RxbPawDkGq4UiCQQfZHb6wX9qQqkbpPqaxQFcl8d9QzZqo0tGE0VcrdwA==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      array-buffer-byte-length: 1.0.0
+      arraybuffer.prototype.slice: 1.0.2
+      available-typed-arrays: 1.0.5
+      call-bind: 1.0.5
+      es-set-tostringtag: 2.0.2
+      es-to-primitive: 1.2.1
+      function.prototype.name: 1.1.6
+      get-intrinsic: 1.2.2
+      get-symbol-description: 1.0.0
+      globalthis: 1.0.3
+      gopd: 1.0.1
+      has-property-descriptors: 1.0.0
+      has-proto: 1.0.1
+      has-symbols: 1.0.3
+      hasown: 2.0.0
+      internal-slot: 1.0.5
+      is-array-buffer: 3.0.2
+      is-callable: 1.2.7
+      is-negative-zero: 2.0.2
+      is-regex: 1.1.4
+      is-shared-array-buffer: 1.0.2
+      is-string: 1.0.7
+      is-typed-array: 1.1.12
+      is-weakref: 1.0.2
+      object-inspect: 1.13.1
+      object-keys: 1.1.1
+      object.assign: 4.1.4
+      regexp.prototype.flags: 1.5.1
+      safe-array-concat: 1.1.0
+      safe-regex-test: 1.0.2
+      string.prototype.trim: 1.2.8
+      string.prototype.trimend: 1.0.7
+      string.prototype.trimstart: 1.0.7
+      typed-array-buffer: 1.0.0
+      typed-array-byte-length: 1.0.0
+      typed-array-byte-offset: 1.0.0
+      typed-array-length: 1.0.4
+      unbox-primitive: 1.0.2
+      which-typed-array: 1.1.13
+    dev: true
+
   /es-get-iterator@1.1.3:
     resolution: {integrity: sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==}
     dependencies:
-      call-bind: 1.0.2
-      get-intrinsic: 1.2.1
+      call-bind: 1.0.5
+      get-intrinsic: 1.2.2
       has-symbols: 1.0.3
       is-arguments: 1.1.1
       is-map: 2.0.2
@@ -4840,6 +4981,49 @@ packages:
       is-string: 1.0.7
       isarray: 2.0.5
       stop-iteration-iterator: 1.0.0
+    dev: true
+
+  /es-iterator-helpers@1.0.15:
+    resolution: {integrity: sha512-GhoY8uYqd6iwUl2kgjTm4CZAf6oo5mHK7BPqx3rKgx893YSsy0LGHV6gfqqQvZt/8xM8xeOnfXBCfqclMKkJ5g==}
+    dependencies:
+      asynciterator.prototype: 1.0.0
+      call-bind: 1.0.2
+      define-properties: 1.2.1
+      es-abstract: 1.22.3
+      es-set-tostringtag: 2.0.2
+      function-bind: 1.1.1
+      get-intrinsic: 1.2.1
+      globalthis: 1.0.3
+      has-property-descriptors: 1.0.0
+      has-proto: 1.0.1
+      has-symbols: 1.0.3
+      internal-slot: 1.0.5
+      iterator.prototype: 1.1.2
+      safe-array-concat: 1.1.0
+    dev: true
+
+  /es-set-tostringtag@2.0.2:
+    resolution: {integrity: sha512-BuDyupZt65P9D2D2vA/zqcI3G5xRsklm5N3xCwuiy+/vKy8i0ifdsQP1sLgO4tZDSCaQUSnmC48khknGMV3D2Q==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      get-intrinsic: 1.2.2
+      has-tostringtag: 1.0.0
+      hasown: 2.0.0
+    dev: true
+
+  /es-shim-unscopables@1.0.2:
+    resolution: {integrity: sha512-J3yBRXCzDu4ULnQwxyToo/OjdMx6akgVC7K6few0a7F/0wLtmKKN7I73AH5T2836UuXRqN7Qg+IIUw/+YJksRw==}
+    dependencies:
+      hasown: 2.0.0
+    dev: true
+
+  /es-to-primitive@1.2.1:
+    resolution: {integrity: sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      is-callable: 1.2.7
+      is-date-object: 1.0.5
+      is-symbol: 1.0.4
     dev: true
 
   /esbuild@0.17.19:
@@ -4914,6 +5098,31 @@ packages:
       eslint: '>=7'
     dependencies:
       eslint: 8.38.0
+    dev: true
+
+  /eslint-plugin-react@7.33.2(eslint@8.38.0):
+    resolution: {integrity: sha512-73QQMKALArI8/7xGLNI/3LylrEYrlKZSb5C9+q3OtOewTnMQi5cT+aE9E41sLCmli3I9PGGmD1yiZydyo4FEPw==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
+    dependencies:
+      array-includes: 3.1.7
+      array.prototype.flatmap: 1.3.2
+      array.prototype.tosorted: 1.1.2
+      doctrine: 2.1.0
+      es-iterator-helpers: 1.0.15
+      eslint: 8.38.0
+      estraverse: 5.3.0
+      jsx-ast-utils: 3.3.5
+      minimatch: 3.1.2
+      object.entries: 1.1.7
+      object.fromentries: 2.0.7
+      object.hasown: 1.1.3
+      object.values: 1.1.7
+      prop-types: 15.8.1
+      resolve: 2.0.0-next.5
+      semver: 6.3.1
+      string.prototype.matchall: 4.0.10
     dev: true
 
   /eslint-scope@5.1.1:
@@ -5317,6 +5526,20 @@ packages:
 
   /function-bind@1.1.1:
     resolution: {integrity: sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==}
+    dev: true
+
+  /function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  /function.prototype.name@1.1.6:
+    resolution: {integrity: sha512-Z5kx79swU5P27WEayXM1tBi5Ze/lbIyiNgU3qyXUOf9b2rgXYyF9Dy9Cx+IQv/Lc8WCG6L82zwUPpSS9hGehIg==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind: 1.0.5
+      define-properties: 1.2.1
+      es-abstract: 1.22.3
+      functions-have-names: 1.2.3
+    dev: true
 
   /functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
@@ -5345,6 +5568,15 @@ packages:
       has-symbols: 1.0.3
     dev: true
 
+  /get-intrinsic@1.2.2:
+    resolution: {integrity: sha512-0gSo4ml/0j98Y3lngkFEot/zhiCeWsbYIlZ+uZOVgzLyLaUw7wxUL+nCTP0XJvJg1AXulJRI3UJi8GsbDuxdGA==}
+    dependencies:
+      function-bind: 1.1.2
+      has-proto: 1.0.1
+      has-symbols: 1.0.3
+      hasown: 2.0.0
+    dev: true
+
   /get-nonce@1.0.1:
     resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
     engines: {node: '>=6'}
@@ -5355,6 +5587,14 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       pump: 3.0.0
+    dev: true
+
+  /get-symbol-description@1.0.0:
+    resolution: {integrity: sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind: 1.0.5
+      get-intrinsic: 1.2.2
     dev: true
 
   /getos@3.2.1:
@@ -5429,6 +5669,13 @@ packages:
       type-fest: 0.20.2
     dev: true
 
+  /globalthis@1.0.3:
+    resolution: {integrity: sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      define-properties: 1.2.1
+    dev: true
+
   /globby@11.1.0:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
     engines: {node: '>=10'}
@@ -5448,7 +5695,7 @@ packages:
   /gopd@1.0.1:
     resolution: {integrity: sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==}
     dependencies:
-      get-intrinsic: 1.2.1
+      get-intrinsic: 1.2.2
     dev: true
 
   /graceful-fs@4.2.11:
@@ -5501,6 +5748,12 @@ packages:
       get-intrinsic: 1.2.1
     dev: true
 
+  /has-property-descriptors@1.0.1:
+    resolution: {integrity: sha512-VsX8eaIewvas0xnvinAe9bw4WfIeODpGYikiWYLH+dma0Jw6KHYqWiWfhQlgOVK8D6PvjubK5Uc4P0iIhIcNVg==}
+    dependencies:
+      get-intrinsic: 1.2.2
+    dev: true
+
   /has-proto@1.0.1:
     resolution: {integrity: sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==}
     engines: {node: '>= 0.4'}
@@ -5522,7 +5775,14 @@ packages:
     resolution: {integrity: sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==}
     engines: {node: '>= 0.4.0'}
     dependencies:
-      function-bind: 1.1.1
+      function-bind: 1.1.2
+    dev: true
+
+  /hasown@2.0.0:
+    resolution: {integrity: sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      function-bind: 1.1.2
 
   /headers-polyfill@3.1.2:
     resolution: {integrity: sha512-tWCK4biJ6hcLqTviLXVR9DTRfYGQMXEIUj3gwJ2rZ5wO/at3XtkI4g8mCvFdUF9l1KMBNCfmNAdnahm1cgavQA==}
@@ -5746,20 +6006,27 @@ packages:
     resolution: {integrity: sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==}
     engines: {node: '>= 0.4'}
     dependencies:
-      call-bind: 1.0.2
+      call-bind: 1.0.5
       has-tostringtag: 1.0.0
     dev: true
 
   /is-array-buffer@3.0.2:
     resolution: {integrity: sha512-y+FyyR/w8vfIRq4eQcM1EYgSTnmHXPqaF+IgzgraytCFq5Xh8lllDVmAZolPJiZttZLeFSINPYMaEJ7/vWUa1w==}
     dependencies:
-      call-bind: 1.0.2
-      get-intrinsic: 1.2.1
-      is-typed-array: 1.1.10
+      call-bind: 1.0.5
+      get-intrinsic: 1.2.2
+      is-typed-array: 1.1.12
     dev: true
 
   /is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
+
+  /is-async-function@2.0.0:
+    resolution: {integrity: sha512-Y1JXKrfykRJGdlDwdKlLpLyMIiWqWvuSd17TvZk68PLAOGOoF4Xyav1z0Xhoi+gCYjZVeC5SI+hYFOfvXmGRCA==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      has-tostringtag: 1.0.0
+    dev: true
 
   /is-bigint@1.0.4:
     resolution: {integrity: sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==}
@@ -5778,7 +6045,7 @@ packages:
     resolution: {integrity: sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==}
     engines: {node: '>= 0.4'}
     dependencies:
-      call-bind: 1.0.2
+      call-bind: 1.0.5
       has-tostringtag: 1.0.0
     dev: true
 
@@ -5794,10 +6061,10 @@ packages:
       ci-info: 3.8.0
     dev: true
 
-  /is-core-module@2.12.1:
-    resolution: {integrity: sha512-Q4ZuBAe2FUsKtyQJoQHlvP8OvBERxO3jEmy1I7hcRXcJBGGHFh/aJBswbXuS9sgrDH2QUO8ilkwNPHvHMd8clg==}
+  /is-core-module@2.13.1:
+    resolution: {integrity: sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==}
     dependencies:
-      has: 1.0.3
+      hasown: 2.0.0
 
   /is-date-object@1.0.5:
     resolution: {integrity: sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==}
@@ -5809,6 +6076,12 @@ packages:
   /is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
+    dev: true
+
+  /is-finalizationregistry@1.0.2:
+    resolution: {integrity: sha512-0by5vtUJs8iFQb5TYUHHPudOR+qXYIMKtiUzvLIZITZUjknFmziyBJuLhVRc+Ds0dREFlskDNJKYIdIzu/9pfw==}
+    dependencies:
+      call-bind: 1.0.5
     dev: true
 
   /is-fullwidth-code-point@3.0.0:
@@ -5845,6 +6118,11 @@ packages:
 
   /is-map@2.0.2:
     resolution: {integrity: sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg==}
+    dev: true
+
+  /is-negative-zero@2.0.2:
+    resolution: {integrity: sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==}
+    engines: {node: '>= 0.4'}
     dev: true
 
   /is-node-process@1.2.0:
@@ -5886,7 +6164,7 @@ packages:
     resolution: {integrity: sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==}
     engines: {node: '>= 0.4'}
     dependencies:
-      call-bind: 1.0.2
+      call-bind: 1.0.5
       has-tostringtag: 1.0.0
     dev: true
 
@@ -5897,7 +6175,7 @@ packages:
   /is-shared-array-buffer@1.0.2:
     resolution: {integrity: sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==}
     dependencies:
-      call-bind: 1.0.2
+      call-bind: 1.0.5
     dev: true
 
   /is-stream@2.0.1:
@@ -5919,15 +6197,11 @@ packages:
       has-symbols: 1.0.3
     dev: true
 
-  /is-typed-array@1.1.10:
-    resolution: {integrity: sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==}
+  /is-typed-array@1.1.12:
+    resolution: {integrity: sha512-Z14TF2JNG8Lss5/HMqt0//T9JeHXttXy5pH/DBU4vi98ozO2btxzq9MwYDZYnKwU8nRsz/+GVFVRDq3DkVuSPg==}
     engines: {node: '>= 0.4'}
     dependencies:
-      available-typed-arrays: 1.0.5
-      call-bind: 1.0.2
-      for-each: 0.3.3
-      gopd: 1.0.1
-      has-tostringtag: 1.0.0
+      which-typed-array: 1.1.13
     dev: true
 
   /is-typedarray@1.0.0:
@@ -5943,11 +6217,17 @@ packages:
     resolution: {integrity: sha512-NSBR4kH5oVj1Uwvv970ruUkCV7O1mzgVFO4/rev2cLRda9Tm9HrL70ZPut4rOHgY0FNrUu9BCbXA2sdQ+x0chA==}
     dev: true
 
+  /is-weakref@1.0.2:
+    resolution: {integrity: sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==}
+    dependencies:
+      call-bind: 1.0.5
+    dev: true
+
   /is-weakset@2.0.2:
     resolution: {integrity: sha512-t2yVvttHkQktwnNNmBQ98AhENLdPUTDTE21uPqAQ0ARwQfGeQKRVS0NNurH7bTf7RrvcVn1OOge45CnBeHCSmg==}
     dependencies:
-      call-bind: 1.0.2
-      get-intrinsic: 1.2.1
+      call-bind: 1.0.5
+      get-intrinsic: 1.2.2
     dev: true
 
   /is-what@4.1.15:
@@ -6011,6 +6291,16 @@ packages:
     dependencies:
       html-escaper: 2.0.2
       istanbul-lib-report: 3.0.0
+    dev: true
+
+  /iterator.prototype@1.1.2:
+    resolution: {integrity: sha512-DR33HMMr8EzwuRL8Y9D3u2BMj8+RqSE850jfGu59kS7tbmPLzGkZmVSfyCFSDxuZiEY6Rzt3T2NA/qU+NwVj1w==}
+    dependencies:
+      define-properties: 1.2.1
+      get-intrinsic: 1.2.1
+      has-symbols: 1.0.3
+      reflect.getprototypeof: 1.0.4
+      set-function-name: 2.0.1
     dev: true
 
   /jest-diff@29.6.1:
@@ -6213,6 +6503,16 @@ packages:
       extsprintf: 1.3.0
       json-schema: 0.4.0
       verror: 1.10.0
+    dev: true
+
+  /jsx-ast-utils@3.3.5:
+    resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
+    engines: {node: '>=4.0'}
+    dependencies:
+      array-includes: 3.1.7
+      array.prototype.flat: 1.3.2
+      object.assign: 4.1.4
+      object.values: 1.1.7
     dev: true
 
   /kind-of@6.0.3:
@@ -6601,7 +6901,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       hosted-git-info: 4.1.0
-      is-core-module: 2.12.1
+      is-core-module: 2.13.1
       semver: 7.5.4
       validate-npm-package-license: 3.0.4
     dev: true
@@ -6625,18 +6925,17 @@ packages:
   /object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
-    dev: false
 
-  /object-inspect@1.12.3:
-    resolution: {integrity: sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==}
+  /object-inspect@1.13.1:
+    resolution: {integrity: sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==}
     dev: true
 
   /object-is@1.1.5:
     resolution: {integrity: sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==}
     engines: {node: '>= 0.4'}
     dependencies:
-      call-bind: 1.0.2
-      define-properties: 1.2.0
+      call-bind: 1.0.5
+      define-properties: 1.2.1
     dev: true
 
   /object-keys@1.1.1:
@@ -6649,9 +6948,43 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.2.0
+      define-properties: 1.2.1
       has-symbols: 1.0.3
       object-keys: 1.1.1
+    dev: true
+
+  /object.entries@1.1.7:
+    resolution: {integrity: sha512-jCBs/0plmPsOnrKAfFQXRG2NFjlhZgjjcBLSmTnEhU8U6vVTsVe8ANeQJCHTl3gSsI4J+0emOoCgoKlmQPMgmA==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind: 1.0.2
+      define-properties: 1.2.0
+      es-abstract: 1.22.3
+    dev: true
+
+  /object.fromentries@2.0.7:
+    resolution: {integrity: sha512-UPbPHML6sL8PI/mOqPwsH4G6iyXcCGzLin8KvEPenOZN5lpCNBZZQ+V62vdjB1mQHrmqGQt5/OJzemUA+KJmEA==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind: 1.0.2
+      define-properties: 1.2.0
+      es-abstract: 1.22.3
+    dev: true
+
+  /object.hasown@1.1.3:
+    resolution: {integrity: sha512-fFI4VcYpRHvSLXxP7yiZOMAd331cPfd2p7PFDVbgUsYOfCT3tICVqXWngbjr4m49OvsBwUBQ6O2uQoJvy3RexA==}
+    dependencies:
+      define-properties: 1.2.0
+      es-abstract: 1.22.3
+    dev: true
+
+  /object.values@1.1.7:
+    resolution: {integrity: sha512-aU6xnDFYT3x17e/f0IiiwlGPTy2jzMySGfUB4fq6z7CV8l85CWHDk5ErhyhpfDHhrOMwGFhSQkhMGHaIotA6Ng==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind: 1.0.2
+      define-properties: 1.2.0
+      es-abstract: 1.22.3
     dev: true
 
   /once@1.4.0:
@@ -6937,7 +7270,6 @@ packages:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
-    dev: false
 
   /proxy-from-env@1.0.0:
     resolution: {integrity: sha512-F2JHgJQ1iqwnHDcQjVBsq3n/uoaFL+iPW/eAeL7kVxy/2RrWaN4WroKjjvbsoRtv0ftelNyC01bjRhn/bhcf4A==}
@@ -7068,7 +7400,6 @@ packages:
 
   /react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
-    dev: false
 
   /react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
@@ -7264,6 +7595,18 @@ packages:
       strip-indent: 3.0.0
     dev: true
 
+  /reflect.getprototypeof@1.0.4:
+    resolution: {integrity: sha512-ECkTw8TmJwW60lOTR+ZkODISW6RQ8+2CL3COqtiJKLd6MmB45hN51HprHFziKLGkAuTGQhBb91V8cy+KHlaCjw==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind: 1.0.5
+      define-properties: 1.2.1
+      es-abstract: 1.22.3
+      get-intrinsic: 1.2.2
+      globalthis: 1.0.3
+      which-builtin-type: 1.1.3
+    dev: true
+
   /regenerator-runtime@0.13.11:
     resolution: {integrity: sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==}
 
@@ -7271,9 +7614,18 @@ packages:
     resolution: {integrity: sha512-0SutC3pNudRKgquxGoRGIz946MZVHqbNfPjBdxeOhBrdgDKlRoXmYLQN9xRbrR09ZXWeGAdPuif7egofn6v5LA==}
     engines: {node: '>= 0.4'}
     dependencies:
-      call-bind: 1.0.2
-      define-properties: 1.2.0
+      call-bind: 1.0.5
+      define-properties: 1.2.1
       functions-have-names: 1.2.3
+    dev: true
+
+  /regexp.prototype.flags@1.5.1:
+    resolution: {integrity: sha512-sy6TXMN+hnP/wMy+ISxg3krXx7BAtWVO4UouuCN/ziM9UEne0euamVNafDfvC83bRNr95y0V5iijeDQFUNpvrg==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind: 1.0.5
+      define-properties: 1.2.1
+      set-function-name: 2.0.1
     dev: true
 
   /remove-accents@0.4.2:
@@ -7312,9 +7664,18 @@ packages:
     resolution: {integrity: sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==}
     hasBin: true
     dependencies:
-      is-core-module: 2.12.1
+      is-core-module: 2.13.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
+
+  /resolve@2.0.0-next.5:
+    resolution: {integrity: sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==}
+    hasBin: true
+    dependencies:
+      is-core-module: 2.13.1
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
+    dev: true
 
   /restore-cursor@3.1.0:
     resolution: {integrity: sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==}
@@ -7369,8 +7730,27 @@ packages:
       tslib: 2.6.0
     dev: true
 
+  /safe-array-concat@1.1.0:
+    resolution: {integrity: sha512-ZdQ0Jeb9Ofti4hbt5lX3T2JcAamT9hfzYU1MNB+z/jaEbB6wfFfPIR/zEORmZqobkCCJhSjodobH6WHNmJ97dg==}
+    engines: {node: '>=0.4'}
+    dependencies:
+      call-bind: 1.0.5
+      get-intrinsic: 1.2.2
+      has-symbols: 1.0.3
+      isarray: 2.0.5
+    dev: true
+
   /safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+    dev: true
+
+  /safe-regex-test@1.0.2:
+    resolution: {integrity: sha512-83S9w6eFq12BBIJYvjMux6/dkirb8+4zJRA9cxNBVb7Wq5fJBW+Xze48WqR8pxua7bDuAaaAxtVVd4Idjp1dBQ==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind: 1.0.5
+      get-intrinsic: 1.2.2
+      is-regex: 1.1.4
     dev: true
 
   /safer-buffer@2.1.2:
@@ -7421,6 +7801,26 @@ packages:
     resolution: {integrity: sha512-RVnVQxTXuerk653XfuliOxBP81Sf0+qfQE73LIYKcyMYHG94AuH0kgrQpRDuTZnSmjpysHmzxJXKNfa6PjFhyQ==}
     dev: true
 
+  /set-function-length@1.2.0:
+    resolution: {integrity: sha512-4DBHDoyHlM1IRPGYcoxexgh67y4ueR53FKV1yyxwFMY7aCqcN/38M1+SwZ/qJQ8iLv7+ck385ot4CcisOAPT9w==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      define-data-property: 1.1.1
+      function-bind: 1.1.2
+      get-intrinsic: 1.2.2
+      gopd: 1.0.1
+      has-property-descriptors: 1.0.1
+    dev: true
+
+  /set-function-name@2.0.1:
+    resolution: {integrity: sha512-tMNCiqYVkXIZgc2Hnoy2IvC/f8ezc5koaRFkCjrpWzGpCd3qbZXPzVy9MAZzK1ch/X0jvSkojys3oqJN0qCmdA==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      define-data-property: 1.1.1
+      functions-have-names: 1.2.3
+      has-property-descriptors: 1.0.1
+    dev: true
+
   /shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
     engines: {node: '>=8'}
@@ -7436,9 +7836,9 @@ packages:
   /side-channel@1.0.4:
     resolution: {integrity: sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==}
     dependencies:
-      call-bind: 1.0.2
-      get-intrinsic: 1.2.1
-      object-inspect: 1.12.3
+      call-bind: 1.0.5
+      get-intrinsic: 1.2.2
+      object-inspect: 1.13.1
     dev: true
 
   /siginfo@2.0.0:
@@ -7582,6 +7982,45 @@ packages:
       emoji-regex: 8.0.0
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
+    dev: true
+
+  /string.prototype.matchall@4.0.10:
+    resolution: {integrity: sha512-rGXbGmOEosIQi6Qva94HUjgPs9vKW+dkG7Y8Q5O2OYkWL6wFaTRZO8zM4mhP94uX55wgyrXzfS2aGtGzUL7EJQ==}
+    dependencies:
+      call-bind: 1.0.2
+      define-properties: 1.2.0
+      es-abstract: 1.22.3
+      get-intrinsic: 1.2.1
+      has-symbols: 1.0.3
+      internal-slot: 1.0.5
+      regexp.prototype.flags: 1.5.0
+      set-function-name: 2.0.1
+      side-channel: 1.0.4
+    dev: true
+
+  /string.prototype.trim@1.2.8:
+    resolution: {integrity: sha512-lfjY4HcixfQXOfaqCvcBuOIapyaroTXhbkfJN3gcB1OtyupngWK4sEET9Knd0cXd28kTUqu/kHoV4HKSJdnjiQ==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind: 1.0.5
+      define-properties: 1.2.1
+      es-abstract: 1.22.3
+    dev: true
+
+  /string.prototype.trimend@1.0.7:
+    resolution: {integrity: sha512-Ni79DqeB72ZFq1uH/L6zJ+DKZTkOtPIHovb3YZHQViE+HDouuU4mBrLOLDn5Dde3RF8qw5qVETEjhu9locMLvA==}
+    dependencies:
+      call-bind: 1.0.5
+      define-properties: 1.2.1
+      es-abstract: 1.22.3
+    dev: true
+
+  /string.prototype.trimstart@1.0.7:
+    resolution: {integrity: sha512-NGhtDFu3jCEm7B4Fy0DpLewdJQOZcQ0rGbwQ/+stjnrp2i+rlKeCvos9hOIeCmqwratM47OBxY7uFZzjxHXmrg==}
+    dependencies:
+      call-bind: 1.0.5
+      define-properties: 1.2.1
+      es-abstract: 1.22.3
     dev: true
 
   /string_decoder@1.3.0:
@@ -7987,6 +8426,44 @@ packages:
     engines: {node: '>=12.20'}
     dev: true
 
+  /typed-array-buffer@1.0.0:
+    resolution: {integrity: sha512-Y8KTSIglk9OZEr8zywiIHG/kmQ7KWyjseXs1CbSo8vC42w7hg2HgYTxSWwP0+is7bWDc1H+Fo026CpHFwm8tkw==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind: 1.0.5
+      get-intrinsic: 1.2.2
+      is-typed-array: 1.1.12
+    dev: true
+
+  /typed-array-byte-length@1.0.0:
+    resolution: {integrity: sha512-Or/+kvLxNpeQ9DtSydonMxCx+9ZXOswtwJn17SNLvhptaXYDJvkFFP5zbfU/uLmvnBJlI4yrnXRxpdWH/M5tNA==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind: 1.0.5
+      for-each: 0.3.3
+      has-proto: 1.0.1
+      is-typed-array: 1.1.12
+    dev: true
+
+  /typed-array-byte-offset@1.0.0:
+    resolution: {integrity: sha512-RD97prjEt9EL8YgAgpOkf3O4IF9lhJFr9g0htQkm0rchFp/Vx7LW5Q8fSXXub7BXAODyUQohRMyOc3faCPd0hg==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      available-typed-arrays: 1.0.5
+      call-bind: 1.0.5
+      for-each: 0.3.3
+      has-proto: 1.0.1
+      is-typed-array: 1.1.12
+    dev: true
+
+  /typed-array-length@1.0.4:
+    resolution: {integrity: sha512-KjZypGq+I/H7HI5HlOoGHkWUUGq+Q0TPhQurLbyrVrvnKTBgzLhIJ7j6J/XTQOi0d1RjyZ0wdas8bKs2p0x3Ng==}
+    dependencies:
+      call-bind: 1.0.5
+      for-each: 0.3.3
+      is-typed-array: 1.1.12
+    dev: true
+
   /typescript@5.0.4:
     resolution: {integrity: sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==}
     engines: {node: '>=12.20'}
@@ -8004,6 +8481,15 @@ packages:
     requiresBuild: true
     dev: true
     optional: true
+
+  /unbox-primitive@1.0.2:
+    resolution: {integrity: sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==}
+    dependencies:
+      call-bind: 1.0.5
+      has-bigints: 1.0.2
+      has-symbols: 1.0.3
+      which-boxed-primitive: 1.0.2
+    dev: true
 
   /universalify@0.2.0:
     resolution: {integrity: sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==}
@@ -8105,8 +8591,8 @@ packages:
       inherits: 2.0.4
       is-arguments: 1.1.1
       is-generator-function: 1.0.10
-      is-typed-array: 1.1.10
-      which-typed-array: 1.1.10
+      is-typed-array: 1.1.12
+      which-typed-array: 1.1.13
     dev: true
 
   /uuid@8.3.2:
@@ -8366,6 +8852,24 @@ packages:
       is-symbol: 1.0.4
     dev: true
 
+  /which-builtin-type@1.1.3:
+    resolution: {integrity: sha512-YmjsSMDBYsM1CaFiayOVT06+KJeXf0o5M/CAd4o1lTadFAtacTUM49zoYxr/oroopFDfhvN6iEcBxUyc3gvKmw==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      function.prototype.name: 1.1.6
+      has-tostringtag: 1.0.0
+      is-async-function: 2.0.0
+      is-date-object: 1.0.5
+      is-finalizationregistry: 1.0.2
+      is-generator-function: 1.0.10
+      is-regex: 1.1.4
+      is-weakref: 1.0.2
+      isarray: 2.0.5
+      which-boxed-primitive: 1.0.2
+      which-collection: 1.0.1
+      which-typed-array: 1.1.13
+    dev: true
+
   /which-collection@1.0.1:
     resolution: {integrity: sha512-W8xeTUwaln8i3K/cY1nGXzdnVZlidBcagyNFtBdD5kxnb4TvGKR7FfSIS3mYpwWS1QUCutfKz8IY8RjftB0+1A==}
     dependencies:
@@ -8375,16 +8879,15 @@ packages:
       is-weakset: 2.0.2
     dev: true
 
-  /which-typed-array@1.1.10:
-    resolution: {integrity: sha512-uxoA5vLUfRPdjCuJ1h5LlYdmTLbYfums398v3WLkM+i/Wltl2/XyZpQWKbN++ck5L64SR/grOHqtXCUKmlZPNA==}
+  /which-typed-array@1.1.13:
+    resolution: {integrity: sha512-P5Nra0qjSncduVPEAr7xhoF5guty49ArDTwzJ/yNuPIbZppyRxFQsRCWrocxIY+CnMVG+qfbU2FmDKyvSGClow==}
     engines: {node: '>= 0.4'}
     dependencies:
       available-typed-arrays: 1.0.5
-      call-bind: 1.0.2
+      call-bind: 1.0.5
       for-each: 0.3.3
       gopd: 1.0.1
       has-tostringtag: 1.0.0
-      is-typed-array: 1.1.10
     dev: true
 
   /which@1.3.1:

--- a/hivemq-edge/src/frontend/src/__test-utils__/react-flow/CustomNodeTesting.tsx
+++ b/hivemq-edge/src/frontend/src/__test-utils__/react-flow/CustomNodeTesting.tsx
@@ -11,7 +11,7 @@ interface MockReactFlowProps {
 
 export const CustomNodeTesting: FC<MockReactFlowProps> = ({ nodeTypes, nodes }) => {
   return (
-    <Box w={'90vw'} h={'90vh'}>
+    <Box w="90vw" h="90vh">
       <ReactFlow
         nodes={nodes}
         nodeTypes={nodeTypes}

--- a/hivemq-edge/src/frontend/src/components/Chakra/ButtonBadge.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/components/Chakra/ButtonBadge.spec.cy.tsx
@@ -12,7 +12,7 @@ describe('ButtonBadge', () => {
     const onClick = cy.stub().as('onClick')
     cy.mountWithProviders(
       <ButtonBadge
-        aria-label={'You have no notification'}
+        aria-label="You have no notification"
         badgeCount={1}
         icon={<FiMail />}
         isDisabled
@@ -27,7 +27,7 @@ describe('ButtonBadge', () => {
   it('should render properly', () => {
     const onClick = cy.stub().as('onClick')
     cy.mountWithProviders(
-      <ButtonBadge aria-label={'You have one notification'} badgeCount={1} icon={<FiMail />} onClick={onClick} />
+      <ButtonBadge aria-label="You have one notification" badgeCount={1} icon={<FiMail />} onClick={onClick} />
     )
 
     cy.getByAriaLabel('You have one notification').click()
@@ -36,7 +36,7 @@ describe('ButtonBadge', () => {
 
   it('should be accessible', () => {
     cy.injectAxe()
-    cy.mountWithProviders(<ButtonBadge aria-label={'You have one notification'} badgeCount={1} icon={<FiMail />} />)
+    cy.mountWithProviders(<ButtonBadge aria-label="You have one notification" badgeCount={1} icon={<FiMail />} />)
     cy.checkAccessibility()
     cy.percySnapshot('Component: ButtonBadge')
   })

--- a/hivemq-edge/src/frontend/src/components/Chakra/ButtonBadge.tsx
+++ b/hivemq-edge/src/frontend/src/components/Chakra/ButtonBadge.tsx
@@ -47,8 +47,8 @@ const ButtonBadge: FC<ButtonBadgeProps> = ({
       {...props}
     >
       {((badgeCount && !isDisabled) || !isDisabled) && (
-        <AvatarBadge borderColor="yellow.500" bg="yellow.500" boxSize="1.25em" data-testid={'buttonBadge-counter'}>
-          <Text fontSize={'.95rem'}>{badgeCount}</Text>
+        <AvatarBadge borderColor="yellow.500" bg="yellow.500" boxSize="1.25em" data-testid="buttonBadge-counter">
+          <Text fontSize=".95rem">{badgeCount}</Text>
         </AvatarBadge>
       )}
     </Avatar>

--- a/hivemq-edge/src/frontend/src/components/Chakra/ClipboardCopyIconButton.tsx
+++ b/hivemq-edge/src/frontend/src/components/Chakra/ClipboardCopyIconButton.tsx
@@ -54,15 +54,15 @@ const ClipboardCopyIconButton: FC<ClipboardCopyIconButtonProps> = ({ content, pl
         data-state={state}
         spinner={
           state === CopyStatus.ERROR ? (
-            <Icon as={VscError} fontSize={'1rem'} color="red.500" />
+            <Icon as={VscError} fontSize="1rem" color="red.500" />
           ) : (
-            <Icon as={VscCheck} fontSize={'1rem'} color="green.500" />
+            <Icon as={VscCheck} fontSize="1rem" color="green.500" />
           )
         }
         data-testid="metrics-copy"
-        size={'xs'}
-        variant={'ghost'}
-        icon={<Icon as={LuClipboardCopy} fontSize={'1rem'} />}
+        size="xs"
+        variant="ghost"
+        icon={<Icon as={LuClipboardCopy} fontSize="1rem" />}
         onClick={handleClick}
         aria-label={t('ClipboardCopyIconButton.ariaLabel')}
         {...props}

--- a/hivemq-edge/src/frontend/src/components/Chakra/ColorPicker.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/components/Chakra/ColorPicker.spec.cy.tsx
@@ -28,7 +28,7 @@ describe('ColorPicker', () => {
         colorScheme={mockColorScheme}
         onChange={onChange}
         colorSchemes={mockDdefaultColorSchemes}
-        ml={'75px'}
+        ml="75px"
       />
     )
 

--- a/hivemq-edge/src/frontend/src/components/Chakra/ColorPicker.tsx
+++ b/hivemq-edge/src/frontend/src/components/Chakra/ColorPicker.tsx
@@ -38,7 +38,7 @@ export const ColorPicker = forwardRef<ColorPickerProps, 'div'>(
           <Button
             ref={ref}
             isDisabled={isDisabled}
-            data-testid={'colorPicker-trigger'}
+            data-testid="colorPicker-trigger"
             data-color-scheme={selectedColorScheme}
             aria-label={t('ColorPicker.trigger', { scheme: selectedColorScheme }) as string}
             bg={`${selectedColorScheme}.500`}
@@ -60,23 +60,23 @@ export const ColorPicker = forwardRef<ColorPickerProps, 'div'>(
             <PopoverContent
               w="auto"
               boxShadow="md"
-              data-testid={'colorPicker-popover'}
-              aria-label={'ColorPicker.popover'}
+              data-testid="colorPicker-popover"
+              aria-label="ColorPicker.popover"
             >
               <PopoverArrow backgroundColor={`${selectedColorScheme}.500`} />
               <SimpleGrid columns={1}>
                 <Flex
-                  data-testid={'colorPicker-sample'}
-                  alignItems={'center'}
-                  justifyContent={'center'}
+                  data-testid="colorPicker-sample"
+                  alignItems="center"
+                  justifyContent="center"
                   borderWidth={0}
-                  borderTopRadius={'sm'}
+                  borderTopRadius="sm"
                   h={10}
                   w="100%"
                   p={0}
-                  fontSize={'lg'}
+                  fontSize="lg"
                   bg={`${selectedColorScheme}.500`}
-                  color={'black'}
+                  color="black"
                 >
                   {selectedColorScheme}
                 </Flex>

--- a/hivemq-edge/src/frontend/src/components/Chakra/ColorPicker.tsx
+++ b/hivemq-edge/src/frontend/src/components/Chakra/ColorPicker.tsx
@@ -57,12 +57,7 @@ export const ColorPicker = forwardRef<ColorPickerProps, 'div'>(
               },
             }}
           >
-            <PopoverContent
-              w="auto"
-              boxShadow="md"
-              data-testid="colorPicker-popover"
-              aria-label="ColorPicker.popover"
-            >
+            <PopoverContent w="auto" boxShadow="md" data-testid="colorPicker-popover" aria-label="ColorPicker.popover">
               <PopoverArrow backgroundColor={`${selectedColorScheme}.500`} />
               <SimpleGrid columns={1}>
                 <Flex

--- a/hivemq-edge/src/frontend/src/components/Chakra/IconButton.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/components/Chakra/IconButton.spec.cy.tsx
@@ -9,7 +9,7 @@ describe('IconButton', () => {
   })
 
   it('should render properly', () => {
-    cy.mountWithProviders(<IconButton id={'toolTipButton'} aria-label={'This is the button'} icon={<MdLightMode />} />)
+    cy.mountWithProviders(<IconButton id="toolTipButton" aria-label="This is the button" icon={<MdLightMode />} />)
 
     cy.get('#toolTipButton').click()
     cy.get("[role='tooltip']").should('contain.text', 'This is the button')

--- a/hivemq-edge/src/frontend/src/components/Chakra/IconButton.tsx
+++ b/hivemq-edge/src/frontend/src/components/Chakra/IconButton.tsx
@@ -8,7 +8,7 @@ interface IconTooltipButtonProps extends Omit<IconButtonProps, 'icon'> {
 
 const IconButton: FC<IconTooltipButtonProps> = ({ 'aria-label': ariaLabel, tooltipProps, ...props }) => {
   return (
-    <Tooltip label={ariaLabel} placement={'top'} {...tooltipProps} hasArrow>
+    <Tooltip label={ariaLabel} placement="top" {...tooltipProps} hasArrow>
       <CuiIconButton aria-label={ariaLabel} {...props} />
     </Tooltip>
   )

--- a/hivemq-edge/src/frontend/src/components/Chakra/LoaderSpinner.tsx
+++ b/hivemq-edge/src/frontend/src/components/Chakra/LoaderSpinner.tsx
@@ -2,7 +2,7 @@ import { FC } from 'react'
 import { Spinner, type SpinnerProps } from '@chakra-ui/react'
 
 const LoaderSpinner: FC<SpinnerProps> = (props) => {
-  return <Spinner data-testid={'loading-spinner'} thickness="4px" speed="0.65s" emptyColor="gray.200" {...props} />
+  return <Spinner data-testid="loading-spinner" thickness="4px" speed="0.65s" emptyColor="gray.200" {...props} />
 }
 
 export default LoaderSpinner

--- a/hivemq-edge/src/frontend/src/components/Chakra/SwitchModeButton.tsx
+++ b/hivemq-edge/src/frontend/src/components/Chakra/SwitchModeButton.tsx
@@ -12,8 +12,8 @@ const SwitchModeButton: FC<Omit<IconButtonProps, 'aria-label'>> = ({ ...props })
     <IconButton
       aria-label={t('action.mode', { context: colorMode })}
       onClick={() => toggleColorMode()}
-      data-testid={'chakra-ui-switch-mode'}
-      icon={<Icon as={colorMode !== 'light' ? MdLightMode : MdDarkMode} boxSize={'24px'} />}
+      data-testid="chakra-ui-switch-mode"
+      icon={<Icon as={colorMode !== 'light' ? MdLightMode : MdDarkMode} boxSize="24px" />}
       {...props}
     />
   )

--- a/hivemq-edge/src/frontend/src/components/ConnectionController/components/ConnectionButton.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/components/ConnectionController/components/ConnectionButton.spec.cy.tsx
@@ -12,7 +12,7 @@ describe('ConnectionButton', () => {
 
   it('should be accessible', () => {
     cy.injectAxe()
-    cy.mountWithProviders(<ConnectionButton id={'my-id'} isRunning />)
+    cy.mountWithProviders(<ConnectionButton id="my-id" isRunning />)
     cy.checkAccessibility()
     cy.percySnapshot('Component: ConnectionButton')
   })

--- a/hivemq-edge/src/frontend/src/components/ConnectionController/components/ConnectionButton.tsx
+++ b/hivemq-edge/src/frontend/src/components/ConnectionController/components/ConnectionButton.tsx
@@ -14,7 +14,7 @@ const ConnectionButton: FC<ConnectionElementProps> = ({ id, isRunning, onChangeS
       {!isRunning && (
         <IconButton
           isDisabled={isLoading}
-          data-testid={'device-action-start'}
+          data-testid="device-action-start"
           aria-label={t('action.start')}
           icon={<MdPlayArrow />}
           onClick={() => onChangeStatus?.(id, StatusTransitionCommand.command.START)}
@@ -23,7 +23,7 @@ const ConnectionButton: FC<ConnectionElementProps> = ({ id, isRunning, onChangeS
       {isRunning && (
         <IconButton
           isDisabled={isLoading}
-          data-testid={'device-action-stop'}
+          data-testid="device-action-stop"
           aria-label={t('action.stop')}
           icon={<MdStop />}
           onClick={() => onChangeStatus?.(id, StatusTransitionCommand.command.STOP)}
@@ -31,7 +31,7 @@ const ConnectionButton: FC<ConnectionElementProps> = ({ id, isRunning, onChangeS
       )}
       <IconButton
         isDisabled={isLoading || !isRunning}
-        data-testid={'device-action-restart'}
+        data-testid="device-action-restart"
         aria-label={t('action.restart')}
         icon={<MdRestartAlt />}
         onClick={() => onChangeStatus?.(id, StatusTransitionCommand.command.RESTART)}

--- a/hivemq-edge/src/frontend/src/components/ConnectionController/components/ConnectionMenu.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/components/ConnectionController/components/ConnectionMenu.spec.cy.tsx
@@ -9,7 +9,7 @@ const MOCK_ID = 'my-id'
 
 const Wrapper: FC<PropsWithChildren> = ({ children }) => (
   <Menu>
-    <MenuButton data-testid={'mock-trigger'}>my custom menu</MenuButton>
+    <MenuButton data-testid="mock-trigger">my custom menu</MenuButton>
     <MenuList>{children}</MenuList>
   </Menu>
 )
@@ -23,7 +23,7 @@ describe('ConnectionMenu', () => {
     cy.injectAxe()
     cy.mountWithProviders(
       <Wrapper>
-        <ConnectionMenu id={'my-id'} isRunning />
+        <ConnectionMenu id="my-id" isRunning />
       </Wrapper>
     )
     cy.checkAccessibility()
@@ -36,7 +36,7 @@ describe('ConnectionMenu', () => {
 
     cy.mountWithProviders(
       <Wrapper>
-        <ConnectionMenu id={'my-id'} isRunning onChangeStatus={onChangeStatus} />
+        <ConnectionMenu id="my-id" isRunning onChangeStatus={onChangeStatus} />
       </Wrapper>
     )
 
@@ -53,7 +53,7 @@ describe('ConnectionMenu', () => {
 
     cy.mountWithProviders(
       <Wrapper>
-        <ConnectionMenu id={'my-id'} isRunning={false} onChangeStatus={onChangeStatus} />
+        <ConnectionMenu id="my-id" isRunning={false} onChangeStatus={onChangeStatus} />
       </Wrapper>
     )
 
@@ -70,7 +70,7 @@ describe('ConnectionMenu', () => {
 
     cy.mountWithProviders(
       <Wrapper>
-        <ConnectionMenu id={'my-id'} isRunning={false} onChangeStatus={onChangeStatus} />
+        <ConnectionMenu id="my-id" isRunning={false} onChangeStatus={onChangeStatus} />
       </Wrapper>
     )
 
@@ -85,7 +85,7 @@ describe('ConnectionMenu', () => {
 
     cy.mountWithProviders(
       <Wrapper>
-        <ConnectionMenu id={'my-id'} isRunning={true} onChangeStatus={onChangeStatus} />
+        <ConnectionMenu id="my-id" isRunning={true} onChangeStatus={onChangeStatus} />
       </Wrapper>
     )
 
@@ -99,7 +99,7 @@ describe('ConnectionMenu', () => {
   it('should render disable states when isLoading (running)', () => {
     cy.mountWithProviders(
       <Wrapper>
-        <ConnectionMenu id={'my-id'} isRunning isLoading />
+        <ConnectionMenu id="my-id" isRunning isLoading />
       </Wrapper>
     )
 
@@ -110,7 +110,7 @@ describe('ConnectionMenu', () => {
   it('should render disable states when isLoading (not running)', () => {
     cy.mountWithProviders(
       <Wrapper>
-        <ConnectionMenu id={'my-id'} isRunning={false} isLoading />
+        <ConnectionMenu id="my-id" isRunning={false} isLoading />
       </Wrapper>
     )
 

--- a/hivemq-edge/src/frontend/src/components/ConnectionController/components/ConnectionMenu.tsx
+++ b/hivemq-edge/src/frontend/src/components/ConnectionController/components/ConnectionMenu.tsx
@@ -12,7 +12,7 @@ const ConnectionMenu: FC<ConnectionElementProps> = ({ id, isRunning, isLoading, 
       {!isRunning && (
         <MenuItem
           isDisabled={isLoading}
-          data-testid={'device-action-start'}
+          data-testid="device-action-start"
           onClick={() => onChangeStatus?.(id, StatusTransitionCommand.command.START)}
         >
           {t('action.start')}
@@ -22,7 +22,7 @@ const ConnectionMenu: FC<ConnectionElementProps> = ({ id, isRunning, isLoading, 
       {isRunning && (
         <MenuItem
           isDisabled={isLoading}
-          data-testid={'device-action-stop'}
+          data-testid="device-action-stop"
           onClick={() => onChangeStatus?.(id, StatusTransitionCommand.command.STOP)}
         >
           {t('action.stop')}
@@ -31,7 +31,7 @@ const ConnectionMenu: FC<ConnectionElementProps> = ({ id, isRunning, isLoading, 
 
       <MenuItem
         isDisabled={isLoading || !isRunning}
-        data-testid={'device-action-restart'}
+        data-testid="device-action-restart"
         onClick={() => onChangeStatus?.(id, StatusTransitionCommand.command.RESTART)}
       >
         {t('action.restart')}

--- a/hivemq-edge/src/frontend/src/components/ConnectionStatusBadge/ConnectionStatusBadge.tsx
+++ b/hivemq-edge/src/frontend/src/components/ConnectionStatusBadge/ConnectionStatusBadge.tsx
@@ -28,7 +28,7 @@ const ConnectionStatusBadge: FC<ConnectionStatusBadgeProps> = ({ status }) => {
     ]
 
   return (
-    <Badge variant="subtle" colorScheme={mapping.color} borderRadius={15} data-testid={'connection-status'}>
+    <Badge variant="subtle" colorScheme={mapping.color} borderRadius={15} data-testid="connection-status">
       {t('hivemq.connection.status', { context: mapping.text })}
     </Badge>
   )

--- a/hivemq-edge/src/frontend/src/components/DateTime/DateTimeRangeSelector.tsx
+++ b/hivemq-edge/src/frontend/src/components/DateTime/DateTimeRangeSelector.tsx
@@ -47,7 +47,7 @@ const DateTimeRangeSelector: FC<DateTimeRangeSelectorProps> = ({ min, max, setFi
   return (
     <CreatableSelect<RangeOption>
       chakraStyles={{ menuList: (provided) => ({ ...provided, width: '200px' }) }}
-      size={'sm'}
+      size="sm"
       menuPortalTarget={document.body}
       // value={{ value: columnFilterValue, label: columnFilterValue }}
       onChange={onHandleChange}

--- a/hivemq-edge/src/frontend/src/components/DateTime/DateTimeRenderer.tsx
+++ b/hivemq-edge/src/frontend/src/components/DateTime/DateTimeRenderer.tsx
@@ -38,13 +38,13 @@ const DateTimeRenderer: FC<DateTimeRendererProps> = ({ date, isApprox = false, i
     const relative = toHuman(date)
     return (
       <Tooltip
-        data-testid={'date-time-tooltip'}
+        data-testid="date-time-tooltip"
         hasArrow
         label={formatter.format(date.toJSDate())}
         placement="top"
-        maxW={'200px'}
+        maxW="200px"
       >
-        <Text data-testid={'date-time-approx'} width={'fit-content'} {...props}>
+        <Text data-testid="date-time-approx" width="fit-content" {...props}>
           {relative || t('DateTimeRenderer.seconds', { context: 'minus' })}
         </Text>
       </Tooltip>
@@ -52,7 +52,7 @@ const DateTimeRenderer: FC<DateTimeRendererProps> = ({ date, isApprox = false, i
   }
 
   return (
-    <Text data-testid={'date-time-full'} {...props}>
+    <Text data-testid="date-time-full" {...props}>
       {formatter.format(date.toJSDate())}
     </Text>
   )

--- a/hivemq-edge/src/frontend/src/components/DateTime/components/Option.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/components/DateTime/components/Option.spec.cy.tsx
@@ -39,7 +39,7 @@ describe('DateTimeRangeSelector > Option', () => {
 
   it('should render properly', () => {
     // @ts-ignore force mocked partial object
-    cy.mountWithProviders(<Option children={MOCK_OPTIONS[0].label} {...MOCK_PROPS} />)
+    cy.mountWithProviders(<Option {...MOCK_PROPS}>{MOCK_OPTIONS[0].label}</Option>)
 
     // cy.getByAriaLabel('Go to the first page').should('be.visible').click()
     // cy.get('@setPageIndex').should('have.been.calledOnceWith', 0)

--- a/hivemq-edge/src/frontend/src/components/DateTime/components/Option.tsx
+++ b/hivemq-edge/src/frontend/src/components/DateTime/components/Option.tsx
@@ -18,7 +18,7 @@ const Option: ComponentType<OptionProps<RangeOption, false, GroupBase<RangeOptio
 
   return (
     <chakraComponents.Option {...props}>
-      <HStack flexWrap={'nowrap'}>
+      <HStack flexWrap="nowrap">
         {!isOptionCreate && <OptionBadge data={props.data} />}
         <Text>{children}</Text>
       </HStack>

--- a/hivemq-edge/src/frontend/src/components/DateTime/components/OptionBadge.tsx
+++ b/hivemq-edge/src/frontend/src/components/DateTime/components/OptionBadge.tsx
@@ -16,10 +16,10 @@ const OptionBadge: FC<OptionBadgeProps> = ({ data }) => {
 
   return (
     <Badge
-      as={'p'}
-      textAlign={'center'}
-      textTransform={'lowercase'}
-      size={'sm'}
+      as="p"
+      textAlign="center"
+      textTransform="lowercase"
+      size="sm"
       data-testid={`dateRange-option-badge-${data.value}`}
       data-group={data.colorScheme}
       variant="solid"

--- a/hivemq-edge/src/frontend/src/components/DateTime/components/OptionCommand.tsx
+++ b/hivemq-edge/src/frontend/src/components/DateTime/components/OptionCommand.tsx
@@ -8,8 +8,8 @@ interface OptionCommandProps {
 
 const OptionCommand: FC<OptionCommandProps> = ({ data }) => {
   return (
-    <Box w={'100%'}>
-      <Button variant={'ghost'} size={'sm'} isDisabled>
+    <Box w="100%">
+      <Button variant="ghost" size="sm" isDisabled>
         {data.label}
       </Button>
     </Box>

--- a/hivemq-edge/src/frontend/src/components/MQTT/Client.tsx
+++ b/hivemq-edge/src/frontend/src/components/MQTT/Client.tsx
@@ -11,7 +11,7 @@ interface TopicProps extends TagProps {
 const Client: FC<TopicProps> = ({ client, ...rest }) => {
   const expandedTopic = typeof client === 'string' ? formatTopicString(client) : client
   return (
-    <Tag data-testid={'client-wrapper'} {...rest} letterSpacing={'-0.05rem'}>
+    <Tag data-testid="client-wrapper" {...rest} letterSpacing="-0.05rem">
       <Icon as={AiOutlineCloudServer} boxSize="18px" mr={2} />
       {typeof client === 'string' ? <TagLabel>{expandedTopic}</TagLabel> : client}
     </Tag>

--- a/hivemq-edge/src/frontend/src/components/MQTT/Topic.tsx
+++ b/hivemq-edge/src/frontend/src/components/MQTT/Topic.tsx
@@ -12,7 +12,7 @@ interface TopicProps extends TagProps {
 const Topic: FC<TopicProps> = ({ topic, ...rest }) => {
   const expandedTopic = typeof topic === 'string' ? formatTopicString(topic) : topic
   return (
-    <Tag data-testid={'topic-wrapper'} {...rest} letterSpacing={'-0.05rem'}>
+    <Tag data-testid="topic-wrapper" {...rest} letterSpacing="-0.05rem">
       <TopicIcon boxSize="12px" mr={2} />
       {typeof topic === 'string' ? <TagLabel>{expandedTopic}</TagLabel> : topic}
     </Tag>

--- a/hivemq-edge/src/frontend/src/components/MQTT/TopicCreatableSelect.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/components/MQTT/TopicCreatableSelect.spec.cy.tsx
@@ -15,7 +15,7 @@ describe('SingleTopicCreatableSelect', () => {
     const mockOnChange = cy.stub().as('onChange')
 
     cy.mountWithProviders(
-      <SingleTopicCreatableSelect options={[]} isLoading={false} id={MOCK_ID} value={''} onChange={mockOnChange} />
+      <SingleTopicCreatableSelect options={[]} isLoading={false} id={MOCK_ID} value="" onChange={mockOnChange} />
     )
 
     cy.get('#my-id').click()

--- a/hivemq-edge/src/frontend/src/components/PageContainer.tsx
+++ b/hivemq-edge/src/frontend/src/components/PageContainer.tsx
@@ -13,10 +13,10 @@ const PageContainer: FC<PageContainerProps> = ({ title, subtitle, children, cta 
   const { t } = useTranslation()
 
   return (
-    <Flex flexDirection={'column'} p={4} pt={6} flexGrow={1}>
-      <Flex gap={'50px'}>
+    <Flex flexDirection="column" p={4} pt={6} flexGrow={1}>
+      <Flex gap="50px">
         <Box maxW="50vw" pb={6}>
-          <Heading as={'h1'}>
+          <Heading as="h1">
             {title ? (
               title
             ) : (
@@ -27,7 +27,7 @@ const PageContainer: FC<PageContainerProps> = ({ title, subtitle, children, cta 
           </Heading>
           {subtitle && <Text fontSize="md">{subtitle}</Text>}
         </Box>
-        <Box flexGrow={1} alignItems={'flex-end'}>
+        <Box flexGrow={1} alignItems="flex-end">
           {cta}
         </Box>
       </Flex>

--- a/hivemq-edge/src/frontend/src/components/PaginatedTable/PaginatedTable.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/components/PaginatedTable/PaginatedTable.spec.cy.tsx
@@ -50,12 +50,7 @@ describe('PaginatedTable', () => {
 
   it('should sort the columns', () => {
     cy.mountWithProviders(
-      <PaginatedTable<MOCK_TYPE>
-        data={MOCK_DATA(4)}
-        columns={MOCK_COLUMN}
-        pageSizes={[5, 10, 20]}
-        aria-label="table"
-      />
+      <PaginatedTable<MOCK_TYPE> data={MOCK_DATA(4)} columns={MOCK_COLUMN} pageSizes={[5, 10, 20]} aria-label="table" />
     )
 
     const checkRowOrder = (direction?: SortDirection) => {

--- a/hivemq-edge/src/frontend/src/components/PaginatedTable/PaginatedTable.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/components/PaginatedTable/PaginatedTable.spec.cy.tsx
@@ -36,7 +36,7 @@ describe('PaginatedTable', () => {
         data={MOCK_DATA(100)}
         columns={MOCK_COLUMN}
         pageSizes={[5, 10, 20]}
-        aria-label={'table'}
+        aria-label="table"
       />
     )
 
@@ -54,7 +54,7 @@ describe('PaginatedTable', () => {
         data={MOCK_DATA(4)}
         columns={MOCK_COLUMN}
         pageSizes={[5, 10, 20]}
-        aria-label={'table'}
+        aria-label="table"
       />
     )
 
@@ -96,7 +96,7 @@ describe('PaginatedTable', () => {
 
   it('should indicate when there is no data to render', () => {
     cy.mountWithProviders(
-      <PaginatedTable<MOCK_TYPE> data={[]} columns={MOCK_COLUMN} pageSizes={[5, 10, 20]} aria-label={'table'} />
+      <PaginatedTable<MOCK_TYPE> data={[]} columns={MOCK_COLUMN} pageSizes={[5, 10, 20]} aria-label="table" />
     )
 
     cy.get('[role="alert"]').should('contain.text', 'No data received yet.')
@@ -109,8 +109,8 @@ describe('PaginatedTable', () => {
         data={[]}
         columns={MOCK_COLUMN}
         pageSizes={[5, 10, 20]}
-        noDataText={'This is a message'}
-        aria-label={'table'}
+        noDataText="This is a message"
+        aria-label="table"
       />
     )
 
@@ -125,7 +125,7 @@ describe('PaginatedTable', () => {
         columns={MOCK_COLUMN}
         pageSizes={[5, 10, 20]}
         enableColumnFilters
-        aria-label={'table'}
+        aria-label="table"
       />
     )
 
@@ -153,7 +153,7 @@ describe('PaginatedTable', () => {
         data={MOCK_DATA(100)}
         columns={MOCK_COLUMN}
         pageSizes={[5, 10, 20]}
-        aria-label={'table'}
+        aria-label="table"
       />
     )
     cy.checkAccessibility()

--- a/hivemq-edge/src/frontend/src/components/PaginatedTable/PaginatedTable.tsx
+++ b/hivemq-edge/src/frontend/src/components/PaginatedTable/PaginatedTable.tsx
@@ -74,8 +74,8 @@ const PaginatedTable = <T,>({
 
   return (
     <>
-      <TableContainer overflowY={'auto'} overflowX={'auto'} whiteSpace={'normal'}>
-        <Table variant="simple" size={'sm'} aria-label={ariaLabel}>
+      <TableContainer overflowY="auto" overflowX="auto" whiteSpace="normal">
+        <Table variant="simple" size="sm" aria-label={ariaLabel}>
           <Thead>
             {table.getHeaderGroups().map((headerGroup) => (
               <Tr key={headerGroup.id}>
@@ -83,26 +83,26 @@ const PaginatedTable = <T,>({
                   <Th
                     key={header.id}
                     colSpan={header.colSpan}
-                    verticalAlign={'top'}
+                    verticalAlign="top"
                     aria-sort={getAriaSort(header.column.getCanSort(), header.column.getIsSorted())}
                   >
-                    <VStack alignItems={'flex-start'}>
+                    <VStack alignItems="flex-start">
                       {header.isPlaceholder && null}
                       {!header.isPlaceholder && header.column.getCanSort() && (
                         <Button
                           px={1}
                           onClick={header.column.getToggleSortingHandler()}
-                          size={'sm'}
+                          size="sm"
                           variant="ghost"
-                          textTransform={'inherit'}
-                          fontWeight={'inherit'}
-                          fontSize={'inherit'}
-                          height={'24px'}
-                          userSelect={'none'}
+                          textTransform="inherit"
+                          fontWeight="inherit"
+                          fontSize="inherit"
+                          height="24px"
+                          userSelect="none"
                           rightIcon={
                             {
-                              asc: <Icon as={BiSortUp} fontSize={'24px'} />,
-                              desc: <Icon as={BiSortDown} fontSize={'24px'} />,
+                              asc: <Icon as={BiSortUp} fontSize="24px" />,
+                              desc: <Icon as={BiSortDown} fontSize="24px" />,
                             }[header.column.getIsSorted() as string] ?? undefined
                           }
                         >
@@ -110,7 +110,7 @@ const PaginatedTable = <T,>({
                         </Button>
                       )}
                       {!header.isPlaceholder && !header.column.getCanSort() && (
-                        <Text userSelect={'none'} pt={1}>
+                        <Text userSelect="none" pt={1}>
                           {flexRender(header.column.columnDef.header, header.getContext())}
                         </Text>
                       )}

--- a/hivemq-edge/src/frontend/src/components/PaginatedTable/components/Filter.tsx
+++ b/hivemq-edge/src/frontend/src/components/PaginatedTable/components/Filter.tsx
@@ -42,7 +42,7 @@ export const Filter = <T,>({
     const max = Number(b)
 
     return (
-      <Box w={'100%'} textTransform={'none'} fontWeight={'initial'}>
+      <Box w="100%" textTransform="none" fontWeight="initial">
         <DateTimeRangeSelector
           min={DateTime.fromMillis(min)}
           max={DateTime.fromMillis(max)}
@@ -59,9 +59,9 @@ export const Filter = <T,>({
   if (typeof firstValue === 'number') return null
 
   return (
-    <Box w={'100%'} textTransform={'none'} fontWeight={'initial'}>
+    <Box w="100%" textTransform="none" fontWeight="initial">
       <CreatableSelect
-        size={'sm'}
+        size="sm"
         inputId={id}
         menuPortalTarget={document.body}
         // value={{ value: columnFilterValue, label: columnFilterValue }}

--- a/hivemq-edge/src/frontend/src/components/PaginatedTable/components/PaginationBar.tsx
+++ b/hivemq-edge/src/frontend/src/components/PaginatedTable/components/PaginationBar.tsx
@@ -27,14 +27,14 @@ interface PaginationProps<T> {
 }
 
 const PaginationButton: FC<IconButtonProps> = (props) => (
-  <IconButton {...props} size={'sm'} fontSize={'24px'} icon={<BiSkipNext />} />
+  <IconButton {...props} size="sm" fontSize="24px" icon={<BiSkipNext />} />
 )
 
 const PaginationBar = <T,>({ table, pageSizes }: PaginationProps<T>) => {
   const { t } = useTranslation()
   return (
-    <HStack as={'nav'} aria-label={t('components:pagination.ariaLabel') as string} gap={8} mt={4}>
-      <ButtonGroup isAttached variant={'ghost'}>
+    <HStack as="nav" aria-label={t('components:pagination.ariaLabel') as string} gap={8} mt={4}>
+      <ButtonGroup isAttached variant="ghost">
         <PaginationButton
           icon={<BiSkipPrevious />}
           onClick={() => table.setPageIndex(0)}
@@ -61,8 +61,8 @@ const PaginationBar = <T,>({ table, pageSizes }: PaginationProps<T>) => {
         />
       </ButtonGroup>
 
-      <Box role={'group'}>
-        <Text fontSize={'md'} whiteSpace={'nowrap'}>
+      <Box role="group">
+        <Text fontSize="md" whiteSpace="nowrap">
           {t('components:pagination.pageOf', {
             page: table.getState().pagination.pageIndex + 1,
             max: table.getPageCount(),
@@ -70,11 +70,11 @@ const PaginationBar = <T,>({ table, pageSizes }: PaginationProps<T>) => {
         </Text>
       </Box>
 
-      <FormControl display={'flex'} alignItems={'center'} w={'inherit'}>
+      <FormControl display="flex" alignItems="center" w="inherit">
         <FormLabel mb={0}>{t('components:pagination.goPage')}</FormLabel>
         <NumberInput
           size="sm"
-          maxWidth={'80px'}
+          maxWidth="80px"
           defaultValue={table.getState().pagination.pageIndex + 1}
           min={1}
           max={table.getPageCount()}
@@ -89,11 +89,11 @@ const PaginationBar = <T,>({ table, pageSizes }: PaginationProps<T>) => {
       </FormControl>
 
       <Flex flex={1}>
-        <FormControl display={'flex'} alignItems={'baseline'} justifyContent={'flex-end'}>
+        <FormControl display="flex" alignItems="baseline" justifyContent="flex-end">
           <FormLabel> {t('components:pagination.perPage')}</FormLabel>
           <Select
-            maxWidth={'80px'}
-            size={'sm'}
+            maxWidth="80px"
+            size="sm"
             value={table.getState().pagination.pageSize}
             onChange={(e) => {
               table.setPageSize(Number(e.target.value))

--- a/hivemq-edge/src/frontend/src/components/WarningMessage.tsx
+++ b/hivemq-edge/src/frontend/src/components/WarningMessage.tsx
@@ -11,16 +11,16 @@ interface WarningMessageProps extends HTMLChakraProps<'div'> {
 
 const WarningMessage: FC<WarningMessageProps> = ({ image = DefaultLogo, prompt, alt, title, ...rest }) => {
   return (
-    <Flex flexDirection={'column'} alignItems={'center'} gap={4} {...rest}>
+    <Flex flexDirection="column" alignItems="center" gap={4} {...rest}>
       {title && (
-        <Heading as={'h2'} size="md" color={'gray.500'}>
+        <Heading as="h2" size="md" color="gray.500">
           {title}
         </Heading>
       )}
       <Circle size="335" bg="gray.100">
         <Image objectFit="cover" src={image} alt={alt} />
       </Circle>
-      <Text align={'center'} maxW={'400'} color={'gray.600'}>
+      <Text align="center" maxW="400" color="gray.600">
         {prompt}
       </Text>
     </Flex>

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/DataHubPage.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/DataHubPage.tsx
@@ -17,7 +17,7 @@ const DataHubPage: FC = () => {
     <PageContainer title={t('page.title') as string} subtitle={t('page.description') as string}>
       {hasDataHub && <Outlet />}
       {!hasDataHub && (
-        <Box width={'100%'}>
+        <Box width="100%">
           <WarningMessage
             image={AdapterEmptyLogo}
             title={t('error.notActivated.title') as string}

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/CanvasControls.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/CanvasControls.tsx
@@ -29,8 +29,8 @@ const CanvasControls: FC<ControlProps> = ({ onInteractiveChange }) => {
   }
 
   return (
-    <Panel position={'bottom-left'}>
-      <ButtonGroup variant="outline" isAttached size={'sm'} aria-label={t('workspace.controls.aria-label') as string}>
+    <Panel position="bottom-left">
+      <ButtonGroup variant="outline" isAttached size="sm" aria-label={t('workspace.controls.aria-label') as string}>
         <IconButton icon={<FaPlus />} onClick={() => zoomIn()} aria-label={t('workspace.controls.zoomIn') as string} />
         <IconButton
           icon={<FaMinus />}

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/Minimap.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/Minimap.spec.cy.tsx
@@ -11,7 +11,7 @@ describe('Minimap', () => {
   it('should renders properly', () => {
     cy.mountWithProviders(
       <ReactFlowProvider>
-        <Minimap position={'top-left'} />
+        <Minimap position="top-left" />
       </ReactFlowProvider>
     )
   })

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/PropertyPanelController.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/PropertyPanelController.tsx
@@ -79,23 +79,23 @@ const PropertyPanelController = () => {
 
   return (
     <Drawer
-      size={'lg'}
+      size="lg"
       isOpen={isOpen}
       placement="right"
       onClose={onDrawerClose}
       // finalFocusRef={btnRef}
     >
       <DrawerOverlay />
-      <DrawerContent data-testid={'node-editor-content'}>
+      <DrawerContent data-testid="node-editor-content">
         <DrawerCloseButton />
         <DrawerHeader>
           <Flex>
-            <Avatar icon={<NodeIcon type={type} />} bg="gray.200" data-testid={'node-editor-icon'} />
+            <Avatar icon={<NodeIcon type={type} />} bg="gray.200" data-testid="node-editor-icon" />
             <Box ml="3">
-              <Text fontWeight="bold" data-testid={'node-editor-name'}>
+              <Text fontWeight="bold" data-testid="node-editor-name">
                 {t('workspace.nodes.type', { context: type })}
               </Text>
-              <Text fontSize="sm" data-testid={'node-editor-id'}>
+              <Text fontSize="sm" data-testid="node-editor-id">
                 id: {nodeId}
               </Text>
             </Box>
@@ -106,15 +106,15 @@ const PropertyPanelController = () => {
           {isEditorValid ? (
             <Editor selectedNode={nodeId} onFormSubmit={onFormSubmit} />
           ) : (
-            <AbsoluteCenter axis="both" data-testid={'node-editor-under-construction'}>
+            <AbsoluteCenter axis="both" data-testid="node-editor-under-construction">
               <Icon as={LuConstruction} boxSize={100} />
             </AbsoluteCenter>
           )}
         </DrawerBody>
         <DrawerFooter borderTopWidth="1px">
           {isEditorValid && (
-            <Flex flexGrow={1} justifyContent={'flex-end'}>
-              <Button variant={'primary'} type="submit" form="datahub-node-form">
+            <Flex flexGrow={1} justifyContent="flex-end">
+              <Button variant="primary" type="submit" form="datahub-node-form">
                 {t('workspace.panel.submit')}
               </Button>
             </Flex>

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/Tool.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/Tool.tsx
@@ -26,7 +26,7 @@ const Tool: FC<ToolProps> = ({ nodeType, isDisabled }) => {
 
   return (
     <IconButton
-      size={'lg'}
+      size="lg"
       onDragStart={onButtonDragStart}
       draggable
       isDisabled={isDisabled}

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/Toolbox.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/Toolbox.tsx
@@ -14,8 +14,8 @@ export const Toolbox = () => {
   const [hidden, setHidden] = useState(!isOpen)
 
   return (
-    <Panel position={'top-left'} style={{ margin: '5px' }}>
-      <HStack alignItems={'flex-start'}>
+    <Panel position="top-left" style={{ margin: '5px' }}>
+      <HStack alignItems="flex-start">
         <Box>
           <IconButton
             aria-label={t('workspace.toolbox.trigger', { context: !isOpen ? 'open' : 'close' })}
@@ -44,35 +44,35 @@ export const Toolbox = () => {
           <HStack
             pb={2}
             gap={5}
-            role={'group'}
+            role="group"
             aria-label={t('workspace.toolbox.aria-label') as string}
-            backgroundColor={'var(--chakra-colors-chakra-body-bg)'}
+            backgroundColor="var(--chakra-colors-chakra-body-bg)"
           >
-            <VStack pl={2} alignItems={'flex-start'}>
-              <Text id={'group-pipeline'}>{t('workspace.toolbox.group.pipeline')}</Text>
-              <ButtonGroup variant="outline" size={'sm'} aria-labelledby={'group-pipeline'}>
+            <VStack pl={2} alignItems="flex-start">
+              <Text id="group-pipeline">{t('workspace.toolbox.group.pipeline')}</Text>
+              <ButtonGroup variant="outline" size="sm" aria-labelledby="group-pipeline">
                 <Tool nodeType={DataHubNodeType.TOPIC_FILTER} />
                 <Tool nodeType={DataHubNodeType.CLIENT_FILTER} />
               </ButtonGroup>
             </VStack>
-            <VStack alignItems={'flex-start'}>
-              <Text id={'group-dataPolicy'}>{t('workspace.toolbox.group.dataPolicy')}</Text>
-              <ButtonGroup variant="outline" size={'sm'} aria-labelledby={'group-dataPolicy'}>
+            <VStack alignItems="flex-start">
+              <Text id="group-dataPolicy">{t('workspace.toolbox.group.dataPolicy')}</Text>
+              <ButtonGroup variant="outline" size="sm" aria-labelledby="group-dataPolicy">
                 <Tool nodeType={DataHubNodeType.DATA_POLICY} />
                 <Tool nodeType={DataHubNodeType.VALIDATOR} />
                 <Tool nodeType={DataHubNodeType.SCHEMA} />{' '}
               </ButtonGroup>
             </VStack>
-            <VStack alignItems={'flex-start'}>
-              <Text id={'group-behaviorPolicy'}>{t('workspace.toolbox.group.behaviorPolicy')}</Text>
-              <ButtonGroup variant="outline" size={'sm'} aria-labelledby={'group-behaviorPolicy'}>
+            <VStack alignItems="flex-start">
+              <Text id="group-behaviorPolicy">{t('workspace.toolbox.group.behaviorPolicy')}</Text>
+              <ButtonGroup variant="outline" size="sm" aria-labelledby="group-behaviorPolicy">
                 <Tool nodeType={DataHubNodeType.BEHAVIOR_POLICY} />
                 <Tool nodeType={DataHubNodeType.TRANSITION} />
               </ButtonGroup>
             </VStack>
-            <VStack alignItems={'flex-start'} pr={2}>
-              <Text id={'group-action'}>{t('workspace.toolbox.group.action')}</Text>
-              <ButtonGroup variant="outline" size={'sm'} aria-labelledby={'group-action'}>
+            <VStack alignItems="flex-start" pr={2}>
+              <Text id="group-action">{t('workspace.toolbox.group.action')}</Text>
+              <ButtonGroup variant="outline" size="sm" aria-labelledby="group-action">
                 <Tool nodeType={DataHubNodeType.OPERATION} />
               </ButtonGroup>
             </VStack>

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/helpers/NodeIcon.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/helpers/NodeIcon.tsx
@@ -12,15 +12,15 @@ import { DataHubNodeType } from '../../types.ts'
 import { useTranslation } from 'react-i18next'
 
 const iconMapping: Record<string, (label: string) => JSX.Element> = {
-  [DataHubNodeType.ADAPTOR]: (label) => <Icon as={GrConnect} boxSize={'24px'} aria-label={label} />,
-  [DataHubNodeType.TOPIC_FILTER]: (label) => <Icon as={SiMqtt} boxSize={'16px'} aria-label={label} />,
-  [DataHubNodeType.CLIENT_FILTER]: (label) => <Icon as={AiOutlineCloudServer} boxSize={'24px'} aria-label={label} />,
-  [DataHubNodeType.DATA_POLICY]: (label) => <Icon as={MdPolicy} boxSize={'24px'} aria-label={label} />,
-  [DataHubNodeType.BEHAVIOR_POLICY]: (label) => <Icon as={MdPolicy} boxSize={'24px'} aria-label={label} />,
-  [DataHubNodeType.VALIDATOR]: (label) => <Icon as={GrValidate} boxSize={'24px'} aria-label={label} />,
-  [DataHubNodeType.SCHEMA]: (label) => <Icon as={MdSchema} boxSize={'24px'} aria-label={label} />,
-  [DataHubNodeType.OPERATION]: (label) => <Icon as={LuFunctionSquare} boxSize={'24px'} aria-label={label} />,
-  [DataHubNodeType.TRANSITION]: (label) => <Icon as={TbTransitionRight} boxSize={'24px'} aria-label={label} />,
+  [DataHubNodeType.ADAPTOR]: (label) => <Icon as={GrConnect} boxSize="24px" aria-label={label} />,
+  [DataHubNodeType.TOPIC_FILTER]: (label) => <Icon as={SiMqtt} boxSize="16px" aria-label={label} />,
+  [DataHubNodeType.CLIENT_FILTER]: (label) => <Icon as={AiOutlineCloudServer} boxSize="24px" aria-label={label} />,
+  [DataHubNodeType.DATA_POLICY]: (label) => <Icon as={MdPolicy} boxSize="24px" aria-label={label} />,
+  [DataHubNodeType.BEHAVIOR_POLICY]: (label) => <Icon as={MdPolicy} boxSize="24px" aria-label={label} />,
+  [DataHubNodeType.VALIDATOR]: (label) => <Icon as={GrValidate} boxSize="24px" aria-label={label} />,
+  [DataHubNodeType.SCHEMA]: (label) => <Icon as={MdSchema} boxSize="24px" aria-label={label} />,
+  [DataHubNodeType.OPERATION]: (label) => <Icon as={LuFunctionSquare} boxSize="24px" aria-label={label} />,
+  [DataHubNodeType.TRANSITION]: (label) => <Icon as={TbTransitionRight} boxSize="24px" aria-label={label} />,
 }
 
 interface NodeIconProps {
@@ -31,7 +31,7 @@ const NodeIcon: FC<NodeIconProps> = ({ type }) => {
   const { t } = useTranslation('datahub')
 
   if (!type || !iconMapping[type]) {
-    return <Icon as={GrStatusUnknown} boxSize={'24px'} aria-label={t('workspace.nodes.type') as string} />
+    return <Icon as={GrStatusUnknown} boxSize="24px" aria-label={t('workspace.nodes.type') as string} />
   }
   return iconMapping[type](t('workspace.nodes.type', { context: type }))
 }

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/helpers/ReactFlowSchemaForm.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/helpers/ReactFlowSchemaForm.tsx
@@ -25,7 +25,7 @@ function TitleFieldTemplate<T = unknown, S extends StrictRJSFSchema = RJSFSchema
 }: TitleFieldProps<T, S>) {
   return (
     <Box id={id} mt={1} mb={4}>
-      <Heading as={'h2'} size={'lg'}>
+      <Heading as="h2" size="lg">
         {title}
       </Heading>
       <Divider />
@@ -132,7 +132,7 @@ function FieldTemplate<
           uiSchema={uiSchema}
           registry={registry}
         >
-          <FormControl variant={'hivemq'} isRequired={required} isInvalid={rawErrors && rawErrors.length > 0} mb={4}>
+          <FormControl variant="hivemq" isRequired={required} isInvalid={rawErrors && rawErrors.length > 0} mb={4}>
             {children}
           </FormControl>
         </WrapIfAdditionalTemplate>

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/BehaviorPolicyNode.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/BehaviorPolicyNode.tsx
@@ -18,11 +18,11 @@ export const BehaviorPolicyNode: FC<NodeProps<BehaviorPolicyData>> = (props) => 
         <VStack>
           <HStack>
             <NodeIcon type={DataHubNodeType.BEHAVIOR_POLICY} />
-            <Text data-testid={'node-title'} w={'45%'}>
+            <Text data-testid="node-title" w="45%">
               {t('workspace.nodes.type', { context: type })}
             </Text>
             <VStack>
-              <Text data-testid={`node-model`}>{data.model || t('error.noSet.select')}</Text>
+              <Text data-testid="node-model">{data.model || t('error.noSet.select')}</Text>
             </VStack>
           </HStack>
         </VStack>

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/ClientFilterNode.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/ClientFilterNode.tsx
@@ -18,10 +18,10 @@ export const ClientFilterNode: FC<NodeProps<ClientFilterData>> = (props) => {
       <NodeWrapper route={`node/${type}/${id}`} {...props}>
         <HStack>
           <VStack>
-            <Text data-testid={'node-title'}> {t('workspace.nodes.type', { context: type })}</Text>
+            <Text data-testid="node-title"> {t('workspace.nodes.type', { context: type })}</Text>
           </VStack>
         </HStack>
-        <VStack ml={6} data-testid={'node-model'}>
+        <VStack ml={6} data-testid="node-model">
           {data.clients?.map((t) => (
             <Client client={t} key={t} />
           ))}

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/DataPolicyNode.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/DataPolicyNode.tsx
@@ -20,9 +20,7 @@ export const DataPolicyNode: FC<NodeProps<DataPolicyData>> = (props) => {
           <Text data-testid="node-title"> {t('workspace.nodes.type', { context: type })}</Text>
         </HStack>
         <VStack ml={6} alignItems="flex-end" data-testid="node-model">
-          <Text fontSize="xs">
-            {t('workspace.handles.validation', { context: DataPolicyData.Handle.ON_SUCCESS })}
-          </Text>
+          <Text fontSize="xs">{t('workspace.handles.validation', { context: DataPolicyData.Handle.ON_SUCCESS })}</Text>
           <Text fontSize="xs">{t('workspace.handles.validation', { context: DataPolicyData.Handle.ON_ERROR })}</Text>
         </VStack>
       </NodeWrapper>

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/DataPolicyNode.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/DataPolicyNode.tsx
@@ -17,13 +17,13 @@ export const DataPolicyNode: FC<NodeProps<DataPolicyData>> = (props) => {
       <NodeWrapper route={`node/${DataHubNodeType.DATA_POLICY}/${id}`} {...props}>
         <HStack>
           <NodeIcon type={DataHubNodeType.DATA_POLICY} />
-          <Text data-testid={'node-title'}> {t('workspace.nodes.type', { context: type })}</Text>
+          <Text data-testid="node-title"> {t('workspace.nodes.type', { context: type })}</Text>
         </HStack>
-        <VStack ml={6} alignItems={'flex-end'} data-testid={'node-model'}>
-          <Text fontSize={'xs'}>
+        <VStack ml={6} alignItems="flex-end" data-testid="node-model">
+          <Text fontSize="xs">
             {t('workspace.handles.validation', { context: DataPolicyData.Handle.ON_SUCCESS })}
           </Text>
-          <Text fontSize={'xs'}>{t('workspace.handles.validation', { context: DataPolicyData.Handle.ON_ERROR })}</Text>
+          <Text fontSize="xs">{t('workspace.handles.validation', { context: DataPolicyData.Handle.ON_ERROR })}</Text>
         </VStack>
       </NodeWrapper>
       <CustomHandle type="target" position={Position.Left} id={DataPolicyData.Handle.TOPIC_FILTER} />

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/NodeWrapper.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/NodeWrapper.tsx
@@ -24,9 +24,9 @@ export const NodeWrapper: FC<NodeWrapperProps> = ({ selected, children, route, w
 
   return (
     <Card
-      variant={'elevated'}
+      variant="elevated"
       {...(selected ? { ...selectedStyle } : {})}
-      size={'sm'}
+      size="sm"
       onClick={(event) => {
         if (internalSelection) {
           navigate(route, { state: { origin: pathname } })

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/OperationNode.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/OperationNode.tsx
@@ -28,9 +28,9 @@ export const OperationNode: FC<NodeProps<OperationData>> = (props) => {
       <NodeWrapper route={`node/${DataHubNodeType.OPERATION}/${id}`} {...props}>
         <HStack>
           <NodeIcon type={DataHubNodeType.OPERATION} />
-          <Text data-testid={'node-title'}> {t('workspace.nodes.type', { context: type })}</Text>
+          <Text data-testid="node-title"> {t('workspace.nodes.type', { context: type })}</Text>
           <VStack>
-            <Text data-testid={'node-model'}>{model?.functionId || t('error.noSet.select')}</Text>
+            <Text data-testid="node-model">{model?.functionId || t('error.noSet.select')}</Text>
           </VStack>
         </HStack>
       </NodeWrapper>

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/SchemaNode.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/SchemaNode.tsx
@@ -17,9 +17,9 @@ export const SchemaNode: FC<NodeProps<SchemaData>> = (props) => {
       <NodeWrapper route={`node/${DataHubNodeType.SCHEMA}/${id}`} {...props}>
         <HStack>
           <NodeIcon type={DataHubNodeType.SCHEMA} />
-          <Text data-testid={'node-title'}> {t('workspace.nodes.type', { context: type })}</Text>
+          <Text data-testid="node-title"> {t('workspace.nodes.type', { context: type })}</Text>
           <VStack>
-            <Text data-testid={'node-model'}>{data?.type || t('error.noSet.select')}</Text>
+            <Text data-testid="node-model">{data?.type || t('error.noSet.select')}</Text>
           </VStack>
         </HStack>
       </NodeWrapper>

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/TopicFilterNode.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/TopicFilterNode.tsx
@@ -22,7 +22,7 @@ export const TopicFilterNode: FC<NodeProps<TopicFilterData>> = (props) => {
             <Text data-testid={`node-topicFilter-${id}`}> {t('workspace.nodes.type', { context: type })}</Text>
           </VStack>
         </HStack>
-        <VStack ml={6} alignItems={'flex-end'}>
+        <VStack ml={6} alignItems="flex-end">
           {data.topics?.map((t) => (
             <Topic topic={t} key={t} />
           ))}

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/TransitionNode.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/TransitionNode.tsx
@@ -17,9 +17,9 @@ export const TransitionNode: FC<NodeProps<TransitionData>> = (props) => {
       <NodeWrapper route={`node/${DataHubNodeType.TRANSITION}/${id}`} {...props}>
         <HStack>
           <NodeIcon type={DataHubNodeType.TRANSITION} />
-          <Text data-testid={'node-title'}> {t('workspace.nodes.type', { context: type })}</Text>
+          <Text data-testid="node-title"> {t('workspace.nodes.type', { context: type })}</Text>
           <VStack>
-            <Text data-testid={'node-model'}>{data.type || t('error.noSet.select')}</Text>
+            <Text data-testid="node-model">{data.type || t('error.noSet.select')}</Text>
           </VStack>
         </HStack>
       </NodeWrapper>

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/ValidatorNode.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/ValidatorNode.tsx
@@ -16,10 +16,10 @@ export const ValidatorNode: FC<NodeProps<ValidatorData>> = (props) => {
       <NodeWrapper route={`node/${DataHubNodeType.VALIDATOR}/${id}`} {...props}>
         <HStack>
           <NodeIcon type={DataHubNodeType.VALIDATOR} />
-          <Text data-testid={'node-title'} w={'50%'}>
+          <Text data-testid="node-title" w="50%">
             {t('workspace.nodes.type', { context: type })}
           </Text>
-          <VStack data-testid={'node-model'}>
+          <VStack data-testid="node-model">
             <Text>{data.type}</Text>
             <Text>{data.strategy}</Text>
           </VStack>

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/PolicyEditor.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/PolicyEditor.spec.cy.tsx
@@ -25,7 +25,7 @@ describe('PolicyEditor', () => {
           <Route
             path="/:policyType/:policyId"
             element={
-              <Box w={'100%'} h={'95vh'}>
+              <Box w="100%" h="95vh">
                 <PolicyEditor />
               </Box>
             }
@@ -49,7 +49,7 @@ describe('PolicyEditor', () => {
           <Route
             path="/:policyType/:policyId"
             element={
-              <Box w={'100%'} h={'95vh'}>
+              <Box w="100%" h="95vh">
                 <PolicyEditor />
               </Box>
             }

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/PolicyEditor.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/PolicyEditor.tsx
@@ -116,11 +116,7 @@ const PolicyEditor: FC = () => {
           onDrop={onDrop}
           isValidConnection={checkValidity}
         >
-          <Box
-            role="toolbar"
-            aria-label={t('workspace.aria-label') as string}
-            aria-controls="edge-workspace-canvas"
-          >
+          <Box role="toolbar" aria-label={t('workspace.aria-label') as string} aria-controls="edge-workspace-canvas">
             <Toolbox />
             <CanvasControls />
             <Minimap />

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/PolicyEditor.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/PolicyEditor.tsx
@@ -97,7 +97,7 @@ const PolicyEditor: FC = () => {
       <ReactFlowProvider>
         <ReactFlow
           ref={reactFlowWrapper}
-          id={'edge-workspace-canvas'}
+          id="edge-workspace-canvas"
           nodes={nodes}
           edges={edges}
           nodeTypes={nodeTypes}
@@ -117,9 +117,9 @@ const PolicyEditor: FC = () => {
           isValidConnection={checkValidity}
         >
           <Box
-            role={'toolbar'}
+            role="toolbar"
             aria-label={t('workspace.aria-label') as string}
-            aria-controls={'edge-workspace-canvas'}
+            aria-controls="edge-workspace-canvas"
           >
             <Toolbox />
             <CanvasControls />

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/PolicyTable.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/PolicyTable.tsx
@@ -60,7 +60,7 @@ const PolicyTable: FC = () => {
       {
         accessorKey: 'id',
         cell: (info) => (
-          <Skeleton isLoaded={!isLoading} whiteSpace={'nowrap'}>
+          <Skeleton isLoaded={!isLoading} whiteSpace="nowrap">
             <Text>{info.getValue<string>()}</Text>
           </Skeleton>
         ),
@@ -69,7 +69,7 @@ const PolicyTable: FC = () => {
         accessorKey: 'type',
         cell: (info) => {
           return (
-            <Skeleton isLoaded={!isLoading} whiteSpace={'nowrap'}>
+            <Skeleton isLoaded={!isLoading} whiteSpace="nowrap">
               <Text>{t('policy.type', { context: info.getValue<string>() })}</Text>
             </Skeleton>
           )
@@ -81,7 +81,7 @@ const PolicyTable: FC = () => {
         cell: (info) => {
           const matching = info.getValue<DataPolicyMatching | BehaviorPolicyMatching>()
           return (
-            <Skeleton isLoaded={!isLoading} whiteSpace={'nowrap'}>
+            <Skeleton isLoaded={!isLoading} whiteSpace="nowrap">
               <Text>
                 {(matching as DataPolicyMatching).topicFilter || (matching as BehaviorPolicyMatching).clientIdRegex}
               </Text>
@@ -95,7 +95,7 @@ const PolicyTable: FC = () => {
         sortType: 'datetime',
         accessorFn: (row) => (row.createdAt ? DateTime.fromISO(row.createdAt).toMillis() : undefined),
         cell: (info) => (
-          <Skeleton isLoaded={!isLoading} whiteSpace={'nowrap'}>
+          <Skeleton isLoaded={!isLoading} whiteSpace="nowrap">
             <DateTimeRenderer date={DateTime.fromMillis(info.getValue() as number)} isApprox />
           </Skeleton>
         ),
@@ -109,7 +109,7 @@ const PolicyTable: FC = () => {
           return (
             <Skeleton isLoaded={!isLoading}>
               <IconButton
-                size={'sm'}
+                size="sm"
                 onClick={() => navigate(`/datahub/${info.row.original.type}/id`)}
                 aria-label={t('policyTable.action.edit')}
                 icon={<FaEdit />}

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/panels/BehaviorPolicyPanel.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/panels/BehaviorPolicyPanel.spec.cy.tsx
@@ -22,7 +22,7 @@ const wrapper: React.JSXElementConstructor<{ children: React.ReactNode }> = ({ c
     }}
   >
     {children}
-    <Button variant={'primary'} type="submit" form="datahub-node-form">
+    <Button variant="primary" type="submit" form="datahub-node-form">
       SUBMIT{' '}
     </Button>
   </MockStoreWrapper>
@@ -36,7 +36,7 @@ describe('BehaviorPolicyPanel', () => {
   it('should render the fields for a Validator', () => {
     const onSubmit = cy.stub().as('onSubmit')
 
-    cy.mountWithProviders(<BehaviorPolicyPanel selectedNode={'3'} onFormSubmit={onSubmit} />, { wrapper })
+    cy.mountWithProviders(<BehaviorPolicyPanel selectedNode="3" onFormSubmit={onSubmit} />, { wrapper })
 
     // first select
     cy.get('label#root_type-label').should('contain.text', 'Behavior Model')
@@ -80,7 +80,7 @@ describe('BehaviorPolicyPanel', () => {
 
   it('should be accessible', () => {
     cy.injectAxe()
-    cy.mountWithProviders(<BehaviorPolicyPanel selectedNode={'3'} />, { wrapper })
+    cy.mountWithProviders(<BehaviorPolicyPanel selectedNode="3" />, { wrapper })
 
     cy.checkAccessibility()
     cy.percySnapshot('Component: BehaviorPolicyPanel')

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/panels/ClientFilterPanel.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/panels/ClientFilterPanel.spec.cy.tsx
@@ -22,7 +22,7 @@ const wrapper: React.JSXElementConstructor<{ children: React.ReactNode }> = ({ c
     }}
   >
     {children}
-    <Button variant={'primary'} type="submit" form="datahub-node-form">
+    <Button variant="primary" type="submit" form="datahub-node-form">
       SUBMIT{' '}
     </Button>
   </MockStoreWrapper>
@@ -36,7 +36,7 @@ describe('ClientFilterPanel', () => {
   it('should render the fields for a Validator', () => {
     const onSubmit = cy.stub().as('onSubmit')
 
-    cy.mountWithProviders(<ClientFilterPanel selectedNode={'3'} onFormSubmit={onSubmit} />, { wrapper })
+    cy.mountWithProviders(<ClientFilterPanel selectedNode="3" onFormSubmit={onSubmit} />, { wrapper })
 
     cy.get('h2').eq(0).should('contain.text', 'Client Filters')
     // first item
@@ -61,7 +61,7 @@ describe('ClientFilterPanel', () => {
 
   it('should be accessible', () => {
     cy.injectAxe()
-    cy.mountWithProviders(<ClientFilterPanel selectedNode={'3'} />, { wrapper })
+    cy.mountWithProviders(<ClientFilterPanel selectedNode="3" />, { wrapper })
 
     cy.checkAccessibility()
     cy.percySnapshot('Component: ClientFilterPanel')

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/panels/OperationPanel.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/panels/OperationPanel.spec.cy.tsx
@@ -22,7 +22,7 @@ const wrapper: React.JSXElementConstructor<{ children: React.ReactNode }> = ({ c
     }}
   >
     {children}
-    <Button variant={'primary'} type="submit" form="datahub-node-form">
+    <Button variant="primary" type="submit" form="datahub-node-form">
       SUBMIT{' '}
     </Button>
   </MockStoreWrapper>
@@ -34,7 +34,7 @@ describe('OperationPanel', () => {
   })
 
   it('should render the fields for a Validator', () => {
-    cy.mountWithProviders(<OperationPanel selectedNode={'3'} />, { wrapper })
+    cy.mountWithProviders(<OperationPanel selectedNode="3" />, { wrapper })
 
     // first select
     cy.get('label#root_action-label').should('contain.text', 'Function')
@@ -56,7 +56,7 @@ describe('OperationPanel', () => {
 
   it('should be accessible', () => {
     cy.injectAxe()
-    cy.mountWithProviders(<OperationPanel selectedNode={'3'} />, { wrapper })
+    cy.mountWithProviders(<OperationPanel selectedNode="3" />, { wrapper })
 
     cy.checkAccessibility()
     cy.percySnapshot('Component: OperationPanel')

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/panels/SchemaPanel.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/panels/SchemaPanel.spec.cy.tsx
@@ -22,7 +22,7 @@ const wrapper: React.JSXElementConstructor<{ children: React.ReactNode }> = ({ c
     }}
   >
     {children}
-    <Button variant={'primary'} type="submit" form="datahub-node-form">
+    <Button variant="primary" type="submit" form="datahub-node-form">
       SUBMIT{' '}
     </Button>
   </MockStoreWrapper>
@@ -34,7 +34,7 @@ describe('SchemaPanel', () => {
   })
 
   it('should render the fields for a Validator', () => {
-    cy.mountWithProviders(<SchemaPanel selectedNode={'3'} />, { wrapper })
+    cy.mountWithProviders(<SchemaPanel selectedNode="3" />, { wrapper })
 
     // first select
     cy.get('label#root_type-label').should('contain.text', 'Schema')
@@ -61,7 +61,7 @@ describe('SchemaPanel', () => {
 
   it('should be accessible', () => {
     cy.injectAxe()
-    cy.mountWithProviders(<SchemaPanel selectedNode={'3'} />, { wrapper })
+    cy.mountWithProviders(<SchemaPanel selectedNode="3" />, { wrapper })
 
     cy.checkAccessibility()
     cy.percySnapshot('Component: SchemaPanel')

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/panels/TopicFilterPanel.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/panels/TopicFilterPanel.spec.cy.tsx
@@ -22,7 +22,7 @@ const wrapper: React.JSXElementConstructor<{ children: React.ReactNode }> = ({ c
     }}
   >
     {children}
-    <Button variant={'primary'} type="submit" form="datahub-node-form">
+    <Button variant="primary" type="submit" form="datahub-node-form">
       SUBMIT{' '}
     </Button>
   </MockStoreWrapper>
@@ -34,7 +34,7 @@ describe('TopicFilterPanel', () => {
   })
 
   it('should render the fields for a Validator', () => {
-    cy.mountWithProviders(<TopicFilterPanel selectedNode={'3'} />, { wrapper })
+    cy.mountWithProviders(<TopicFilterPanel selectedNode="3" />, { wrapper })
 
     cy.get('h2').eq(0).should('contain.text', 'Topic Filters')
     // first item
@@ -47,7 +47,7 @@ describe('TopicFilterPanel', () => {
 
   it('should be accessible', () => {
     cy.injectAxe()
-    cy.mountWithProviders(<TopicFilterPanel selectedNode={'3'} />, { wrapper })
+    cy.mountWithProviders(<TopicFilterPanel selectedNode="3" />, { wrapper })
 
     cy.checkAccessibility()
     cy.percySnapshot('Component: TopicFilterPanel')

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/panels/TransitionPanel.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/panels/TransitionPanel.spec.cy.tsx
@@ -22,7 +22,7 @@ const wrapper: React.JSXElementConstructor<{ children: React.ReactNode }> = ({ c
     }}
   >
     {children}
-    <Button variant={'primary'} type="submit" form="datahub-node-form">
+    <Button variant="primary" type="submit" form="datahub-node-form">
       SUBMIT{' '}
     </Button>
   </MockStoreWrapper>
@@ -34,7 +34,7 @@ describe('TransitionPanel', () => {
   })
 
   it('should render the fields for a Validator', () => {
-    cy.mountWithProviders(<TransitionPanel selectedNode={'3'} />, { wrapper })
+    cy.mountWithProviders(<TransitionPanel selectedNode="3" />, { wrapper })
 
     // first select
     cy.get('label#root_type-label').should('contain.text', 'Transition')
@@ -75,7 +75,7 @@ describe('TransitionPanel', () => {
 
   it('should be accessible', () => {
     cy.injectAxe()
-    cy.mountWithProviders(<TransitionPanel selectedNode={'3'} />, { wrapper })
+    cy.mountWithProviders(<TransitionPanel selectedNode="3" />, { wrapper })
 
     cy.checkAccessibility()
     cy.percySnapshot('Component: TransitionPanel')

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/panels/ValidatorPanel.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/panels/ValidatorPanel.spec.cy.tsx
@@ -22,7 +22,7 @@ const wrapper: React.JSXElementConstructor<{ children: React.ReactNode }> = ({ c
     }}
   >
     {children}
-    <Button variant={'primary'} type="submit" form="datahub-node-form">
+    <Button variant="primary" type="submit" form="datahub-node-form">
       SUBMIT{' '}
     </Button>
   </MockStoreWrapper>
@@ -34,7 +34,7 @@ describe('ValidatorPanel', () => {
   })
 
   it('should render the fields for a Validator', () => {
-    cy.mountWithProviders(<ValidatorPanel selectedNode={'3'} />, { wrapper })
+    cy.mountWithProviders(<ValidatorPanel selectedNode="3" />, { wrapper })
 
     // first select
     cy.get('label#root_type-label').should('contain.text', 'Validator Type')
@@ -70,7 +70,7 @@ describe('ValidatorPanel', () => {
   })
 
   it('should render the error message with data not found', () => {
-    cy.mountWithProviders(<ValidatorPanel selectedNode={'not valid'} />, { wrapper })
+    cy.mountWithProviders(<ValidatorPanel selectedNode="not valid" />, { wrapper })
 
     cy.get("[role='alert']").find('div[data-status]').should('have.length', 2)
     cy.get("[role='alert']").find('div[data-status]').eq(0).should('contain.text', 'Error loading the node')
@@ -82,7 +82,7 @@ describe('ValidatorPanel', () => {
 
   it('should be accessible', () => {
     cy.injectAxe()
-    cy.mountWithProviders(<ValidatorPanel selectedNode={'3'} />, { wrapper })
+    cy.mountWithProviders(<ValidatorPanel selectedNode="3" />, { wrapper })
 
     cy.checkAccessibility()
     cy.percySnapshot('Component: ValidatorPanel')

--- a/hivemq-edge/src/frontend/src/hooks/useEdgeToast/useEdgeToast.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/hooks/useEdgeToast/useEdgeToast.spec.cy.tsx
@@ -33,11 +33,11 @@ const TestingComponent = () => {
   const { successToast, errorToast } = useEdgeToast()
   return (
     <div>
-      <Button data-testid={'trigger-success'} onClick={() => successToast({ title: 'This is a success' })}>
+      <Button data-testid="trigger-success" onClick={() => successToast({ title: 'This is a success' })}>
         successToast
       </Button>
       <Button
-        data-testid={'trigger-error'}
+        data-testid="trigger-error"
         onClick={() =>
           errorToast({ title: 'This is an error', description: 'And the error is this one' }, MOCK_API_ERROR)
         }

--- a/hivemq-edge/src/frontend/src/modules/App/MainApp.tsx
+++ b/hivemq-edge/src/frontend/src/modules/App/MainApp.tsx
@@ -21,7 +21,7 @@ const MainApp: FC = () => {
           <RouterProvider router={routes} />
         </AuthProvider>
       </ChakraProvider>
-      {import.meta.env.MODE === 'development' && <ReactQueryDevtools position={'bottom-right'} initialIsOpen={false} />}
+      {import.meta.env.MODE === 'development' && <ReactQueryDevtools position="bottom-right" initialIsOpen={false} />}
     </QueryClientProvider>
   )
 }

--- a/hivemq-edge/src/frontend/src/modules/App/components/ErrorPage.tsx
+++ b/hivemq-edge/src/frontend/src/modules/App/components/ErrorPage.tsx
@@ -22,12 +22,12 @@ const ErrorPage = () => {
         <Text fontSize={{ md: 'xl' }}>
           {error.statusText} | {error.status}
         </Text>
-        <Button as={RouterLink} to={'/'} aria-label="Back to Home" leftIcon={<FaHome />} size="lg">
+        <Button as={RouterLink} to="/" aria-label="Back to Home" leftIcon={<FaHome />} size="lg">
           {t('error.backHome')}
         </Button>
       </VStack>
       {import.meta.env.MODE === 'development' && (
-        <VStack m={8} maxH={'250px'} mt={20} p={2} overflow={'auto'} bgColor={'gray.100'}>
+        <VStack m={8} maxH="250px" mt={20} p={2} overflow="auto" bgColor="gray.100">
           <pre style={{ width: '100%' }}>{error.error?.stack}</pre>{' '}
         </VStack>
       )}

--- a/hivemq-edge/src/frontend/src/modules/Bridges/BridgePage.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Bridges/BridgePage.tsx
@@ -19,12 +19,12 @@ const BridgePage: FC = () => {
       title={t('bridge.title') as string}
       subtitle={t('bridge.description') as string}
       cta={
-        <Flex height={'100%'} justifyContent={'flex-end'} alignItems={'flex-end'} pb={6}>
+        <Flex height="100%" justifyContent="flex-end" alignItems="flex-end" pb={6}>
           <Button
             leftIcon={<BiAddToQueue />}
             onClick={() => navigate('/mqtt-bridges/new')}
             isDisabled={isLoading || isError}
-            variant={'primary'}
+            variant="primary"
           >
             {t('bridge.action.add')}
           </Button>

--- a/hivemq-edge/src/frontend/src/modules/Bridges/Bridges.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Bridges/Bridges.tsx
@@ -26,7 +26,7 @@ const Bridges: FC = () => {
 
   if (isError) {
     return (
-      <Box mt={'20%'} mx={'20%'} alignItems={'center'}>
+      <Box mt="20%" mx="20%" alignItems="center">
         <ErrorMessage
           type={error?.message}
           message={(error?.body as ProblemDetails)?.title || (t('bridge.error.loading') as string)}
@@ -37,7 +37,7 @@ const Bridges: FC = () => {
 
   if (isLoading) {
     return (
-      <Flex mt={8} flexDirection={'row'} flexWrap={'wrap'} gap={'20px'}>
+      <Flex mt={8} flexDirection="row" flexWrap="wrap" gap="20px">
         <BridgeCard {...mockBridge} isLoading />
       </Flex>
     )
@@ -59,11 +59,11 @@ const Bridges: FC = () => {
       spacing={4}
       templateColumns={{ base: 'repeat(1, 1fr)', lg: 'repeat(2, 1fr)', '2xl': 'repeat(3, 1fr)' }}
       gap={6}
-      role={'list'}
+      role="list"
       aria-label={t('bridge.list') as string}
     >
       {data?.map((bridge, i) => (
-        <BridgeCard key={`${bridge.id}-${i}`} {...bridge} onNavigate={handleNavigate} role={'listitem'} />
+        <BridgeCard key={`${bridge.id}-${i}`} {...bridge} onNavigate={handleNavigate} role="listitem" />
       ))}
     </SimpleGrid>
   )

--- a/hivemq-edge/src/frontend/src/modules/Bridges/components/overview/BridgeCard.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Bridges/components/overview/BridgeCard.tsx
@@ -45,10 +45,10 @@ const BridgeCard: FC<BridgeCardProps> = ({ isLoading, onNavigate, role, ...props
   )
 
   return (
-    <Card overflow="hidden" aria-labelledby={'bridge-name'} role={role}>
+    <Card overflow="hidden" aria-labelledby="bridge-name" role={role}>
       <CardHeader>
-        <Skeleton isLoaded={!isLoading} display={'flex'}>
-          <Heading size="md" flex={1} m={'auto'} data-testid={'bridge-name'} id={'bridge-name'}>
+        <Skeleton isLoaded={!isLoading} display="flex">
+          <Heading size="md" flex={1} m="auto" data-testid="bridge-name" id="bridge-name">
             {props.id}
           </Heading>
           <Box>
@@ -71,7 +71,7 @@ const BridgeCard: FC<BridgeCardProps> = ({ isLoading, onNavigate, role, ...props
         </HStack>
       </CardBody>
       <CardFooter>
-        <Skeleton isLoaded={!isLoading} as={Flex} w={'100%'}>
+        <Skeleton isLoaded={!isLoading} as={Flex} w="100%">
           <Box flex={1}>
             <span
               style={{
@@ -85,12 +85,12 @@ const BridgeCard: FC<BridgeCardProps> = ({ isLoading, onNavigate, role, ...props
                 borderRadius: '100%',
               }}
             />
-            <Text as={'span'} mr={2}>
+            <Text as="span" mr={2}>
               {t('bridge.status.label')}
             </Text>
             <ConnectionStatusBadge status={status} />
           </Box>
-          <Flex justifyContent={'flex-end'} role={'toolbar'}>
+          <Flex justifyContent="flex-end" role="toolbar">
             <ConnectionController type={DeviceTypes.BRIDGE} id={props.id} status={props.status} />
           </Flex>
         </Skeleton>

--- a/hivemq-edge/src/frontend/src/modules/Bridges/components/overview/ConnectionSummary.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Bridges/components/overview/ConnectionSummary.tsx
@@ -14,13 +14,13 @@ const ConnectionSummary: FC<BridgeConnection> = ({ host, port, clientId, localSu
   const { t } = useTranslation()
 
   return (
-    <Chakra.dl display={'grid'} gridTemplateColumns={'repeat(2, minmax(0px, 1fr))'} columnGap={4} alignItems={'center'}>
+    <Chakra.dl display="grid" gridTemplateColumns="repeat(2, minmax(0px, 1fr))" columnGap={4} alignItems="center">
       <Chakra.dt>
         <VisuallyHidden>{t('bridge.connection.host')}</VisuallyHidden>
       </Chakra.dt>
-      <Chakra.dd gridColumn={'1/ span 2'}>
+      <Chakra.dd gridColumn="1/ span 2">
         <Tooltip label={host} hasArrow placement="top">
-          <Box overflow={'hidden'} textOverflow={'ellipsis'} fontWeight={'bold'}>
+          <Box overflow="hidden" textOverflow="ellipsis" fontWeight="bold">
             {formatHost(host, 20)}
           </Box>
         </Tooltip>

--- a/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/BridgeMainDrawer.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/BridgeMainDrawer.tsx
@@ -64,9 +64,9 @@ const BridgeMainDrawer: FC<BridgeMainDrawerProps> = ({
   return (
     <>
       <Drawer
-        variant={'hivemq'}
+        variant="hivemq"
         closeOnOverlayClick={false}
-        size={'lg'}
+        size="lg"
         isOpen={isOpen}
         placement="right"
         onClose={onClose}
@@ -74,7 +74,7 @@ const BridgeMainDrawer: FC<BridgeMainDrawerProps> = ({
         <DrawerOverlay />
         <DrawerContent aria-label={t('bridge.drawer.label') as string}>
           <DrawerCloseButton />
-          <DrawerHeader id={'bridge-form-header'} borderBottomWidth="1px">
+          <DrawerHeader id="bridge-form-header" borderBottomWidth="1px">
             {isNewBridge ? t('bridge.drawer.title.create') : t('bridge.drawer.title.update')}
           </DrawerHeader>
 
@@ -105,11 +105,11 @@ const BridgeMainDrawer: FC<BridgeMainDrawerProps> = ({
                       <TabPanels>
                         <TabPanel px={0}>
                           <Text fontSize={{ md: 'sm' }}>{t('bridge.subscription.local.info')}</Text>
-                          <SubscriptionsPanel form={form} type={'localSubscriptions'} />
+                          <SubscriptionsPanel form={form} type="localSubscriptions" />
                         </TabPanel>
                         <TabPanel px={0}>
                           <Text fontSize={{ md: 'sm' }}>{t('bridge.subscription.remote.info')}</Text>
-                          <SubscriptionsPanel form={form} type={'remoteSubscriptions'} />
+                          <SubscriptionsPanel form={form} type="remoteSubscriptions" />
                         </TabPanel>
                       </TabPanels>
                     </Tabs>
@@ -138,11 +138,11 @@ const BridgeMainDrawer: FC<BridgeMainDrawerProps> = ({
                 {t('bridge.action.delete')}
               </Button>
             )}
-            <Flex flexGrow={1} justifyContent={'flex-end'}>
+            <Flex flexGrow={1} justifyContent="flex-end">
               <Button
                 isDisabled={!form.formState.isValid}
                 isLoading={isSubmitting}
-                variant={'primary'}
+                variant="primary"
                 type="submit"
                 form="bridge-form"
               >

--- a/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/ConnectionPanel.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/ConnectionPanel.tsx
@@ -27,17 +27,17 @@ const ConnectionPanel: FC<BridgePanelType> = ({ form }) => {
   } = form
 
   return (
-    <Flex flexDirection={'column'} m={'auto'} mt={4} mb={4} gap={4}>
-      <FormControl variant={'hivemq'} flex={1} display={'flex'} gap={4} as={'fieldset'}>
+    <Flex flexDirection="column" m="auto" mt={4} mb={4} gap={4}>
+      <FormControl variant="hivemq" flex={1} display="flex" gap={4} as="fieldset">
         <FormControl isInvalid={!!errors.host} isRequired>
           <FormLabel htmlFor="host">{t('bridge.connection.host')}</FormLabel>
           <Input id="host" type="text" required {...register('host', getRulesForProperty($Bridge.properties.host))} />
           <FormErrorMessage>{errors.host && errors.host.message}</FormErrorMessage>
         </FormControl>
 
-        <FormControl isInvalid={!!errors.port} isRequired w={'unset'}>
+        <FormControl isInvalid={!!errors.port} isRequired w="unset">
           <FormLabel htmlFor="port">{t('bridge.connection.port')}</FormLabel>
-          <NumberInput allowMouseWheel focusInputOnChange w={'100px'} id="port" step={1} min={1}>
+          <NumberInput allowMouseWheel focusInputOnChange w="100px" id="port" step={1} min={1}>
             <NumberInputField {...register('port', getRulesForProperty($Bridge.properties.port))} />
             <NumberInputStepper>
               <NumberIncrementStepper />
@@ -48,7 +48,7 @@ const ConnectionPanel: FC<BridgePanelType> = ({ form }) => {
         </FormControl>
       </FormControl>
 
-      <FormControl variant={'hivemq'} flexGrow={1} display={'flex'} gap={4} as={'fieldset'}>
+      <FormControl variant="hivemq" flexGrow={1} display="flex" gap={4} as="fieldset">
         <Box flexGrow={1}>
           <FormControl isInvalid={!!errors.username}>
             <FormLabel htmlFor="username">{t('bridge.connection.username')}</FormLabel>

--- a/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/CustomUserProperties.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/CustomUserProperties.tsx
@@ -28,8 +28,8 @@ const CustomUserProperties: FC<CustomUserPropertiesProps> = ({ form, subscriptio
           {/*<TableCaption placement={'top'}>{t('bridge.subscription.type', { context: type })}</TableCaption>*/}
           <Thead>
             <Tr>
-              <Th w={'50%'}>{t('bridge.subscription.customUserProperties.headers.key')}</Th>
-              <Th w={'50%'}>{t('bridge.subscription.customUserProperties.headers.value')}</Th>
+              <Th w="50%">{t('bridge.subscription.customUserProperties.headers.key')}</Th>
+              <Th w="50%">{t('bridge.subscription.customUserProperties.headers.value')}</Th>
               <Th>{t('bridge.subscription.customUserProperties.headers.action')}</Th>
             </Tr>
           </Thead>
@@ -50,7 +50,7 @@ const CustomUserProperties: FC<CustomUserPropertiesProps> = ({ form, subscriptio
                           {...field}
                           id={`${type}.${subscriptionIndex}.customUserProperties.${index}.key`}
                           type="text"
-                          size={'sm'}
+                          size="sm"
                           placeholder={t('bridge.options.id.placeholder') as string}
                         />
                       )}
@@ -70,7 +70,7 @@ const CustomUserProperties: FC<CustomUserPropertiesProps> = ({ form, subscriptio
                           {...field}
                           id={`${type}.${subscriptionIndex}.customUserProperties.${index}.value`}
                           type="text"
-                          size={'sm'}
+                          size="sm"
                           placeholder={t('bridge.options.id.placeholder') as string}
                         />
                       )}
@@ -81,7 +81,7 @@ const CustomUserProperties: FC<CustomUserPropertiesProps> = ({ form, subscriptio
                     <ButtonGroup size="sm" isAttached variant="outline">
                       <IconButton
                         variant="outline"
-                        size={'xs'}
+                        size="xs"
                         aria-label={t('bridge.subscription.customUserProperties.actions.delete')}
                         icon={<MdRemove />}
                         onClick={() => remove(index)}
@@ -96,7 +96,7 @@ const CustomUserProperties: FC<CustomUserPropertiesProps> = ({ form, subscriptio
                 <ButtonGroup size="sm" isAttached variant="outline">
                   <IconButton
                     variant="outline"
-                    size={'xs'}
+                    size="xs"
                     aria-label={t('bridge.subscription.customUserProperties.actions.add')}
                     icon={<AddIcon />}
                     onClick={() => append({ key: '', value: '' })}

--- a/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/NamePanel.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/NamePanel.tsx
@@ -17,14 +17,14 @@ const NamePanel: FC<BridgePanelType> = ({ form, isNewBridge = false }) => {
   const getRulesForProperty = useValidationRules()
 
   return (
-    <FormControl as={'fieldset'} variant={'hivemq'} isInvalid={!!validationErrors.id} isRequired={isNewBridge}>
+    <FormControl as="fieldset" variant="hivemq" isInvalid={!!validationErrors.id} isRequired={isNewBridge}>
       <FormLabel htmlFor="name">{t('bridge.options.id.label')}</FormLabel>
       <Input
         isDisabled={!isNewBridge}
         autoFocus
         id="name"
         type="text"
-        autoComplete={'name'}
+        autoComplete="name"
         placeholder={t('bridge.options.id.placeholder') as string}
         {...register('id', {
           ...getRulesForProperty($Bridge.properties.id),

--- a/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/OptionsPanel.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/OptionsPanel.tsx
@@ -26,7 +26,7 @@ const OptionsPanel: FC<BridgePanelType> = ({ form }) => {
   const getRulesForProperty = useValidationRules()
 
   return (
-    <FormControl variant={'hivemq'} flexGrow={1} display={'flex'} flexDirection={'column'} gap={4} as={'fieldset'}>
+    <FormControl variant="hivemq" flexGrow={1} display="flex" flexDirection="column" gap={4} as="fieldset">
       <FormControl isInvalid={!!errors.cleanStart}>
         <Checkbox defaultChecked {...register('cleanStart')}>
           {t('bridge.options.cleanStart.label')}

--- a/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/PersistencePanel.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/PersistencePanel.spec.cy.tsx
@@ -26,7 +26,7 @@ const TestingComponent: FC<TestingComponentProps> = ({ onSubmit, defaultValues }
       <form id="bridge-form" onSubmit={form.handleSubmit(onSubmit)}>
         <PersistencePanel form={form} hasPersistence={MOCK_CAPABILITY_PERSISTENCE} />
       </form>
-      <Button variant={'primary'} type={'submit'} form="bridge-form" data-testid={'form-submit'} mt={8}>
+      <Button variant="primary" type="submit" form="bridge-form" data-testid="form-submit" mt={8}>
         Submit
       </Button>
     </div>

--- a/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/PersistencePanel.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/PersistencePanel.tsx
@@ -17,7 +17,7 @@ const PersistencePanel: FC<PersistencePanelType> = ({ form }) => {
   } = form
 
   return (
-    <FormControl variant={'hivemq'} flexGrow={1} display={'flex'} flexDirection={'column'} gap={4} as={'fieldset'}>
+    <FormControl variant="hivemq" flexGrow={1} display="flex" flexDirection="column" gap={4} as="fieldset">
       <FormControl isInvalid={!!errors.persist}>
         <Checkbox {...register('persist')}>{t('bridge.persistence.persist.label')}</Checkbox>
         <FormHelperText>{t('bridge.persistence.persist.helper')}</FormHelperText>

--- a/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/SecurityPanel.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/SecurityPanel.spec.cy.tsx
@@ -23,7 +23,7 @@ const TestingComponent: FC<TestingComponentProps> = ({ onSubmit, defaultValues }
       <form id="bridge-form" onSubmit={form.handleSubmit(onSubmit)}>
         <SecurityPanel form={form} />
       </form>
-      <Button variant={'primary'} type={'submit'} form="bridge-form" data-testid={'form-submit'} mt={8}>
+      <Button variant="primary" type="submit" form="bridge-form" data-testid="form-submit" mt={8}>
         Submit
       </Button>
     </div>

--- a/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/SecurityPanel.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/SecurityPanel.tsx
@@ -93,9 +93,7 @@ const SecurityPanel: FC<BridgePanelType> = ({ form }) => {
 
             <HStack>
               <FormControl isInvalid={!!errors.tlsConfiguration?.keystorePath}>
-                <FormLabel htmlFor="tlsConfiguration.keystorePath">
-                  {t('bridge.security.keystorePath.label')}
-                </FormLabel>
+                <FormLabel htmlFor="tlsConfiguration.keystorePath">{t('bridge.security.keystorePath.label')}</FormLabel>
                 <Controller
                   name="tlsConfiguration.keystorePath"
                   control={form.control}

--- a/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/SecurityPanel.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/SecurityPanel.tsx
@@ -21,11 +21,11 @@ const SecurityPanel: FC<BridgePanelType> = ({ form }) => {
   const isTlsEnabled = useWatch({ name: 'tlsConfiguration.enabled', control: form.control })
 
   return (
-    <FormControl variant={'hivemq'} flexGrow={1} display={'flex'} flexDirection={'column'} gap={4} as={'fieldset'}>
+    <FormControl variant="hivemq" flexGrow={1} display="flex" flexDirection="column" gap={4} as="fieldset">
       <FormControl>
-        <FormLabel htmlFor={'tlsConfiguration.enabled'}>{t('bridge.security.enabled.label')}</FormLabel>
+        <FormLabel htmlFor="tlsConfiguration.enabled">{t('bridge.security.enabled.label')}</FormLabel>
         <Switch
-          id={'tlsConfiguration.enabled'}
+          id="tlsConfiguration.enabled"
           {...register('tlsConfiguration.enabled', {
             ...getRulesForProperty($TlsConfiguration.properties.enabled),
           })}
@@ -36,22 +36,22 @@ const SecurityPanel: FC<BridgePanelType> = ({ form }) => {
       {isTlsEnabled && (
         <>
           <FormControl isInvalid={!!errors.tlsConfiguration?.cipherSuites}>
-            <FormLabel htmlFor={'tlsConfiguration.cipherSuites'}>{t('bridge.security.cipherSuites.label')}</FormLabel>
+            <FormLabel htmlFor="tlsConfiguration.cipherSuites">{t('bridge.security.cipherSuites.label')}</FormLabel>
             <Controller
-              name={'tlsConfiguration.cipherSuites'}
+              name="tlsConfiguration.cipherSuites"
               control={form.control}
               render={({ field }) => (
                 <Select
-                  size={'sm'}
+                  size="sm"
                   {...field}
-                  inputId={'tlsConfiguration.cipherSuites'}
+                  inputId="tlsConfiguration.cipherSuites"
                   // @ts-ignore TODO[NVL] Need to fix the Typescript definition
                   // defaultValue={}
                   // @ts-ignore
                   options={CYPHER_SUITES.map((e) => ({ label: e, value: e }))}
                   // menuIsOpen={false}
                   isClearable={true}
-                  placeholder={'add topic'}
+                  placeholder="add topic"
                   isMulti={true}
                   components={{
                     DropdownIndicator: null,
@@ -63,15 +63,15 @@ const SecurityPanel: FC<BridgePanelType> = ({ form }) => {
           </FormControl>
 
           <FormControl isInvalid={!!errors.tlsConfiguration?.protocols}>
-            <FormLabel htmlFor={'tlsConfiguration.protocols'}>{t('bridge.security.protocols.label')}</FormLabel>
+            <FormLabel htmlFor="tlsConfiguration.protocols">{t('bridge.security.protocols.label')}</FormLabel>
             <Controller
-              name={'tlsConfiguration.protocols'}
+              name="tlsConfiguration.protocols"
               control={form.control}
               render={({ field }) => (
                 <Select
-                  size={'sm'}
+                  size="sm"
                   {...field}
-                  inputId={'tlsConfiguration.protocols'}
+                  inputId="tlsConfiguration.protocols"
                   // @ts-ignore TODO[NVL] Need to fix the Typescript definition
                   // @ts-ignore
                   options={TLS_PROTOCOLS.map((e) => ({ label: e, value: e }))}
@@ -93,32 +93,32 @@ const SecurityPanel: FC<BridgePanelType> = ({ form }) => {
 
             <HStack>
               <FormControl isInvalid={!!errors.tlsConfiguration?.keystorePath}>
-                <FormLabel htmlFor={'tlsConfiguration.keystorePath'}>
+                <FormLabel htmlFor="tlsConfiguration.keystorePath">
                   {t('bridge.security.keystorePath.label')}
                 </FormLabel>
                 <Controller
-                  name={'tlsConfiguration.keystorePath'}
+                  name="tlsConfiguration.keystorePath"
                   control={form.control}
                   render={({ field }) => {
                     const { value, ...rest } = field
-                    return <Input id={'tlsConfiguration.keystorePath'} {...rest} value={value as string} />
+                    return <Input id="tlsConfiguration.keystorePath" {...rest} value={value as string} />
                   }}
                 />
                 <FormHelperText>{t('bridge.security.keystorePath.helper')}</FormHelperText>
               </FormControl>
 
               <FormControl isInvalid={!!errors.tlsConfiguration?.keystorePassword}>
-                <FormLabel htmlFor={'tlsConfiguration.keystorePassword'}>
+                <FormLabel htmlFor="tlsConfiguration.keystorePassword">
                   {t('bridge.security.keystorePassword.label')}
                 </FormLabel>
                 <Controller
-                  name={'tlsConfiguration.keystorePassword'}
+                  name="tlsConfiguration.keystorePassword"
                   control={form.control}
                   render={({ field }) => (
                     <Input
-                      autoComplete={'current-password'}
-                      type={'text'}
-                      id={'tlsConfiguration.keystorePassword'}
+                      autoComplete="current-password"
+                      type="text"
+                      id="tlsConfiguration.keystorePassword"
                       {...field}
                     />
                   )}
@@ -133,32 +133,32 @@ const SecurityPanel: FC<BridgePanelType> = ({ form }) => {
 
             <HStack>
               <FormControl isInvalid={!!errors.tlsConfiguration?.truststorePath}>
-                <FormLabel htmlFor={'tlsConfiguration.truststorePath'}>
+                <FormLabel htmlFor="tlsConfiguration.truststorePath">
                   {t('bridge.security.truststorePath.label')}
                 </FormLabel>
                 <Controller
-                  name={'tlsConfiguration.truststorePath'}
+                  name="tlsConfiguration.truststorePath"
                   control={form.control}
                   render={({ field }) => {
                     const { value, ...rest } = field
-                    return <Input id={'tlsConfiguration.truststorePath'} {...rest} value={value as string} />
+                    return <Input id="tlsConfiguration.truststorePath" {...rest} value={value as string} />
                   }}
                 />
                 <FormHelperText>{t('bridge.security.truststorePath.helper')}</FormHelperText>
               </FormControl>
 
               <FormControl isInvalid={!!errors.tlsConfiguration?.truststorePassword}>
-                <FormLabel htmlFor={'tlsConfiguration.truststorePassword'}>
+                <FormLabel htmlFor="tlsConfiguration.truststorePassword">
                   {t('bridge.security.truststorePassword.label')}
                 </FormLabel>
                 <Controller
-                  name={'tlsConfiguration.truststorePassword'}
+                  name="tlsConfiguration.truststorePassword"
                   control={form.control}
                   render={({ field }) => (
                     <Input
-                      autoComplete={'current-password'}
-                      type={'text'}
-                      id={'tlsConfiguration.truststorePassword'}
+                      autoComplete="current-password"
+                      type="text"
+                      id="tlsConfiguration.truststorePassword"
                       {...field}
                     />
                   )}
@@ -169,17 +169,17 @@ const SecurityPanel: FC<BridgePanelType> = ({ form }) => {
           </FormControl>
 
           <FormControl isInvalid={!!errors.tlsConfiguration?.privateKeyPassword}>
-            <FormLabel htmlFor={'tlsConfiguration.privateKeyPassword'}>
+            <FormLabel htmlFor="tlsConfiguration.privateKeyPassword">
               {t('bridge.security.privateKeyPassword.label')}
             </FormLabel>
             <Controller
-              name={'tlsConfiguration.privateKeyPassword'}
+              name="tlsConfiguration.privateKeyPassword"
               control={form.control}
               render={({ field }) => (
                 <Input
-                  type={'text'}
-                  autoComplete={'current-password'}
-                  id={'tlsConfiguration.privateKeyPassword'}
+                  type="text"
+                  autoComplete="current-password"
+                  id="tlsConfiguration.privateKeyPassword"
                   {...field}
                 />
               )}

--- a/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/SubscriptionsPanel.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/SubscriptionsPanel.spec.cy.tsx
@@ -29,7 +29,7 @@ const TestingComponent: FC<TestingComponentProps> = ({ onSubmit, defaultValues, 
       <form id="bridge-form" onSubmit={form.handleSubmit(onSubmit)}>
         <SubscriptionsPanel form={form} type={type} />
       </form>
-      <Button variant={'primary'} type={'submit'} form="bridge-form" data-testid={'form-submit'} mt={8}>
+      <Button variant="primary" type="submit" form="bridge-form" data-testid="form-submit" mt={8}>
         Submit
       </Button>
     </div>
@@ -85,7 +85,7 @@ describe('SubscriptionsPanel', () => {
         <TestingComponent
           onSubmit={cy.stub}
           defaultValues={{ ...mockBridge, persist: true }}
-          type={'localSubscriptions'}
+          type="localSubscriptions"
         />
       )
 
@@ -101,7 +101,7 @@ describe('SubscriptionsPanel', () => {
         <TestingComponent
           onSubmit={cy.stub}
           defaultValues={{ ...mockBridge, persist: false }}
-          type={'localSubscriptions'}
+          type="localSubscriptions"
         />
       )
 
@@ -117,7 +117,7 @@ describe('SubscriptionsPanel', () => {
         <TestingComponent
           onSubmit={cy.stub}
           defaultValues={{ ...mockBridge, persist: false }}
-          type={'localSubscriptions'}
+          type="localSubscriptions"
         />
       )
 

--- a/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/SubscriptionsPanel.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/SubscriptionsPanel.tsx
@@ -58,15 +58,15 @@ const SubscriptionsPanel: FC<BridgeSubscriptionsProps> = ({ form, type }) => {
 
   return (
     <>
-      <VStack spacing={4} align="stretch" mt={4} role={'list'}>
+      <VStack spacing={4} align="stretch" mt={4} role="list">
         {fields.map((field, index) => {
           const maxQoS = form.watch(`${type}.${index}.maxQoS`)
           const isQoSValidForPersistence = maxQoS.toString() === '1' || maxQoS.toString() == '2'
           return (
-            <Card shadow="xs" flexDirection={'column'} key={field.id} role={'listitem'}>
+            <Card shadow="xs" flexDirection="column" key={field.id} role="listitem">
               <HStack>
                 <CardBody>
-                  <Flex gap={4} flexDirection={'column'}>
+                  <Flex gap={4} flexDirection="column">
                     <FormControl
                       data-testid={`${type}.${index}.filters`}
                       isInvalid={!!errors[type]?.[index]?.filters}
@@ -140,7 +140,7 @@ const SubscriptionsPanel: FC<BridgeSubscriptionsProps> = ({ form, type }) => {
                     </FormControl>
                   </Flex>
                 </CardBody>
-                <CardHeader alignSelf={'flex-start'}>
+                <CardHeader alignSelf="flex-start">
                   <ButtonGroup size="sm" isAttached variant="outline">
                     <IconButton
                       onClick={() => remove(index)}
@@ -229,7 +229,7 @@ const SubscriptionsPanel: FC<BridgeSubscriptionsProps> = ({ form, type }) => {
                                   // options={[{ value: 'ddfd', label: 'fgg' }]}
                                   // menuIsOpen={false}
                                   isClearable={true}
-                                  placeholder={'add topic'}
+                                  placeholder="add topic"
                                   isMulti={true}
                                   components={{
                                     DropdownIndicator: null,
@@ -265,7 +265,7 @@ const SubscriptionsPanel: FC<BridgeSubscriptionsProps> = ({ form, type }) => {
       </VStack>
       <Box mt={4}>
         <IconButton
-          data-testid={'bridge-subscription-add'}
+          data-testid="bridge-subscription-add"
           isDisabled={!!errors[type]}
           aria-label={t('bridge.subscription.add')}
           icon={<AddIcon />}

--- a/hivemq-edge/src/frontend/src/modules/Dashboard/Dashboard.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Dashboard/Dashboard.tsx
@@ -29,9 +29,9 @@ const Dashboard: FC = () => {
   return (
     <>
       <SkipNavLink>{t('translation:action.skipNavLink')}</SkipNavLink>
-      <Flex flexDirection="row" h={'100vh'} overflow={'hidden'}>
+      <Flex flexDirection="row" h="100vh" overflow="hidden">
         <SidePanel />
-        <Flex as={'main'} flexGrow={1} overflow={'auto'}>
+        <Flex as="main" flexGrow={1} overflow="auto">
           <SkipNavContent />
           <Suspense
             fallback={

--- a/hivemq-edge/src/frontend/src/modules/Dashboard/components/NavLink.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Dashboard/components/NavLink.tsx
@@ -13,14 +13,14 @@ export const NavLink: FC<{ link: MainNavLinkType }> = ({ link }) => {
   // TODO[NVL] Styling should be done in a proper theme's variant
   return (
     <Button
-      justifyContent={'flex-start'}
+      justifyContent="flex-start"
       variant={active ? 'solid' : 'ghost'}
       size="sm"
-      w={'100%'}
+      w="100%"
       as={isDisabled ? undefined : RouterLink}
       to={href}
       target={isExternal ? '_blank' : undefined}
-      h={'40px'}
+      h="40px"
       borderLeftColor={active ? '#FFC000' : '#f5f5f5'}
       borderLeftWidth={active ? 8 : 0}
       borderRadius={0}
@@ -29,7 +29,7 @@ export const NavLink: FC<{ link: MainNavLinkType }> = ({ link }) => {
         <Center w="6" h="6">
           {icon}
         </Center>
-        <Text as={'span'}>{label}</Text>
+        <Text as="span">{label}</Text>
       </HStack>
     </Button>
   )

--- a/hivemq-edge/src/frontend/src/modules/Dashboard/components/NavLinksBlock.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Dashboard/components/NavLinksBlock.tsx
@@ -6,8 +6,8 @@ import { NavLinksBlockType } from '../types.ts'
 
 const NavLinksBlock: FC<NavLinksBlockType> = ({ title, items }) => {
   return (
-    <Flex flexDirection={'column'} m={0}>
-      <Text m={4} my={0} fontWeight={'bold'}>
+    <Flex flexDirection="column" m={0}>
+      <Text m={4} my={0} fontWeight="bold">
         {title}
       </Text>
       <Box pb={2} pt={2}>

--- a/hivemq-edge/src/frontend/src/modules/Dashboard/components/SidePanel.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Dashboard/components/SidePanel.tsx
@@ -35,13 +35,13 @@ const SidePanel: FC = () => {
         }}
         flexDirection="column"
         w={256}
-        h={'100%'}
-        overflow={'auto'}
+        h="100%"
+        overflow="auto"
       >
         <VStack p={4} mb={4}>
           <Image src={colorMode === 'light' ? logo1 : logo2} alt={t('branding.company') as string} boxSize="100px" />
           {configuration && (
-            <Text data-testid="edge-release" fontSize="xs" textAlign={'center'}>
+            <Text data-testid="edge-release" fontSize="xs" textAlign="center">
               [ {configuration.environment?.properties?.version} ]
             </Text>
           )}
@@ -58,11 +58,11 @@ const SidePanel: FC = () => {
         </Flex>
 
         <Flex flexDirection="column" flex={1}></Flex>
-        <Flex p={4} flexDirection={'row'} alignItems={'center'} justifyContent={'space-between'} ml={2}>
+        <Flex p={4} flexDirection="row" alignItems="center" justifyContent="space-between" ml={2}>
           <Button leftIcon={<FiLogOut />} variant="link" onClick={() => auth.logout(() => navigate('/login'))}>
             {t('translation:action.logout')}
           </Button>
-          <SwitchModeButton size={'sm'} />
+          <SwitchModeButton size="sm" />
         </Flex>
       </Flex>
     </nav>

--- a/hivemq-edge/src/frontend/src/modules/Dashboard/hooks/useGetNavItems.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Dashboard/hooks/useGetNavItems.tsx
@@ -40,7 +40,7 @@ const useGetNavItems = (): { data: NavLinksBlockType[]; isSuccess: boolean } => 
         },
         ...workspaceLink,
         {
-          icon: <Icon as={PiBridgeThin} fontSize={'20px'} />,
+          icon: <Icon as={PiBridgeThin} fontSize="20px" />,
           href: '/mqtt-bridges',
           label: t('translation:navigation.gateway.routes.bridges') as string,
         },
@@ -71,7 +71,7 @@ const useGetNavItems = (): { data: NavLinksBlockType[]; isSuccess: boolean } => 
           label: t('translation:navigation.extensions.routes.namespace') as string,
         },
         {
-          icon: <Icon as={MdPolicy} fontSize={'16px'} />,
+          icon: <Icon as={MdPolicy} fontSize="16px" />,
           href: '/datahub',
           label: t('datahub:navigation.mainPage') as string,
         },

--- a/hivemq-edge/src/frontend/src/modules/EventLog/components/SeverityBadge.tsx
+++ b/hivemq-edge/src/frontend/src/modules/EventLog/components/SeverityBadge.tsx
@@ -24,7 +24,7 @@ const SeverityBadge: FC<SeverityBadgeProps> = ({ event, ...alertProps }) => {
   }
 
   return (
-    <Alert status={status} {...alertProps} addRole={false} px={2} py={'2px'} borderRadius={'15px'}>
+    <Alert status={status} {...alertProps} addRole={false} px={2} py="2px" borderRadius="15px">
       <AlertIcon />
       {event.severity}
     </Alert>

--- a/hivemq-edge/src/frontend/src/modules/EventLog/components/SourceLink.tsx
+++ b/hivemq-edge/src/frontend/src/modules/EventLog/components/SourceLink.tsx
@@ -31,7 +31,7 @@ const LinkWrapper: Record<TypeIdentifier.type, LinkWrapperProps> = {
     Icon: <Icon as={PiPlugsConnectedFill} mr={2} />,
   },
   [TypeIdentifier.type.BRIDGE]: {
-    Icon: <Icon as={PiBridgeThin} fontSize={'20px'} mr={2} />,
+    Icon: <Icon as={PiBridgeThin} fontSize="20px" mr={2} />,
     To: (id: string) => `/mqtt-bridges/${id}`,
   },
   [TypeIdentifier.type.EVENT]: {
@@ -47,7 +47,7 @@ const SourceLink: FC<SourceLinkProps> = ({ source, type }) => {
 
   if (!SourceType?.To)
     return (
-      <Box whiteSpace={'nowrap'} display={'inline-flex'}>
+      <Box whiteSpace="nowrap" display="inline-flex">
         {source?.identifier}
       </Box>
     )
@@ -57,8 +57,8 @@ const SourceLink: FC<SourceLinkProps> = ({ source, type }) => {
       as={ReactRouterLink}
       to={source?.identifier && SourceType.To?.(source.identifier)}
       state={type?.identifier && SourceType.State?.(type?.identifier)}
-      whiteSpace={'nowrap'}
-      display={'inline-flex'}
+      whiteSpace="nowrap"
+      display="inline-flex"
     >
       {source?.type && SourceType.Icon}
       {source?.identifier}

--- a/hivemq-edge/src/frontend/src/modules/EventLog/components/panel/EventDrawer.tsx
+++ b/hivemq-edge/src/frontend/src/modules/EventLog/components/panel/EventDrawer.tsx
@@ -44,14 +44,7 @@ const EventDrawer: FC<BridgeMainDrawerProps> = ({ event, isOpen, onClose }) => {
 
   return (
     <>
-      <Drawer
-        variant="hivemq"
-        closeOnOverlayClick={true}
-        size="lg"
-        isOpen={isOpen}
-        placement="right"
-        onClose={onClose}
-      >
+      <Drawer variant="hivemq" closeOnOverlayClick={true} size="lg" isOpen={isOpen} placement="right" onClose={onClose}>
         <DrawerContent aria-label={t('bridge.drawer.label') as string}>
           <DrawerCloseButton />
           <DrawerHeader id="bridge-form-header">{t('eventLog.panel.title')}</DrawerHeader>
@@ -99,14 +92,7 @@ const EventDrawer: FC<BridgeMainDrawerProps> = ({ event, isOpen, onClose }) => {
                     </Badge>
                   </CardHeader>
                   <CardBody pt={0}>
-                    <Code
-                      w="100%"
-                      p={2}
-                      whiteSpace="pre-wrap"
-                      overflow="auto"
-                      sx={{ textWrap: 'nowrap' }}
-                      maxH={400}
-                    >
+                    <Code w="100%" p={2} whiteSpace="pre-wrap" overflow="auto" sx={{ textWrap: 'nowrap' }} maxH={400}>
                       {JSONFormat && JSONFormat}
                       {XMLFormat && XMLFormat}
                       {!isJSON && !isXML && event.payload?.content}

--- a/hivemq-edge/src/frontend/src/modules/EventLog/components/panel/EventDrawer.tsx
+++ b/hivemq-edge/src/frontend/src/modules/EventLog/components/panel/EventDrawer.tsx
@@ -45,54 +45,54 @@ const EventDrawer: FC<BridgeMainDrawerProps> = ({ event, isOpen, onClose }) => {
   return (
     <>
       <Drawer
-        variant={'hivemq'}
+        variant="hivemq"
         closeOnOverlayClick={true}
-        size={'lg'}
+        size="lg"
         isOpen={isOpen}
         placement="right"
         onClose={onClose}
       >
         <DrawerContent aria-label={t('bridge.drawer.label') as string}>
           <DrawerCloseButton />
-          <DrawerHeader id={'bridge-form-header'}>{t('eventLog.panel.title')}</DrawerHeader>
+          <DrawerHeader id="bridge-form-header">{t('eventLog.panel.title')}</DrawerHeader>
 
           <DrawerBody>
             <VStack gap={2}>
-              <Card w={'100%'}>
+              <Card w="100%">
                 <CardHeader>
                   <SeverityBadge event={event} />
                 </CardHeader>
                 <CardBody>
                   <Grid templateColumns="repeat(2, 1fr)" gap={6}>
-                    <GridItem data-testid={'event-title-created'}>
+                    <GridItem data-testid="event-title-created">
                       <Text>{t('eventLog.table.header.created')}</Text>
                     </GridItem>
-                    <GridItem data-testid={'event-value-created'}>
+                    <GridItem data-testid="event-value-created">
                       <DateTimeRenderer date={DateTime.fromISO(event?.created || '')} />
                     </GridItem>
-                    <GridItem data-testid={'event-title-source'}>
+                    <GridItem data-testid="event-title-source">
                       <Text>{t('eventLog.table.header.source')}</Text>
                     </GridItem>
-                    <GridItem data-testid={'event-value-source'}>
+                    <GridItem data-testid="event-value-source">
                       <SourceLink source={event?.source} />
                     </GridItem>
-                    <GridItem data-testid={'event-title-associatedObject'}>
+                    <GridItem data-testid="event-title-associatedObject">
                       <Text>{t('eventLog.table.header.associatedObject')}</Text>
                     </GridItem>
-                    <GridItem data-testid={'event-value-associatedObject'}>
+                    <GridItem data-testid="event-value-associatedObject">
                       <SourceLink source={event?.associatedObject} />
                     </GridItem>
                   </Grid>
                 </CardBody>
               </Card>
 
-              <Card w={'100%'}>
-                <CardBody data-testid={'event-value-message'}>{event.message}</CardBody>
+              <Card w="100%">
+                <CardBody data-testid="event-value-message">{event.message}</CardBody>
               </Card>
 
               {event.payload && (
-                <Card w={'100%'}>
-                  <CardHeader data-testid={'event-title-payload'}>
+                <Card w="100%">
+                  <CardHeader data-testid="event-title-payload">
                     {t('eventLog.table.header.payload')}
                     <Badge variant="outline" mx={2}>
                       {event.payload?.contentType}
@@ -100,10 +100,10 @@ const EventDrawer: FC<BridgeMainDrawerProps> = ({ event, isOpen, onClose }) => {
                   </CardHeader>
                   <CardBody pt={0}>
                     <Code
-                      w={'100%'}
+                      w="100%"
                       p={2}
-                      whiteSpace={'pre-wrap'}
-                      overflow={'auto'}
+                      whiteSpace="pre-wrap"
+                      overflow="auto"
                       sx={{ textWrap: 'nowrap' }}
                       maxH={400}
                     >

--- a/hivemq-edge/src/frontend/src/modules/EventLog/components/table/EventLogTable.tsx
+++ b/hivemq-edge/src/frontend/src/modules/EventLog/components/table/EventLogTable.tsx
@@ -52,7 +52,7 @@ const EventLogTable: FC<EventLogTableProps> = ({ onOpen, globalSourceFilter, var
             <Skeleton isLoaded={!isLoading}>
               {info.row.original.payload ? (
                 <IconButton
-                  size={'sm'}
+                  size="sm"
                   mr={2}
                   onClick={() => onOpen?.(info.row.original)}
                   aria-label={t('eventLog.table.cta.open')}
@@ -68,7 +68,7 @@ const EventLogTable: FC<EventLogTableProps> = ({ onOpen, globalSourceFilter, var
         sortType: 'datetime',
         accessorFn: (row) => DateTime.fromISO(row.created).toMillis(),
         cell: (info) => (
-          <Skeleton isLoaded={!isLoading} whiteSpace={'nowrap'}>
+          <Skeleton isLoaded={!isLoading} whiteSpace="nowrap">
             <DateTimeRenderer date={DateTime.fromMillis(info.getValue() as number)} isApprox />
           </Skeleton>
         ),
@@ -100,7 +100,7 @@ const EventLogTable: FC<EventLogTableProps> = ({ onOpen, globalSourceFilter, var
         enableColumnFilter: false,
         cell: (info) => {
           return (
-            <Skeleton isLoaded={!isLoading} overflow={'hidden'}>
+            <Skeleton isLoaded={!isLoading} overflow="hidden">
               <Text>{info.getValue() as string}</Text>
             </Skeleton>
           )
@@ -111,7 +111,7 @@ const EventLogTable: FC<EventLogTableProps> = ({ onOpen, globalSourceFilter, var
 
   if (error) {
     return (
-      <Box mt={'20%'} mx={'20%'} alignItems={'center'}>
+      <Box mt="20%" mx="20%" alignItems="center">
         <ErrorMessage
           type={error?.message}
           message={(error?.body as ProblemDetails)?.title || (t('eventLog.error.loading') as string)}
@@ -126,12 +126,12 @@ const EventLogTable: FC<EventLogTableProps> = ({ onOpen, globalSourceFilter, var
   return (
     <>
       {variant === 'full' && (
-        <Flex justifyContent={'flex-end'}>
+        <Flex justifyContent="flex-end">
           <Button
             isLoading={isFetching}
             loadingText={t('eventLog.table.cta.refetch')}
-            variant={'outline'}
-            size={'sm'}
+            variant="outline"
+            size="sm"
             leftIcon={<Icon as={BiRefresh} fontSize={20} />}
             onClick={() => refetch()}
           >

--- a/hivemq-edge/src/frontend/src/modules/Login/LoginPage.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Login/LoginPage.tsx
@@ -20,23 +20,23 @@ const LoginPage: FC = () => {
 
   return (
     <main>
-      <Stack minH={'100vh'} direction={{ base: 'column', md: 'row' }}>
+      <Stack minH="100vh" direction={{ base: 'column', md: 'row' }}>
         <Flex
           flex={{ base: '0', md: '3' }}
           bg={bgColour}
-          align={'center'}
-          justify={'center'}
+          align="center"
+          justify="center"
           backgroundImage={`url(${bgImage})`}
         >
           <EdgeAside />
         </Flex>
-        <Flex p={8} flex={2} align={'center'} justify={'center'} flexDirection={'column'}>
-          <Box flex={1} width={'100%'} display={{ base: 'none', md: 'inherit' }}>
+        <Flex p={8} flex={2} align="center" justify="center" flexDirection="column">
+          <Box flex={1} width="100%" display={{ base: 'none', md: 'inherit' }}>
             <Image
               src={colorMode === 'light' ? logoLight : logoDark}
               alt={t('branding.appName') as string}
-              boxSize={'50px'}
-              w={'initial'}
+              boxSize="50px"
+              w="initial"
             />
           </Box>
           <div>

--- a/hivemq-edge/src/frontend/src/modules/Login/components/EdgeAside.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Login/components/EdgeAside.tsx
@@ -17,7 +17,7 @@ const EdgeAside: FC = () => {
           <Heading
             textAlign={{ base: 'center', md: 'left' }}
             pt={{ base: '0', md: '20' }}
-            color={'white'}
+            color="white"
             lineHeight={1.1}
             display={{ base: 'none', md: 'inherit' }}
             fontSize={{ md: '6xl', lg: '7xl' }}
@@ -36,7 +36,7 @@ const EdgeAside: FC = () => {
             <Heading
               textAlign={{ base: 'center', md: 'left' }}
               pt={{ base: '0', md: '20' }}
-              color={'white'}
+              color="white"
               lineHeight={1.1}
               fontSize={{ base: 'md', sm: '2xl', md: '4xl', lg: '5xl' }}
             >
@@ -44,7 +44,7 @@ const EdgeAside: FC = () => {
             </Heading>
             <Text
               fontSize={{ base: 'md', sm: '2xl', md: '4xl' }}
-              color={'white'}
+              color="white"
               textAlign={{ base: 'center', md: 'left' }}
             >
               {t('login.aside.subheader')}
@@ -52,7 +52,7 @@ const EdgeAside: FC = () => {
           </Box>
           <Text
             fontSize={{ base: 'sm', md: 'lg' }}
-            color={'white'}
+            color="white"
             textAlign={{ base: 'center', md: 'left' }}
             mt={{ base: 0, md: 10 }}
           >

--- a/hivemq-edge/src/frontend/src/modules/Login/components/Login.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Login/components/Login.tsx
@@ -102,13 +102,13 @@ const Login: FC<{ first?: FirstUseInformation; preLoadError?: ApiError | null }>
         )}
       </Box>
 
-      <Box width={'100%'} maxWidth={'450px'} p={3}>
-        <Heading as={'h1'} mb={6}>
+      <Box width="100%" maxWidth="450px" p={3}>
+        <Heading as="h1" mb={6}>
           {t('translation:login.title')}
         </Heading>
       </Box>
 
-      <Box p={4} width={'100%'} maxWidth={'450px'}>
+      <Box p={4} width="100%" maxWidth="450px">
         <form onSubmit={handleSubmit(onSubmit)}>
           <FormControl isInvalid={!!errors.userName} isRequired>
             <FormLabel htmlFor="username">{t('translation:login.username.label')}</FormLabel>
@@ -123,13 +123,13 @@ const Login: FC<{ first?: FirstUseInformation; preLoadError?: ApiError | null }>
             />
             <FormErrorMessage>{errors.userName && errors.userName.message}</FormErrorMessage>
           </FormControl>
-          <FormControl isInvalid={!!errors.password} mt={'2em'} isRequired>
+          <FormControl isInvalid={!!errors.password} mt="2em" isRequired>
             <FormLabel htmlFor="password">{t('translation:login.password.label')}</FormLabel>
             <PasswordInput
               id="password"
-              name={'password'}
+              name="password"
               placeholder={t('translation:login.password.placeholder') as string}
-              autoComplete={'current-password'}
+              autoComplete="current-password"
               register={register}
               options={{
                 required: t('translation:login.password.error.required') as string,
@@ -139,11 +139,11 @@ const Login: FC<{ first?: FirstUseInformation; preLoadError?: ApiError | null }>
           </FormControl>
           <Button
             data-testid="loginPage-submit"
-            width={'100%'}
-            mt={'7em'}
+            width="100%"
+            mt="7em"
             type="submit"
             isLoading={isLoading}
-            variant={'primary'}
+            variant="primary"
           >
             {t('translation:login.submit.label')}
           </Button>
@@ -151,7 +151,7 @@ const Login: FC<{ first?: FirstUseInformation; preLoadError?: ApiError | null }>
       </Box>
 
       {(!first?.firstUseDescription || !first?.firstUseTitle) && (
-        <Text fontFamily={'heading'} textAlign={'center'}>
+        <Text fontFamily="heading" textAlign="center">
           {t('login.password.support')}
         </Text>
       )}

--- a/hivemq-edge/src/frontend/src/modules/Metrics/Metrics.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Metrics/Metrics.spec.cy.tsx
@@ -16,7 +16,7 @@ describe('Metrics', () => {
   it('should render the collapsible component', () => {
     cy.mountWithProviders(
       <Metrics
-        nodeId={'bridge@bridge-id-01'}
+        nodeId="bridge@bridge-id-01"
         initMetrics={[]}
         adapterIDs={[mockBridgeId]}
         type={NodeTypes.BRIDGE_NODE}

--- a/hivemq-edge/src/frontend/src/modules/Metrics/Metrics.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Metrics/Metrics.spec.cy.tsx
@@ -15,12 +15,7 @@ describe('Metrics', () => {
 
   it('should render the collapsible component', () => {
     cy.mountWithProviders(
-      <Metrics
-        nodeId="bridge@bridge-id-01"
-        initMetrics={[]}
-        adapterIDs={[mockBridgeId]}
-        type={NodeTypes.BRIDGE_NODE}
-      />
+      <Metrics nodeId="bridge@bridge-id-01" initMetrics={[]} adapterIDs={[mockBridgeId]} type={NodeTypes.BRIDGE_NODE} />
     )
 
     cy.getByTestId('metrics-toggle').should('have.attr', 'aria-expanded', 'false')

--- a/hivemq-edge/src/frontend/src/modules/Metrics/Metrics.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Metrics/Metrics.tsx
@@ -76,7 +76,7 @@ const Metrics: FC<MetricsProps> = ({ nodeId, adapterIDs, initMetrics, defaultCha
   return (
     <>
       {showEditor && (
-        <Card size={'sm'}>
+        <Card size="sm">
           <Accordion
             allowToggle
             onChange={(expandedIndex) => {
@@ -108,7 +108,7 @@ const Metrics: FC<MetricsProps> = ({ nodeId, adapterIDs, initMetrics, defaultCha
       <SimpleGrid
         spacing={4}
         templateColumns="repeat(auto-fill, minmax(200px, 1fr))"
-        role={'list'}
+        role="list"
         aria-label={t('metrics.charts.list') as string}
       >
         {metrics.map((e) => {
@@ -123,7 +123,7 @@ const Metrics: FC<MetricsProps> = ({ nodeId, adapterIDs, initMetrics, defaultCha
                 chartTheme={{ colourScheme: chartTheme[colorSchemeIndex] }}
                 onClose={() => handleRemoveMetrics(e.metrics)}
                 canEdit={isOpen}
-                role={'listitem'}
+                role="listitem"
               />
             )
           else
@@ -135,7 +135,7 @@ const Metrics: FC<MetricsProps> = ({ nodeId, adapterIDs, initMetrics, defaultCha
                 chartTheme={{ colourScheme: chartTheme[colorSchemeIndex] }}
                 onClose={() => handleRemoveMetrics(e.metrics)}
                 canEdit={isOpen}
-                role={'listitem'}
+                role="listitem"
               />
             )
         })}

--- a/hivemq-edge/src/frontend/src/modules/Metrics/components/charts/BarChart.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Metrics/components/charts/BarChart.spec.cy.tsx
@@ -8,7 +8,7 @@ import BarChart from './BarChart.tsx'
 
 const mockAriaLabel = 'aria-label'
 const Wrapper: FC<PropsWithChildren> = ({ children }) => (
-  <Box w={'100%'} h={400}>
+  <Box w="100%" h={400}>
     {children}
   </Box>
 )
@@ -24,7 +24,7 @@ describe('BarChart', () => {
     cy.mountWithProviders(
       <Wrapper>
         <BarChart
-          h={'100%'}
+          h="100%"
           data={MOCK_METRIC_SAMPLE_ARRAY}
           metricName={MOCK_METRICS[0].name as string}
           aria-label={mockAriaLabel}

--- a/hivemq-edge/src/frontend/src/modules/Metrics/components/charts/BarChart.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Metrics/components/charts/BarChart.tsx
@@ -36,7 +36,7 @@ const BarChart: FC<ChartProps> = ({ data, metricName, 'aria-label': ariaLabel, c
   const colorElement = colors[colorScheme][500]
 
   return (
-    <Box w={'100%'} {...props}>
+    <Box w="100%" {...props}>
       <ResponsiveBar
         data={barSeries}
         keys={[seriesName]}

--- a/hivemq-edge/src/frontend/src/modules/Metrics/components/charts/LineChart.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Metrics/components/charts/LineChart.spec.cy.tsx
@@ -8,7 +8,7 @@ import LineChart from './LineChart.tsx'
 
 const mockAriaLabel = 'aria-label'
 const Wrapper: FC<PropsWithChildren> = ({ children }) => (
-  <Box w={'100%'} h={400}>
+  <Box w="100%" h={400}>
     {children}
   </Box>
 )
@@ -24,7 +24,7 @@ describe('LineChart', () => {
     cy.mountWithProviders(
       <Wrapper>
         <LineChart
-          h={'100%'}
+          h="100%"
           data={MOCK_METRIC_SAMPLE_ARRAY}
           metricName={MOCK_METRICS[0].name as string}
           aria-label={mockAriaLabel}

--- a/hivemq-edge/src/frontend/src/modules/Metrics/components/charts/LineChart.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Metrics/components/charts/LineChart.tsx
@@ -27,11 +27,11 @@ const LineChart: FC<ChartProps> = ({ data, metricName, 'aria-label': ariaLabel, 
   const colorElement = colors[colorScheme][500]
 
   return (
-    <Box w={'100%'} {...props} role={'application'} aria-label={ariaLabel}>
+    <Box w="100%" {...props} role="application" aria-label={ariaLabel}>
       <ResponsiveLine
         useMesh
         // TODO[NVL] ResponsiveLine doesn't support aria-label; adding it to the wrapper element
-        role={'none'}
+        role="none"
         data={[
           {
             id: seriesName,

--- a/hivemq-edge/src/frontend/src/modules/Metrics/components/charts/SampleRenderer.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Metrics/components/charts/SampleRenderer.tsx
@@ -57,12 +57,12 @@ const SampleRenderer: FC<SampleRendererProps> = ({
   const colorElement = colors[colorScheme][500]
 
   return (
-    <HStack alignItems={'flex-start'} gap={0} role={role} aria-labelledby={`sample-title-${id}-${suffix}`}>
+    <HStack alignItems="flex-start" gap={0} role={role} aria-labelledby={`sample-title-${id}-${suffix}`}>
       <Stat
         variant="hivemq"
         {...rest}
-        overflowX={'hidden'}
-        h={'100%'}
+        overflowX="hidden"
+        h="100%"
         sx={{
           borderColor: colorElement,
           "dd[data-testid='metric-value']": {
@@ -70,21 +70,21 @@ const SampleRenderer: FC<SampleRendererProps> = ({
           },
         }}
       >
-        <StatLabel isTruncated h={'100%'} id={`sample-title-${id}-${suffix}`}>
-          <Tooltip label={t(`metrics.${device}.${suffix}`).replaceAll('.', ' ')} placement={'top'}>
-            <Text textOverflow={'ellipsis'}>{t(`metrics.${device}.${suffix}`).replaceAll('.', ' ')}</Text>
+        <StatLabel isTruncated h="100%" id={`sample-title-${id}-${suffix}`}>
+          <Tooltip label={t(`metrics.${device}.${suffix}`).replaceAll('.', ' ')} placement="top">
+            <Text textOverflow="ellipsis">{t(`metrics.${device}.${suffix}`).replaceAll('.', ' ')}</Text>
           </Tooltip>
           <Text>{id}</Text>
         </StatLabel>
 
-        <StatNumber py={2} data-testid={`metric-value`}>
-          {isLoading && <Spinner data-testid={`metric-loader`} />}
+        <StatNumber py={2} data-testid="metric-value">
+          {isLoading && <Spinner data-testid="metric-loader" />}
           {!!error && <NotAllowedIcon color="red.100" />}
           {isNaN(n) && '-'}
           {!isNaN(n) && formatNumber.format(n)}
         </StatNumber>
         {!!change && (
-          <StatHelpText data-testid={`metric-change`}>
+          <StatHelpText data-testid="metric-change">
             <StatArrow type={change > 0 ? 'increase' : 'decrease'} />
             {formatNumber.format(Math.abs(change))}
           </StatHelpText>

--- a/hivemq-edge/src/frontend/src/modules/Metrics/components/container/ChartContainer.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Metrics/components/container/ChartContainer.tsx
@@ -57,8 +57,8 @@ const ChartContainer: FC<ChartContainerProps> = ({
 
   const Chart = chartType === ChartType.BAR_CHART ? BarChart : LineChart
   return (
-    <HStack alignItems={'flex-start'} gap={0} {...props} gridColumn={gridSpan ? '1 / span 2' : 'auto'}>
-      <Card size={'sm'} w={'100%'} data-testid={'chart-container'}>
+    <HStack alignItems="flex-start" gap={0} {...props} gridColumn={gridSpan ? '1 / span 2' : 'auto'}>
+      <Card size="sm" w="100%" data-testid="chart-container">
         <CardBody h={180}>
           <Chart
             h={gridSpan ? 250 : 200}
@@ -69,24 +69,24 @@ const ChartContainer: FC<ChartContainerProps> = ({
           />
         </CardBody>
       </Card>
-      <VStack ml={1} data-testid={'chart-container-toolbar'}>
+      <VStack ml={1} data-testid="chart-container-toolbar">
         {canEdit && (
           <>
             <Box flex={1}>
               <CloseButton
                 data-testid="metrics-remove"
                 aria-label={t('metrics.command.remove.ariaLabel') as string}
-                size={'sm'}
+                size="sm"
                 onClick={onClose}
               />
             </Box>
             <Box>
               <IconButton
-                variant={'ghost'}
+                variant="ghost"
                 colorScheme="gray"
                 aria-label={gridSpan ? t('metrics.command.resize.collapse') : t('metrics.command.resize.expand')}
-                size={'xs'}
-                icon={<Icon as={gridSpan ? BiCollapseHorizontal : BiExpandHorizontal} fontSize={'1rem'} />}
+                size="xs"
+                icon={<Icon as={gridSpan ? BiCollapseHorizontal : BiExpandHorizontal} fontSize="1rem" />}
                 onClick={() => setGridSpan((old) => !old)}
               />
             </Box>

--- a/hivemq-edge/src/frontend/src/modules/Metrics/components/container/Sample.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Metrics/components/container/Sample.tsx
@@ -57,7 +57,7 @@ const Sample: FC<SampleProps> = ({ metricName, chartTheme, onClose, canEdit = tr
             <CloseButton
               data-testid="metrics-remove"
               aria-label={t('metrics.command.remove.ariaLabel') as string}
-              size={'sm'}
+              size="sm"
               onClick={onClose}
             />
           </Box>

--- a/hivemq-edge/src/frontend/src/modules/Metrics/components/editor/MetricEditor.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Metrics/components/editor/MetricEditor.tsx
@@ -75,12 +75,12 @@ const MetricEditor: FC<MetricEditorProps> = ({ onSubmit, filter, selectedMetrics
       onSubmit={handleSubmit(onSubmit)}
       style={{ display: 'flex', flexDirection: 'column', gap: '18px' }}
     >
-      <VStack gap={2} alignItems={'flex-end'}>
+      <VStack gap={2} alignItems="flex-end">
         <FormControl>
-          <FormLabel htmlFor={'metrics-select'}>{t('metrics.editor.select-metric')}</FormLabel>
+          <FormLabel htmlFor="metrics-select">{t('metrics.editor.select-metric')}</FormLabel>
 
           <Controller
-            name={'selectedTopic'}
+            name="selectedTopic"
             control={control}
             rules={{
               required: true,
@@ -97,8 +97,8 @@ const MetricEditor: FC<MetricEditorProps> = ({ onSubmit, filter, selectedMetrics
                   styles={{
                     menuPortal: (provided) => ({ ...provided, zIndex: 1401 }),
                   }}
-                  id={'metrics-select-container'}
-                  inputId={'metrics-select'}
+                  id="metrics-select-container"
+                  inputId="metrics-select"
                   value={value || null}
                   onChange={(values) => onChange(values)}
                   options={sortedItems}
@@ -115,10 +115,10 @@ const MetricEditor: FC<MetricEditorProps> = ({ onSubmit, filter, selectedMetrics
         </FormControl>
         {!selectedChart && (
           <FormControl>
-            <FormLabel htmlFor={'chart-select'}>{t('metrics.editor.select-chart')}</FormLabel>
+            <FormLabel htmlFor="chart-select">{t('metrics.editor.select-chart')}</FormLabel>
 
             <Controller
-              name={'selectedChart'}
+              name="selectedChart"
               control={control}
               rules={{
                 required: true,
@@ -132,8 +132,8 @@ const MetricEditor: FC<MetricEditorProps> = ({ onSubmit, filter, selectedMetrics
                     styles={{
                       menuPortal: (provided) => ({ ...provided, zIndex: 1401 }),
                     }}
-                    id={'chart-select-container'}
-                    inputId={'chart-select'}
+                    id="chart-select-container"
+                    inputId="chart-select"
                     value={value || null}
                     onChange={(values) => onChange(values)}
                     options={chartTypeOptions}

--- a/hivemq-edge/src/frontend/src/modules/Metrics/components/parts/ChartTooltip.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Metrics/components/parts/ChartTooltip.spec.cy.tsx
@@ -11,9 +11,7 @@ describe('ChartTooltip', () => {
   it('should be accessible', () => {
     const mockTime = DateTime.fromMillis(1000)
     cy.injectAxe()
-    cy.mountWithProviders(
-      <ChartTooltip formattedValue="the value" color="red.300" date={mockTime} id="the task" />
-    )
+    cy.mountWithProviders(<ChartTooltip formattedValue="the value" color="red.300" date={mockTime} id="the task" />)
 
     const formatShortDate = new Intl.DateTimeFormat(navigator.language, {
       month: 'short',

--- a/hivemq-edge/src/frontend/src/modules/Metrics/components/parts/ChartTooltip.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Metrics/components/parts/ChartTooltip.spec.cy.tsx
@@ -12,7 +12,7 @@ describe('ChartTooltip', () => {
     const mockTime = DateTime.fromMillis(1000)
     cy.injectAxe()
     cy.mountWithProviders(
-      <ChartTooltip formattedValue={'the value'} color={'red.300'} date={mockTime} id={'the task'} />
+      <ChartTooltip formattedValue="the value" color="red.300" date={mockTime} id="the task" />
     )
 
     const formatShortDate = new Intl.DateTimeFormat(navigator.language, {

--- a/hivemq-edge/src/frontend/src/modules/Metrics/components/parts/ChartTooltip.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Metrics/components/parts/ChartTooltip.tsx
@@ -12,14 +12,14 @@ interface TooltipProps {
 
 const ChartTooltip: FC<TooltipProps> = ({ formattedValue, color, date, id }) => {
   return (
-    <Card p={1} data-testid={'chart-tooltip'}>
-      <HStack data-testid={'chart-tooltip-id'}>
+    <Card p={1} data-testid="chart-tooltip">
+      <HStack data-testid="chart-tooltip-id">
         <Square size={4} bg={color} />
         <Text>{id}</Text>
       </HStack>
 
       <DateTimeRenderer date={date} isShort />
-      <Text fontWeight={'bold'} data-testid={'chart-tooltip-value'}>
+      <Text fontWeight="bold" data-testid="chart-tooltip-value">
         {formattedValue}
       </Text>
     </Card>

--- a/hivemq-edge/src/frontend/src/modules/Notifications/NotificationBadge.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Notifications/NotificationBadge.tsx
@@ -39,7 +39,7 @@ const NotificationBadge: FC = () => {
       aria-label={t('notifications.badge.ariaLabel')}
       badgeCount={notifications.length}
       isDisabled={!notifications.length}
-      icon={<Icon as={IoNotifications} fontSize={'2xl'} />}
+      icon={<Icon as={IoNotifications} fontSize="2xl" />}
       onClick={handleClick}
     />
   )

--- a/hivemq-edge/src/frontend/src/modules/Notifications/components/SkipNotification.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Notifications/components/SkipNotification.tsx
@@ -19,12 +19,12 @@ export const SkipNotification: FC<SkipNotificationProps> = ({ id }) => {
     }
   }
   return (
-    <HStack justifyContent={'flex-end'}>
+    <HStack justifyContent="flex-end">
       <Checkbox
         onChange={handleOnChange}
         colorScheme="blackAlpha"
-        borderColor={'blackAlpha.500'}
-        data-testid={'notification-skip'}
+        borderColor="blackAlpha.500"
+        data-testid="notification-skip"
       >
         {t('notifications.toast.skipNotification')}
       </Checkbox>

--- a/hivemq-edge/src/frontend/src/modules/Notifications/hooks/useGetManagedNotifications.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Notifications/hooks/useGetManagedNotifications.tsx
@@ -56,15 +56,15 @@ export const useGetManagedNotifications = () => {
           id: name,
           title: (
             <Text>
-              <Text as={'span'}>{t('notifications.releases.title')} </Text>
-              <Badge colorScheme={'yellow'}>{name}</Badge>
+              <Text as="span">{t('notifications.releases.title')} </Text>
+              <Badge colorScheme="yellow">{name}</Badge>
             </Text>
           ),
           description: (
             <Text>
               {t('notifications.releases.description')}{' '}
               <Link href={html_url} isExternal>
-                <ExternalLinkIcon mx="2px" mb={'4px'} /> hivemq/hivemq-edge
+                <ExternalLinkIcon mx="2px" mb="4px" /> hivemq/hivemq-edge
               </Link>
             </Text>
           ),

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/ProtocolAdapterPage.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/ProtocolAdapterPage.tsx
@@ -26,12 +26,12 @@ const ProtocolAdapterPage: FC = () => {
 
   return (
     <PageContainer title={t('protocolAdapter.title') as string} subtitle={t('protocolAdapter.description') as string}>
-      <Tabs onChange={handleTabsChange} index={tabIndex} isLazy colorScheme={'brand'}>
+      <Tabs onChange={handleTabsChange} index={tabIndex} isLazy colorScheme="brand">
         <TabList>
-          <Tab fontSize="lg" fontWeight={'bold'}>
+          <Tab fontSize="lg" fontWeight="bold">
             {t('protocolAdapter.tabs.protocols')}
           </Tab>
-          <Tab fontSize="lg" fontWeight={'bold'}>
+          <Tab fontSize="lg" fontWeight="bold">
             {t('protocolAdapter.tabs.adapters')}
           </Tab>
         </TabList>

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/IntegrationStore/FacetSearch.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/IntegrationStore/FacetSearch.tsx
@@ -61,21 +61,21 @@ const FacetSearch: FC<SearchFilterAdaptersProps> = ({ items, isLoading, facet, o
 
   return (
     <Flex
-      flexDirection={'column'}
+      flexDirection="column"
       gap={4}
-      maxW={'250px'}
-      minW={'fit-content'}
+      maxW="250px"
+      minW="fit-content"
       role="region"
       aria-label={t('protocolAdapter.facet.description') as string}
     >
-      <FormControl role={'search'}>
+      <FormControl role="search">
         <FormLabel>{t('protocolAdapter.facet.search.label')}</FormLabel>
         <InputGroup>
           <InputLeftElement pointerEvents="none">
             <SearchIcon />
           </InputLeftElement>
           <Input
-            id={'facet-search-input'}
+            id="facet-search-input"
             placeholder={t('protocolAdapter.facet.search.placeholder') as string}
             onChange={handleChangeSearch}
             value={facet?.search || ''}
@@ -83,7 +83,7 @@ const FacetSearch: FC<SearchFilterAdaptersProps> = ({ items, isLoading, facet, o
           />
           <InputRightElement>
             <CloseButton
-              id={'facet-search-clear'}
+              id="facet-search-clear"
               onClick={handleClearSearch}
               aria-label={t('protocolAdapter.facet.search.clear') as string}
             />
@@ -91,19 +91,19 @@ const FacetSearch: FC<SearchFilterAdaptersProps> = ({ items, isLoading, facet, o
         </InputGroup>
       </FormControl>
 
-      <Flex flexDirection={'column'}>
+      <Flex flexDirection="column">
         <Box pb={4} pt={4}>
-          <List spacing={3} aria-labelledby={'facet-filter-clear'}>
+          <List spacing={3} aria-labelledby="facet-filter-clear">
             <ListItem>
               <Skeleton isLoaded={!isLoading}>
                 <Button
-                  id={`facet-filter-clear`}
-                  data-testid={`facet-filter-clear`}
-                  justifyContent={'flex-start'}
+                  id="facet-filter-clear"
+                  data-testid="facet-filter-clear"
+                  justifyContent="flex-start"
                   variant={!facet?.filter ? 'outline' : 'ghost'}
                   aria-pressed={!facet?.filter}
                   size="sm"
-                  w={'100%'}
+                  w="100%"
                   onClick={() => handleFilter(null)}
                 >
                   {t('protocolAdapter.facet.filter.allFilters')}
@@ -112,21 +112,21 @@ const FacetSearch: FC<SearchFilterAdaptersProps> = ({ items, isLoading, facet, o
             </ListItem>
           </List>
         </Box>
-        <Box aria-hidden={true} id={`facet-filter-category`}>
+        <Box aria-hidden={true} id="facet-filter-category">
           {t('protocolAdapter.facet.filter.category')}
         </Box>
         <Box pb={4} pt={4}>
-          <List spacing={3} aria-labelledby={'facet-filter-category'}>
+          <List spacing={3} aria-labelledby="facet-filter-category">
             {categories.map((item) => (
               <ListItem key={item.name}>
                 <Skeleton isLoaded={!isLoading}>
                   <Button
                     data-testid={`facet-filter-category-${item.name}`}
-                    justifyContent={'flex-start'}
+                    justifyContent="flex-start"
                     variant={facet?.filter?.value === item.name ? 'outline' : 'ghost'}
                     aria-pressed={facet?.filter?.value === item.name}
                     size="sm"
-                    w={'100%'}
+                    w="100%"
                     onClick={() => handleFilter({ value: item.name, key: 'category' })}
                   >
                     {item.displayName}
@@ -136,20 +136,20 @@ const FacetSearch: FC<SearchFilterAdaptersProps> = ({ items, isLoading, facet, o
             ))}
           </List>
         </Box>
-        <Box aria-hidden={true} id={`facet-filter-tags`}>
+        <Box aria-hidden={true} id="facet-filter-tags">
           {t('protocolAdapter.facet.filter.tags')}
         </Box>
         <Box pb={4} pt={4}>
-          <List spacing={3} aria-labelledby={'facet-filter-tags'}>
+          <List spacing={3} aria-labelledby="facet-filter-tags">
             {tags.map((item) => (
               <ListItem key={item}>
                 <Skeleton isLoaded={!isLoading}>
                   <Button
                     data-testid={`facet-filter-tag-${item}`}
-                    justifyContent={'flex-start'}
+                    justifyContent="flex-start"
                     variant={facet?.filter?.value === item ? 'outline' : 'ghost'}
                     size="sm"
-                    w={'100%'}
+                    w="100%"
                     onClick={() => handleFilter({ value: item, key: 'tags' })}
                     aria-pressed={facet?.filter?.value === item}
                   >

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/IntegrationStore/ProtocolsBrowser.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/IntegrationStore/ProtocolsBrowser.tsx
@@ -27,7 +27,7 @@ const ProtocolsBrowser: FC<ProtocolsBrowserProps> = ({ items, facet, onCreate, i
 
   if (!filteredAdapters.length)
     return (
-      <Box width={'100%'}>
+      <Box width="100%">
         <WarningMessage
           image={AdapterEmptyLogo}
           prompt={t('protocolAdapter.noFilterWarning.description')}
@@ -42,11 +42,11 @@ const ProtocolsBrowser: FC<ProtocolsBrowserProps> = ({ items, facet, onCreate, i
       templateColumns={{ base: 'repeat(1, 1fr)', xl: 'repeat(2, 1fr)' }}
       spacing={4}
       gap={6}
-      role={'list'}
+      role="list"
       aria-label={t('protocolAdapter.list') as string}
     >
       {filteredAdapters?.map((e) => (
-        <Card key={e.id} minW={'300px'} role={'listitem'} aria-labelledby={`adapter-${e.id}`}>
+        <Card key={e.id} minW="300px" role="listitem" aria-labelledby={`adapter-${e.id}`}>
           <CardBody p={2}>
             <AdapterTypeSummary key={e.id} adapter={e} searchQuery={facet?.search} isLoading={isLoading} />
           </CardBody>
@@ -54,8 +54,8 @@ const ProtocolsBrowser: FC<ProtocolsBrowserProps> = ({ items, facet, onCreate, i
             <Skeleton isLoaded={!isLoading}>
               {!!e.installed && (
                 <Button
-                  data-testid={'protocol-create-adapter'}
-                  size={'sm'}
+                  data-testid="protocol-create-adapter"
+                  size="sm"
                   rightIcon={<ArrowForwardIcon />}
                   onClick={() => onCreate?.(e.id)}
                 >

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/adapters/AdapterActionMenu.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/adapters/AdapterActionMenu.tsx
@@ -24,27 +24,27 @@ const AdapterActionMenu: FC<AdapterActionMenuProps> = ({ adapter, onCreate, onEd
     <Menu>
       <MenuButton
         variant="outline"
-        size={'sm'}
+        size="sm"
         // Cannot have tooltip because of the popup menu
         as={IconButton}
         icon={<ChevronDownIcon />}
         aria-label={t('protocolAdapter.table.actions.label') as string}
       />
       <MenuList>
-        <ConnectionController type={DeviceTypes.ADAPTER} id={id} status={status} variant={'menuItem'} />
+        <ConnectionController type={DeviceTypes.ADAPTER} id={id} status={status} variant="menuItem" />
 
-        <MenuItem data-testid={'adapter-action-workspace'} onClick={() => onViewWorkspace?.(id, type as string)}>
+        <MenuItem data-testid="adapter-action-workspace" onClick={() => onViewWorkspace?.(id, type as string)}>
           {t('protocolAdapter.table.actions.workspace')}
         </MenuItem>
         <MenuDivider />
-        <MenuItem data-testid={'adapter-action-create'} onClick={() => onCreate?.(type as string)}>
+        <MenuItem data-testid="adapter-action-create" onClick={() => onCreate?.(type as string)}>
           {t('protocolAdapter.table.actions.create')}
         </MenuItem>
-        <MenuItem data-testid={'adapter-action-edit'} onClick={() => onEdit?.(id, type as string)}>
+        <MenuItem data-testid="adapter-action-edit" onClick={() => onEdit?.(id, type as string)}>
           {t('protocolAdapter.table.actions.edit')}
         </MenuItem>
         <MenuItem
-          data-testid={'adapter-action-delete'}
+          data-testid="adapter-action-delete"
           onClick={() => onDelete?.(id)}
           sx={{
             color: 'red.500',

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/adapters/AdapterTypeSummary.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/adapters/AdapterTypeSummary.spec.cy.tsx
@@ -27,20 +27,20 @@ describe('AdapterTypeSummary', () => {
   })
 
   it('should render the in-text search highlight', () => {
-    cy.mountWithProviders(<AdapterTypeSummary adapter={mockProtocolAdapter} searchQuery={'traffic from an edge'} />)
+    cy.mountWithProviders(<AdapterTypeSummary adapter={mockProtocolAdapter} searchQuery="traffic from an edge" />)
 
     cy.getByTestId('protocol-description').find('mark').should('contain.text', 'traffic from an edge')
   })
 
   it('should render the in-text search highlight', () => {
-    cy.mountWithProviders(<AdapterTypeSummary adapter={mockProtocolAdapter} searchQuery={'Simulated Edge'} />)
+    cy.mountWithProviders(<AdapterTypeSummary adapter={mockProtocolAdapter} searchQuery="Simulated Edge" />)
 
     cy.getByTestId('protocol-name').find('mark').should('contain.text', 'Simulated Edge')
   })
 
   it('should be accessible', () => {
     cy.injectAxe()
-    cy.mountWithProviders(<AdapterTypeSummary adapter={mockProtocolAdapter} searchQuery={'traffic from an edge'} />)
+    cy.mountWithProviders(<AdapterTypeSummary adapter={mockProtocolAdapter} searchQuery="traffic from an edge" />)
     cy.checkAccessibility()
     cy.percySnapshot('Component: AdapterTypeSummary')
   })

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/adapters/AdapterTypeSummary.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/adapters/AdapterTypeSummary.tsx
@@ -26,22 +26,22 @@ const AdapterTypeSummary: FC<AdapterTypeSummaryProps> = ({ adapter, searchQuery,
         <Image boxSize="100px" objectFit="scale-down" src={adapter.logoUrl} aria-label={adapter.id} />
       </Skeleton>
       <Box ml="3">
-        <Skeleton isLoaded={!isLoading} as={'p'}>
-          <Text fontWeight="bold" data-testid={'protocol-name'} id={`adapter-${adapter.id}`} as={'span'}>
+        <Skeleton isLoaded={!isLoading} as="p">
+          <Text fontWeight="bold" data-testid="protocol-name" id={`adapter-${adapter.id}`} as="span">
             <AdapterHighlight query={searchQuery || ''}>{adapter.name || ''}</AdapterHighlight>
           </Text>
-          <Badge ml="1" colorScheme="brand" variant={'solid'} data-testid={'protocol-version'}>
+          <Badge ml="1" colorScheme="brand" variant="solid" data-testid="protocol-version">
             {adapter.version}
           </Badge>
         </Skeleton>
         <Skeleton isLoaded={!isLoading} mt={1}>
-          <Text fontSize="sm" data-testid={'protocol-type'}>
+          <Text fontSize="sm" data-testid="protocol-type">
             {t('protocolAdapter.overview.type')} {adapter.protocol}
           </Text>
-          <Text fontSize="sm" data-testid={'protocol-author'}>
+          <Text fontSize="sm" data-testid="protocol-author">
             {t('protocolAdapter.overview.author')} {adapter.author}
           </Text>
-          <Text fontSize="sm" data-testid={'protocol-description'}>
+          <Text fontSize="sm" data-testid="protocol-description">
             <AdapterHighlight query={searchQuery || ''}>{adapter.description || ''}</AdapterHighlight>
           </Text>
         </Skeleton>

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/drawers/AdapterInstanceDrawer.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/drawers/AdapterInstanceDrawer.tsx
@@ -74,14 +74,7 @@ const AdapterInstanceDrawer: FC<AdapterInstanceDrawerProps> = ({
   }
 
   return (
-    <Drawer
-      variant="hivemq"
-      closeOnOverlayClick={false}
-      size="lg"
-      isOpen={isOpen}
-      placement="right"
-      onClose={onClose}
-    >
+    <Drawer variant="hivemq" closeOnOverlayClick={false} size="lg" isOpen={isOpen} placement="right" onClose={onClose}>
       <DrawerOverlay />
       <DrawerContent aria-label={t('protocolAdapter.drawer.label') as string}>
         {!schema && <LoaderSpinner />}

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/drawers/AdapterInstanceDrawer.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/drawers/AdapterInstanceDrawer.tsx
@@ -75,9 +75,9 @@ const AdapterInstanceDrawer: FC<AdapterInstanceDrawerProps> = ({
 
   return (
     <Drawer
-      variant={'hivemq'}
+      variant="hivemq"
       closeOnOverlayClick={false}
-      size={'lg'}
+      size="lg"
       isOpen={isOpen}
       placement="right"
       onClose={onClose}
@@ -88,13 +88,13 @@ const AdapterInstanceDrawer: FC<AdapterInstanceDrawerProps> = ({
         {schema && (
           <>
             <DrawerCloseButton />
-            <DrawerHeader id={'adapter-instance-header'} borderBottomWidth="1px">
+            <DrawerHeader id="adapter-instance-header" borderBottomWidth="1px">
               <Text>
                 {isNewAdapter ? t('protocolAdapter.drawer.title.create') : t('protocolAdapter.drawer.title.update')}
               </Text>
               <HStack>
                 <Image boxSize="30px" objectFit="scale-down" src={logo} aria-label={name} />
-                <Text fontSize={'md'} fontWeight={'500'}>
+                <Text fontSize="md" fontWeight="500">
                   {name}
                 </Text>
               </HStack>
@@ -116,7 +116,7 @@ const AdapterInstanceDrawer: FC<AdapterInstanceDrawerProps> = ({
                     liveValidate
                     onSubmit={onValidate}
                     validator={customFormatsValidator}
-                    showErrorList={'bottom'}
+                    showErrorList="bottom"
                     onError={(errors) => console.log('XXXXXXX', errors)}
                     formData={defaultValues}
                     customValidate={customValidate(schema, allAdapters, t)}
@@ -126,8 +126,8 @@ const AdapterInstanceDrawer: FC<AdapterInstanceDrawerProps> = ({
             </DrawerBody>
 
             <DrawerFooter borderTopWidth="1px">
-              <Flex flexGrow={1} justifyContent={'flex-end'}>
-                <Button variant={'primary'} type="submit" form="adapter-instance-form">
+              <Flex flexGrow={1} justifyContent="flex-end">
+                <Button variant="primary" type="submit" form="adapter-instance-form">
                   {isNewAdapter ? t('protocolAdapter.action.create') : t('protocolAdapter.action.update')}
                 </Button>
               </Flex>

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/drawers/ProtocolSelectorDrawer.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/drawers/ProtocolSelectorDrawer.tsx
@@ -36,11 +36,11 @@ const ProtocolSelectorDrawer: FC<ProtocolSelectorDrawerProps> = ({ isOpen, onClo
 
   return (
     <>
-      <Drawer closeOnOverlayClick={false} size={'lg'} isOpen={isOpen} placement="right" onClose={onClose}>
+      <Drawer closeOnOverlayClick={false} size="lg" isOpen={isOpen} placement="right" onClose={onClose}>
         <DrawerOverlay />
         <DrawerContent aria-label={t('protocolAdapter.store.label') as string}>
           <DrawerCloseButton />
-          <DrawerHeader id={'adapter-selector-header'} borderBottomWidth="1px">
+          <DrawerHeader id="adapter-selector-header" borderBottomWidth="1px">
             {t('protocolAdapter.store.title.create')}
           </DrawerHeader>
 
@@ -54,7 +54,7 @@ const ProtocolSelectorDrawer: FC<ProtocolSelectorDrawerProps> = ({ isOpen, onClo
             </form>
           </DrawerBody>
           <DrawerFooter>
-            <Flex flexGrow={1} justifyContent={'flex-end'}>
+            <Flex flexGrow={1} justifyContent="flex-end">
               <Button isDisabled={!form.formState.isValid} type="submit" form="adapter-selector-form">
                 {t('protocolAdapter.action.instantiate')}
               </Button>

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/panels/ProtocolAdapters.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/panels/ProtocolAdapters.tsx
@@ -47,7 +47,7 @@ const AdapterTypeContainer: FC<ProtocolAdapter> = (adapter) => {
   return (
     <HStack>
       <Image boxSize="30px" objectFit="scale-down" src={adapter.logoUrl} aria-label={adapter.id} />
-      <Text fontSize={'md'} fontWeight={'500'}>
+      <Text fontSize="md" fontWeight="500">
         {adapter.name}
       </Text>
     </HStack>
@@ -154,7 +154,7 @@ const ProtocolAdapters: FC = () => {
               />
               {id === selectedActiveAdapter?.adapterId && (
                 <IconButton
-                  size={'sm'}
+                  size="sm"
                   ml={2}
                   onClick={() => handleViewWorkspace(id, type as string)}
                   aria-label={t('bridge.subscription.delete')}
@@ -198,7 +198,7 @@ const ProtocolAdapters: FC = () => {
 
   if (isError || isErrorAllAdapters) {
     return (
-      <Box mt={'20%'} mx={'20%'} alignItems={'center'}>
+      <Box mt="20%" mx="20%" alignItems="center">
         <ErrorMessage
           type={errorAllAdapters ? errorAllAdapters.message : error?.message}
           message={(error?.body as ProblemDetails)?.title || (t('protocolAdapter.error.loading') as string)}

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/panels/ProtocolIntegrationStore.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/panels/ProtocolIntegrationStore.tsx
@@ -50,7 +50,7 @@ const ProtocolIntegrationStore: FC = () => {
 
   if (isError) {
     return (
-      <Box mt={'20%'} mx={'20%'} alignItems={'center'}>
+      <Box mt="20%" mx="20%" alignItems="center">
         <ErrorMessage
           type={error?.message}
           message={(error?.body as ProblemDetails)?.title || (t('protocolAdapter.error.loading') as string)}
@@ -71,13 +71,13 @@ const ProtocolIntegrationStore: FC = () => {
     )
 
   return (
-    <Flex flexDirection={'column'} gap={4}>
+    <Flex flexDirection="column" gap={4}>
       <Text>
         {isLoading
           ? t('protocolAdapter.loading.protocolAdapters')
           : t('protocolAdapter.protocols.description', { count: safeData.length })}{' '}
       </Text>
-      <Flex flexDirection={'row'} alignItems={'flex-start'} gap={6}>
+      <Flex flexDirection="row" alignItems="flex-start" gap={6}>
         {config.features.PROTOCOL_ADAPTER_FACET && (
           <FacetSearch items={safeData} facet={facet} onChange={handleOnSearch} isLoading={isLoading} />
         )}

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/templates/ArrayFieldItemTemplate.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/templates/ArrayFieldItemTemplate.tsx
@@ -31,10 +31,10 @@ export const ArrayFieldItemTemplate: FC<ArrayFieldTemplateItemType> = (props) =>
 
   return (
     <HStack
-      alignItems={'flex-end'}
+      alignItems="flex-end"
       py={1}
       // TODO[NVL] This is NOT a good approach to add a "role"; submit a PR!
-      role={'listitem'}
+      role="listitem"
     >
       <Box w="100%">{children}</Box>
       {hasToolbar && (
@@ -42,9 +42,9 @@ export const ArrayFieldItemTemplate: FC<ArrayFieldTemplateItemType> = (props) =>
           <ButtonGroup
             isAttached
             mb={1}
-            role={'toolbar'}
+            role="toolbar"
             // TODO[NVL] This is NOT a good approach to add a "role"; submit a PR!
-            orientation={'vertical'}
+            orientation="vertical"
           >
             {(hasMoveUp || hasMoveDown) && (
               <MoveUpButton

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/templates/ArrayFieldTemplate.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/templates/ArrayFieldTemplate.tsx
@@ -39,7 +39,7 @@ export const ArrayFieldTemplate: FC<ArrayFieldTemplateProps> = (props) => {
         <Grid
           key={`array-item-list-${idSchema.$id}`}
           // TODO[NVL] This is NOT a good approach to add a "role"; submit a PR!
-          role={'list'}
+          role="list"
         >
           <GridItem>
             {items.length > 0 &&
@@ -49,7 +49,7 @@ export const ArrayFieldTemplate: FC<ArrayFieldTemplateProps> = (props) => {
           </GridItem>
         </Grid>
         {canAdd && (
-          <GridItem justifySelf={'flex-end'}>
+          <GridItem justifySelf="flex-end">
             <Box mt={2}>
               <AddButton
                 className="array-item-add"

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/templates/FieldTemplate.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/templates/FieldTemplate.tsx
@@ -55,7 +55,7 @@ export const FieldTemplate: FC<FieldTemplateProps> = (props) => {
       uiSchema={uiSchema}
       registry={registry}
     >
-      <RenderFieldTemplate {...props} children={children} />
+      <RenderFieldTemplate {...props}>{children}</RenderFieldTemplate>
     </WrapIfAdditionalTemplate>
   )
 }

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/templates/ObjectFieldTemplate.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/templates/ObjectFieldTemplate.tsx
@@ -69,7 +69,7 @@ export const ObjectFieldTemplate = <
             const filteredProps = properties.filter((p) => e.properties.includes(p.name))
             if (!filteredProps.length) return null
             return (
-              <TabPanel key={e.id} p={0} pt={'1px'} mb={6}>
+              <TabPanel key={e.id} p={0} pt="1px" mb={6}>
                 <>
                   {filteredProps.map((prop) => (
                     <Box _first={{ marginTop: '24px' }} _notLast={{ marginBottom: '24px' }} key={prop.content.key}>

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/templates/__internals/RenderFieldTemplate.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/templates/__internals/RenderFieldTemplate.spec.cy.tsx
@@ -12,7 +12,7 @@ const makeMockProps = (props: Partial<FieldTemplateProps>): Partial<FieldTemplat
     children: (
       <>
         <FormLabel>{props.label}</FormLabel>
-        <Input value={'a dumb value'} />
+        <Input value="a dumb value" />
       </>
     ),
     errors: <FormErrorMessage>{props.rawErrors?.join(', ')}</FormErrorMessage>,

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/templates/__internals/RenderFieldTemplate.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/templates/__internals/RenderFieldTemplate.spec.cy.tsx
@@ -39,7 +39,7 @@ describe('CustomFieldTemplate', () => {
     cy.injectAxe()
 
     // @ts-ignore
-    cy.mountWithProviders(<RenderFieldTemplate {...rest} children={children} />)
+    cy.mountWithProviders(<RenderFieldTemplate {...rest}>{children}</RenderFieldTemplate>)
     cy.get('[role="group"]').should('not.contain.text', MOCK_TEXT)
     cy.get('[role="group"]').should('contain.text', MOCK_ERROR)
     cy.checkAccessibility()
@@ -50,7 +50,7 @@ describe('CustomFieldTemplate', () => {
     cy.injectAxe()
 
     // @ts-ignore
-    cy.mountWithProviders(<RenderFieldTemplate {...rest} children={children} />)
+    cy.mountWithProviders(<RenderFieldTemplate {...rest}>{children}</RenderFieldTemplate>)
     cy.get('[role="group"]').should('contain.text', MOCK_TEXT)
     cy.get('[role="group"]').should('not.contain.text', MOCK_ERROR)
     cy.checkAccessibility()

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/templates/__internals/RenderFieldTemplate.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/templates/__internals/RenderFieldTemplate.tsx
@@ -19,7 +19,7 @@ export const RenderFieldTemplate: FC<FieldTemplateProps> = ({
   }
 
   return (
-    <FormControl variant={'hivemq'} isRequired={required} isInvalid={rawErrors && rawErrors.length > 0}>
+    <FormControl variant="hivemq" isRequired={required} isInvalid={rawErrors && rawErrors.length > 0}>
       {children}
       {rawErrors && rawErrors.length > 0 ? (
         errors

--- a/hivemq-edge/src/frontend/src/modules/UnifiedNamespace/UnifiedNamespacePage.tsx
+++ b/hivemq-edge/src/frontend/src/modules/UnifiedNamespace/UnifiedNamespacePage.tsx
@@ -41,9 +41,9 @@ const UnifiedNamespacePage: FC = () => {
       title={t('unifiedNamespace.title') as string}
       subtitle={t('unifiedNamespace.description') as string}
       cta={
-        <Flex height={'100%'} justifyContent={'flex-end'} alignItems={'flex-end'} pb={6}>
+        <Flex height="100%" justifyContent="flex-end" alignItems="flex-end" pb={6}>
           <Button
-            variant={'primary'}
+            variant="primary"
             leftIcon={<BiPlus />}
             onClick={() => navigate('/namespace/edit')}
             isDisabled={isLoading || isError}
@@ -54,7 +54,7 @@ const UnifiedNamespacePage: FC = () => {
       }
     >
       {isError && (
-        <Box mt={'20%'} mx={'20%'} alignItems={'center'}>
+        <Box mt="20%" mx="20%" alignItems="center">
           <ErrorMessage
             type={error?.message}
             message={(error?.body as ProblemDetails)?.title || (t('unifiedNamespace.error.loading') as string)}

--- a/hivemq-edge/src/frontend/src/modules/UnifiedNamespace/components/NamespaceDisplay.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/UnifiedNamespace/components/NamespaceDisplay.spec.cy.tsx
@@ -45,7 +45,7 @@ describe('NamespaceDisplay', () => {
 
   it('should be accessible for small size', () => {
     cy.injectAxe()
-    cy.mountWithProviders(<NamespaceDisplay namespace={MOCK_NAMESPACE} fontSize={'sm'} />)
+    cy.mountWithProviders(<NamespaceDisplay namespace={MOCK_NAMESPACE} fontSize="sm" />)
     cy.checkAccessibility()
   })
 })

--- a/hivemq-edge/src/frontend/src/modules/UnifiedNamespace/components/NamespaceForm.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/UnifiedNamespace/components/NamespaceForm.spec.cy.tsx
@@ -24,7 +24,7 @@ describe('NamespaceForm', () => {
     cy.mountWithProviders(
       <div>
         <NamespaceForm onSubmit={mockOnSubmit} defaultValues={MOCK_NAMESPACE} />
-        <Button variant="primary" type={'submit'} form="namespace-form" data-testid={'form-submit'}>
+        <Button variant="primary" type="submit" form="namespace-form" data-testid="form-submit">
           Submit
         </Button>
       </div>
@@ -44,7 +44,7 @@ describe('NamespaceForm', () => {
     cy.mountWithProviders(
       <div>
         <NamespaceForm onSubmit={mockOnSubmit} defaultValues={MOCK_NAMESPACE} />
-        <Button variant="primary" type={'submit'} form="namespace-form" data-testid={'form-submit'}>
+        <Button variant="primary" type="submit" form="namespace-form" data-testid="form-submit">
           Submit
         </Button>
       </div>
@@ -65,7 +65,7 @@ describe('NamespaceForm', () => {
     cy.mountWithProviders(
       <div>
         <NamespaceForm onSubmit={mockOnSubmit} defaultValues={MOCK_NAMESPACE} />
-        <Button variant="primary" type={'submit'} form="namespace-form" data-testid={'form-submit'}>
+        <Button variant="primary" type="submit" form="namespace-form" data-testid="form-submit">
           Submit
         </Button>
       </div>

--- a/hivemq-edge/src/frontend/src/modules/UnifiedNamespace/components/NamespaceForm.tsx
+++ b/hivemq-edge/src/frontend/src/modules/UnifiedNamespace/components/NamespaceForm.tsx
@@ -25,7 +25,7 @@ interface NamespaceFormProps {
 }
 
 const FormControlSeparator = () => (
-  <Text pt={'2.33rem'} textAlign={'center'}>
+  <Text pt="2.33rem" textAlign="center">
     {NAMESPACE_SEPARATOR}
   </Text>
 )
@@ -46,18 +46,18 @@ const NamespaceForm: FC<NamespaceFormProps> = ({ defaultValues, onSubmit }) => {
 
   return (
     <form id="namespace-form" onSubmit={handleSubmit(onSubmit)}>
-      <Flex flexDirection={'column'} gap={6}>
+      <Flex flexDirection="column" gap={6}>
         <FormControl>
-          <FormLabel htmlFor={'unifiedNamespace-preview'}>{t('unifiedNamespace.preview.label')}</FormLabel>
-          <NamespaceDisplay namespace={preview} fontSize={'sm'} />
+          <FormLabel htmlFor="unifiedNamespace-preview">{t('unifiedNamespace.preview.label')}</FormLabel>
+          <NamespaceDisplay namespace={preview} fontSize="sm" />
         </FormControl>
 
-        <Flex flexDirection={'column'} gap={4}>
+        <Flex flexDirection="column" gap={4}>
           <Grid templateColumns="repeat(2, 1fr 20px)" gap={6}>
             <FormControl isInvalid={!!errors.enterprise}>
-              <FormLabel htmlFor={'unifiedNamespace-enterprise'}>{t('unifiedNamespace.enterprise.label')}</FormLabel>
+              <FormLabel htmlFor="unifiedNamespace-enterprise">{t('unifiedNamespace.enterprise.label')}</FormLabel>
               <Input
-                id={'unifiedNamespace-enterprise'}
+                id="unifiedNamespace-enterprise"
                 {...register('enterprise', {
                   ...getRulesForProperty($ISA95ApiBean.properties.enterprise),
                 })}
@@ -69,9 +69,9 @@ const NamespaceForm: FC<NamespaceFormProps> = ({ defaultValues, onSubmit }) => {
             <FormControlSeparator />
 
             <FormControl>
-              <FormLabel htmlFor={'unifiedNamespace-site'}>{t('unifiedNamespace.site.label')}</FormLabel>
+              <FormLabel htmlFor="unifiedNamespace-site">{t('unifiedNamespace.site.label')}</FormLabel>
               <Input
-                id={'unifiedNamespace-site'}
+                id="unifiedNamespace-site"
                 {...register('site', {
                   ...getRulesForProperty($ISA95ApiBean.properties.site),
                 })}
@@ -82,9 +82,9 @@ const NamespaceForm: FC<NamespaceFormProps> = ({ defaultValues, onSubmit }) => {
             <FormControlSeparator />
 
             <FormControl>
-              <FormLabel htmlFor={'unifiedNamespace-area'}>{t('unifiedNamespace.area.label')}</FormLabel>
+              <FormLabel htmlFor="unifiedNamespace-area">{t('unifiedNamespace.area.label')}</FormLabel>
               <Input
-                id={'unifiedNamespace-area'}
+                id="unifiedNamespace-area"
                 {...register('area', {
                   ...getRulesForProperty($ISA95ApiBean.properties.area),
                 })}
@@ -95,11 +95,11 @@ const NamespaceForm: FC<NamespaceFormProps> = ({ defaultValues, onSubmit }) => {
             <FormControlSeparator />
 
             <FormControl>
-              <FormLabel htmlFor={'unifiedNamespace-productionLine'}>
+              <FormLabel htmlFor="unifiedNamespace-productionLine">
                 {t('unifiedNamespace.productionLine.label')}
               </FormLabel>
               <Input
-                id={'unifiedNamespace-productionLine'}
+                id="unifiedNamespace-productionLine"
                 {...register('productionLine', {
                   ...getRulesForProperty($ISA95ApiBean.properties.productionLine),
                 })}
@@ -110,9 +110,9 @@ const NamespaceForm: FC<NamespaceFormProps> = ({ defaultValues, onSubmit }) => {
             <FormControlSeparator />
 
             <FormControl>
-              <FormLabel htmlFor={'unifiedNamespace-workCell'}>{t('unifiedNamespace.workCell.label')}</FormLabel>
+              <FormLabel htmlFor="unifiedNamespace-workCell">{t('unifiedNamespace.workCell.label')}</FormLabel>
               <Input
-                id={'unifiedNamespace-workCell'}
+                id="unifiedNamespace-workCell"
                 {...register('workCell', {
                   ...getRulesForProperty($ISA95ApiBean.properties.workCell),
                 })}
@@ -126,7 +126,7 @@ const NamespaceForm: FC<NamespaceFormProps> = ({ defaultValues, onSubmit }) => {
           <FormLabel as="legend">{t('unifiedNamespace.options.legend')}</FormLabel>
           <Checkbox
             data-testid="unifiedNamespace-prefixAllTopics"
-            id={'unifiedNamespace-prefixAllTopics'}
+            id="unifiedNamespace-prefixAllTopics"
             {...register('prefixAllTopics', {
               ...getRulesForProperty($ISA95ApiBean.properties.prefixAllTopics),
             })}

--- a/hivemq-edge/src/frontend/src/modules/UnifiedNamespace/components/UnifiedNamespaceEditor.tsx
+++ b/hivemq-edge/src/frontend/src/modules/UnifiedNamespace/components/UnifiedNamespaceEditor.tsx
@@ -68,11 +68,11 @@ const UnifiedNamespaceEditor: FC<UnifiedNamespaceEditorProps> = () => {
   if (!data) return null
 
   return (
-    <Drawer closeOnOverlayClick={false} size={'lg'} isOpen={isOpen} placement="right" onClose={handleEditorOnClose}>
+    <Drawer closeOnOverlayClick={false} size="lg" isOpen={isOpen} placement="right" onClose={handleEditorOnClose}>
       <DrawerOverlay />
       <DrawerContent aria-label={t('bridge.drawer.label') as string}>
         <DrawerCloseButton />
-        <DrawerHeader id={'bridge-form-header'} borderBottomWidth="1px">
+        <DrawerHeader id="bridge-form-header" borderBottomWidth="1px">
           {t('unifiedNamespace.title') as string}
         </DrawerHeader>
 
@@ -80,7 +80,7 @@ const UnifiedNamespaceEditor: FC<UnifiedNamespaceEditorProps> = () => {
           <NamespaceForm defaultValues={data} onSubmit={handleOnSubmit} />
         </DrawerBody>
         <DrawerFooter>
-          <Button variant={'primary'} isLoading={isUploading} type="submit" form="namespace-form">
+          <Button variant="primary" isLoading={isUploading} type="submit" form="namespace-form">
             {t('unifiedNamespace.submit.label')}
           </Button>
         </DrawerFooter>

--- a/hivemq-edge/src/frontend/src/modules/UnifiedNamespace/components/panels/InfoPanel.tsx
+++ b/hivemq-edge/src/frontend/src/modules/UnifiedNamespace/components/panels/InfoPanel.tsx
@@ -26,10 +26,10 @@ const InfoPanel: FC = () => {
           variant="link"
           as={RouterLink}
           to={config.documentation.namespace}
-          target={'hivemq:docs'}
+          target="hivemq:docs"
           aria-label={t('unifiedNamespace.container.info.link') as string}
           leftIcon={<GoLinkExternal />}
-          data-testid={'namespace-info-documentation'}
+          data-testid="namespace-info-documentation"
           size="lg"
         >
           {t('unifiedNamespace.container.info.link') as string}

--- a/hivemq-edge/src/frontend/src/modules/UnifiedNamespace/components/panels/PrefixPanel.tsx
+++ b/hivemq-edge/src/frontend/src/modules/UnifiedNamespace/components/panels/PrefixPanel.tsx
@@ -64,10 +64,10 @@ const PrefixPanel: FC<PrefixPanelProps> = ({ data, isLoading }) => {
       <CardFooter>
         <Skeleton isLoaded={!isLoading}>
           <FormControl>
-            <FormLabel htmlFor={'unifiedNamespace-enabled'}>{t('unifiedNamespace.enabled.label')}</FormLabel>
+            <FormLabel htmlFor="unifiedNamespace-enabled">{t('unifiedNamespace.enabled.label')}</FormLabel>
             <Switch
-              id={'unifiedNamespace-enabled'}
-              colorScheme={'brand'}
+              id="unifiedNamespace-enabled"
+              colorScheme="brand"
               isChecked={data.enabled}
               onChange={handleOnChange}
             />

--- a/hivemq-edge/src/frontend/src/modules/UnifiedNamespace/components/panels/RecommendationPanel.tsx
+++ b/hivemq-edge/src/frontend/src/modules/UnifiedNamespace/components/panels/RecommendationPanel.tsx
@@ -14,10 +14,10 @@ const RecommendationPanel = () => {
         </Heading>
       </CardHeader>
       <CardBody>
-        <Flex flexDirection={'column'}>
+        <Flex flexDirection="column">
           <Box>
-            <Text as={'span'}> {t('unifiedNamespace.container.recommend.by')}</Text>{' '}
-            <Text as={'span'} fontSize="2xl">
+            <Text as="span"> {t('unifiedNamespace.container.recommend.by')}</Text>{' '}
+            <Text as="span" fontSize="2xl">
               {t('unifiedNamespace.standard')}
             </Text>
           </Box>

--- a/hivemq-edge/src/frontend/src/modules/Welcome/WelcomePage.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Welcome/WelcomePage.tsx
@@ -15,7 +15,7 @@ const WelcomePage: FC = () => {
 
   return (
     <PageContainer title={t('welcome.title') as string} subtitle={t('welcome.description') as string}>
-      <Flex flexDirection={'column'}>
+      <Flex flexDirection="column">
         <Flex flexDirection={{ base: 'column', lg: 'row' }}>
           <Onboarding tasks={content} flex={1} />
           <Center flex={1} m={4}>

--- a/hivemq-edge/src/frontend/src/modules/Welcome/components/Onboarding.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Welcome/components/Onboarding.tsx
@@ -34,7 +34,7 @@ const Onboarding: FC<OnboardingProps> = ({ tasks, ...props }) => {
       <SimpleGrid spacing={6} templateColumns="repeat(auto-fill, minmax(33vw, 10fr))">
         {data &&
           data.map((e, i) => (
-            <Card flex={1} key={e.header} as={'aside'} aria-labelledby={`heading-task-${i}`}>
+            <Card flex={1} key={e.header} as="aside" aria-labelledby={`heading-task-${i}`}>
               <CardHeader>
                 <Skeleton isLoaded={!e.isLoading}>
                   <Heading as="h3" size="md" id={`heading-task-${i}`}>

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/ReactFlowWrapper.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/ReactFlowWrapper.tsx
@@ -48,7 +48,7 @@ const ReactFlowWrapper = () => {
 
   return (
     <ReactFlow
-      id={'edge-workspace-canvas'}
+      id="edge-workspace-canvas"
       nodes={nodes}
       edges={edges}
       nodeTypes={nodeTypes}
@@ -61,9 +61,9 @@ const ReactFlowWrapper = () => {
       deleteKeyCode={null}
     >
       <Box
-        role={'toolbar'}
+        role="toolbar"
         aria-label={t('workspace.controls.aria-label') as string}
-        aria-controls={'edge-workspace-canvas'}
+        aria-controls="edge-workspace-canvas"
       >
         <GroupNodesControl />
         <SelectionListener />

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/controls/CanvasControls.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/controls/CanvasControls.tsx
@@ -33,8 +33,8 @@ const CanvasControls: FC<ControlProps> = ({ onInteractiveChange }) => {
 
   // + - f l
   return (
-    <Panel position={'bottom-left'}>
-      <ButtonGroup variant="outline" isAttached size={'sm'}>
+    <Panel position="bottom-left">
+      <ButtonGroup variant="outline" isAttached size="sm">
         <IconButton icon={<FaPlus />} onClick={() => zoomIn()} aria-label={t('workspace.controls.zoomIn') as string} />
         <IconButton
           icon={<FaMinus />}

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/drawers/GroupPropertyDrawer.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/drawers/GroupPropertyDrawer.tsx
@@ -49,14 +49,14 @@ const GroupPropertyDrawer: FC<GroupPropertyDrawerProps> = ({
     : (t('workspace.observability.header', { context: selectedNode.type }) as string)
 
   return (
-    <Drawer isOpen={isOpen} placement="right" size={'lg'} onClose={onClose} variant={'hivemq'}>
+    <Drawer isOpen={isOpen} placement="right" size="lg" onClose={onClose} variant="hivemq">
       <DrawerOverlay />
       <DrawerContent aria-label={panelTitle}>
         <DrawerCloseButton />
 
         <DrawerHeader>
-          <Text data-testid={'group-panel-title'}>{panelTitle}</Text>
-          <Box data-testid={'group-panel-keys'}>
+          <Text data-testid="group-panel-title">{panelTitle}</Text>
+          <Box data-testid="group-panel-keys">
             {selectedNode.data.childrenNodeIds.map((e) => (
               <Text key={e}>
                 {t('workspace.device.type', { context: NodeTypes.ADAPTER_NODE })}:{' '}
@@ -65,7 +65,7 @@ const GroupPropertyDrawer: FC<GroupPropertyDrawerProps> = ({
             ))}
           </Box>
         </DrawerHeader>
-        <DrawerBody display={'flex'} flexDirection={'column'} gap={6}>
+        <DrawerBody display="flex" flexDirection="column" gap={6}>
           {showConfig && (
             <GroupMetadataEditor
               group={selectedNode}

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/drawers/LinkPropertyDrawer.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/drawers/LinkPropertyDrawer.tsx
@@ -21,7 +21,7 @@ const LinkPropertyDrawer: FC<LinkPropertyDrawerProps> = ({ nodeId, isOpen, selec
   const { t } = useTranslation()
 
   return (
-    <Drawer isOpen={isOpen} placement="right" size={'md'} onClose={onClose} variant={'hivemq'}>
+    <Drawer isOpen={isOpen} placement="right" size="md" onClose={onClose} variant="hivemq">
       {/*<DrawerOverlay />*/}
       <DrawerContent>
         <DrawerCloseButton />
@@ -34,7 +34,7 @@ const LinkPropertyDrawer: FC<LinkPropertyDrawerProps> = ({ nodeId, isOpen, selec
             </Text>
           </Box>
         </DrawerHeader>
-        <DrawerBody display={'flex'} flexDirection={'column'} gap={6}>
+        <DrawerBody display="flex" flexDirection="column" gap={6}>
           <Metrics
             nodeId={nodeId}
             type={selectedNode.type as NodeTypes}

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/drawers/NodePropertyDrawer.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/drawers/NodePropertyDrawer.spec.cy.tsx
@@ -58,7 +58,7 @@ describe('NodePropertyDrawer', () => {
     cy.injectAxe()
     cy.mountWithProviders(
       <NodePropertyDrawer
-        nodeId={'adapter@fgffgf'}
+        nodeId="adapter@fgffgf"
         selectedNode={mockNode}
         isOpen={true}
         onClose={cy.stub()}

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/drawers/NodePropertyDrawer.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/drawers/NodePropertyDrawer.tsx
@@ -44,14 +44,14 @@ const NodePropertyDrawer: FC<NodePropertyDrawerProps> = ({ nodeId, isOpen, selec
   const { t } = useTranslation()
 
   return (
-    <Drawer isOpen={isOpen} placement="right" size={'md'} onClose={onClose} variant={'hivemq'}>
+    <Drawer isOpen={isOpen} placement="right" size="md" onClose={onClose} variant="hivemq">
       <DrawerOverlay />
       <DrawerContent aria-label={t('workspace.property.header', { context: selectedNode.type }) as string}>
         <DrawerCloseButton />
         <DrawerHeader>
           <Text> {t('workspace.property.header', { context: selectedNode.type })}</Text>
         </DrawerHeader>
-        <DrawerBody display={'flex'} flexDirection={'column'} gap={6}>
+        <DrawerBody display="flex" flexDirection="column" gap={6}>
           <NodeNameCard selectedNode={selectedNode} />
           <Metrics
             nodeId={nodeId}
@@ -60,18 +60,18 @@ const NodePropertyDrawer: FC<NodePropertyDrawerProps> = ({ nodeId, isOpen, selec
             initMetrics={getDefaultMetricsFor(selectedNode)}
             defaultChartType={ChartType.SAMPLE}
           />
-          <Card size={'sm'}>
+          <Card size="sm">
             <CardHeader>
               <Text>
                 {t('workspace.property.eventLog.header', { type: selectedNode.type, id: selectedNode.data.id })}
               </Text>
             </CardHeader>
             <CardBody>
-              <EventLogTable globalSourceFilter={(selectedNode?.data as Adapter).id} variant={'summary'} />
+              <EventLogTable globalSourceFilter={(selectedNode?.data as Adapter).id} variant="summary" />
             </CardBody>
-            <CardFooter justifyContent={'flex-end'} pt={0}>
+            <CardFooter justifyContent="flex-end" pt={0}>
               <Button
-                data-testid={'navigate-eventLog-filtered'}
+                data-testid="navigate-eventLog-filtered"
                 variant="link"
                 as={RouterLink}
                 // URL options not yet supported
@@ -85,11 +85,11 @@ const NodePropertyDrawer: FC<NodePropertyDrawerProps> = ({ nodeId, isOpen, selec
           </Card>
         </DrawerBody>
         <DrawerFooter borderTopWidth="1px">
-          <Flex flexGrow={1} justifyContent={'flex-start'} gap={5}>
+          <Flex flexGrow={1} justifyContent="flex-start" gap={5}>
             <Button
-              data-testid={'protocol-create-adapter'}
-              variant={'outline'}
-              size={'sm'}
+              data-testid="protocol-create-adapter"
+              variant="outline"
+              size="sm"
               rightIcon={<EditIcon />}
               onClick={onEditEntity}
             >

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/drawers/WorkspaceOptionsDrawer.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/drawers/WorkspaceOptionsDrawer.tsx
@@ -35,7 +35,7 @@ const WorkspaceOptionsDrawer: FC = () => {
   })
 
   return (
-    <Drawer isOpen={optionDrawer.isOpen || false} placement="right" size={'md'} onClose={optionDrawer.onClose}>
+    <Drawer isOpen={optionDrawer.isOpen || false} placement="right" size="md" onClose={optionDrawer.onClose}>
       <DrawerOverlay />
       <DrawerContent>
         <DrawerCloseButton />
@@ -55,7 +55,7 @@ const WorkspaceOptionsDrawer: FC = () => {
                   setOptions((old) => ({ ...old, ...oldOptions, ...newOptions }))
                 }}
               >
-                <Stack direction={'column'}>
+                <Stack direction="column">
                   <Checkbox value="showTopics">{t('workspace.configuration.content.showTopics')}</Checkbox>
                   <Checkbox value="showStatus">{t('workspace.configuration.content.showStatus')}</Checkbox>
                   <Checkbox value="showMonitoringOnEdge">

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeAdapter.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeAdapter.tsx
@@ -35,9 +35,9 @@ const NodeAdapter: FC<NodeProps<Adapter>> = ({ id, data: adapter, selected }) =>
         p={2}
       >
         <VStack>
-          <HStack w={'100%'}>
+          <HStack w="100%">
             <Image aria-label={adapter.type} boxSize="20px" objectFit="scale-down" src={adapterProtocol?.logoUrl} />
-            <Text flex={1} data-testid={'adapter-node-name'}>
+            <Text flex={1} data-testid="adapter-node-name">
               {adapter.id}
             </Text>
           </HStack>

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeBridge.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeBridge.tsx
@@ -25,9 +25,9 @@ const NodeBridge: FC<NodeProps<Bridge>> = ({ id, selected, data: bridge }) => {
         <VStack>
           {options.showTopics && <TopicsContainer topics={topics.remote} />}
 
-          <HStack w={'100%'}>
+          <HStack w="100%">
             <Image boxSize="20px" objectFit="scale-down" src={logo} alt={t('workspace.node.bridge') as string} />
-            <Text flex={1} data-testid={'bridge-node-name'}>
+            <Text flex={1} data-testid="bridge-node-name">
               {bridge.id}
             </Text>
           </HStack>

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeEdge.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeEdge.tsx
@@ -10,7 +10,7 @@ const NodeEdge: FC<NodeProps> = () => {
 
   return (
     <>
-      <Image data-testid={'edge-node'} src={logo} alt={t('workspace.node.edge') as string} boxSize="96px" />
+      <Image data-testid="edge-node" src={logo} alt={t('workspace.node.edge') as string} boxSize="96px" />
       <Handle type="target" position={Position.Bottom} id="Bottom" isConnectable={false} style={{ bottom: '1px' }} />
       <Handle type="target" position={Position.Top} id="Top" isConnectable={false} style={{ top: '1px' }} />
       <Handle

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeGroup.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeGroup.tsx
@@ -65,17 +65,17 @@ const NodeGroup: FC<NodeProps<Group>> = ({ id, data, selected, ...props }) => {
       <NodeToolbar
         isVisible={selected}
         position={Position.Top}
-        role={'toolbar'}
+        role="toolbar"
         aria-controls={`node-group-${id}`}
         aria-label={t('workspace.grouping.toolbar.aria-label', { id }) as string}
         style={{ display: 'flex', gap: '12px' }}
       >
-        <ButtonGroup size="sm" isAttached variant="outline" colorScheme={'gray'}>
-          <Button data-testid={'node-group-toolbar-expand'} onClick={handleToggle}>
+        <ButtonGroup size="sm" isAttached variant="outline" colorScheme="gray">
+          <Button data-testid="node-group-toolbar-expand" onClick={handleToggle}>
             {!data.isOpen ? t('workspace.grouping.command.expand') : t('workspace.grouping.command.collapse')}
           </Button>
           <IconButton
-            data-testid={'node-group-toolbar-ungroup'}
+            data-testid="node-group-toolbar-ungroup"
             icon={<Icon as={ImUngroup} boxSize={5} />}
             aria-label={t('workspace.grouping.command.ungroup')}
             onClick={onConfirmUngroup}
@@ -84,8 +84,8 @@ const NodeGroup: FC<NodeProps<Group>> = ({ id, data, selected, ...props }) => {
         <IconButton
           size="sm"
           variant="solid"
-          colorScheme={'gray'}
-          data-testid={'node-group-toolbar-panel'}
+          colorScheme="gray"
+          data-testid="node-group-toolbar-panel"
           icon={<Icon as={LuPanelRightOpen} boxSize={5} />}
           aria-label={t('workspace.grouping.command.overview')}
           onClick={onContextMenu}
@@ -103,18 +103,18 @@ const NodeGroup: FC<NodeProps<Group>> = ({ id, data, selected, ...props }) => {
 
       <Box
         id={`node-group-${id}`}
-        w={'100%'}
-        h={'100%'}
+        w="100%"
+        h="100%"
         backgroundColor={
           data.isOpen ? undefined : data.colorScheme ? colors[data.colorScheme][isLight ? 50 : 900] : colors.red[50]
         }
         borderColor={data.colorScheme ? colors[data.colorScheme][500] : colors.red[50]}
         borderWidth={1}
-        borderStyle={'solid'}
+        borderStyle="solid"
         onDoubleClick={onContextMenu}
         onContextMenu={onContextMenu}
       >
-        <Text m={2} colorScheme={'black'}>
+        <Text m={2} colorScheme="black">
           {data.title}
         </Text>
       </Box>

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeHost.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeHost.tsx
@@ -8,7 +8,7 @@ const NodeHost: FC<NodeProps> = ({ selected, data }) => {
   const { label } = data
   return (
     <>
-      <NodeWrapper isSelected={selected} wordBreak={'break-word'} maxW={200} textAlign={'center'} p={3}>
+      <NodeWrapper isSelected={selected} wordBreak="break-word" maxW={200} textAlign="center" p={3}>
         <Text>{label}</Text>
       </NodeWrapper>
       <Handle type="target" position={Position.Top} isConnectable={false} />

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeListener.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeListener.tsx
@@ -26,7 +26,7 @@ const NodeListener: FC<NodeProps<Listener>> = ({ selected, data }) => {
         p={2}
         borderRadius={60}
         backgroundColor={selected ? '#dddfe2' : 'white'}
-        alignContent={'center'}
+        alignContent="center"
         sx={{
           _dark: {
             backgroundColor: selected ? '#dddfe2' : 'lightslategrey',

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/parts/GroupMetadataEditor.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/parts/GroupMetadataEditor.tsx
@@ -39,7 +39,7 @@ const GroupMetadataEditor: FC<GroupMetadataEditorProps> = ({ group, onSubmit }) 
   }
 
   return (
-    <Card size={'sm'}>
+    <Card size="sm">
       <Accordion allowToggle>
         <AccordionItem>
           <AccordionButton data-testid="metrics-toggle">
@@ -50,21 +50,21 @@ const GroupMetadataEditor: FC<GroupMetadataEditorProps> = ({ group, onSubmit }) 
           </AccordionButton>
 
           <AccordionPanel pb={4}>
-            <VStack gap={2} alignItems={'stretch'}>
+            <VStack gap={2} alignItems="stretch">
               <form
                 id="group-form"
                 onSubmit={handleSubmit(handleFormSubmit)}
                 style={{ display: 'flex', flexDirection: 'row', gap: '18px' }}
               >
                 <FormControl>
-                  <FormLabel htmlFor={'group-title'}>{t('workspace.grouping.editor.input-title')}</FormLabel>
-                  <Input id={'group-title'} {...register('title')} />
+                  <FormLabel htmlFor="group-title">{t('workspace.grouping.editor.input-title')}</FormLabel>
+                  <Input id="group-title" {...register('title')} />
                 </FormControl>
 
                 <FormControl as="fieldset">
                   <FormLabel as="legend">{t('workspace.grouping.editor.input-color')}</FormLabel>
                   <Controller
-                    name={`colorScheme`}
+                    name="colorScheme"
                     render={({ field }) => {
                       const { value, onChange, ...rest } = field
                       return <ColorPicker colorScheme={value} onChange={(value) => onChange(value)} {...rest} />
@@ -73,12 +73,12 @@ const GroupMetadataEditor: FC<GroupMetadataEditorProps> = ({ group, onSubmit }) 
                   />
                 </FormControl>
               </form>
-              <VStack alignItems={'end'}>
+              <VStack alignItems="end">
                 <Button
                   isDisabled={!formState.isDirty}
-                  type={'submit'}
+                  type="submit"
                   form="group-form"
-                  data-testid={'form-submit'}
+                  data-testid="form-submit"
                   mt={8}
                 >
                   {t('workspace.grouping.editor.save')}

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/parts/NodeNameCard.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/parts/NodeNameCard.tsx
@@ -29,12 +29,7 @@ const NodeNameCard: FC<NodeNameCardProps> = ({ selectedNode }) => {
   const EntityIcon = useMemo(() => {
     if (type === NodeTypes.BRIDGE_NODE)
       return (
-        <Icon
-          data-testid="node-type-icon"
-          data-nodeicon={NodeTypes.BRIDGE_NODE}
-          as={PiBridgeThin}
-          fontSize="40px"
-        />
+        <Icon data-testid="node-type-icon" data-nodeicon={NodeTypes.BRIDGE_NODE} as={PiBridgeThin} fontSize="40px" />
       )
     return <Icon data-testid="node-type-icon" data-nodeicon={NodeTypes.ADAPTER_NODE} as={PiPlugsConnectedFill} />
   }, [type])

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/parts/NodeNameCard.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/parts/NodeNameCard.tsx
@@ -30,29 +30,29 @@ const NodeNameCard: FC<NodeNameCardProps> = ({ selectedNode }) => {
     if (type === NodeTypes.BRIDGE_NODE)
       return (
         <Icon
-          data-testid={'node-type-icon'}
+          data-testid="node-type-icon"
           data-nodeicon={NodeTypes.BRIDGE_NODE}
           as={PiBridgeThin}
-          fontSize={'40px'}
+          fontSize="40px"
         />
       )
-    return <Icon data-testid={'node-type-icon'} data-nodeicon={NodeTypes.ADAPTER_NODE} as={PiPlugsConnectedFill} />
+    return <Icon data-testid="node-type-icon" data-nodeicon={NodeTypes.ADAPTER_NODE} as={PiPlugsConnectedFill} />
   }, [type])
 
   return (
-    <Card size={'sm'} direction={'row'}>
+    <Card size="sm" direction="row">
       <CardBody>
         <HStack divider={<StackDivider />}>
           <VStack>
             {EntityIcon}
-            <Tag data-testid={'node-type-text'} textTransform={'uppercase'}>
+            <Tag data-testid="node-type-text" textTransform="uppercase">
               {t('workspace.device.type', { context: type })}{' '}
             </Tag>
           </VStack>
 
-          <VStack alignItems={'flex-start'}>
-            {adapterType && <Text data-testid={'node-adapter-type'}>{adapterType.name}</Text>}
-            <Text data-testid={'node-name'} noOfLines={1}>
+          <VStack alignItems="flex-start">
+            {adapterType && <Text data-testid="node-adapter-type">{adapterType.name}</Text>}
+            <Text data-testid="node-name" noOfLines={1}>
               {selectedNode.data.id}
             </Text>
           </VStack>

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/parts/NodeWrapper.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/parts/NodeWrapper.tsx
@@ -16,11 +16,11 @@ const NodeWrapper: FC<NodeWrapperProps> = ({ children, isSelected = false, ...re
 
   return (
     <Card
-      variant={'elevated'}
+      variant="elevated"
       // colorScheme={'green'}
       p={6}
-      rounded={'md'}
-      border={`1px`}
+      rounded="md"
+      border="1px"
       // borderColor={'#bec3c9'}
       // backgroundColor={colors.white}
       // _hover={{ bg: '#ebedf0' }}

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/parts/TopicsContainer.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/parts/TopicsContainer.tsx
@@ -12,14 +12,14 @@ const MAX_TOPICS = 2
 
 const TopicsContainer: FC<NodeTopicsProps> = ({ topics }) => {
   return (
-    <HStack spacing="4" data-testid={'topics-container'}>
-      <VStack alignItems={'flex-start'}>
+    <HStack spacing="4" data-testid="topics-container">
+      <VStack alignItems="flex-start">
         {topics.slice(0, MAX_TOPICS).map((e, i) => (
           <Topic key={`local-${i}`} topic={e.topic} />
         ))}
       </VStack>
       {topics.length > MAX_TOPICS && (
-        <Tag size={'sm'} data-testid={'topics-show-more'}>
+        <Tag size="sm" data-testid="topics-show-more">
           <TagLabel>+{topics.length - MAX_TOPICS}</TagLabel>
         </Tag>
       )}


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/18908/details/

A housekeeping PR to add `react/jsx-curly-brace-presenc` to the `ESLint` rules, preventing the use of unnecessary curly braces in JSX props and/or children, e.g. 

```jsx
<App prop={'foo'} attr={"bar"}>{'Hello world'}</App>
```

should be fixed to 

```jsx
<App prop="foo" attr="bar">Hello world</App>
```