### PR TITLE
feat(18844): Add a simple UX connection between Edge and DataHub

### DIFF
--- a/hivemq-edge/src/frontend/src/extensions/datahub/api/__generated__/schemas/TopicFilterData.json
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/api/__generated__/schemas/TopicFilterData.json
@@ -2,6 +2,11 @@
   "type": "object",
   "description": "To start a policy, you have to indicate a topic (or a topic filter) to apply it on. This\n         is a simple way to handle this operation, until we can use the Topic Tree Selector.\n          ",
   "properties": {
+    "adapter": {
+      "type": "string",
+      "title": "Adapter source",
+      "description": "If an adapter is selected, the filters created below will be validated from the subscriptions"
+    },
     "topics": {
       "type": "array",
       "title": "Topic Filters",

--- a/hivemq-edge/src/frontend/src/extensions/datahub/api/specs/TopicFilterData.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/api/specs/TopicFilterData.ts
@@ -6,6 +6,9 @@ import schema from '../__generated__/schemas/TopicFilterData.json'
 export const MOCK_TOPIC_FILTER_SCHEMA: PanelSpecs = {
   schema: schema as RJSFSchema,
   uiSchema: {
+    adapter: {
+      'ui:widget': 'edge:adapter-selector',
+    },
     topics: {
       'ui:options': {
         // TODO[NVL] Reordering the topic reorders the handles and edges are gone

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/helpers/AdapterSelect.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/helpers/AdapterSelect.spec.cy.tsx
@@ -1,0 +1,27 @@
+/// <reference types="cypress" />
+
+import { WidgetProps } from '@rjsf/utils'
+import { AdapterSelect } from '@datahub/components/helpers/AdapterSelect.tsx'
+
+// @ts-ignore No need for the whole props for testing
+const MOCK_ADAPTER_PROPS: WidgetProps = {
+  id: 'adapter-widget',
+  label: 'Adapter',
+  name: 'adapter-select',
+  onBlur: () => undefined,
+  onChange: () => undefined,
+  onFocus: () => undefined,
+  schema: {},
+  options: {},
+}
+
+describe('AdapterSelect', () => {
+  beforeEach(() => {
+    cy.viewport(800, 600)
+    cy.intercept('/api/v1/management/protocol-adapters/adapters', { items: [] }).as('getAdapters')
+  })
+
+  it('should render the AdapterSelect', () => {
+    cy.mountWithProviders(<AdapterSelect {...MOCK_ADAPTER_PROPS} />)
+  })
+})

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/helpers/AdapterSelect.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/helpers/AdapterSelect.tsx
@@ -1,0 +1,64 @@
+import { FocusEvent, useCallback, useMemo } from 'react'
+import { labelValue, WidgetProps } from '@rjsf/utils'
+import { getChakra } from '@rjsf/chakra-ui/lib/utils'
+import { FormControl, FormLabel } from '@chakra-ui/react'
+import { Select, OnChangeValue } from 'chakra-react-select'
+
+import { useListProtocolAdapters } from '@/api/hooks/useProtocolAdapters/useListProtocolAdapters.tsx'
+
+interface AdapterType {
+  label: string
+  value: string
+}
+
+export const AdapterSelect = (props: WidgetProps) => {
+  // TODO[NVL] This is one of the components that break boundary with the DataHub "extension". Need a better way
+  const { data: adapters, isLoading, isError } = useListProtocolAdapters()
+
+  const chakraProps = getChakra({ uiSchema: props.uiSchema })
+
+  const onChange = useCallback<(newValue: OnChangeValue<{ label: string; value: string }, false>) => void>(
+    (newValue) => {
+      props.onChange(newValue?.value || undefined)
+    },
+    [props]
+  )
+  const onBlur = ({ target: { value } }: FocusEvent<HTMLInputElement>) => props.onBlur(props.id, value)
+  const onFocus = ({ target: { value } }: FocusEvent<HTMLInputElement>) => props.onFocus(props.id, value)
+
+  const options = useMemo(() => {
+    if (!adapters) return []
+    return adapters.map<AdapterType>((e) => ({ label: e.id, value: e.id }))
+  }, [adapters])
+
+  return (
+    <FormControl
+      mb={1}
+      {...chakraProps}
+      isDisabled={props.disabled || props.readonly}
+      isRequired={props.required}
+      isReadOnly={props.readonly}
+      isInvalid={props.rawErrors && props.rawErrors.length > 0}
+    >
+      {labelValue(
+        <FormLabel htmlFor={props.id} id={`${props.id}-label`}>
+          {props.label}
+        </FormLabel>,
+        props.hideLabel || !props.label
+      )}
+
+      <Select
+        isClearable
+        isLoading={isLoading}
+        isInvalid={isError}
+        inputId={props.id}
+        isRequired={props.required}
+        options={options}
+        value={{ label: props.value, value: props.value }}
+        onBlur={onBlur}
+        onFocus={onFocus}
+        onChange={onChange}
+      />
+    </FormControl>
+  )
+}

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/helpers/AdapterSelect.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/helpers/AdapterSelect.tsx
@@ -43,7 +43,7 @@ const Option = (props: OptionProps<Adapter>) => {
 }
 
 export const AdapterSelect = (props: WidgetProps) => {
-  // TODO[NVL] This is one of the components that break boundary with the DataHub "extension". Need a better way
+  // TODO[19017] This is one of the components that break boundary with the DataHub "extension". Need a better way
   const { data: adapters, isLoading, isError } = useListProtocolAdapters()
 
   const chakraProps = getChakra({ uiSchema: props.uiSchema })

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/helpers/EditorWidgetRegistry.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/helpers/EditorWidgetRegistry.tsx
@@ -5,6 +5,7 @@ import FunctionCreatableSelect from './FunctionCreatableSelect.tsx'
 import { JsFunctionInput, MetricCounterInput } from './MetricCounterInput.tsx'
 import { JavascriptEditor, JSONSchemaEditor, ProtoSchemaEditor } from './CodeEditor.tsx'
 import { MessageInterpolationTextArea } from './MessageInterpolationTextArea.tsx'
+import { AdapterSelect } from './AdapterSelect.tsx'
 
 export const datahubRJSFWidgets: RegistryWidgetsType = {
   'application/schema+json': JSONSchemaEditor,
@@ -15,4 +16,5 @@ export const datahubRJSFWidgets: RegistryWidgetsType = {
   'datahub:function-name': JsFunctionInput,
   'datahub:version': VersionManagerSelect,
   'datahub:message-interpolation': MessageInterpolationTextArea,
+  'edge:adapter-selector': AdapterSelect,
 }

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/panels/TopicFilterPanel.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/panels/TopicFilterPanel.spec.cy.tsx
@@ -36,6 +36,8 @@ describe('TopicFilterPanel', () => {
   it('should render the fields for a Validator', () => {
     cy.mountWithProviders(<TopicFilterPanel selectedNode="3" />, { wrapper })
 
+    cy.get('label#root_adapter-label').should('contain.text', 'Adapter source')
+
     cy.get('h2').eq(0).should('contain.text', 'Topic Filters')
     cy.get('label#root_topics_0-label').should('contain.text', 'topics-0')
     cy.get('label#root_topics_0-label + input').should('have.value', 'root/test1')

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/panels/TopicFilterPanel.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/panels/TopicFilterPanel.tsx
@@ -4,19 +4,19 @@ import { CustomValidator } from '@rjsf/utils'
 import { Card, CardBody } from '@chakra-ui/react'
 import { useTranslation } from 'react-i18next'
 
-import { MOCK_TOPIC_FILTER_SCHEMA } from '../../api/specs/'
-import useDataHubDraftStore from '../../hooks/useDataHubDraftStore.ts'
-import { PanelProps, TopicFilterData } from '../../types.ts'
-import { validateDuplicates } from '../../utils/rjsf.utils.ts'
-import { ReactFlowSchemaForm } from '../helpers/ReactFlowSchemaForm.tsx'
+import { PanelProps, TopicFilterData } from '@datahub/types.ts'
+import { MOCK_TOPIC_FILTER_SCHEMA } from '@datahub/api/specs/'
+import { ReactFlowSchemaForm } from '@datahub/components/helpers'
+import useDataHubDraftStore from '@datahub/hooks/useDataHubDraftStore.ts'
+import { validateDuplicates } from '@datahub/utils/rjsf.utils.ts'
 
 export const TopicFilterPanel: FC<PanelProps> = ({ selectedNode, onFormSubmit }) => {
   const { t } = useTranslation('datahub')
   const { nodes } = useDataHubDraftStore()
 
-  const topics = useMemo(() => {
+  const formData = useMemo(() => {
     const adapterNode = nodes.find((e) => e.id === selectedNode) as Node<TopicFilterData> | undefined
-    return adapterNode ? adapterNode.data.topics : null
+    return adapterNode ? adapterNode.data : null
   }, [selectedNode, nodes])
 
   const customValidate: CustomValidator<TopicFilterData> = (formData, errors) => {
@@ -40,7 +40,7 @@ export const TopicFilterPanel: FC<PanelProps> = ({ selectedNode, onFormSubmit })
         <ReactFlowSchemaForm
           schema={MOCK_TOPIC_FILTER_SCHEMA.schema}
           uiSchema={MOCK_TOPIC_FILTER_SCHEMA.uiSchema}
-          formData={{ topics: topics }}
+          formData={formData}
           customValidate={customValidate}
           onSubmit={onFormSubmit}
         />

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/panels/TopicFilterPanel.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/panels/TopicFilterPanel.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from 'react-i18next'
 
 import { PanelProps, TopicFilterData } from '@datahub/types.ts'
 import { MOCK_TOPIC_FILTER_SCHEMA } from '@datahub/api/specs/'
-import { ReactFlowSchemaForm } from '@datahub/components/helpers'
+import { datahubRJSFWidgets, ReactFlowSchemaForm } from '@datahub/components/helpers'
 import useDataHubDraftStore from '@datahub/hooks/useDataHubDraftStore.ts'
 import { validateDuplicates } from '@datahub/utils/rjsf.utils.ts'
 
@@ -42,6 +42,7 @@ export const TopicFilterPanel: FC<PanelProps> = ({ selectedNode, onFormSubmit })
           uiSchema={MOCK_TOPIC_FILTER_SCHEMA.uiSchema}
           formData={formData}
           customValidate={customValidate}
+          widgets={datahubRJSFWidgets}
           onSubmit={onFormSubmit}
         />
       </CardBody>

--- a/hivemq-edge/src/frontend/src/extensions/datahub/types.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/types.ts
@@ -73,6 +73,7 @@ export enum NodeCategory {
 export interface DataHubNodeData {}
 
 export interface TopicFilterData extends DataHubNodeData {
+  adapter?: string
   topics: string[]
 }
 


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/18844/details/

This PR creates the first step in allowing the users to naturally navigate between the core functionality of `Edge` and `DataHub`

The `Topic Filters` element of the data policy flow now accepts an optional `Adapter` in the configuration panel. The select widget contains the list of all live adapters and can be searched for instances. 

Once selected, two extra features will be enabled: 
- in the `Workspace`, the link that connects this adapter to `Edge` will now contain a second icon, which allows users to navigate to the `DataHub` sketch directly, selecting the relevant node
- in the `Topic Filters` configuration panel, the list of strings now runs an extra validation step: if the edited topic filters don't match one of the topic subscriptions defined in the adapter, an error will be raised.

Note that selecting an adapter is optional and doesn't change the current approach of filters. They still have to be edited individually (and therefore can be generated by an external source to define the `matching` property of the payload).

The PR also adds a small fix to the `Vite`/`TypeScript` configuration, defining the `@datahub` alias for the file import and allowing proper containerisation of the "extension".

### Out-of-scope
- The configuration panel only supports `Adapter` for the time being. Support for topics from `Bridge` will be added in a subsequent ticket.

### Before
  
![screenshot-localhost_3000-2024 01 31-17_51_29](https://github.com/hivemq/hivemq-edge/assets/2743481/2078ef54-93cb-4545-b891-d3f5ab50a299)
![screenshot-localhost_3000-2024 01 31-17_51_59](https://github.com/hivemq/hivemq-edge/assets/2743481/ad45537a-57ba-4a3b-904a-c562b04117db)

### After
![screenshot-localhost_3000-2024 01 31-17_50_13](https://github.com/hivemq/hivemq-edge/assets/2743481/89f91a1e-adb0-4070-a9e4-df3e31dcda7d)

![screenshot-localhost_3000-2024 01 31-17_50_26](https://github.com/hivemq/hivemq-edge/assets/2743481/8544a773-8d0c-4816-9a8c-64d47a928c41)

