### PR TITLE
refactor(18991): Refactor "Transform" Operation to include serialisers

### DIFF
--- a/hivemq-edge/src/frontend/src/extensions/datahub/api/__generated__/schemas/OperationData.json
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/api/__generated__/schemas/OperationData.json
@@ -150,17 +150,22 @@
       "properties": {}
     },
     "DataHub.transform": {
-      "title": "Transform function",
-      "description": "Javascript Transformation function",
+      "title": "Transformation",
+      "description": "The list of Javascript functions used in this transformation operation. Add them directly on the graph",
       "metadata": {
         "isTerminal": false,
         "hasArguments": true
       },
       "properties": {
         "transform": {
-          "type": "string",
-          "title": "Function name",
-          "format": "datahub:function-name"
+          "type": "array",
+          "title": "Execution order",
+          "description": "Change the order in which the transform functions will be executed",
+          "items": {
+            "type": "string",
+            "title": "Function name",
+            "format": "datahub:function-name"
+          }
         }
       }
     },

--- a/hivemq-edge/src/frontend/src/extensions/datahub/api/specs/OperationData.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/api/specs/OperationData.ts
@@ -9,7 +9,13 @@ export const MOCK_OPERATION_SCHEMA: PanelSpecs = {
     functionId: {
       'ui:widget': 'datahub:function-selector',
     },
+
     formData: {
+      transform: {
+        'ui:options': {
+          removable: false,
+        },
+      },
       message: {
         'ui:widget': 'datahub:message-interpolation',
       },

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/FunctionNode.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/FunctionNode.tsx
@@ -16,12 +16,6 @@ export const FunctionNode: FC<NodeProps<FunctionData>> = (props) => {
     <>
       <NodeWrapper route={`node/${DataHubNodeType.FUNCTION}/${id}`} {...props}>
         <VStack>
-          {import.meta.env.VITE_FLAG_DATAHUB_TRANSFORM_EXTENDED === 'true' && (
-            <HStack w="100%" justifyContent="space-around">
-              <Text fontSize="xs">{FunctionData.Handle.SERIALISER}</Text>
-              <Text fontSize="xs">{FunctionData.Handle.DESERIALISER}</Text>
-            </HStack>
-          )}
           <HStack>
             <NodeIcon type={DataHubNodeType.FUNCTION} />
             <Text data-testid="node-title"> {t('workspace.nodes.type', { context: type })}</Text>
@@ -32,22 +26,6 @@ export const FunctionNode: FC<NodeProps<FunctionData>> = (props) => {
         </VStack>
       </NodeWrapper>
       <CustomHandle type="source" position={Position.Bottom} id="source" />
-      {import.meta.env.VITE_FLAG_DATAHUB_TRANSFORM_EXTENDED === 'true' && (
-        <>
-          <CustomHandle
-            type="target"
-            position={Position.Top}
-            id={FunctionData.Handle.SERIALISER}
-            style={{ left: '25%' }}
-          />
-          <CustomHandle
-            type="target"
-            position={Position.Top}
-            id={FunctionData.Handle.DESERIALISER}
-            style={{ left: '75%' }}
-          />
-        </>
-      )}
     </>
   )
 }

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/OperationNode.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/OperationNode.spec.cy.tsx
@@ -25,9 +25,10 @@ describe('OperationNode', () => {
     cy.getByTestId(`node-title`).should('contain.text', 'Operation')
     cy.getByTestId(`node-model`).should('contain.text', '< not set >')
 
-    // TODO[NVL] Create a PageObject and generalise the selectors
-    cy.get('div[data-handleid]').should('have.length', 2)
-    cy.get('div[data-handleid]')
+    cy.get('div[data-handleid]').as('nodeHandles')
+
+    cy.get('@nodeHandles').should('have.length', 2)
+    cy.get('@nodeHandles')
       .eq(0)
       .should('have.attr', 'data-handlepos', 'left')
       .should('have.attr', 'data-id')
@@ -35,7 +36,7 @@ describe('OperationNode', () => {
         expect((attr as unknown as string).endsWith('target')).to.be.true
       })
 
-    cy.get('div[data-handleid]')
+    cy.get('@nodeHandles')
       .eq(1)
       .should('have.attr', 'data-handlepos', 'right')
       .should('have.attr', 'data-handleid', 'output')
@@ -48,18 +49,18 @@ describe('OperationNode', () => {
   it('should render properly with arguments', () => {
     const data: NodeProps<OperationData> = {
       ...MOCK_NODE_OPERATION,
-      data: { functionId: 'test', metadata: { hasArguments: true } },
+      data: { functionId: 'DataHub.transform', metadata: { hasArguments: true } },
     }
     cy.mountWithProviders(mockReactFlow(<OperationNode {...data} selected={true} />))
     cy.getByTestId(`node-title`).should('contain.text', 'Operation')
-    cy.getByTestId(`node-model`).should('contain.text', 'test')
+    cy.getByTestId(`node-model`).should('contain.text', 'DataHub.transform')
 
-    // TODO[NVL] Create a PageObject and generalise the selectors
-    cy.get('div[data-handleid]').should('have.length', 3)
-    cy.get('div[data-handleid]')
+    cy.get('div[data-handleid]').as('nodeHandles')
+    cy.get('@nodeHandles').should('have.length', 5)
+    cy.get('@nodeHandles')
       .eq(2)
       .should('have.attr', 'data-handlepos', 'top')
-      .should('have.attr', 'data-handleid', 'schema')
+      .should('have.attr', 'data-handleid', 'serialiser')
       .should('have.attr', 'data-id')
       .then((attr) => {
         expect((attr as unknown as string).endsWith('target')).to.be.true
@@ -75,9 +76,9 @@ describe('OperationNode', () => {
     cy.getByTestId(`node-title`).should('contain.text', 'Operation')
     cy.getByTestId(`node-model`).should('contain.text', 'test')
 
-    // TODO[NVL] Create a PageObject and generalise the selectors
-    cy.get('div[data-handleid]').should('have.length', 1)
-    cy.get('div[data-handleid]')
+    cy.get('div[data-handleid]').as('nodeHandles')
+    cy.get('@nodeHandles').should('have.length', 1)
+    cy.get('@nodeHandles')
       .eq(0)
       .should('have.attr', 'data-handlepos', 'left')
       .should('have.attr', 'data-id')

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/OperationNode.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/OperationNode.tsx
@@ -3,27 +3,44 @@ import { useTranslation } from 'react-i18next'
 import { NodeProps, Position } from 'reactflow'
 import { HStack, Text, VStack } from '@chakra-ui/react'
 
-import { DataHubNodeType, OperationData } from '../../types.ts'
-import NodeIcon from '../helpers/NodeIcon.tsx'
-import NodeParams from '../helpers/NodeParams.tsx'
-import { NodeWrapper } from './NodeWrapper.tsx'
-import { CustomHandle } from './CustomHandle.tsx'
+import { DataHubNodeType, OperationData } from '@datahub/types.ts'
+import { NodeIcon } from '@datahub/components/helpers'
+import { NodeWrapper } from '@datahub/components/nodes/NodeWrapper.tsx'
+import NodeParams from '@datahub/components/helpers/NodeParams.tsx'
+import { CustomHandle } from '@datahub/components/nodes/CustomHandle.tsx'
 
 export const OperationNode: FC<NodeProps<OperationData>> = (props) => {
   const { t } = useTranslation('datahub')
   const { data, id, type } = props
   const { functionId, metadata } = data
 
+  const isTransform = metadata?.hasArguments && data.functionId === 'DataHub.transform'
+  const isSerialiser =
+    metadata?.hasArguments && (data.functionId === 'Serdes.serialize' || data.functionId === 'Serdes.deserialize')
+
   return (
     <>
       <NodeWrapper route={`node/${DataHubNodeType.OPERATION}/${id}`} {...props}>
-        <HStack>
-          <NodeIcon type={DataHubNodeType.OPERATION} />
-          <Text data-testid="node-title"> {t('workspace.nodes.type', { context: type })}</Text>
-          <VStack data-testid="node-model">
-            <NodeParams value={functionId || t('error.noSet.select')} />
-          </VStack>
-        </HStack>
+        <VStack>
+          <HStack w="100%" justifyContent="space-around">
+            {isSerialiser && <Text fontSize="xs">{OperationData.Handle.SCHEMA}</Text>}
+            {isTransform && (
+              <>
+                <Text fontSize="xs">{OperationData.Handle.DESERIALISER}</Text>
+                <Text fontSize="xs">{OperationData.Handle.FUNCTION}</Text>
+                <Text fontSize="xs">{OperationData.Handle.SERIALISER}</Text>
+              </>
+            )}
+          </HStack>
+
+          <HStack>
+            <NodeIcon type={DataHubNodeType.OPERATION} />
+            <Text data-testid="node-title"> {t('workspace.nodes.type', { context: type })}</Text>
+            <VStack data-testid="node-model">
+              <NodeParams value={functionId || t('error.noSet.select')} />
+            </VStack>
+          </HStack>
+        </VStack>
       </NodeWrapper>
       <CustomHandle type="target" position={Position.Left} id={OperationData.Handle.INPUT} />
       {!metadata?.isTerminal && (
@@ -35,8 +52,23 @@ export const OperationNode: FC<NodeProps<OperationData>> = (props) => {
           // isConnectable={1}
         />
       )}
-      {metadata?.hasArguments && (
-        <CustomHandle type="target" position={Position.Top} id={OperationData.Handle.SCHEMA} />
+      {isSerialiser && <CustomHandle type="target" position={Position.Top} id={OperationData.Handle.SCHEMA} />}
+      {isTransform && (
+        <>
+          <CustomHandle
+            type="target"
+            position={Position.Top}
+            id={OperationData.Handle.SERIALISER}
+            style={{ left: '20%' }}
+          />
+          <CustomHandle type="target" position={Position.Top} id={OperationData.Handle.FUNCTION} />
+          <CustomHandle
+            type="target"
+            position={Position.Top}
+            id={OperationData.Handle.DESERIALISER}
+            style={{ left: '80%' }}
+          />
+        </>
       )}
     </>
   )

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/PolicyTable.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/PolicyTable.tsx
@@ -122,7 +122,6 @@ const PolicyTable: FC = () => {
           <Button
             leftIcon={<BiAddToQueue />}
             onClick={() => navigate(`/datahub/${PolicyType.CREATE_POLICY}`)}
-            isDisabled={isLoading}
             variant="primary"
           >
             {t('policyTable.action.create')}

--- a/hivemq-edge/src/frontend/src/extensions/datahub/types.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/types.ts
@@ -61,6 +61,13 @@ export enum DataHubNodeType {
   EVENT = 'EVENT',
 }
 
+export enum NodeCategory {
+  DEFAULT = 'DEFAULT',
+  INITIAL = 'INITIAL',
+  POLICY = 'POLICY',
+  RESOURCE = 'RESOURCE',
+}
+
 // TODO[NVL] Not sure of the pertinence of an empty interface
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface DataHubNodeData {}
@@ -128,8 +135,7 @@ export interface FunctionData {
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace FunctionData {
   export enum Handle {
-    SERIALISER = 'serialiser',
-    DESERIALISER = 'deserialiser',
+    SCHEMA = 'schema',
   }
 }
 
@@ -160,6 +166,9 @@ export namespace OperationData {
     INPUT = 'input',
     OUTPUT = 'output',
     SCHEMA = 'schema',
+    FUNCTION = 'function',
+    SERIALISER = 'serialiser',
+    DESERIALISER = 'deserialiser',
   }
 }
 

--- a/hivemq-edge/src/frontend/src/extensions/datahub/utils/node.utils.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/utils/node.utils.ts
@@ -7,7 +7,6 @@ import {
   DataHubNodeData,
   DataHubNodeType,
   DataPolicyData,
-  FunctionData,
   OperationData,
   SchemaData,
   SchemaType,
@@ -69,13 +68,13 @@ export const validConnections: ConnectionValidity = {
   [DataHubNodeType.SCHEMA]: [
     DataHubNodeType.VALIDATOR,
     [DataHubNodeType.OPERATION, OperationData.Handle.SCHEMA],
-    [DataHubNodeType.FUNCTION, FunctionData.Handle.SERIALISER],
-    [DataHubNodeType.FUNCTION, FunctionData.Handle.DESERIALISER],
+    [DataHubNodeType.OPERATION, OperationData.Handle.SERIALISER],
+    [DataHubNodeType.OPERATION, OperationData.Handle.DESERIALISER],
   ],
   [DataHubNodeType.CLIENT_FILTER]: [[DataHubNodeType.BEHAVIOR_POLICY, BehaviorPolicyData.Handle.CLIENT_FILTER]],
   [DataHubNodeType.BEHAVIOR_POLICY]: [DataHubNodeType.TRANSITION],
   [DataHubNodeType.TRANSITION]: [DataHubNodeType.OPERATION],
-  [DataHubNodeType.FUNCTION]: [[DataHubNodeType.OPERATION, OperationData.Handle.SCHEMA]],
+  [DataHubNodeType.FUNCTION]: [[DataHubNodeType.OPERATION, OperationData.Handle.FUNCTION]],
 }
 
 export const isValidPolicyConnection = (connection: Connection, nodes: Node[]) => {

--- a/hivemq-edge/src/frontend/tsconfig.json
+++ b/hivemq-edge/src/frontend/tsconfig.json
@@ -24,7 +24,8 @@
     // alias
     "baseUrl": "./",
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["src/*"],
+      "@datahub/*": ["src/extensions/datahub/*"]
     }
   },
   "include": ["src", "**/*.*"],

--- a/hivemq-edge/src/frontend/vite.config.ts
+++ b/hivemq-edge/src/frontend/vite.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),
+      '@datahub': path.resolve(__dirname, './src/extensions/datahub'),
     },
   },
   plugins: [react()],

--- a/hivemq-edge/src/frontend/vitest.config.ts
+++ b/hivemq-edge/src/frontend/vitest.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),
+      '@datahub': path.resolve(__dirname, './src/extensions/datahub'),
     },
   },
   test: {


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/18991/details/

This PR changes the UX for the `DataHub.transform` Operation definition to add the `deserialiser` and `serialiser` handles to the node. It allows the pipeline not to have to explicitly use the two dedicated nodes and makes the abstraction more meaningful to the users. It also changes the schema, to allow multiple functions to be added.

The API payload is not changing: the node will be converted to the three individual actions when submitted. 

### Before
![screenshot-localhost_3000-2024 02 01-09_29_10](https://github.com/hivemq/hivemq-edge/assets/2743481/8f5f0bdf-2af1-48b2-ad5c-f3b6601b00f9)

### After
![screenshot-localhost_3000-2024 02 01-09_27_18](https://github.com/hivemq/hivemq-edge/assets/2743481/b32f9bef-4271-4390-bc83-c69de4f59d2e)
