### PR TITLE
fix(19439) - CipherSuite placeholder text fix

### DIFF
--- a/hivemq-edge/src/frontend/src/locales/en/translation.json
+++ b/hivemq-edge/src/frontend/src/locales/en/translation.json
@@ -295,6 +295,7 @@
     "security": {
       "cipherSuites": {
         "label": "Cipher Suites",
+        "placeholder": "Add cipher suite",
         "helper": "Select the cipher suites. Leave empty to use the default cipher suites."
       },
       "enabled": {

--- a/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/SecurityPanel.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/SecurityPanel.tsx
@@ -51,7 +51,7 @@ const SecurityPanel: FC<BridgePanelType> = ({ form }) => {
                   options={CYPHER_SUITES.map((e) => ({ label: e, value: e }))}
                   // menuIsOpen={false}
                   isClearable={true}
-                  placeholder={'add topic'}
+                  placeholder={t('bridge.security.cipherSuites.placeholder')}
                   isMulti={true}
                   components={{
                     DropdownIndicator: null,


### PR DESCRIPTION
Added definition for cipher Suite placeholder text in i18n bundle and utilised bundle in the form component.