### PR TITLE
feat(19819): Add safeguard and feedback to the deletion of items in the data hub tables

### DIFF
--- a/hivemq-edge/src/frontend/src/extensions/datahub/api/hooks/DataHubSchemasService/__handlers__/index.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/api/hooks/DataHubSchemasService/__handlers__/index.ts
@@ -30,6 +30,7 @@ export const mockSchemaTempHumidity: Schema = {
   schemaDefinition: btoa(JSON.stringify(MOCK_SCHEMA_SOURCE)),
   //TODO[NVL] Should be typed (enum): JSON, PROTOBUF
   type: 'JSON',
+  version: 1,
 }
 
 export const handlers = [

--- a/hivemq-edge/src/frontend/src/extensions/datahub/api/hooks/DataHubScriptsService/__handlers__/index.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/api/hooks/DataHubScriptsService/__handlers__/index.ts
@@ -23,6 +23,8 @@ export const mockScript: Script = {
   createdAt: MOCK_CREATED_AT,
   functionType: Script.functionType.TRANSFORMATION,
   source: btoa(JSON.stringify(MOCK_SCRIPT_SOURCE)),
+  version: 1,
+  description: 'this is a description',
 }
 
 export const handlers = [

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/helpers/DataHubListAction.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/helpers/DataHubListAction.tsx
@@ -1,9 +1,8 @@
 import { FC, MouseEventHandler } from 'react'
 import { ButtonGroup } from '@chakra-ui/react'
 import IconButton from '@/components/Chakra/IconButton.tsx'
-import { FaEdit } from 'react-icons/fa'
 import { useTranslation } from 'react-i18next'
-import { FaTrashCan } from 'react-icons/fa6'
+import { LuFileEdit, LuTrash2 } from 'react-icons/lu'
 
 interface DataHubListActionProps {
   onEdit?: MouseEventHandler<HTMLButtonElement>
@@ -19,14 +18,14 @@ const DataHubListAction: FC<DataHubListActionProps> = ({ onEdit, onDelete, isEdi
         data-testid="list-action-edit"
         onClick={onEdit}
         aria-label={t('Listings.action.edit')}
-        icon={<FaEdit />}
+        icon={<LuFileEdit />}
         isDisabled={isEditDisabled}
       />
       <IconButton
         data-testid="list-action-delete"
         onClick={onDelete}
         aria-label={t('Listings.action.delete')}
-        icon={<FaTrashCan />}
+        icon={<LuTrash2 />}
       />
     </ButtonGroup>
   )

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/DataHubListings.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/DataHubListings.spec.cy.tsx
@@ -1,6 +1,7 @@
 /// <reference types="cypress" />
 
 import DataHubListings from '@datahub/components/pages/DataHubListings.tsx'
+import { mockSchemaTempHumidity } from '@datahub/api/hooks/DataHubSchemasService/__handlers__'
 
 describe('DataHubListings', () => {
   beforeEach(() => {
@@ -32,5 +33,35 @@ describe('DataHubListings', () => {
 
     cy.get('@tabs').eq(2).click()
     cy.get("[role='tabpanel']").eq(2).should('contain.text', 'Your transformation code will be listed there')
+  })
+
+  it('should support deletion', () => {
+    cy.intercept('/api/v1/data-hub/schemas', { items: [mockSchemaTempHumidity] }).as('getSchemas')
+    cy.intercept('/api/v1/data-hub/schemas/my-schema-id', {}).as('postDelete')
+    cy.mountWithProviders(<DataHubListings />)
+
+    cy.getByTestId('list-tabs').find('button[role="tab"]').as('tabs')
+    cy.get('@tabs').eq(1).click()
+    cy.get('tbody tr').first().as('firstItem')
+
+    cy.get('@firstItem').find('td').as('firstItemContent')
+    cy.get('@firstItemContent').should('have.length', 5)
+    cy.getByTestId('list-action-delete').click()
+
+    cy.get("[role='alertdialog']").as('modal').should('be.visible')
+    cy.get('@modal').find('header').should('have.text', 'Delete Item')
+    cy.get('@modal').find('header').should('have.text', 'Delete Item')
+    cy.get('@modal').find('footer').find('button').as('actions')
+    cy.get('@actions').eq(0).click()
+    cy.get("[role='alertdialog']").as('modal').should('not.exist')
+
+    cy.getByTestId('list-action-delete').click()
+    cy.get("[role='alertdialog']").as('modal').should('be.visible')
+    cy.get('@actions').eq(1).click()
+    // cy.get('@postDelete').should('have.been.called')
+    cy.get('div#toast-1-title')
+      .should('have.attr', 'data-status', 'success')
+      .should('be.visible')
+      .should('contain.text', 'Schema deleted')
   })
 })

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/DataHubListings.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/DataHubListings.tsx
@@ -8,12 +8,8 @@ import ScriptTable from '@datahub/components/pages/ScriptTable.tsx'
 const DataHubListings: FC = () => {
   const { t } = useTranslation('datahub')
 
-  function handleTabsChange() {
-    console.log('XXX')
-  }
-
   return (
-    <Tabs onChange={handleTabsChange} isLazy colorScheme="brand" data-testid="list-tabs">
+    <Tabs isLazy colorScheme="brand" data-testid="list-tabs">
       <TabList>
         <Tab fontSize="lg" fontWeight="bold">
           {t('Listings.tabs.policy.title')}

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/DataHubListings.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/DataHubListings.tsx
@@ -90,8 +90,8 @@ const DataHubListings: FC = () => {
         isOpen={isConfirmDeleteOpen}
         onClose={handleConfirmOnClose}
         onSubmit={handleConfirmOnSubmit}
-        message={t('modals.generics.confirmation')}
-        header={t('modals.deleteBridgeDialog.header')}
+        message={t('Listings.modal.delete.header')}
+        header={t('Listings.modal.delete.message')}
       />
     </Tabs>
   )

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/DataHubListings.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/DataHubListings.tsx
@@ -32,8 +32,6 @@ const DataHubListings: FC = () => {
   }
 
   const handleConfirmOnSubmit = () => {
-    console.log(deleteItem)
-    if (!deleteItem?.mutation) return
     deleteItem
       ?.mutation(deleteItem?.id)
       .then(() =>

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/DataHubListings.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/DataHubListings.tsx
@@ -1,12 +1,62 @@
-import { FC } from 'react'
+import { FC, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Tab, TabList, TabPanel, TabPanels, Tabs, Text } from '@chakra-ui/react'
+import { Tab, TabList, TabPanel, TabPanels, Tabs, Text, useDisclosure, useToast } from '@chakra-ui/react'
+import { UseMutateAsyncFunction } from '@tanstack/react-query'
+
+import ConfirmationDialog from '@/components/Modal/ConfirmationDialog.tsx'
+
 import PolicyTable from '@datahub/components/pages/PolicyTable.tsx'
 import SchemaTable from '@datahub/components/pages/SchemaTable.tsx'
 import ScriptTable from '@datahub/components/pages/ScriptTable.tsx'
+import { dataHubToastOption } from '@datahub/utils/toast.utils.ts'
+
+interface DeleteMutationRequest {
+  mutation: UseMutateAsyncFunction<void, unknown, string, unknown>
+  type: string
+  id: string
+}
 
 const DataHubListings: FC = () => {
   const { t } = useTranslation('datahub')
+  const { isOpen: isConfirmDeleteOpen, onOpen: onConfirmDeleteOpen, onClose: onConfirmDeleteClose } = useDisclosure()
+  const [deleteItem, setDeleteItem] = useState<DeleteMutationRequest | undefined>(undefined)
+  const toast = useToast()
+
+  const handleConfirmOnClose = () => {
+    onConfirmDeleteClose()
+    setDeleteItem(undefined)
+  }
+
+  const handleConfirmOnSubmit = () => {
+    console.log(deleteItem)
+    if (!deleteItem?.mutation) return
+    deleteItem
+      ?.mutation(deleteItem?.id)
+      .then(() =>
+        toast({
+          ...dataHubToastOption,
+          title: t('error.delete.title', { source: deleteItem?.type }),
+          status: 'success',
+        })
+      )
+      .catch((e) =>
+        toast({
+          ...dataHubToastOption,
+          title: t('error.delete.error', { source: deleteItem?.type }),
+          description: e.toString(),
+          status: 'error',
+        })
+      )
+  }
+
+  const handleOnDelete = (
+    mutation: UseMutateAsyncFunction<void, unknown, string, unknown>,
+    type: string,
+    id: string
+  ) => {
+    onConfirmDeleteOpen()
+    setDeleteItem({ mutation, type, id })
+  }
 
   return (
     <Tabs isLazy colorScheme="brand" data-testid="list-tabs">
@@ -25,7 +75,7 @@ const DataHubListings: FC = () => {
       <TabPanels>
         <TabPanel>
           <Text mb={3}>{t('Listings.tabs.policy.description')}</Text>
-          <PolicyTable />
+          <PolicyTable onDeleteItem={handleOnDelete} />
         </TabPanel>
         <TabPanel>
           <Text mb={3}>{t('Listings.tabs.schema.description')}</Text>
@@ -36,6 +86,13 @@ const DataHubListings: FC = () => {
           <ScriptTable />
         </TabPanel>
       </TabPanels>
+      <ConfirmationDialog
+        isOpen={isConfirmDeleteOpen}
+        onClose={handleConfirmOnClose}
+        onSubmit={handleConfirmOnSubmit}
+        message={t('modals.generics.confirmation')}
+        header={t('modals.deleteBridgeDialog.header')}
+      />
     </Tabs>
   )
 }

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/DataHubListings.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/DataHubListings.tsx
@@ -94,8 +94,8 @@ const DataHubListings: FC = () => {
         isOpen={isConfirmDeleteOpen}
         onClose={handleConfirmOnClose}
         onSubmit={handleConfirmOnSubmit}
-        message={t('Listings.modal.delete.header')}
-        header={t('Listings.modal.delete.message')}
+        message={t('Listings.modal.delete.message')}
+        header={t('Listings.modal.delete.header')}
       />
     </Tabs>
   )

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/DataHubListings.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/DataHubListings.tsx
@@ -16,6 +16,10 @@ interface DeleteMutationRequest {
   id: string
 }
 
+export interface DataHubTableProps {
+  onDeleteItem?: (mutation: UseMutateAsyncFunction<void, unknown, string, unknown>, type: string, id: string) => void
+}
+
 const DataHubListings: FC = () => {
   const { t } = useTranslation('datahub')
   const { isOpen: isConfirmDeleteOpen, onOpen: onConfirmDeleteOpen, onClose: onConfirmDeleteClose } = useDisclosure()

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/DataHubListings.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/DataHubListings.tsx
@@ -83,11 +83,11 @@ const DataHubListings: FC = () => {
         </TabPanel>
         <TabPanel>
           <Text mb={3}>{t('Listings.tabs.schema.description')}</Text>
-          <SchemaTable />
+          <SchemaTable onDeleteItem={handleOnDelete} />
         </TabPanel>
         <TabPanel>
           <Text mb={3}>{t('Listings.tabs.script.description')}</Text>
-          <ScriptTable />
+          <ScriptTable onDeleteItem={handleOnDelete} />
         </TabPanel>
       </TabPanels>
       <ConfirmationDialog

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/PolicyTable.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/PolicyTable.tsx
@@ -1,6 +1,6 @@
 import { FC, useMemo } from 'react'
 import { CellContext, ColumnDef } from '@tanstack/react-table'
-import { UseMutateAsyncFunction, UseMutationResult } from '@tanstack/react-query'
+import { UseMutationResult } from '@tanstack/react-query'
 import { DateTime } from 'luxon'
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
@@ -20,14 +20,11 @@ import { mockBehaviorPolicy } from '@datahub/api/hooks/DataHubBehaviorPoliciesSe
 import { useGetAllDataPolicies } from '@datahub/api/hooks/DataHubDataPoliciesService/useGetAllDataPolicies.tsx'
 import DataHubListAction from '@datahub/components/helpers/DataHubListAction.tsx'
 import { useDeleteBehaviorPolicy } from '@datahub/api/hooks/DataHubBehaviorPoliciesService/useDeleteBehaviorPolicy.tsx'
+import { DataHubTableProps } from '@datahub/components/pages/DataHubListings.tsx'
 
 type CombinedPolicy = (DataPolicy & { type: PolicyType }) | (BehaviorPolicy & { type: PolicyType })
 
-interface PolicyTablePRops {
-  onDeleteItem?: (mutation: UseMutateAsyncFunction<void, unknown, string, unknown>, type: string, id: string) => void
-}
-
-const PolicyTable: FC<PolicyTablePRops> = ({ onDeleteItem }) => {
+const PolicyTable: FC<DataHubTableProps> = ({ onDeleteItem }) => {
   const { t } = useTranslation('datahub')
   const { isLoading: isDataLoading, data: dataPolicies, isError: isDataError } = useGetAllDataPolicies()
   const {

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/SchemaTable.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/SchemaTable.spec.cy.tsx
@@ -1,6 +1,7 @@
 /// <reference types="cypress" />
 
 import SchemaTable from '@datahub/components/pages/SchemaTable.tsx'
+import { mockSchemaTempHumidity } from '@datahub/api/hooks/DataHubSchemasService/__handlers__'
 
 describe('SchemaTable', () => {
   beforeEach(() => {
@@ -17,5 +18,20 @@ describe('SchemaTable', () => {
     cy.get('table').find('thead').find('th').eq(2).should('have.text', 'Version')
     cy.get('table').find('thead').find('th').eq(3).should('have.text', 'Created')
     cy.get('table').find('thead').find('th').eq(4).should('have.text', 'Actions')
+  })
+
+  it('should render the data', () => {
+    cy.intercept('/api/v1/data-hub/schemas', { items: [mockSchemaTempHumidity] }).as('getSchemas')
+
+    cy.mountWithProviders(<SchemaTable />)
+    cy.get('tbody tr').should('have.length', 1)
+    cy.get('tbody tr').first().as('firstItem')
+
+    cy.get('@firstItem').find('td').as('firstItemContent')
+    cy.get('@firstItemContent').should('have.length', 5)
+    cy.get('@firstItemContent').eq(0).should('have.text', 'my-schema-id')
+    cy.get('@firstItemContent').eq(1).should('have.text', 'JSON')
+    cy.get('@firstItemContent').eq(2).should('have.text', '1')
+    cy.get('@firstItemContent').eq(3).should('have.text', '5 months ago')
   })
 })

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/SchemaTable.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/SchemaTable.tsx
@@ -13,8 +13,10 @@ import { useGetAllSchemas } from '@datahub/api/hooks/DataHubSchemasService/useGe
 import { mockSchemaTempHumidity } from '@datahub/api/hooks/DataHubSchemasService/__handlers__'
 import { useDeleteSchema } from '@datahub/api/hooks/DataHubSchemasService/useDeleteSchema.tsx'
 import DataHubListAction from '@datahub/components/helpers/DataHubListAction.tsx'
+import { DataHubTableProps } from '@datahub/components/pages/DataHubListings.tsx'
+import { DataHubNodeType } from '@datahub/types.ts'
 
-const SchemaTable: FC = () => {
+const SchemaTable: FC<DataHubTableProps> = ({ onDeleteItem }) => {
   const { t } = useTranslation('datahub')
   const { isLoading, data, isError } = useGetAllSchemas()
   const deleteSchema = useDeleteSchema()
@@ -78,19 +80,14 @@ const SchemaTable: FC = () => {
             <Skeleton isLoaded={!isLoading}>
               <DataHubListAction
                 isEditDisabled={true}
-                onDelete={() =>
-                  deleteSchema
-                    .mutateAsync(info.row.original.id)
-                    .then((e) => console.log('XXXXXX', e))
-                    .catch((e) => console.log('XXXXX', e.toString(), info))
-                }
+                onDelete={() => onDeleteItem?.(deleteSchema.mutateAsync, DataHubNodeType.SCHEMA, info.row.original.id)}
               />
             </Skeleton>
           )
         },
       },
     ]
-  }, [deleteSchema, isLoading, t])
+  }, [deleteSchema.mutateAsync, isLoading, onDeleteItem, t])
 
   return (
     <PaginatedTable<Schema>

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/ScriptTable.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/ScriptTable.spec.cy.tsx
@@ -1,6 +1,7 @@
 /// <reference types="cypress" />
 
 import ScriptTable from '@datahub/components/pages/ScriptTable.tsx'
+import { mockScript } from '@datahub/api/hooks/DataHubScriptsService/__handlers__'
 
 describe('ScriptTable', () => {
   beforeEach(() => {
@@ -18,5 +19,25 @@ describe('ScriptTable', () => {
     cy.get('table').find('thead').find('th').eq(3).should('have.text', 'Description')
     cy.get('table').find('thead').find('th').eq(4).should('have.text', 'Created')
     cy.get('table').find('thead').find('th').eq(5).should('have.text', 'Actions')
+
+    cy.get("[role='alert']")
+      .should('have.attr', 'data-status', 'error')
+      .should('contain.text', 'There was an error loading the data')
+  })
+
+  it('should render the data', () => {
+    cy.intercept('/api/v1/data-hub/scripts', { items: [mockScript] }).as('getScripts')
+
+    cy.mountWithProviders(<ScriptTable />)
+    cy.get('tbody tr').should('have.length', 1)
+    cy.get('tbody tr').first().as('firstItem')
+
+    cy.get('@firstItem').find('td').as('firstItemContent')
+    cy.get('@firstItemContent').should('have.length', 6)
+    cy.get('@firstItemContent').eq(0).should('have.text', 'my-script-id')
+    cy.get('@firstItemContent').eq(1).should('have.text', 'Transformation')
+    cy.get('@firstItemContent').eq(2).should('have.text', '1')
+    cy.get('@firstItemContent').eq(3).should('have.text', 'this is a description')
+    cy.get('@firstItemContent').eq(4).should('have.text', '5 months ago')
   })
 })

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/ScriptTable.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/ScriptTable.tsx
@@ -12,8 +12,10 @@ import { useGetAllScripts } from '@datahub/api/hooks/DataHubScriptsService/useGe
 import { useDeleteScript } from '@datahub/api/hooks/DataHubScriptsService/useDeleteScript.tsx'
 import { mockScript } from '@datahub/api/hooks/DataHubScriptsService/__handlers__'
 import DataHubListAction from '@datahub/components/helpers/DataHubListAction.tsx'
+import { DataHubTableProps } from '@datahub/components/pages/DataHubListings.tsx'
+import { DataHubNodeType } from '@datahub/types.ts'
 
-const ScriptTable: FC = () => {
+const ScriptTable: FC<DataHubTableProps> = ({ onDeleteItem }) => {
   const { t } = useTranslation('datahub')
   const { isLoading, data, isError } = useGetAllScripts({})
   const deleteScript = useDeleteScript()
@@ -89,10 +91,7 @@ const ScriptTable: FC = () => {
               <DataHubListAction
                 isEditDisabled={true}
                 onDelete={() =>
-                  deleteScript
-                    .mutateAsync(info.row.original.id)
-                    .then((e) => console.log('XXXXXX', e))
-                    .catch((e) => console.log('XXXXX', e.toString(), info))
+                  onDeleteItem?.(deleteScript.mutateAsync, DataHubNodeType.FUNCTION, info.row.original.id)
                 }
               />
             </Skeleton>
@@ -100,7 +99,7 @@ const ScriptTable: FC = () => {
         },
       },
     ]
-  }, [deleteScript, isLoading, t])
+  }, [deleteScript.mutateAsync, isLoading, onDeleteItem, t])
 
   return (
     <PaginatedTable<Script>

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/operation/OperationNode.utils.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/operation/OperationNode.utils.ts
@@ -145,7 +145,7 @@ export const processOperations =
     } else {
       const operation: PolicyOperation = {
         functionId: node.data.functionId,
-        arguments: node.data.formData,
+        arguments: node.data.formData || {},
         // TODO[19466] Id should be user-facing; Need to fix before merging!
         id: node.id,
       }

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/transition/TransitionNode.utils.spec.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/transition/TransitionNode.utils.spec.ts
@@ -176,7 +176,7 @@ describe('checkValidityTransitions', () => {
     const [{ node, data, error, resources }] = behaviorPolicyTransitions
     expect(data).toEqual({
       'Mqtt.OnInboundDisconnect': {
-        pipelines: [
+        pipeline: [
           {
             arguments: {
               level: 'DEBUG',

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/transition/TransitionNode.utils.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/transition/TransitionNode.utils.ts
@@ -2,7 +2,7 @@ import { getOutgoers, Node } from 'reactflow'
 
 import { BehaviorPolicyData, DataHubNodeType, DryRunResults, TransitionData, WorkspaceState } from '@datahub/types.ts'
 import { PolicyCheckErrors } from '@datahub/designer/validation.errors.ts'
-import { BehaviorPolicyOnTransition, PolicyOperation } from '@/api/__generated__'
+import { BehaviorPolicyOnEvent, BehaviorPolicyOnTransition, PolicyOperation } from '@/api/__generated__'
 import { checkValidityPipeline } from '@datahub/designer/operation/OperationNode.utils.ts'
 import { isTransitionNodeType } from '@datahub/utils/node.utils.ts'
 
@@ -43,13 +43,16 @@ export function checkValidityTransitions(
 
     // TODO[19240] Making an assumption: we can incorporate the "correct" parts of the pipeline
     const validPipeline = pipeline.filter((operation) => !!operation.data)
+    const policyEvents: BehaviorPolicyOnEvent = {
+      pipeline: validPipeline.map((operation) => operation.data as PolicyOperation),
+    }
 
     return {
       node: transition,
       data: {
         fromState: transition.data.from,
         toState: transition.data.to,
-        [transition.data.event]: { pipelines: validPipeline.map((operation) => operation.data) },
+        [transition.data.event]: policyEvents,
       },
     }
   })

--- a/hivemq-edge/src/frontend/src/extensions/datahub/locales/en/datahub.json
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/locales/en/datahub.json
@@ -10,8 +10,8 @@
     "description": "The Edge Data Hub provides mechanisms to define how MQTT data and MQTT client behavior are handled from the adaptors to the HiveMQ broker"
   },
   "policy": {
-    "type_DATA": "Data Policy",
-    "type_BEHAVIOR": "Behavior Policy"
+    "type_DATA_POLICY": "Data Policy",
+    "type_BEHAVIOR_POLICY": "Behavior Policy"
   },
 
   "resource": {
@@ -56,7 +56,12 @@
         "create": "Create a new policy"
       }
     },
-
+    "modal": {
+      "delete": {
+        "header": "Delete Item",
+        "message": "Are you sure? You can't undo this action afterwards."
+      }
+    },
     "schema": {
       "label": "List of schemas",
       "header": {
@@ -205,6 +210,10 @@
       "title": "$t(datahub:workspace.nodes.type, { 'context': '{{source}}' }) published",
       "description": "We've created a new $t(datahub:workspace.nodes.type, { 'context': '{{source}}' }) for you.",
       "error": "Error publishing $t(datahub:workspace.nodes.type, { 'context': '{{source}}' })"
+    },
+    "delete": {
+      "title": "$t(datahub:workspace.nodes.type, { 'context': '{{source}}' }) deleted",
+      "error": "Error deleting $t(datahub:workspace.nodes.type, { 'context': '{{source}}' })"
     },
     "noSet": {
       "select": "< not set >"

--- a/hivemq-edge/src/frontend/src/extensions/datahub/types.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/types.ts
@@ -55,12 +55,6 @@ export interface PolicyCheckAction {
   getErrors: () => ProblemDetailsExtended[] | undefined
 }
 
-export enum PolicyType {
-  CREATE_POLICY = 'CREATE_POLICY',
-  DATA = 'DATA',
-  BEHAVIOR = 'BEHAVIOR',
-}
-
 export enum DataHubNodeType {
   ADAPTOR = 'ADAPTOR',
   EDGE = 'EDGE',
@@ -75,6 +69,12 @@ export enum DataHubNodeType {
   TRANSITION = 'TRANSITION',
   FUNCTION = 'FUNCTION',
   EVENT = 'EVENT',
+}
+
+export enum PolicyType {
+  CREATE_POLICY = 'CREATE_POLICY',
+  DATA = DataHubNodeType.DATA_POLICY,
+  BEHAVIOR = DataHubNodeType.BEHAVIOR_POLICY,
 }
 
 export enum NodeCategory {


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/19819/details/

The PR adds the confirmation dialogue to the deletion of items in the `policy`, `script` and `schema` tables, to ensure deletion doesn't occur by mistake (they are non-reversible). 

Upon confirmation, the usual toast confirms the deletion of the item or shows any error. 

### Before 
![screenshot-localhost_3000-2024 03 01-12_33_39](https://github.com/hivemq/hivemq-edge/assets/2743481/70a0e402-5b11-4e6d-a3d3-605308069b33)

### After 
![screenshot-localhost_3000-2024 03 01-12_34_40](https://github.com/hivemq/hivemq-edge/assets/2743481/3a8f63e0-d7f0-4bd8-adb6-8fb6e79a6a4d)

![screenshot-localhost_3000-2024 03 01-12_34_52](https://github.com/hivemq/hivemq-edge/assets/2743481/52f848e4-c038-457c-a99f-7797426ff845)

