### PR TITLE
fix(19348) - Modbus change data calculation should only publish deltas

### DIFF
--- a/hivemq-edge/src/main/java/com/hivemq/edge/modules/adapters/data/AdapterDataUtils.java
+++ b/hivemq-edge/src/main/java/com/hivemq/edge/modules/adapters/data/AdapterDataUtils.java
@@ -11,8 +11,9 @@ public class AdapterDataUtils {
                 .anyMatch(dp -> dp.getTagValue().equals(point.getTagValue())); // Then check for tagValue
     }
 
-    public static List<ProtocolAdapterDataSample.DataPoint> margeChangedSamples(final @NotNull List<ProtocolAdapterDataSample.DataPoint> historicalSamples,
-                                           final @NotNull List<ProtocolAdapterDataSample.DataPoint> currentSamples) {
+    public static List<ProtocolAdapterDataSample.DataPoint> mergeChangedSamples(
+            final @NotNull List<ProtocolAdapterDataSample.DataPoint> historicalSamples,
+            final @NotNull List<ProtocolAdapterDataSample.DataPoint> currentSamples) {
         List<ProtocolAdapterDataSample.DataPoint> delta = new ArrayList<>();
         for (int i = 0; i < currentSamples.size(); i++) {
             ProtocolAdapterDataSample.DataPoint currentSample = currentSamples.get(i);

--- a/hivemq-edge/src/main/java/com/hivemq/edge/modules/adapters/data/AdapterDataUtils.java
+++ b/hivemq-edge/src/main/java/com/hivemq/edge/modules/adapters/data/AdapterDataUtils.java
@@ -1,0 +1,27 @@
+package com.hivemq.edge.modules.adapters.data;
+
+import com.hivemq.extension.sdk.api.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class AdapterDataUtils {
+    public static boolean matches(final @NotNull ProtocolAdapterDataSample.DataPoint point, final @NotNull List<ProtocolAdapterDataSample.DataPoint> list) {
+        return list.stream().filter(dp -> dp.getTagName().equals(point.getTagName())) // First filter by tagName
+                .anyMatch(dp -> dp.getTagValue().equals(point.getTagValue())); // Then check for tagValue
+    }
+
+    public static List<ProtocolAdapterDataSample.DataPoint> margeChangedSamples(final @NotNull List<ProtocolAdapterDataSample.DataPoint> historicalSamples,
+                                           final @NotNull List<ProtocolAdapterDataSample.DataPoint> currentSamples) {
+        List<ProtocolAdapterDataSample.DataPoint> delta = new ArrayList<>();
+        for (int i = 0; i < currentSamples.size(); i++) {
+            ProtocolAdapterDataSample.DataPoint currentSample = currentSamples.get(i);
+            // If the current sample does not match any in the historical samples, it has changed
+            if (!matches(currentSample, historicalSamples)) {
+                historicalSamples.set(i, currentSample);
+                delta.add(currentSample);
+            }
+        }
+        return delta;
+    }
+}

--- a/hivemq-edge/src/main/java/com/hivemq/edge/modules/adapters/data/ProtocolAdapterDataSample.java
+++ b/hivemq-edge/src/main/java/com/hivemq/edge/modules/adapters/data/ProtocolAdapterDataSample.java
@@ -81,9 +81,13 @@ public class ProtocolAdapterDataSample<T extends AbstractProtocolAdapterConfig> 
         dataPoints.add(new DataPoint(tagName,tagValue));
     }
 
+    public void setDataPoints(List<DataPoint> list){
+        this.dataPoints = list;
+    }
+
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public List<DataPoint> getDataPoints(){
-        return Collections.unmodifiableList(dataPoints);
+        return dataPoints;
     }
 
     public static class DataPoint {

--- a/hivemq-edge/src/main/java/com/hivemq/edge/modules/config/impl/AbstractProtocolAdapterConfig.java
+++ b/hivemq-edge/src/main/java/com/hivemq/edge/modules/config/impl/AbstractProtocolAdapterConfig.java
@@ -60,7 +60,7 @@ public class AbstractProtocolAdapterConfig implements CustomConfig {
                            description = "The topic to publish data on",
                            required = true,
                            format = ModuleConfigField.FieldType.MQTT_TOPIC)
-        private @Nullable String destination;
+        protected @Nullable String destination;
 
         @JsonProperty(value = "qos", required = true)
         @ModuleConfigField(title = "QoS",
@@ -69,7 +69,7 @@ public class AbstractProtocolAdapterConfig implements CustomConfig {
                            numberMin = 0,
                            numberMax = 2,
                            defaultValue = "0")
-        private int qos = 0;
+        protected int qos = 0;
 
         @JsonProperty(value = "messageHandlingOptions")
         @ModuleConfigField(title = "Message Handling Options",
@@ -78,19 +78,19 @@ public class AbstractProtocolAdapterConfig implements CustomConfig {
                            enumDisplayValues = {"MQTT Message Per Device Tag",
                                                 "MQTT Message Per Subscription (Potentially Multiple Data Points Per Sample)"},
                            defaultValue = "MQTTMessagePerTag")
-        private @Nullable MessageHandlingOptions messageHandlingOptions = MessageHandlingOptions.MQTTMessagePerTag;
+        protected @Nullable MessageHandlingOptions messageHandlingOptions = MessageHandlingOptions.MQTTMessagePerTag;
 
         @JsonProperty(value = "includeTimestamp")
         @ModuleConfigField(title = "Include Sample Timestamp In Publish?",
                            description = "Include the unix timestamp of the sample time in the resulting MQTT message",
                            defaultValue = "true")
-        private @Nullable Boolean includeTimestamp = Boolean.TRUE;
+        protected @Nullable Boolean includeTimestamp = Boolean.TRUE;
 
         @JsonProperty(value = "includeTagNames")
         @ModuleConfigField(title = "Include Tag Names In Publish?",
                            description = "Include the names of the tags in the resulting MQTT publish",
                            defaultValue = "false")
-        private @Nullable Boolean includeTagNames = Boolean.FALSE;
+        protected @Nullable Boolean includeTagNames = Boolean.FALSE;
 
         @JsonProperty(value = "userProperties")
         @ModuleConfigField(title = "User Properties",

--- a/hivemq-edge/src/main/java/com/hivemq/edge/modules/config/impl/AbstractProtocolAdapterConfig.java
+++ b/hivemq-edge/src/main/java/com/hivemq/edge/modules/config/impl/AbstractProtocolAdapterConfig.java
@@ -105,7 +105,7 @@ public class AbstractProtocolAdapterConfig implements CustomConfig {
         public Subscription(
                 @JsonProperty("destination") @Nullable final String destination,
                 @JsonProperty("qos") final int qos,
-                @JsonProperty("userProperties") List<UserProperty> userProperties) {
+                @JsonProperty("userProperties") @Nullable List<UserProperty> userProperties) {
             this.destination = destination;
             this.qos = qos;
             this.userProperties = userProperties;

--- a/modules/hivemq-edge-module-modbus/src/main/java/com/hivemq/edge/adapters/modbus/ModBusUtils.java
+++ b/modules/hivemq-edge-module-modbus/src/main/java/com/hivemq/edge/adapters/modbus/ModBusUtils.java
@@ -15,6 +15,11 @@
  */
 package com.hivemq.edge.adapters.modbus;
 
+import com.hivemq.edge.modules.adapters.data.ProtocolAdapterDataSample;
+import com.hivemq.extension.sdk.api.annotations.NotNull;
+
+import java.util.List;
+
 /**
  * @author Simon L Johnson
  */

--- a/modules/hivemq-edge-module-modbus/src/main/java/com/hivemq/edge/adapters/modbus/ModbusAdapterConfig.java
+++ b/modules/hivemq-edge-module-modbus/src/main/java/com/hivemq/edge/adapters/modbus/ModbusAdapterConfig.java
@@ -27,9 +27,7 @@ import com.hivemq.extension.sdk.api.annotations.NotNull;
 import com.hivemq.extension.sdk.api.annotations.Nullable;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 
 public class ModbusAdapterConfig extends AbstractPollingProtocolAdapterConfig {
@@ -107,8 +105,9 @@ public class ModbusAdapterConfig extends AbstractPollingProtocolAdapterConfig {
         public Subscription(
                 @JsonProperty("destination") @Nullable final String destination,
                 @JsonProperty("qos") final int qos,
-                @JsonProperty("addressRange") @NotNull final AddressRange addressRange) {
-            super(destination, qos);
+                @JsonProperty("addressRange") @NotNull final AddressRange addressRange,
+                @JsonProperty("userProperties") @Nullable List<UserProperty> userProperties) {
+            super(destination, qos, userProperties);
             this.addressRange = addressRange;
         }
 

--- a/modules/hivemq-edge-module-modbus/src/main/java/com/hivemq/edge/adapters/modbus/ModbusAdapterConfig.java
+++ b/modules/hivemq-edge-module-modbus/src/main/java/com/hivemq/edge/adapters/modbus/ModbusAdapterConfig.java
@@ -16,6 +16,7 @@
 package com.hivemq.edge.adapters.modbus;
 
 import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.hivemq.edge.modules.adapters.annotations.ModuleConfigField;
@@ -23,11 +24,13 @@ import com.hivemq.edge.modules.config.CustomConfig;
 import com.hivemq.edge.modules.config.impl.AbstractPollingProtocolAdapterConfig;
 import com.hivemq.edge.modules.config.impl.AbstractProtocolAdapterConfig;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
+import com.hivemq.extension.sdk.api.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 public class ModbusAdapterConfig extends AbstractPollingProtocolAdapterConfig {
 
@@ -100,8 +103,30 @@ public class ModbusAdapterConfig extends AbstractPollingProtocolAdapterConfig {
                            description = "Define the start and end index values for your memory addresses")
         private @NotNull AddressRange addressRange;
 
+        @JsonCreator
+        public Subscription(
+                @JsonProperty("destination") @Nullable final String destination,
+                @JsonProperty("qos") final int qos,
+                @JsonProperty("addressRange") @NotNull final AddressRange addressRange) {
+            super(destination, qos);
+            this.addressRange = addressRange;
+        }
+
         public @NotNull AddressRange getAddressRange() {
             return addressRange;
+        }
+
+        @Override
+        public boolean equals(final Object o) {
+            if (this == o) return true;
+            if (!(o instanceof Subscription)) return false;
+            Subscription that = (Subscription) o;
+            return Objects.equals(addressRange, that.addressRange);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(addressRange);
         }
     }
 
@@ -134,6 +159,19 @@ public class ModbusAdapterConfig extends AbstractPollingProtocolAdapterConfig {
             sb.append(", to=").append(endIdx);
             sb.append('}');
             return sb.toString();
+        }
+
+        @Override
+        public boolean equals(final Object o) {
+            if (this == o) return true;
+            if (!(o instanceof AddressRange)) return false;
+            AddressRange that = (AddressRange) o;
+            return startIdx == that.startIdx && endIdx == that.endIdx;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(startIdx, endIdx);
         }
     }
 }

--- a/modules/hivemq-edge-module-modbus/src/main/java/com/hivemq/edge/adapters/modbus/ModbusProtocolAdapter.java
+++ b/modules/hivemq-edge-module-modbus/src/main/java/com/hivemq/edge/adapters/modbus/ModbusProtocolAdapter.java
@@ -31,7 +31,6 @@ import com.hivemq.edge.modules.api.adapters.ProtocolAdapterInformation;
 import com.hivemq.edge.modules.config.impl.AbstractProtocolAdapterConfig;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
 import com.hivemq.extension.sdk.api.annotations.Nullable;
-import com.hivemq.mqtt.handler.publish.PublishReturnCode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -124,7 +123,7 @@ public class ModbusProtocolAdapter extends AbstractPollingPerSubscriptionAdapter
                 List<ProtocolAdapterDataSample.DataPoint> previousSampleDataPoints = previousSample.getDataPoints();
                 List<ProtocolAdapterDataSample.DataPoint> currentSamplePoints = data.getDataPoints();
                 List<ProtocolAdapterDataSample.DataPoint> delta =
-                        AdapterDataUtils.margeChangedSamples(previousSampleDataPoints, currentSamplePoints);
+                        AdapterDataUtils.mergeChangedSamples(previousSampleDataPoints, currentSamplePoints);
                 if(log.isTraceEnabled()){
                     log.trace("Calculating change data old {} samples, new {} sample, delta {}",
                             previousSampleDataPoints.size(), currentSamplePoints.size(), delta.size());

--- a/modules/hivemq-edge-module-modbus/src/test/java/com/hivemq/edge/adapters/modbus/ModbusProtocolAdapterTest.java
+++ b/modules/hivemq-edge-module-modbus/src/test/java/com/hivemq/edge/adapters/modbus/ModbusProtocolAdapterTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
@@ -55,7 +56,7 @@ class ModbusProtocolAdapterTest {
     @Test
     void test_captureDataSample_expectedPayloadPresent() throws ExecutionException, InterruptedException {
         final ModbusAdapterConfig.Subscription subscription =
-                new ModbusAdapterConfig.Subscription("topic", 2, null);
+                new ModbusAdapterConfig.Subscription("topic", 2, null, null);
         final ModBusData data = new ModBusData(subscription, ModBusData.TYPE.INPUT_REGISTERS);
         data.addDataPoint("register", "hello world");
 
@@ -73,11 +74,13 @@ class ModbusProtocolAdapterTest {
         final ModBusData data2 = createSampleData(10);
 
         Assertions.assertEquals(0,
-                AdapterDataUtils.margeChangedSamples(data1.getDataPoints(), data2.getDataPoints()).size(), "There should be no deltas");
+                AdapterDataUtils.mergeChangedSamples(data1.getDataPoints(), data2.getDataPoints()).size(),
+                "There should be no deltas");
         data2.getDataPoints().set(5, new ProtocolAdapterDataSample.DataPoint("register-5", 777));
 
         Assertions.assertEquals(1,
-                AdapterDataUtils.margeChangedSamples(data1.getDataPoints(), data2.getDataPoints()).size(), "There should be 1 delta");
+                AdapterDataUtils.mergeChangedSamples(data1.getDataPoints(), data2.getDataPoints()).size(),
+                "There should be 1 delta");
     }
 
     @Test
@@ -87,14 +90,14 @@ class ModbusProtocolAdapterTest {
         final ModBusData data2 = createSampleData(10);
         data2.getDataPoints().set(5, new ProtocolAdapterDataSample.DataPoint("register-5", 777));
 
-        AdapterDataUtils.margeChangedSamples(data1.getDataPoints(), data2.getDataPoints());
+        AdapterDataUtils.mergeChangedSamples(data1.getDataPoints(), data2.getDataPoints());
 
         Assertions.assertEquals(777, ((ProtocolAdapterDataSample.DataPoint)data1.getDataPoints().get(5)).getTagValue(), "Merged data should contain new value");
     }
 
     protected static ModBusData createSampleData(final int registerCount){
         final AbstractProtocolAdapterConfig.Subscription subscription =
-                new AbstractProtocolAdapterConfig.Subscription("topic", 2);
+                new AbstractProtocolAdapterConfig.Subscription("topic", 2, List.of());
         final ModBusData data = new ModBusData(subscription, ModBusData.TYPE.INPUT_REGISTERS);
         for (int i = 0; i < registerCount; i++){
             data.addDataPoint("register-" + i, i);


### PR DESCRIPTION
When the checkbox only publish data items that have changed since last poll was set, the entire previous graph (which may have contained multiple indices) was sent with each poll if a single items had changed. The calculation now considered each item individually.