### PR TITLE
refactor(20139): Add validation and error handling for PROTOBUF code

### DIFF
--- a/hivemq-edge/src/frontend/package.json
+++ b/hivemq-edge/src/frontend/package.json
@@ -60,6 +60,7 @@
     "i18next": "^22.4.15",
     "luxon": "^3.3.0",
     "mermaid": "^10.8.0",
+    "protobufjs": "^7.2.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.43.9",

--- a/hivemq-edge/src/frontend/pnpm-lock.yaml
+++ b/hivemq-edge/src/frontend/pnpm-lock.yaml
@@ -103,6 +103,9 @@ dependencies:
   mermaid:
     specifier: ^10.8.0
     version: 10.8.0
+  protobufjs:
+    specifier: ^7.2.6
+    version: 7.2.6
   react:
     specifier: ^18.2.0
     version: 18.2.0
@@ -2606,6 +2609,49 @@ packages:
     resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
     dev: false
 
+  /@protobufjs/aspromise@1.1.2:
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+    dev: false
+
+  /@protobufjs/base64@1.1.2:
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+    dev: false
+
+  /@protobufjs/codegen@2.0.4:
+    resolution: {integrity: sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==}
+    dev: false
+
+  /@protobufjs/eventemitter@1.1.0:
+    resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
+    dev: false
+
+  /@protobufjs/fetch@1.1.0:
+    resolution: {integrity: sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==}
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/inquire': 1.1.0
+    dev: false
+
+  /@protobufjs/float@1.0.2:
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+    dev: false
+
+  /@protobufjs/inquire@1.1.0:
+    resolution: {integrity: sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==}
+    dev: false
+
+  /@protobufjs/path@1.1.2:
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+    dev: false
+
+  /@protobufjs/pool@1.1.0:
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+    dev: false
+
+  /@protobufjs/utf8@1.1.0:
+    resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
+    dev: false
+
   /@react-spring/animated@9.7.3(react@18.2.0):
     resolution: {integrity: sha512-5CWeNJt9pNgyvuSzQH+uy2pvTg8Y4/OisoscZIR8/ZNLIOI+CatFBhGZpDGTF/OzdNFsAoGk3wiUYTwoJ0YIvw==}
     peerDependencies:
@@ -3274,7 +3320,6 @@ packages:
 
   /@types/node@20.4.2:
     resolution: {integrity: sha512-Dd0BYtWgnWJKwO1jkmTrzofjK2QXXcai0dmtzvIBhcA+RsG5h8R3xlyta0kGOZRNfL9GuRtb1knmPEhQrePCEw==}
-    dev: true
 
   /@types/normalize-package-data@2.4.1:
     resolution: {integrity: sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==}
@@ -3361,7 +3406,7 @@ packages:
     resolution: {integrity: sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==}
     requiresBuild: true
     dependencies:
-      '@types/node': 14.18.53
+      '@types/node': 20.4.2
     dev: true
     optional: true
 
@@ -6891,6 +6936,10 @@ packages:
       wrap-ansi: 6.2.0
     dev: true
 
+  /long@5.2.3:
+    resolution: {integrity: sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q==}
+    dev: false
+
   /loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
@@ -7768,6 +7817,25 @@ packages:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
+
+  /protobufjs@7.2.6:
+    resolution: {integrity: sha512-dgJaEDDL6x8ASUZ1YqWciTRrdOuYNzoOf27oHNfdyvKqHr5i0FV7FSLU+aIeFjyFgVxrpTOtQUi0BLLBymZaBw==}
+    engines: {node: '>=12.0.0'}
+    requiresBuild: true
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.4
+      '@protobufjs/eventemitter': 1.1.0
+      '@protobufjs/fetch': 1.1.0
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/inquire': 1.1.0
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.0
+      '@types/node': 20.4.2
+      long: 5.2.3
+    dev: false
 
   /proxy-from-env@1.0.0:
     resolution: {integrity: sha512-F2JHgJQ1iqwnHDcQjVBsq3n/uoaFL+iPW/eAeL7kVxy/2RrWaN4WroKjjvbsoRtv0ftelNyC01bjRhn/bhcf4A==}

--- a/hivemq-edge/src/frontend/src/extensions/datahub/api/__generated__/schemas/SchemaData.json
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/api/__generated__/schemas/SchemaData.json
@@ -28,6 +28,7 @@
           }
         },
         {
+          "required": ["messageType"],
           "properties": {
             "type": {
               "enum": ["PROTOBUF"]
@@ -35,6 +36,10 @@
             "schemaSource": {
               "type": "string",
               "format": "application/octet-stream"
+            },
+            "messageType": {
+              "type": "string",
+              "description": "The name of the message to use for Data Hub, from the source"
             }
           }
         }

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/schema/SchemaNode.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/schema/SchemaNode.tsx
@@ -15,16 +15,15 @@ export const SchemaNode: FC<NodeProps<SchemaData>> = (props) => {
   const title = useMemo(() => {
     if (!data.schemaSource) return undefined
 
-    // TODO[NVL] PROTOBUF parser needed for extracting title out of the source
-    if (data.type !== SchemaType.JSON) return undefined
+    if (data.type === SchemaType.PROTOBUF) return data.messageType
 
     try {
       const schema = JSON.parse(data.schemaSource) as RJSFSchema
       return schema.title
-    } catch (e) {
+    } catch (error) {
       return undefined
     }
-  }, [data.schemaSource, data.type])
+  }, [data.messageType, data.schemaSource, data.type])
 
   return (
     <>

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/schema/SchemaNode.utils.spec.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/schema/SchemaNode.utils.spec.ts
@@ -50,7 +50,7 @@ describe('checkValiditySchema', () => {
     expect(data).toStrictEqual({
       arguments: {},
       id: 'node-id',
-      schemaDefinition: btoa(JSON.stringify(MOCK_NODE_SCHEMA.data.schemaSource)),
+      schemaDefinition: 'eyB0ZzogMX0=',
       type: 'JSON',
       version: 1,
     })

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/schema/SchemaNode.utils.spec.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/schema/SchemaNode.utils.spec.ts
@@ -48,7 +48,6 @@ describe('checkValiditySchema', () => {
     const { node, error, data, resources } = checkValiditySchema(MOCK_NODE_SCHEMA)
     expect(node).toStrictEqual(MOCK_NODE_SCHEMA)
     expect(data).toStrictEqual({
-      arguments: {},
       id: 'node-id',
       schemaDefinition: 'eyB0ZzogMX0=',
       type: 'JSON',

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/schema/SchemaNode.utils.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/schema/SchemaNode.utils.ts
@@ -1,8 +1,11 @@
 import { Node } from 'reactflow'
-import { DryRunResults, SchemaData, SchemaProtobufArguments, SchemaType } from '@datahub/types.ts'
-import { Schema } from '@/api/__generated__'
-import { parse } from 'protobufjs'
+import { parse, util as protobufUtils } from 'protobufjs'
+import descriptor from 'protobufjs/ext/descriptor'
 
+import i18n from '@/config/i18n.config.ts'
+
+import { Schema } from '@/api/__generated__'
+import { DryRunResults, SchemaData, SchemaType } from '@datahub/types.ts'
 import { PolicyCheckErrors } from '@datahub/designer/validation.errors.ts'
 
 export function checkValiditySchema(schemaNode: Node<SchemaData>): DryRunResults<Schema> {
@@ -13,32 +16,67 @@ export function checkValiditySchema(schemaNode: Node<SchemaData>): DryRunResults
     }
   }
 
-  // TODO[20139] No definition of arguments in OpenAPI!
-  let args: SchemaProtobufArguments | undefined = undefined
+  if (schemaNode.data.type === SchemaType.JSON) {
+    const jsonSchema: Schema = {
+      // TODO[19466] Id should be user-facing; Need to fix before merging!
+      id: schemaNode.id,
+      type: schemaNode.data.type,
+      version: schemaNode.data.version,
+      schemaDefinition: btoa(schemaNode.data.schemaSource),
+    }
+    return { data: jsonSchema, node: schemaNode }
+  }
+
   if (schemaNode.data.type === SchemaType.PROTOBUF) {
+    // TODO[DATAHUB] Compilation of descriptor a very experimental and outdated solution.
+    //    See https://github.com/protobufjs/protobuf.js/tree/master/ext/descriptor
     if (!schemaNode.data.messageType)
       return {
         node: schemaNode,
         error: PolicyCheckErrors.notConfigured(schemaNode, 'messageType'),
       }
-    args = { messageType: schemaNode.data.messageType }
 
     try {
-      parse(schemaNode.data.schemaSource)
-      // TODO[20139] No compilation of PROTOBUF descriptor
+      const root = parse(schemaNode.data.schemaSource).root
+      // @ts-ignore No typescript definition
+      const MyMessage = root.toDescriptor('proto3')
+      const buffer = descriptor.FileDescriptorSet.encode(MyMessage).finish()
+      const encoded = protobufUtils.base64.encode(buffer, 0, buffer.length)
+
+      // verifying the double encoding
+      const encodedGraphBytes = new Uint8Array(protobufUtils.base64.length(encoded))
+      protobufUtils.base64.decode(encoded, encodedGraphBytes, 0)
+      const decodedMessage = descriptor.FileDescriptorSet.decode(encodedGraphBytes)
+      if (JSON.stringify(MyMessage) !== JSON.stringify(decodedMessage))
+        return {
+          node: schemaNode,
+          error: PolicyCheckErrors.internal(
+            schemaNode,
+            new Error(i18n.t('datahub:error.validation.protobuf.encoding') as string)
+          ),
+        }
+
+      const schema: Schema = {
+        // @ts-ignore TODO[19466] Id should be user-facing; Need to fix before merging!
+        id: schemaNode.id,
+        type: schemaNode.data.type,
+        version: schemaNode.data.version,
+        schemaDefinition: encoded,
+        // TODO[20139] No definition of arguments in OpenAPI!
+        arguments: { messageType: schemaNode.data.messageType },
+      }
+      return { data: schema, node: schemaNode }
     } catch (e) {
       console.log(e)
+      return {
+        node: schemaNode,
+        error: PolicyCheckErrors.internal(schemaNode, e),
+      }
     }
   }
 
-  const schema: Schema = {
-    // @ts-ignore TODO[19466] Id should be user-facing; Need to fix before merging!
-    id: schemaNode.id,
-    type: schemaNode.data.type,
-    version: schemaNode.data.version,
-    // TODO[20139] No compiled PROTOBUF descriptor. schemaDefinition is wrong
-    schemaDefinition: btoa(schemaNode.data.schemaSource),
-    arguments: { ...args },
+  return {
+    node: schemaNode,
+    error: PolicyCheckErrors.notConfigured(schemaNode, 'schemaSource'),
   }
-  return { data: schema, node: schemaNode }
 }

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/schema/SchemaNode.utils.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/schema/SchemaNode.utils.ts
@@ -1,7 +1,7 @@
 import { Node } from 'reactflow'
 import { DryRunResults, SchemaData, SchemaProtobufArguments, SchemaType } from '@datahub/types.ts'
 import { Schema } from '@/api/__generated__'
-import { parse, Root } from 'protobufjs'
+import { parse } from 'protobufjs'
 
 import { PolicyCheckErrors } from '@datahub/designer/validation.errors.ts'
 
@@ -24,10 +24,11 @@ export function checkValiditySchema(schemaNode: Node<SchemaData>): DryRunResults
     args = { messageType: schemaNode.data.messageType }
 
     try {
-      // @ts-ignore
-      const root: Root = parse(schemaNode.data.schemaSource).root
+      parse(schemaNode.data.schemaSource)
       // TODO[20139] No compilation of PROTOBUF descriptor
-    } catch (e) {}
+    } catch (e) {
+      console.log(e)
+    }
   }
 
   const schema: Schema = {

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/schema/SchemaNode.utils.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/schema/SchemaNode.utils.ts
@@ -1,6 +1,8 @@
 import { Node } from 'reactflow'
-import { DryRunResults, SchemaData } from '@datahub/types.ts'
+import { DryRunResults, SchemaData, SchemaProtobufArguments, SchemaType } from '@datahub/types.ts'
 import { Schema } from '@/api/__generated__'
+import { parse, Root } from 'protobufjs'
+
 import { PolicyCheckErrors } from '@datahub/designer/validation.errors.ts'
 
 export function checkValiditySchema(schemaNode: Node<SchemaData>): DryRunResults<Schema> {
@@ -11,14 +13,31 @@ export function checkValiditySchema(schemaNode: Node<SchemaData>): DryRunResults
     }
   }
 
+  // TODO[20139] No definition of arguments in OpenAPI!
+  let args: SchemaProtobufArguments | undefined = undefined
+  if (schemaNode.data.type === SchemaType.PROTOBUF) {
+    if (!schemaNode.data.messageType)
+      return {
+        node: schemaNode,
+        error: PolicyCheckErrors.notConfigured(schemaNode, 'messageType'),
+      }
+    args = { messageType: schemaNode.data.messageType }
+
+    try {
+      // @ts-ignore
+      const root: Root = parse(schemaNode.data.schemaSource).root
+      // TODO[20139] No compilation of PROTOBUF descriptor
+    } catch (e) {}
+  }
+
   const schema: Schema = {
     // @ts-ignore TODO[19466] Id should be user-facing; Need to fix before merging!
     id: schemaNode.id,
     type: schemaNode.data.type,
     version: schemaNode.data.version,
-    schemaDefinition: btoa(JSON.stringify(schemaNode.data.schemaSource)),
-    // TODO[19240] No definition of arguments!
-    arguments: {},
+    // TODO[20139] No compiled PROTOBUF descriptor. schemaDefinition is wrong
+    schemaDefinition: btoa(schemaNode.data.schemaSource),
+    arguments: { ...args },
   }
   return { data: schema, node: schemaNode }
 }

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/schema/SchemaPanel.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/schema/SchemaPanel.tsx
@@ -2,8 +2,9 @@ import { FC, useMemo } from 'react'
 import { Node } from 'reactflow'
 import { Card, CardBody } from '@chakra-ui/react'
 import { CustomValidator } from '@rjsf/utils'
+import { parse } from 'protobufjs'
 
-import { PanelProps, SchemaData } from '@datahub/types.ts'
+import { PanelProps, SchemaData, SchemaType } from '@datahub/types.ts'
 import useDataHubDraftStore from '@datahub/hooks/useDataHubDraftStore.ts'
 import { ReactFlowSchemaForm } from '@datahub/components/forms/ReactFlowSchemaForm.tsx'
 import { datahubRJSFWidgets } from '@datahub/designer/datahubRJSFWidgets.tsx'
@@ -20,8 +21,8 @@ export const SchemaPanel: FC<PanelProps> = ({ selectedNode, onFormSubmit }) => {
 
   const customValidate: CustomValidator<SchemaData> = (formData, errors) => {
     if (!formData) return errors
+    const { type, schemaSource } = formData
 
-    // TODO[NVL] Consider live validation
     // if (type === SchemaType.JAVASCRIPT && schemaSource) {
     //   try {
     //     const program = Parser.parse(schemaSource, { ecmaVersion: 'latest' })
@@ -39,14 +40,13 @@ export const SchemaPanel: FC<PanelProps> = ({ selectedNode, onFormSubmit }) => {
     //     // setFields(null)
     //   }
     // }
-    // if (type === SchemaType.PROTO && schemaSource) {
-    //   try {
-    //     const parsed = parse(schemaSource)
-    //   } catch (e) {
-    //     errors.schemaSource?.addError((e as SyntaxError).message)
-    //     // setFields(null)
-    //   }
-    // }
+    if (type === SchemaType.PROTOBUF && schemaSource) {
+      try {
+        parse(schemaSource)
+      } catch (e) {
+        errors.schemaSource?.addError((e as SyntaxError).message)
+      }
+    }
 
     return errors
   }

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/validation.errors.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/validation.errors.ts
@@ -30,4 +30,17 @@ export const PolicyCheckErrors = {
     ...commonProperties,
     id: source.id,
   }),
+  internal: <T>(source: Node<T>, error: unknown) => {
+    let message: string
+    if (error instanceof Error) message = error.message
+    else message = String(error)
+
+    return {
+      title: source.type as string,
+      detail: i18n.t('datahub:error.dryRun.internal', { source: source.type, error: message }),
+      type: 'datahub.notConfigured',
+      ...commonProperties,
+      id: source.id,
+    }
+  },
 }

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/validator/ValidatorNode.utils.spec.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/validator/ValidatorNode.utils.spec.ts
@@ -94,7 +94,7 @@ describe('checkValidityPolicyValidator', () => {
         data: {
           arguments: {},
           id: 'node-schema',
-          schemaDefinition: 'Int9Ig==',
+          schemaDefinition: 'e30=',
           type: 'JSON',
           version: 1,
         },

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/validator/ValidatorNode.utils.spec.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/validator/ValidatorNode.utils.spec.ts
@@ -92,7 +92,6 @@ describe('checkValidityPolicyValidator', () => {
     expect(resources?.[0]).toStrictEqual(
       expect.objectContaining({
         data: {
-          arguments: {},
           id: 'node-schema',
           schemaDefinition: 'e30=',
           type: 'JSON',

--- a/hivemq-edge/src/frontend/src/extensions/datahub/locales/en/datahub.json
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/locales/en/datahub.json
@@ -205,11 +205,17 @@
     }
   },
   "error": {
+    "validation": {
+      "protobuf": {
+        "encoding": "The encoding of the PROTOBUF code into a Base64 descriptor cannot be validated."
+      }
+    },
     "dryRun": {
       "notConnected": "No $t(datahub:workspace.nodes.type, { 'context': '{{source}}' }) connected to $t(datahub:workspace.nodes.type, { 'context': '{{target}}' })",
       "noHandleConnected": "No $t(datahub:workspace.nodes.type, { 'context': '{{source}}' }) connected to the \"{{ handle }}\" handle of $t(datahub:workspace.nodes.type, { 'context': '{{target}}' })",
       "cardinality": "Too many $t(datahub:workspace.nodes.type, { 'context': '{{source}}' }) connected to $t(datahub:workspace.nodes.type, { 'context': '{{target}}' })",
-      "notConfigured": "The $t(datahub:workspace.nodes.type, { 'context': '{{source}}' }) is not properly defined. The following properties are missing: {{ properties }}"
+      "notConfigured": "The $t(datahub:workspace.nodes.type, { 'context': '{{source}}' }) is not properly defined. The following properties are missing: {{ properties }}",
+      "internal": "Encountered an error while processing $t(datahub:workspace.nodes.type, { 'context': '{{source}}' }): {{ error }}"
     },
     "publish": {
       "title": "$t(datahub:workspace.nodes.type, { 'context': '{{source}}' }) published",

--- a/hivemq-edge/src/frontend/src/extensions/datahub/types.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/types.ts
@@ -137,13 +137,18 @@ export interface ValidatorData extends DataHubNodeData {
 // TODO[18755] Add to the OpenAPI specs; see https://hivemq.kanbanize.com/ctrl_board/4/cards/18755/details/
 export enum SchemaType {
   JSON = 'JSON',
-  PROTO = 'PROTOBUF',
+  PROTOBUF = 'PROTOBUF',
+}
+
+export interface SchemaProtobufArguments {
+  messageType: string
 }
 
 export interface SchemaData extends DataHubNodeData {
   type: SchemaType
   version: number
   schemaSource?: string
+  messageType?: string
   core?: Schema
 }
 


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/20139/details/

The PR fixes a few bugs with the text version of PROTOBUF in the `Schema` node and its side panel. 

A field for selecting the active message has been added to the JSON Schema of the PROTOBUF configuration. 
Validation of the code and error reporting are now supported. 

The PROTOBUF code is now compiled to a descriptor buffer and then encoded to a `base64` fully on the browser side. It means the end-user has access to the full flow of PROTOBUF schemas, from the editing (or copy-and-paste) to the validation, then to the submission to the backend, then to the listing of created schemas, then finally to the modifying of the original code. 

The client-side encoding relies on a self-described experimental feature of the `protobufjs` library (and a 5 years old extension) so an encoding-decoding test has been added to validate the PROTOBUF source. 

### Out-of-scope
- loading of a PROTOBUF compiled descriptor, as part of a policy, will be handled in a different ticket

### After

![screenshot-localhost_3000-2024 03 08-10_41_06](https://github.com/hivemq/hivemq-edge/assets/2743481/bae831e3-f6b3-41d6-9fae-2a9bc0d27877)

![screenshot-localhost_3000-2024 03 08-10_42_22](https://github.com/hivemq/hivemq-edge/assets/2743481/6ad67ef7-4fe5-4a36-8097-758bca8c852f)
