### PR TITLE
refactor(19826): Cleanup the menu of HiveMQ Edge

### DIFF
--- a/hivemq-edge/src/frontend/src/extensions/datahub/locales/en/datahub.json
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/locales/en/datahub.json
@@ -1,9 +1,9 @@
 {
   "brand": {
-    "extension": "Data Hub"
+    "extension": "Data Hub on Edge"
   },
   "navigation": {
-    "mainPage": "Data Hub"
+    "mainPage": "Data Hub on Edge"
   },
   "flag": {
     "behaviorPolicy": {
@@ -11,8 +11,8 @@
     }
   },
   "page": {
-    "title": "Data Hub",
-    "description": "The Edge Data Hub provides mechanisms to define how MQTT data and MQTT client behavior are handled from the adaptors to the HiveMQ broker"
+    "title": "Data Hub on Edge",
+    "description": "The Data Hub on Edge provides mechanisms to define how MQTT data and MQTT client behavior are handled from the adaptors to the HiveMQ broker"
   },
   "policy": {
     "type_DATA_POLICY": "Data Policy",
@@ -224,7 +224,7 @@
       "select": "< not set >"
     },
     "notActivated": {
-      "title": "Data Hub is now available to commercial licenses",
+      "title": "Data Hub on Edge is now available to commercial licenses",
       "description": "Please contact our sales team to gain access"
     },
     "notDefined": {

--- a/hivemq-edge/src/frontend/src/modules/Dashboard/hooks/useGetNavItems.spec.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Dashboard/hooks/useGetNavItems.spec.tsx
@@ -34,9 +34,9 @@ describe('useSpringClient', () => {
       expect(result.current.isSuccess).toBeTruthy()
     })
 
-    expect(result.current.data.map((e) => e.title)).toStrictEqual(['HiveMQ Edge', 'Extensions', 'External resources'])
-    expect(result.current.data[0].items).toHaveLength(5)
-    expect(result.current.data[2].items.map((e) => e.href)).toStrictEqual([
+    expect(result.current.data.map((e) => e.title)).toStrictEqual(['HiveMQ Edge', 'External resources'])
+    expect(result.current.data[0].items).toHaveLength(7)
+    expect(result.current.data[1].items.map((e) => e.href)).toStrictEqual([
       'https://www.hivemq.com/articles/power-of-iot-data-management-in-smart-manufacturing/',
       'https://github.com/hivemq/hivemq-edge',
       'https://github.com/hivemq/hivemq-edge/wiki',

--- a/hivemq-edge/src/frontend/src/modules/Dashboard/hooks/useGetNavItems.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Dashboard/hooks/useGetNavItems.tsx
@@ -4,7 +4,6 @@ import { Icon } from '@chakra-ui/react'
 import { IoHomeOutline } from 'react-icons/io5'
 import { PiBridgeThin, PiPlugsConnectedFill } from 'react-icons/pi'
 import { BsIntersect } from 'react-icons/bs'
-import { HiOutlinePuzzle } from 'react-icons/hi'
 import { GoLinkExternal } from 'react-icons/go'
 import { MdOutlineEventNote, MdPolicy } from 'react-icons/md'
 
@@ -54,26 +53,15 @@ const useGetNavItems = (): { data: NavLinksBlockType[]; isSuccess: boolean } => 
           href: '/event-logs',
           label: t('translation:navigation.gateway.routes.eventLogs') as string,
         },
-      ],
-    },
-    {
-      title: t('translation:navigation.extensions.title'),
-      items: [
         {
-          icon: <HiOutlinePuzzle />,
-          href: '/modules',
-          isDisabled: true,
-          label: t('translation:navigation.extensions.routes.modules') as string,
+          icon: <Icon as={MdPolicy} fontSize="16px" />,
+          href: '/datahub',
+          label: t('datahub:navigation.mainPage') as string,
         },
         {
           icon: <BsIntersect />,
           href: '/namespace',
           label: t('translation:navigation.extensions.routes.namespace') as string,
-        },
-        {
-          icon: <Icon as={MdPolicy} fontSize="16px" />,
-          href: '/datahub',
-          label: t('datahub:navigation.mainPage') as string,
         },
       ],
     },


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/19826/details/

The PR reorganise the main navigation menu of Edge
- Extension section removed
- Main links reorderer
- Change name to `Data Hub on Edge`

### Before 
![screenshot-localhost_3000-2024 03 08-14_08_24](https://github.com/hivemq/hivemq-edge/assets/2743481/71240d90-ba8c-4fdb-8cbc-aac9d820f727)

### After
![screenshot-localhost_3000-2024 03 08-14_01_00](https://github.com/hivemq/hivemq-edge/assets/2743481/b3e5f149-66fb-4181-9cb2-077872404d5d)

![screenshot-localhost_3000-2024 03 08-14_01_16](https://github.com/hivemq/hivemq-edge/assets/2743481/2a84892e-2d59-4e74-b24f-dc84de8c8da3)
