### PR TITLE
fix(20147): allow data policy to be created without validators

### DIFF
--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/validator/ValidatorNode.utils.spec.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/validator/ValidatorNode.utils.spec.ts
@@ -112,30 +112,6 @@ describe('checkValidityPolicyValidators', () => {
     position: { x: 0, y: 0 },
   }
 
-  it('should return error if not connected', async () => {
-    const MOCK_STORE: WorkspaceState = {
-      nodes: [],
-      edges: [],
-      functions: [],
-    }
-
-    const results = checkValidityPolicyValidators(MOCK_NODE_DATA_POLICY, MOCK_STORE)
-    expect(results).toHaveLength(1)
-    const { node, data, error, resources } = results[0]
-    expect(node).toStrictEqual(MOCK_NODE_DATA_POLICY)
-    expect(error).toEqual(
-      expect.objectContaining({
-        detail: 'No Policy Validator connected to Data Policy',
-        id: 'node-policy',
-        status: 404,
-        title: 'DATA_POLICY',
-        type: 'datahub.notConnected',
-      })
-    )
-    expect(data).toBeUndefined()
-    expect(resources).toBeUndefined()
-  })
-
   it('should return a payload otherwise', async () => {
     const MOCK_NODE_SCHEMA: Node<SchemaData> = {
       id: 'node-schema',

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/validator/ValidatorNode.utils.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/validator/ValidatorNode.utils.ts
@@ -57,15 +57,6 @@ export function checkValidityPolicyValidators(
 
   const incomers = getIncomers(dataPolicyNode, nodes, edges).filter(isValidatorNodeType)
 
-  if (!incomers.length) {
-    return [
-      {
-        node: dataPolicyNode,
-        error: PolicyCheckErrors.notConnected(DataHubNodeType.VALIDATOR, dataPolicyNode),
-      },
-    ]
-  }
-
   return incomers.map((validator) => checkValidityPolicyValidator(validator, store))
 }
 

--- a/hivemq-edge/src/frontend/src/extensions/datahub/hooks/usePolicyDryRun.spec.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/hooks/usePolicyDryRun.spec.ts
@@ -50,7 +50,7 @@ describe('usePolicyDryRun', () => {
     const { result } = renderHook(usePolicyDryRun)
     await act(async () => {
       const results = await result.current.checkPolicyAsync(MOCK_NODE_DATA_POLICY)
-      expect(results).toHaveLength(2)
+      expect(results).toHaveLength(1)
       const { node } = results[0]
       expect(node).toStrictEqual(MOCK_NODE_DATA_POLICY)
     })

--- a/hivemq-edge/src/frontend/src/extensions/datahub/locales/en/datahub.json
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/locales/en/datahub.json
@@ -3,7 +3,7 @@
     "extension": "Data Hub on Edge"
   },
   "navigation": {
-    "mainPage": "Data Hub on Edge"
+    "mainPage": "Data Hub"
   },
   "flag": {
     "behaviorPolicy": {

--- a/hivemq-edge/src/frontend/src/extensions/datahub/locales/en/datahub.json
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/locales/en/datahub.json
@@ -21,7 +21,8 @@
 
   "resource": {
     "schema": {
-      "type_JSON": "JSON"
+      "type_JSON": "JSON",
+      "type_PROTOBUF": "PROTOBUF"
     },
     "script": {
       "functionType_TRANSFORMATION": "Transformation"


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/20147/details/

The PR fixes a bug with the check of `Data Policies`, which is now accepting them to be without any explicit validation. 

It also fixes translations, in particular the `Dat Hub` navigation menu

### After


![screenshot-localhost_3000-2024 03 12-11_23_49](https://github.com/hivemq/hivemq-edge/assets/2743481/ecf713da-98d7-40b9-96aa-b7a95b6706dd)

