### PR TITLE
Fix(18091) - Payload in HTTP adapter

### DIFF
--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/hooks/useGetUISchema.ts
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/hooks/useGetUISchema.ts
@@ -49,6 +49,8 @@ const useGetUiSchema = (isNewAdapter = true) => {
         'httpRequestBody',
         'httpHeaders',
         'httpConnectTimeout',
+        'httpRequestBodyContentType',
+        'assertResponseIsJson',
         'httpPublishSuccessStatusCodeOnly',
         'allowUntrustedCertificates',
       ],

--- a/hivemq-edge/src/main/java/com/hivemq/edge/modules/adapters/data/ProtocolAdapterDataSample.java
+++ b/hivemq-edge/src/main/java/com/hivemq/edge/modules/adapters/data/ProtocolAdapterDataSample.java
@@ -17,6 +17,7 @@ package com.hivemq.edge.modules.adapters.data;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.google.common.base.Preconditions;
 import com.hivemq.edge.modules.config.impl.AbstractProtocolAdapterConfig;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
@@ -75,6 +76,7 @@ public class ProtocolAdapterDataSample<T extends AbstractProtocolAdapterConfig> 
         dataPoints.add(new DataPoint(tagName,tagValue));
     }
 
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public List<DataPoint> getDataPoints(){
         return Collections.unmodifiableList(dataPoints);
     }

--- a/hivemq-edge/src/main/java/com/hivemq/edge/modules/adapters/impl/AbstractPollingProtocolAdapter.java
+++ b/hivemq-edge/src/main/java/com/hivemq/edge/modules/adapters/impl/AbstractPollingProtocolAdapter.java
@@ -33,7 +33,6 @@ import com.hivemq.edge.modules.config.impl.AbstractPollingProtocolAdapterConfig;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
 import com.hivemq.extension.sdk.api.annotations.Nullable;
 import com.hivemq.mqtt.handler.publish.PublishReturnCode;
-import net.javacrumbs.futureconverter.java8guava.FutureConverter;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;

--- a/hivemq-edge/src/main/java/com/hivemq/edge/modules/adapters/impl/AbstractProtocolAdapter.java
+++ b/hivemq-edge/src/main/java/com/hivemq/edge/modules/adapters/impl/AbstractProtocolAdapter.java
@@ -79,7 +79,7 @@ public abstract class AbstractProtocolAdapter<T extends AbstractProtocolAdapterC
     protected @NotNull T adapterConfig;
     protected @Nullable Long lastStartAttemptTime;
     protected @Nullable String errorMessage;
-    protected @Nullable volatile Object lock = new Object();
+    protected @Nullable final Object lock = new Object();
     protected @NotNull AtomicReference<RuntimeStatus> runtimeStatus =
             new AtomicReference<>(RuntimeStatus.STOPPED);
     protected @NotNull AtomicReference<ConnectionStatus> connectionStatus =

--- a/modules/hivemq-edge-module-http/src/main/java/com/hivemq/edge/adapters/http/HttpAdapterConfig.java
+++ b/modules/hivemq-edge-module-http/src/main/java/com/hivemq/edge/adapters/http/HttpAdapterConfig.java
@@ -34,6 +34,7 @@ import java.util.List;
         "httpConnectTimeout",
         "httpRequestBodyContentType",
         "httpRequestBody",
+        "assertResponseIsJson",
         "httpPublishSuccessStatusCodeOnly",
         "httpHeaders"})
 public class HttpAdapterConfig extends AbstractPollingProtocolAdapterConfig {
@@ -64,7 +65,6 @@ public class HttpAdapterConfig extends AbstractPollingProtocolAdapterConfig {
 
     @JsonProperty("url")
     @ModuleConfigField(title = "URL", description = "The url of the http request you would like to make",
-//                       stringPattern = HttpConstants.HTTP_URL_REGEX,
                        format = ModuleConfigField.FieldType.URI, required = true)
     private @NotNull String url;
 
@@ -123,6 +123,13 @@ public class HttpAdapterConfig extends AbstractPollingProtocolAdapterConfig {
                        format = ModuleConfigField.FieldType.BOOLEAN)
     private boolean allowUntrustedCertificates = false;
 
+    @JsonProperty("assertResponseIsJson")
+    @ModuleConfigField(title = "Assert JSON Response?",
+                       description = "Always attempt to parse the body of the response as JSON data, regardless of the Content-Type on the response.",
+                       defaultValue = "false",
+                       format = ModuleConfigField.FieldType.BOOLEAN)
+    private boolean assertResponseIsJson = false;
+
     public HttpAdapterConfig() {
     }
 
@@ -132,6 +139,10 @@ public class HttpAdapterConfig extends AbstractPollingProtocolAdapterConfig {
 
     public boolean isHttpPublishSuccessStatusCodeOnly() {
         return httpPublishSuccessStatusCodeOnly;
+    }
+
+    public boolean isAssertResponseIsJson() {
+        return assertResponseIsJson;
     }
 
     public @NotNull HttpMethod getHttpRequestMethod() {

--- a/modules/hivemq-edge-module-http/src/main/java/com/hivemq/edge/adapters/http/HttpProtocolAdapter.java
+++ b/modules/hivemq-edge-module-http/src/main/java/com/hivemq/edge/adapters/http/HttpProtocolAdapter.java
@@ -187,7 +187,7 @@ public class HttpProtocolAdapter extends AbstractPollingProtocolAdapter<HttpAdap
                         payloadData = objectMapper.readTree(bodyData);
                     } catch (Exception e){
                         if(log.isDebugEnabled()){
-                            log.debug("Invalid json data was [{}]", bodyData);
+                            log.debug("Invalid JSON data was [{}]", bodyData);
                         }
                         eventService.fireEvent(
                                 eventBuilder(Event.SEVERITY.WARN).

--- a/modules/hivemq-edge-module-http/src/main/java/com/hivemq/edge/adapters/http/HttpProtocolAdapter.java
+++ b/modules/hivemq-edge-module-http/src/main/java/com/hivemq/edge/adapters/http/HttpProtocolAdapter.java
@@ -21,6 +21,7 @@ import com.hivemq.edge.adapters.http.model.HttpData;
 import com.hivemq.edge.modules.adapters.impl.AbstractPollingProtocolAdapter;
 import com.hivemq.edge.modules.adapters.model.ProtocolAdapterStartOutput;
 import com.hivemq.edge.modules.api.adapters.ProtocolAdapterInformation;
+import com.hivemq.edge.modules.api.events.model.Event;
 import com.hivemq.edge.modules.config.impl.AbstractProtocolAdapterConfig;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
 import com.hivemq.extension.sdk.api.annotations.Nullable;
@@ -178,16 +179,21 @@ public class HttpProtocolAdapter extends AbstractPollingProtocolAdapter<HttpAdap
             String bodyData = response.body() == null ? null : response.body();
             //-- if the content type is json, then apply the JSON to the output data,
             //-- else encode using base64 (as we dont know what the content is).
-            if(bodyData != null){
+             if(bodyData != null){
                 responseContentType = response.headers().firstValue(HttpConstants.CONTENT_TYPE_HEADER).orElse(null);
+                responseContentType = config.isAssertResponseIsJson() ? HttpConstants.JSON_MIME_TYPE : responseContentType;
                 if(HttpConstants.JSON_MIME_TYPE.equals(responseContentType)) {
                     try {
                         payloadData = objectMapper.readTree(bodyData);
                     } catch (Exception e){
-                        log.warn("Error encountered marshalling HTTP response data to json", e);
                         if(log.isDebugEnabled()){
                             log.debug("Invalid json data was [{}]", bodyData);
                         }
+                        eventService.fireEvent(
+                                eventBuilder(Event.SEVERITY.WARN).
+                                        withMessage(String.format("Http response on adapter '%s' could not be parsed as JSON data.",
+                                        adapterConfig.getId())).build());
+                        throw new RuntimeException("unable to parse JSON data from HTTP response");
                     }
                 } else {
                     if(responseContentType == null){
@@ -203,7 +209,13 @@ public class HttpProtocolAdapter extends AbstractPollingProtocolAdapter<HttpAdap
                 adapterConfig.getUrl(),
                 response.statusCode(),
                 responseContentType);
-        data.addDataPoint(RESPONSE_DATA, payloadData);
+        if(payloadData != null){
+            data.addDataPoint(RESPONSE_DATA, payloadData);
+        } else {
+            //When the body is empty, just include the metadata
+            data.addDataPoint(RESPONSE_DATA,
+                    new HttpData(null, adapterConfig.getUrl(), response.statusCode(), responseContentType));
+        }
         return data;
     }
 

--- a/modules/hivemq-edge-module-http/src/main/java/com/hivemq/edge/adapters/http/model/HttpData.java
+++ b/modules/hivemq-edge-module-http/src/main/java/com/hivemq/edge/adapters/http/model/HttpData.java
@@ -15,6 +15,7 @@
  */
 package com.hivemq.edge.adapters.http.model;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.hivemq.edge.modules.adapters.data.ProtocolAdapterDataSample;
 import com.hivemq.edge.modules.config.impl.AbstractProtocolAdapterConfig;
 import com.hivemq.extension.sdk.api.annotations.NotNull;
@@ -22,6 +23,7 @@ import com.hivemq.extension.sdk.api.annotations.NotNull;
 /**
  * @author HiveMQ Adapter Generator
  */
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class HttpData extends ProtocolAdapterDataSample {
 
     private final String requestUrl;
@@ -38,6 +40,7 @@ public class HttpData extends ProtocolAdapterDataSample {
         this.httpStatusCode = httpStatusCode;
     }
 
+
     public String getRequestUrl() {
         return requestUrl;
     }
@@ -49,4 +52,6 @@ public class HttpData extends ProtocolAdapterDataSample {
     public int getHttpStatusCode() {
         return httpStatusCode;
     }
+
+
 }


### PR DESCRIPTION
**Motivation**

Resolves #18091

I have added a new checkbox “Assert JSON Payload” which, when checked will always attempt to parse the payload as JSON regardless of the content type on the response object. I considered using a dropdown with multiple content types for the response, but actually the reality is that it will almost always be either dynamic (existing behaviour) OR JSON.

**Changes**
