### PR TITLE
fix(20145): Fix placeholder for function

### DIFF
--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/forms/MetricCounterInput.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/forms/MetricCounterInput.tsx
@@ -4,7 +4,7 @@ import { labelValue, WidgetProps } from '@rjsf/utils'
 import { getChakra } from '@rjsf/chakra-ui/lib/utils'
 import { FormControl, FormLabel, Input, InputGroup, InputLeftAddon } from '@chakra-ui/react'
 
-const PrefixInput = (prefix: string, props: WidgetProps) => {
+const PrefixInput = (prefix: string, placeholder: string, props: WidgetProps) => {
   const { t } = useTranslation('datahub')
   const chakraProps = getChakra({ uiSchema: props.uiSchema })
 
@@ -34,7 +34,7 @@ const PrefixInput = (prefix: string, props: WidgetProps) => {
         <Input
           id={props.id}
           isRequired={props.required}
-          placeholder={t('workspace.function.metricName.placeholder') as string}
+          placeholder={t(placeholder) as string}
           value={props.value}
           onBlur={onBlur}
           onFocus={onFocus}
@@ -45,6 +45,8 @@ const PrefixInput = (prefix: string, props: WidgetProps) => {
   )
 }
 
-export const MetricCounterInput = (props: WidgetProps) => PrefixInput('com.hivemq.data-hub.custom.counters.', props)
+export const MetricCounterInput = (props: WidgetProps) =>
+  PrefixInput('com.hivemq.data-hub.custom.counters.', 'workspace.function.metricName.placeholder', props)
 
-export const JsFunctionInput = (props: WidgetProps) => PrefixInput('fn:', props)
+export const JsFunctionInput = (props: WidgetProps) =>
+  PrefixInput('fn:', 'workspace.function.transform.placeholder', props)

--- a/hivemq-edge/src/frontend/src/extensions/datahub/locales/en/datahub.json
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/locales/en/datahub.json
@@ -157,6 +157,9 @@
       "isDataOnly": "[Data]",
       "metricName": {
         "placeholder": "metricName"
+      },
+      "transform": {
+        "placeholder": "functionName"
       }
     },
     "codeEditor": {


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/20145/details/

The PR fixes the placeholder for `JS Function` in the `Operation` side panel.

### Before 

![screenshot-localhost_3000-2024 03 12-14_58_21](https://github.com/hivemq/hivemq-edge/assets/2743481/ae27df5a-6803-4e64-899c-0a587e9ade83)

### After  
![screenshot-localhost_3000-2024 03 12-14_57_34](https://github.com/hivemq/hivemq-edge/assets/2743481/3331069c-4eaf-4da9-a92a-cd37dfcb79cd)
