### PR TITLE
Fix metric name prefix

### DIFF
--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/forms/MetricCounterInput.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/forms/MetricCounterInput.tsx
@@ -46,7 +46,7 @@ const PrefixInput = (prefix: string, placeholder: string, props: WidgetProps) =>
 }
 
 export const MetricCounterInput = (props: WidgetProps) =>
-  PrefixInput('com.hivemq.data-hub.custom.counters.', 'workspace.function.metricName.placeholder', props)
+  PrefixInput('com.hivemq.com.data-hub.custom.counters.', 'workspace.function.metricName.placeholder', props)
 
 export const JsFunctionInput = (props: WidgetProps) =>
   PrefixInput('fn:', 'workspace.function.transform.placeholder', props)


### PR DESCRIPTION
Fixes the prefix for metric names in the UI to `com.hivemq.edge` 