### PR TITLE
feat(20275): Improve the UX flow for draft and edited policy

### DIFF
--- a/hivemq-edge/src/frontend/src/extensions/datahub/api/__generated__/schemas/FunctionData.json
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/api/__generated__/schemas/FunctionData.json
@@ -20,7 +20,8 @@
     "sourceCode": {
       "title": "Source",
       "type": "string",
-      "format": "text/javascript"
+      "format": "text/javascript",
+      "default": "/**\n *\n * @param {Object} publish\n * @param {string} publish.topic    The MQTT topic that is currently specified for this PUBLISH packet.\n * @param {Object} publish.payload  A list of the name and value of all user properties of the MQTT 5 PUBLISH packet. This setting has no effect on MQTT 3 clients.\n * @param {Record<string, string>[]} publish.userProperties The JSON object representation of the deserialized MQTT payload.\n * @param {Object} context\n * @param {Record<string, string>[]} context.arguments  The arguments provided to the script. Currently, arguments can only be provided via a data policy.\n * @param {string} context.policyId The policy id of the policy from which the transformation function is called.\n * @param {string} context.clientId The client Id of the client from which the MQTT publish was sent.\n * @returns {Object} The publish-object is passed as a parameter into the transform function. The same object or a new object is returned as the transformed object.\n */\nfunction transform(publish, context) {\n  return publish\n}"
     }
   }
 }

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/DesignerToolbox.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/DesignerToolbox.tsx
@@ -47,7 +47,7 @@ const DesignerToolbox: FC = () => {
 
   return (
     <Panel position="top-left" style={{ margin: '4px' }}>
-      <HStack alignItems="flex-start">
+      <HStack alignItems="flex-start" userSelect="none">
         <Box>
           <IconButton
             data-testid="toolbox-trigger"

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/DesignerToolbox.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/DesignerToolbox.tsx
@@ -26,6 +26,7 @@ import { MdSkipNext, MdSkipPrevious } from 'react-icons/md'
 import { ToolboxNodes } from '@datahub/components/controls/ToolboxNodes.tsx'
 import { ToolboxDryRun } from '@datahub/components/controls/ToolboxDryRun.tsx'
 import { ToolboxPublish } from '@datahub/components/controls/ToolboxPublish.tsx'
+import DraftStatus from '@datahub/components/helpers/DraftStatus.tsx'
 
 const stepKeys = ['build', 'check', 'publish']
 
@@ -139,6 +140,7 @@ const DesignerToolbox: FC = () => {
             </Stepper>
           </Stack>
         </motion.div>
+        <DraftStatus />
       </HStack>
     </Panel>
   )

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/ToolboxNodes.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/ToolboxNodes.tsx
@@ -2,9 +2,13 @@ import { useTranslation } from 'react-i18next'
 import { HStack, Text, VStack, ButtonGroup } from '@chakra-ui/react'
 import { DataHubNodeType } from '@datahub/types.ts'
 import Tool from '@datahub/components/controls/Tool.tsx'
+import useDataHubDraftStore from '@datahub/hooks/useDataHubDraftStore.ts'
 
 export const ToolboxNodes = () => {
   const { t } = useTranslation('datahub')
+  const { nodes } = useDataHubDraftStore()
+
+  const isDraftEmpty = nodes.length === 0
   const isBehaviorPolicyEnabled = import.meta.env.VITE_FLAG_DATAHUB_BEHAVIOR_ENABLED === 'true'
 
   return (
@@ -19,8 +23,8 @@ export const ToolboxNodes = () => {
         <VStack alignItems="flex-start">
           <Text id="group-pipeline">{t('workspace.toolbox.group.pipeline')}</Text>
           <HStack>
-            <Tool nodeType={DataHubNodeType.TOPIC_FILTER} />
-            <Tool nodeType={DataHubNodeType.CLIENT_FILTER} />
+            <Tool nodeType={DataHubNodeType.TOPIC_FILTER} isDisabled={isDraftEmpty} />
+            <Tool nodeType={DataHubNodeType.CLIENT_FILTER} isDisabled={isDraftEmpty} />
           </HStack>
         </VStack>
       </ButtonGroup>
@@ -29,8 +33,8 @@ export const ToolboxNodes = () => {
           <Text id="group-dataPolicy">{t('workspace.toolbox.group.dataPolicy')}</Text>
           <HStack>
             <Tool nodeType={DataHubNodeType.DATA_POLICY} />
-            <Tool nodeType={DataHubNodeType.VALIDATOR} />
-            <Tool nodeType={DataHubNodeType.SCHEMA} />{' '}
+            <Tool nodeType={DataHubNodeType.VALIDATOR} isDisabled={isDraftEmpty} />
+            <Tool nodeType={DataHubNodeType.SCHEMA} isDisabled={isDraftEmpty} />
           </HStack>
         </VStack>
       </ButtonGroup>
@@ -40,7 +44,7 @@ export const ToolboxNodes = () => {
             <Text id="group-behaviorPolicy">{t('workspace.toolbox.group.behaviorPolicy')}</Text>
             <HStack>
               <Tool nodeType={DataHubNodeType.BEHAVIOR_POLICY} />
-              <Tool nodeType={DataHubNodeType.TRANSITION} />
+              <Tool nodeType={DataHubNodeType.TRANSITION} isDisabled={isDraftEmpty} />
             </HStack>
           </VStack>
         </ButtonGroup>
@@ -49,8 +53,8 @@ export const ToolboxNodes = () => {
         <VStack alignItems="flex-start" pr={2}>
           <Text id="group-operation">{t('workspace.toolbox.group.operation')}</Text>
           <HStack>
-            <Tool nodeType={DataHubNodeType.OPERATION} />
-            <Tool nodeType={DataHubNodeType.FUNCTION} />
+            <Tool nodeType={DataHubNodeType.OPERATION} isDisabled={isDraftEmpty} />
+            <Tool nodeType={DataHubNodeType.FUNCTION} isDisabled={isDraftEmpty} />
           </HStack>
         </VStack>
       </ButtonGroup>

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/helpers/DraftCTA.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/helpers/DraftCTA.tsx
@@ -1,0 +1,38 @@
+import { FC, useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useNavigate } from 'react-router-dom'
+import { Button } from '@chakra-ui/react'
+import { LuFilePlus, LuFileEdit, LuFileQuestion } from 'react-icons/lu'
+
+import { DesignerStatus, PolicyType } from '@datahub/types.ts'
+import useDataHubDraftStore from '@datahub/hooks/useDataHubDraftStore.ts'
+
+const DraftCTA: FC = () => {
+  const { t } = useTranslation('datahub')
+  const navigate = useNavigate()
+  const { setStatus, status, nodes } = useDataHubDraftStore()
+
+  const isCleanDraft = status === DesignerStatus.DRAFT && nodes.length === 0
+  const isModifiedDraft = status === DesignerStatus.DRAFT && nodes.length !== 0
+  const isLoaded = status === DesignerStatus.LOADED || status === DesignerStatus.MODIFIED
+  const Icon = useMemo(() => {
+    if (isCleanDraft) return <LuFilePlus />
+    if (isModifiedDraft) return <LuFileEdit />
+    return <LuFileQuestion />
+  }, [isCleanDraft, isModifiedDraft])
+
+  const handleOnClick = () => {
+    setStatus(DesignerStatus.DRAFT)
+    navigate(`/datahub/${PolicyType.CREATE_POLICY}`)
+  }
+
+  return (
+    <Button leftIcon={Icon} onClick={handleOnClick} variant="primary">
+      {isCleanDraft && t('Listings.policy.action.create')}
+      {isModifiedDraft && t('Listings.policy.action.draft')}
+      {isLoaded && t('Listings.policy.action.clear')}
+    </Button>
+  )
+}
+
+export default DraftCTA

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/helpers/DraftStatus.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/helpers/DraftStatus.tsx
@@ -1,0 +1,28 @@
+import { FC } from 'react'
+import { HStack, Text } from '@chakra-ui/react'
+import { NodeIcon } from '@datahub/components/helpers/index.ts'
+import { DataHubNodeType } from '@datahub/types.ts'
+import { useTranslation } from 'react-i18next'
+import useDataHubDraftStore from '@datahub/hooks/useDataHubDraftStore.ts'
+
+const DraftStatus: FC = () => {
+  const { t } = useTranslation('datahub')
+  const { status, name, type } = useDataHubDraftStore()
+
+  return (
+    <HStack
+      alignItems="flex-start"
+      p={2}
+      borderWidth={1}
+      bg="var(--chakra-colors-chakra-body-bg)"
+      borderRadius="var(--chakra-radii-base)"
+      boxShadow="var(--chakra-shadows-lg)"
+      sx={{ textWrap: 'nowrap' }}
+    >
+      <NodeIcon type={DataHubNodeType.DATA_POLICY} />
+      <Text>{t('workspace.toolbox.draft.status', { context: status, name: name, type })}</Text>
+    </HStack>
+  )
+}
+
+export default DraftStatus

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/helpers/DraftStatus.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/helpers/DraftStatus.tsx
@@ -1,13 +1,22 @@
 import { FC } from 'react'
-import { HStack, Text } from '@chakra-ui/react'
+import { ButtonGroup, HStack, Text } from '@chakra-ui/react'
+import { useTranslation } from 'react-i18next'
+import { LuTrash2 } from 'react-icons/lu'
+
+import IconButton from '@/components/Chakra/IconButton.tsx'
+
 import { NodeIcon } from '@datahub/components/helpers/index.ts'
 import { DataHubNodeType } from '@datahub/types.ts'
-import { useTranslation } from 'react-i18next'
 import useDataHubDraftStore from '@datahub/hooks/useDataHubDraftStore.ts'
 
 const DraftStatus: FC = () => {
   const { t } = useTranslation('datahub')
-  const { status, name, type } = useDataHubDraftStore()
+  const { status, name, type, reset } = useDataHubDraftStore()
+
+  function onHandleClear() {
+    // TODO[NVL] Add confirmation modal
+    reset()
+  }
 
   return (
     <HStack
@@ -21,6 +30,14 @@ const DraftStatus: FC = () => {
     >
       <NodeIcon type={DataHubNodeType.DATA_POLICY} />
       <Text>{t('workspace.toolbox.draft.status', { context: status, name: name, type })}</Text>
+      <ButtonGroup size="xs" isAttached>
+        <IconButton
+          data-testid="designer-clear-draft"
+          onClick={onHandleClear}
+          aria-label={t('workspace.controls.clear')}
+          icon={<LuTrash2 />}
+        />
+      </ButtonGroup>
     </HStack>
   )
 }

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/PolicyEditorLoader.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/PolicyEditorLoader.tsx
@@ -5,7 +5,7 @@ import { Spinner, useToast } from '@chakra-ui/react'
 
 import ErrorMessage from '@/components/ErrorMessage.tsx'
 
-import { PolicyType } from '@datahub/types.ts'
+import { DesignerStatus, PolicyType } from '@datahub/types.ts'
 import PolicyEditor from '@datahub/components/pages/PolicyEditor.tsx'
 import { useGetDataPolicy } from '@datahub/api/hooks/DataHubDataPoliciesService/useGetDataPolicy.tsx'
 import { useGetBehaviorPolicy } from '@datahub/api/hooks/DataHubBehaviorPoliciesService/useGetBehaviorPolicy.tsx'
@@ -50,6 +50,7 @@ export const DataPolicyLoader: FC<PolicyLoaderProps> = ({ policyId }) => {
       loadTopicFilter(dataPolicy, store)
       loadValidators(dataPolicy, schemas.items || [], store)
       loadDataPolicyPipelines(dataPolicy, schemas.items || [], scripts.items || [], store)
+      store.setStatus(DesignerStatus.LOADED, { name: dataPolicy.id })
     } catch (error) {
       let message
       if (error instanceof Error) message = error.message
@@ -98,6 +99,7 @@ export const BehaviorPolicyLoader: FC<PolicyLoaderProps> = ({ policyId }) => {
       loadBehaviorPolicy(behaviorPolicy, store)
       loadClientFilter(behaviorPolicy, store)
       loadTransitions(behaviorPolicy, schemas.items || [], scripts.items || [], store)
+      store.setStatus(DesignerStatus.LOADED, { name: behaviorPolicy.id })
     } catch (error) {
       let message
       if (error instanceof Error) message = error.message

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/PolicyTable.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/PolicyTable.tsx
@@ -10,7 +10,7 @@ import DateTimeRenderer from '@/components/DateTime/DateTimeRenderer.tsx'
 import PaginatedTable from '@/components/PaginatedTable/PaginatedTable.tsx'
 
 import { BehaviorPolicy, BehaviorPolicyMatching, DataPolicy, DataPolicyMatching } from '@/api/__generated__'
-import { DesignerStatus, PolicyType } from '@datahub/types.ts'
+import { PolicyType } from '@datahub/types.ts'
 import { useGetAllBehaviorPolicies } from '@datahub/api/hooks/DataHubBehaviorPoliciesService/useGetAllBehaviorPolicies.tsx'
 import { useDeleteDataPolicy } from '@datahub/api/hooks/DataHubDataPoliciesService/useDeleteDataPolicy.tsx'
 import { mockDataPolicy } from '@datahub/api/hooks/DataHubDataPoliciesService/__handlers__'
@@ -20,7 +20,6 @@ import DataHubListAction from '@datahub/components/helpers/DataHubListAction.tsx
 import { useDeleteBehaviorPolicy } from '@datahub/api/hooks/DataHubBehaviorPoliciesService/useDeleteBehaviorPolicy.tsx'
 import { DataHubTableProps } from '@datahub/components/pages/DataHubListings.tsx'
 import DraftCTA from '@datahub/components/helpers/DraftCTA.tsx'
-import useDataHubDraftStore from '@datahub/hooks/useDataHubDraftStore.ts'
 
 type CombinedPolicy = (DataPolicy & { type: PolicyType }) | (BehaviorPolicy & { type: PolicyType })
 

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/PolicyTable.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/PolicyTable.tsx
@@ -4,15 +4,13 @@ import { UseMutationResult } from '@tanstack/react-query'
 import { DateTime } from 'luxon'
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
-
-import { Button, Skeleton, Text } from '@chakra-ui/react'
-import { BiAddToQueue } from 'react-icons/bi'
+import { Skeleton, Text } from '@chakra-ui/react'
 
 import DateTimeRenderer from '@/components/DateTime/DateTimeRenderer.tsx'
 import PaginatedTable from '@/components/PaginatedTable/PaginatedTable.tsx'
 
 import { BehaviorPolicy, BehaviorPolicyMatching, DataPolicy, DataPolicyMatching } from '@/api/__generated__'
-import { PolicyType } from '@datahub/types.ts'
+import { DesignerStatus, PolicyType } from '@datahub/types.ts'
 import { useGetAllBehaviorPolicies } from '@datahub/api/hooks/DataHubBehaviorPoliciesService/useGetAllBehaviorPolicies.tsx'
 import { useDeleteDataPolicy } from '@datahub/api/hooks/DataHubDataPoliciesService/useDeleteDataPolicy.tsx'
 import { mockDataPolicy } from '@datahub/api/hooks/DataHubDataPoliciesService/__handlers__'
@@ -21,6 +19,8 @@ import { useGetAllDataPolicies } from '@datahub/api/hooks/DataHubDataPoliciesSer
 import DataHubListAction from '@datahub/components/helpers/DataHubListAction.tsx'
 import { useDeleteBehaviorPolicy } from '@datahub/api/hooks/DataHubBehaviorPoliciesService/useDeleteBehaviorPolicy.tsx'
 import { DataHubTableProps } from '@datahub/components/pages/DataHubListings.tsx'
+import DraftCTA from '@datahub/components/helpers/DraftCTA.tsx'
+import useDataHubDraftStore from '@datahub/hooks/useDataHubDraftStore.ts'
 
 type CombinedPolicy = (DataPolicy & { type: PolicyType }) | (BehaviorPolicy & { type: PolicyType })
 
@@ -132,15 +132,7 @@ const PolicyTable: FC<DataHubTableProps> = ({ onDeleteItem }) => {
             </Skeleton>
           )
         },
-        footer: () => (
-          <Button
-            leftIcon={<BiAddToQueue />}
-            onClick={() => navigate(`/datahub/${PolicyType.CREATE_POLICY}`)}
-            variant="primary"
-          >
-            {t('Listings.policy.action.create')}
-          </Button>
-        ),
+        footer: () => <DraftCTA />,
       },
     ]
   }, [deleteBehaviourPolicy, deleteDataPolicy, isLoading, navigate, onDeleteItem, t])

--- a/hivemq-edge/src/frontend/src/extensions/datahub/hooks/useDataHubDraftStore.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/hooks/useDataHubDraftStore.ts
@@ -16,14 +16,16 @@ import {
   BehaviorPolicyData,
   DataHubNodeType,
   DataPolicyData,
+  DesignerStatus,
   FunctionSpecs,
   WorkspaceAction,
   WorkspaceState,
+  WorkspaceStatus,
 } from '../types.ts'
 import { initialStore } from '../utils/store.utils.ts'
 import { styleDefaultEdge } from '../utils/edge.utils.ts'
 
-const useDataHubDraftStore = create<WorkspaceState & WorkspaceAction>()(
+const useDataHubDraftStore = create<WorkspaceState & WorkspaceStatus & WorkspaceAction>()(
   persist(
     (set, get) => ({
       ...initialStore(),
@@ -90,6 +92,14 @@ const useDataHubDraftStore = create<WorkspaceState & WorkspaceAction>()(
       onSerializePolicy: (node: Node<DataPolicyData | BehaviorPolicyData>) => {
         if (node.type !== DataHubNodeType.BEHAVIOR_POLICY && node.type !== DataHubNodeType.DATA_POLICY) return undefined
         return undefined
+      },
+      setStatus: (
+        status: DesignerStatus,
+        option?: { name?: string; type?: DataHubNodeType.DATA_POLICY | DataHubNodeType.BEHAVIOR_POLICY }
+      ) => {
+        set({ status: status })
+        if (option?.name) set({ name: option.name })
+        if (option?.type) set({ type: option.type })
       },
     }),
     {

--- a/hivemq-edge/src/frontend/src/extensions/datahub/locales/en/datahub.json
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/locales/en/datahub.json
@@ -31,8 +31,7 @@
   "Listings": {
     "action": {
       "edit": "Edit",
-      "delete": "Delete",
-      "create": "Create a new policy"
+      "delete": "Delete"
     },
     "tabs": {
       "policy": {
@@ -48,6 +47,12 @@
         "description": "Your transformation code will be listed there."
       }
     },
+    "modal": {
+      "delete": {
+        "header": "Delete Item",
+        "message": "Are you sure? You can't undo this action afterwards."
+      }
+    },
     "policy": {
       "label": "List of policies",
       "header": {
@@ -57,17 +62,12 @@
         "actions": "Actions"
       },
       "action": {
-        "edit": "Edit",
-        "delete": "Delete",
-        "create": "Create a new policy"
+        "create": "Create a new policy",
+        "draft": "Continue on draft",
+        "clear": "Clear the draft"
       }
     },
-    "modal": {
-      "delete": {
-        "header": "Delete Item",
-        "message": "Are you sure? You can't undo this action afterwards."
-      }
-    },
+
     "schema": {
       "label": "List of schemas",
       "header": {
@@ -126,6 +126,11 @@
         "dataPolicy": "Data Policy",
         "behaviorPolicy": "Behavior Policy",
         "operation": "Operation"
+      },
+      "draft": {
+        "status_DRAFT": "Draft Policy",
+        "status_LOADED": "{{ type }} {{ name }} - Loaded",
+        "status_MODIFIED": "{{ type }} {{ name }} - Modified"
       }
     },
     "nodes": {

--- a/hivemq-edge/src/frontend/src/extensions/datahub/locales/en/datahub.json
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/locales/en/datahub.json
@@ -50,7 +50,7 @@
     "modal": {
       "delete": {
         "header": "Delete Item",
-        "message": "Are you sure? You can't undo this action afterwards."
+        "message": "Are you sure? You can't undo this action afterward."
       }
     },
     "policy": {
@@ -97,7 +97,8 @@
       "zoomIn": "Zoom in",
       "zoomIOut": "Zoom out",
       "fitView": "Fit to the canvas",
-      "toggleInteractivity": "Lock the canvas"
+      "toggleInteractivity": "Lock the canvas",
+      "clear": "Clear the Designer"
     },
     "toolbox": {
       "aria-label": "Policy controls",

--- a/hivemq-edge/src/frontend/src/extensions/datahub/types.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/types.ts
@@ -22,10 +22,22 @@ export interface PanelProps {
   onFormSubmit?: (data: IChangeEvent) => void
 }
 
+export enum DesignerStatus {
+  DRAFT = 'DRAFT',
+  LOADED = 'LOADED',
+  MODIFIED = 'MODIFIED',
+}
+
 export interface WorkspaceState {
   nodes: Node[]
   edges: Edge[]
   functions: FunctionSpecs[]
+}
+
+export interface WorkspaceStatus {
+  status: DesignerStatus
+  name: string
+  type: DataHubNodeType.DATA_POLICY | DataHubNodeType.BEHAVIOR_POLICY | undefined
 }
 
 export interface WorkspaceAction {
@@ -41,6 +53,11 @@ export interface WorkspaceAction {
   onSerializePolicy: (node: Node<DataPolicyData | BehaviorPolicyData>) => string | undefined
 
   isDirty: () => boolean
+
+  setStatus: (
+    status: DesignerStatus,
+    option?: { name?: string; type?: DataHubNodeType.DATA_POLICY | DataHubNodeType.BEHAVIOR_POLICY }
+  ) => void
 }
 
 export interface PolicyCheckState {

--- a/hivemq-edge/src/frontend/src/extensions/datahub/utils/store.utils.spec.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/utils/store.utils.spec.ts
@@ -1,16 +1,19 @@
 import { describe, expect } from 'vitest'
 import { getFunctions, initialStore } from './store.utils.ts'
-import { WorkspaceState } from '@/extensions/datahub/types.ts'
+import { DesignerStatus, WorkspaceState, WorkspaceStatus } from '@/extensions/datahub/types.ts'
 import { RJSFSchema } from '@rjsf/utils'
 import { GenericObjectType } from '@rjsf/utils/src/types.ts'
 
 describe('initialStore', () => {
   it('should return the initial state of the store', async () => {
     const store = initialStore()
-    expect(store).toStrictEqual<WorkspaceState>({
+    expect(store).toStrictEqual<WorkspaceState & WorkspaceStatus>({
       nodes: [],
       edges: [],
       functions: expect.arrayContaining([]),
+      name: '',
+      status: DesignerStatus.DRAFT,
+      type: undefined,
     })
     expect(store.functions).toHaveLength(9)
   })

--- a/hivemq-edge/src/frontend/src/extensions/datahub/utils/store.utils.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/utils/store.utils.ts
@@ -1,7 +1,7 @@
 import { Edge, Node } from 'reactflow'
 import { RJSFSchema } from '@rjsf/utils'
 
-import { FunctionSpecs, WorkspaceState } from '@datahub/types.ts'
+import { DesignerStatus, FunctionSpecs, WorkspaceState, WorkspaceStatus } from '@datahub/types.ts'
 import { MOCK_OPERATION_SCHEMA } from '@datahub/designer/operation/OperationData.ts'
 
 export const getFunctions = (schema: RJSFSchema) => {
@@ -30,11 +30,11 @@ export const getFunctions = (schema: RJSFSchema) => {
   })
 }
 
-export const initialStore = (): WorkspaceState => {
+export const initialStore = (): WorkspaceState & WorkspaceStatus => {
   const nodes: Node[] = []
   const edges: Edge[] = []
 
   const functions = getFunctions(MOCK_OPERATION_SCHEMA.schema)
 
-  return { nodes, edges, functions: functions }
+  return { nodes, edges, functions: functions, name: '', status: DesignerStatus.DRAFT, type: undefined }
 }


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/20275/details/

The PR clarifies the status of the Data Hub Designer when dealing with draft or loaded/modified policies. 

- A `status` is added to the `Data Hub store, indicating whether the canvas contains a `DRAFT`, a `LOADED` policy or a `MODIFIED` policy.
- An info panel is added to the toolbar, indicating the `status` of the Designer's canvas and, if appropriate, the name and type of a loaded policy
- The primary CTA on the policy table changes state depending on the `status` (Create a new policy, Continue on draft, Clear the draft)

The PR also improves several aspects of the UX
- The texts in the toolbar cannot be selected by the user; it improves usability
- The Designer building buttons are disabled until a `data policy` or `behavior policy` is created on the canvas
- A default template is added to any newly created `JS Function` node

### Out-of-scope
- clearing the canvas doesn't have any confirmation guard. It will be added in a subsequent ticket
- the name of a policy, as displayed in the toolbar, can stretch a long way. Overflow/ellipsis will be added in a subsequent ticket


### Before
![screenshot-localhost_3000-2024 03 13-11_12_09](https://github.com/hivemq/hivemq-edge/assets/2743481/49eab6fd-4359-4cbb-8532-ac5311cda268)

### After
![screenshot-localhost_3000-2024 03 13-11_09_58](https://github.com/hivemq/hivemq-edge/assets/2743481/65d416e2-57f9-4578-92e7-d2f860aaa4d5)

![screenshot-localhost_3000-2024 03 13-11_10_19](https://github.com/hivemq/hivemq-edge/assets/2743481/bcd1fd97-afad-4127-be2f-9103ed8bc884)

![screenshot-localhost_3000-2024 03 13-11_10_37](https://github.com/hivemq/hivemq-edge/assets/2743481/a711f953-5879-4aaa-9db3-7653456ecb69)
