### PR TITLE
feat(20401): Support downloading payloads and read-only canvas

### DIFF
--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/ToolboxDryRun.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/ToolboxDryRun.tsx
@@ -12,7 +12,7 @@ import {
   AlertStatus,
   CloseButton,
 } from '@chakra-ui/react'
-import { DataHubNodeData, PolicyDryRunStatus } from '@datahub/types.ts'
+import { DataHubNodeData, DesignerStatus, PolicyDryRunStatus } from '@datahub/types.ts'
 import { useTranslation } from 'react-i18next'
 import { getDryRunStatusIcon, isBehaviorPolicyNodeType, isDataPolicyNodeType } from '@datahub/utils/node.utils.ts'
 import { useOnSelectionChange, useReactFlow } from 'reactflow'
@@ -25,10 +25,12 @@ export const ToolboxDryRun: FC = () => {
   const { t } = useTranslation('datahub')
   const { checkPolicyAsync } = usePolicyDryRun()
   const { fitView } = useReactFlow()
-  const { nodes, onUpdateNodes } = useDataHubDraftStore()
+  const { nodes, onUpdateNodes, status: statusDraft } = useDataHubDraftStore()
   const { status, node, report, setNode, initReport, setReport, getErrors, reset } = usePolicyChecksStore()
 
   const CheckIcon = useMemo(() => getDryRunStatusIcon(status), [status])
+  const isEditEnabled =
+    import.meta.env.VITE_FLAG_DATAHUB_EDIT_POLICY_ENABLED === 'true' || statusDraft === DesignerStatus.DRAFT
 
   useOnSelectionChange({
     onChange: ({ nodes }) => {
@@ -69,7 +71,9 @@ export const ToolboxDryRun: FC = () => {
             isLoading={status === PolicyDryRunStatus.RUNNING}
             loadingText={t('workspace.dryRun.toolbar.checking')}
             onClick={handleCheckPolicy}
-            isDisabled={!node || status === PolicyDryRunStatus.SUCCESS || status === PolicyDryRunStatus.FAILURE}
+            isDisabled={
+              !node || status === PolicyDryRunStatus.SUCCESS || status === PolicyDryRunStatus.FAILURE || !isEditEnabled
+            }
           >
             {t('workspace.toolbar.policy.check')}
           </Button>

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/ToolboxNodes.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/ToolboxNodes.tsx
@@ -1,15 +1,17 @@
 import { useTranslation } from 'react-i18next'
 import { HStack, Text, VStack, ButtonGroup } from '@chakra-ui/react'
-import { DataHubNodeType } from '@datahub/types.ts'
+import { DataHubNodeType, DesignerStatus } from '@datahub/types.ts'
 import Tool from '@datahub/components/controls/Tool.tsx'
 import useDataHubDraftStore from '@datahub/hooks/useDataHubDraftStore.ts'
 
 export const ToolboxNodes = () => {
   const { t } = useTranslation('datahub')
-  const { nodes } = useDataHubDraftStore()
+  const { nodes, status } = useDataHubDraftStore()
 
-  const isDraftEmpty = nodes.length === 0
   const isBehaviorPolicyEnabled = import.meta.env.VITE_FLAG_DATAHUB_BEHAVIOR_ENABLED === 'true'
+  const isEditEnabled =
+    import.meta.env.VITE_FLAG_DATAHUB_EDIT_POLICY_ENABLED === 'true' || status === DesignerStatus.DRAFT
+  const isDraftEmpty = nodes.length === 0
 
   return (
     <HStack
@@ -23,8 +25,8 @@ export const ToolboxNodes = () => {
         <VStack alignItems="flex-start">
           <Text id="group-pipeline">{t('workspace.toolbox.group.pipeline')}</Text>
           <HStack>
-            <Tool nodeType={DataHubNodeType.TOPIC_FILTER} isDisabled={isDraftEmpty} />
-            <Tool nodeType={DataHubNodeType.CLIENT_FILTER} isDisabled={isDraftEmpty} />
+            <Tool nodeType={DataHubNodeType.TOPIC_FILTER} isDisabled={isDraftEmpty || !isEditEnabled} />
+            <Tool nodeType={DataHubNodeType.CLIENT_FILTER} isDisabled={isDraftEmpty || !isEditEnabled} />
           </HStack>
         </VStack>
       </ButtonGroup>
@@ -32,9 +34,9 @@ export const ToolboxNodes = () => {
         <VStack alignItems="flex-start">
           <Text id="group-dataPolicy">{t('workspace.toolbox.group.dataPolicy')}</Text>
           <HStack>
-            <Tool nodeType={DataHubNodeType.DATA_POLICY} />
-            <Tool nodeType={DataHubNodeType.VALIDATOR} isDisabled={isDraftEmpty} />
-            <Tool nodeType={DataHubNodeType.SCHEMA} isDisabled={isDraftEmpty} />
+            <Tool nodeType={DataHubNodeType.DATA_POLICY} isDisabled={!isEditEnabled} />
+            <Tool nodeType={DataHubNodeType.VALIDATOR} isDisabled={isDraftEmpty || !isEditEnabled} />
+            <Tool nodeType={DataHubNodeType.SCHEMA} isDisabled={isDraftEmpty || !isEditEnabled} />
           </HStack>
         </VStack>
       </ButtonGroup>
@@ -43,8 +45,8 @@ export const ToolboxNodes = () => {
           <VStack alignItems="flex-start">
             <Text id="group-behaviorPolicy">{t('workspace.toolbox.group.behaviorPolicy')}</Text>
             <HStack>
-              <Tool nodeType={DataHubNodeType.BEHAVIOR_POLICY} />
-              <Tool nodeType={DataHubNodeType.TRANSITION} isDisabled={isDraftEmpty} />
+              <Tool nodeType={DataHubNodeType.BEHAVIOR_POLICY} isDisabled={!isEditEnabled} />
+              <Tool nodeType={DataHubNodeType.TRANSITION} isDisabled={isDraftEmpty || !isEditEnabled} />
             </HStack>
           </VStack>
         </ButtonGroup>
@@ -53,8 +55,8 @@ export const ToolboxNodes = () => {
         <VStack alignItems="flex-start" pr={2}>
           <Text id="group-operation">{t('workspace.toolbox.group.operation')}</Text>
           <HStack>
-            <Tool nodeType={DataHubNodeType.OPERATION} isDisabled={isDraftEmpty} />
-            <Tool nodeType={DataHubNodeType.FUNCTION} isDisabled={isDraftEmpty} />
+            <Tool nodeType={DataHubNodeType.OPERATION} isDisabled={isDraftEmpty || !isEditEnabled} />
+            <Tool nodeType={DataHubNodeType.FUNCTION} isDisabled={isDraftEmpty || !isEditEnabled} />
           </HStack>
         </VStack>
       </ButtonGroup>

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/ToolboxPublish.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/ToolboxPublish.tsx
@@ -8,12 +8,13 @@ import { MdPublishedWithChanges } from 'react-icons/md'
 import { BehaviorPolicy, DataPolicy, Schema, Script } from '@/api/__generated__'
 
 import { usePolicyChecksStore } from '@datahub/hooks/usePolicyChecksStore.ts'
-import { DataHubNodeType, DryRunResults } from '@datahub/types.ts'
+import { DataHubNodeType, DesignerStatus, DryRunResults } from '@datahub/types.ts'
 import { useCreateSchema } from '@datahub/api/hooks/DataHubSchemasService/useCreateSchema.tsx'
 import { useCreateScript } from '@datahub/api/hooks/DataHubScriptsService/useCreateScript.tsx'
 import { useCreateDataPolicy } from '@datahub/api/hooks/DataHubDataPoliciesService/useCreateDataPolicy.tsx'
 import { useCreateBehaviorPolicy } from '@datahub/api/hooks/DataHubBehaviorPoliciesService/useCreateBehaviorPolicy.tsx'
 import { dataHubToastOption } from '@datahub/utils/toast.utils.ts'
+import useDataHubDraftStore from '@datahub/hooks/useDataHubDraftStore.ts'
 
 interface Mutate<T> {
   type: DataHubNodeType
@@ -40,12 +41,15 @@ const resourceReducer =
 export const ToolboxPublish: FC = () => {
   const { t } = useTranslation('datahub')
   const { report } = usePolicyChecksStore()
+  const { status: statusDraft } = useDataHubDraftStore()
   const createSchema = useCreateSchema()
   const createScript = useCreateScript()
   const createDataPolicy = useCreateDataPolicy()
   const createBehaviorPolicy = useCreateBehaviorPolicy()
   const toast = useToast()
 
+  const isEditEnabled =
+    import.meta.env.VITE_FLAG_DATAHUB_EDIT_POLICY_ENABLED === 'true' || statusDraft === DesignerStatus.DRAFT
   const isValid = !!report && report.length >= 1 && report?.every((e) => !e.error)
 
   const handleMutation = async (promise: Promise<ValidMutate>, type: DataHubNodeType) => {
@@ -145,7 +149,7 @@ export const ToolboxPublish: FC = () => {
           <Button
             leftIcon={<Icon as={MdPublishedWithChanges} boxSize="24px" />}
             onClick={handlePublish}
-            isDisabled={!isValid}
+            isDisabled={!isValid || !isEditEnabled}
             isLoading={createSchema.isLoading}
           >
             {t('workspace.toolbar.policy.publish')}

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/helpers/DataHubListAction.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/helpers/DataHubListAction.spec.cy.tsx
@@ -19,7 +19,7 @@ describe('DataHubListAction', () => {
   })
 
   it('should render the buttons disabled', () => {
-    cy.mountWithProviders(<DataHubListAction isEditDisabled />)
+    cy.mountWithProviders(<DataHubListAction isAccessDisabled />)
 
     cy.get('button').should('have.length', 1)
     cy.getByTestId('list-action-edit').should('not.exist')

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/helpers/DataHubListAction.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/helpers/DataHubListAction.spec.cy.tsx
@@ -10,9 +10,9 @@ describe('DataHubListAction', () => {
   it('should render the actions', () => {
     cy.mountWithProviders(<DataHubListAction onEdit={cy.stub().as('onEdit')} onDelete={cy.stub().as('onDelete')} />)
 
-    cy.get('button').should('have.length', 2)
-    cy.getByTestId('list-action-edit').should('not.be.disabled')
-    cy.getByTestId('list-action-edit').click()
+    cy.get('button').should('have.length', 3)
+    cy.getByTestId('list-action-view').should('not.be.disabled')
+    cy.getByTestId('list-action-view').click()
     cy.get('@onEdit').should('have.been.called')
     cy.getByTestId('list-action-delete').click()
     cy.get('@onDelete').should('have.been.called')
@@ -21,7 +21,7 @@ describe('DataHubListAction', () => {
   it('should render the buttons disabled', () => {
     cy.mountWithProviders(<DataHubListAction isAccessDisabled />)
 
-    cy.get('button').should('have.length', 1)
-    cy.getByTestId('list-action-edit').should('not.exist')
+    cy.get('button').should('have.length', 2)
+    cy.getByTestId('list-action-view').should('not.exist')
   })
 })

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/helpers/DataHubListAction.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/helpers/DataHubListAction.tsx
@@ -2,27 +2,46 @@ import { FC, MouseEventHandler } from 'react'
 import { ButtonGroup } from '@chakra-ui/react'
 import IconButton from '@/components/Chakra/IconButton.tsx'
 import { useTranslation } from 'react-i18next'
-import { LuFileEdit, LuTrash2 } from 'react-icons/lu'
+import { LuFileEdit, LuTrash2, LuFileSearch, LuDownload } from 'react-icons/lu'
 
 interface DataHubListActionProps {
   onEdit?: MouseEventHandler<HTMLButtonElement>
   onDelete?: MouseEventHandler<HTMLButtonElement>
-  isEditDisabled?: boolean
+  onDownload?: MouseEventHandler<HTMLButtonElement>
+  isAccessDisabled?: boolean
 }
 
-const DataHubListAction: FC<DataHubListActionProps> = ({ onEdit, onDelete, isEditDisabled = false }) => {
+const DataHubListAction: FC<DataHubListActionProps> = ({ onEdit, onDelete, onDownload, isAccessDisabled = false }) => {
   const { t } = useTranslation('datahub')
+  const isEditEnabled = import.meta.env.VITE_FLAG_DATAHUB_EDIT_POLICY_ENABLED === 'true'
+
   return (
     <ButtonGroup size="sm" isAttached>
-      {!isEditDisabled && (
-        <IconButton
-          data-testid="list-action-edit"
-          onClick={onEdit}
-          aria-label={t('Listings.action.edit')}
-          icon={<LuFileEdit />}
-          isDisabled={isEditDisabled}
-        />
+      {!isAccessDisabled && (
+        <>
+          {isEditEnabled ? (
+            <IconButton
+              data-testid="list-action-edit"
+              onClick={onEdit}
+              aria-label={t('Listings.action.edit')}
+              icon={<LuFileEdit />}
+            />
+          ) : (
+            <IconButton
+              data-testid="list-action-view"
+              onClick={onEdit}
+              aria-label={t('Listings.action.view')}
+              icon={<LuFileSearch />}
+            />
+          )}
+        </>
       )}
+      <IconButton
+        data-testid="list-action-download"
+        onClick={onDownload}
+        aria-label={t('Listings.action.download')}
+        icon={<LuDownload />}
+      />
       <IconButton
         data-testid="list-action-delete"
         onClick={onDelete}

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/helpers/DraftStatus.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/helpers/DraftStatus.tsx
@@ -6,16 +6,19 @@ import { LuTrash2 } from 'react-icons/lu'
 import IconButton from '@/components/Chakra/IconButton.tsx'
 
 import { NodeIcon } from '@datahub/components/helpers/index.ts'
-import { DataHubNodeType } from '@datahub/types.ts'
+import { DataHubNodeType, PolicyType } from '@datahub/types.ts'
 import useDataHubDraftStore from '@datahub/hooks/useDataHubDraftStore.ts'
+import { useNavigate } from 'react-router-dom'
 
 const DraftStatus: FC = () => {
   const { t } = useTranslation('datahub')
   const { status, name, type, reset } = useDataHubDraftStore()
+  const navigate = useNavigate()
 
   function onHandleClear() {
     // TODO[NVL] Add confirmation modal
     reset()
+    navigate(`/datahub/${PolicyType.CREATE_POLICY}`)
   }
 
   return (

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/PolicyTable.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/PolicyTable.tsx
@@ -20,6 +20,7 @@ import DataHubListAction from '@datahub/components/helpers/DataHubListAction.tsx
 import { useDeleteBehaviorPolicy } from '@datahub/api/hooks/DataHubBehaviorPoliciesService/useDeleteBehaviorPolicy.tsx'
 import { DataHubTableProps } from '@datahub/components/pages/DataHubListings.tsx'
 import DraftCTA from '@datahub/components/helpers/DraftCTA.tsx'
+import { downloadTimeStamp } from '@datahub/utils/date.utils.ts'
 
 type CombinedPolicy = (DataPolicy & { type: PolicyType }) | (BehaviorPolicy & { type: PolicyType })
 
@@ -75,6 +76,16 @@ const PolicyTable: FC<DataHubTableProps> = ({ onDeleteItem }) => {
       navigate(`/datahub/${info.row.original.type}/${info.row.original.id}`)
     }
 
+    const onHandleDownload = (info: CellContext<CombinedPolicy, unknown>) => () => {
+      const { type, ...policy } = info.row.original
+      const jsonString = `data:text/json;charset=utf-8,${encodeURIComponent(JSON.stringify(policy))}`
+      const link = document.createElement('a')
+      link.href = jsonString
+      link.download = `${info.row.original.id}-${downloadTimeStamp()}.json`
+
+      link.click()
+    }
+
     return [
       {
         accessorKey: 'id',
@@ -127,7 +138,11 @@ const PolicyTable: FC<DataHubTableProps> = ({ onDeleteItem }) => {
         cell: (info) => {
           return (
             <Skeleton isLoaded={!isLoading}>
-              <DataHubListAction onDelete={onHandleDelete(info)} onEdit={onHandleEdit(info)} />
+              <DataHubListAction
+                onDelete={onHandleDelete(info)}
+                onEdit={onHandleEdit(info)}
+                onDownload={onHandleDownload(info)}
+              />
             </Skeleton>
           )
         },

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/PolicyTable.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/PolicyTable.tsx
@@ -20,7 +20,7 @@ import DataHubListAction from '@datahub/components/helpers/DataHubListAction.tsx
 import { useDeleteBehaviorPolicy } from '@datahub/api/hooks/DataHubBehaviorPoliciesService/useDeleteBehaviorPolicy.tsx'
 import { DataHubTableProps } from '@datahub/components/pages/DataHubListings.tsx'
 import DraftCTA from '@datahub/components/helpers/DraftCTA.tsx'
-import { downloadTimeStamp } from '@datahub/utils/date.utils.ts'
+import { downloadJSON } from '@datahub/utils/download.utils.ts'
 
 type CombinedPolicy = (DataPolicy & { type: PolicyType }) | (BehaviorPolicy & { type: PolicyType })
 
@@ -78,12 +78,7 @@ const PolicyTable: FC<DataHubTableProps> = ({ onDeleteItem }) => {
 
     const onHandleDownload = (info: CellContext<CombinedPolicy, unknown>) => () => {
       const { type, ...policy } = info.row.original
-      const jsonString = `data:text/json;charset=utf-8,${encodeURIComponent(JSON.stringify(policy))}`
-      const link = document.createElement('a')
-      link.href = jsonString
-      link.download = `${info.row.original.id}-${downloadTimeStamp()}.json`
-
-      link.click()
+      downloadJSON<DataPolicy | BehaviorPolicy>(info.row.original.id, policy)
     }
 
     return [

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/SchemaTable.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/SchemaTable.tsx
@@ -1,5 +1,5 @@
 import { FC, useMemo } from 'react'
-import { ColumnDef } from '@tanstack/react-table'
+import { CellContext, ColumnDef } from '@tanstack/react-table'
 import { DateTime } from 'luxon'
 import { useTranslation } from 'react-i18next'
 
@@ -15,6 +15,7 @@ import { useDeleteSchema } from '@datahub/api/hooks/DataHubSchemasService/useDel
 import DataHubListAction from '@datahub/components/helpers/DataHubListAction.tsx'
 import { DataHubTableProps } from '@datahub/components/pages/DataHubListings.tsx'
 import { DataHubNodeType } from '@datahub/types.ts'
+import { downloadJSON } from '@datahub/utils/download.utils.ts'
 
 const SchemaTable: FC<DataHubTableProps> = ({ onDeleteItem }) => {
   const { t } = useTranslation('datahub')
@@ -28,6 +29,10 @@ const SchemaTable: FC<DataHubTableProps> = ({ onDeleteItem }) => {
   }, [isLoading, data?.items])
 
   const columns = useMemo<ColumnDef<Schema>[]>(() => {
+    const onHandleDownload = (info: CellContext<Schema, unknown>) => () => {
+      downloadJSON<Schema>(info.row.original.id, info.row.original)
+    }
+
     return [
       {
         accessorKey: 'id',
@@ -79,8 +84,9 @@ const SchemaTable: FC<DataHubTableProps> = ({ onDeleteItem }) => {
           return (
             <Skeleton isLoaded={!isLoading}>
               <DataHubListAction
-                isEditDisabled
+                isAccessDisabled
                 onDelete={() => onDeleteItem?.(deleteSchema.mutateAsync, DataHubNodeType.SCHEMA, info.row.original.id)}
+                onDownload={onHandleDownload(info)}
               />
             </Skeleton>
           )

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/ScriptTable.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/ScriptTable.tsx
@@ -1,5 +1,5 @@
 import { FC, useMemo } from 'react'
-import { ColumnDef } from '@tanstack/react-table'
+import { CellContext, ColumnDef } from '@tanstack/react-table'
 import { DateTime } from 'luxon'
 import { useTranslation } from 'react-i18next'
 import { Skeleton, Text } from '@chakra-ui/react'
@@ -14,6 +14,7 @@ import { mockScript } from '@datahub/api/hooks/DataHubScriptsService/__handlers_
 import DataHubListAction from '@datahub/components/helpers/DataHubListAction.tsx'
 import { DataHubTableProps } from '@datahub/components/pages/DataHubListings.tsx'
 import { DataHubNodeType } from '@datahub/types.ts'
+import { downloadJSON } from '@datahub/utils/download.utils.ts'
 
 const ScriptTable: FC<DataHubTableProps> = ({ onDeleteItem }) => {
   const { t } = useTranslation('datahub')
@@ -27,6 +28,10 @@ const ScriptTable: FC<DataHubTableProps> = ({ onDeleteItem }) => {
   }, [isLoading, data?.items])
 
   const columns = useMemo<ColumnDef<Script>[]>(() => {
+    const onHandleDownload = (info: CellContext<Script, unknown>) => () => {
+      downloadJSON<Script>(info.row.original.id, info.row.original)
+    }
+
     return [
       {
         accessorKey: 'id',
@@ -89,10 +94,11 @@ const ScriptTable: FC<DataHubTableProps> = ({ onDeleteItem }) => {
           return (
             <Skeleton isLoaded={!isLoading}>
               <DataHubListAction
-                isEditDisabled
+                isAccessDisabled
                 onDelete={() =>
                   onDeleteItem?.(deleteScript.mutateAsync, DataHubNodeType.FUNCTION, info.row.original.id)
                 }
+                onDownload={onHandleDownload(info)}
               />
             </Skeleton>
           )

--- a/hivemq-edge/src/frontend/src/extensions/datahub/locales/en/datahub.json
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/locales/en/datahub.json
@@ -31,6 +31,8 @@
   "Listings": {
     "action": {
       "edit": "Edit",
+      "view": "View",
+      "download": "Download",
       "delete": "Delete"
     },
     "tabs": {

--- a/hivemq-edge/src/frontend/src/extensions/datahub/utils/date.utils.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/utils/date.utils.ts
@@ -1,4 +1,0 @@
-import { DateTime } from 'luxon'
-
-export const downloadTimeStamp = () =>
-  DateTime.now().startOf('second').toISO({ suppressMilliseconds: true, suppressSeconds: true, includeOffset: false })

--- a/hivemq-edge/src/frontend/src/extensions/datahub/utils/date.utils.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/utils/date.utils.ts
@@ -1,0 +1,4 @@
+import { DateTime } from 'luxon'
+
+export const downloadTimeStamp = () =>
+  DateTime.now().startOf('second').toISO({ suppressMilliseconds: true, suppressSeconds: true, includeOffset: false })

--- a/hivemq-edge/src/frontend/src/extensions/datahub/utils/download.utils.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/utils/download.utils.ts
@@ -1,0 +1,13 @@
+import { DateTime } from 'luxon'
+
+const downloadTimeStamp = () =>
+  DateTime.now().startOf('second').toISO({ suppressMilliseconds: true, suppressSeconds: true, includeOffset: false })
+
+export function downloadJSON<T>(name: string, source: T) {
+  const jsonString = `data:text/json;charset=utf-8,${encodeURIComponent(JSON.stringify(source))}`
+  const link = document.createElement('a')
+  link.href = jsonString
+  link.download = `${name}-${downloadTimeStamp()}.json`
+
+  link.click()
+}


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/20401/details/

The PR adds two features allowing a partial release of the `Data Hub Designer`:
- the payload of the `policies`, `scripts` and `schemas` can be downloaded from the main tables. The JSON is exported and minified in a file automatically named from the `id` of the object and the timestamp of the download.
- access to the canvas of a saved policy is through a "view" command rather than the previous "edit". The canvas can still be explored, manipulated (and, unfortunately, modified) but it cannot be checked or published

The PR also fixes a small issue with the "clearing the canvas" action by navigating back to the right location. 

### Before
![screenshot-localhost_3000-2024 03 14-12_54_22](https://github.com/hivemq/hivemq-edge/assets/2743481/f3de79a0-88ae-4d9d-a10b-bdc82d7e8fad)

### After
![screenshot-localhost_3000-2024 03 14-12_53_34](https://github.com/hivemq/hivemq-edge/assets/2743481/ebf606ae-03fb-437b-8524-f5ab162f760c)

![screenshot-localhost_3000-2024 03 14-12_53_47](https://github.com/hivemq/hivemq-edge/assets/2743481/779c0508-e2f6-46d0-a487-cad794b61479)
