### PR TITLE
feat(18854): Add reset to the workspace

### DIFF
--- a/hivemq-edge/src/frontend/src/components/Modal/ConfirmationDialog.tsx
+++ b/hivemq-edge/src/frontend/src/components/Modal/ConfirmationDialog.tsx
@@ -16,10 +16,11 @@ interface ConfirmationDialogProps {
   onClose: () => void
   header: string
   message: string
+  action?: string | null
   onSubmit?: () => void
 }
 
-const ConfirmationDialog: FC<ConfirmationDialogProps> = ({ isOpen, onClose, header, message, onSubmit }) => {
+const ConfirmationDialog: FC<ConfirmationDialogProps> = ({ isOpen, onClose, header, message, action, onSubmit }) => {
   const { t } = useTranslation()
   const cancelRef = useRef<HTMLButtonElement>()
 
@@ -45,7 +46,7 @@ const ConfirmationDialog: FC<ConfirmationDialogProps> = ({ isOpen, onClose, head
               variant="danger"
               ml={3}
             >
-              {t('action.delete')}
+              {action || t('action.delete')}
             </Button>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/hivemq-edge/src/frontend/src/locales/en/translation.json
+++ b/hivemq-edge/src/frontend/src/locales/en/translation.json
@@ -628,6 +628,15 @@
       "layout": {
         "header": "Topology Graph: Layout",
         "prompt": "Select the grouping attributes, in order of application"
+      },
+      "reset": {
+        "legend": "Reset Visualisation",
+        "prompt": "If you experience disparities between your known topologies and the visualisation in the workspace, use the reset below to regenerate the graph.",
+        "warning": "Groups and panel configurations will be cleared too. The action cannot be reverted.",
+        "action": "Reset",
+        "modal": {
+          "description": "Are you sure you want to reset the workspace? Groups and panel configurations will be cleared too. The action cannot be reverted"
+        }
       }
     },
     "node": {

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/drawers/WorkspaceOptionsDrawer.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/drawers/WorkspaceOptionsDrawer.tsx
@@ -1,8 +1,7 @@
 import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
 import {
-  Checkbox,
-  CheckboxGroup,
+  Button,
   Drawer,
   DrawerBody,
   DrawerCloseButton,
@@ -10,29 +9,27 @@ import {
   DrawerHeader,
   DrawerOverlay,
   FormControl,
-  FormHelperText,
   FormLabel,
-  Stack,
-  VStack,
+  Text,
+  useDisclosure,
 } from '@chakra-ui/react'
 
-import { EdgeFlowOptions } from '../../types.ts'
 import { useEdgeFlowContext } from '../../hooks/useEdgeFlowContext.tsx'
+import useWorkspaceStore from '@/modules/Workspace/hooks/useWorkspaceStore.ts'
+import ConfirmationDialog from '@/components/Modal/ConfirmationDialog.tsx'
+import { useNavigate } from 'react-router-dom'
 
 const WorkspaceOptionsDrawer: FC = () => {
   const { t } = useTranslation()
-  const { optionDrawer, options, setOptions } = useEdgeFlowContext()
-  const optionKeys: (keyof EdgeFlowOptions)[] = [
-    'showTopics',
-    'showStatus',
-    'showGateway',
-    'showHosts',
-    'showMonitoringOnEdge',
-  ]
-  const initValues = optionKeys.filter((option) => {
-    const keyOption = option as keyof EdgeFlowOptions
-    return options[keyOption]
-  })
+  const { optionDrawer } = useEdgeFlowContext()
+  const { reset } = useWorkspaceStore()
+  const { isOpen, onOpen, onClose } = useDisclosure()
+  const navigate = useNavigate()
+
+  const onReset = () => {
+    reset()
+    navigate('/')
+  }
 
   return (
     <Drawer isOpen={optionDrawer.isOpen || false} placement="right" size="md" onClose={optionDrawer.onClose}>
@@ -42,34 +39,27 @@ const WorkspaceOptionsDrawer: FC = () => {
         <DrawerHeader>{t('workspace.configuration.header')}</DrawerHeader>
 
         <DrawerBody>
-          <VStack gap={4}>
-            <FormControl as="fieldset" borderWidth="1px" p={2}>
-              <FormLabel as="legend">{t('workspace.configuration.content.header')}</FormLabel>
-              <CheckboxGroup
-                colorScheme="brand"
-                defaultValue={initValues}
-                onChange={(options) => {
-                  const newOptions = options.reduce((a, opt) => ({ ...a, [opt]: true }), {})
-                  const oldOptions = optionKeys.reduce((a, opt) => ({ ...a, [opt]: false }), {})
+          <FormControl as="fieldset">
+            <FormLabel as="legend">{t('workspace.configuration.reset.legend')}</FormLabel>
+            <Text>{t('workspace.configuration.reset.prompt')}</Text>
 
-                  setOptions((old) => ({ ...old, ...oldOptions, ...newOptions }))
-                }}
-              >
-                <Stack direction="column">
-                  <Checkbox value="showTopics">{t('workspace.configuration.content.showTopics')}</Checkbox>
-                  <Checkbox value="showStatus">{t('workspace.configuration.content.showStatus')}</Checkbox>
-                  <Checkbox value="showMonitoringOnEdge">
-                    {t('workspace.configuration.content.showMonitoringOnEdge')}
-                  </Checkbox>
-                  <Checkbox value="showHosts">{t('workspace.configuration.content.showHosts')}</Checkbox>
-                  <Checkbox value="showGateway">{t('workspace.configuration.content.showGateway')}</Checkbox>
-                </Stack>
-              </CheckboxGroup>
-              <FormHelperText>{t('workspace.configuration.content.prompt')}</FormHelperText>
+            <FormControl m={4}>
+              <Button variant="danger" onClick={onOpen}>
+                {t('workspace.configuration.reset.action')}
+              </Button>
             </FormControl>
-          </VStack>
+            <Text>{t('workspace.configuration.reset.warning')}</Text>
+          </FormControl>
         </DrawerBody>
       </DrawerContent>
+      <ConfirmationDialog
+        isOpen={isOpen}
+        onClose={onClose}
+        onSubmit={onReset}
+        message={t('workspace.configuration.reset.modal.description')}
+        header={t('workspace.configuration.reset.legend')}
+        action={t('workspace.configuration.reset.action')}
+      />
     </Drawer>
   )
 }


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/18854/details/

The PR adds a `reset` option to the `workspace` configuration panel, allowing users to clean any discrepancies between the content of the workspace and the Edge topology.

The issue arises from aspects of the workspace visualisation being persisted on the `localStorage` of the browser but occasionally being dissociated from the elements (i.e. adapters and bridges) effectively known to the Esge system. 

The manual reset will help with that situation but many aspects of the user personalisation of the workspace being lost: location of the nodes on the graph, groups created, configuration of the analytics panel. 

Confirmation is required before resetting. The user will be navigated back to the main, to action the reset. The next access to the workspace will have an up-to-date version of the canvas.

The PR also removes the configuration of the visible elements (also impacted by local storage). 

### Before
![screenshot-localhost_3000-2024 03 14-15_26_12](https://github.com/hivemq/hivemq-edge/assets/2743481/cbc221e3-f07e-4566-bdc7-3f4ba46d82d2)

### After
![screenshot-localhost_3000-2024 03 14-15_25_13](https://github.com/hivemq/hivemq-edge/assets/2743481/22ca3aba-4f15-4f86-823e-fbd2d2183aa0)

![screenshot-localhost_3000-2024 03 14-15_25_30](https://github.com/hivemq/hivemq-edge/assets/2743481/650689d6-a692-41c9-8a6c-d54381c639aa)

