### PR TITLE
fix(hotfix): Remove client filter and interpolation for the release version

### DIFF
--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/ToolboxNodes.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/ToolboxNodes.tsx
@@ -26,7 +26,9 @@ export const ToolboxNodes = () => {
           <Text id="group-pipeline">{t('workspace.toolbox.group.pipeline')}</Text>
           <HStack>
             <Tool nodeType={DataHubNodeType.TOPIC_FILTER} isDisabled={isDraftEmpty || !isEditEnabled} />
-            <Tool nodeType={DataHubNodeType.CLIENT_FILTER} isDisabled={isDraftEmpty || !isEditEnabled} />
+            {isBehaviorPolicyEnabled && (
+              <Tool nodeType={DataHubNodeType.CLIENT_FILTER} isDisabled={isDraftEmpty || !isEditEnabled} />
+            )}
           </HStack>
         </VStack>
       </ButtonGroup>

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/forms/MessageInterpolationTextArea.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/forms/MessageInterpolationTextArea.tsx
@@ -7,6 +7,7 @@ import { Button, ButtonGroup, FormControl, FormLabel, Textarea, VStack } from '@
 export const MessageInterpolationTextArea = (props: WidgetProps) => {
   const { t } = useTranslation('datahub')
   const chakraProps = getChakra({ uiSchema: props.uiSchema })
+  const isInterpolationEnabled = import.meta.env.VITE_FLAG_DATAHUB_INTERPOLATION_ENABLED === 'true'
 
   const [currentSelection, setCurrentSelection] = useState<[number, number] | undefined>(undefined)
 
@@ -53,17 +54,19 @@ export const MessageInterpolationTextArea = (props: WidgetProps) => {
         props.hideLabel || !props.label
       )}
       <VStack alignItems="flex-start">
-        <ButtonGroup size="xs" variant="outline" fontFamily="monospace" flexWrap="wrap">
-          <Interpolation text="clientId" icon="#️⃣" />
-          <Interpolation text="policyId" icon="*️⃣" />
-          <ButtonGroup isAttached size="xs">
-            <Interpolation text="fromState" icon="📗" />
-            <Interpolation text="toState" icon="📕" />
+        {isInterpolationEnabled && (
+          <ButtonGroup size="xs" variant="outline" fontFamily="monospace" flexWrap="wrap">
+            <Interpolation text="clientId" icon="#️⃣" />
+            <Interpolation text="policyId" icon="*️⃣" />
+            <ButtonGroup isAttached size="xs">
+              <Interpolation text="fromState" icon="📗" />
+              <Interpolation text="toState" icon="📕" />
+            </ButtonGroup>
+            <Interpolation text="validationResult" icon="🧾" />
+            <Interpolation text="triggerEvent" icon="☑️" />
+            <Interpolation text="timestamp" icon="⏲️" />
           </ButtonGroup>
-          <Interpolation text="validationResult" icon="🧾" />
-          <Interpolation text="triggerEvent" icon="☑️" />
-          <Interpolation text="timestamp" icon="⏲️" />
-        </ButtonGroup>
+        )}
         <Textarea
           id={props.id}
           isRequired={props.required}


### PR DESCRIPTION
The PR hides the client filter button from the toolbar and the interpolation buttoins from the `Sytem.log` operation configuration panel 

They are hidden for the current release behind two internal feature flags

### After
![screenshot-localhost_3000-2024 03 15-13_59_32](https://github.com/hivemq/hivemq-edge/assets/2743481/3f87b331-7740-437c-8875-6b1a5fd3764e)

![screenshot-localhost_3000-2024 03 15-14_02_06](https://github.com/hivemq/hivemq-edge/assets/2743481/e9f31ad4-7892-4fc6-8335-f8caa3d9b994)

