### PR TITLE
refactor(20325): Improve the license warning

### DIFF
--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/DataHubPage.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/DataHubPage.spec.cy.tsx
@@ -11,7 +11,7 @@ describe('DataHubPage', () => {
   it('should render the commercial warning', () => {
     cy.mountWithProviders(<DataHubPage />)
     cy.get('h1').should('contain.text', 'Data Hub on Edge')
-    cy.get('h2').should('contain.text', 'Data Hub on Edge is now available to commercial licenses')
+    cy.get('h2').should('contain.text', 'Data Hub on Edge is available under a commercial license, please contact us.')
   })
 
   it('should be accessible', () => {

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/DataHubPage.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/DataHubPage.tsx
@@ -4,26 +4,18 @@ import { Outlet } from 'react-router-dom'
 import { Box } from '@chakra-ui/react'
 
 import PageContainer from '@/components/PageContainer.tsx'
-import WarningMessage from '@/components/WarningMessage.tsx'
-import { CAPABILITY, useGetCapability } from '@/api/hooks/useFrontendServices/useGetCapability.tsx'
-import AdapterEmptyLogo from '@/assets/app/adaptor-empty.svg'
+import LicenseWarning from '@datahub/components/helpers/LicenseWarning.tsx'
 
 const DataHubPage: FC = () => {
   const { t } = useTranslation('datahub')
-  const hasDataHub = useGetCapability(CAPABILITY.DATAHUB)
+  const hasDataHub = false // = useGetCapability(CAPABILITY.DATAHUB)
 
   return (
     <PageContainer title={t('page.title') as string} subtitle={t('page.description') as string}>
       {hasDataHub && <Outlet />}
       {!hasDataHub && (
-        <Box width="100%">
-          <WarningMessage
-            image={AdapterEmptyLogo}
-            title={t('error.notActivated.title') as string}
-            prompt={t('error.notActivated.description') as string}
-            alt={t('brand.extension')}
-            mt={10}
-          />
+        <Box width="100%" mt={20}>
+          <LicenseWarning />
         </Box>
       )}
     </PageContainer>

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/DataHubPage.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/DataHubPage.tsx
@@ -4,11 +4,12 @@ import { Outlet } from 'react-router-dom'
 import { Box } from '@chakra-ui/react'
 
 import PageContainer from '@/components/PageContainer.tsx'
+import { CAPABILITY, useGetCapability } from '@/api/hooks/useFrontendServices/useGetCapability.tsx'
 import LicenseWarning from '@datahub/components/helpers/LicenseWarning.tsx'
 
 const DataHubPage: FC = () => {
   const { t } = useTranslation('datahub')
-  const hasDataHub = false // = useGetCapability(CAPABILITY.DATAHUB)
+  const hasDataHub = useGetCapability(CAPABILITY.DATAHUB)
 
   return (
     <PageContainer title={t('page.title') as string} subtitle={t('page.description') as string}>

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/helpers/LicenseWarning.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/helpers/LicenseWarning.spec.cy.tsx
@@ -1,0 +1,15 @@
+/// <reference types="cypress" />
+import LicenseWarning from '@datahub/components/helpers/LicenseWarning.tsx'
+
+describe('LicenseWarning', () => {
+  beforeEach(() => {
+    cy.viewport(800, 500)
+  })
+
+  it('should renders properly', () => {
+    cy.mountWithProviders(<LicenseWarning />)
+    cy.get('img').should('have.attr', 'alt', 'Data Hub on Edge')
+    cy.get('h2').should('contain.text', 'Data Hub on Edge is available under a commercial license, please contact us.')
+    cy.get('h2').find('a').should('have.attr', 'href', 'https://www.hivemq.com/contact/')
+  })
+})

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/helpers/LicenseWarning.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/helpers/LicenseWarning.tsx
@@ -1,0 +1,27 @@
+import { FC } from 'react'
+import { Circle, Flex, Heading, Image, Link } from '@chakra-ui/react'
+import { Trans, useTranslation } from 'react-i18next'
+
+import AdapterEmptyLogo from '@/assets/app/adaptor-empty.svg'
+
+const LicenseWarning: FC = () => {
+  const { t } = useTranslation('datahub')
+
+  return (
+    <Flex flexDirection="column" alignItems="center" gap={4} textAlign="center">
+      <Circle size="335" bg="gray.100">
+        <Image objectFit="cover" src={AdapterEmptyLogo} alt={t('brand.extension') as string} />
+      </Circle>
+
+      <Heading as="h2" size="md" color="gray.500">
+        <Trans
+          t={t}
+          i18nKey="error.notActivated.title"
+          components={{ 1: <Link isExternal href="https://www.hivemq.com/contact/" /> }}
+        />
+      </Heading>
+    </Flex>
+  )
+}
+
+export default LicenseWarning

--- a/hivemq-edge/src/frontend/src/extensions/datahub/locales/en/datahub.json
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/locales/en/datahub.json
@@ -263,8 +263,7 @@
       "select": "< not set >"
     },
     "notActivated": {
-      "title": "Data Hub on Edge is now available to commercial licenses",
-      "description": "Please contact our sales team to gain access"
+      "title": "Data Hub on Edge is available under a commercial license, <1>please contact us</1>."
     },
     "notDefined": {
       "title": "Not identified",


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/20325/details/

The PR updates the rendering of the license warning message. The message is streamlined and the "contact us" links to the  https://www.hivemq.com/contact/ page

### Before
![screenshot-localhost_3000-2024 03 19-15_22_09](https://github.com/hivemq/hivemq-edge/assets/2743481/7a4c214f-cba5-49be-92ed-6795df539834)

### After

![screenshot-localhost_3000-2024 03 19-15_16_46](https://github.com/hivemq/hivemq-edge/assets/2743481/8fbd3a08-120f-433f-8dcb-b868e25b6c51)
