### PR TITLE
chore(CI): reduce verbosity of cypress output

### DIFF
--- a/.github/workflows/frontend-cli.yml
+++ b/.github/workflows/frontend-cli.yml
@@ -98,7 +98,6 @@ jobs:
         uses: cypress-io/github-action@v6
         with:
           component: true
-          morgan: false
           start: pnpm preview
           working-directory: ./hivemq-edge/src/frontend/
 
@@ -134,7 +133,6 @@ jobs:
       - name: 🧪 Run Cypress E2E
         uses: cypress-io/github-action@v6
         with:
-          morgan: false
           start: pnpm preview --port 3000
           working-directory: ./hivemq-edge/src/frontend/
 

--- a/.github/workflows/frontend-cli.yml
+++ b/.github/workflows/frontend-cli.yml
@@ -95,9 +95,10 @@ jobs:
           path: hivemq-edge/src/frontend/dist
 
       - name: 🧪 Run Cypress Component
-        uses: cypress-io/github-action@v5
+        uses: cypress-io/github-action@v6
         with:
           component: true
+          morgan: false
           start: pnpm preview
           working-directory: ./hivemq-edge/src/frontend/
 
@@ -131,8 +132,9 @@ jobs:
           path: hivemq-edge/src/frontend/dist
 
       - name: 🧪 Run Cypress E2E
-        uses: cypress-io/github-action@v5
+        uses: cypress-io/github-action@v6
         with:
+          morgan: false
           start: pnpm preview --port 3000
           working-directory: ./hivemq-edge/src/frontend/
 

--- a/.github/workflows/frontend-visual.yml
+++ b/.github/workflows/frontend-visual.yml
@@ -44,14 +44,12 @@ jobs:
       - name: 🧪 Run Cypress E2E
         uses: cypress-io/github-action@v6
         with:
-          morgan: false
           working-directory: ./hivemq-edge/src/frontend/
           start: pnpm dev
 
       - name: 🧪 Run Cypress Component
         uses: cypress-io/github-action@v6
         with:
-          morgan: false
           working-directory: ./hivemq-edge/src/frontend/
           component: true
           start: pnpm dev

--- a/.github/workflows/frontend-visual.yml
+++ b/.github/workflows/frontend-visual.yml
@@ -42,14 +42,16 @@ jobs:
         run: pnpm run build
 
       - name: 🧪 Run Cypress E2E
-        uses: cypress-io/github-action@v5
+        uses: cypress-io/github-action@v6
         with:
+          morgan: false
           working-directory: ./hivemq-edge/src/frontend/
           start: pnpm dev
 
       - name: 🧪 Run Cypress Component
-        uses: cypress-io/github-action@v5
+        uses: cypress-io/github-action@v6
         with:
+          morgan: false
           working-directory: ./hivemq-edge/src/frontend/
           component: true
           start: pnpm dev

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/PropertyPanelController.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/PropertyPanelController.spec.cy.tsx
@@ -7,6 +7,7 @@ import PropertyPanelController from './PropertyPanelController.tsx'
 describe('PropertyPanelController', () => {
   beforeEach(() => {
     cy.viewport(800, 600)
+    cy.intercept('/api/v1/management/protocol-adapters/adapters', { statusCode: 404 })
   })
 
   it('should display an error panel without an action', () => {

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/DataHubListings.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/DataHubListings.spec.cy.tsx
@@ -40,8 +40,8 @@ describe('DataHubListings', () => {
   })
 
   it('should support deletion', () => {
-    cy.intercept('/api/v1/data-hub/schemas', { items: [mockSchemaTempHumidity] }).as('getSchemas')
-    cy.intercept('/api/v1/data-hub/schemas/my-schema-id', {}).as('postDelete')
+    cy.intercept('/api/v1/data-hub/schemas', { items: [mockSchemaTempHumidity] })
+    cy.intercept('/api/v1/data-hub/schemas/my-schema-id', {})
     cy.mountWithProviders(<DataHubListings />)
 
     cy.getByTestId('list-tabs').find('button[role="tab"]').as('tabs')
@@ -57,10 +57,10 @@ describe('DataHubListings', () => {
     cy.get('@modal').find('header').should('have.text', 'Delete Item')
     cy.get('@modal').find('footer').find('button').as('actions')
     cy.get('@actions').eq(0).click()
-    cy.get("[role='alertdialog']").as('modal').should('not.exist')
+    cy.get("[role='alertdialog']").should('not.exist')
 
     cy.getByTestId('list-action-delete').click()
-    cy.get("[role='alertdialog']").as('modal').should('be.visible')
+    cy.get("[role='alertdialog']").should('be.visible')
     cy.get('@actions').eq(1).click()
     // cy.get('@postDelete').should('have.been.called')
     cy.get('div#toast-1-title')

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/DataHubListings.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/DataHubListings.spec.cy.tsx
@@ -6,6 +6,9 @@ import { mockSchemaTempHumidity } from '@datahub/api/hooks/DataHubSchemasService
 describe('DataHubListings', () => {
   beforeEach(() => {
     cy.viewport(800, 800)
+    cy.intercept('/api/v1/data-hub/data-validation/policies', { statusCode: 404 })
+    cy.intercept('/api/v1/data-hub/behavior-validation/policies', { statusCode: 404 })
+    cy.intercept('/api/v1/data-hub/schemas', { statusCode: 404 })
   })
 
   it('should render the tabs', () => {

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/DataHubListings.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/DataHubListings.spec.cy.tsx
@@ -9,6 +9,7 @@ describe('DataHubListings', () => {
     cy.intercept('/api/v1/data-hub/data-validation/policies', { statusCode: 404 })
     cy.intercept('/api/v1/data-hub/behavior-validation/policies', { statusCode: 404 })
     cy.intercept('/api/v1/data-hub/schemas', { statusCode: 404 })
+    cy.intercept('/api/v1/data-hub/scripts', { statusCode: 404 })
   })
 
   it('should render the tabs', () => {

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/PolicyTable.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/PolicyTable.spec.cy.tsx
@@ -7,12 +7,12 @@ import PolicyTable from './PolicyTable.tsx'
 describe('PolicyTable', () => {
   beforeEach(() => {
     cy.viewport(800, 800)
+    cy.intercept('/api/v1/data-hub/data-validation/policies', { statusCode: 404 })
+    cy.intercept('/api/v1/data-hub/behavior-validation/policies', { statusCode: 404 })
   })
 
   it('should render the table component', () => {
     cy.mountWithProviders(<PolicyTable />)
-    cy.intercept('/api/v1/data-hub/data-validation/policies', { statusCode: 404 })
-    cy.intercept('/api/v1/data-hub/behavior-validation/policies', { statusCode: 404 })
 
     cy.get('table').should('have.attr', 'aria-label', 'List of policies')
     cy.get('table').find('thead').find('th').should('have.length', 5)
@@ -25,8 +25,6 @@ describe('PolicyTable', () => {
 
   it('should render the error message', () => {
     cy.mountWithProviders(<PolicyTable />)
-    cy.intercept('/api/v1/data-hub/data-validation/policies', { statusCode: 404 })
-    cy.intercept('/api/v1/data-hub/behavior-validation/policies', { statusCode: 404 })
 
     cy.get('div.chakra-skeleton').should('have.length', 10)
     cy.get('[role="alert"]')

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/PolicyTable.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/PolicyTable.spec.cy.tsx
@@ -11,6 +11,8 @@ describe('PolicyTable', () => {
 
   it('should render the table component', () => {
     cy.mountWithProviders(<PolicyTable />)
+    cy.intercept('/api/v1/data-hub/data-validation/policies', { statusCode: 404 })
+    cy.intercept('/api/v1/data-hub/behavior-validation/policies', { statusCode: 404 })
 
     cy.get('table').should('have.attr', 'aria-label', 'List of policies')
     cy.get('table').find('thead').find('th').should('have.length', 5)
@@ -23,6 +25,8 @@ describe('PolicyTable', () => {
 
   it('should render the error message', () => {
     cy.mountWithProviders(<PolicyTable />)
+    cy.intercept('/api/v1/data-hub/data-validation/policies', { statusCode: 404 })
+    cy.intercept('/api/v1/data-hub/behavior-validation/policies', { statusCode: 404 })
 
     cy.get('div.chakra-skeleton').should('have.length', 10)
     cy.get('[role="alert"]')
@@ -59,6 +63,8 @@ describe('PolicyTable', () => {
   it('should be accessible', () => {
     cy.injectAxe()
     cy.mountWithProviders(<PolicyTable />)
+    cy.intercept('/api/v1/data-hub/data-validation/policies', { statusCode: 404 })
+    cy.intercept('/api/v1/data-hub/behavior-validation/policies', { statusCode: 404 })
 
     cy.checkAccessibility()
     cy.percySnapshot('Component: PolicyTable')

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/SchemaTable.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/SchemaTable.spec.cy.tsx
@@ -10,6 +10,7 @@ describe('SchemaTable', () => {
 
   it('should render the table component', () => {
     cy.mountWithProviders(<SchemaTable />)
+    cy.intercept('/api/v1/data-hub/schemas', { statusCode: 404 })
 
     cy.get('table').should('have.attr', 'aria-label', 'List of schemas')
     cy.get('table').find('thead').find('th').should('have.length', 5)

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/SchemaTable.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/SchemaTable.spec.cy.tsx
@@ -6,11 +6,11 @@ import { mockSchemaTempHumidity } from '@datahub/api/hooks/DataHubSchemasService
 describe('SchemaTable', () => {
   beforeEach(() => {
     cy.viewport(800, 800)
+    cy.intercept('/api/v1/data-hub/schemas', { statusCode: 404 })
   })
 
   it('should render the table component', () => {
     cy.mountWithProviders(<SchemaTable />)
-    cy.intercept('/api/v1/data-hub/schemas', { statusCode: 404 })
 
     cy.get('table').should('have.attr', 'aria-label', 'List of schemas')
     cy.get('table').find('thead').find('th').should('have.length', 5)

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/SchemaTable.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/SchemaTable.spec.cy.tsx
@@ -22,7 +22,7 @@ describe('SchemaTable', () => {
   })
 
   it('should render the data', () => {
-    cy.intercept('/api/v1/data-hub/schemas', { items: [mockSchemaTempHumidity] }).as('getSchemas')
+    cy.intercept('/api/v1/data-hub/schemas', { items: [mockSchemaTempHumidity] })
 
     cy.mountWithProviders(<SchemaTable />)
     cy.get('tbody tr').should('have.length', 1)

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/ScriptTable.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/ScriptTable.spec.cy.tsx
@@ -9,6 +9,7 @@ describe('ScriptTable', () => {
   })
 
   it('should render the table component', () => {
+    cy.intercept('/api/v1/data-hub/scripts', { statusCode: 404 })
     cy.mountWithProviders(<ScriptTable />)
 
     cy.get('table').should('have.attr', 'aria-label', 'List of scripts')

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/ScriptTable.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/ScriptTable.spec.cy.tsx
@@ -27,7 +27,7 @@ describe('ScriptTable', () => {
   })
 
   it('should render the data', () => {
-    cy.intercept('/api/v1/data-hub/scripts', { items: [mockScript] }).as('getScripts')
+    cy.intercept('/api/v1/data-hub/scripts', { items: [mockScript] })
 
     cy.mountWithProviders(<ScriptTable />)
     cy.get('tbody tr').should('have.length', 1)

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/topic_filter/TopicFilterPanel.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/topic_filter/TopicFilterPanel.spec.cy.tsx
@@ -32,6 +32,7 @@ const wrapper: React.JSXElementConstructor<{ children: React.ReactNode }> = ({ c
 describe('TopicFilterPanel', () => {
   beforeEach(() => {
     cy.viewport(800, 800)
+    cy.intercept('/api/v1/management/protocol-adapters/adapters', { statusCode: 404 })
   })
 
   it('should render the fields for a Validator', () => {

--- a/hivemq-edge/src/frontend/src/modules/Bridges/components/overview/BridgeCard.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Bridges/components/overview/BridgeCard.spec.cy.tsx
@@ -25,6 +25,7 @@ describe('BridgeCard', () => {
   })
 
   it('should be accessible', () => {
+    cy.intercept('/api/v1/management/bridges/status', { statusCode: 404 })
     cy.injectAxe()
     cy.mountWithProviders(<BridgeCard {...mockBridge} />)
     cy.checkAccessibility()

--- a/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/SubscriptionsPanel.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/SubscriptionsPanel.spec.cy.tsx
@@ -46,6 +46,7 @@ describe('SubscriptionsPanel', () => {
   })
 
   it('should be accessible', () => {
+    cy.intercept('/api/v1/frontend/capabilities', { statusCode: 404 })
     cy.injectAxe()
     cy.mountWithProviders(<TestingComponent onSubmit={cy.stub} defaultValues={mockBridge} />)
     cy.getByTestId('bridge-subscription-add').click()
@@ -65,6 +66,7 @@ describe('SubscriptionsPanel', () => {
   })
 
   it('should initialise with OpenAPI defaults', () => {
+    cy.intercept('/api/v1/frontend/capabilities', { statusCode: 404 })
     cy.mountWithProviders(<TestingComponent onSubmit={cy.stub} defaultValues={mockBridge} />)
     cy.getByTestId('bridge-subscription-add').click()
     // force validation to trigger error messages. Better alternative?

--- a/hivemq-edge/src/frontend/src/modules/Dashboard/components/SidePanel.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Dashboard/components/SidePanel.spec.cy.tsx
@@ -7,6 +7,7 @@ import { mockGatewayConfiguration } from '@/api/hooks/useFrontendServices/__hand
 describe('SidePanel', () => {
   beforeEach(() => {
     cy.viewport(350, 800)
+    cy.intercept('/api/v1/frontend/notifications', { statusCode: 404 })
     cy.intercept('/api/v1/frontend/configuration', mockGatewayConfiguration).as('getConfig')
   })
 

--- a/hivemq-edge/src/frontend/src/modules/Dashboard/components/SidePanel.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Dashboard/components/SidePanel.spec.cy.tsx
@@ -8,7 +8,7 @@ describe('SidePanel', () => {
   beforeEach(() => {
     cy.viewport(350, 800)
     cy.intercept('/api/v1/frontend/notifications', { statusCode: 404 })
-    cy.intercept('/api/v1/frontend/configuration', mockGatewayConfiguration).as('getConfig')
+    cy.intercept('/api/v1/frontend/configuration', mockGatewayConfiguration)
   })
 
   it('should contain the version', () => {

--- a/hivemq-edge/src/frontend/src/modules/Notifications/NotificationBadge.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Notifications/NotificationBadge.spec.cy.tsx
@@ -6,9 +6,7 @@ import { MOCK_NOTIFICATIONS } from '@/api/hooks/useFrontendServices/__handlers__
 describe('NotificationBadge', () => {
   beforeEach(() => {
     cy.viewport(900, 500)
-    cy.intercept('/api/v1/frontend/configuration', {
-      statusCode: 400,
-    })
+    cy.intercept('/api/v1/frontend/configuration', { statusCode: 404 })
     cy.intercept('https://api.github.com/repos/hivemq/hivemq-edge/releases', []).as('getReleases')
     cy.intercept('/api/v1/frontend/notifications', { items: MOCK_NOTIFICATIONS }).as('getNotifications')
   })

--- a/hivemq-edge/src/frontend/src/modules/Notifications/NotificationBadge.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Notifications/NotificationBadge.spec.cy.tsx
@@ -6,6 +6,9 @@ import { MOCK_NOTIFICATIONS } from '@/api/hooks/useFrontendServices/__handlers__
 describe('NotificationBadge', () => {
   beforeEach(() => {
     cy.viewport(900, 500)
+    cy.intercept('/api/v1/frontend/configuration', {
+      statusCode: 400,
+    })
     cy.intercept('https://api.github.com/repos/hivemq/hivemq-edge/releases', []).as('getReleases')
     cy.intercept('/api/v1/frontend/notifications', { items: MOCK_NOTIFICATIONS }).as('getNotifications')
   })

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/drawers/NodePropertyDrawer.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/drawers/NodePropertyDrawer.spec.cy.tsx
@@ -17,9 +17,9 @@ describe('NodePropertyDrawer', () => {
   beforeEach(() => {
     cy.viewport(800, 800)
     cy.intercept('/api/v1/management/protocol-adapters/types', { statusCode: 404 })
-    cy.intercept('/api/v1/metrics', []).as('getMetrics')
-    cy.intercept('/api/v1/metrics/**', []).as('getMetricForX')
-    cy.intercept('/api/v1/management/events?*', []).as('getEvents')
+    cy.intercept('/api/v1/metrics', [])
+    cy.intercept('/api/v1/metrics/**', [])
+    cy.intercept('/api/v1/management/events?*', [])
   })
 
   it('should render properly', () => {

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/drawers/NodePropertyDrawer.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/drawers/NodePropertyDrawer.spec.cy.tsx
@@ -16,6 +16,7 @@ const mockNode: Node<Bridge | Adapter> = {
 describe('NodePropertyDrawer', () => {
   beforeEach(() => {
     cy.viewport(800, 800)
+    cy.intercept('/api/v1/management/protocol-adapters/types', { statusCode: 404 })
     cy.intercept('/api/v1/metrics', []).as('getMetrics')
     cy.intercept('/api/v1/metrics/**', []).as('getMetricForX')
     cy.intercept('/api/v1/management/events?*', []).as('getEvents')


### PR DESCRIPTION
In the `CI` pipeline, the output of the `Cypress` was very verbose (more than 35K lines in the stdout). This was mostly due to every API request not being used by the tests, to not be intercepted by Cypress, resulting in an ECONNREFUSED error which dumped the whole request message in the stdout. A lot of noise masking the details of errors in the tests. 

An option to disable `morgan` outputs (see https://github.com/cypress-io/cypress/issues/26284#issuecomment-1498191390) didn't seem to be working with the GitHub actions

```
Warning: Unexpected input(s) 'morgan', valid inputs are ['record', 'auto-cancel-after-failures', 'config', 'config-file', 'env', 'browser', 'command', 'start', 'start-windows', 'build', 'install', 'install-command', 'runTests', 'wait-on', 'wait-on-timeout', 'parallel', 'group', 'tag', 'working-directory', 'headed', 'publish-summary', 'summary-title', 'spec', 'project', 'command-prefix', 'ci-build-id', 'cache-key', 'quiet', 'component']
```

The PR adds intercepts to all API requests, returning a `404` when they are not in use for the tests. 

The result is a mere 4K lines in the log output, offering unobfuscated access to the errors.

The PR also updates the version of the `Cypress` action and cleans a few linting warnings (unused aliases).