### PR TITLE
Improve Logging in case Binding Port of API Server is already in use.

### DIFF
--- a/hivemq-edge/src/main/java/com/hivemq/http/JaxrsHttpServer.java
+++ b/hivemq-edge/src/main/java/com/hivemq/http/JaxrsHttpServer.java
@@ -41,6 +41,7 @@ import org.slf4j.LoggerFactory;
 import javax.ws.rs.ProcessingException;
 import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.ext.ExceptionMapper;
+import java.net.BindException;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
@@ -128,10 +129,17 @@ public class JaxrsHttpServer {
                                     ((HttpsServer) httpServer).setHttpsConfigurator(config.getHttpsConfigurator());
                                 }
                             } catch (ProcessingException processingException) {
-                                logger.error(
-                                        "Unable to start the Https Server for uri '{}'. Is another service using the port '{}'?",
-                                        baseUri,
-                                        config.getPort());
+                                if (processingException.getCause() instanceof BindException) {
+                                    logger.error(
+                                            "Unable to start the Http Server for uri '{}'. The port '{}' is already in use.",
+                                            baseUri,
+                                            config.getPort());
+                                } else {
+                                    logger.error(
+                                            "Unable to start the Http Server for uri '{}'. Is another service using the port '{}'?",
+                                            baseUri,
+                                            config.getPort());
+                                }
                                 // still throw the exception to mitigate a silent fail
                                 throw processingException;
                             }
@@ -140,10 +148,17 @@ public class JaxrsHttpServer {
                             try {
                                 httpServer = JdkHttpServerFactory.createHttpServer(baseUri, resources, false);
                             } catch (ProcessingException processingException) {
-                                logger.error(
-                                        "Unable to start the Http Server for uri '{}'. Is another service using the port '{}'?",
-                                        baseUri,
-                                        config.getPort());
+                                if (processingException.getCause() instanceof BindException) {
+                                    logger.error(
+                                            "Unable to start the Https Server for uri '{}'. The port '{}' is already in use.",
+                                            baseUri,
+                                            config.getPort());
+                                } else {
+                                    logger.error(
+                                            "Unable to start the Https Server for uri '{}'. Is another service using the port '{}'?",
+                                            baseUri,
+                                            config.getPort());
+                                }
                                 // still throw the exception to mitigate a silent fail
                                 throw processingException;
                             }

--- a/hivemq-edge/src/test/java/com/hivemq/api/JaxrsResourceTests.java
+++ b/hivemq-edge/src/test/java/com/hivemq/api/JaxrsResourceTests.java
@@ -34,6 +34,8 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 
+import static org.mockito.Mockito.mock;
+
 /**
  * @author Simon L Johnson
  */
@@ -61,7 +63,7 @@ public class JaxrsResourceTests {
         //-- ensure we supplied our own test mapper as this can effect output
         ObjectMapper mapper = new ObjectMapper();
         config.setObjectMapper(mapper);
-        server = new JaxrsHttpServer(List.of(config), null);
+        server = new JaxrsHttpServer(mock(), List.of(config), null);
         server.startServer();
     }
 

--- a/hivemq-edge/src/test/java/com/hivemq/api/auth/BasicAuthenticationTests.java
+++ b/hivemq-edge/src/test/java/com/hivemq/api/auth/BasicAuthenticationTests.java
@@ -44,6 +44,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.mockito.Mockito.mock;
+
 /**
  * @author Simon L Johnson
  */
@@ -78,7 +80,7 @@ public class BasicAuthenticationTests {
         //-- ensure we supplied our own test mapper as this can effect output
         ObjectMapper mapper = new ObjectMapper();
         config.setObjectMapper(mapper);
-        server = new JaxrsHttpServer(List.of(config), conf);
+        server = new JaxrsHttpServer(mock(), List.of(config), conf);
         server.startServer();
     }
 

--- a/hivemq-edge/src/test/java/com/hivemq/api/auth/BearerTokenAuthTests.java
+++ b/hivemq-edge/src/test/java/com/hivemq/api/auth/BearerTokenAuthTests.java
@@ -52,6 +52,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.mockito.Mockito.mock;
+
 /**
  * @author Simon L Johnson
  */
@@ -92,7 +94,7 @@ public class BearerTokenAuthTests {
         //-- ensure we supplied our own test mapper as this can effect output
         ObjectMapper mapper = new ObjectMapper();
         config.setObjectMapper(mapper);
-        server = new JaxrsHttpServer(List.of(config), conf);
+        server = new JaxrsHttpServer(mock(), List.of(config), conf);
         server.startServer();
     }
 


### PR DESCRIPTION
**Motivation**

Resolves #285 

**Changes**

Log the port and URI in case the HttpServer start fails
No change in further error handling to avoid a silent fail