### PR TITLE
refactor(20712): update the edit flow for the Scripts

### DIFF
--- a/.github/workflows/frontend-cli.yml
+++ b/.github/workflows/frontend-cli.yml
@@ -98,6 +98,7 @@ jobs:
         uses: cypress-io/github-action@v6
         with:
           component: true
+          morgan: false
           start: pnpm preview
           working-directory: ./hivemq-edge/src/frontend/
           quiet: true

--- a/.github/workflows/frontend-cli.yml
+++ b/.github/workflows/frontend-cli.yml
@@ -98,7 +98,6 @@ jobs:
         uses: cypress-io/github-action@v6
         with:
           component: true
-          morgan: false
           start: pnpm preview
           working-directory: ./hivemq-edge/src/frontend/
           quiet: true

--- a/hivemq-edge/src/frontend/.prettierignore
+++ b/hivemq-edge/src/frontend/.prettierignore
@@ -1,5 +1,6 @@
 pnpm-lock.*
 
+.idea/
 docs/
 dist/
 coverage/

--- a/hivemq-edge/src/frontend/src/extensions/datahub/api/__generated__/schemas/FunctionData.json
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/api/__generated__/schemas/FunctionData.json
@@ -2,6 +2,11 @@
   "type": "object",
   "required": ["type", "name", "version"],
   "properties": {
+    "name": {
+      "title": "Name",
+      "type": "string",
+      "pattern": "^([a-zA-Z_0-9-_])*$"
+    },
     "type": {
       "title": "Format",
       "type": "string",
@@ -9,13 +14,13 @@
       "default": "Javascript",
       "readOnly": true
     },
-    "name": {
-      "title": "Name",
+    "version": {
+      "title": "Version",
       "type": "string"
     },
-    "version": {
-      "type": "number",
-      "format": "datahub:version"
+    "description": {
+      "title": "Description",
+      "type": "string"
     },
     "sourceCode": {
       "title": "Source",

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/forms/ResourceNameCreatableSelect.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/forms/ResourceNameCreatableSelect.spec.cy.tsx
@@ -5,6 +5,7 @@ import {
   ScriptNameCreatableSelect,
 } from '@datahub/components/forms/ResourceNameCreatableSelect.tsx'
 import { mockSchemaTempHumidity } from '@datahub/api/hooks/DataHubSchemasService/__handlers__'
+import { mockScript } from '@datahub/api/hooks/DataHubScriptsService/__handlers__'
 
 // @ts-ignore No need for the whole props for testing
 const MOCK_RESOURCE_NAME_PROPS: WidgetProps = {
@@ -18,7 +19,7 @@ const MOCK_RESOURCE_NAME_PROPS: WidgetProps = {
   options: {},
 }
 
-describe.only('SchemaNameCreatableSelect', () => {
+describe('SchemaNameCreatableSelect', () => {
   beforeEach(() => {
     cy.viewport(800, 600)
     cy.intercept('/api/v1/data-hub/schemas', { items: [mockSchemaTempHumidity] }).as('getSchemas')
@@ -66,12 +67,17 @@ describe.only('SchemaNameCreatableSelect', () => {
 describe('ScriptNameCreatableSelect', () => {
   beforeEach(() => {
     cy.viewport(800, 600)
+    cy.intercept('/api/v1/data-hub/scripts', { items: [mockScript] }).as('getSchemas')
   })
 
   it('should render the ScriptNameCreatableSelect', () => {
     cy.injectAxe()
 
     cy.mountWithProviders(<ScriptNameCreatableSelect {...MOCK_RESOURCE_NAME_PROPS} />)
+    cy.get('#resource-label').should('have.text', 'Select a resource')
+    cy.get('#resource-label + div').should('have.text', 'Select...')
+    cy.get('#resource-label').click()
+    cy.get('#resource').type('my')
 
     cy.checkAccessibility(undefined, {
       rules: {

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/forms/ResourceNameCreatableSelect.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/forms/ResourceNameCreatableSelect.tsx
@@ -148,6 +148,27 @@ const ResourceNameCreatableSelect = (
   )
 }
 
+const createNewSchemaOption = (inputValue: string) => {
+  const schemaData = getNodePayload(DataHubNodeType.SCHEMA) as SchemaData
+  const newValue: ResourceFamily = {
+    name: inputValue,
+    versions: [1],
+    type: schemaData.type,
+    internalStatus: ResourceStatus.DRAFT,
+  }
+  return newValue
+}
+
+const createNewScriptOption = (inputValue: string) => {
+  const functionData = getNodePayload(DataHubNodeType.FUNCTION) as FunctionData
+  const newValue: ResourceFamily = {
+    name: inputValue,
+    versions: [1],
+    type: functionData.type,
+  }
+  return newValue
+}
+
 export const SchemaNameCreatableSelect = (props: WidgetProps) => {
   const { data, isLoading } = useGetAllSchemas()
   const options = useMemo<ResourceFamily[]>(() => {
@@ -157,38 +178,17 @@ export const SchemaNameCreatableSelect = (props: WidgetProps) => {
     return Object.values(options)
   }, [data])
 
-  const createNewOption = (inputValue: string) => {
-    const schemaData = getNodePayload(DataHubNodeType.SCHEMA) as SchemaData
-    const newValue: ResourceFamily = {
-      name: inputValue,
-      versions: [1],
-      type: schemaData.type,
-      internalStatus: ResourceStatus.DRAFT,
-    }
-    return newValue
-  }
-
-  return ResourceNameCreatableSelect(props, DataHubNodeType.SCHEMA, options, createNewOption, isLoading)
+  return ResourceNameCreatableSelect(props, DataHubNodeType.SCHEMA, options, createNewSchemaOption, isLoading)
 }
 
 export const ScriptNameCreatableSelect = (props: WidgetProps) => {
   const { isLoading, data } = useGetAllScripts({})
-  const createNewOption = (inputValue: string) => {
-    const schemaData = getNodePayload(DataHubNodeType.FUNCTION) as FunctionData
-    const newValue: ResourceFamily = {
-      name: inputValue,
-      versions: [1],
-      type: schemaData.type,
-    }
-    return newValue
-  }
 
   const options = useMemo<ResourceFamily[]>(() => {
-    if (!data) return []
-    if (!data.items) return []
+    if (!data?.items) return []
     const options = getScriptFamilies(data.items)
     return Object.values(options)
   }, [data])
 
-  return ResourceNameCreatableSelect(props, DataHubNodeType.FUNCTION, options, createNewOption, isLoading)
+  return ResourceNameCreatableSelect(props, DataHubNodeType.FUNCTION, options, createNewScriptOption, isLoading)
 }

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/forms/ResourceNameCreatableSelect.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/forms/ResourceNameCreatableSelect.tsx
@@ -17,7 +17,7 @@ import { useTranslation } from 'react-i18next'
 import { DataHubNodeType, FunctionData, ResourceFamily, ResourceStatus, SchemaData } from '@datahub/types.ts'
 import { useGetAllSchemas } from '@datahub/api/hooks/DataHubSchemasService/useGetAllSchemas.tsx'
 import { useGetAllScripts } from '@datahub/api/hooks/DataHubScriptsService/useGetAllScripts.tsx'
-import { getSchemaFamilies } from '@datahub/designer/schema/SchemaNode.utils.ts'
+import { getSchemaFamilies, getScriptFamilies } from '@datahub/designer/schema/SchemaNode.utils.ts'
 import { getNodePayload } from '@datahub/utils/node.utils.ts'
 
 const SingleValue = <T extends ResourceFamily>(props: SingleValueProps<T>) => {
@@ -172,7 +172,7 @@ export const SchemaNameCreatableSelect = (props: WidgetProps) => {
 }
 
 export const ScriptNameCreatableSelect = (props: WidgetProps) => {
-  const { isLoading } = useGetAllScripts({})
+  const { isLoading, data } = useGetAllScripts({})
   const createNewOption = (inputValue: string) => {
     const schemaData = getNodePayload(DataHubNodeType.FUNCTION) as FunctionData
     const newValue: ResourceFamily = {
@@ -182,6 +182,13 @@ export const ScriptNameCreatableSelect = (props: WidgetProps) => {
     }
     return newValue
   }
-  // TODO[NVL] Don't forget to convert the scripts
-  return ResourceNameCreatableSelect(props, DataHubNodeType.FUNCTION, [], createNewOption, isLoading)
+
+  const options = useMemo<ResourceFamily[]>(() => {
+    if (!data) return []
+    if (!data.items) return []
+    const options = getScriptFamilies(data.items)
+    return Object.values(options)
+  }, [data])
+
+  return ResourceNameCreatableSelect(props, DataHubNodeType.FUNCTION, options, createNewOption, isLoading)
 }

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/datahubRJSFWidgets.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/datahubRJSFWidgets.tsx
@@ -2,11 +2,14 @@ import { RegistryWidgetsType } from '@rjsf/utils'
 
 import { AdapterSelect, JavascriptEditor, JSONSchemaEditor, ProtoSchemaEditor } from '@datahub/components/forms'
 import FunctionCreatableSelect from '@datahub/components/forms/FunctionCreatableSelect.tsx'
-import { JsFunctionInput, MetricCounterInput } from '@datahub/components/forms/MetricCounterInput.tsx'
+import { MetricCounterInput } from '@datahub/components/forms/MetricCounterInput.tsx'
 import { VersionManagerSelect } from '@datahub/components/forms/VersionManagerSelect.tsx'
 import { MessageInterpolationTextArea } from '@datahub/components/forms/MessageInterpolationTextArea.tsx'
 import { TransitionSelect } from '@datahub/components/forms/TransitionSelect.tsx'
-import { SchemaNameCreatableSelect } from '@datahub/components/forms/ResourceNameCreatableSelect.tsx'
+import {
+  SchemaNameCreatableSelect,
+  ScriptNameCreatableSelect,
+} from '@datahub/components/forms/ResourceNameCreatableSelect.tsx'
 
 export const datahubRJSFWidgets: RegistryWidgetsType = {
   'application/schema+json': JSONSchemaEditor,
@@ -15,7 +18,7 @@ export const datahubRJSFWidgets: RegistryWidgetsType = {
   'datahub:function-selector': FunctionCreatableSelect,
   'datahub:transition-selector': TransitionSelect,
   'datahub:metric-counter': MetricCounterInput,
-  'datahub:function-name': JsFunctionInput,
+  'datahub:function-name': ScriptNameCreatableSelect,
   'datahub:schema-name': SchemaNameCreatableSelect,
   'datahub:version': VersionManagerSelect,
   'datahub:message-interpolation': MessageInterpolationTextArea,

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/operation/OperationNode.utils.spec.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/operation/OperationNode.utils.spec.ts
@@ -340,7 +340,7 @@ describe('checkValidityTransformFunction', () => {
         expect.objectContaining({
           arguments: {
             schemaId: 'node-schema',
-            schemaVersion: 'latest',
+            schemaVersion: '1',
           },
           functionId: 'Serdes.deserialize',
           id: 'node-id-deserializer',
@@ -356,7 +356,7 @@ describe('checkValidityTransformFunction', () => {
         expect.objectContaining({
           arguments: {
             schemaId: 'node-schema',
-            schemaVersion: 'latest',
+            schemaVersion: '1',
           },
           functionId: OperationData.Function.SERDES_SERIALIZE,
           id: 'node-id-serializer',

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/operation/OperationNode.utils.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/operation/OperationNode.utils.ts
@@ -99,7 +99,7 @@ export function checkValidityTransformFunction(
     return `fn:${functionNode.data.name}:latest`
   }
 
-  const sourceDeserial = serialisers.find((e) => e.id === deserial.source)
+  const sourceDeserial = serialisers.find((node) => node.id === deserial.source)
   if (!sourceDeserial) {
     return [
       {
@@ -128,7 +128,7 @@ export function checkValidityTransformFunction(
     id: operationNode.id,
   }
 
-  const sourceSerial = serialisers.find((e) => e.id === serial.source)
+  const sourceSerial = serialisers.find((node) => node.id === serial.source)
   if (!sourceSerial) {
     return [
       {

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/operation/OperationNode.utils.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/operation/OperationNode.utils.ts
@@ -10,6 +10,7 @@ import {
   FunctionData,
   OperationData,
   PolicyOperationArguments,
+  ResourceStatus,
   TransitionData,
   WorkspaceAction,
   WorkspaceState,
@@ -98,12 +99,23 @@ export function checkValidityTransformFunction(
     return `fn:${functionNode.data.name}:latest`
   }
 
+  const sourceDeserial = serialisers.find((e) => e.id === deserial.source)
+  if (!sourceDeserial) {
+    return [
+      {
+        node: operationNode,
+        error: PolicyCheckErrors.notConnected(DataHubNodeType.SCHEMA, operationNode, OperationData.Handle.DESERIALISER),
+      },
+    ]
+  }
   const deserializer: PolicyOperation = {
     functionId: OperationData.Function.SERDES_DESERIALIZE,
     arguments: {
-      // TODO[19466] Id should come from the node's data when fixed; Need to fix before merging!
-      schemaId: serial.source,
-      schemaVersion: 'latest',
+      schemaId: sourceDeserial.data.name,
+      schemaVersion:
+        sourceDeserial.data.version === ResourceStatus.DRAFT || sourceDeserial.data.version === ResourceStatus.MODIFIED
+          ? 'latest'
+          : sourceDeserial.data.version.toString(),
     } as PolicyOperationArguments,
     id: `${operationNode.id}-deserializer`,
   }
@@ -116,12 +128,24 @@ export function checkValidityTransformFunction(
     id: operationNode.id,
   }
 
+  const sourceSerial = serialisers.find((e) => e.id === serial.source)
+  if (!sourceSerial) {
+    return [
+      {
+        node: operationNode,
+        error: PolicyCheckErrors.notConnected(DataHubNodeType.SCHEMA, operationNode, OperationData.Handle.SERIALISER),
+      },
+    ]
+  }
+
   const serializer: PolicyOperation = {
     functionId: OperationData.Function.SERDES_SERIALIZE,
     arguments: {
-      // TODO[19466] Id should come from the node's data when fixed; Need to fix before merging!
-      schemaId: deserial.source,
-      schemaVersion: 'latest',
+      schemaId: sourceSerial.data.name,
+      schemaVersion:
+        sourceSerial.data.version === ResourceStatus.DRAFT || sourceSerial.data.version === ResourceStatus.MODIFIED
+          ? 'latest'
+          : sourceSerial.data.version.toString(),
     } as PolicyOperationArguments,
     id: `${operationNode.id}-serializer`,
   }

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/schema/SchemaNode.utils.spec.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/schema/SchemaNode.utils.spec.ts
@@ -4,7 +4,8 @@ import { MOCK_DEFAULT_NODE } from '@/__test-utils__/react-flow/nodes.ts'
 
 import { mockSchemaTempHumidity } from '@datahub/api/hooks/DataHubSchemasService/__handlers__'
 import { DataHubNodeType, SchemaData, SchemaType } from '@datahub/types.ts'
-import { checkValiditySchema, getSchemaFamilies } from '@datahub/designer/schema/SchemaNode.utils.ts'
+import { checkValiditySchema, getSchemaFamilies, getScriptFamilies } from '@datahub/designer/schema/SchemaNode.utils.ts'
+import { mockScript } from '@datahub/api/hooks/DataHubScriptsService/__handlers__'
 
 describe('getSchemaFamilies', () => {
   it('should deal with an empty list of schemas', () => {
@@ -32,6 +33,38 @@ describe('getSchemaFamilies', () => {
     expect(results).toEqual(
       expect.objectContaining({
         'my-schema-id': expect.objectContaining({ name: 'my-schema-id', versions: [1, 2] }),
+        'the other id': expect.objectContaining({ name: 'the other id', versions: [1] }),
+      })
+    )
+  })
+})
+
+describe('getScriptFamilies', () => {
+  it('should deal with an empty list of scripts', () => {
+    expect(getSchemaFamilies([])).toEqual({})
+  })
+
+  it('should isolate families of schemas', () => {
+    const results = getScriptFamilies([mockScript, { ...mockScript, id: 'the other id' }])
+
+    expect(results).toEqual(
+      expect.objectContaining({
+        'my-script-id': expect.objectContaining({}),
+        'the other id': expect.objectContaining({}),
+      })
+    )
+  })
+
+  it('should identify list of versions', () => {
+    const results = getScriptFamilies([
+      mockScript,
+      { ...mockScript, id: 'the other id' },
+      { ...mockScript, version: 2 },
+    ])
+
+    expect(results).toEqual(
+      expect.objectContaining({
+        'my-script-id': expect.objectContaining({ name: 'my-script-id', versions: [1, 2] }),
         'the other id': expect.objectContaining({ name: 'the other id', versions: [1] }),
       })
     )

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/schema/SchemaNode.utils.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/schema/SchemaNode.utils.ts
@@ -4,7 +4,7 @@ import descriptor from 'protobufjs/ext/descriptor'
 
 import i18n from '@/config/i18n.config.ts'
 
-import { Schema, SchemaReference } from '@/api/__generated__'
+import { Schema, SchemaReference, Script } from '@/api/__generated__'
 import {
   DataHubNodeData,
   DataHubNodeType,
@@ -19,6 +19,18 @@ import {
 import { PolicyCheckErrors } from '@datahub/designer/validation.errors.ts'
 import { enumFromStringValue } from '@/utils/types.utils.ts'
 import { CANVAS_POSITION } from '@datahub/designer/checks.utils.ts'
+
+export const getScriptFamilies = (items: Script[]) => {
+  return items.reduce<Record<string, ResourceFamily>>((acc, script) => {
+    if (acc[script.id]) {
+      if (script.version) acc[script.id].versions.push(script.version)
+    } else {
+      acc[script.id] = { name: script.id, versions: [], type: script.functionType }
+      if (script.version) acc[script.id].versions.push(script.version)
+    }
+    return acc
+  }, {})
+}
 
 export const getSchemaFamilies = (items: Schema[]) => {
   return items.reduce<Record<string, ResourceFamily>>((acc, schema) => {

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/schema/SchemaPanel.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/schema/SchemaPanel.tsx
@@ -32,7 +32,7 @@ export const SchemaPanel: FC<PanelProps> = ({ selectedNode, onFormSubmit }) => {
     (changeEvent: IChangeEvent, id?: string | undefined) => {
       // id have form "root_XXXXXX", which makes the test unsafe
       if (id?.includes('name')) {
-        const schema = allSchemas?.items?.findLast((e) => e.id === changeEvent.formData.name)
+        const schema = allSchemas?.items?.findLast((schema) => schema.id === changeEvent.formData.name)
         if (schema) {
           setFormData({
             name: schema.id,
@@ -70,7 +70,7 @@ export const SchemaPanel: FC<PanelProps> = ({ selectedNode, onFormSubmit }) => {
       }
       if (id?.includes('version') && formData) {
         const schema = allSchemas?.items?.find(
-          (e) => e.id === formData.name && e.version?.toString() === changeEvent.formData.version
+          (schema) => schema.id === formData.name && schema.version?.toString() === changeEvent.formData.version
         )
 
         if (schema) {

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/script/FunctionData.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/script/FunctionData.ts
@@ -5,12 +5,4 @@ import schema from '@datahub/api/__generated__/schemas/FunctionData.json'
 
 export const MOCK_FUNCTION_SCHEMA: PanelSpecs = {
   schema: schema as RJSFSchema,
-  uiSchema: {
-    type: {
-      'ui:widget': 'hidden',
-    },
-    name: {
-      'ui:widget': 'datahub:function-name',
-    },
-  },
 }

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/script/FunctionPanel.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/script/FunctionPanel.spec.cy.tsx
@@ -1,0 +1,109 @@
+/// <reference types="cypress" />
+
+import { Button } from '@chakra-ui/react'
+
+import { MockStoreWrapper } from '@datahub/__test-utils__/MockStoreWrapper.tsx'
+import { DataHubNodeType, SchemaType } from '@datahub/types.ts'
+import { getNodePayload } from '@datahub/utils/node.utils.ts'
+import { mockScript } from '@datahub/api/hooks/DataHubScriptsService/__handlers__'
+import { FunctionPanel } from '@datahub/designer/script/FunctionPanel.tsx'
+
+const wrapper: React.JSXElementConstructor<{ children: React.ReactNode }> = ({ children }) => (
+  <MockStoreWrapper
+    config={{
+      initialState: {
+        nodes: [
+          {
+            id: '3',
+            type: DataHubNodeType.FUNCTION,
+            position: { x: 0, y: 0 },
+            data: getNodePayload(DataHubNodeType.FUNCTION),
+          },
+        ],
+      },
+    }}
+  >
+    {children}
+    <Button variant="primary" type="submit" form="datahub-node-form">
+      SUBMIT
+    </Button>
+  </MockStoreWrapper>
+)
+
+describe('FunctionPanel', () => {
+  beforeEach(() => {
+    cy.viewport(800, 800)
+    cy.intercept('/api/v1/data-hub/scripts', { items: [{ ...mockScript, type: SchemaType.PROTOBUF }] }).as('getSchemas')
+  })
+
+  it('should render the fields for a Function node', () => {
+    cy.mountWithProviders(<FunctionPanel selectedNode="3" />, { wrapper })
+
+    cy.get('label#root_name-label').should('contain.text', 'Name')
+    cy.get('label#root_name-label + div').should('contain.text', 'Select...')
+    cy.get('label#root_name-label').should('have.attr', 'data-invalid')
+
+    cy.get('label#root_version-label').should('contain.text', 'Version')
+    cy.get('label#root_version-label + div').should('contain.text', '')
+
+    cy.get('label#root_description-label').should('contain.text', 'Description')
+    cy.get('input#root_description').should('contain.text', '')
+    cy.get('input#root_description').should('have.attr', 'placeholder', 'A short description for this version')
+
+    cy.get('label#root_sourceCode-label').should('contain.text', 'Source')
+    cy.get('div#root_sourceCode').should('contain.html', '&nbsp;*&nbsp;@param&nbsp;{Object}&nbsp;publish')
+  })
+
+  it('should control the editing flow', () => {
+    cy.mountWithProviders(<FunctionPanel selectedNode="3" />, { wrapper })
+
+    cy.get('#root_name-label + div').should('contain.text', 'Select...')
+    cy.get('#root_version-label + div').should('contain.text', '')
+
+    // create a draft
+    cy.get('#root_name-label + div').click()
+    cy.get('#root_name-label + div').type('new-schema')
+    cy.get('#root_name-label + div').find('[role="option"]').as('optionList')
+    cy.get('@optionList').eq(0).click()
+
+    cy.get('#root_name-label + div').should('contain.text', 'new-schema')
+    cy.get('#root_version-label + div').should('contain.text', 'DRAFT')
+    cy.get('div#root_sourceCode').should('contain.html', '&nbsp;*&nbsp;@param&nbsp;{Object}&nbsp;publish')
+    cy.get('div#root_sourceCode').find('div.monaco-mouse-cursor-text').as('editor')
+    // TODO[NVL] this doesn't work
+    // cy.get('@editor').click()
+    // cy.get('@editor').type('{command}a rr', { delay: 50, waitForAnimations: true })
+    // cy.get('#root_schemaSource-label + div').should('contain.text', 'rr')
+
+    // select an existing schema
+    cy.get('#root_name-label + div').click()
+    cy.get('#root_name-label + div').type('my-script')
+    cy.get('#root_name-label + div').find('[role="option"]').as('optionList')
+    cy.get('@optionList').eq(0).click()
+
+    cy.get('#root_name-label + div').should('contain.text', 'my-script-id')
+    cy.get('#root_version-label + div').should('contain.text', '1')
+
+    // // TODO[NVL] This is a bug. Fix it!
+    cy.get('#root_version-label').should('have.attr', 'data-invalid')
+    cy.get('#root_version-label + div').click()
+    cy.get('#root_version-label + div').find('[role="option"]').as('optionList2')
+    cy.get('@optionList2').eq(0).click()
+    cy.get('#root_version-label').should('not.have.attr', 'data-invalid')
+    // // TODO[NVL] This is a bug. Fix it!
+  })
+
+  // TODO[NVL] Weird import worker error
+  it.skip('should be accessible', () => {
+    cy.injectAxe()
+    cy.mountWithProviders(<FunctionPanel selectedNode="3" />, { wrapper })
+
+    cy.checkAccessibility(undefined, {
+      rules: {
+        // TODO[a11y] False positive with the react-select [?]
+        'color-contrast': { enabled: false },
+      },
+    })
+    cy.percySnapshot('Component: SchemaPanel')
+  })
+})

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/script/FunctionPanel.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/script/FunctionPanel.tsx
@@ -21,7 +21,7 @@ export const FunctionPanel: FC<PanelProps> = ({ selectedNode, onFormSubmit }) =>
       <CardBody>
         <ReactFlowSchemaForm
           schema={MOCK_FUNCTION_SCHEMA.schema}
-          uiSchema={MOCK_FUNCTION_SCHEMA.uiSchema}
+          uiSchema={getUISchema(formData)}
           widgets={datahubRJSFWidgets}
           formData={data}
           onSubmit={onFormSubmit}

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/script/FunctionPanel.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/script/FunctionPanel.tsx
@@ -1,30 +1,130 @@
-import { FC, useMemo } from 'react'
+import { FC, useCallback, useState } from 'react'
 import { Node } from 'reactflow'
 import { Card, CardBody } from '@chakra-ui/react'
+import { UiSchema } from '@rjsf/utils'
+import { IChangeEvent } from '@rjsf/core/src/components/Form.tsx'
 
-import { FunctionData, PanelProps } from '@datahub/types.ts'
+import { MOCK_JAVASCRIPT_SCHEMA } from '@datahub/__test-utils__/schema.mocks.ts'
+import { FunctionData, PanelProps, ResourceStatus } from '@datahub/types.ts'
 import useDataHubDraftStore from '@datahub/hooks/useDataHubDraftStore.ts'
+import { useGetAllScripts } from '@datahub/api/hooks/DataHubScriptsService/useGetAllScripts.tsx'
 import { ReactFlowSchemaForm } from '@datahub/components/forms/ReactFlowSchemaForm.tsx'
 import { datahubRJSFWidgets } from '@datahub/designer/datahubRJSFWidgets.tsx'
 import { MOCK_FUNCTION_SCHEMA } from '@datahub/designer/script/FunctionData.ts'
+import { getScriptFamilies } from '@datahub/designer/schema/SchemaNode.utils.ts'
 
 export const FunctionPanel: FC<PanelProps> = ({ selectedNode, onFormSubmit }) => {
+  const { data: allScripts } = useGetAllScripts({})
   const { nodes } = useDataHubDraftStore()
 
-  const data = useMemo(() => {
-    const adapterNode = nodes.find((e) => e.id === selectedNode) as Node<FunctionData> | undefined
-    return adapterNode ? adapterNode.data : null
-  }, [selectedNode, nodes])
+  const [formData, setFormData] = useState<FunctionData | null>(() => {
+    const sourceNode = nodes.find((node) => node.id === selectedNode) as Node<FunctionData> | undefined
+
+    const internalStatus =
+      typeof sourceNode?.data.version === 'number' ? ResourceStatus.LOADED : sourceNode?.data.version
+
+    return sourceNode ? { ...sourceNode.data, internalStatus } : null
+  })
+
+  const getUISchema = (script: FunctionData | null): UiSchema => {
+    const { internalStatus, internalVersions } = script || {}
+    return {
+      type: {
+        'ui:widget': 'hidden',
+      },
+      // 'ui:order':
+      //   internalStatus === ResourceStatus.DRAFT || !internalStatus
+      //     ? ['name', 'type', 'schemaSource', 'messageType', 'version']
+      //     : ['name', 'version', 'schemaSource', 'messageType', 'type'],
+      name: {
+        'ui:widget': 'datahub:function-name',
+        'ui:options': {
+          isDraft: script?.version === ResourceStatus.DRAFT,
+        },
+      },
+      version: {
+        'ui:widget': 'datahub:version',
+        'ui:options': {
+          readonly:
+            internalStatus === ResourceStatus.DRAFT || internalStatus === ResourceStatus.MODIFIED || !internalStatus,
+          selectOptions: internalVersions,
+        },
+      },
+      sourceCode: {
+        'ui:options': {
+          readonly: !internalStatus,
+        },
+      },
+      description: {
+        'ui:placeholder': 'A short description for this version',
+      },
+    }
+  }
+
+  const onReactFlowSchemaFormChange = useCallback(
+    (changeEvent: IChangeEvent, id?: string | undefined) => {
+      if (id?.includes('name')) {
+        const selectedScript = allScripts?.items?.findLast((script) => script.id === changeEvent.formData.name)
+        if (selectedScript) {
+          setFormData({
+            name: selectedScript.id,
+            type: 'Javascript',
+            version: selectedScript.version || ResourceStatus.MODIFIED,
+            description: changeEvent.formData.description,
+            sourceCode: atob(selectedScript.source),
+            internalVersions: getScriptFamilies(allScripts?.items || [])[selectedScript.id].versions,
+            internalStatus: ResourceStatus.LOADED,
+          })
+        } else {
+          setFormData({
+            name: changeEvent.formData.name,
+            type: 'Javascript',
+            version: ResourceStatus.DRAFT,
+            sourceCode: MOCK_JAVASCRIPT_SCHEMA,
+          })
+        }
+        return
+      }
+      if (
+        (id?.includes('sourceCode') || id?.includes('description')) &&
+        formData &&
+        formData.internalStatus === ResourceStatus.LOADED
+      ) {
+        setFormData({
+          ...formData,
+          version: ResourceStatus.MODIFIED,
+          internalStatus: ResourceStatus.MODIFIED,
+        })
+        return
+      }
+      if (id?.includes('version') && formData) {
+        const versionedScript = allScripts?.items?.find(
+          (script) => script.id === formData.name && script.version?.toString() === changeEvent.formData.version
+        )
+        if (versionedScript) {
+          setFormData({
+            ...formData,
+            version: changeEvent.formData.version,
+            description: versionedScript.description,
+            sourceCode: atob(versionedScript.source),
+          })
+        }
+        return
+      }
+    },
+    [allScripts?.items, formData]
+  )
 
   return (
     <Card>
       <CardBody>
         <ReactFlowSchemaForm
+          widgets={datahubRJSFWidgets}
           schema={MOCK_FUNCTION_SCHEMA.schema}
           uiSchema={getUISchema(formData)}
-          widgets={datahubRJSFWidgets}
-          formData={data}
+          formData={formData}
           onSubmit={onFormSubmit}
+          onChange={onReactFlowSchemaFormChange}
         />
       </CardBody>
     </Card>

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/script/FunctionPanel.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/script/FunctionPanel.tsx
@@ -52,7 +52,7 @@ export const FunctionPanel: FC<PanelProps> = ({ selectedNode, onFormSubmit }) =>
       },
       sourceCode: {
         'ui:options': {
-          readonly: !internalStatus,
+          // readonly: !internalStatus,
         },
       },
       description: {

--- a/hivemq-edge/src/frontend/src/extensions/datahub/types.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/types.ts
@@ -197,6 +197,7 @@ export interface SchemaData extends ResourceState {
 export interface FunctionData extends ResourceState {
   name: string
   type: 'Javascript'
+  description?: string
   sourceCode?: string
   core?: Script
 }


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/20712/details/

This PR replicate the editing flow of the `Schemas` (see #334 ) to the `Scripts`. The same states and transitions are applied to the elements of the editing form (name, version and description + source ). 


```mermaid
stateDiagram-v2
    [*] --> DRAFT: create
    [*] --> VERSION_N: load

    DRAFT --> DRAFT: select type
    DRAFT --> DRAFT: edit content
    DRAFT --> DRAFT: create new name

    DRAFT --> VERSION_LATEST: select name
    VERSION_N:::namedSchema --> VERSION_LATEST: select name
    
    VERSION_N --> DRAFT: create new name
    VERSION_LATEST:::namedSchema --> DRAFT: create new name
    
    VERSION_LATEST --> VERSION_N: select version
    VERSION_N --> VERSION_N: select version

    VERSION_LATEST --> MODIFIED: edit content
    VERSION_N --> MODIFIED: edit content
    
    DRAFT --> [*]: publish
    VERSION_N --> [*]: publish
    VERSION_LATEST --> [*]: publish
    MODIFIED --> [*]: publish

  classDef namedSchema fill:#f96,color:black
```

The PR also adds the `description` property to the form.

### Before
![screenshot-localhost_3000-2024 04 08-11_35_06](https://github.com/hivemq/hivemq-edge/assets/2743481/372dde5f-993f-4ae0-9947-151143245e54)

### After
![screenshot-localhost_3000-2024 04 08-11_34_26](https://github.com/hivemq/hivemq-edge/assets/2743481/97df08ec-2af3-4509-816d-014a1070c228)

![screenshot-localhost_3000-2024 04 08-11_34_39](https://github.com/hivemq/hivemq-edge/assets/2743481/4448d802-c491-4c36-ab2b-481b9bb0db6d)



