### PR TITLE
fix(19238): Fix the default cleanStart checkbox

### DIFF
--- a/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/OptionsPanel.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/OptionsPanel.spec.cy.tsx
@@ -1,0 +1,59 @@
+/// <reference types="cypress" />
+
+import { FC } from 'react'
+import { useForm } from 'react-hook-form'
+
+import { Bridge } from '@/api/__generated__'
+import { mockBridge } from '@/api/hooks/useGetBridges/__handlers__'
+import OptionsPanel from '@/modules/Bridges/components/panels/OptionsPanel.tsx'
+import { Button } from '@chakra-ui/react'
+
+interface TestingComponentProps {
+  onSubmit: (data: Bridge) => void
+  defaultValues: Bridge
+}
+
+const TestingComponent: FC<TestingComponentProps> = ({ onSubmit, defaultValues }) => {
+  const form = useForm<Bridge>({
+    mode: 'all',
+    criteriaMode: 'all',
+    defaultValues: defaultValues,
+  })
+
+  return (
+    <div>
+      <form id="bridge-form" onSubmit={form.handleSubmit(onSubmit)}>
+        <OptionsPanel form={form} />
+      </form>
+      <Button variant="primary" type="submit" form="bridge-form" data-testid="form-submit" mt={8}>
+        Submit
+      </Button>
+    </div>
+  )
+}
+
+describe('OptionsPanel', () => {
+  beforeEach(() => {
+    cy.viewport(800, 800)
+  })
+
+  it('should be accessible', () => {
+    cy.injectAxe()
+    cy.mountWithProviders(<TestingComponent onSubmit={cy.stub().as('submit')} defaultValues={mockBridge} />)
+
+    cy.get('#cleanStart').should('be.checked')
+    cy.get('#keepAlive').should('have.value', 0)
+    cy.get('#sessionExpiry').should('have.value', 0)
+    cy.get('#loopPreventionEnabled').should('not.be.checked')
+    cy.get('#loopPreventionHopCount').should('have.value', '')
+    cy.get('#clientId').should('have.value', 'my-client-id')
+
+    cy.get('#clientId').type('-test123')
+
+    cy.getByTestId('form-submit').click()
+    cy.get('@submit').should('have.been.calledWithMatch', { clientId: 'my-client-id-test123' })
+
+    cy.checkAccessibility()
+    cy.percySnapshot('Component: OptionsPanel')
+  })
+})

--- a/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/OptionsPanel.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/OptionsPanel.tsx
@@ -28,7 +28,9 @@ const OptionsPanel: FC<BridgePanelType> = ({ form }) => {
   return (
     <FormControl variant="hivemq" flexGrow={1} display="flex" flexDirection="column" gap={4} as="fieldset">
       <FormControl isInvalid={!!errors.cleanStart}>
-        <Checkbox {...register('cleanStart')}>{t('bridge.options.cleanStart.label')}</Checkbox>
+        <Checkbox id="cleanStart" {...register('cleanStart')}>
+          {t('bridge.options.cleanStart.label')}
+        </Checkbox>
         <FormHelperText> {t('bridge.options.cleanStart.helper')}</FormHelperText>
         <FormErrorMessage>{errors.cleanStart && errors.cleanStart.message}</FormErrorMessage>
       </FormControl>
@@ -68,6 +70,7 @@ const OptionsPanel: FC<BridgePanelType> = ({ form }) => {
 
       <FormControl isInvalid={!!errors.loopPreventionEnabled} mt={3}>
         <Checkbox
+          id="loopPreventionEnabled"
           {...register('loopPreventionEnabled', {
             ...getRulesForProperty($Bridge.properties.loopPreventionEnabled),
           })}

--- a/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/OptionsPanel.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/OptionsPanel.tsx
@@ -28,9 +28,7 @@ const OptionsPanel: FC<BridgePanelType> = ({ form }) => {
   return (
     <FormControl variant="hivemq" flexGrow={1} display="flex" flexDirection="column" gap={4} as="fieldset">
       <FormControl isInvalid={!!errors.cleanStart}>
-        <Checkbox defaultChecked {...register('cleanStart')}>
-          {t('bridge.options.cleanStart.label')}
-        </Checkbox>
+        <Checkbox {...register('cleanStart')}>{t('bridge.options.cleanStart.label')}</Checkbox>
         <FormHelperText> {t('bridge.options.cleanStart.helper')}</FormHelperText>
         <FormErrorMessage>{errors.cleanStart && errors.cleanStart.message}</FormErrorMessage>
       </FormControl>
@@ -70,7 +68,6 @@ const OptionsPanel: FC<BridgePanelType> = ({ form }) => {
 
       <FormControl isInvalid={!!errors.loopPreventionEnabled} mt={3}>
         <Checkbox
-          defaultChecked
           {...register('loopPreventionEnabled', {
             ...getRulesForProperty($Bridge.properties.loopPreventionEnabled),
           })}


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/19238/details/

The PR fixes the two checkboxes in the Brodge form that are constantly checked out at the initial opening of the form, regardless of their values

### Before
![screenshot-localhost_3000-2024 04 08-16_19_45](https://github.com/hivemq/hivemq-edge/assets/2743481/80919f74-a1f7-46e5-83e2-6fa76632bf0b)


### After 
![screenshot-localhost_3000-2024 04 08-16_20_08](https://github.com/hivemq/hivemq-edge/assets/2743481/52810717-ac56-479b-8c6d-7ba0dee8c093)
