### PR TITLE
fix(20074): Fix the tooltip

### DIFF
--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/panels/ProtocolAdapters.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/panels/ProtocolAdapters.tsx
@@ -157,7 +157,7 @@ const ProtocolAdapters: FC = () => {
                   size="sm"
                   ml={2}
                   onClick={() => handleViewWorkspace(id, type as string)}
-                  aria-label={t('bridge.subscription.delete')}
+                  aria-label={t('protocolAdapter.table.actions.workspace')}
                   icon={<WorkspaceIcon />}
                 />
               )}


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/20074/details/

The PR fixes the tooltip of the button icon in the protocol adapter table,

### Before
![screenshot-localhost_3000-2024 04 09-10_44_54](https://github.com/hivemq/hivemq-edge/assets/2743481/82ad3402-f099-49bb-94dd-5457a02c28b2)

### After
![screenshot-localhost_3000-2024 04 09-10_44_17](https://github.com/hivemq/hivemq-edge/assets/2743481/191d7aa9-ae5c-4595-baaf-9cb7416767c9)
