### PR TITLE
refactor(21032): Add status of terminal transitions to the node

### DIFF
--- a/hivemq-edge/src/frontend/src/extensions/datahub/api/__generated__/schemas/BehaviorPolicyData.json
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/api/__generated__/schemas/BehaviorPolicyData.json
@@ -66,6 +66,12 @@
             "toState": "Violated",
             "description": "Transition that gets triggered then the client sends a publish, which does not exceed the maximum amount of publishes.",
             "event": "Connection.OnDisconnect"
+          },
+          {
+            "fromState": "Publishing",
+            "toState": "Disconnected",
+            "description": "Once the client connection is closed, the model transitions into the Disconnected state",
+            "event": "Connection.OnDisconnect"
           }
         ]
       },
@@ -138,6 +144,12 @@
             "toState": "Connected",
             "description": "Transition that gets triggered then the connected client disconnects.",
             "event": "Mqtt.OnInboundDisconnect"
+          },
+          {
+            "fromState": "Connected",
+            "toState": "Disconnected",
+            "description": "Once the client connection is closed, the model transitions into the Disconnected state",
+            "event": "Connection.OnDisconnect"
           }
         ]
       },
@@ -233,6 +245,18 @@
             "fromState": "NotDuplicated",
             "toState": "Violated",
             "description": "Transition that gets triggered then the client disconnects and the DUPLICATE state has every been reached during this connection.",
+            "event": "Connection.OnDisconnect"
+          },
+          {
+            "fromState": "Connected",
+            "toState": "Disconnected",
+            "description": "Once the client connection is closed, the model transitions into the Disconnected state",
+            "event": "Connection.OnDisconnect"
+          },
+          {
+            "fromState": "NotDuplicated",
+            "toState": "Disconnected",
+            "description": "Once the client connection is closed, the model transitions into the Disconnected state",
             "event": "Connection.OnDisconnect"
           }
         ]

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/forms/TransitionSelect.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/forms/TransitionSelect.spec.cy.tsx
@@ -38,7 +38,7 @@ describe('TransitionSelect', () => {
     cy.get('label#transition-label + div').click()
 
     cy.get('div#react-select-transition-listbox').find('[role="option"]').as('optionList')
-    cy.get('@optionList').should('have.length', 7)
+    cy.get('@optionList').should('have.length', 8)
     cy.get('#react-select-transition-option-0').should('contain.text', 'Mqtt.OnInboundConnect')
 
     cy.checkAccessibility(undefined, {

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/forms/TransitionSelect.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/forms/TransitionSelect.tsx
@@ -85,7 +85,7 @@ export const TransitionSelect = (props: WidgetProps) => {
 
     const states = metadata.states
     const opts = metadata.transitions.map<FsmTransitionWithId>((transition) => {
-      const endState = states.find((e) => e.name === transition.toState)
+      const endState = states.find((state) => state.name === transition.toState)
 
       return {
         ...transition,

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/transition/TransitionNode.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/transition/TransitionNode.tsx
@@ -1,15 +1,21 @@
-import { FC } from 'react'
+import { FC, useMemo } from 'react'
 import { HStack, Text, VStack } from '@chakra-ui/react'
 import { useTranslation } from 'react-i18next'
 import { NodeProps, Position } from 'reactflow'
 
-import { DataHubNodeType, TransitionData } from '@datahub/types.ts'
+import { DataHubNodeType, FsmState, TransitionData } from '@datahub/types.ts'
 import { CustomHandle, NodeWrapper } from '@datahub/components/nodes'
 import { NodeIcon, NodeParams } from '@datahub/components/helpers'
 
 export const TransitionNode: FC<NodeProps<TransitionData>> = (props) => {
   const { t } = useTranslation('datahub')
   const { data, id, type } = props
+
+  const className = useMemo(() => {
+    if (data.type === FsmState.Type.SUCCESS) return TransitionData.Handle.ON_SUCCESS
+    if (data.type === FsmState.Type.FAILED) return TransitionData.Handle.ON_ERROR
+    return undefined
+  }, [data.type])
 
   return (
     <>
@@ -23,7 +29,13 @@ export const TransitionNode: FC<NodeProps<TransitionData>> = (props) => {
         </HStack>
       </NodeWrapper>
       <CustomHandle type="target" position={Position.Left} id={TransitionData.Handle.BEHAVIOR_POLICY} />
-      <CustomHandle type="source" id={TransitionData.Handle.OPERATION} position={Position.Right} isConnectable={1} />
+      <CustomHandle
+        type="source"
+        id={TransitionData.Handle.OPERATION}
+        position={Position.Right}
+        isConnectable={1}
+        className={className}
+      />
     </>
   )
 }

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/transition/TransitionPanel.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/transition/TransitionPanel.spec.cy.tsx
@@ -53,7 +53,7 @@ describe('TransitionPanel', () => {
     cy.get('label#root_event-label + div').click()
 
     cy.get('div#react-select-root_event-listbox').find('[role="option"]').as('optionList')
-    cy.get('@optionList').should('have.length', 7)
+    cy.get('@optionList').should('have.length', 8)
     cy.get('@optionList').eq(0).should('contain.text', 'Mqtt.OnInboundConnect')
   })
 

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/transition/TransitionPanel.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/transition/TransitionPanel.tsx
@@ -7,6 +7,7 @@ import {
   BehaviorPolicyData,
   DataHubNodeType,
   FiniteStateMachineSchema,
+  FsmState,
   PanelProps,
   StateType,
   TransitionData,
@@ -53,12 +54,12 @@ export const TransitionPanel: FC<PanelProps> = ({ selectedNode, onFormSubmit }) 
       return null
     }
 
-    const { event, from, to } = adapterNode.data
+    const { event, from, to, type } = adapterNode.data
     const tempData: TransitionData = {
       ...adapterNode.data,
       model: parentPolicy ? parentPolicy.data.model : undefined,
       // @ts-ignore
-      event: `${event || ''}-${from || ''}-${to || ''}`,
+      event: `${event || ''}-${from || ''}-${to || ''}-${type || ''}`,
     }
     return tempData
   }, [nodes, parentPolicy, selectedNode])
@@ -90,12 +91,18 @@ export const TransitionPanel: FC<PanelProps> = ({ selectedNode, onFormSubmit }) 
       if (formData) {
         const { event: originalEvent } = formData
         if (originalEvent) {
-          const [event, from, to] = originalEvent.split('-') as [TransitionType, StateType, StateType]
+          const [event, from, to, type] = originalEvent.split('-') as [
+            TransitionType,
+            StateType,
+            StateType,
+            FsmState.Type | undefined
+          ]
           initData.formData = {
             ...initData.formData,
             event,
             from,
             to,
+            type: type,
           }
         }
       }

--- a/hivemq-edge/src/frontend/src/extensions/datahub/types.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/types.ts
@@ -286,6 +286,7 @@ export interface TransitionData extends DataHubNodeData {
   event?: TransitionType
   from?: StateType
   to?: StateType
+  type?: FsmState.Type
   core?: BehaviorPolicyOnTransition
 }
 

--- a/hivemq-edge/src/frontend/src/extensions/datahub/types.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/types.ts
@@ -300,8 +300,19 @@ export namespace TransitionData {
 export interface FsmState {
   name: string
   description: string
-  type: string
+  type: FsmState.Type
 }
+
+// eslint-disable-next-line @typescript-eslint/no-namespace
+export namespace FsmState {
+  export enum Type {
+    INITIAL = 'INITIAL',
+    INTERMEDIATE = 'INTERMEDIATE',
+    SUCCESS = 'SUCCESS',
+    FAILED = 'FAILED',
+  }
+}
+
 export interface FsmTransition {
   fromState: string
   toState: string

--- a/hivemq-edge/src/frontend/src/extensions/datahub/types.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/types.ts
@@ -295,6 +295,8 @@ export namespace TransitionData {
   export enum Handle {
     BEHAVIOR_POLICY = 'target',
     OPERATION = 'source',
+    ON_SUCCESS = 'onSuccess',
+    ON_ERROR = 'onError',
   }
 }
 


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/21032/details/

The PR improves the rendering of a `behaviour policy` by highlighting, when appropriate, the terminal status of a transition. 

The highlight is materialised by a `success` or `failure` handle of the `Transition` node and, by doing so, aligns with a similar status materialised for the `data policy` 

The PR also adds `success` disconnected transitions that are missing from the generated model.

### Out-of-scope
- The rendering of the `transition` node only shows the transition name, not the end state of the FSM. It certainly creates ambiguity, since the transition names are not unique. Guards, indicating further conditions to the application of the transition, will be added in a future ticket, ensuring unicity of names.

### Before
![screenshot-localhost_3000-2024 04 09-14_36_31](https://github.com/hivemq/hivemq-edge/assets/2743481/04559ed5-e4f6-45e7-85b0-96bf3e1699d1)

### After 
![screenshot-localhost_3000-2024 04 09-14_36_10](https://github.com/hivemq/hivemq-edge/assets/2743481/4b9096fa-b056-49a3-bbd7-5a89b4ad9dad)
