### PR TITLE
fix(21115): re-enable behaviour policy

### DIFF
--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/ToolboxNodes.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/ToolboxNodes.spec.cy.tsx
@@ -12,11 +12,10 @@ describe('Toolbox', () => {
 
     cy.getByAriaLabel('Policy controls').find('[role="group"]').as('policyControlsGroups')
 
-    // Behavior policy disabled, see VITE_FLAG_DATAHUB_BEHAVIOR_ENABLED
-    cy.get('@policyControlsGroups').should('have.length', 3)
+    cy.get('@policyControlsGroups').should('have.length', 4)
     cy.get('@policyControlsGroups').eq(0).should('contain.text', 'Pipeline')
     cy.get('@policyControlsGroups').eq(1).should('contain.text', 'Data Policy')
-    // cy.get('@policyControlsGroups').eq(2).should('contain.text', 'Behavior Policy')
-    cy.get('@policyControlsGroups').eq(2).should('contain.text', 'Operation')
+    cy.get('@policyControlsGroups').eq(2).should('contain.text', 'Behavior Policy')
+    cy.get('@policyControlsGroups').eq(3).should('contain.text', 'Operation')
   })
 })

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/ToolboxNodes.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/ToolboxNodes.tsx
@@ -8,7 +8,6 @@ export const ToolboxNodes = () => {
   const { t } = useTranslation('datahub')
   const { nodes, status } = useDataHubDraftStore()
 
-  const isBehaviorPolicyEnabled = import.meta.env.VITE_FLAG_DATAHUB_BEHAVIOR_ENABLED === 'true'
   const isEditEnabled =
     import.meta.env.VITE_FLAG_DATAHUB_EDIT_POLICY_ENABLED === 'true' || status === DesignerStatus.DRAFT
   const isDraftEmpty = nodes.length === 0
@@ -26,9 +25,7 @@ export const ToolboxNodes = () => {
           <Text id="group-pipeline">{t('workspace.toolbox.group.pipeline')}</Text>
           <HStack>
             <Tool nodeType={DataHubNodeType.TOPIC_FILTER} isDisabled={isDraftEmpty || !isEditEnabled} />
-            {isBehaviorPolicyEnabled && (
-              <Tool nodeType={DataHubNodeType.CLIENT_FILTER} isDisabled={isDraftEmpty || !isEditEnabled} />
-            )}
+            <Tool nodeType={DataHubNodeType.CLIENT_FILTER} isDisabled={isDraftEmpty || !isEditEnabled} />
           </HStack>
         </VStack>
       </ButtonGroup>
@@ -42,17 +39,15 @@ export const ToolboxNodes = () => {
           </HStack>
         </VStack>
       </ButtonGroup>
-      {isBehaviorPolicyEnabled && (
-        <ButtonGroup variant="outline" size="sm" aria-labelledby="group-behaviorPolicy">
-          <VStack alignItems="flex-start">
-            <Text id="group-behaviorPolicy">{t('workspace.toolbox.group.behaviorPolicy')}</Text>
-            <HStack>
-              <Tool nodeType={DataHubNodeType.BEHAVIOR_POLICY} isDisabled={!isEditEnabled} />
-              <Tool nodeType={DataHubNodeType.TRANSITION} isDisabled={isDraftEmpty || !isEditEnabled} />
-            </HStack>
-          </VStack>
-        </ButtonGroup>
-      )}
+      <ButtonGroup variant="outline" size="sm" aria-labelledby="group-behaviorPolicy">
+        <VStack alignItems="flex-start">
+          <Text id="group-behaviorPolicy">{t('workspace.toolbox.group.behaviorPolicy')}</Text>
+          <HStack>
+            <Tool nodeType={DataHubNodeType.BEHAVIOR_POLICY} isDisabled={!isEditEnabled} />
+            <Tool nodeType={DataHubNodeType.TRANSITION} isDisabled={isDraftEmpty || !isEditEnabled} />
+          </HStack>
+        </VStack>
+      </ButtonGroup>
       <ButtonGroup variant="outline" size="sm" aria-labelledby="group-operation">
         <VStack alignItems="flex-start" pr={2}>
           <Text id="group-operation">{t('workspace.toolbox.group.operation')}</Text>

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/DataHubListings.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/DataHubListings.tsx
@@ -25,7 +25,6 @@ const DataHubListings: FC = () => {
   const { isOpen: isConfirmDeleteOpen, onOpen: onConfirmDeleteOpen, onClose: onConfirmDeleteClose } = useDisclosure()
   const [deleteItem, setDeleteItem] = useState<DeleteMutationRequest | undefined>(undefined)
   const toast = useToast()
-  const isBehaviorPolicyEnabled = import.meta.env.VITE_FLAG_DATAHUB_BEHAVIOR_ENABLED === 'true'
 
   const handleConfirmOnClose = () => {
     onConfirmDeleteClose()
@@ -77,9 +76,7 @@ const DataHubListings: FC = () => {
 
       <TabPanels>
         <TabPanel>
-          <Text mb={3}>
-            {t('Listings.tabs.policy.description')} {!isBehaviorPolicyEnabled && t('flag.behaviorPolicy.notEnabled')}
-          </Text>
+          <Text mb={3}>{t('Listings.tabs.policy.description')}</Text>
 
           <PolicyTable onDeleteItem={handleOnDelete} />
         </TabPanel>

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/PolicyTable.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/PolicyTable.tsx
@@ -35,7 +35,6 @@ const PolicyTable: FC<DataHubTableProps> = ({ onDeleteItem }) => {
   const navigate = useNavigate()
   const deleteDataPolicy = useDeleteDataPolicy()
   const deleteBehaviourPolicy = useDeleteBehaviorPolicy()
-  const isBehaviorPolicyEnabled = import.meta.env.VITE_FLAG_DATAHUB_BEHAVIOR_ENABLED === 'true'
 
   const isError = useMemo(() => {
     return isDataError || isBehaviorError
@@ -56,11 +55,11 @@ const PolicyTable: FC<DataHubTableProps> = ({ onDeleteItem }) => {
       ...(dataPolicies?.items
         ? dataPolicies.items.map((e) => ({ ...e, type: PolicyType.DATA_POLICY } as CombinedPolicy))
         : []),
-      ...(isBehaviorPolicyEnabled && behaviorPolicies?.items
+      ...(behaviorPolicies?.items
         ? behaviorPolicies.items.map((e) => ({ ...e, type: PolicyType.BEHAVIOR_POLICY } as CombinedPolicy))
         : []),
     ]
-  }, [isLoading, dataPolicies?.items, isBehaviorPolicyEnabled, behaviorPolicies?.items])
+  }, [isLoading, dataPolicies?.items, behaviorPolicies?.items])
 
   const columns = useMemo<ColumnDef<CombinedPolicy>[]>(() => {
     const onHandleDelete = (info: CellContext<CombinedPolicy, unknown>) => {

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/checks.utils.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/checks.utils.ts
@@ -5,7 +5,7 @@ export const CANVAS_POSITION = {
   Client: { x: -300, y: 0 } as XYPosition,
   Topic: { x: -300, y: 0 } as XYPosition,
   Function: { x: 0, y: -275 } as XYPosition,
-  Transition: { x: 350, y: -100 } as XYPosition,
+  Transition: { x: 400, y: 100 } as XYPosition,
   Schema: { x: 0, y: -150 } as XYPosition,
   Validator: { x: 0, y: -150 } as XYPosition,
   OperationSuccess: { x: 200, y: 0 } as XYPosition,

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/transition/TransitionNode.utils.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/transition/TransitionNode.utils.ts
@@ -119,9 +119,10 @@ export const loadTransitions = (
   const model = enumFromStringValue(BehaviorPolicyType, behaviorPolicy.behavior.id)
   if (!model) throw new Error(i18n.t('datahub:error.loading.behavior.noModel') as string)
 
+  const delta = ((Math.max(behaviorPolicy.onTransitions?.length || 0, 1) - 1) * CANVAS_POSITION.Transition.y) / 2
   const position: XYPosition = {
     x: BehaviorPolicyNode.position.x + CANVAS_POSITION.Transition.x,
-    y: BehaviorPolicyNode.position.y + CANVAS_POSITION.Transition.y,
+    y: BehaviorPolicyNode.position.y - CANVAS_POSITION.Transition.y - delta,
   }
 
   const shiftBottom = () => {


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/21115/details/

The PR re-enables the behaviour policies in the `Data Hub Designer` and fixed two bugs with the loading of payload:
- terminal status of the transitions is computed properly
- improve the automatic layout of the transition

# Before

![screenshot-localhost_3000-2024 04 11-11_31_19](https://github.com/hivemq/hivemq-edge/assets/2743481/8db30df0-1f8a-46e3-8fd8-2416c13a1bdd)

# After
![screenshot-localhost_3000-2024 04 11-11_31_56](https://github.com/hivemq/hivemq-edge/assets/2743481/84e13cec-1a69-4c99-bf33-e43172db1b76)

