### PR TITLE
fix(20360): Fix the serialisation of multiple scripts

### DIFF
--- a/hivemq-edge/src/frontend/package.json
+++ b/hivemq-edge/src/frontend/package.json
@@ -25,10 +25,6 @@
     "test:ui": "vitest --ui",
     "preview": "vite preview"
   },
-  "engines": {
-    "node": "20",
-    "pnpm": "8"
-  },
   "dependencies": {
     "@chakra-ui/anatomy": "^2.1.1",
     "@chakra-ui/icons": "^2.0.19",

--- a/hivemq-edge/src/frontend/src/components/PaginatedTable/PaginatedTable.tsx
+++ b/hivemq-edge/src/frontend/src/components/PaginatedTable/PaginatedTable.tsx
@@ -93,7 +93,6 @@ const PaginatedTable = <T,>({
       .flat()
       .filter(Boolean).length > 0
 
-  console.log('XXXXX', hasFooters)
   return (
     <>
       <TableContainer overflowY="auto" overflowX="auto" whiteSpace="normal">

--- a/hivemq-edge/src/frontend/src/extensions/datahub/api/__generated__/schemas/OperationData.json
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/api/__generated__/schemas/OperationData.json
@@ -163,8 +163,7 @@
           "description": "Change the order in which the transform functions will be executed",
           "items": {
             "type": "string",
-            "title": "Function name",
-            "format": "datahub:function-name"
+            "title": "Function name"
           }
         }
       }

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/ToolboxDryRun.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/ToolboxDryRun.tsx
@@ -1,23 +1,7 @@
 import { FC, useCallback, useMemo } from 'react'
 import { Node } from 'reactflow'
 import { useTranslation } from 'react-i18next'
-import {
-  Alert,
-  AlertDescription,
-  AlertIcon,
-  AlertTitle,
-  Box,
-  Button,
-  HStack,
-  Icon,
-  Stack,
-  AlertStatus,
-  CloseButton,
-  Link,
-  Text,
-} from '@chakra-ui/react'
-
-import { ConditionalWrapper } from '@/components/ConditonalWrapper.tsx'
+import { Box, Button, HStack, Icon, Stack } from '@chakra-ui/react'
 
 import PolicyErrorReport from '@datahub/components/helpers/PolicyErrorReport.tsx'
 import { usePolicyDryRun } from '@datahub/hooks/usePolicyDryRun.ts'
@@ -26,6 +10,7 @@ import { usePolicyChecksStore } from '@datahub/hooks/usePolicyChecksStore.ts'
 import { getDryRunStatusIcon } from '@datahub/utils/node.utils.ts'
 import { DataHubNodeData, DesignerStatus, PolicyDryRunStatus } from '@datahub/types.ts'
 import { DesignerToolBoxProps } from '@datahub/components/controls/DesignerToolbox.tsx'
+import PolicySummaryReport from '@datahub/components/helpers/PolicySummaryReport.tsx'
 
 interface ToolboxDryRunProps extends DesignerToolBoxProps {
   onShowNode?: (node: Node) => void
@@ -72,7 +57,6 @@ export const ToolboxDryRun: FC<ToolboxDryRunProps> = ({ onActiveStep, onShowNode
     })
   }
   const errorNodeFrom = useCallback((id: string) => nodes.find((node) => node.id === id), [nodes])
-  const alertStatus: AlertStatus = status === PolicyDryRunStatus.SUCCESS ? 'success' : 'warning'
 
   return (
     <Stack maxW={500}>
@@ -98,30 +82,11 @@ export const ToolboxDryRun: FC<ToolboxDryRunProps> = ({ onActiveStep, onShowNode
 
       {report && (
         <>
-          <Alert status={alertStatus} data-testid="toolbox-policy-check-status">
-            <AlertIcon />
-            <Box whiteSpace="normal">
-              <AlertTitle>
-                <Text as="span">{t('workspace.dryRun.report.success.title', { context: alertStatus })}</Text>
-              </AlertTitle>
-              <AlertDescription>
-                <ConditionalWrapper
-                  condition={status === PolicyDryRunStatus.SUCCESS}
-                  wrapper={(children) => (
-                    <Link
-                      aria-label={t('workspace.toolbox.navigation.goPublish') as string}
-                      onClick={() => onActiveStep?.(DesignerToolBoxProps.Steps.TOOLBOX_CHECK)}
-                    >
-                      {children}
-                    </Link>
-                  )}
-                >
-                  <Text as="span">{t('workspace.dryRun.report.success.description', { context: alertStatus })}</Text>
-                </ConditionalWrapper>
-              </AlertDescription>
-            </Box>
-            <CloseButton alignSelf="flex-start" position="relative" right={-1} top={-1} onClick={handleClearPolicy} />
-          </Alert>
+          <PolicySummaryReport
+            status={status || PolicyDryRunStatus.FAILURE}
+            onOpenPublish={() => onActiveStep?.(DesignerToolBoxProps.Steps.TOOLBOX_PUBLISH)}
+            onClearPolicy={handleClearPolicy}
+          />
           <PolicyErrorReport
             errors={getErrors() || []}
             onFitView={(id) => {

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/helpers/PolicySummaryReport.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/helpers/PolicySummaryReport.tsx
@@ -1,0 +1,52 @@
+import { FC } from 'react'
+import {
+  Alert,
+  AlertDescription,
+  AlertIcon,
+  AlertStatus,
+  AlertTitle,
+  Box,
+  CloseButton,
+  Link,
+  Text,
+} from '@chakra-ui/react'
+import { useTranslation } from 'react-i18next'
+import { ConditionalWrapper } from '@/components/ConditonalWrapper.tsx'
+import { PolicyDryRunStatus } from '@datahub/types.ts'
+
+interface PolicySummaryReportProps {
+  status: PolicyDryRunStatus
+  onOpenPublish?: () => void
+  onClearPolicy?: () => void
+}
+
+const PolicySummaryReport: FC<PolicySummaryReportProps> = ({ status, onOpenPublish, onClearPolicy }) => {
+  const { t } = useTranslation('datahub')
+  const alertStatus: AlertStatus = status === PolicyDryRunStatus.SUCCESS ? 'success' : 'warning'
+
+  return (
+    <Alert status={alertStatus} data-testid="toolbox-policy-check-status">
+      <AlertIcon />
+      <Box whiteSpace="normal">
+        <AlertTitle>
+          <Text as="span">{t('workspace.dryRun.report.success.title', { context: alertStatus })}</Text>
+        </AlertTitle>
+        <AlertDescription>
+          <ConditionalWrapper
+            condition={status === PolicyDryRunStatus.SUCCESS}
+            wrapper={(children) => (
+              <Link aria-label={t('workspace.toolbox.navigation.goPublish') as string} onClick={onOpenPublish}>
+                {children}
+              </Link>
+            )}
+          >
+            <Text as="span">{t('workspace.dryRun.report.success.description', { context: alertStatus })}</Text>
+          </ConditionalWrapper>
+        </AlertDescription>
+      </Box>
+      <CloseButton alignSelf="flex-start" position="relative" right={-1} top={-1} onClick={onClearPolicy} />
+    </Alert>
+  )
+}
+
+export default PolicySummaryReport

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/checks.utils.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/checks.utils.ts
@@ -4,7 +4,7 @@ import { XYPosition } from 'reactflow'
 export const CANVAS_POSITION = {
   Client: { x: -300, y: 0 } as XYPosition,
   Topic: { x: -300, y: 0 } as XYPosition,
-  Function: { x: 0, y: -275 } as XYPosition,
+  Function: { x: 350, y: -400 } as XYPosition,
   Transition: { x: 400, y: 100 } as XYPosition,
   Schema: { x: 0, y: -150 } as XYPosition,
   Validator: { x: 0, y: -150 } as XYPosition,

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/operation/OperationNode.utils.spec.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/operation/OperationNode.utils.spec.ts
@@ -351,7 +351,7 @@ describe('checkValidityTransformFunction', () => {
       const { node, data, error, resources } = results[2]
       expect(node).toStrictEqual(MOCK_NODE_OPERATION)
       expect(error).toBeUndefined()
-      expect(resources).toBeUndefined()
+      expect(resources).toHaveLength(2)
       expect(data).toEqual(
         expect.objectContaining({
           arguments: {
@@ -367,14 +367,12 @@ describe('checkValidityTransformFunction', () => {
       const { node, data, error, resources } = results[1]
       expect(node).toStrictEqual(MOCK_NODE_OPERATION)
       expect(error).toBeUndefined()
-      expect(resources).toHaveLength(2)
+      expect(resources).toBeUndefined()
       expect(data).toEqual(
         expect.objectContaining({
-          arguments: {
-            transform: ['the_function'],
-          },
+          arguments: {},
           functionId: 'fn:the_function:latest',
-          id: 'node-id',
+          id: 'node-function',
         })
       )
     }

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/script/FunctionNode.utils.spec.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/script/FunctionNode.utils.spec.ts
@@ -3,7 +3,11 @@ import { Node } from 'reactflow'
 import { MOCK_DEFAULT_NODE } from '@/__test-utils__/react-flow/nodes.ts'
 
 import { DataHubNodeType, FunctionData } from '@datahub/types.ts'
-import { checkValidityJSScript } from '@datahub/designer/script/FunctionNode.utils.ts'
+import {
+  checkValidityJSScript,
+  formatScriptName,
+  parseScriptName,
+} from '@datahub/designer/script/FunctionNode.utils.ts'
 
 describe('checkValidityJSScript', () => {
   it('should return error when not configured', async () => {
@@ -58,5 +62,30 @@ describe('checkValidityJSScript', () => {
     )
     expect(error).toBeUndefined()
     expect(resources).toBeUndefined()
+  })
+})
+
+describe('parseScriptName', () => {
+  it('should extract the function name from the operation', async () => {
+    expect(parseScriptName({ functionId: 'fn:my-function:1', id: 'fakeId', arguments: {} })).toEqual('my-function')
+    expect(parseScriptName({ functionId: 'my-raw-id', id: 'fakeId', arguments: {} })).toEqual('my-raw-id')
+  })
+})
+
+describe('formatScriptName', () => {
+  it('should format the id of the script', async () => {
+    const MOCK_NODE_SCRIPT: Node<FunctionData> = {
+      id: 'node-id',
+      type: DataHubNodeType.FUNCTION,
+      data: {
+        type: 'Javascript',
+        name: 'my-name',
+        version: 1,
+      },
+      ...MOCK_DEFAULT_NODE,
+      position: { x: 0, y: 0 },
+    }
+
+    expect(formatScriptName(MOCK_NODE_SCRIPT)).toEqual('fn:my-name:latest')
   })
 })

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/script/FunctionNode.utils.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/script/FunctionNode.utils.ts
@@ -1,4 +1,4 @@
-import { Node, NodeAddChange } from 'reactflow'
+import { Node, NodeAddChange, XYPosition } from 'reactflow'
 
 import { PolicyOperation, Script } from '@/api/__generated__'
 import i18n from '@/config/i18n.config.ts'
@@ -55,6 +55,18 @@ export const loadScripts = (
   store: WorkspaceState & WorkspaceAction
 ) => {
   const { onAddNodes, onConnect } = store
+
+  const delta = ((Math.max(functions.length || 0, 1) - 1) * CANVAS_POSITION.Function.x) / 2
+  const position: XYPosition = {
+    x: parentNode.position.x - CANVAS_POSITION.Function.x - delta,
+    y: parentNode.position.y + CANVAS_POSITION.Function.y,
+  }
+
+  const shiftLeft = () => {
+    position.x += CANVAS_POSITION.Function.x
+    return position
+  }
+
   for (const fct of functions) {
     const [, functionName] = fct.functionId.split(':')
     const functionScript = scripts.find((script) => script.id === functionName)
@@ -66,10 +78,7 @@ export const loadScripts = (
     const functionScriptNode: Node<FunctionData> = {
       id: functionScript.id,
       type: DataHubNodeType.FUNCTION,
-      position: {
-        x: parentNode.position.x + CANVAS_POSITION.Function.x,
-        y: parentNode.position.y + CANVAS_POSITION.Function.y,
-      },
+      position: { ...shiftLeft() },
       data: {
         type: 'Javascript',
         name: functionScript.id,

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/script/FunctionNode.utils.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/script/FunctionNode.utils.ts
@@ -14,6 +14,21 @@ import {
 } from '@datahub/types.ts'
 import { PolicyCheckErrors } from '@datahub/designer/validation.errors.ts'
 import { CANVAS_POSITION } from '@datahub/designer/checks.utils.ts'
+import {
+  SCRIPT_FUNCTION_LATEST,
+  SCRIPT_FUNCTION_PREFIX,
+  SCRIPT_FUNCTION_SEPARATOR,
+} from '@datahub/utils/datahub.utils.ts'
+
+export const formatScriptName = (functionNode: Node<FunctionData>): string => {
+  return `${SCRIPT_FUNCTION_PREFIX}:${functionNode.data.name}:${SCRIPT_FUNCTION_LATEST}`
+}
+
+export const parseScriptName = (operation: PolicyOperation): string => {
+  const splitId = operation.functionId.split(SCRIPT_FUNCTION_SEPARATOR)
+  if (splitId.length !== 3) return splitId[0]
+  return splitId[1]
+}
 
 export function checkValidityJSScript(scriptNode: Node<FunctionData>): DryRunResults<Script> {
   if (!scriptNode.data.name || !scriptNode.data.version || !scriptNode.data.sourceCode) {

--- a/hivemq-edge/src/frontend/src/extensions/datahub/hooks/usePolicyDryRun.spec.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/hooks/usePolicyDryRun.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'vitest'
 import { act, renderHook } from '@testing-library/react'
-import { resourceReducer, usePolicyDryRun } from '@datahub/hooks/usePolicyDryRun.ts'
+import { onlyNonNullResources, usePolicyDryRun } from '@datahub/hooks/usePolicyDryRun.ts'
 import {
   BehaviorPolicyData,
   BehaviorPolicyType,
@@ -11,7 +11,7 @@ import {
 import { Node } from 'reactflow'
 import { MOCK_DEFAULT_NODE } from '@/__test-utils__/react-flow/nodes.ts'
 
-describe('resourceReducer', () => {
+describe('onlyNonNullResources', () => {
   it('should return an async function', async () => {
     const MOCK_NODE_DATA_POLICY: Node<DataPolicyData> = {
       id: 'node-id',
@@ -32,8 +32,8 @@ describe('resourceReducer', () => {
       resources: [{ node: MOCK_NODE_TEST }],
     }
 
-    expect(resourceReducer([], {} as DryRunResults<unknown, never>)).toStrictEqual([])
-    expect(resourceReducer([], result)).toStrictEqual([{ node: MOCK_NODE_TEST }])
+    expect(onlyNonNullResources([], {} as DryRunResults<unknown, never>)).toStrictEqual([])
+    expect(onlyNonNullResources([], result)).toStrictEqual([{ node: MOCK_NODE_TEST }])
   })
 })
 

--- a/hivemq-edge/src/frontend/src/extensions/datahub/hooks/usePolicyDryRun.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/hooks/usePolicyDryRun.ts
@@ -36,6 +36,14 @@ export const onlyNonNullResources = (acc: DryRunResults<unknown, never>[], oper:
   return acc
 }
 
+export const onlyUniqueResources = (acc: DryRunResults<unknown, never>[], item: DryRunResults<unknown, never>) => {
+  const existingResourceIds = acc.map((e) => e.node.id)
+  if (!existingResourceIds.includes(item.node.id)) {
+    acc.push(item)
+  }
+  return acc
+}
+
 export const usePolicyDryRun = () => {
   const store = useDataHubDraftStore()
   const { nodes, edges, onUpdateNodes } = store

--- a/hivemq-edge/src/frontend/src/extensions/datahub/hooks/usePolicyDryRun.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/hooks/usePolicyDryRun.ts
@@ -29,7 +29,7 @@ import { isClientFilterNodeType, isTopicFilterNodeType } from '@datahub/utils/no
 /* istanbul ignore next -- @preserve */
 const mockDelay = (ms = 100) => new Promise((resolve) => setTimeout(resolve, ms))
 
-export const resourceReducer = (acc: DryRunResults<unknown, never>[], oper: DryRunResults<unknown, never>) => {
+export const onlyNonNullResources = (acc: DryRunResults<unknown, never>[], oper: DryRunResults<unknown, never>) => {
   if (oper.resources) {
     acc.push(...oper.resources)
   }
@@ -78,10 +78,10 @@ export const usePolicyDryRun = () => {
     const onSuccessPipeline = checkValidityPipeline(dataPolicyNode, DataPolicyData.Handle.ON_SUCCESS, reducedStore)
     const onErrorPipeline = checkValidityPipeline(dataPolicyNode, DataPolicyData.Handle.ON_ERROR, reducedStore)
 
-    const successResources = onSuccessPipeline.reduce(resourceReducer, [] as DryRunResults<Script>[])
-    const errorResources = onErrorPipeline.reduce(resourceReducer, [] as DryRunResults<Script>[])
-    const schemaResources = validators.reduce(resourceReducer, [] as DryRunResults<Schema>[])
-    const allResources = [...successResources, ...errorResources, ...schemaResources]
+    const successResources = onSuccessPipeline.reduce(onlyNonNullResources, [] as DryRunResults<Script>[])
+    const errorResources = onErrorPipeline.reduce(onlyNonNullResources, [] as DryRunResults<Script>[])
+    const schemaResources = validators.reduce(onlyNonNullResources, [] as DryRunResults<Schema>[])
+    const allResources = [...successResources, ...errorResources, ...schemaResources].reduce(onlyUniqueResources, [])
 
     const processedNodes = [filter, ...validators, ...onSuccessPipeline, ...onErrorPipeline, ...allResources]
     const hasError = processedNodes.some((e) => !!e.error)
@@ -115,7 +115,7 @@ export const usePolicyDryRun = () => {
     const model = checkValidityModel(behaviourPolicyNode)
     const { behaviorPolicyTransitions, pipelines } = checkValidityTransitions(behaviourPolicyNode, reducedStore)
 
-    const pipelineResources = pipelines?.reduce(resourceReducer, [] as DryRunResults<Schema>[])
+    const pipelineResources = pipelines?.reduce(onlyNonNullResources, [] as DryRunResults<Schema>[])
 
     // TODO[19240] This is wrong. Only if no errors
     const behaviorPolicy = checkValidityBehaviorPolicy(behaviourPolicyNode, clients, model, behaviorPolicyTransitions)

--- a/hivemq-edge/src/frontend/src/extensions/datahub/utils/datahub.utils.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/utils/datahub.utils.ts
@@ -1,5 +1,8 @@
-// TODO[NVL] Should be integrated with the ChakraUI Theme
+export const SCRIPT_FUNCTION_SEPARATOR = ':'
+export const SCRIPT_FUNCTION_PREFIX = 'fn'
+export const SCRIPT_FUNCTION_LATEST = 'latest'
 
+// TODO[NVL] Should be integrated with the ChakraUI Theme
 export const ANIMATION = {
   FIT_VIEW_DURATION_MS: 500,
 }

--- a/hivemq-edge/src/frontend/vitest.config.ts
+++ b/hivemq-edge/src/frontend/vitest.config.ts
@@ -16,7 +16,8 @@ export default defineConfig({
     environment: 'jsdom',
     setupFiles: './src/__test-utils__/setup.ts',
     coverage: {
-      exclude: ['**/src/api/__generated__/**', '**/__handlers__/**', '**/*.tsx'],
+      include: ['**/src/'],
+      exclude: ['**/src/api/__generated__/**', '**/__handlers__/**', '**/__test-utils__/**', '**/*.tsx'],
       provider: 'istanbul', // or 'v8'
       reporter: ['text', 'json', 'html', 'lcov'],
     },


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/20360/details/

The PR fixes the publishing process of multiple scripts in a transformation node. The current process was only saving the first script connected to the `Operation` node. 

The PR also slighlty improves the rendering of the successful report on a `dry run` and the default layout for (multiple) schemas and scripts.


### Before


### After
![screenshot-localhost_3000-2024 04 22-16_41_51](https://github.com/hivemq/hivemq-edge/assets/2743481/af5ee824-232c-41f2-b0d2-97481e28c5ff)
