### PR TITLE
refactor(19388): Fix the icons of the table pagination toolbar

### DIFF
--- a/hivemq-edge/src/frontend/src/components/PaginatedTable/components/PaginationBar.tsx
+++ b/hivemq-edge/src/frontend/src/components/PaginatedTable/components/PaginationBar.tsx
@@ -1,5 +1,6 @@
 import { FC } from 'react'
 import { Table } from '@tanstack/react-table'
+import { useTranslation } from 'react-i18next'
 import {
   Box,
   ButtonGroup,
@@ -14,11 +15,10 @@ import {
   NumberInputStepper,
   Select,
   Text,
+  type IconButtonProps,
 } from '@chakra-ui/react'
-import { type IconButtonProps } from '@chakra-ui/react'
-import { MdArrowLeft, MdArrowRight } from 'react-icons/md'
-import { BiSkipNext, BiSkipPrevious } from 'react-icons/bi'
-import { useTranslation } from 'react-i18next'
+import { LuSkipBack, LuSkipForward, LuStepBack, LuStepForward } from 'react-icons/lu'
+
 import IconButton from '@/components/Chakra/IconButton.tsx'
 
 interface PaginationProps<T> {
@@ -27,7 +27,7 @@ interface PaginationProps<T> {
 }
 
 const PaginationButton: FC<IconButtonProps> = (props) => (
-  <IconButton {...props} size="sm" fontSize="24px" icon={<BiSkipNext />} />
+  <IconButton icon={<LuSkipBack />} {...props} size="sm" fontSize="18px" />
 )
 
 const PaginationBar = <T,>({ table, pageSizes }: PaginationProps<T>) => {
@@ -36,25 +36,25 @@ const PaginationBar = <T,>({ table, pageSizes }: PaginationProps<T>) => {
     <HStack as="nav" aria-label={t('components:pagination.ariaLabel') as string} gap={8} mt={4}>
       <ButtonGroup isAttached variant="ghost">
         <PaginationButton
-          icon={<BiSkipPrevious />}
+          icon={<LuSkipBack />}
           onClick={() => table.setPageIndex(0)}
           aria-label={t('components:pagination.goFirstPage')}
           isDisabled={!table.getCanPreviousPage()}
         />
         <PaginationButton
-          icon={<MdArrowLeft />}
+          icon={<LuStepBack />}
           onClick={() => table.previousPage()}
           aria-label={t('components:pagination.goPreviousPage')}
           isDisabled={!table.getCanPreviousPage()}
         />
         <PaginationButton
-          icon={<MdArrowRight />}
+          icon={<LuStepForward />}
           onClick={() => table.nextPage()}
           aria-label={t('components:pagination.goNextPage')}
           isDisabled={!table.getCanNextPage()}
         />
         <PaginationButton
-          icon={<BiSkipNext />}
+          icon={<LuSkipForward />}
           onClick={() => table.setPageIndex(table.getPageCount() - 1)}
           aria-label={t('components:pagination.goLastPage')}
           isDisabled={!table.getCanNextPage()}


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/19388/details/

The PR fixes the bug in the pagination toolbar, which had all the icons identical. It also updates all icons to the Lucide set.

### Before
![screenshot-localhost_3000-2024 04 23-11_01_56](https://github.com/hivemq/hivemq-edge/assets/2743481/3a650120-7141-4e74-bb9b-2f85487a3223)

### After
![screenshot-localhost_3000-2024 04 23-10_59_19](https://github.com/hivemq/hivemq-edge/assets/2743481/13a9508a-616e-4458-bad3-a68805cb47b8)
