### PR TITLE
refactor(20321): Refactoring the policy loading 

### DIFF
--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/NodeWrapper.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/NodeWrapper.tsx
@@ -36,6 +36,8 @@ export const NodeWrapper: FC<NodeWrapperProps> = ({ selected, children, route, w
     boxShadow: '0 0 10px 2px rgba(0,121,36, 0.75), 0 1px 1px rgb(0 0 0 / 15%)',
   }
 
+  const isDryRun = data.dryRunStatus !== undefined && data.dryRunStatus !== PolicyDryRunStatus.IDLE
+
   return (
     <Card
       variant="elevated"
@@ -52,7 +54,7 @@ export const NodeWrapper: FC<NodeWrapperProps> = ({ selected, children, route, w
         setInternalSelection(true)
       }}
     >
-      {data.dryRunStatus !== PolicyDryRunStatus.IDLE && (
+      {isDryRun && (
         <Avatar
           position="absolute"
           left="-1rem"

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/PolicyEditorLoader.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/PolicyEditorLoader.tsx
@@ -64,7 +64,9 @@ export const DataPolicyLoader: FC<PolicyLoaderProps> = ({ policyId }) => {
       )
 
       store.onNodesChange(nodeChanges)
-      edgeConnects.map((connection) => store.onConnect(connection))
+      for (const connection of edgeConnects) {
+        store.onConnect(connection)
+      }
       store.setStatus(DesignerStatus.LOADED, { name: dataPolicy.id })
     } catch (error) {
       let message
@@ -131,7 +133,9 @@ export const BehaviorPolicyLoader: FC<PolicyLoaderProps> = ({ policyId }) => {
       )
 
       store.onNodesChange(nodeChanges)
-      edgeConnects.map((connection) => store.onConnect(connection))
+      for (const connection of edgeConnects) {
+        store.onConnect(connection)
+      }
       store.setStatus(DesignerStatus.LOADED, { name: behaviorPolicy.id })
     } catch (error) {
       let message

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/PolicyEditorLoader.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/PolicyEditorLoader.tsx
@@ -59,7 +59,9 @@ export const DataPolicyLoader: FC<PolicyLoaderProps> = ({ policyId }) => {
         if (nodeChange.item && !allIds.includes(nodeChange.item.id)) acc.push(nodeChange)
         return acc
       }, [])
-      const edgeConnects = allArtefactsLoaded.filter((element) => (element as Connection).source) as Connection[]
+      const edgeConnects = allArtefactsLoaded.filter(
+        (element): element is Connection => !!(element as Connection).source
+      )
 
       store.onNodesChange(nodeChanges)
       edgeConnects.map((connection) => store.onConnect(connection))
@@ -124,7 +126,9 @@ export const BehaviorPolicyLoader: FC<PolicyLoaderProps> = ({ policyId }) => {
         if (nodeChange.item && !allIds.includes(nodeChange.item.id)) acc.push(nodeChange)
         return acc
       }, [])
-      const edgeConnects = allArtefactsLoaded.filter((element) => (element as Connection).source) as Connection[]
+      const edgeConnects = allArtefactsLoaded.filter(
+        (element): element is Connection => !!(element as Connection).source
+      )
 
       store.onNodesChange(nodeChanges)
       edgeConnects.map((connection) => store.onConnect(connection))

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/behavior_policy/BehaviorPolicyNode.utils.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/behavior_policy/BehaviorPolicyNode.utils.ts
@@ -47,7 +47,7 @@ export function checkValidityBehaviorPolicy(
   }
 }
 
-export const loadBehaviorPolicy = (behaviorPolicy: BehaviorPolicy) => {
+export const loadBehaviorPolicy = (behaviorPolicy: BehaviorPolicy): NodeAddChange => {
   const model = enumFromStringValue(BehaviorPolicyType, behaviorPolicy.behavior.id)
   if (!model)
     throw new Error(
@@ -69,5 +69,5 @@ export const loadBehaviorPolicy = (behaviorPolicy: BehaviorPolicy) => {
     },
   }
 
-  return { item: behaviorPolicyNode, type: 'add' } as NodeAddChange
+  return { item: behaviorPolicyNode, type: 'add' }
 }

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/behavior_policy/BehaviorPolicyNode.utils.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/behavior_policy/BehaviorPolicyNode.utils.ts
@@ -5,14 +5,7 @@ import { enumFromStringValue } from '@/utils/types.utils.ts'
 import i18n from '@/config/i18n.config.ts'
 
 import { PolicyCheckErrors } from '@datahub/designer/validation.errors.ts'
-import {
-  BehaviorPolicyData,
-  BehaviorPolicyType,
-  DataHubNodeType,
-  DryRunResults,
-  WorkspaceAction,
-  WorkspaceState,
-} from '@datahub/types.ts'
+import { BehaviorPolicyData, BehaviorPolicyType, DataHubNodeType, DryRunResults } from '@datahub/types.ts'
 
 export function checkValidityModel(behaviorPolicy: Node<BehaviorPolicyData>): DryRunResults<BehaviorPolicyBehavior> {
   if (!behaviorPolicy.data.model) {
@@ -54,9 +47,7 @@ export function checkValidityBehaviorPolicy(
   }
 }
 
-export const loadBehaviorPolicy = (behaviorPolicy: BehaviorPolicy, store: WorkspaceState & WorkspaceAction) => {
-  const { onNodesChange } = store
-
+export const loadBehaviorPolicy = (behaviorPolicy: BehaviorPolicy) => {
   const model = enumFromStringValue(BehaviorPolicyType, behaviorPolicy.behavior.id)
   if (!model)
     throw new Error(
@@ -78,5 +69,5 @@ export const loadBehaviorPolicy = (behaviorPolicy: BehaviorPolicy, store: Worksp
     },
   }
 
-  onNodesChange([{ item: behaviorPolicyNode, type: 'add' } as NodeAddChange])
+  return { item: behaviorPolicyNode, type: 'add' } as NodeAddChange
 }

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/client_filter/ClientFilterNode.utils.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/client_filter/ClientFilterNode.utils.ts
@@ -1,17 +1,10 @@
-import { getIncomers, Node, NodeAddChange, XYPosition } from 'reactflow'
+import { Connection, getIncomers, Node, NodeAddChange, XYPosition } from 'reactflow'
 
 import { getNodeId, isClientFilterNodeType } from '@datahub/utils/node.utils.ts'
 import { BehaviorPolicy } from '@/api/__generated__'
 import i18n from '@/config/i18n.config.ts'
 
-import {
-  BehaviorPolicyData,
-  ClientFilterData,
-  DataHubNodeType,
-  DryRunResults,
-  WorkspaceAction,
-  WorkspaceState,
-} from '@datahub/types.ts'
+import { BehaviorPolicyData, ClientFilterData, DataHubNodeType, DryRunResults, WorkspaceState } from '@datahub/types.ts'
 import { PolicyCheckErrors } from '@datahub/designer/validation.errors.ts'
 import { CANVAS_POSITION } from '@datahub/designer/checks.utils.ts'
 
@@ -45,16 +38,14 @@ export function checkValidityClients(
   }
 }
 
-export const loadClientFilter = (behaviorPolicy: BehaviorPolicy, store: WorkspaceState & WorkspaceAction) => {
-  const { onNodesChange, onConnect } = store
-  const BehaviorPolicyNode = store.nodes.find((node) => node.id === behaviorPolicy.id)
-  if (!BehaviorPolicyNode)
+export const loadClientFilter = (behaviorPolicy: BehaviorPolicy, behaviorPolicyNode: Node<BehaviorPolicyData>) => {
+  if (behaviorPolicyNode.id !== behaviorPolicy.id)
     throw new Error(
       i18n.t('datahub:error.loading.connection.notFound', { type: DataHubNodeType.BEHAVIOR_POLICY }) as string
     )
   const position: XYPosition = {
-    x: BehaviorPolicyNode.position.x + CANVAS_POSITION.Client.x,
-    y: BehaviorPolicyNode.position.y + CANVAS_POSITION.Client.y,
+    x: behaviorPolicyNode.position.x + CANVAS_POSITION.Client.x,
+    y: behaviorPolicyNode.position.y + CANVAS_POSITION.Client.y,
   }
 
   const topicNode: Node<ClientFilterData> = {
@@ -66,6 +57,8 @@ export const loadClientFilter = (behaviorPolicy: BehaviorPolicy, store: Workspac
     },
   }
 
-  onNodesChange([{ item: topicNode, type: 'add' } as NodeAddChange])
-  onConnect({ source: topicNode.id, target: BehaviorPolicyNode.id, sourceHandle: null, targetHandle: null })
+  return [
+    { item: topicNode, type: 'add' } as NodeAddChange,
+    { source: topicNode.id, target: behaviorPolicyNode.id, sourceHandle: null, targetHandle: null } as Connection,
+  ]
 }

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/client_filter/ClientFilterNode.utils.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/client_filter/ClientFilterNode.utils.ts
@@ -38,7 +38,10 @@ export function checkValidityClients(
   }
 }
 
-export const loadClientFilter = (behaviorPolicy: BehaviorPolicy, behaviorPolicyNode: Node<BehaviorPolicyData>) => {
+export const loadClientFilter = (
+  behaviorPolicy: BehaviorPolicy,
+  behaviorPolicyNode: Node<BehaviorPolicyData>
+): (NodeAddChange | Connection)[] => {
   if (behaviorPolicyNode.id !== behaviorPolicy.id)
     throw new Error(
       i18n.t('datahub:error.loading.connection.notFound', { type: DataHubNodeType.BEHAVIOR_POLICY }) as string
@@ -58,7 +61,7 @@ export const loadClientFilter = (behaviorPolicy: BehaviorPolicy, behaviorPolicyN
   }
 
   return [
-    { item: topicNode, type: 'add' } as NodeAddChange,
-    { source: topicNode.id, target: behaviorPolicyNode.id, sourceHandle: null, targetHandle: null } as Connection,
+    { item: topicNode, type: 'add' },
+    { source: topicNode.id, target: behaviorPolicyNode.id, sourceHandle: null, targetHandle: null },
   ]
 }

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/data_policy/DataPolicyNode.utils.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/data_policy/DataPolicyNode.utils.ts
@@ -1,7 +1,7 @@
 import { getIncomers, getOutgoers, Node, NodeAddChange, XYPosition } from 'reactflow'
 
 import { DataPolicy, DataPolicyValidator, PolicyOperation } from '@/api/__generated__'
-import { DataHubNodeType, DataPolicyData, DryRunResults, WorkspaceAction, WorkspaceState } from '@datahub/types.ts'
+import { DataHubNodeType, DataPolicyData, DryRunResults, WorkspaceState } from '@datahub/types.ts'
 import { PolicyCheckErrors } from '@datahub/designer/validation.errors.ts'
 import { isTopicFilterNodeType } from '@datahub/utils/node.utils.ts'
 
@@ -115,9 +115,7 @@ export const checkValidityDataPolicy = (
   }
 }
 
-export const loadDataPolicy = (policy: DataPolicy, store: WorkspaceState & WorkspaceAction) => {
-  const { onNodesChange } = store
-
+export const loadDataPolicy = (policy: DataPolicy) => {
   const position: XYPosition = {
     x: 0,
     y: 0,
@@ -130,5 +128,5 @@ export const loadDataPolicy = (policy: DataPolicy, store: WorkspaceState & Works
     data: {},
   }
 
-  onNodesChange([{ item: dataPolicyNode, type: 'add' } as NodeAddChange])
+  return { item: dataPolicyNode, type: 'add' } as NodeAddChange
 }

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/data_policy/DataPolicyNode.utils.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/data_policy/DataPolicyNode.utils.ts
@@ -115,7 +115,7 @@ export const checkValidityDataPolicy = (
   }
 }
 
-export const loadDataPolicy = (policy: DataPolicy) => {
+export const loadDataPolicy = (policy: DataPolicy): NodeAddChange => {
   const position: XYPosition = {
     x: 0,
     y: 0,
@@ -128,5 +128,5 @@ export const loadDataPolicy = (policy: DataPolicy) => {
     data: {},
   }
 
-  return { item: dataPolicyNode, type: 'add' } as NodeAddChange
+  return { item: dataPolicyNode, type: 'add' }
 }

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/operation/OperationNode.utils.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/operation/OperationNode.utils.ts
@@ -95,11 +95,11 @@ export function checkValidityTransformFunction(
   }
 
   const { transform } = operationNode.data.formData as unknown as OperationData.DataHubTransformType
-  const defaultOrder = transform.length ? transform : scriptNodes.map((e) => e.data?.id)
+  const defaultOrder = transform.length ? transform : scriptNodes.map((scriptNode) => scriptNode.data?.id)
 
   const allTransformScripts: DryRunResults<PolicyOperation, Script>[] = []
   for (const scriptId of defaultOrder) {
-    const script = scriptNodes.find((e) => e.data?.id === scriptId)
+    const script = scriptNodes.find((scriptNode) => scriptNode.data?.id === scriptId)
     if (script) {
       const scriptName = script.node as Node<FunctionData>
 
@@ -224,9 +224,10 @@ export const loadBehaviorPolicyPipelines = (
   behaviorPolicy: BehaviorPolicy,
   transitionNode: Node,
   schemas: Schema[],
-  scripts: Script[],
-  store: WorkspaceState & WorkspaceAction
+  scripts: Script[]
 ) => {
+  const newNodes: (NodeAddChange | Connection)[] = []
+
   for (const transition of behaviorPolicy.onTransitions || []) {
     const activeTransition = getActiveTransition(transition)
     if (!activeTransition)
@@ -236,8 +237,10 @@ export const loadBehaviorPolicyPipelines = (
     if (!transitionOnEvent)
       throw new Error(i18n.t('datahub:error.loading.operation.noTransition', { source: activeTransition }) as string)
 
-    loadPipeline(transitionNode, transitionOnEvent.pipeline, null, schemas, scripts, store)
+    const pipelines = loadPipeline(transitionNode, transitionOnEvent.pipeline, null, schemas, scripts)
+    newNodes.push(...pipelines)
   }
+  return newNodes
 }
 
 export const loadDataPolicyPipelines = (

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/operation/OperationNode.utils.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/operation/OperationNode.utils.ts
@@ -378,10 +378,7 @@ export const loadPipeline = (
 
     if (!operationNode) throw new Error(i18n.t('datahub:error.loading.operation.unknown') as string)
     if (!Array.isArray(operationNode)) {
-      newNodes.push(
-        { item: operationNode, type: 'add' } as NodeAddChange,
-        { ...connect, target: operationNode.id } as Connection
-      )
+      newNodes.push({ item: operationNode, type: 'add' }, { ...connect, target: operationNode.id })
       connect = {
         source: operationNode.id,
         target: null,

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/operation/OperationNode.utils.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/operation/OperationNode.utils.ts
@@ -15,12 +15,7 @@ import {
   WorkspaceAction,
   WorkspaceState,
 } from '@datahub/types.ts'
-import {
-  checkValidityJSScript,
-  formatScriptName,
-  loadScripts,
-  parseScriptName,
-} from '@datahub/designer/script/FunctionNode.utils.ts'
+import { checkValidityJSScript, loadScripts } from '@datahub/designer/script/FunctionNode.utils.ts'
 import { checkValiditySchema, loadSchema } from '@datahub/designer/schema/SchemaNode.utils.ts'
 import { PolicyCheckErrors } from '@datahub/designer/validation.errors.ts'
 import { isFunctionNodeType, isSchemaNodeType } from '@datahub/utils/node.utils.ts'
@@ -86,6 +81,11 @@ export function checkValidityTransformFunction(
   const scriptNodes = functions.map((node) => checkValidityJSScript(node))
   const schemaNodes = serialisers.map((node) => checkValiditySchema(node))
 
+  // TODO[19497] This should not have to happen on the client side!
+  const formattedScriptName = (functionNode: Node<FunctionData>): string => {
+    return `fn:${functionNode.data.name}:latest`
+  }
+
   if (!scriptNodes.length) {
     return [
       {
@@ -105,7 +105,7 @@ export function checkValidityTransformFunction(
       const scriptName = script.node as Node<FunctionData>
 
       const operation: PolicyOperation = {
-        functionId: formatScriptName(scriptName),
+        functionId: formattedScriptName(scriptName),
         arguments: {},
         // TODO[19466] Id should be user-facing; Need to fix before merging!
         id: scriptName.id,
@@ -306,6 +306,8 @@ export const loadPipeline = (
             throw new Error(i18n.t('datahub:error.loading.operation.unknown') as string)
           const [deserializer, ...functions] = operationNode as PolicyOperation[]
 
+          console.log('XXXXXX fc', functions)
+
           operationNode = {
             id: policyOperation.id,
             type: DataHubNodeType.OPERATION,
@@ -316,7 +318,7 @@ export const loadPipeline = (
                 isTerminal: false,
                 hasArguments: true,
               },
-              formData: { transform: functions.map((operation) => parseScriptName(operation)) },
+              formData: { transform: functions.map((e) => e.functionId) },
             },
           }
 

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/schema/SchemaNode.utils.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/schema/SchemaNode.utils.ts
@@ -124,7 +124,7 @@ export function loadSchema(
   positionDeltaX: number,
   schemaRef: SchemaReference,
   schemas: Schema[]
-) {
+): (NodeAddChange | Connection)[] {
   const schema = schemas.find((schema) => schema.id === schemaRef.schemaId)
   if (!schema)
     throw new Error(i18n.t('datahub:error.loading.connection.notFound', { source: DataHubNodeType.SCHEMA }) as string)
@@ -148,13 +148,13 @@ export function loadSchema(
     }
 
     return [
-      { item: schemaNode, type: 'add' } as NodeAddChange,
+      { item: schemaNode, type: 'add' },
       {
         source: schemaNode.id,
         target: parentNode.id,
         sourceHandle: null,
         targetHandle: targetHandle,
-      } as Connection,
+      },
     ]
   }
 
@@ -181,13 +181,13 @@ export function loadSchema(
     }
 
     return [
-      { item: schemaNode, type: 'add' } as NodeAddChange,
+      { item: schemaNode, type: 'add' },
       {
         source: schemaNode.id,
         target: parentNode.id,
         sourceHandle: null,
         targetHandle: targetHandle,
-      } as Connection,
+      },
     ]
   }
 

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/schema/SchemaNode.utils.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/schema/SchemaNode.utils.ts
@@ -1,4 +1,4 @@
-import { Node, NodeAddChange } from 'reactflow'
+import { Connection, Node, NodeAddChange } from 'reactflow'
 import { parse, util as protobufUtils } from 'protobufjs'
 import descriptor from 'protobufjs/ext/descriptor'
 
@@ -13,8 +13,6 @@ import {
   ResourceStatus,
   SchemaData,
   SchemaType,
-  WorkspaceAction,
-  WorkspaceState,
 } from '@datahub/types.ts'
 import { PolicyCheckErrors } from '@datahub/designer/validation.errors.ts'
 import { enumFromStringValue } from '@/utils/types.utils.ts'
@@ -125,10 +123,8 @@ export function loadSchema(
   targetHandle: string | null,
   positionDeltaX: number,
   schemaRef: SchemaReference,
-  schemas: Schema[],
-  store: WorkspaceState & WorkspaceAction
+  schemas: Schema[]
 ) {
-  const { onNodesChange, onConnect } = store
   const schema = schemas.find((schema) => schema.id === schemaRef.schemaId)
   if (!schema)
     throw new Error(i18n.t('datahub:error.loading.connection.notFound', { source: DataHubNodeType.SCHEMA }) as string)
@@ -150,14 +146,19 @@ export function loadSchema(
         internalVersions: schema.version ? [schema.version] : undefined,
       },
     }
-    onNodesChange([{ item: schemaNode, type: 'add' } as NodeAddChange])
-    onConnect({
-      source: schemaNode.id,
-      target: parentNode.id,
-      sourceHandle: null,
-      targetHandle: targetHandle,
-    })
-  } else if (schema.type === SchemaType.PROTOBUF) {
+
+    return [
+      { item: schemaNode, type: 'add' } as NodeAddChange,
+      {
+        source: schemaNode.id,
+        target: parentNode.id,
+        sourceHandle: null,
+        targetHandle: targetHandle,
+      } as Connection,
+    ]
+  }
+
+  if (schema.type === SchemaType.PROTOBUF) {
     const encodedGraphBytes = new Uint8Array(protobufUtils.base64.length(schema.schemaDefinition))
     protobufUtils.base64.decode(schema.schemaDefinition, encodedGraphBytes, 0)
     const decodedMessage = descriptor.FileDescriptorSet.decode(encodedGraphBytes)
@@ -178,12 +179,17 @@ export function loadSchema(
         version: 1,
       },
     }
-    onNodesChange([{ item: schemaNode, type: 'add' } as NodeAddChange])
-    onConnect({
-      source: schemaNode.id,
-      target: parentNode.id,
-      sourceHandle: null,
-      targetHandle: targetHandle,
-    })
-  } else throw new Error(i18n.t('datahub:error.loading.schema.unknown', { type: schema.type }) as string)
+
+    return [
+      { item: schemaNode, type: 'add' } as NodeAddChange,
+      {
+        source: schemaNode.id,
+        target: parentNode.id,
+        sourceHandle: null,
+        targetHandle: targetHandle,
+      } as Connection,
+    ]
+  }
+
+  throw new Error(i18n.t('datahub:error.loading.schema.unknown', { type: schema.type }) as string)
 }

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/script/FunctionNode.utils.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/script/FunctionNode.utils.ts
@@ -1,17 +1,9 @@
-import { Node, NodeAddChange, XYPosition } from 'reactflow'
+import { Connection, Node, NodeAddChange, XYPosition } from 'reactflow'
 
 import { PolicyOperation, Script } from '@/api/__generated__'
 import i18n from '@/config/i18n.config.ts'
 
-import {
-  DataHubNodeData,
-  DataHubNodeType,
-  DryRunResults,
-  FunctionData,
-  OperationData,
-  WorkspaceAction,
-  WorkspaceState,
-} from '@datahub/types.ts'
+import { DataHubNodeData, DataHubNodeType, DryRunResults, FunctionData, OperationData } from '@datahub/types.ts'
 import { PolicyCheckErrors } from '@datahub/designer/validation.errors.ts'
 import { CANVAS_POSITION } from '@datahub/designer/checks.utils.ts'
 import {
@@ -48,14 +40,7 @@ export function checkValidityJSScript(scriptNode: Node<FunctionData>): DryRunRes
   return { data: script, node: scriptNode }
 }
 
-export const loadScripts = (
-  parentNode: Node<DataHubNodeData>,
-  functions: PolicyOperation[],
-  scripts: Script[],
-  store: WorkspaceState & WorkspaceAction
-) => {
-  const { onAddNodes, onConnect } = store
-
+export const loadScripts = (parentNode: Node<DataHubNodeData>, functions: PolicyOperation[], scripts: Script[]) => {
   const delta = ((Math.max(functions.length || 0, 1) - 1) * CANVAS_POSITION.Function.x) / 2
   const position: XYPosition = {
     x: parentNode.position.x - CANVAS_POSITION.Function.x - delta,
@@ -67,6 +52,7 @@ export const loadScripts = (
     return position
   }
 
+  const newNodes: (NodeAddChange | Connection)[] = []
   for (const fct of functions) {
     const [, functionName] = fct.functionId.split(':')
     const functionScript = scripts.find((script) => script.id === functionName)
@@ -86,12 +72,16 @@ export const loadScripts = (
         sourceCode: atob(functionScript.source),
       },
     }
-    onAddNodes([{ item: functionScriptNode, type: 'add' } as NodeAddChange])
-    onConnect({
-      source: functionScriptNode.id,
-      target: parentNode.id,
-      sourceHandle: null,
-      targetHandle: OperationData.Handle.FUNCTION,
-    })
+
+    newNodes.push(
+      { item: functionScriptNode, type: 'add' } as NodeAddChange,
+      {
+        source: functionScriptNode.id,
+        target: parentNode.id,
+        sourceHandle: null,
+        targetHandle: OperationData.Handle.FUNCTION,
+      } as Connection
+    )
   }
+  return newNodes
 }

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/script/FunctionNode.utils.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/script/FunctionNode.utils.ts
@@ -74,13 +74,13 @@ export const loadScripts = (parentNode: Node<DataHubNodeData>, functions: Policy
     }
 
     newNodes.push(
-      { item: functionScriptNode, type: 'add' } as NodeAddChange,
+      { item: functionScriptNode, type: 'add' },
       {
         source: functionScriptNode.id,
         target: parentNode.id,
         sourceHandle: null,
         targetHandle: OperationData.Handle.FUNCTION,
-      } as Connection
+      }
     )
   }
   return newNodes

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/topic_filter/TopicFilterNode.utils.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/topic_filter/TopicFilterNode.utils.ts
@@ -1,23 +1,21 @@
-import { Node, NodeAddChange, XYPosition } from 'reactflow'
+import { Connection, Node, NodeAddChange, XYPosition } from 'reactflow'
 
 import { DataPolicy } from '@/api/__generated__'
 import i18n from '@/config/i18n.config.ts'
 
 import { getNodeId } from '@datahub/utils/node.utils.ts'
-import { DataHubNodeType, TopicFilterData, WorkspaceAction, WorkspaceState } from '@datahub/types.ts'
+import { DataHubNodeType, DataPolicyData, TopicFilterData } from '@datahub/types.ts'
 import { CANVAS_POSITION } from '@datahub/designer/checks.utils.ts'
 
-export const loadTopicFilter = (policy: DataPolicy, store: WorkspaceState & WorkspaceAction) => {
-  const { onNodesChange, onConnect } = store
-  const dataNode = store.nodes.find((node) => node.id === policy.id)
-  if (!dataNode)
+export const loadTopicFilter = (policy: DataPolicy, dataPolicyNode: Node<DataPolicyData>) => {
+  if (dataPolicyNode.id !== policy.id)
     throw new Error(
       i18n.t('datahub:error.loading.connection.notFound', { type: DataHubNodeType.DATA_POLICY }) as string
     )
 
   const position: XYPosition = {
-    x: dataNode.position.x + CANVAS_POSITION.Topic.x,
-    y: dataNode.position.y + CANVAS_POSITION.Topic.y,
+    x: dataPolicyNode.position.x + CANVAS_POSITION.Topic.x,
+    y: dataPolicyNode.position.y + CANVAS_POSITION.Topic.y,
   }
 
   const topicNode: Node<TopicFilterData> = {
@@ -31,6 +29,8 @@ export const loadTopicFilter = (policy: DataPolicy, store: WorkspaceState & Work
     },
   }
 
-  onNodesChange([{ item: topicNode, type: 'add' } as NodeAddChange])
-  onConnect({ source: topicNode.id, target: dataNode.id, sourceHandle: null, targetHandle: null })
+  return [
+    { item: topicNode, type: 'add' } as NodeAddChange,
+    { source: topicNode.id, target: dataPolicyNode.id, sourceHandle: null, targetHandle: null } as Connection,
+  ]
 }

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/topic_filter/TopicFilterNode.utils.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/topic_filter/TopicFilterNode.utils.ts
@@ -7,7 +7,10 @@ import { getNodeId } from '@datahub/utils/node.utils.ts'
 import { DataHubNodeType, DataPolicyData, TopicFilterData } from '@datahub/types.ts'
 import { CANVAS_POSITION } from '@datahub/designer/checks.utils.ts'
 
-export const loadTopicFilter = (policy: DataPolicy, dataPolicyNode: Node<DataPolicyData>) => {
+export const loadTopicFilter = (
+  policy: DataPolicy,
+  dataPolicyNode: Node<DataPolicyData>
+): (NodeAddChange | Connection)[] => {
   if (dataPolicyNode.id !== policy.id)
     throw new Error(
       i18n.t('datahub:error.loading.connection.notFound', { type: DataHubNodeType.DATA_POLICY }) as string
@@ -30,7 +33,7 @@ export const loadTopicFilter = (policy: DataPolicy, dataPolicyNode: Node<DataPol
   }
 
   return [
-    { item: topicNode, type: 'add' } as NodeAddChange,
-    { source: topicNode.id, target: dataPolicyNode.id, sourceHandle: null, targetHandle: null } as Connection,
+    { item: topicNode, type: 'add' },
+    { source: topicNode.id, target: dataPolicyNode.id, sourceHandle: null, targetHandle: null },
   ]
 }

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/transition/TransitionNode.utils.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/transition/TransitionNode.utils.ts
@@ -145,7 +145,7 @@ export const loadTransitions = (
       position: { ...shiftBottom() },
       data: extractEventStates(model, behaviorPolicyTransition),
     }
-    const pipelines = loadBehaviorPolicyPipelines(behaviorPolicy, transitionNode, schemas, scripts)
+    const pipelines = loadBehaviorPolicyPipelines(behaviorPolicyTransition, transitionNode, schemas, scripts)
 
     newNodes.push(
       { item: transitionNode, type: 'add' } as NodeAddChange,

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/transition/TransitionNode.utils.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/transition/TransitionNode.utils.ts
@@ -148,13 +148,13 @@ export const loadTransitions = (
     const pipelines = loadBehaviorPolicyPipelines(behaviorPolicyTransition, transitionNode, schemas, scripts)
 
     newNodes.push(
-      { item: transitionNode, type: 'add' } as NodeAddChange,
+      { item: transitionNode, type: 'add' },
       {
         source: behaviorPolicy.id,
         target: transitionNode.id,
         sourceHandle: null,
         targetHandle: null,
-      } as Connection,
+      },
       ...pipelines
     )
   }

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/validator/ValidatorNode.utils.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/validator/ValidatorNode.utils.ts
@@ -91,13 +91,13 @@ export const loadValidators = (policy: DataPolicy, schemas: Schema[], dataPolicy
       },
     }
 
-    newNodes.push({ item: validatorNode, type: 'add' } as NodeAddChange)
+    newNodes.push({ item: validatorNode, type: 'add' })
     newNodes.push({
       source: validatorNode.id,
       target: dataPolicyNode.id,
       sourceHandle: null,
       targetHandle: DataPolicyData.Handle.VALIDATION,
-    } as Connection)
+    })
 
     for (const schemaRef of validatorArguments.schemas) {
       const schemaNodes = loadSchema(validatorNode, null, 0, schemaRef, schemas)

--- a/hivemq-edge/src/frontend/src/extensions/datahub/hooks/useDataHubDraftStore.spec.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/hooks/useDataHubDraftStore.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'vitest'
 import { act, renderHook } from '@testing-library/react'
-import { NodeAddChange, EdgeAddChange, Node, Edge, NodeProps } from 'reactflow'
+import { EdgeAddChange, Node, Edge, NodeProps } from 'reactflow'
 
 import { DataHubNodeType, DataPolicyData, FunctionSpecs, WorkspaceAction, WorkspaceState } from '../types.ts'
 import useDataHubDraftStore from '@/extensions/datahub/hooks/useDataHubDraftStore.ts'
@@ -36,8 +36,8 @@ describe('useDataHubDraftStore', () => {
 
     act(() => {
       const { onNodesChange } = result.current
-      const item: Partial<Node> = { ...MOCK_NODE, position: { x: 0, y: 0 } }
-      onNodesChange([{ item, type: 'add' } as NodeAddChange])
+      const item: Node = { ...MOCK_NODE, position: { x: 0, y: 0 } }
+      onNodesChange([{ item, type: 'add' }])
     })
 
     expect(result.current.nodes).toHaveLength(1)
@@ -66,9 +66,12 @@ describe('useDataHubDraftStore', () => {
 
     act(() => {
       const { onNodesChange } = result.current
-      const item1: Partial<Node> = { ...MOCK_NODE, id: '1', position: { x: 0, y: 0 } }
-      const item2: Partial<Node> = { ...MOCK_NODE, id: '2', position: { x: 0, y: 0 } }
-      onNodesChange([{ item: item1, type: 'add' } as NodeAddChange, { item: item2, type: 'add' } as NodeAddChange])
+      const item1: Node = { ...MOCK_NODE, id: '1', position: { x: 0, y: 0 } }
+      const item2: Node = { ...MOCK_NODE, id: '2', position: { x: 0, y: 0 } }
+      onNodesChange([
+        { item: item1, type: 'add' },
+        { item: item2, type: 'add' },
+      ])
     })
 
     expect(result.current.nodes).toHaveLength(2)
@@ -90,8 +93,8 @@ describe('useDataHubDraftStore', () => {
 
     act(() => {
       const { onAddNodes } = result.current
-      const item1: Partial<Node> = { ...MOCK_NODE, position: { x: 0, y: 0 } }
-      onAddNodes([{ item: item1, type: 'add' } as NodeAddChange])
+      const item1: Node = { ...MOCK_NODE, position: { x: 0, y: 0 } }
+      onAddNodes([{ item: item1, type: 'add' }])
     })
 
     expect(result.current.nodes).toHaveLength(1)
@@ -99,8 +102,8 @@ describe('useDataHubDraftStore', () => {
 
     act(() => {
       const { onAddNodes } = result.current
-      const item1: Partial<Node> = { ...MOCK_NODE, position: { x: 0, y: 0 } }
-      onAddNodes([{ item: item1, type: 'add' } as NodeAddChange])
+      const item1: Node = { ...MOCK_NODE, position: { x: 0, y: 0 } }
+      onAddNodes([{ item: item1, type: 'add' }])
     })
 
     expect(result.current.nodes).toHaveLength(1)
@@ -108,8 +111,8 @@ describe('useDataHubDraftStore', () => {
 
     act(() => {
       const { onAddNodes } = result.current
-      const item1: Partial<Node> = { ...MOCK_NODE, id: '2', position: { x: 0, y: 0 } }
-      onAddNodes([{ item: item1, type: 'add' } as NodeAddChange])
+      const item1: Node = { ...MOCK_NODE, id: '2', position: { x: 0, y: 0 } }
+      onAddNodes([{ item: item1, type: 'add' }])
     })
 
     expect(result.current.nodes).toHaveLength(2)
@@ -156,8 +159,8 @@ describe('useDataHubDraftStore', () => {
 
     act(() => {
       const { onAddNodes } = result.current
-      const item1: Partial<Node> = { ...MOCK_NODE, position: { x: 0, y: 0 } }
-      onAddNodes([{ item: item1, type: 'add' } as NodeAddChange])
+      const item1: Node = { ...MOCK_NODE, position: { x: 0, y: 0 } }
+      onAddNodes([{ item: item1, type: 'add' }])
     })
 
     expect(result.current.nodes).toHaveLength(1)

--- a/hivemq-edge/src/frontend/src/locales/en/translation.json
+++ b/hivemq-edge/src/frontend/src/locales/en/translation.json
@@ -261,7 +261,7 @@
         "helper": "The unique name of this bridge",
         "error": {
           "required": "The name of the bridge is required",
-          "pattern": "Should only contain alpha-numeric characters with spaces and hyphens",
+          "pattern": "Should only contain alphanumeric characters with spaces and hyphens",
           "notUnique": "The name is already in use for another bridge"
         }
       },
@@ -304,7 +304,7 @@
       },
       "protocols": {
         "label": "TLS Protocols",
-        "helper": "Select the protocols. Leave emtpy to use the default protocols."
+        "helper": "Select the protocols. Leave empty to use the default protocols."
       },
       "keystorePath": {
         "label": "Key Store Path",
@@ -704,7 +704,7 @@
   },
   "modals": {
     "generics": {
-      "confirmation": "Are you sure? You can't undo this action afterwards."
+      "confirmation": "Are you sure? You can't undo this action afterward."
     },
     "StepperCancelDialog": {
       "header": "Delete Bridge"

--- a/hivemq-edge/src/frontend/src/modules/Workspace/hooks/useWorkspaceStore.spec.ts
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/hooks/useWorkspaceStore.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'vitest'
 import { act, renderHook } from '@testing-library/react'
-import { NodeAddChange, EdgeAddChange, Node, Edge, Rect } from 'reactflow'
+import { EdgeAddChange, Node, Edge, Rect } from 'reactflow'
 
 import { Group, IdStubs, NodeTypes, WorkspaceAction, WorkspaceState } from '../types.ts'
 import useWorkspaceStore from './useWorkspaceStore.ts'
@@ -29,8 +29,8 @@ describe('useWorkspaceStore', () => {
 
     act(() => {
       const { onNodesChange } = result.current
-      const item: Partial<Node> = { ...MOCK_NODE_ADAPTER, position: { x: 0, y: 0 } }
-      onNodesChange([{ item, type: 'add' } as NodeAddChange])
+      const item: Node = { ...MOCK_NODE_ADAPTER, position: { x: 0, y: 0 } }
+      onNodesChange([{ item, type: 'add' }])
     })
 
     expect(result.current.nodes).toHaveLength(1)
@@ -59,18 +59,18 @@ describe('useWorkspaceStore', () => {
 
     act(() => {
       const { onNodesChange, onEdgesChange } = result.current
-      const nodeEdge: Partial<Node> = { ...MOCK_NODE_EDGE, id: IdStubs.EDGE_NODE, position: { x: 0, y: 0 } }
-      const item1: Partial<Node> = { ...MOCK_NODE_ADAPTER, position: { x: 0, y: 0 } }
-      const item2: Partial<Node> = { ...MOCK_NODE_BRIDGE, position: { x: 0, y: 0 } }
+      const nodeEdge: Node = { ...MOCK_NODE_EDGE, id: IdStubs.EDGE_NODE, position: { x: 0, y: 0 } }
+      const item1: Node = { ...MOCK_NODE_ADAPTER, position: { x: 0, y: 0 } }
+      const item2: Node = { ...MOCK_NODE_BRIDGE, position: { x: 0, y: 0 } }
 
-      const item: Partial<Edge> = { id: '1-2', source: 'idAdapter', target: IdStubs.EDGE_NODE }
+      const item: Edge = { id: '1-2', source: 'idAdapter', target: IdStubs.EDGE_NODE }
 
       onNodesChange([
-        { item: nodeEdge, type: 'add' } as NodeAddChange,
-        { item: item1, type: 'add' } as NodeAddChange,
-        { item: item2, type: 'add' } as NodeAddChange,
+        { item: nodeEdge, type: 'add' },
+        { item: item1, type: 'add' },
+        { item: item2, type: 'add' },
       ])
-      onEdgesChange([{ item, type: 'add' } as EdgeAddChange])
+      onEdgesChange([{ item, type: 'add' }])
     })
     expect(result.current.nodes).toHaveLength(3)
     expect(result.current.edges).toHaveLength(1)


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/20321/details/

The PR refactors how the policy payload is transformed into a designer graph. 

The previous process was creating the graph elements (nodes and edges) from the payload and inserting them iteratively into the Design store. This created a re-render race condition, with parent nodes not yet inserted into the graph when their connecting edges were added. The error message at the first loading was the visual result of the faulty operation. 

The new process iteratively creates ALL the graph elements BEFORE inserting them in two distinct operations: nodes first then edges. 

The PR also fixes a bug with the behaviour policy, in which pipelines were connected to every transition created, regardless of the real dependency. 

### Before 
![screenshot-localhost_3000-2024 04 23-13_03_01](https://github.com/hivemq/hivemq-edge/assets/2743481/69a828bf-5073-46c0-94fc-fd279b145ba3)

![screenshot-localhost_3000-2024 04 23-13_03_27](https://github.com/hivemq/hivemq-edge/assets/2743481/5491bc5c-e32d-4638-9f70-430cee75f20f)



### After 
 
![screenshot-localhost_3000-2024 04 23-13_02_26](https://github.com/hivemq/hivemq-edge/assets/2743481/caf5e780-b105-4cf1-b5e1-86e6d9ce27e9)
