### PR TITLE
feat(21481): Add node duplication and copy-and-paste support

### DIFF
--- a/hivemq-edge/src/frontend/package.json
+++ b/hivemq-edge/src/frontend/package.json
@@ -75,6 +75,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.43.9",
+    "react-hotkeys-hook": "^4.5.0",
     "react-i18next": "^12.3.0",
     "react-icons": "^5.0.1",
     "react-router-dom": "^6.11.2",

--- a/hivemq-edge/src/frontend/pnpm-lock.yaml
+++ b/hivemq-edge/src/frontend/pnpm-lock.yaml
@@ -1,9 +1,5 @@
 lockfileVersion: '6.0'
 
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false
-
 dependencies:
   '@chakra-ui/anatomy':
     specifier: ^2.1.1
@@ -152,6 +148,9 @@ dependencies:
   react-hook-form:
     specifier: ^7.43.9
     version: 7.43.9(react@18.2.0)
+  react-hotkeys-hook:
+    specifier: ^4.5.0
+    version: 4.5.0(react-dom@18.2.0)(react@18.2.0)
   react-i18next:
     specifier: ^12.3.0
     version: 12.3.1(i18next@22.4.15)(react-dom@18.2.0)(react@18.2.0)
@@ -8916,6 +8915,16 @@ packages:
       react: 18.2.0
     dev: false
 
+  /react-hotkeys-hook@4.5.0(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-Samb85GSgAWFQNvVt3PS90LPPGSf9mkH/r4au81ZP1yOIFayLC3QAvqTgGtJ8YEDMXtPmaVBs6NgipHO6h4Mug==}
+    peerDependencies:
+      react: '>=16.8.1'
+      react-dom: '>=16.8.1'
+    dependencies:
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
+
   /react-i18next@12.3.1(i18next@22.4.15)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-5v8E2XjZDFzK7K87eSwC7AJcAkcLt5xYZ4+yTPDAW1i7C93oOY1dnr4BaQM7un4Hm+GmghuiPvevWwlca5PwDA==}
     peerDependencies:
@@ -10619,3 +10628,7 @@ packages:
       react: 18.2.0
       use-sync-external-store: 1.2.0(react@18.2.0)
     dev: false
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false

--- a/hivemq-edge/src/frontend/src/components/Chakra/ShortcutRenderer.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/components/Chakra/ShortcutRenderer.spec.cy.tsx
@@ -20,7 +20,7 @@ describe('ShortcutRenderer', () => {
   it('should render multiple shortcuts', () => {
     cy.mountWithProviders(<ShortcutRenderer hotkeys="CTRL+C,Meta+V,ESC" description="This is a description" />)
 
-    cy.get('[role="term"]').should('contain.text', 'CTRL + C , Meta + V , ESC')
+    cy.get('[role="term"]').should('contain.text', 'CTRL + C , Command + V , ESC')
     cy.get('kbd').should('have.length', 5)
   })
 

--- a/hivemq-edge/src/frontend/src/components/Chakra/ShortcutRenderer.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/components/Chakra/ShortcutRenderer.spec.cy.tsx
@@ -1,0 +1,33 @@
+/// <reference types="cypress" />
+
+import ShortcutRenderer from '@/components/Chakra/ShortcutRenderer.tsx'
+
+describe('ShortcutRenderer', () => {
+  beforeEach(() => {
+    cy.viewport(400, 150)
+  })
+
+  it('should render a term and its definition', () => {
+    cy.mountWithProviders(<ShortcutRenderer hotkeys="CTRL+C" description="This is a description" />)
+
+    cy.get('[role="term"]').should('contain.text', 'CTRL + C')
+    cy.get('kbd').should('have.length', 2)
+    cy.get('kbd').eq(0).should('contain.text', 'CTRL')
+    cy.get('kbd').eq(1).should('contain.text', 'C')
+    cy.get('[role="definition"]').should('contain.text', 'This is a description')
+  })
+
+  it('should render multiple shortcuts', () => {
+    cy.mountWithProviders(<ShortcutRenderer hotkeys="CTRL+C,Meta+V,ESC" description="This is a description" />)
+
+    cy.get('[role="term"]').should('contain.text', 'CTRL + C , Meta + V , ESC')
+    cy.get('kbd').should('have.length', 5)
+  })
+
+  it('should be accessible', () => {
+    cy.injectAxe()
+    cy.mountWithProviders(<ShortcutRenderer hotkeys="CTRL+C" description="This is a description" />)
+    cy.checkAccessibility()
+    cy.percySnapshot('Component: ShortcutRenderer')
+  })
+})

--- a/hivemq-edge/src/frontend/src/components/Chakra/ShortcutRenderer.tsx
+++ b/hivemq-edge/src/frontend/src/components/Chakra/ShortcutRenderer.tsx
@@ -10,20 +10,37 @@ const ShortcutRenderer: FC<ShortcutRendererProps> = ({ hotkeys, description }) =
   const listHotkeys = hotkeys.split(',')
   const shortcuts = listHotkeys.map((e) => e.split('+'))
 
+  const localiseKeyboard = (shortcut: string[]) => {
+    const [modifier, ...rest] = shortcut
+
+    if (modifier === 'Meta') {
+      const os = window.navigator.platform
+      if (os.startsWith('Mac')) {
+        return ['Command', ...rest]
+      } else {
+        return ['Ctrl', ...rest]
+      }
+    }
+    return shortcut
+  }
+
   return (
     <>
       <span role="term" aria-label={hotkeys}>
-        {shortcuts.map((shortcut, indexShortcut) => (
-          <Fragment key={`${shortcut}-${indexShortcut}`}>
-            {indexShortcut !== 0 && ' , '}
-            {shortcut.map((element, indexElement) => (
-              <chakra.span key={`$${shortcut}-${indexShortcut}-${indexElement}`} aria-hidden="true">
-                {indexElement !== 0 && ' + '}
-                <Kbd>{element}</Kbd>
-              </chakra.span>
-            ))}
-          </Fragment>
-        ))}
+        {shortcuts.map((shortcut, indexShortcut) => {
+          const localisedShortcut = localiseKeyboard(shortcut)
+          return (
+            <Fragment key={`${shortcut}-${indexShortcut}`}>
+              {indexShortcut !== 0 && ' , '}
+              {localisedShortcut.map((element, indexElement) => (
+                <chakra.span key={`$${shortcut}-${indexShortcut}-${indexElement}`} aria-hidden="true">
+                  {indexElement !== 0 && ' + '}
+                  <Kbd>{element}</Kbd>
+                </chakra.span>
+              ))}
+            </Fragment>
+          )
+        })}
       </span>
       {description && (
         <>

--- a/hivemq-edge/src/frontend/src/components/Chakra/ShortcutRenderer.tsx
+++ b/hivemq-edge/src/frontend/src/components/Chakra/ShortcutRenderer.tsx
@@ -1,0 +1,40 @@
+import { FC, Fragment } from 'react'
+import { chakra, Kbd, Text } from '@chakra-ui/react'
+
+interface ShortcutRendererProps {
+  hotkeys: string
+  description?: string
+}
+
+const ShortcutRenderer: FC<ShortcutRendererProps> = ({ hotkeys, description }) => {
+  const listHotkeys = hotkeys.split(',')
+  const shortcuts = listHotkeys.map((e) => e.split('+'))
+
+  return (
+    <>
+      <span role="term" aria-label={hotkeys}>
+        {shortcuts.map((shortcut, indexShortcut) => (
+          <Fragment key={`${shortcut}-${indexShortcut}`}>
+            {indexShortcut !== 0 && ' , '}
+            {shortcut.map((element, indexElement) => (
+              <chakra.span key={`$${shortcut}-${indexShortcut}-${indexElement}`} aria-hidden="true">
+                {indexElement !== 0 && ' + '}
+                <Kbd>{element}</Kbd>
+              </chakra.span>
+            ))}
+          </Fragment>
+        ))}
+      </span>
+      {description && (
+        <>
+          <Text ml={4} as={chakra.span} role="definition">
+            {' '}
+            {description}
+          </Text>
+        </>
+      )}
+    </>
+  )
+}
+
+export default ShortcutRenderer

--- a/hivemq-edge/src/frontend/src/extensions/datahub/__test-utils__/MockStoreWrapper.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/__test-utils__/MockStoreWrapper.tsx
@@ -16,7 +16,11 @@ interface MockStoreWrapperProps {
 }
 
 export const MockStoreWrapper: FC<MockStoreWrapperProps> = ({ config, children }) => {
-  const { onAddNodes, onAddEdges } = useDataHubDraftStore()
+  const { onAddNodes, onAddEdges, reset } = useDataHubDraftStore()
+
+  useEffect(() => {
+    reset()
+  }, [reset])
 
   useEffect(() => {
     const { initialState } = config

--- a/hivemq-edge/src/frontend/src/extensions/datahub/__test-utils__/MockStoreWrapper.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/__test-utils__/MockStoreWrapper.tsx
@@ -46,7 +46,11 @@ interface MockChecksStoreWrapperProps {
 
 export const MockChecksStoreWrapper: FC<MockChecksStoreWrapperProps> = ({ config, children }) => {
   const { setNode, setReport } = usePolicyChecksStore()
-  const { onAddNodes } = useDataHubDraftStore()
+  const { onAddNodes, reset } = useDataHubDraftStore()
+
+  useEffect(() => {
+    reset()
+  }, [reset])
 
   useEffect(() => {
     const { node, report } = config

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/CanvasControls.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/CanvasControls.spec.cy.tsx
@@ -14,10 +14,12 @@ describe('CanvasControls', () => {
         <CanvasControls />
       </ReactFlowProvider>
     )
-    cy.get("[role='group']").find('button').should('have.length', 4)
-    cy.get("[role='group']").find('button').eq(0).should('have.attr', 'aria-label', 'Zoom in')
-    cy.get("[role='group']").find('button').eq(1).should('have.attr', 'aria-label', 'Zoom out')
-    cy.get("[role='group']").find('button').eq(2).should('have.attr', 'aria-label', 'Fit to the canvas')
-    cy.get("[role='group']").find('button').eq(3).should('have.attr', 'aria-label', 'Lock the canvas')
+    cy.get("[role='group']").find('button').as('toolbox')
+    cy.get('@toolbox').should('have.length', 5)
+    cy.get('@toolbox').eq(0).should('have.attr', 'aria-label', 'Zoom in')
+    cy.get('@toolbox').eq(1).should('have.attr', 'aria-label', 'Zoom out')
+    cy.get('@toolbox').eq(2).should('have.attr', 'aria-label', 'Fit to the canvas')
+    cy.get('@toolbox').eq(3).should('have.attr', 'aria-label', 'Lock the canvas')
+    cy.get('@toolbox').eq(4).should('have.attr', 'aria-label', 'Help using the Designer')
   })
 })

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/CanvasControls.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/CanvasControls.tsx
@@ -1,12 +1,12 @@
 import { FC } from 'react'
 import { ControlProps, Panel, ReactFlowState, useReactFlow, useStore, useStoreApi } from 'reactflow'
-
+import { useTranslation } from 'react-i18next'
 import { ButtonGroup } from '@chakra-ui/react'
 import { FaLock, FaLockOpen, FaMinus, FaPlus } from 'react-icons/fa6'
 import { LuBoxSelect } from 'react-icons/lu'
-import { useTranslation } from 'react-i18next'
 
 import IconButton from '@/components/Chakra/IconButton.tsx'
+import DesignerCheatSheet from '@datahub/components/controls/DesignerCheatSheet.tsx'
 
 import 'reactflow/dist/style.css'
 
@@ -47,6 +47,7 @@ const CanvasControls: FC<ControlProps> = ({ onInteractiveChange }) => {
           onClick={onToggleInteractivity}
           aria-label={t('workspace.controls.toggleInteractivity') as string}
         />
+        <DesignerCheatSheet />
       </ButtonGroup>
     </Panel>
   )

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/CopyPasteListener.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/CopyPasteListener.spec.cy.tsx
@@ -1,0 +1,43 @@
+/// <reference types="cypress" />
+
+import { Node } from 'reactflow'
+import { CopyPasteListener } from '@datahub/components/controls/CopyPasteListener.tsx'
+import { Text } from '@chakra-ui/react'
+import { DataHubNodeType, DataPolicyData } from '@datahub/types.ts'
+import { MOCK_DEFAULT_NODE } from '@/__test-utils__/react-flow/nodes.ts'
+import { MockChecksStoreWrapper } from '@datahub/__test-utils__/MockStoreWrapper.tsx'
+
+const MOCK_NODE_DATA_POLICY: Node<DataPolicyData> = {
+  id: 'node-id',
+  type: DataHubNodeType.DATA_POLICY,
+  data: {},
+  ...MOCK_DEFAULT_NODE,
+  position: { x: 0, y: 0 },
+  selected: true,
+}
+
+const wrapper: React.JSXElementConstructor<{ children: React.ReactNode }> = ({ children }) => (
+  <MockChecksStoreWrapper
+    config={{
+      node: MOCK_NODE_DATA_POLICY,
+    }}
+  >
+    {children}
+  </MockChecksStoreWrapper>
+)
+
+describe('CopyPasteListener', () => {
+  beforeEach(() => {
+    cy.viewport(800, 250)
+  })
+
+  it('should renders properly', () => {
+    cy.mountWithProviders(<CopyPasteListener render={(n) => <Text data-testid="ss">fdfddf : {n.length}</Text>} />, {
+      wrapper,
+    })
+
+    // cy.getByTestId('ss').click()
+    cy.get('body').type('{meta}C')
+    cy.get('body').type('{meta}V')
+  })
+})

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/CopyPasteListener.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/CopyPasteListener.spec.cy.tsx
@@ -1,43 +1,131 @@
 /// <reference types="cypress" />
 
-import { Node } from 'reactflow'
-import { CopyPasteListener } from '@datahub/components/controls/CopyPasteListener.tsx'
+import { Edge, Node } from 'reactflow'
 import { Text } from '@chakra-ui/react'
-import { DataHubNodeType, DataPolicyData } from '@datahub/types.ts'
-import { MOCK_DEFAULT_NODE } from '@/__test-utils__/react-flow/nodes.ts'
-import { MockChecksStoreWrapper } from '@datahub/__test-utils__/MockStoreWrapper.tsx'
+import { DataHubNodeType } from '@datahub/types.ts'
+import { MockStoreWrapper } from '@datahub/__test-utils__/MockStoreWrapper.tsx'
+import { getNodePayload } from '@datahub/utils/node.utils.ts'
+import useDataHubDraftStore from '@datahub/hooks/useDataHubDraftStore.ts'
 
-const MOCK_NODE_DATA_POLICY: Node<DataPolicyData> = {
-  id: 'node-id',
-  type: DataHubNodeType.DATA_POLICY,
-  data: {},
-  ...MOCK_DEFAULT_NODE,
-  position: { x: 0, y: 0 },
-  selected: true,
+import { CopyPasteListener } from '@datahub/components/controls/CopyPasteListener.tsx'
+
+const getWrapperWith = (initNodes: Node[], initEdges?: Edge[]) => {
+  const Wrapper: React.JSXElementConstructor<{ children: React.ReactNode }> = ({ children }) => {
+    const { nodes, edges } = useDataHubDraftStore()
+    return (
+      <MockStoreWrapper
+        config={{
+          initialState: {
+            nodes: initNodes,
+            edges: initEdges,
+          },
+        }}
+      >
+        {children}
+        <Text data-testid="nodes">{nodes.length}</Text>
+        <Text data-testid="edges">{edges.length}</Text>
+      </MockStoreWrapper>
+    )
+  }
+
+  return Wrapper
 }
-
-const wrapper: React.JSXElementConstructor<{ children: React.ReactNode }> = ({ children }) => (
-  <MockChecksStoreWrapper
-    config={{
-      node: MOCK_NODE_DATA_POLICY,
-    }}
-  >
-    {children}
-  </MockChecksStoreWrapper>
-)
 
 describe('CopyPasteListener', () => {
   beforeEach(() => {
     cy.viewport(800, 250)
   })
 
-  it('should renders properly', () => {
-    cy.mountWithProviders(<CopyPasteListener render={(n) => <Text data-testid="ss">fdfddf : {n.length}</Text>} />, {
-      wrapper,
+  it('should not copy if no node selected', () => {
+    cy.mountWithProviders(<CopyPasteListener render={(n) => <Text data-testid="copied">{n.length}</Text>} />, {
+      wrapper: getWrapperWith(
+        [
+          {
+            id: '3',
+            type: DataHubNodeType.FUNCTION,
+            position: { x: 0, y: 0 },
+            data: getNodePayload(DataHubNodeType.FUNCTION),
+          },
+        ],
+        []
+      ),
     })
 
-    // cy.getByTestId('ss').click()
+    cy.getByTestId('copied').should('have.text', 0)
+    cy.getByTestId('nodes').should('have.text', 1)
     cy.get('body').type('{meta}C')
+    cy.getByTestId('copied').should('have.text', 0)
     cy.get('body').type('{meta}V')
+    cy.getByTestId('nodes').should('have.text', 1)
+    cy.getByTestId('copied').should('have.text', 0)
+  })
+
+  it('should copy single node', () => {
+    cy.mountWithProviders(<CopyPasteListener render={(n) => <Text data-testid="copied">{n.length}</Text>} />, {
+      wrapper: getWrapperWith(
+        [
+          {
+            id: '3',
+            type: DataHubNodeType.FUNCTION,
+            position: { x: 0, y: 0 },
+            data: getNodePayload(DataHubNodeType.FUNCTION),
+            selected: true,
+          },
+        ],
+        []
+      ),
+    })
+
+    cy.getByTestId('copied').should('have.text', 0)
+    cy.getByTestId('nodes').should('have.text', 1)
+    cy.get('body').type('{meta}C')
+    cy.getByTestId('copied').should('have.text', 1)
+    cy.get('body').type('{meta}V')
+    cy.getByTestId('nodes').should('have.text', 2)
+    cy.get('body').type('{esc}')
+    cy.getByTestId('copied').should('have.text', 0)
+  })
+
+  it('should copy subgraph', () => {
+    cy.mountWithProviders(<CopyPasteListener render={(n) => <Text data-testid="copied">{n.length}</Text>} />, {
+      wrapper: getWrapperWith(
+        [
+          {
+            id: '1',
+            position: { x: 0, y: 0 },
+            data: undefined,
+            selected: true,
+          },
+          {
+            id: '2',
+            position: { x: 0, y: 0 },
+            data: undefined,
+            selected: false,
+          },
+          {
+            id: '3',
+            position: { x: 0, y: 0 },
+            data: undefined,
+            selected: true,
+          },
+        ],
+        [
+          { id: 'e1', source: '1', target: '3' },
+          { id: 'e2', source: '1', target: '2' },
+          { id: 'e3', source: '2', target: '3' },
+        ]
+      ),
+    })
+
+    cy.getByTestId('copied').should('have.text', 0)
+    cy.getByTestId('nodes').should('have.text', 3)
+    cy.getByTestId('edges').should('have.text', 3)
+    cy.get('body').type('{meta}C')
+    cy.getByTestId('copied').should('have.text', 2)
+    cy.get('body').type('{meta}V')
+    cy.getByTestId('nodes').should('have.text', 5)
+    cy.getByTestId('edges').should('have.text', 4)
+    cy.get('body').type('{esc}')
+    cy.getByTestId('copied').should('have.text', 0)
   })
 })

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/CopyPasteListener.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/CopyPasteListener.tsx
@@ -5,6 +5,7 @@ import { useHotkeys } from 'react-hotkeys-hook'
 
 import useDataHubDraftStore from '@datahub/hooks/useDataHubDraftStore.ts'
 import { DATAHUB_HOTKEY } from '@datahub/utils/datahub.utils.ts'
+import { DesignerStatus } from '@datahub/types.ts'
 
 const DEFAULT_POSITION_DELTA: XYPosition = { x: 100, y: 75 }
 
@@ -13,7 +14,7 @@ interface CopyPasteListenerProps {
 }
 
 export const CopyPasteListener: FC<CopyPasteListenerProps> = ({ render }) => {
-  const { nodes, edges, onNodesChange, onEdgesChange } = useDataHubDraftStore()
+  const { status, nodes, edges, onNodesChange, onEdgesChange } = useDataHubDraftStore()
   const [copiedNodes, setCopiedNodes] = useState<Node[]>([])
   const [delta, setDelta] = useState<XYPosition>(DEFAULT_POSITION_DELTA)
 
@@ -25,14 +26,14 @@ export const CopyPasteListener: FC<CopyPasteListenerProps> = ({ render }) => {
 
   useHotkeys(DATAHUB_HOTKEY.COPY, () => {
     const selectedNodes = nodes.filter((node) => node.selected)
-    if (selectedNodes.length) {
+    if (selectedNodes.length && status !== DesignerStatus.LOADED) {
       setCopiedNodes(selectedNodes)
     } else setCopiedNodes([])
     setDelta(DEFAULT_POSITION_DELTA)
   })
 
   useHotkeys(DATAHUB_HOTKEY.PASTE, () => {
-    if (!copiedNodes.length) return
+    if (!copiedNodes.length && status !== DesignerStatus.LOADED) return
 
     const ids = copiedNodes.map((node) => node.id)
     const newIds = copiedNodes.reduce<Record<string, string>>((acc, node) => {

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/CopyPasteListener.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/CopyPasteListener.tsx
@@ -1,0 +1,69 @@
+import { FC, ReactElement, useState } from 'react'
+import { Edge, EdgeAddChange, getConnectedEdges, Node, NodeAddChange, NodeSelectionChange, XYPosition } from 'reactflow'
+import { v4 as uuidv4 } from 'uuid'
+import { useHotkeys } from 'react-hotkeys-hook'
+
+import useDataHubDraftStore from '@datahub/hooks/useDataHubDraftStore.ts'
+import { DATAHUB_HOTKEY } from '@datahub/utils/datahub.utils.ts'
+
+const DEFAULT_POSITION_DELTA: XYPosition = { x: 100, y: 75 }
+
+interface CopyPasteListenerProps {
+  render?: (nodes: Node[]) => ReactElement
+}
+
+export const CopyPasteListener: FC<CopyPasteListenerProps> = ({ render }) => {
+  const { nodes, edges, onNodesChange, onEdgesChange } = useDataHubDraftStore()
+  const [copiedNodes, setCopiedNodes] = useState<Node[]>([])
+  const [delta, setDelta] = useState<XYPosition>(DEFAULT_POSITION_DELTA)
+
+  useHotkeys(DATAHUB_HOTKEY.ESCAPE, () => {
+    setCopiedNodes([])
+    setDelta(DEFAULT_POSITION_DELTA)
+    onNodesChange(nodes.map<NodeSelectionChange>((node) => ({ id: node.id, type: 'select', selected: false })))
+  })
+
+  useHotkeys(DATAHUB_HOTKEY.COPY, () => {
+    const selectedNodes = nodes.filter((node) => node.selected)
+    if (selectedNodes.length) {
+      setCopiedNodes(selectedNodes)
+    } else setCopiedNodes([])
+    setDelta(DEFAULT_POSITION_DELTA)
+  })
+
+  useHotkeys(DATAHUB_HOTKEY.PASTE, () => {
+    if (!copiedNodes.length) return
+
+    const ids = copiedNodes.map((node) => node.id)
+    const newIds = copiedNodes.reduce<Record<string, string>>((acc, node) => {
+      acc[node.id] = uuidv4()
+      return acc
+    }, {})
+
+    const selectedEdges = getConnectedEdges(copiedNodes, edges).filter(
+      (edge) => ids.includes(edge.source) && ids.includes(edge.target)
+    )
+
+    const duplicateNodes = copiedNodes.map<Node>((node) => ({
+      ...node,
+      id: newIds[node.id],
+      position: { x: node.position.x + delta.x, y: node.position.y + delta.y },
+      selected: true,
+    }))
+    const duplicateEdges = selectedEdges.map<Edge>((edge) => ({
+      ...edge,
+      id: uuidv4(),
+      source: newIds[edge.source],
+      target: newIds[edge.target],
+    }))
+    setDelta({ x: delta.x + DEFAULT_POSITION_DELTA.x, y: delta.y + DEFAULT_POSITION_DELTA.y })
+
+    onNodesChange([
+      ...copiedNodes.map<NodeSelectionChange>((node) => ({ id: node.id, type: 'select', selected: false })),
+      ...duplicateNodes.map<NodeAddChange>((node) => ({ item: node, type: 'add' })),
+    ])
+    onEdgesChange([...duplicateEdges.map<EdgeAddChange>((edge) => ({ item: edge, type: 'add' }))])
+  })
+
+  return render?.(copiedNodes) || null
+}

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/CopyPasteStatus.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/CopyPasteStatus.spec.cy.tsx
@@ -1,0 +1,24 @@
+/// <reference types="cypress" />
+
+import CopyPasteStatus from '@datahub/components/controls/CopyPasteStatus.tsx'
+import { ReactFlowProvider } from 'reactflow'
+
+const wrapper: React.JSXElementConstructor<{ children: React.ReactNode }> = ({ children }) => (
+  <ReactFlowProvider>{children}</ReactFlowProvider>
+)
+
+describe('CopyPasteStatus', () => {
+  beforeEach(() => {
+    cy.viewport(800, 250)
+  })
+
+  it('should renders properly when no copied content', () => {
+    cy.mountWithProviders(<CopyPasteStatus nbCopied={0} />, { wrapper })
+    cy.getByTestId('copy-paste-status').should('contain.text', '0')
+  })
+
+  it('should renders properly with copied content', () => {
+    cy.mountWithProviders(<CopyPasteStatus nbCopied={2} />, { wrapper })
+    cy.getByTestId('copy-paste-status').should('contain.text', '2')
+  })
+})

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/CopyPasteStatus.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/CopyPasteStatus.tsx
@@ -1,0 +1,21 @@
+import { FC } from 'react'
+import { Panel } from 'reactflow'
+import { Tag, TagLabel, TagLeftIcon } from '@chakra-ui/react'
+import { LuCopy, LuCopyCheck } from 'react-icons/lu'
+
+interface CopyPasteStatusProps {
+  nbCopied: number | undefined
+}
+
+const CopyPasteStatus: FC<CopyPasteStatusProps> = ({ nbCopied }) => {
+  return (
+    <Panel position="bottom-center">
+      <Tag size="lg" variant="subtle" userSelect="none" data-testid="copy-paste-status">
+        <TagLeftIcon boxSize="12px" as={nbCopied ? LuCopyCheck : LuCopy} />
+        <TagLabel>{nbCopied}</TagLabel>
+      </Tag>
+    </Panel>
+  )
+}
+
+export default CopyPasteStatus

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/DesignerCheatSheet.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/DesignerCheatSheet.spec.cy.tsx
@@ -1,0 +1,18 @@
+/// <reference types="cypress" />
+
+import DesignerCheatSheet from '@datahub/components/controls/DesignerCheatSheet.tsx'
+
+describe('DesignerCheatSheet', () => {
+  beforeEach(() => {
+    cy.viewport(800, 800)
+  })
+
+  it('should renders properly ', () => {
+    cy.mountWithProviders(<DesignerCheatSheet />)
+
+    cy.get("[role='dialog']").should('not.exist')
+    cy.getByTestId('canvas-control-help').click()
+    cy.get("[role='dialog']").should('be.visible')
+    cy.get("[role='dialog'] header").should('contain.text', 'Keyboard shortcuts')
+  })
+})

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/DesignerCheatSheet.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/DesignerCheatSheet.tsx
@@ -41,11 +41,7 @@ const DesignerCheatSheet: FC = () => {
 
   return (
     <>
-      <IconButton
-        icon={<LuBadgeHelp />}
-        onClick={onOpen}
-        aria-label={t('workspace.controls.toggleInteractivity') as string}
-      />
+      <IconButton icon={<LuBadgeHelp />} onClick={onOpen} aria-label={t('workspace.controls.shortcuts') as string} />
       <Modal isOpen={isOpen} onClose={onClose} size="2xl" isCentered motionPreset="scale" scrollBehavior="inside">
         <ModalOverlay />
         <ModalContent>

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/DesignerCheatSheet.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/DesignerCheatSheet.tsx
@@ -29,7 +29,7 @@ const DesignerCheatSheet: FC = () => {
   const { isOpen, onOpen, onClose } = useDisclosure()
 
   const groupedKeys = useMemo(() => {
-    const groups = DATAHUB_HOTKEY_CONTEXT.reduce<Record<string, HotKeyItem[]>>((acc, item) => {
+    return DATAHUB_HOTKEY_CONTEXT.reduce<Record<string, HotKeyItem[]>>((acc, item) => {
       if (!acc[item.category]) {
         acc[item.category] = []
       }
@@ -37,7 +37,6 @@ const DesignerCheatSheet: FC = () => {
       acc[item.category].push(item)
       return acc
     }, {})
-    return groups
   }, [])
 
   return (

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/DesignerCheatSheet.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/DesignerCheatSheet.tsx
@@ -1,0 +1,87 @@
+import { FC, useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+import {
+  Card,
+  CardBody,
+  CardHeader,
+  HStack,
+  List,
+  ListItem,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  Text,
+  useDisclosure,
+} from '@chakra-ui/react'
+import { LuBadgeHelp } from 'react-icons/lu'
+
+import ShortcutRenderer from '@/components/Chakra/ShortcutRenderer.tsx'
+import IconButton from '@/components/Chakra/IconButton.tsx'
+import { DATAHUB_HOTKEY_CONTEXT } from '@datahub/utils/datahub.utils.ts'
+import { HotKeyItem } from '@datahub/types.ts'
+
+const DesignerCheatSheet: FC = () => {
+  const { t } = useTranslation('datahub')
+  const { isOpen, onOpen, onClose } = useDisclosure()
+
+  const groupedKeys = useMemo(() => {
+    const groups = DATAHUB_HOTKEY_CONTEXT.reduce<Record<string, HotKeyItem[]>>((acc, item) => {
+      if (!acc[item.category]) {
+        acc[item.category] = []
+      }
+
+      acc[item.category].push(item)
+      return acc
+    }, {})
+    return groups
+  }, [])
+
+  return (
+    <>
+      <IconButton
+        icon={<LuBadgeHelp />}
+        onClick={onOpen}
+        aria-label={t('workspace.controls.toggleInteractivity') as string}
+      />
+      <Modal isOpen={isOpen} onClose={onClose} size="2xl" isCentered motionPreset="scale" scrollBehavior="inside">
+        <ModalOverlay />
+        <ModalContent>
+          <ModalHeader>
+            <Text fontSize="md">{t(`shortcuts.header`)}</Text>
+          </ModalHeader>
+          <ModalCloseButton />
+          <ModalBody>
+            <HStack gap={4} alignItems="flex-start">
+              {Object.entries(groupedKeys).map(([group, keys]) => (
+                <Card key={group} role="group" aria-labelledby={`group-${group}`} flex={1}>
+                  <CardHeader id={`group-${group}`} p={2} borderBottomWidth={1}>
+                    {t(`shortcuts.categories.${group}`)}
+                  </CardHeader>
+                  <CardBody p={2}>
+                    <List spacing={3}>
+                      {keys.map((item) => (
+                        <ListItem key={`${group}-${item.key}`}>
+                          <ShortcutRenderer
+                            hotkeys={item.key}
+                            description={t(`shortcuts.keys.${item.key}`, { context: item.category }) as string}
+                          />
+                        </ListItem>
+                      ))}
+                    </List>
+                  </CardBody>
+                </Card>
+              ))}
+            </HStack>
+          </ModalBody>
+          <ModalFooter />
+        </ModalContent>
+      </Modal>
+    </>
+  )
+}
+
+export default DesignerCheatSheet

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/DesignerCheatSheet.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/DesignerCheatSheet.tsx
@@ -41,7 +41,12 @@ const DesignerCheatSheet: FC = () => {
 
   return (
     <>
-      <IconButton icon={<LuBadgeHelp />} onClick={onOpen} aria-label={t('workspace.controls.shortcuts') as string} />
+      <IconButton
+        icon={<LuBadgeHelp />}
+        onClick={onOpen}
+        aria-label={t('workspace.controls.shortcuts') as string}
+        data-testid="canvas-control-help"
+      />
       <Modal isOpen={isOpen} onClose={onClose} size="2xl" isCentered motionPreset="scale" scrollBehavior="inside">
         <ModalOverlay />
         <ModalContent>

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/PolicyEditor.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/PolicyEditor.spec.cy.tsx
@@ -32,7 +32,7 @@ describe('PolicyEditor', () => {
     cy.get('[role="toolbar"]').should('have.attr', 'aria-label', 'Workspace toolbar')
     cy.getByAriaLabel('Open the toolbox').should('be.visible')
     cy.getByTestId('rf__minimap').should('be.visible')
-    cy.getByAriaLabel('Canvas controls').find('button').should('have.length', 4)
+    cy.getByAriaLabel('Canvas controls').find('button').should('have.length', 5)
   })
 
   it('should be accessible', () => {

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/PolicyEditor.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/PolicyEditor.tsx
@@ -1,8 +1,8 @@
 import React, { FC, useCallback, useMemo, useRef, useState } from 'react'
-import ReactFlow, { Connection, Node, Panel, ReactFlowInstance, ReactFlowProvider, XYPosition } from 'reactflow'
+import ReactFlow, { Connection, Node, ReactFlowInstance, ReactFlowProvider, XYPosition } from 'reactflow'
 import { Outlet } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
-import { Box, Text } from '@chakra-ui/react'
+import { Box } from '@chakra-ui/react'
 
 import styles from './PolicyEditor.module.scss'
 
@@ -14,6 +14,7 @@ import Minimap from '@datahub/components/controls/Minimap.tsx'
 import DesignerToolbox from '@datahub/components/controls/DesignerToolbox.tsx'
 import ToolboxSelectionListener from '@datahub/components/controls/ToolboxSelectionListener.tsx'
 import { CopyPasteListener } from '@datahub/components/controls/CopyPasteListener.tsx'
+import CopyPasteStatus from '@datahub/components/controls/CopyPasteStatus.tsx'
 
 const PolicyEditor: FC = () => {
   const { t } = useTranslation('datahub')
@@ -89,13 +90,7 @@ const PolicyEditor: FC = () => {
         >
           <Box role="toolbar" aria-label={t('workspace.aria-label') as string} aria-controls="edge-workspace-canvas">
             <ToolboxSelectionListener />
-            <CopyPasteListener
-              render={(copiedNodes) => (
-                <Panel position="bottom-center">
-                  {!!copiedNodes.length && <Text>{copiedNodes.length} elements copied!</Text>}
-                </Panel>
-              )}
-            />
+            <CopyPasteListener render={(copiedNodes) => <CopyPasteStatus nbCopied={copiedNodes.length} />} />
             <DesignerToolbox />
             <CanvasControls />
             <Minimap />

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/PolicyEditor.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/PolicyEditor.tsx
@@ -1,8 +1,8 @@
 import React, { FC, useCallback, useMemo, useRef, useState } from 'react'
-import ReactFlow, { Connection, Node, ReactFlowInstance, ReactFlowProvider, XYPosition } from 'reactflow'
+import ReactFlow, { Connection, Node, Panel, ReactFlowInstance, ReactFlowProvider, XYPosition } from 'reactflow'
 import { Outlet } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
-import { Box } from '@chakra-ui/react'
+import { Box, Text } from '@chakra-ui/react'
 
 import styles from './PolicyEditor.module.scss'
 
@@ -13,6 +13,7 @@ import CanvasControls from '@datahub/components/controls/CanvasControls.tsx'
 import Minimap from '@datahub/components/controls/Minimap.tsx'
 import DesignerToolbox from '@datahub/components/controls/DesignerToolbox.tsx'
 import ToolboxSelectionListener from '@datahub/components/controls/ToolboxSelectionListener.tsx'
+import { CopyPasteListener } from '@datahub/components/controls/CopyPasteListener.tsx'
 
 const PolicyEditor: FC = () => {
   const { t } = useTranslation('datahub')
@@ -83,10 +84,18 @@ const PolicyEditor: FC = () => {
           onDragOver={onDragOver}
           onDrop={onDrop}
           isValidConnection={checkValidity}
+
           // onError={(id: string, message: string) => console.log('XXXXXX e', id, message)}
         >
           <Box role="toolbar" aria-label={t('workspace.aria-label') as string} aria-controls="edge-workspace-canvas">
             <ToolboxSelectionListener />
+            <CopyPasteListener
+              render={(copiedNodes) => (
+                <Panel position="bottom-center">
+                  {!!copiedNodes.length && <Text>{copiedNodes.length} elements copied!</Text>}
+                </Panel>
+              )}
+            />
             <DesignerToolbox />
             <CanvasControls />
             <Minimap />

--- a/hivemq-edge/src/frontend/src/extensions/datahub/locales/en/datahub.json
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/locales/en/datahub.json
@@ -100,7 +100,8 @@
       "zoomIOut": "Zoom out",
       "fitView": "Fit to the canvas",
       "toggleInteractivity": "Lock the canvas",
-      "clear": "Clear the Designer"
+      "clear": "Clear the Designer",
+      "shortcuts": "Help using the Designer"
     },
     "toolbox": {
       "aria-label": "Policy controls",

--- a/hivemq-edge/src/frontend/src/extensions/datahub/locales/en/datahub.json
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/locales/en/datahub.json
@@ -292,5 +292,27 @@
       "title": "Error loading the node",
       "description": "The $t(datahub:workspace.nodes.type, { 'context': '{{nodeType}}' }) is not a valid element"
     }
+  },
+  "shortcuts": {
+    "header": "Keyboard shortcuts",
+    "categories": {
+      "Designer": "In the Designer",
+      "Selected": "Selected Nodes"
+    },
+    "keys": {
+      "ESC": "Cancel the node selection and the copy",
+      "TAB": "Set the focus on the next node",
+      "ENTER": "Select the focused node",
+      "Meta+ENTER": "Add the focused node to the selection (or remove it if selected)",
+      "Meta+C_Selected": "Copy the selected nodes (and their connections)",
+      "Meta+V_Designer": "Create new nodes from the previous copy",
+      "ArrowLeft_Selected": "Move the nodes one grid space to the left",
+      "ArrowRight_Selected": "Move the nodes one grid space to the right",
+      "ArrowUp_Selected": "Move the nodes one grid space up",
+      "ArrowDown_Selected": "Move the nodes one grid space down",
+      "Backspace_Selected": "Delete the selected nodes",
+      "Shift+drag_Designer": "Select all the nodes in the area",
+      "Meta+click_Designer": "Add the clicked node to the selection (or remove if selected)"
+    }
   }
 }

--- a/hivemq-edge/src/frontend/src/extensions/datahub/types.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/types.ts
@@ -13,6 +13,11 @@ import { RJSFSchema, UiSchema } from '@rjsf/utils'
 import { IChangeEvent } from '@rjsf/core'
 import { ProblemDetailsExtended } from '@/api/types/http-problem-details.ts'
 
+export interface HotKeyItem {
+  key: string
+  category: string
+}
+
 export interface PanelSpecs {
   schema: RJSFSchema
   uiSchema?: UiSchema

--- a/hivemq-edge/src/frontend/src/extensions/datahub/utils/datahub.utils.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/utils/datahub.utils.ts
@@ -1,3 +1,5 @@
+import { HotKeyItem } from '@datahub/types.ts'
+
 export const SCRIPT_FUNCTION_SEPARATOR = ':'
 export const SCRIPT_FUNCTION_PREFIX = 'fn'
 export const SCRIPT_FUNCTION_LATEST = 'latest'
@@ -12,3 +14,19 @@ export const DATAHUB_HOTKEY = {
   PASTE: 'Meta+V',
   ESCAPE: 'ESC',
 }
+
+export const DATAHUB_HOTKEY_CONTEXT: HotKeyItem[] = [
+  { key: 'TAB', category: 'Designer' },
+  { key: 'ENTER', category: 'Designer' },
+  { key: 'Meta+ENTER', category: 'Designer' },
+  { key: DATAHUB_HOTKEY.PASTE, category: 'Designer' },
+  { key: DATAHUB_HOTKEY.ESCAPE, category: 'Designer' },
+  { key: DATAHUB_HOTKEY.COPY, category: 'Selected' },
+  { key: 'ArrowLeft', category: 'Selected' },
+  { key: 'ArrowRight', category: 'Selected' },
+  { key: 'ArrowUp', category: 'Selected' },
+  { key: 'ArrowDown', category: 'Selected' },
+  { key: 'Backspace', category: 'Selected' },
+  { key: 'Shift+drag', category: 'Designer' },
+  { key: 'Meta+click', category: 'Designer' },
+]

--- a/hivemq-edge/src/frontend/src/extensions/datahub/utils/datahub.utils.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/utils/datahub.utils.ts
@@ -6,3 +6,9 @@ export const SCRIPT_FUNCTION_LATEST = 'latest'
 export const ANIMATION = {
   FIT_VIEW_DURATION_MS: 500,
 }
+
+export const DATAHUB_HOTKEY = {
+  COPY: 'Meta+C',
+  PASTE: 'Meta+V',
+  ESCAPE: 'ESC',
+}


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/21481/details/

This PR improves the UX of the `Data Hub Designer` by allowing users to copy nodes from the graph and duplicate them as new elements. 

The operation is an internal "copy-and-paste" of the selection in the designer:
- one or many nodes can be selected manually from the graph  
- on "copy", the subgraph containing the selected nodes (i.e. including all the edges that have both start and end nodes in the selection) is duplicated (i.e. new id, new shifted position but the same configuration of the nodes
- on "paste", the new nodes are added to the graph but not connected to existing nodes. 
- subsequent "paste" will duplicate the selected nodes in a shifting pattern on the graph, allowing multiple duplications
- "copy" is bound to the usual "META + C" and "paste" to "META + V". "ESC" will clear the selection and the existing copied content

A small feedback widget has been added to the bottom centre of the Designer. It contains a "copy" indicator, with the number of nodes copied.

Note that copied content is not shared in the clipboard and its scope is limited to the current draft. Leaving the Designer will wipe the buffer. The copy-and-paste feature is also only available on DRAFT policies.

The PR also adds a "cheat sheet" with all the keyboard shortcuts supported by `React Flow` or the `Data Hub Designer`. The modal is available from the canvas toolbox.

### After
![screenshot-localhost_3000-2024 04 25-09_30_37](https://github.com/hivemq/hivemq-edge/assets/2743481/8c1496ca-32cd-4280-913b-a386f0751ee4)

![screenshot-localhost_3000-2024 04 25-09_30_51](https://github.com/hivemq/hivemq-edge/assets/2743481/f33ba654-4776-4612-9c12-988faa2b5655)

![screenshot-localhost_3000-2024 04 25-09_31_05](https://github.com/hivemq/hivemq-edge/assets/2743481/a5039f4b-70c8-4acc-a15d-eb7868fd5088)
