### PR TITLE
fix(19310): Improve Data Hub translations

### DIFF
--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/ToolboxNodes.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/ToolboxNodes.spec.cy.tsx
@@ -13,7 +13,7 @@ describe('Toolbox', () => {
     cy.getByAriaLabel('Policy controls').find('[role="group"]').as('policyControlsGroups')
 
     cy.get('@policyControlsGroups').should('have.length', 4)
-    cy.get('@policyControlsGroups').eq(0).should('contain.text', 'Pipeline')
+    cy.get('@policyControlsGroups').eq(0).should('contain.text', 'Edge Integration')
     cy.get('@policyControlsGroups').eq(1).should('contain.text', 'Data Policy')
     cy.get('@policyControlsGroups').eq(2).should('contain.text', 'Behavior Policy')
     cy.get('@policyControlsGroups').eq(3).should('contain.text', 'Operation')

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/ToolboxNodes.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/ToolboxNodes.tsx
@@ -23,9 +23,9 @@ export const ToolboxNodes: FC<DesignerToolBoxProps> = () => {
       aria-label={t('workspace.toolbox.aria-label') as string}
       backgroundColor="var(--chakra-colors-chakra-body-bg)"
     >
-      <ButtonGroup variant="outline" size="sm" aria-labelledby="group-pipeline">
+      <ButtonGroup variant="outline" size="sm" aria-labelledby="group-integrations">
         <VStack alignItems="flex-start">
-          <Text id="group-pipeline">{t('workspace.toolbox.group.pipeline')}</Text>
+          <Text id="group-integrations">{t('workspace.toolbox.group.integration.edge')}</Text>
           <HStack>
             <Tool nodeType={DataHubNodeType.TOPIC_FILTER} isDisabled={isDraftEmpty || !isEditEnabled} />
             <Tool nodeType={DataHubNodeType.CLIENT_FILTER} isDisabled={isDraftEmpty || !isEditEnabled} />

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/operation/OperationNode.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/operation/OperationNode.tsx
@@ -25,12 +25,20 @@ export const OperationNode: FC<NodeProps<OperationData>> = (props) => {
       <NodeWrapper route={`node/${DataHubNodeType.OPERATION}/${id}`} {...props}>
         <VStack>
           <HStack w="100%" justifyContent="space-around">
-            {isSerialiser && <Text fontSize="xs">{OperationData.Handle.SCHEMA}</Text>}
+            {isSerialiser && (
+              <Text fontSize="xs">{t('workspace.handles.operation', { context: OperationData.Handle.SCHEMA })}</Text>
+            )}
             {isTransform && (
               <>
-                <Text fontSize="xs">{OperationData.Handle.DESERIALISER}</Text>
-                <Text fontSize="xs">{OperationData.Handle.FUNCTION}</Text>
-                <Text fontSize="xs">{OperationData.Handle.SERIALISER}</Text>
+                <Text fontSize="xs">
+                  {t('workspace.handles.operation', { context: OperationData.Handle.DESERIALISER })}
+                </Text>
+                <Text fontSize="xs">
+                  {t('workspace.handles.operation', { context: OperationData.Handle.FUNCTION })}
+                </Text>
+                <Text fontSize="xs">
+                  {t('workspace.handles.operation', { context: OperationData.Handle.SERIALISER })}
+                </Text>
               </>
             )}
           </HStack>

--- a/hivemq-edge/src/frontend/src/extensions/datahub/locales/en/datahub.json
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/locales/en/datahub.json
@@ -157,7 +157,11 @@
       "validation_onSuccess": "onSuccess",
       "validation_onError": "onError",
       "behavior_serial.will": "onWill",
-      "behavior_serial.publish": "onPublish"
+      "behavior_serial.publish": "onPublish",
+      "operation_deserialiser": "deserializer",
+      "operation_serialiser": "serializer",
+      "operation_function": "functions",
+      "operation_schema": "schemas"
     },
     "panel": {
       "submit": "Submit"

--- a/hivemq-edge/src/frontend/src/extensions/datahub/locales/en/datahub.json
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/locales/en/datahub.json
@@ -127,7 +127,9 @@
         "goPublish": "Go to Publish"
       },
       "group": {
-        "pipeline": "Pipeline",
+        "integration": {
+          "edge": "Edge Integration"
+        },
         "dataPolicy": "Data Policy",
         "behaviorPolicy": "Behavior Policy",
         "operation": "Operation"


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/19310/details/

Fix the translations for the app, focusing on the `EN-US` language. 

Changed the label for the first group of icons in the Designer toolbox, to reflect the focus on integration between `Data Hub` and `Edge`.

### Before
![screenshot-localhost_3000-2024 04 26-10_23_34](https://github.com/hivemq/hivemq-edge/assets/2743481/56082beb-9995-478a-98f5-9ee0d4f81ed9)

### After
![screenshot-localhost_3000-2024 04 26-10_22_12 (1)](https://github.com/hivemq/hivemq-edge/assets/2743481/f7265702-1533-45e1-a216-f1e3538532cf)
