### PR TITLE
fix(21625): Prevent cycles in the Designer graphs

### DIFF
--- a/hivemq-edge/src/frontend/src/components/Chakra/ShortcutRenderer.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/components/Chakra/ShortcutRenderer.spec.cy.tsx
@@ -19,8 +19,10 @@ describe('ShortcutRenderer', () => {
 
   it('should render multiple shortcuts', () => {
     cy.mountWithProviders(<ShortcutRenderer hotkeys="CTRL+C,Meta+V,ESC" description="This is a description" />)
+    const cmd = Cypress.platform === 'darwin' ? 'Command' : 'Ctrl'
+    console.log('XXXXXX', cmd)
 
-    cy.get('[role="term"]').should('contain.text', 'CTRL + C , Command + V , ESC')
+    cy.get('[role="term"]').should('contain.text', `CTRL + C , ${cmd} + V , ESC`)
     cy.get('kbd').should('have.length', 5)
   })
 

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/PolicyEditor.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/PolicyEditor.tsx
@@ -24,7 +24,10 @@ const PolicyEditor: FC = () => {
 
   const nodeTypes = useMemo(() => CustomNodeTypes, [])
 
-  const checkValidity = useCallback((connection: Connection) => isValidPolicyConnection(connection, nodes), [nodes])
+  const checkValidity = useCallback(
+    (connection: Connection) => isValidPolicyConnection(connection, nodes, edges),
+    [edges, nodes]
+  )
 
   const onDragOver = useCallback((event: React.DragEvent<HTMLElement> | undefined) => {
     if (event) {

--- a/hivemq-edge/src/frontend/src/extensions/datahub/utils/node.utils.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/utils/node.utils.ts
@@ -91,6 +91,7 @@ export const isValidPolicyConnection = (connection: Connection, nodes: Node[], e
       if (outgoer.id === connection.source) return true
       if (hasCycle(outgoer, visited)) return true
     }
+    return false
   }
 
   if (!source || !destination) {


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/21625/details/

The PR prevents cycles from being created in the Designer when connecting nodes either to themselves or back to the beginning of a chain. 

This is the case exclusively of the `OPERATION` node, as being the only content that can be chained. 

### Before
![screenshot-localhost_3000-2024 04 25-20_41_26](https://github.com/hivemq/hivemq-edge/assets/2743481/27cc4b11-2f1d-434d-ad16-acff5d6d0e50)


### After
![screenshot-localhost_3000-2024 04 26-15_43_40](https://github.com/hivemq/hivemq-edge/assets/2743481/852416cc-29d8-4f2a-9836-c72ae7d52d06)
