### PR TITLE
feat(20611): Add uniqueness validation to topic filter

### DIFF
--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/client_filter/ClientFilterPanel.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/client_filter/ClientFilterPanel.spec.cy.tsx
@@ -1,25 +1,25 @@
 /// <reference types="cypress" />
 
 import { Button } from '@chakra-ui/react'
+import { Node } from 'reactflow'
 
 import { MockStoreWrapper } from '@datahub/__test-utils__/MockStoreWrapper.tsx'
-import { DataHubNodeType } from '@datahub/types.ts'
-import { getNodePayload } from '@datahub/utils/node.utils.ts'
+import { ClientFilterData, DataHubNodeType } from '@datahub/types.ts'
 
 import { ClientFilterPanel } from './ClientFilterPanel.tsx'
+
+const MOCK_CLIENT_FILTER: Node<ClientFilterData> = {
+  id: '3',
+  type: DataHubNodeType.CLIENT_FILTER,
+  position: { x: 0, y: 0 },
+  data: { clients: ['client10', 'client20', 'client30'] },
+}
 
 const wrapper: React.JSXElementConstructor<{ children: React.ReactNode }> = ({ children }) => (
   <MockStoreWrapper
     config={{
       initialState: {
-        nodes: [
-          {
-            id: '3',
-            type: DataHubNodeType.CLIENT_FILTER,
-            position: { x: 0, y: 0 },
-            data: getNodePayload(DataHubNodeType.CLIENT_FILTER),
-          },
-        ],
+        nodes: [MOCK_CLIENT_FILTER],
       },
     }}
   >

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/topic_filter/TopicFilterPanel.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/topic_filter/TopicFilterPanel.spec.cy.tsx
@@ -1,24 +1,24 @@
 /// <reference types="cypress" />
 
 import { Button } from '@chakra-ui/react'
+import { Node } from 'reactflow'
 
 import { MockStoreWrapper } from '@datahub/__test-utils__/MockStoreWrapper.tsx'
-import { DataHubNodeType } from '@datahub/types.ts'
-import { getNodePayload } from '@datahub/utils/node.utils.ts'
+import { DataHubNodeType, TopicFilterData } from '@datahub/types.ts'
 import { TopicFilterPanel } from './TopicFilterPanel.tsx'
+
+const MOCK_TOPIC_FILTER: Node<TopicFilterData> = {
+  id: '3',
+  type: DataHubNodeType.CLIENT_FILTER,
+  position: { x: 0, y: 0 },
+  data: { topics: ['root/test1', 'root/test2'] },
+}
 
 const wrapper: React.JSXElementConstructor<{ children: React.ReactNode }> = ({ children }) => (
   <MockStoreWrapper
     config={{
       initialState: {
-        nodes: [
-          {
-            id: '3',
-            type: DataHubNodeType.TOPIC_FILTER,
-            position: { x: 0, y: 0 },
-            data: getNodePayload(DataHubNodeType.TOPIC_FILTER),
-          },
-        ],
+        nodes: [MOCK_TOPIC_FILTER],
       },
     }}
   >

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/topic_filter/TopicFilterPanel.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/topic_filter/TopicFilterPanel.spec.cy.tsx
@@ -6,12 +6,13 @@ import { Node } from 'reactflow'
 import { MockStoreWrapper } from '@datahub/__test-utils__/MockStoreWrapper.tsx'
 import { DataHubNodeType, TopicFilterData } from '@datahub/types.ts'
 import { TopicFilterPanel } from './TopicFilterPanel.tsx'
+import { mockDataPolicy } from '@datahub/api/hooks/DataHubDataPoliciesService/__handlers__'
 
 const MOCK_TOPIC_FILTER: Node<TopicFilterData> = {
   id: '3',
   type: DataHubNodeType.CLIENT_FILTER,
   position: { x: 0, y: 0 },
-  data: { topics: ['root/test1', 'root/test2'] },
+  data: { topics: ['root/test1', 'root/test2', 'root/test1', 'root/topic/ref/1'] },
 }
 
 const wrapper: React.JSXElementConstructor<{ children: React.ReactNode }> = ({ children }) => (
@@ -33,6 +34,7 @@ describe('TopicFilterPanel', () => {
   beforeEach(() => {
     cy.viewport(800, 800)
     cy.intercept('/api/v1/management/protocol-adapters/adapters', { statusCode: 404 })
+    cy.intercept('/api/v1/data-hub/data-validation/policies', { statusCode: 404 })
   })
 
   it('should render the fields for a Validator', () => {
@@ -45,6 +47,22 @@ describe('TopicFilterPanel', () => {
     cy.get('label#root_topics_0-label + input').should('have.value', 'root/test1')
     cy.get('label#root_topics_1-label').should('contain.text', 'topics-1')
     cy.get('label#root_topics_1-label + input').should('have.value', 'root/test2')
+  })
+
+  it('should validate properly the topic filters', () => {
+    cy.intercept('/api/v1/data-hub/data-validation/policies', {
+      items: [mockDataPolicy],
+    }).as('getPolicies')
+    cy.mountWithProviders(<TopicFilterPanel selectedNode="3" />, { wrapper })
+    cy.get('label#root_topics_0-label').should('have.attr', 'data-invalid')
+    cy.get('label#root_topics_1-label').should('not.have.attr', 'data-invalid')
+    cy.get('label#root_topics_2-label').should('have.attr', 'data-invalid')
+    cy.get('label#root_topics_3-label').should('not.have.attr', 'data-invalid')
+
+    cy.wait('@getPolicies')
+
+    cy.get('button[type=submit]').click()
+    cy.get('label#root_topics_3-label').should('have.attr', 'data-invalid')
   })
 
   it('should be accessible', () => {

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/topic_filter/TopicFilterPanel.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/topic_filter/TopicFilterPanel.tsx
@@ -34,7 +34,7 @@ export const TopicFilterPanel: FC<PanelProps> = ({ selectedNode, onFormSubmit })
     if (hasDuplicate) {
       for (const [key, value] of duplicates) {
         for (const index of value) {
-          errors['topics']?.[index]?.addError(t(`the topic ${key} is already defined`))
+          errors['topics']?.[index]?.addError(t('error.validation.topicFilter.duplicate', { filter: key }))
         }
       }
     }

--- a/hivemq-edge/src/frontend/src/extensions/datahub/locales/en/datahub.json
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/locales/en/datahub.json
@@ -247,6 +247,10 @@
       "protobuf": {
         "template": "// CANNOT DECODE THE PROTOBUF SOURCE - {{ source }}",
         "encoding": "The encoding of the PROTOBUF code into a Base64 descriptor cannot be validated."
+      },
+      "topicFilter": {
+        "duplicate": "the topic filter {{ filter }} is already defined",
+        "alreadyMatching": "A policy is already matching the topic filter {{ filter }}"
       }
     },
     "loading": {

--- a/hivemq-edge/src/frontend/src/extensions/datahub/locales/en/datahub.json
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/locales/en/datahub.json
@@ -249,7 +249,7 @@
         "encoding": "The encoding of the PROTOBUF code into a Base64 descriptor cannot be validated."
       },
       "topicFilter": {
-        "duplicate": "the topic filter {{ filter }} is already defined",
+        "duplicate": "The topic filter {{ filter }} is already defined",
         "alreadyMatching": "A policy is already matching the topic filter {{ filter }}"
       }
     },

--- a/hivemq-edge/src/frontend/src/extensions/datahub/utils/node.utils.spec.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/utils/node.utils.spec.ts
@@ -25,13 +25,13 @@ describe('getNodePayload', () => {
     {
       type: DataHubNodeType.TOPIC_FILTER,
       expected: {
-        topics: ['root/test1', 'root/test2'],
+        topics: ['topic/example/1'],
       },
     },
     {
       type: DataHubNodeType.CLIENT_FILTER,
       expected: {
-        clients: ['client10', 'client20', 'client30'],
+        clients: ['client/example/1'],
       },
     },
     {

--- a/hivemq-edge/src/frontend/src/extensions/datahub/utils/node.utils.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/utils/node.utils.ts
@@ -27,12 +27,12 @@ export const getNodeId = (stub = 'node') => `${stub}_${uuidv4()}`
 export const getNodePayload = (type: string): DataHubNodeData => {
   if (type === DataHubNodeType.TOPIC_FILTER) {
     return {
-      topics: ['root/test1', 'root/test2'],
+      topics: ['topic/example/1'],
     } as TopicFilterData
   }
   if (type === DataHubNodeType.CLIENT_FILTER) {
     return {
-      clients: ['client10', 'client20', 'client30'],
+      clients: ['client/example/1'],
     } as ClientFilterData
   }
 


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/20611/details/

The PR adds a custom validator to the `Topic Filter` configuration panel, ensuring that the filter added to a data policy is not already in use in another policy. Note that the check is purely syntactic on the filter itself, not on the topics it migth match.

### Before
![screenshot-localhost_3000-2024 04 29-12_11_55](https://github.com/hivemq/hivemq-edge/assets/2743481/2e6dea00-0194-4dab-b1bf-69ef624643d5)


### After
![screenshot-localhost_3000-2024 04 29-12_11_03](https://github.com/hivemq/hivemq-edge/assets/2743481/c88a8972-39f4-4d83-ba6a-079c97aadce4)

