### PR TITLE
feat(19269): Allow collapsable items in a RJSF form

### DIFF
--- a/hivemq-edge/src/frontend/src/locales/en/components.json
+++ b/hivemq-edge/src/frontend/src/locales/en/components.json
@@ -60,5 +60,13 @@
     "action_READY": "Ready!",
     "action_COPIED": "Copied!",
     "action_ERROR": "Error!"
+  },
+  "rjsf": {
+    "ArrayFieldItem": {
+      "Buttons": {
+        "expanded_true": "Collapse Item",
+        "expanded_false": "Expand Item"
+      }
+    }
   }
 }

--- a/hivemq-edge/src/frontend/src/locales/en/translation.json
+++ b/hivemq-edge/src/frontend/src/locales/en/translation.json
@@ -319,7 +319,7 @@
         "helper": "Select the Trust Store path"
       },
       "truststorePassword": {
-        "label": "Truth Store Password",
+        "label": "Trust Store Password",
         "helper": "Select the Trust Store password"
       },
       "privateKeyPassword": {

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/ProtocolAdapterPage.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/ProtocolAdapterPage.spec.cy.tsx
@@ -7,13 +7,13 @@ import { mockGatewayConfiguration } from '@/api/hooks/useFrontendServices/__hand
 describe('ProtocolAdapterPage', () => {
   beforeEach(() => {
     cy.viewport(800, 900)
-    cy.intercept('api/v1/management/protocol-adapters/status', { statusCode: 404 }).as('getStatus')
+    cy.intercept('api/v1/management/protocol-adapters/status', { statusCode: 404 })
     cy.intercept('/api/v1/management/protocol-adapters/types', { items: [mockProtocolAdapter] }).as('getProtocols')
     cy.intercept('api/v1/management/protocol-adapters/adapters', { items: [mockAdapter] }).as('getAdapters')
   })
 
   it('should render adapters for returning users', () => {
-    cy.intercept('api/v1/frontend/configuration', mockGatewayConfiguration).as('getConfig')
+    cy.intercept('api/v1/frontend/configuration', mockGatewayConfiguration)
     cy.mountWithProviders(<ProtocolAdapterPage />)
 
     cy.get("[role='tab']").eq(1).should('have.attr', 'aria-selected', 'true')
@@ -24,7 +24,7 @@ describe('ProtocolAdapterPage', () => {
       ...mockGatewayConfiguration,
       firstUseInformation: { ...mockGatewayConfiguration, firstUse: true },
     }
-    cy.intercept('api/v1/frontend/configuration', newUser).as('getConfig')
+    cy.intercept('api/v1/frontend/configuration', newUser)
     cy.mountWithProviders(<ProtocolAdapterPage />)
 
     cy.get("[role='tab']").eq(1).should('have.attr', 'aria-selected', 'true')

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/ProtocolAdapterPage.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/ProtocolAdapterPage.spec.cy.tsx
@@ -1,0 +1,50 @@
+/// <reference types="cypress" />
+
+import ProtocolAdapterPage from '@/modules/ProtocolAdapters/ProtocolAdapterPage.tsx'
+import { mockAdapter, mockProtocolAdapter } from '@/api/hooks/useProtocolAdapters/__handlers__'
+import { mockGatewayConfiguration } from '@/api/hooks/useFrontendServices/__handlers__'
+
+describe('ProtocolAdapterPage', () => {
+  beforeEach(() => {
+    cy.viewport(800, 900)
+    cy.intercept('api/v1/management/protocol-adapters/status', { statusCode: 404 }).as('getStatus')
+    cy.intercept('/api/v1/management/protocol-adapters/types', { items: [mockProtocolAdapter] }).as('getProtocols')
+    cy.intercept('api/v1/management/protocol-adapters/adapters', { items: [mockAdapter] }).as('getAdapters')
+  })
+
+  it('should render adapters for returning users', () => {
+    cy.intercept('api/v1/frontend/configuration', mockGatewayConfiguration).as('getConfig')
+    cy.mountWithProviders(<ProtocolAdapterPage />)
+
+    cy.get("[role='tab']").eq(1).should('have.attr', 'aria-selected', 'true')
+  })
+
+  it('should render protocols for new users', () => {
+    const newUser = {
+      ...mockGatewayConfiguration,
+      firstUseInformation: { ...mockGatewayConfiguration, firstUse: true },
+    }
+    cy.intercept('api/v1/frontend/configuration', newUser).as('getConfig')
+    cy.mountWithProviders(<ProtocolAdapterPage />)
+
+    cy.get("[role='tab']").eq(1).should('have.attr', 'aria-selected', 'true')
+  })
+
+  it('should be accessible', () => {
+    const newUser = {
+      ...mockGatewayConfiguration,
+      firstUseInformation: { ...mockGatewayConfiguration, firstUse: true },
+    }
+    cy.intercept('api/v1/frontend/configuration', newUser).as('getConfig')
+    cy.injectAxe()
+    cy.mountWithProviders(<ProtocolAdapterPage />)
+
+    cy.wait('@getConfig')
+    cy.wait('@getAdapters')
+    cy.wait('@getProtocols')
+    cy.checkAccessibility()
+
+    cy.get("[role='tab']").eq(0).click()
+    cy.checkAccessibility()
+  })
+})

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/ProtocolAdapterPage.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/ProtocolAdapterPage.tsx
@@ -1,6 +1,6 @@
-import { FC, useEffect, useState } from 'react'
+import { FC, Suspense, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Tab, TabList, TabPanel, TabPanels, Tabs } from '@chakra-ui/react'
+import { AbsoluteCenter, Tab, TabList, TabPanel, TabPanels, Tabs } from '@chakra-ui/react'
 
 import { Outlet, useLocation } from 'react-router-dom'
 
@@ -8,6 +8,7 @@ import PageContainer from '@/components/PageContainer.tsx'
 import ProtocolAdapters from '@/modules/ProtocolAdapters/components/panels/ProtocolAdapters.tsx'
 import ProtocolIntegrationStore from '@/modules/ProtocolAdapters/components/panels/ProtocolIntegrationStore.tsx'
 import { AdapterNavigateState } from '@/modules/ProtocolAdapters/types.ts'
+import LoaderSpinner from '@/components/Chakra/LoaderSpinner.tsx'
 
 const ProtocolAdapterPage: FC = () => {
   const { t } = useTranslation()
@@ -45,7 +46,15 @@ const ProtocolAdapterPage: FC = () => {
           </TabPanel>
         </TabPanels>
       </Tabs>
-      <Outlet />
+      <Suspense
+        fallback={
+          <AbsoluteCenter axis="both">
+            <LoaderSpinner />
+          </AbsoluteCenter>
+        }
+      >
+        <Outlet />
+      </Suspense>
     </PageContainer>
   )
 }

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/ProtocolAdapterPage.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/ProtocolAdapterPage.tsx
@@ -1,19 +1,26 @@
-import { FC, Suspense, useEffect, useState } from 'react'
+import { FC, Suspense, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { AbsoluteCenter, Tab, TabList, TabPanel, TabPanels, Tabs } from '@chakra-ui/react'
 
 import { Outlet, useLocation } from 'react-router-dom'
 
+import { useGetConfiguration } from '@/api/hooks/useFrontendServices/useGetConfiguration.tsx'
+import LoaderSpinner from '@/components/Chakra/LoaderSpinner.tsx'
 import PageContainer from '@/components/PageContainer.tsx'
 import ProtocolAdapters from '@/modules/ProtocolAdapters/components/panels/ProtocolAdapters.tsx'
 import ProtocolIntegrationStore from '@/modules/ProtocolAdapters/components/panels/ProtocolIntegrationStore.tsx'
-import { AdapterNavigateState } from '@/modules/ProtocolAdapters/types.ts'
-import LoaderSpinner from '@/components/Chakra/LoaderSpinner.tsx'
+import { AdapterNavigateState, ProtocolAdapterTabIndex } from '@/modules/ProtocolAdapters/types.ts'
 
 const ProtocolAdapterPage: FC = () => {
   const { t } = useTranslation()
   const { state } = useLocation()
-  const [tabIndex, setTabIndex] = useState(0)
+  const { data: configuration } = useGetConfiguration()
+  const isReturningUser = useMemo(() => {
+    return configuration?.firstUseInformation?.firstUse !== true
+  }, [configuration?.firstUseInformation?.firstUse])
+  const [tabIndex, setTabIndex] = useState(
+    isReturningUser ? ProtocolAdapterTabIndex.adapters : ProtocolAdapterTabIndex.protocols
+  )
 
   useEffect(() => {
     if ((state as AdapterNavigateState)?.protocolAdapterTabIndex) {

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/ProtocolAdapterPage.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/ProtocolAdapterPage.tsx
@@ -18,9 +18,11 @@ const ProtocolAdapterPage: FC = () => {
   const isReturningUser = useMemo(() => {
     return configuration?.firstUseInformation?.firstUse !== true
   }, [configuration?.firstUseInformation?.firstUse])
-  const [tabIndex, setTabIndex] = useState(
-    isReturningUser ? ProtocolAdapterTabIndex.adapters : ProtocolAdapterTabIndex.protocols
-  )
+  const [tabIndex, setTabIndex] = useState(0)
+
+  useEffect(() => {
+    setTabIndex(isReturningUser ? ProtocolAdapterTabIndex.adapters : ProtocolAdapterTabIndex.protocols)
+  }, [isReturningUser])
 
   useEffect(() => {
     if ((state as AdapterNavigateState)?.protocolAdapterTabIndex) {

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/drawers/AdapterInstanceDrawer.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/drawers/AdapterInstanceDrawer.spec.cy.tsx
@@ -76,7 +76,7 @@ describe('AdapterInstanceDrawer', () => {
     cy.percySnapshot('Component: AdapterInstanceDrawer')
   })
 
-  describe.only('Custom Templates', () => {
+  describe('Custom Templates', () => {
     it('should render expandable array items', () => {
       cy.mountWithProviders(
         <AdapterInstanceDrawer

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/drawers/AdapterInstanceDrawer.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/drawers/AdapterInstanceDrawer.spec.cy.tsx
@@ -75,4 +75,31 @@ describe('AdapterInstanceDrawer', () => {
     cy.checkAccessibility()
     cy.percySnapshot('Component: AdapterInstanceDrawer')
   })
+
+  describe.only('Custom Templates', () => {
+    it('should render expandable array items', () => {
+      cy.mountWithProviders(
+        <AdapterInstanceDrawer
+          adapterType={mockProtocolAdapter.id}
+          isNewAdapter={true}
+          isOpen={true}
+          isSubmitting={false}
+          onSubmit={cy.stub()}
+          onClose={cy.stub()}
+        />
+      )
+
+      cy.get("[role='tab']").eq(1).as('subscription')
+      cy.get('@subscription').should('have.text', 'Subscription')
+      cy.get('@subscription').click()
+      cy.get('button').contains('Add Item').click()
+
+      cy.get('[role="listitem"]').eq(0).as('firstItem')
+      cy.get('@firstItem').find('h5').should('have.text', 'Subscriptions')
+      cy.get('@firstItem').find('label').eq(0).should('contain.text', 'Destination Topic')
+      cy.get('@firstItem').find('button[aria-label="Collapse Item"]').click()
+      cy.get('@firstItem').find('h5').should('have.text', 'subscriptions-0')
+      cy.get('@firstItem').find('label').should('not.exist')
+    })
+  })
 })

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/drawers/AdapterInstanceDrawer.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/drawers/AdapterInstanceDrawer.spec.cy.tsx
@@ -17,7 +17,7 @@ describe('AdapterInstanceDrawer', () => {
         adapterType={mockProtocolAdapter.id}
         isOpen={true}
         isSubmitting={false}
-        onSubmit={cy.stub().as('onSubmit')}
+        onSubmit={cy.stub()}
         onClose={cy.stub().as('onClose')}
       />
     )
@@ -34,7 +34,7 @@ describe('AdapterInstanceDrawer', () => {
         isOpen={true}
         isSubmitting={false}
         onSubmit={cy.stub().as('onSubmit')}
-        onClose={cy.stub().as('onClose')}
+        onClose={cy.stub()}
       />
     )
     cy.get('button[type="submit"]').click({ force: true })
@@ -49,7 +49,7 @@ describe('AdapterInstanceDrawer', () => {
         isOpen={true}
         isSubmitting={false}
         onSubmit={cy.stub().as('onSubmit')}
-        onClose={cy.stub().as('onClose')}
+        onClose={cy.stub()}
       />
     )
 
@@ -68,8 +68,8 @@ describe('AdapterInstanceDrawer', () => {
         isNewAdapter={true}
         isOpen={true}
         isSubmitting={false}
-        onSubmit={cy.stub().as('onSubmit')}
-        onClose={cy.stub().as('onClose')}
+        onSubmit={cy.stub()}
+        onClose={cy.stub()}
       />
     )
     cy.checkAccessibility()

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/panels/ProtocolAdapters.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/panels/ProtocolAdapters.spec.cy.tsx
@@ -17,11 +17,10 @@ describe('ProtocolAdapters', () => {
     cy.injectAxe()
     cy.mountWithProviders(<ProtocolAdapters />)
 
-    cy.wait('@getAdapters').then(() => {
-      cy.get('tbody').find('tr').should('have.length', 1)
-      cy.get('tbody').find('tr').find('td').eq(0).should('contain.text', MOCK_ADAPTER_ID)
-      cy.checkAccessibility()
-      cy.percySnapshot('Component: ProtocolAdapters')
-    })
+    cy.wait('@getAdapters')
+    cy.get('tbody').find('tr').should('have.length', 1)
+    cy.get('tbody').find('tr').find('td').eq(0).should('contain.text', MOCK_ADAPTER_ID)
+    cy.checkAccessibility()
+    cy.percySnapshot('Component: ProtocolAdapters')
   })
 })

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/templates/ArrayFieldItemTemplate.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/templates/ArrayFieldItemTemplate.tsx
@@ -1,6 +1,10 @@
 import { FC, useMemo } from 'react'
-import { Box, ButtonGroup, HStack } from '@chakra-ui/react'
-import { ArrayFieldTemplateItemType } from '@rjsf/utils'
+import { useTranslation } from 'react-i18next'
+import { ArrayFieldTemplateItemType, getTemplate, getUiOptions } from '@rjsf/utils'
+import { Box, ButtonGroup, FormControl, HStack, useDisclosure, VStack } from '@chakra-ui/react'
+import { LuPanelTopClose, LuPanelTopOpen } from 'react-icons/lu'
+
+import IconButton from '@/components/Chakra/IconButton.tsx'
 
 // TODO[NVL] This is NOT a good approach to add a "role"; submit a PR!
 export const ArrayFieldItemTemplate: FC<ArrayFieldTemplateItemType> = (props) => {
@@ -20,67 +24,98 @@ export const ArrayFieldItemTemplate: FC<ArrayFieldTemplateItemType> = (props) =>
     uiSchema,
     registry,
   } = props
+  const { t } = useTranslation('components')
+  const { isOpen, onToggle, getButtonProps, getDisclosureProps } = useDisclosure({ defaultIsOpen: false })
+  const name = useMemo<string>(() => {
+    const childrenFormData = children.props.formData.destination
+    if (childrenFormData) return `${children.props.name} - ${childrenFormData}`
+    return children.props.name
+  }, [])
+
   const { CopyButton, MoveDownButton, MoveUpButton, RemoveButton } = registry.templates.ButtonTemplates
   const onCopyClick = useMemo(() => onCopyIndexClick(index), [index, onCopyIndexClick])
-
   const onRemoveClick = useMemo(() => onDropIndexClick(index), [index, onDropIndexClick])
-
   const onArrowUpClick = useMemo(() => onReorderClick(index, index - 1), [index, onReorderClick])
-
   const onArrowDownClick = useMemo(() => onReorderClick(index, index + 1), [index, onReorderClick])
+
+  const renderCollapsed = () => {
+    const uiOptions = getUiOptions(uiSchema)
+    const TitleFieldTemplate = getTemplate<'TitleFieldTemplate'>('TitleFieldTemplate', registry, uiOptions)
+    return (
+      <FormControl variant="hivemq">
+        <TitleFieldTemplate
+          title={name}
+          id={children.props.name}
+          registry={registry}
+          uiSchema={uiSchema}
+          schema={props.schema}
+        />
+      </FormControl>
+    )
+  }
+  const { hidden, ...rest } = getDisclosureProps()
 
   return (
     <HStack
-      alignItems="flex-end"
+      flexDirection="row-reverse"
+      alignItems="flex-start"
       py={1}
       // TODO[NVL] This is NOT a good approach to add a "role"; submit a PR!
       role="listitem"
     >
-      <Box w="100%">{children}</Box>
       {hasToolbar && (
-        <Box>
-          <ButtonGroup
-            isAttached
-            mb={1}
-            role="toolbar"
-            // TODO[NVL] This is NOT a good approach to add a "role"; submit a PR!
-            orientation="vertical"
-          >
-            {(hasMoveUp || hasMoveDown) && (
-              <MoveUpButton
-                disabled={disabled || readonly || !hasMoveUp}
-                onClick={onArrowUpClick}
-                uiSchema={uiSchema}
-                registry={registry}
-              />
-            )}
-            {(hasMoveUp || hasMoveDown) && (
-              <MoveDownButton
-                disabled={disabled || readonly || !hasMoveDown}
-                onClick={onArrowDownClick}
-                uiSchema={uiSchema}
-                registry={registry}
-              />
-            )}
-            {hasCopy && (
-              <CopyButton
-                disabled={disabled || readonly}
-                onClick={onCopyClick}
-                uiSchema={uiSchema}
-                registry={registry}
-              />
-            )}
-            {hasRemove && (
-              <RemoveButton
-                disabled={disabled || readonly}
-                onClick={onRemoveClick}
-                uiSchema={uiSchema}
-                registry={registry}
-              />
-            )}
+        // TODO[NVL] This is NOT a good approach to add a "role"; submit a PR!
+        <VStack gap={6} role="toolbar">
+          <ButtonGroup>
+            <IconButton
+              icon={isOpen ? <LuPanelTopClose /> : <LuPanelTopOpen />}
+              onClick={onToggle}
+              {...getButtonProps()}
+              aria-label={t('rjsf.ArrayFieldItem.Buttons.expanded', { context: isOpen ? 'true' : 'false' })}
+            />
           </ButtonGroup>
-        </Box>
+          {isOpen && (
+            <ButtonGroup isAttached mb={1} orientation="vertical">
+              {(hasMoveUp || hasMoveDown) && (
+                <MoveUpButton
+                  disabled={disabled || readonly || !hasMoveUp}
+                  onClick={onArrowUpClick}
+                  uiSchema={uiSchema}
+                  registry={registry}
+                />
+              )}
+              {(hasMoveUp || hasMoveDown) && (
+                <MoveDownButton
+                  disabled={disabled || readonly || !hasMoveDown}
+                  onClick={onArrowDownClick}
+                  uiSchema={uiSchema}
+                  registry={registry}
+                />
+              )}
+              {hasCopy && (
+                <CopyButton
+                  disabled={disabled || readonly}
+                  onClick={onCopyClick}
+                  uiSchema={uiSchema}
+                  registry={registry}
+                />
+              )}
+              {hasRemove && (
+                <RemoveButton
+                  disabled={disabled || readonly}
+                  onClick={onRemoveClick}
+                  uiSchema={uiSchema}
+                  registry={registry}
+                />
+              )}
+            </ButtonGroup>
+          )}
+        </VStack>
       )}
+
+      <Box w="100%" {...rest}>
+        {isOpen ? children : renderCollapsed()}
+      </Box>
     </HStack>
   )
 }

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/templates/ArrayFieldItemTemplate.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/templates/ArrayFieldItemTemplate.tsx
@@ -6,7 +6,7 @@ import { LuPanelTopClose, LuPanelTopOpen } from 'react-icons/lu'
 
 import IconButton from '@/components/Chakra/IconButton.tsx'
 
-// TODO[NVL] This is NOT a good approach to add a "role"; submit a PR!
+// TODO[NVL] This is driven by subscription handling; use uiSchema to allow configuration for individual array property
 export const ArrayFieldItemTemplate: FC<ArrayFieldTemplateItemType> = (props) => {
   const {
     children,
@@ -33,7 +33,7 @@ export const ArrayFieldItemTemplate: FC<ArrayFieldTemplateItemType> = (props) =>
     const childrenFormData = children.props.formData.destination
     if (childrenFormData) return `${children.props.name} - ${childrenFormData}`
     return children.props.name
-  }, [])
+  }, [children.props.formData.destination, children.props.name])
 
   const { CopyButton, MoveDownButton, MoveUpButton, RemoveButton } = registry.templates.ButtonTemplates
   const onCopyClick = useMemo(() => onCopyIndexClick(index), [index, onCopyIndexClick])
@@ -59,15 +59,8 @@ export const ArrayFieldItemTemplate: FC<ArrayFieldTemplateItemType> = (props) =>
   const { hidden, ...rest } = getDisclosureProps()
 
   return (
-    <HStack
-      flexDirection="row-reverse"
-      alignItems="flex-start"
-      py={1}
-      // TODO[NVL] This is NOT a good approach to add a "role"; submit a PR!
-      role="listitem"
-    >
+    <HStack flexDirection="row-reverse" alignItems="flex-start" py={1} role="listitem">
       {hasToolbar && (
-        // TODO[NVL] This is NOT a good approach to add a "role"; submit a PR!
         <VStack gap={6} role="toolbar">
           <ButtonGroup>
             <IconButton

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/templates/ArrayFieldItemTemplate.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/templates/ArrayFieldItemTemplate.tsx
@@ -6,6 +6,11 @@ import { LuPanelTopClose, LuPanelTopOpen } from 'react-icons/lu'
 
 import IconButton from '@/components/Chakra/IconButton.tsx'
 
+// TODO[NVL] Need a better handling of the custom UISchema property, for the Adapter SDK
+interface ArrayFieldItemCollapsableUISchema {
+  titleKey: string
+}
+
 // TODO[NVL] This is driven by subscription handling; use uiSchema to allow configuration for individual array property
 export const ArrayFieldItemTemplate: FC<ArrayFieldTemplateItemType> = (props) => {
   const {

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/templates/ArrayFieldItemTemplate.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/templates/ArrayFieldItemTemplate.tsx
@@ -25,7 +25,10 @@ export const ArrayFieldItemTemplate: FC<ArrayFieldTemplateItemType> = (props) =>
     registry,
   } = props
   const { t } = useTranslation('components')
-  const { isOpen, onToggle, getButtonProps, getDisclosureProps } = useDisclosure({ defaultIsOpen: false })
+  const { isOpen, onToggle, getButtonProps, getDisclosureProps } = useDisclosure({
+    // This is a real hack but didn't find a better way of detecting a new item
+    defaultIsOpen: index === props.totalItems - 1 && children.props.formData.destination === undefined,
+  })
   const name = useMemo<string>(() => {
     const childrenFormData = children.props.formData.destination
     if (childrenFormData) return `${children.props.name} - ${childrenFormData}`

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/hooks/useGetUISchema.ts
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/hooks/useGetUISchema.ts
@@ -108,6 +108,10 @@ const useGetUiSchema = (isNewAdapter = true) => {
     subscriptions: {
       items: {
         'ui:order': ['node', 'holding-registers', 'mqtt-topic', 'destination', 'qos', '*'],
+        'ui:collapsable': {
+          // TODO[NVL] This must be a property of the JSON Schema, will be extracted from formData. Figure out how to check
+          titleKey: 'destination',
+        },
       },
     },
     auth: {

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/edges/ObservabilityEdgeCTA.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/edges/ObservabilityEdgeCTA.spec.cy.tsx
@@ -5,7 +5,7 @@ describe('ObservabilityEdgeCTA', () => {
     cy.viewport(400, 400)
   })
 
-  it.only('should render the button', () => {
+  it('should render the button', () => {
     cy.mountWithProviders(<ObservabilityEdgeCTA source="1" onClick={cy.stub().as('onClick')} />)
     cy.get('button').eq(0).should('not.have.attr', 'aria-describedby')
     cy.get('button').eq(0).focus()
@@ -20,6 +20,5 @@ describe('ObservabilityEdgeCTA', () => {
     cy.injectAxe()
     cy.mountWithProviders(<ObservabilityEdgeCTA source="1" />)
     cy.checkAccessibility()
-    cy.percySnapshot('Component: ObservabilityEdgeCTA')
   })
 })


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/19269/details/

This PR enables items in an array-based property of a `JSONSchema` form to be collapsable, saving precious space 

It extends the custom template used for array items in order to handle the control of the new UI. 

It adds a collapse/expand button on the side toolbar.

The custom handling is configurable through the `UISChema` scheme, with a  'ui:collapsable` attribute added to the `items` property, such as : 

```
    subscriptions: {
      items: {
        'ui:collapsable': {
          titleKey: 'destination',
        },
      },
    },
```

The PR also fixes https://hivemq.kanbanize.com/ctrl_board/57/cards/19931/details/

### Before 
![screenshot-localhost_3000-2024 05 02-16_46_52](https://github.com/hivemq/hivemq-edge/assets/2743481/c13dbda6-8638-480e-af6d-89c8969bb563)

### After
![screenshot-localhost_3000-2024 05 02-16_46_11](https://github.com/hivemq/hivemq-edge/assets/2743481/c36a8f51-1f77-4984-8b26-330753095b3d)
