### PR TITLE
Update README.adoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -59,8 +59,9 @@ More Protocol adapters will be added to the project over time.
 
 * OPC UA
 * Modbus
-* S7
-* ADS
+* Siemens S7
+* Beckhoff ADS
+* Allen-Bradley Ethernet/IP
 * HTTP
 * and many more
 


### PR DESCRIPTION
**Motivation**

Resolves EIP missing from adapter list

**Changes**

Siemens and Beckhoff added to S7 and ADS and AB Ethernet/IP listed to improve finding of HiveMQ Edge for these specific PLC manufacturers