### PR TITLE
fix(19868): Fix disable state of Data Hub check and toolbar

### DIFF
--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/DeleteListener.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/DeleteListener.tsx
@@ -76,7 +76,7 @@ const DeleteListener: FC = () => {
     const { selectedNodes, selectedEdges } = selectedElements
     onEdgesChange(selectedEdges.map<EdgeRemoveChange>((edge) => ({ id: edge.id, type: 'remove' })))
     onNodesChange(selectedNodes.map<NodeRemoveChange>((node) => ({ id: node.id, type: 'remove' })))
-    setStatus(DesignerStatus.MODIFIED)
+    setStatus(status === DesignerStatus.DRAFT ? DesignerStatus.DRAFT : DesignerStatus.MODIFIED)
   }
 
   return (


### PR DESCRIPTION
The PR fixes a bug with the status of the Designer when nodes/edges are deleted, resulting in the toolbar and the "check validity" button to be disabled