### PR TITLE
feat(19466): Add user-editable id to the main DataHub nodes

### DIFF
--- a/hivemq-edge/src/frontend/src/api/hooks/useFrontendServices/useGetCapabilities.tsx
+++ b/hivemq-edge/src/frontend/src/api/hooks/useFrontendServices/useGetCapabilities.tsx
@@ -13,7 +13,7 @@ const getLocalConfig = (): CapabilityList | undefined => {
   console.log('%c[HiveMQ Edge] Capability override: %s', 'color:#ffc000;font-weight:bold;', config)
 
   const capabilities = config.split(',')
-  return { items: MOCK_CAPABILITIES.items?.filter((e) => capabilities.includes(e.id as string)) }
+  return { items: MOCK_CAPABILITIES.items?.filter((capability) => capabilities.includes(capability.id as string)) }
 }
 
 export const useGetCapabilities = () => {

--- a/hivemq-edge/src/frontend/src/extensions/datahub/__test-utils__/react-flow.mocks.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/__test-utils__/react-flow.mocks.tsx
@@ -40,7 +40,7 @@ export const MOCK_INITIAL_POLICY = () => {
 
   const dataPolicyNode: Node<DataPolicyData> = {
     id: '3',
-    data: {},
+    data: { id: 'my-policy-id' },
     type: DataHubNodeType.DATA_POLICY,
     position: { x: 345, y: 105 },
   }

--- a/hivemq-edge/src/frontend/src/extensions/datahub/__test-utils__/react-flow.mocks.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/__test-utils__/react-flow.mocks.tsx
@@ -64,14 +64,14 @@ export const MOCK_INITIAL_POLICY = () => {
 
   const operationNode1: Node<OperationData> = {
     id: '6',
-    data: { functionId: '< not set >', metadata: { hasArguments: true } },
+    data: { id: 'my-operation-id1', functionId: '< not set >', metadata: { hasArguments: true } },
     type: DataHubNodeType.OPERATION,
     position: { x: 945, y: 105 },
   }
 
   const operationNode2: Node<OperationData> = {
     id: '6b',
-    data: { functionId: '< not set >', metadata: { isTerminal: true } },
+    data: { id: 'my-operation-id2', functionId: '< not set >', metadata: { isTerminal: true } },
     type: DataHubNodeType.OPERATION,
     position: { x: 1215, y: 105 },
   }

--- a/hivemq-edge/src/frontend/src/extensions/datahub/__test-utils__/react-flow.mocks.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/__test-utils__/react-flow.mocks.tsx
@@ -78,7 +78,7 @@ export const MOCK_INITIAL_POLICY = () => {
 
   const behaviorPolicyNode: Node<BehaviorPolicyData> = {
     id: '7',
-    data: { model: BehaviorPolicyType.MQTT_EVENT },
+    data: { id: 'my-policy-id', model: BehaviorPolicyType.MQTT_EVENT },
     type: DataHubNodeType.BEHAVIOR_POLICY,
     position: { x: 345, y: 195 },
   }

--- a/hivemq-edge/src/frontend/src/extensions/datahub/api/__generated__/schemas/BehaviorPolicyData.json
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/api/__generated__/schemas/BehaviorPolicyData.json
@@ -279,7 +279,7 @@
       "title": "id",
       "description": "The unique id of this behaviour policy",
       "type": "string",
-      "pattern": "^([a-zA-Z_0-9-_])*$"
+      "pattern": "^[A-Za-z][A-Za-z0-9._-]{0,1023}$"
     },
     "model": {
       "title": "Behavior Model",

--- a/hivemq-edge/src/frontend/src/extensions/datahub/api/__generated__/schemas/BehaviorPolicyData.json
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/api/__generated__/schemas/BehaviorPolicyData.json
@@ -273,8 +273,14 @@
     }
   },
   "type": "object",
-  "required": ["model"],
+  "required": ["id", "model"],
   "properties": {
+    "id": {
+      "title": "id",
+      "description": "The unique id of this behaviour policy",
+      "type": "string",
+      "pattern": "^([a-zA-Z_0-9-_])*$"
+    },
     "model": {
       "title": "Behavior Model",
       "default": "Mqtt.events",

--- a/hivemq-edge/src/frontend/src/extensions/datahub/api/__generated__/schemas/DataPolicyData.json
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/api/__generated__/schemas/DataPolicyData.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "required": ["id"],
+  "properties": {
+    "id": {
+      "title": "id",
+      "description": "The unique id for the data policy",
+      "type": "string",
+      "pattern": "^([a-zA-Z_0-9-_])*$"
+    }
+  }
+}

--- a/hivemq-edge/src/frontend/src/extensions/datahub/api/__generated__/schemas/DataPolicyData.json
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/api/__generated__/schemas/DataPolicyData.json
@@ -6,7 +6,7 @@
       "title": "id",
       "description": "The unique id of this data policy",
       "type": "string",
-      "pattern": "^([a-zA-Z_0-9-_])*$"
+      "pattern": "^[A-Za-z][A-Za-z0-9._-]{0,1023}$"
     }
   }
 }

--- a/hivemq-edge/src/frontend/src/extensions/datahub/api/__generated__/schemas/DataPolicyData.json
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/api/__generated__/schemas/DataPolicyData.json
@@ -4,7 +4,7 @@
   "properties": {
     "id": {
       "title": "id",
-      "description": "The unique id for the data policy",
+      "description": "The unique id of this data policy",
       "type": "string",
       "pattern": "^([a-zA-Z_0-9-_])*$"
     }

--- a/hivemq-edge/src/frontend/src/extensions/datahub/api/__generated__/schemas/OperationData.json
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/api/__generated__/schemas/OperationData.json
@@ -169,7 +169,14 @@
       }
     },
     "functionId": {
+      "required": ["id"],
       "properties": {
+        "id": {
+          "title": "id",
+          "description": "The unique id of this pipeline operation",
+          "type": "string",
+          "pattern": "^[A-Za-z][A-Za-z0-9._-]{0,1023}$"
+        },
         "functionId": {
           "title": "Function",
           "description": "You can use two categories of functions in your policies. Non-terminal functions allow further operations in the pipeline to be executed,\n                          while terminal functions end further operations in the pipeline",

--- a/hivemq-edge/src/frontend/src/extensions/datahub/api/hooks/DataHubDataPoliciesService/__handlers__/index.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/api/hooks/DataHubDataPoliciesService/__handlers__/index.ts
@@ -19,4 +19,7 @@ export const handlers = [
       { status: 200 }
     )
   }),
+  http.get('*/data-hub/data-validation/policies/:policy', () => {
+    return HttpResponse.json<DataPolicy>(mockDataPolicy, { status: 200 })
+  }),
 ]

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/DeleteListener.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/DeleteListener.spec.cy.tsx
@@ -33,12 +33,12 @@ const getWrapperWith = (initNodes: Node[], initEdges?: Edge[]) => {
               <Tr>
                 <Th>nodes</Th>
                 <Td>{nodes.length}</Td>
-                <Td>{nodes.filter((e) => e.selected).length}</Td>
+                <Td>{nodes.filter((node) => node.selected).length}</Td>
               </Tr>
               <Tr>
                 <Th>edges</Th>
                 <Td>{edges.length}</Td>
-                <Td>{edges.filter((e) => e.selected).length}</Td>
+                <Td>{edges.filter((edge) => edge.selected).length}</Td>
               </Tr>
             </Tbody>
           </Table>

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/ToolboxDryRun.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/ToolboxDryRun.spec.cy.tsx
@@ -11,7 +11,7 @@ import { DataHubNodeType, DataPolicyData } from '@datahub/types.ts'
 const MOCK_NODE_DATA_POLICY: Node<DataPolicyData> = {
   id: 'node-id',
   type: DataHubNodeType.DATA_POLICY,
-  data: {},
+  data: { id: 'my-policy-id' },
   ...MOCK_DEFAULT_NODE,
   position: { x: 0, y: 0 },
 }

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/behavior_policy/BehaviorPolicyNode.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/behavior_policy/BehaviorPolicyNode.spec.cy.tsx
@@ -11,7 +11,7 @@ import { BehaviorPolicyNode } from '@datahub/designer/behavior_policy/BehaviorPo
 const MOCK_NODE_BEHAVIOR_POLICY: NodeProps<BehaviorPolicyData> = {
   id: 'node-id',
   type: DataHubNodeType.BEHAVIOR_POLICY,
-  data: { model: BehaviorPolicyType.MQTT_EVENT },
+  data: { id: 'my-policy-id', model: BehaviorPolicyType.MQTT_EVENT },
   ...MOCK_DEFAULT_NODE,
 }
 

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/behavior_policy/BehaviorPolicyNode.utils.spec.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/behavior_policy/BehaviorPolicyNode.utils.spec.ts
@@ -34,7 +34,7 @@ describe('checkValidityModel', () => {
     const MOCK_NODE_BEHAVIOR_POLICY: Node<BehaviorPolicyData> = {
       id: 'node-id',
       type: DataHubNodeType.BEHAVIOR_POLICY,
-      data: { model: BehaviorPolicyType.PUBLISH_DUPLICATE },
+      data: { id: 'my-policy-id', model: BehaviorPolicyType.PUBLISH_DUPLICATE },
       ...MOCK_DEFAULT_NODE,
       position: { x: 0, y: 0 },
     }

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/behavior_policy/BehaviorPolicyNode.utils.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/behavior_policy/BehaviorPolicyNode.utils.ts
@@ -6,6 +6,7 @@ import i18n from '@/config/i18n.config.ts'
 
 import { PolicyCheckErrors } from '@datahub/designer/validation.errors.ts'
 import { BehaviorPolicyData, BehaviorPolicyType, DataHubNodeType, DryRunResults } from '@datahub/types.ts'
+import { getNodeId } from '@datahub/utils/node.utils.ts'
 
 export function checkValidityModel(behaviorPolicy: Node<BehaviorPolicyData>): DryRunResults<BehaviorPolicyBehavior> {
   if (!behaviorPolicy.data.model) {
@@ -26,17 +27,16 @@ export function checkValidityModel(behaviorPolicy: Node<BehaviorPolicyData>): Dr
 // TODO[NVL] Need to find a better way of testing this one
 /* istanbul ignore next -- @preserve */
 export function checkValidityBehaviorPolicy(
-  node: Node<BehaviorPolicyData>,
+  behaviourPolicyNode: Node<BehaviorPolicyData>,
   client: DryRunResults<string, never>,
   model: DryRunResults<BehaviorPolicyBehavior, never>,
   transitions: DryRunResults<BehaviorPolicyOnTransition, never>[]
 ): DryRunResults<BehaviorPolicy, unknown> {
   return {
-    node: node,
+    node: behaviourPolicyNode,
     data: {
       behavior: model.data as BehaviorPolicyBehavior,
-      // TODO[19466] Id should be user-facing; Need to fix before merging!
-      id: node.id,
+      id: behaviourPolicyNode.data.id,
       matching: { clientIdRegex: client.data as string },
       onTransitions: transitions.length
         ? transitions.map((transition) => {
@@ -60,10 +60,11 @@ export const loadBehaviorPolicy = (behaviorPolicy: BehaviorPolicy): NodeAddChang
   }
 
   const behaviorPolicyNode: Node<BehaviorPolicyData> = {
-    id: behaviorPolicy.id,
+    id: getNodeId(),
     type: DataHubNodeType.BEHAVIOR_POLICY,
     position,
     data: {
+      id: behaviorPolicy.id,
       model: model,
       arguments: behaviorPolicy.behavior.arguments,
     },

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/behavior_policy/BehaviorPolicyPanel.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/behavior_policy/BehaviorPolicyPanel.spec.cy.tsx
@@ -43,7 +43,7 @@ describe('BehaviorPolicyPanel', () => {
 
     cy.mountWithProviders(<BehaviorPolicyPanel selectedNode="3" onFormSubmit={onSubmit} />, { wrapper })
 
-    cy.get('#root_id').type('123')
+    cy.get('#root_id').type('a123')
 
     cy.get('label#root_model-label').should('contain.text', 'Behavior Model')
     cy.get('label#root_model-label + div').should('contain.text', 'Mqtt.events')
@@ -73,7 +73,7 @@ describe('BehaviorPolicyPanel', () => {
       .should('deep.include', {
         status: 'submitted',
         formData: {
-          id: '123',
+          id: 'a123',
           model: 'Publish.quota',
           arguments: {
             minPublishes: 0,

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/behavior_policy/BehaviorPolicyPanel.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/behavior_policy/BehaviorPolicyPanel.spec.cy.tsx
@@ -3,9 +3,10 @@
 import { Button } from '@chakra-ui/react'
 
 import { MockStoreWrapper } from '@datahub/__test-utils__/MockStoreWrapper.tsx'
+import { mockBehaviorPolicy } from '@datahub/api/hooks/DataHubBehaviorPoliciesService/__handlers__'
+import { BehaviorPolicyPanel } from '@datahub/designer/behavior_policy/BehaviorPolicyPanel.tsx'
 import { DataHubNodeType } from '@datahub/types.ts'
 import { getNodePayload } from '@datahub/utils/node.utils.ts'
-import { BehaviorPolicyPanel } from './BehaviorPolicyPanel.tsx'
 
 const wrapper: React.JSXElementConstructor<{ children: React.ReactNode }> = ({ children }) => (
   <MockStoreWrapper
@@ -32,12 +33,17 @@ const wrapper: React.JSXElementConstructor<{ children: React.ReactNode }> = ({ c
 describe('BehaviorPolicyPanel', () => {
   beforeEach(() => {
     cy.viewport(800, 800)
+    cy.intercept('/api/v1/data-hub/behavior-validation/policies', {
+      items: [mockBehaviorPolicy],
+    })
   })
 
-  it('should render the fields for a Validator', () => {
+  it('should render the fields for the panel', () => {
     const onSubmit = cy.stub().as('onSubmit')
 
     cy.mountWithProviders(<BehaviorPolicyPanel selectedNode="3" onFormSubmit={onSubmit} />, { wrapper })
+
+    cy.get('#root_id').type('123')
 
     cy.get('label#root_model-label').should('contain.text', 'Behavior Model')
     cy.get('label#root_model-label + div').should('contain.text', 'Mqtt.events')
@@ -55,10 +61,10 @@ describe('BehaviorPolicyPanel', () => {
     cy.get('label#root_model-label + div').find("[role='listbox']").find("[role='option']").eq(0).click()
 
     cy.get('h2').eq(0).should('contain.text', 'Publish')
-    cy.get('label#field-\\:r7\\:-label').should('contain.text', 'minPublishes')
-    cy.get('label#field-\\:r7\\:-label + div > input').should('have.value', '0')
-    cy.get('label#field-\\:r9\\:-label').should('contain.text', 'maxPublishes')
-    cy.get('label#field-\\:r9\\:-label + div > input').should('have.value', '-1')
+    cy.get('label#field-\\:r9\\:-label').should('contain.text', 'minPublishes')
+    cy.get('label#field-\\:r9\\:-label + div > input').should('have.value', '0')
+    cy.get('label#field-\\:rb\\:-label').should('contain.text', 'maxPublishes')
+    cy.get('label#field-\\:rb\\:-label + div > input').should('have.value', '-1')
 
     cy.get("button[type='submit']").click()
     cy.get('@onSubmit')
@@ -67,6 +73,7 @@ describe('BehaviorPolicyPanel', () => {
       .should('deep.include', {
         status: 'submitted',
         formData: {
+          id: '123',
           model: 'Publish.quota',
           arguments: {
             minPublishes: 0,

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/behavior_policy/BehaviorPolicyPanel.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/behavior_policy/BehaviorPolicyPanel.tsx
@@ -1,19 +1,33 @@
 import { FC, useMemo } from 'react'
 import { Node } from 'reactflow'
+import { useTranslation } from 'react-i18next'
 import { Card, CardBody } from '@chakra-ui/react'
+import { CustomValidator } from '@rjsf/utils'
 
 import { BehaviorPolicyData, PanelProps } from '@datahub/types.ts'
-import useDataHubDraftStore from '@datahub/hooks/useDataHubDraftStore.ts'
+import { useGetAllBehaviorPolicies } from '@datahub/api/hooks/DataHubBehaviorPoliciesService/useGetAllBehaviorPolicies.tsx'
 import { ReactFlowSchemaForm } from '@datahub/components/forms/ReactFlowSchemaForm.tsx'
 import { MOCK_BEHAVIOR_POLICY_SCHEMA } from '@datahub/designer/behavior_policy/BehaviorPolicySchema.ts'
+import useDataHubDraftStore from '@datahub/hooks/useDataHubDraftStore.ts'
 
 export const BehaviorPolicyPanel: FC<PanelProps> = ({ selectedNode, onFormSubmit }) => {
+  const { t } = useTranslation('datahub')
   const { nodes } = useDataHubDraftStore()
+  const { data: allPolicies } = useGetAllBehaviorPolicies({})
 
   const data = useMemo(() => {
     const adapterNode = nodes.find((e) => e.id === selectedNode) as Node<BehaviorPolicyData> | undefined
     return adapterNode ? adapterNode.data : null
   }, [selectedNode, nodes])
+
+  const customValidate: CustomValidator<BehaviorPolicyData> = (formData, errors) => {
+    if (!allPolicies) errors['id']?.addError(t('error.validation.behaviourPolicy.notLoading'))
+    else {
+      const isIdNotUnique = Boolean(allPolicies.items?.find((e) => e.id === formData?.id))
+      if (isIdNotUnique) errors['id']?.addError(t('error.validation.behaviourPolicy.notUnique'))
+    }
+    return errors
+  }
 
   return (
     <Card>
@@ -21,6 +35,7 @@ export const BehaviorPolicyPanel: FC<PanelProps> = ({ selectedNode, onFormSubmit
         <ReactFlowSchemaForm
           schema={MOCK_BEHAVIOR_POLICY_SCHEMA.schema}
           uiSchema={MOCK_BEHAVIOR_POLICY_SCHEMA.uiSchema}
+          customValidate={customValidate}
           formData={data}
           onSubmit={onFormSubmit}
         />

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/client_filter/ClientFilterNode.utils.spec.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/client_filter/ClientFilterNode.utils.spec.ts
@@ -15,7 +15,7 @@ describe('checkValidityClients', () => {
   const MOCK_NODE_BEHAVIOR_POLICY: Node<BehaviorPolicyData> = {
     id: 'node-id',
     type: DataHubNodeType.BEHAVIOR_POLICY,
-    data: { model: BehaviorPolicyType.MQTT_EVENT },
+    data: { id: 'my-policy-id', model: BehaviorPolicyType.MQTT_EVENT },
     ...MOCK_DEFAULT_NODE,
     position: { x: 0, y: 0 },
   }

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/client_filter/ClientFilterNode.utils.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/client_filter/ClientFilterNode.utils.ts
@@ -2,7 +2,6 @@ import { Connection, getIncomers, Node, NodeAddChange, XYPosition } from 'reactf
 
 import { getNodeId, isClientFilterNodeType } from '@datahub/utils/node.utils.ts'
 import { BehaviorPolicy } from '@/api/__generated__'
-import i18n from '@/config/i18n.config.ts'
 
 import { BehaviorPolicyData, ClientFilterData, DataHubNodeType, DryRunResults, WorkspaceState } from '@datahub/types.ts'
 import { PolicyCheckErrors } from '@datahub/designer/validation.errors.ts'
@@ -42,10 +41,6 @@ export const loadClientFilter = (
   behaviorPolicy: BehaviorPolicy,
   behaviorPolicyNode: Node<BehaviorPolicyData>
 ): (NodeAddChange | Connection)[] => {
-  if (behaviorPolicyNode.id !== behaviorPolicy.id)
-    throw new Error(
-      i18n.t('datahub:error.loading.connection.notFound', { type: DataHubNodeType.BEHAVIOR_POLICY }) as string
-    )
   const position: XYPosition = {
     x: behaviorPolicyNode.position.x + CANVAS_POSITION.Client.x,
     y: behaviorPolicyNode.position.y + CANVAS_POSITION.Client.y,

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/data_policy/DataPolicyNode.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/data_policy/DataPolicyNode.spec.cy.tsx
@@ -11,7 +11,7 @@ import { DataPolicyNode } from './DataPolicyNode.tsx'
 const MOCK_NODE_DATA_POLICY: NodeProps<DataPolicyData> = {
   id: 'node-id',
   type: DataHubNodeType.DATA_POLICY,
-  data: {},
+  data: { id: 'my-policy-id' },
   ...MOCK_DEFAULT_NODE,
 }
 

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/data_policy/DataPolicyNode.utils.spec.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/data_policy/DataPolicyNode.utils.spec.ts
@@ -10,7 +10,7 @@ describe('checkValidityFilter', () => {
     const MOCK_NODE_DATA_POLICY: Node<DataPolicyData> = {
       id: 'node-id',
       type: DataHubNodeType.DATA_POLICY,
-      data: {},
+      data: { id: 'my-policy-id' },
       ...MOCK_DEFAULT_NODE,
       position: { x: 0, y: 0 },
     }
@@ -39,7 +39,7 @@ describe('checkValidityFilter', () => {
     const MOCK_NODE_DATA_POLICY: Node<DataPolicyData> = {
       id: 'node-id',
       type: DataHubNodeType.DATA_POLICY,
-      data: {},
+      data: { id: 'my-policy-id' },
       ...MOCK_DEFAULT_NODE,
       position: { x: 0, y: 0 },
     }
@@ -101,7 +101,7 @@ describe('checkValidityFilter', () => {
     const MOCK_NODE_DATA_POLICY: Node<DataPolicyData> = {
       id: 'node-id',
       type: DataHubNodeType.DATA_POLICY,
-      data: {},
+      data: { id: 'my-policy-id' },
       ...MOCK_DEFAULT_NODE,
       position: { x: 0, y: 0 },
     }

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/data_policy/DataPolicyNode.utils.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/data_policy/DataPolicyNode.utils.ts
@@ -3,7 +3,7 @@ import { getIncomers, getOutgoers, Node, NodeAddChange, XYPosition } from 'react
 import { DataPolicy, DataPolicyValidator, PolicyOperation } from '@/api/__generated__'
 import { DataHubNodeType, DataPolicyData, DryRunResults, WorkspaceState } from '@datahub/types.ts'
 import { PolicyCheckErrors } from '@datahub/designer/validation.errors.ts'
-import { isTopicFilterNodeType } from '@datahub/utils/node.utils.ts'
+import { getNodeId, isTopicFilterNodeType } from '@datahub/utils/node.utils.ts'
 
 /* istanbul ignore next -- @preserve */
 export function getSubFlow(source: Node, acc: Node[], store: WorkspaceState, only = false) {
@@ -86,8 +86,7 @@ export const checkValidityDataPolicy = (
   return {
     node: dataPolicyNode,
     data: {
-      // TODO[19466] Id should be user-facing; Need to fix before merging!
-      id: dataPolicyNode.id,
+      id: dataPolicyNode.data.id,
       matching: { topicFilter: filter.data as string },
       validation: validators.length
         ? {
@@ -122,10 +121,10 @@ export const loadDataPolicy = (policy: DataPolicy): NodeAddChange => {
   }
 
   const dataPolicyNode: Node<DataPolicyData> = {
-    id: policy.id,
+    id: getNodeId(),
     type: DataHubNodeType.DATA_POLICY,
     position,
-    data: {},
+    data: { id: policy.id },
   }
 
   return { item: dataPolicyNode, type: 'add' }

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/data_policy/DataPolicyPanel.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/data_policy/DataPolicyPanel.spec.cy.tsx
@@ -44,7 +44,7 @@ describe('DataPolicyPanel', () => {
     cy.mountWithProviders(<DataPolicyPanel selectedNode="3" onFormSubmit={onSubmit} />, { wrapper })
 
     cy.get('label#root_id-label').should('contain.text', 'id')
-    cy.get('#root_id').type('123')
+    cy.get('#root_id').type('a123')
 
     cy.get("button[type='submit']").click()
     cy.get('@onSubmit')
@@ -53,7 +53,7 @@ describe('DataPolicyPanel', () => {
       .should('deep.include', {
         status: 'submitted',
         formData: {
-          id: '123',
+          id: 'a123',
         },
       })
   })

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/data_policy/DataPolicyPanel.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/data_policy/DataPolicyPanel.spec.cy.tsx
@@ -41,7 +41,6 @@ describe('DataPolicyPanel', () => {
   it('should render the fields for the panel', () => {
     const onSubmit = cy.stub().as('onSubmit')
 
-    // eslint-disable-next-line react/jsx-no-undef
     cy.mountWithProviders(<DataPolicyPanel selectedNode="3" onFormSubmit={onSubmit} />, { wrapper })
 
     cy.get('label#root_id-label').should('contain.text', 'id')

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/data_policy/DataPolicyPanel.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/data_policy/DataPolicyPanel.spec.cy.tsx
@@ -1,0 +1,69 @@
+/// <reference types="cypress" />
+
+import { Button } from '@chakra-ui/react'
+
+import { MockStoreWrapper } from '@datahub/__test-utils__/MockStoreWrapper.tsx'
+import { mockDataPolicy } from '@datahub/api/hooks/DataHubDataPoliciesService/__handlers__'
+import { DataPolicyPanel } from '@datahub/designer/data_policy/DataPolicyPanel.tsx'
+import { DataHubNodeType } from '@datahub/types.ts'
+import { getNodePayload } from '@datahub/utils/node.utils.ts'
+
+const wrapper: React.JSXElementConstructor<{ children: React.ReactNode }> = ({ children }) => (
+  <MockStoreWrapper
+    config={{
+      initialState: {
+        nodes: [
+          {
+            id: '3',
+            type: DataHubNodeType.BEHAVIOR_POLICY,
+            position: { x: 0, y: 0 },
+            data: getNodePayload(DataHubNodeType.BEHAVIOR_POLICY),
+          },
+        ],
+      },
+    }}
+  >
+    {children}
+    <Button variant="primary" type="submit" form="datahub-node-form">
+      SUBMIT{' '}
+    </Button>
+  </MockStoreWrapper>
+)
+
+describe('DataPolicyPanel', () => {
+  beforeEach(() => {
+    cy.viewport(800, 800)
+    cy.intercept('/api/v1/data-hub/data-validation/policies', {
+      items: [mockDataPolicy],
+    })
+  })
+
+  it('should render the fields for the panel', () => {
+    const onSubmit = cy.stub().as('onSubmit')
+
+    // eslint-disable-next-line react/jsx-no-undef
+    cy.mountWithProviders(<DataPolicyPanel selectedNode="3" onFormSubmit={onSubmit} />, { wrapper })
+
+    cy.get('label#root_id-label').should('contain.text', 'id')
+    cy.get('#root_id').type('123')
+
+    cy.get("button[type='submit']").click()
+    cy.get('@onSubmit')
+      .should('have.been.calledOnceWith', Cypress.sinon.match.object)
+      .its('firstCall.args.0')
+      .should('deep.include', {
+        status: 'submitted',
+        formData: {
+          id: '123',
+        },
+      })
+  })
+
+  it('should be accessible', () => {
+    cy.injectAxe()
+    cy.mountWithProviders(<DataPolicyPanel selectedNode="3" />, { wrapper })
+
+    cy.checkAccessibility()
+    cy.percySnapshot('Component: DataPolicyPanel')
+  })
+})

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/data_policy/DataPolicyPanel.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/data_policy/DataPolicyPanel.tsx
@@ -1,0 +1,45 @@
+import { FC, useMemo } from 'react'
+import { Node } from 'reactflow'
+import { Card, CardBody } from '@chakra-ui/react'
+
+import { DataPolicyData, PanelProps } from '@datahub/types.ts'
+import useDataHubDraftStore from '@datahub/hooks/useDataHubDraftStore.ts'
+import { ReactFlowSchemaForm } from '@datahub/components/forms/ReactFlowSchemaForm.tsx'
+import { MOCK_DATA_POLICY_SCHEMA } from '@datahub/designer/data_policy/DataPolicySchema.ts'
+import { CustomValidator } from '@rjsf/utils'
+import { useGetAllDataPolicies } from '@datahub/api/hooks/DataHubDataPoliciesService/useGetAllDataPolicies.tsx'
+import { useTranslation } from 'react-i18next'
+
+export const DataPolicyPanel: FC<PanelProps> = ({ selectedNode, onFormSubmit }) => {
+  const { t } = useTranslation('datahub')
+  const { nodes } = useDataHubDraftStore()
+  const { data: allPolicies } = useGetAllDataPolicies()
+
+  const data = useMemo(() => {
+    const adapterNode = nodes.find((e) => e.id === selectedNode) as Node<DataPolicyData> | undefined
+    return adapterNode ? adapterNode.data : null
+  }, [selectedNode, nodes])
+
+  const customValidate: CustomValidator<DataPolicyData> = (formData, errors) => {
+    if (!allPolicies) errors['id']?.addError(t('error.validation.dataPolicy.notLoading'))
+    else {
+      const isIdNotUnique = Boolean(allPolicies.items?.find((e) => e.id === formData?.id))
+      if (isIdNotUnique) errors['id']?.addError(t('error.validation.dataPolicy.notUnique'))
+    }
+    return errors
+  }
+
+  return (
+    <Card>
+      <CardBody>
+        <ReactFlowSchemaForm
+          schema={MOCK_DATA_POLICY_SCHEMA.schema}
+          uiSchema={MOCK_DATA_POLICY_SCHEMA.uiSchema}
+          formData={data}
+          onSubmit={onFormSubmit}
+          customValidate={customValidate}
+        />
+      </CardBody>
+    </Card>
+  )
+}

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/data_policy/DataPolicySchema.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/data_policy/DataPolicySchema.ts
@@ -1,0 +1,9 @@
+import { PanelSpecs } from '@/extensions/datahub/types.ts'
+import { RJSFSchema } from '@rjsf/utils'
+
+import schema from '@datahub/api/__generated__/schemas/DataPolicyData.json'
+
+export const MOCK_DATA_POLICY_SCHEMA: PanelSpecs = {
+  schema: schema as RJSFSchema,
+  uiSchema: {},
+}

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/mappings.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/mappings.tsx
@@ -21,6 +21,7 @@ import { BehaviorPolicyNode } from '@datahub/designer/behavior_policy/BehaviorPo
 import { TransitionNode } from '@datahub/designer/transition/TransitionNode.tsx'
 
 import LoaderSpinner from '@/components/Chakra/LoaderSpinner.tsx'
+import { DataPolicyPanel } from '@datahub/designer/data_policy/DataPolicyPanel.tsx'
 
 /**
  * Used in the side panel editor to render the content of the selected node
@@ -29,6 +30,7 @@ export const DefaultEditor: Record<string, FC<PanelProps>> = {
   [DataHubNodeType.INTERNAL]: () => <LoaderSpinner />,
   [DataHubNodeType.TOPIC_FILTER]: TopicFilterPanel,
   [DataHubNodeType.CLIENT_FILTER]: ClientFilterPanel,
+  [DataHubNodeType.DATA_POLICY]: DataPolicyPanel,
   [DataHubNodeType.VALIDATOR]: ValidatorPanel,
   [DataHubNodeType.SCHEMA]: SchemaPanel,
   [DataHubNodeType.BEHAVIOR_POLICY]: BehaviorPolicyPanel,

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/operation/OperationNode.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/operation/OperationNode.spec.cy.tsx
@@ -11,7 +11,7 @@ import { OperationNode } from './OperationNode.tsx'
 const MOCK_NODE_OPERATION: NodeProps<OperationData> = {
   id: 'node-id',
   type: DataHubNodeType.OPERATION,
-  data: {},
+  data: { id: 'my-operation-id' },
   ...MOCK_DEFAULT_NODE,
 }
 
@@ -49,7 +49,7 @@ describe('OperationNode', () => {
   it('should render properly with arguments', () => {
     const data: NodeProps<OperationData> = {
       ...MOCK_NODE_OPERATION,
-      data: { functionId: 'DataHub.transform', metadata: { hasArguments: true } },
+      data: { id: 'my-operation-id', functionId: 'DataHub.transform', metadata: { hasArguments: true } },
     }
     cy.mountWithProviders(mockReactFlow(<OperationNode {...data} selected={true} />))
     cy.getByTestId(`node-title`).should('contain.text', 'Operation')
@@ -70,7 +70,7 @@ describe('OperationNode', () => {
   it('should render properly with terminal', () => {
     const data: NodeProps<OperationData> = {
       ...MOCK_NODE_OPERATION,
-      data: { functionId: 'test', metadata: { isTerminal: true } },
+      data: { id: 'my-operation-id', functionId: 'test', metadata: { isTerminal: true } },
     }
     cy.mountWithProviders(mockReactFlow(<OperationNode {...data} selected={true} />))
     cy.getByTestId(`node-title`).should('contain.text', 'Operation')

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/operation/OperationNode.utils.spec.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/operation/OperationNode.utils.spec.ts
@@ -22,9 +22,7 @@ describe('checkValidityTransformFunction', () => {
     const MOCK_NODE_OPERATION: Node<OperationData> = {
       id: 'node-id',
       type: DataHubNodeType.OPERATION,
-      data: {
-        functionId: 'Javascript',
-      },
+      data: { id: 'my-operation-id', functionId: 'Javascript' },
       ...MOCK_DEFAULT_NODE,
       position: { x: 0, y: 0 },
     }
@@ -56,6 +54,7 @@ describe('checkValidityTransformFunction', () => {
       id: 'node-id',
       type: DataHubNodeType.OPERATION,
       data: {
+        id: 'my-operation-id',
         functionId: 'DataHub.transform',
         formData: {
           transform: ['the_function'],
@@ -115,6 +114,7 @@ describe('checkValidityTransformFunction', () => {
       id: 'node-id',
       type: DataHubNodeType.OPERATION,
       data: {
+        id: 'my-operation-id',
         functionId: 'DataHub.transform',
         formData: {
           transform: ['the_function'],
@@ -186,6 +186,7 @@ describe('checkValidityTransformFunction', () => {
       id: 'node-id',
       type: DataHubNodeType.OPERATION,
       data: {
+        id: 'my-operation-id',
         functionId: 'DataHub.transform',
         formData: {
           transform: ['the_function'],
@@ -264,6 +265,7 @@ describe('checkValidityTransformFunction', () => {
       id: 'node-id',
       type: DataHubNodeType.OPERATION,
       data: {
+        id: 'my-operation-id',
         functionId: 'DataHub.transform',
         formData: {
           transform: ['the_function'],
@@ -431,6 +433,7 @@ describe('processOperations', () => {
       id: 'node-id',
       type: DataHubNodeType.OPERATION,
       data: {
+        id: 'my-operation-id',
         functionId: undefined,
       },
       ...MOCK_DEFAULT_NODE,
@@ -458,6 +461,7 @@ describe('processOperations', () => {
       id: 'node-id',
       type: DataHubNodeType.OPERATION,
       data: {
+        id: 'my-operation-id',
         functionId: 'DataHub.transform',
         formData: {
           transform: ['the_function'],
@@ -492,6 +496,7 @@ describe('processOperations', () => {
       id: 'node-id',
       type: DataHubNodeType.OPERATION,
       data: {
+        id: 'my-operation-id',
         functionId: 'System.log',
         formData: {
           level: 'DEBUG',

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/operation/OperationNode.utils.spec.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/operation/OperationNode.utils.spec.ts
@@ -522,7 +522,7 @@ describe('processOperations', () => {
         message: 'test the message',
       },
       functionId: 'System.log',
-      id: 'node-id',
+      id: 'my-operation-id',
     })
     expect(error).toBeUndefined()
   })

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/operation/OperationNode.utils.spec.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/operation/OperationNode.utils.spec.ts
@@ -384,7 +384,7 @@ describe('checkValidityPipeline', () => {
     const MOCK_NODE_DATA_POLICY: Node<DataPolicyData> = {
       id: 'node-id',
       type: DataHubNodeType.DATA_POLICY,
-      data: {},
+      data: { id: 'my-policy-id' },
       ...MOCK_DEFAULT_NODE,
       position: { x: 0, y: 0 },
     }
@@ -403,7 +403,7 @@ describe('checkValidityPipeline', () => {
     const MOCK_NODE_DATA_POLICY: Node<DataPolicyData> = {
       id: 'node-id',
       type: DataHubNodeType.DATA_POLICY,
-      data: {},
+      data: { id: 'my-policy-id' },
       ...MOCK_DEFAULT_NODE,
       position: { x: 0, y: 0 },
     }

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/operation/OperationNode.utils.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/operation/OperationNode.utils.ts
@@ -29,7 +29,7 @@ import {
 } from '@datahub/designer/script/FunctionNode.utils.ts'
 import { checkValiditySchema, loadSchema } from '@datahub/designer/schema/SchemaNode.utils.ts'
 import { PolicyCheckErrors } from '@datahub/designer/validation.errors.ts'
-import { isFunctionNodeType, isSchemaNodeType } from '@datahub/utils/node.utils.ts'
+import { getNodeId, isFunctionNodeType, isSchemaNodeType } from '@datahub/utils/node.utils.ts'
 import { getActiveTransition } from '@datahub/designer/transition/TransitionNode.utils.ts'
 import { CANVAS_POSITION } from '@datahub/designer/checks.utils.ts'
 
@@ -186,7 +186,7 @@ export const processOperations =
         functionId: node.data.functionId,
         arguments: node.data.formData || {},
         // TODO[19466] Id should be user-facing; Need to fix before merging!
-        id: node.id,
+        id: node.data.id,
       }
       acc.push({ node: node, data: operation })
     }
@@ -324,10 +324,11 @@ export const loadPipeline = (
           const [deserializer, ...functions] = operationNode as PolicyOperation[]
 
           operationNode = {
-            id: policyOperation.id,
+            id: getNodeId(),
             type: DataHubNodeType.OPERATION,
             position: { ...shiftPositionRight() },
             data: {
+              id: policyOperation.id,
               functionId: OperationData.Function.DATAHUB_TRANSFORM,
               metadata: {
                 isTerminal: false,
@@ -361,10 +362,11 @@ export const loadPipeline = (
       default:
         if (operationNode) throw new Error(i18n.t('datahub:error.loading.operation.unknown') as string)
         operationNode = {
-          id: policyOperation.id,
+          id: getNodeId(),
           type: DataHubNodeType.OPERATION,
           position: { ...shiftPositionRight() },
           data: {
+            id: policyOperation.id,
             functionId: policyOperation.functionId,
             formData: policyOperation.arguments,
           },

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/operation/OperationNode.utils.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/operation/OperationNode.utils.ts
@@ -250,11 +250,6 @@ export const loadDataPolicyPipelines = (
   scripts: Script[],
   dataPolicyNode: Node<DataPolicyData>
 ) => {
-  if (dataPolicyNode.id !== policy.id)
-    throw new Error(
-      i18n.t('datahub:error.loading.connection.notFound', { type: DataHubNodeType.DATA_POLICY }) as string
-    )
-
   const newNodes: (NodeAddChange | Connection)[] = []
 
   if (policy.onSuccess && policy.onSuccess.pipeline) {

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/operation/OperationPanel.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/operation/OperationPanel.spec.cy.tsx
@@ -37,6 +37,9 @@ describe('OperationPanel', () => {
   it('should render the fields for a Validator', () => {
     cy.mountWithProviders(<OperationPanel selectedNode="3" />, { wrapper })
 
+    cy.get('label#root_id-label').should('contain.text', 'id')
+    cy.get('#root_id').type('a123')
+
     // first select
     cy.get('label#root_functionId-label').should('contain.text', 'Function')
     cy.get('label#root_functionId-label + div').should('contain.text', '')

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/operation/OperationPanel.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/operation/OperationPanel.tsx
@@ -32,15 +32,14 @@ export const OperationPanel: FC<PanelProps> = ({ selectedNode, onFormSubmit }) =
   }, [edges, nodes, selectedNode])
 
   const onFixFormSubmit = useCallback(
-    (data: IChangeEvent<OperationData>) => {
-      const initData = data
+    (initData: IChangeEvent<OperationData>) => {
       const { formData } = initData
       if (formData) {
-        const { functionId } = formData
+        const { id, functionId } = formData
         const functionSpecs = functions.find((e) => e.functionId === functionId)
         if (functionSpecs) {
           const { metadata } = functionSpecs
-          initData.formData = { ...initData.formData, metadata }
+          initData.formData = { id, ...initData.formData, metadata }
         }
       }
       onFormSubmit?.(initData)

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/schema/SchemaNode.utils.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/schema/SchemaNode.utils.ts
@@ -127,7 +127,7 @@ export function loadSchema(
 ): (NodeAddChange | Connection)[] {
   const schema = schemas.find((schema) => schema.id === schemaRef.schemaId)
   if (!schema)
-    throw new Error(i18n.t('datahub:error.loading.connection.notFound', { source: DataHubNodeType.SCHEMA }) as string)
+    throw new Error(i18n.t('datahub:error.loading.connection.notFound', { type: DataHubNodeType.SCHEMA }) as string)
 
   if (schema.type === SchemaType.JSON) {
     const schemaNode: Node<SchemaData> = {

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/script/FunctionNode.utils.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/script/FunctionNode.utils.ts
@@ -57,9 +57,7 @@ export const loadScripts = (parentNode: Node<DataHubNodeData>, functions: Policy
     const [, functionName] = fct.functionId.split(':')
     const functionScript = scripts.find((script) => script.id === functionName)
     if (!functionScript)
-      throw new Error(
-        i18n.t('datahub:error.loading.connection.notFound', { source: DataHubNodeType.FUNCTION }) as string
-      )
+      throw new Error(i18n.t('datahub:error.loading.connection.notFound', { type: DataHubNodeType.FUNCTION }) as string)
 
     const functionScriptNode: Node<FunctionData> = {
       id: functionScript.id,

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/topic_filter/TopicFilterNode.utils.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/topic_filter/TopicFilterNode.utils.ts
@@ -1,7 +1,6 @@
 import { Connection, Node, NodeAddChange, XYPosition } from 'reactflow'
 
 import { DataPolicy } from '@/api/__generated__'
-import i18n from '@/config/i18n.config.ts'
 
 import { getNodeId } from '@datahub/utils/node.utils.ts'
 import { DataHubNodeType, DataPolicyData, TopicFilterData } from '@datahub/types.ts'
@@ -11,11 +10,6 @@ export const loadTopicFilter = (
   policy: DataPolicy,
   dataPolicyNode: Node<DataPolicyData>
 ): (NodeAddChange | Connection)[] => {
-  if (dataPolicyNode.id !== policy.id)
-    throw new Error(
-      i18n.t('datahub:error.loading.connection.notFound', { type: DataHubNodeType.DATA_POLICY }) as string
-    )
-
   const position: XYPosition = {
     x: dataPolicyNode.position.x + CANVAS_POSITION.Topic.x,
     y: dataPolicyNode.position.y + CANVAS_POSITION.Topic.y,

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/transition/TransitionNode.utils.spec.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/transition/TransitionNode.utils.spec.ts
@@ -17,9 +17,7 @@ import { checkValidityTransitions } from '@datahub/designer/transition/Transitio
 const MOCK_NODE_BEHAVIOR: Node<BehaviorPolicyData> = {
   id: 'node-id',
   type: DataHubNodeType.BEHAVIOR_POLICY,
-  data: {
-    model: BehaviorPolicyType.MQTT_EVENT,
-  },
+  data: { id: 'my-policy-id', model: BehaviorPolicyType.MQTT_EVENT },
   ...MOCK_DEFAULT_NODE,
   position: { x: 0, y: 0 },
 }

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/transition/TransitionNode.utils.spec.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/transition/TransitionNode.utils.spec.ts
@@ -111,7 +111,7 @@ describe('checkValidityTransitions', () => {
             x: 1275,
             y: 225,
           },
-          data: {},
+          data: { id: 'my-operation-id1' },
           width: 233,
           height: 56,
         },
@@ -123,6 +123,7 @@ describe('checkValidityTransitions', () => {
             y: 275,
           },
           data: {
+            id: 'my-operation-id2',
             functionId: 'my-function',
             formData: {
               level: 'DEBUG',

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/transition/TransitionNode.utils.spec.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/transition/TransitionNode.utils.spec.ts
@@ -182,7 +182,7 @@ describe('checkValidityTransitions', () => {
               message: 'the message',
             },
             functionId: 'my-function',
-            id: 'node_8c4b',
+            id: 'my-operation-id2',
           },
         ],
       },

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/transition/TransitionNode.utils.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/transition/TransitionNode.utils.ts
@@ -119,10 +119,6 @@ export const loadTransitions = (
   scripts: Script[],
   behaviorPolicyNode: Node<BehaviorPolicyData>
 ) => {
-  if (behaviorPolicyNode.id !== behaviorPolicy.id)
-    throw new Error(
-      i18n.t('datahub:error.loading.connection.notFound', { type: DataHubNodeType.BEHAVIOR_POLICY }) as string
-    )
   const model = enumFromStringValue(BehaviorPolicyType, behaviorPolicy.behavior.id)
   if (!model) throw new Error(i18n.t('datahub:error.loading.behavior.noModel') as string)
 
@@ -150,7 +146,7 @@ export const loadTransitions = (
     newNodes.push(
       { item: transitionNode, type: 'add' },
       {
-        source: behaviorPolicy.id,
+        source: behaviorPolicyNode.id,
         target: transitionNode.id,
         sourceHandle: null,
         targetHandle: null,

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/validator/ValidatorNode.utils.spec.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/validator/ValidatorNode.utils.spec.ts
@@ -107,7 +107,7 @@ describe('checkValidityPolicyValidators', () => {
   const MOCK_NODE_DATA_POLICY: Node<DataPolicyData> = {
     id: 'node-policy',
     type: DataHubNodeType.DATA_POLICY,
-    data: {},
+    data: { id: 'my-policy-id' },
     ...MOCK_DEFAULT_NODE,
     position: { x: 0, y: 0 },
   }

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/validator/ValidatorNode.utils.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/validator/ValidatorNode.utils.ts
@@ -64,11 +64,6 @@ export function checkValidityPolicyValidators(
 }
 
 export const loadValidators = (policy: DataPolicy, schemas: Schema[], dataPolicyNode: Node<DataPolicyData>) => {
-  if (dataPolicyNode.id !== policy.id)
-    throw new Error(
-      i18n.t('datahub:error.loading.connection.notFound', { type: DataHubNodeType.DATA_POLICY }) as string
-    )
-
   const position: XYPosition = {
     x: dataPolicyNode.position.x + CANVAS_POSITION.Validator.x,
     y: dataPolicyNode.position.y + CANVAS_POSITION.Validator.y,

--- a/hivemq-edge/src/frontend/src/extensions/datahub/hooks/useDataHubDraftStore.spec.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/hooks/useDataHubDraftStore.spec.ts
@@ -204,7 +204,7 @@ describe('useDataHubDraftStore', () => {
       const MOCK_NODE_DATA_POLICY: Node<DataPolicyData> = {
         id: 'node-id',
         type: DataHubNodeType.SCHEMA,
-        data: {},
+        data: { id: 'my-policy-id' },
         ...MOCK_DEFAULT_NODE,
         position: { x: 0, y: 0 },
       }
@@ -217,7 +217,7 @@ describe('useDataHubDraftStore', () => {
       const MOCK_NODE_DATA_POLICY: Node<DataPolicyData> = {
         id: 'node-id',
         type: DataHubNodeType.DATA_POLICY,
-        data: {},
+        data: { id: 'my-other-policy-id' },
         ...MOCK_DEFAULT_NODE,
         position: { x: 0, y: 0 },
       }

--- a/hivemq-edge/src/frontend/src/extensions/datahub/hooks/useDataHubDraftStore.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/hooks/useDataHubDraftStore.ts
@@ -89,7 +89,7 @@ const useDataHubDraftStore = create<WorkspaceState & WorkspaceStatus & Workspace
       onAddFunctions: (changes: FunctionSpecs[]) => {
         set({ functions: [...get().functions, ...changes] })
       },
-      onSerializePolicy: (node: Node<DataPolicyData | BehaviorPolicyData>) => {
+      onSerializePolicy: (node: Node<DataPolicyData | BehaviorPolicyData>): string | undefined => {
         if (node.type !== DataHubNodeType.BEHAVIOR_POLICY && node.type !== DataHubNodeType.DATA_POLICY) return undefined
         return undefined
       },

--- a/hivemq-edge/src/frontend/src/extensions/datahub/hooks/usePolicyChecksStore.spec.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/hooks/usePolicyChecksStore.spec.ts
@@ -16,7 +16,7 @@ import { MOCK_DEFAULT_NODE } from '@/__test-utils__/react-flow/nodes.ts'
 const MOCK_NODE_DATA_POLICY: Node<DataPolicyData> = {
   id: 'node-id',
   type: DataHubNodeType.DATA_POLICY,
-  data: {},
+  data: { id: 'my-policy-id' },
   ...MOCK_DEFAULT_NODE,
   position: { x: 0, y: 0 },
 }

--- a/hivemq-edge/src/frontend/src/extensions/datahub/hooks/usePolicyDryRun.spec.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/hooks/usePolicyDryRun.spec.ts
@@ -60,7 +60,7 @@ describe('usePolicyDryRun', () => {
     const MOCK_NODE_DATA_POLICY: Node<BehaviorPolicyData> = {
       id: 'node-id',
       type: DataHubNodeType.BEHAVIOR_POLICY,
-      data: { model: BehaviorPolicyType.PUBLISH_DUPLICATE },
+      data: { id: 'my-policy-id', model: BehaviorPolicyType.PUBLISH_DUPLICATE },
       ...MOCK_DEFAULT_NODE,
       position: { x: 0, y: 0 },
     }

--- a/hivemq-edge/src/frontend/src/extensions/datahub/hooks/usePolicyDryRun.spec.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/hooks/usePolicyDryRun.spec.ts
@@ -16,14 +16,14 @@ describe('onlyNonNullResources', () => {
     const MOCK_NODE_DATA_POLICY: Node<DataPolicyData> = {
       id: 'node-id',
       type: DataHubNodeType.DATA_POLICY,
-      data: {},
+      data: { id: 'my-policy-id' },
       ...MOCK_DEFAULT_NODE,
       position: { x: 0, y: 0 },
     }
     const MOCK_NODE_TEST: Node<DataPolicyData> = {
       id: 'node-test',
       type: DataHubNodeType.DATA_POLICY,
-      data: {},
+      data: { id: 'my-other-policy-id' },
       ...MOCK_DEFAULT_NODE,
       position: { x: 0, y: 0 },
     }
@@ -42,7 +42,7 @@ describe('usePolicyDryRun', () => {
     const MOCK_NODE_DATA_POLICY: Node<DataPolicyData> = {
       id: 'node-id',
       type: DataHubNodeType.DATA_POLICY,
-      data: {},
+      data: { id: 'my-policy-id' },
       ...MOCK_DEFAULT_NODE,
       position: { x: 0, y: 0 },
     }

--- a/hivemq-edge/src/frontend/src/extensions/datahub/locales/en/datahub.json
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/locales/en/datahub.json
@@ -273,6 +273,10 @@
       "dataPolicy": {
         "notLoading": "Cannot load the existing policies for checking ids",
         "notUnique": "The id is already in use by another data policy"
+      },
+      "behaviourPolicy": {
+        "notLoading": "Cannot load the existing policies for checking ids",
+        "notUnique": "The id is already in use by another behaviour policy"
       }
     },
     "loading": {

--- a/hivemq-edge/src/frontend/src/extensions/datahub/locales/en/datahub.json
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/locales/en/datahub.json
@@ -269,6 +269,10 @@
       "topicFilter": {
         "duplicate": "The topic filter {{ filter }} is already defined",
         "alreadyMatching": "A policy is already matching the topic filter {{ filter }}"
+      },
+      "dataPolicy": {
+        "notLoading": "Cannot load the existing policies for checking ids",
+        "notUnique": "The id is already in use by another data policy"
       }
     },
     "loading": {

--- a/hivemq-edge/src/frontend/src/extensions/datahub/locales/en/datahub.json
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/locales/en/datahub.json
@@ -277,6 +277,10 @@
       "behaviourPolicy": {
         "notLoading": "Cannot load the existing policies for checking ids",
         "notUnique": "The id is already in use by another behaviour policy"
+      },
+      "operation": {
+        "notLoading": "Cannot load the existing operations for checking ids",
+        "notUnique": "The id is already in use by a prior operation in the pipeline"
       }
     },
     "loading": {

--- a/hivemq-edge/src/frontend/src/extensions/datahub/locales/en/datahub.json
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/locales/en/datahub.json
@@ -273,7 +273,7 @@
     },
     "loading": {
       "connection": {
-        "notFound": "Cannot find the $t(datahub:workspace.nodes.type, { 'context': '{{source}}' }) node"
+        "notFound": "Cannot find the $t(datahub:workspace.nodes.type, { 'context': '{{ type }}' }) node"
       },
       "schema": {
         "unknown": "Cannot identify the type of the SCHEMA - {{ type }}"

--- a/hivemq-edge/src/frontend/src/extensions/datahub/locales/en/datahub.json
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/locales/en/datahub.json
@@ -276,7 +276,7 @@
       },
       "behaviourPolicy": {
         "notLoading": "Cannot load the existing policies for checking ids",
-        "notUnique": "The id is already in use by another behaviour policy"
+        "notUnique": "The id is already in use by another behavior policy"
       },
       "operation": {
         "notLoading": "Cannot load the existing operations for checking ids",

--- a/hivemq-edge/src/frontend/src/extensions/datahub/types.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/types.ts
@@ -231,6 +231,7 @@ export interface PolicyOperationArguments {
 }
 
 export interface OperationData extends DataHubNodeData {
+  id: string
   functionId?: string
   metadata?: FunctionDefinition
   formData?: Record<string, string | number | string[]>

--- a/hivemq-edge/src/frontend/src/extensions/datahub/types.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/types.ts
@@ -273,6 +273,7 @@ export enum BehaviorPolicyType {
 }
 
 export interface BehaviorPolicyData extends DataHubNodeData {
+  id: string
   model: BehaviorPolicyType
   arguments?: Record<string, string | number>
   core?: BehaviorPolicy

--- a/hivemq-edge/src/frontend/src/extensions/datahub/types.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/types.ts
@@ -125,6 +125,7 @@ export interface ClientFilterData extends DataHubNodeData {
 }
 
 export interface DataPolicyData extends DataHubNodeData {
+  id: string
   core?: DataPolicy
 }
 

--- a/hivemq-edge/src/frontend/src/extensions/datahub/utils/node.utils.spec.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/utils/node.utils.spec.ts
@@ -4,7 +4,13 @@ import { Edge, Node } from 'reactflow'
 import { MOCK_DEFAULT_NODE } from '@/__test-utils__/react-flow/nodes.ts'
 import { DataPolicyValidator } from '@/api/__generated__'
 import { MOCK_JSONSCHEMA_SCHEMA } from '@datahub/__test-utils__/schema.mocks.ts'
-import { getNodeId, getNodePayload, isValidPolicyConnection } from '@datahub/utils/node.utils.ts'
+import {
+  getAllParents,
+  getNodeId,
+  getNodePayload,
+  isValidPolicyConnection,
+  reduceIdsFrom,
+} from '@datahub/utils/node.utils.ts'
 import { DataHubNodeType, DataPolicyData, OperationData, SchemaType, StrategyType } from '@datahub/types.ts'
 
 describe('getNodeId', () => {
@@ -242,5 +248,92 @@ describe('isValidPolicyConnection', () => {
         edges
       )
     ).toBeFalsy()
+  })
+})
+
+describe('getAllParents', () => {
+  it('should be', async () => {
+    const node: Node = {
+      id: '3',
+      data: {},
+      position: { x: 0, y: 0 },
+    }
+
+    const branch: Node[] = [
+      {
+        id: '1',
+        data: {},
+        position: { x: 0, y: 0 },
+      },
+      {
+        id: '2',
+        data: {},
+        position: { x: 0, y: 0 },
+      },
+      node,
+    ]
+
+    const nodes: Node[] = [
+      ...branch,
+      {
+        id: '4',
+        data: {},
+        position: { x: 0, y: 0 },
+      },
+      {
+        id: '5',
+        data: {},
+        position: { x: 0, y: 0 },
+      },
+    ]
+
+    const edges: Edge[] = [
+      { id: '1', source: '1', target: '2', sourceHandle: null, targetHandle: null },
+      { id: '2', source: '2', target: '3', sourceHandle: null, targetHandle: null },
+      { id: '3', source: '3', target: '5', sourceHandle: null, targetHandle: null },
+    ]
+
+    const expected = [...branch].reverse()
+    expect(Array.from(getAllParents(node, nodes, edges))).toEqual(expected)
+  })
+})
+
+describe('reduceIdsFrom', () => {
+  it('should be', async () => {
+    const allNodes: Node[] = [
+      {
+        id: 'node-id',
+        data: { id: 'first-id' },
+        type: DataHubNodeType.DATA_POLICY,
+        position: { x: 0, y: 0 },
+      },
+      {
+        id: 'node-id',
+        data: {},
+        type: DataHubNodeType.DATA_POLICY,
+        position: { x: 0, y: 0 },
+      },
+      {
+        id: 'node-id',
+        data: { id: 'second-id' },
+        type: DataHubNodeType.OPERATION,
+        position: { x: 0, y: 0 },
+      },
+      {
+        id: 'excluded-node-id',
+        data: { id: 'third-id' },
+        type: DataHubNodeType.DATA_POLICY,
+        position: { x: 0, y: 0 },
+      },
+    ]
+
+    expect(allNodes.reduce(reduceIdsFrom<DataPolicyData>(DataHubNodeType.DATA_POLICY), [])).toEqual([
+      'first-id',
+      'third-id',
+    ])
+    expect(allNodes.reduce(reduceIdsFrom(DataHubNodeType.TRANSITION), [])).toEqual([])
+    expect(allNodes.reduce(reduceIdsFrom<DataPolicyData>(DataHubNodeType.DATA_POLICY, 'excluded-node-id'), [])).toEqual(
+      ['first-id']
+    )
   })
 })

--- a/hivemq-edge/src/frontend/src/extensions/datahub/utils/node.utils.spec.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/utils/node.utils.spec.ts
@@ -113,7 +113,7 @@ describe('isValidPolicyConnection', () => {
     const MOCK_NODE_DATA_POLICY: Node<DataPolicyData> = {
       id: 'node-id',
       type: DataHubNodeType.DATA_POLICY,
-      data: {},
+      data: { id: 'my-policy-id' },
       ...MOCK_DEFAULT_NODE,
       position: { x: 0, y: 0 },
     }

--- a/hivemq-edge/src/frontend/src/extensions/datahub/utils/node.utils.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/utils/node.utils.ts
@@ -1,4 +1,4 @@
-import { Connection, Edge, getOutgoers, Node } from 'reactflow'
+import { Connection, Edge, getIncomers, getOutgoers, Node } from 'reactflow'
 import { v4 as uuidv4 } from 'uuid'
 import { MOCK_JSONSCHEMA_SCHEMA } from '../__test-utils__/schema.mocks.ts'
 import i18n from '@/config/i18n.config.ts'
@@ -328,3 +328,24 @@ export const canDeleteEdge = (
   }
   return { delete: true }
 }
+
+export const getAllParents = (node: Node, nodes: Node[], edges: Edge[], visited = new Set<Node>()): Set<Node> => {
+  if (visited.has(node)) return visited
+  visited.add(node)
+  for (const incomer of getIncomers(node, nodes, edges)) {
+    getAllParents(incomer, nodes, edges, visited)
+  }
+  return visited
+}
+
+export const reduceIdsFrom =
+  <T>(type: DataHubNodeType, exclude?: string) =>
+  (acc: string[], node: Node) => {
+    if (node.type === type) {
+      const { id, data } = node satisfies Node<T>
+      if (data.id && id !== exclude) {
+        acc.push(data.id)
+      }
+    }
+    return acc
+  }

--- a/hivemq-edge/src/frontend/src/modules/Dashboard/components/NavLinksBlock.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Dashboard/components/NavLinksBlock.tsx
@@ -13,7 +13,7 @@ const NavLinksBlock: FC<NavLinksBlockType> = ({ title, items }) => {
       <Box pb={2} pt={2}>
         <List spacing={0}>
           {items
-            .filter((e) => !e.isDisabled)
+            .filter((navLink) => !navLink.isDisabled)
             .map((item) => (
               <ListItem key={item.label}>
                 <NavLink link={item} />

--- a/hivemq-edge/src/frontend/src/modules/Metrics/Metrics.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Metrics/Metrics.tsx
@@ -50,7 +50,7 @@ const Metrics: FC<MetricsProps> = ({ nodeId, adapterIDs, initMetrics, defaultCha
 
   // TODO[NVL] Should go to some kind of reusable routine, with verification
   const colorKeys = Object.keys(colors)
-  const chartTheme = defaultColorSchemes.filter((c) => colorKeys.includes(c))
+  const chartTheme = defaultColorSchemes.filter((color) => colorKeys.includes(color))
 
   const handleCreateMetrics = (value: MetricDefinition) => {
     const { selectedTopic, selectedChart } = value

--- a/hivemq-edge/src/frontend/src/modules/Metrics/components/editor/MetricEditor.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Metrics/components/editor/MetricEditor.tsx
@@ -42,13 +42,13 @@ const MetricEditor: FC<MetricEditorProps> = ({ onSubmit, filter, selectedMetrics
     const groupedMetrics = filter
       .map((adapter) => {
         const metrics: MetricNameOption[] = items
-          .filter((e) => e.name && e.name.includes(adapter))
-          .map((e) => {
-            const { device, suffix } = extractMetricInfo(e.name as string)
+          .filter((metric) => metric.name && metric.name.includes(adapter))
+          .map((metric) => {
+            const { device, suffix } = extractMetricInfo(metric.name as string)
             return {
               label: t(`metrics.${device}.${suffix}`),
-              value: e.name as string,
-              isDisabled: selectedMetrics?.includes(e.name as string),
+              value: metric.name as string,
+              isDisabled: selectedMetrics?.includes(metric.name as string),
             }
           })
           .sort((a, b) => a.label.localeCompare(b.label))

--- a/hivemq-edge/src/frontend/src/modules/Notifications/components/SkipNotification.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Notifications/components/SkipNotification.tsx
@@ -15,7 +15,7 @@ export const SkipNotification: FC<SkipNotificationProps> = ({ id }) => {
     if (e.target.checked) {
       setSkip((old) => [...old, id])
     } else {
-      setSkip((old) => old.filter((e) => e != id))
+      setSkip((old) => old.filter((key) => key != id))
     }
   }
   return (

--- a/hivemq-edge/src/frontend/src/modules/Notifications/hooks/useGetManagedNotifications.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Notifications/hooks/useGetManagedNotifications.tsx
@@ -35,14 +35,17 @@ export const useGetManagedNotifications = () => {
 
     if (notification?.items && notification.items.length > 0) {
       const toasts: UseToastOptions[] = notification.items
-        .filter((e) => !readNotifications.includes(e.title as string) && !skip.includes(e.title as string))
-        .map((e) => ({
+        .filter(
+          (notification) =>
+            !readNotifications.includes(notification.title as string) && !skip.includes(notification.title as string)
+        )
+        .map((notification) => ({
           ...defaults,
-          id: e.title,
-          status: e.level ? 'warning' : 'info',
-          title: <Text>{e.title}</Text>,
-          description: <Text>{e.description}</Text>,
-          onCloseComplete: () => handleReadNotification(e.title as string),
+          id: notification.title,
+          status: notification.level ? 'warning' : 'info',
+          title: <Text>{notification.title}</Text>,
+          description: <Text>{notification.description}</Text>,
+          onCloseComplete: () => handleReadNotification(notification.title as string),
         }))
       list.push(...toasts)
     }

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/templates/ObjectFieldTemplate.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/templates/ObjectFieldTemplate.tsx
@@ -54,7 +54,7 @@ export const ObjectFieldTemplate = <
       <Tabs>
         <TabList>
           {tabs.map((e) => {
-            const filteredProps = properties.filter((p) => e.properties.includes(p.name))
+            const filteredProps = properties.filter((property) => e.properties.includes(property.name))
             if (!filteredProps.length) return null
             return (
               <Tab fontSize="md" key={e.id}>
@@ -66,7 +66,7 @@ export const ObjectFieldTemplate = <
 
         <TabPanels>
           {tabs.map((e) => {
-            const filteredProps = properties.filter((p) => e.properties.includes(p.name))
+            const filteredProps = properties.filter((property) => e.properties.includes(property.name))
             if (!filteredProps.length) return null
             return (
               <TabPanel key={e.id} p={0} pt="1px" mb={6}>
@@ -82,7 +82,7 @@ export const ObjectFieldTemplate = <
           })}
         </TabPanels>
         {properties
-          .filter((e) => !allGrouped.includes(e.name))
+          .filter((property) => !allGrouped.includes(property.name))
           .map((prop) => (
             <Box _first={{ marginTop: '24px' }} _notLast={{ marginBottom: '24px' }} key={prop.content.key}>
               {prop.content}

--- a/hivemq-edge/src/frontend/src/modules/UnifiedNamespace/components/NamespaceDisplay.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/UnifiedNamespace/components/NamespaceDisplay.spec.cy.tsx
@@ -13,7 +13,7 @@ describe('NamespaceDisplay', () => {
     {
       test: 'with site omitted',
       namespace: { ...MOCK_NAMESPACE, site: undefined },
-      breadcrumb: MOCK_BREADCRUMB.filter((e) => e !== 'Site'),
+      breadcrumb: MOCK_BREADCRUMB.filter((crumb) => crumb !== 'Site'),
     },
   ]
   it.each(selectors)(

--- a/hivemq-edge/src/frontend/src/modules/UnifiedNamespace/components/NamespaceDisplay.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/UnifiedNamespace/components/NamespaceDisplay.spec.cy.tsx
@@ -21,9 +21,9 @@ describe('NamespaceDisplay', () => {
     (selector) => {
       cy.mountWithProviders(<NamespaceDisplay namespace={selector.namespace} />)
 
-      cy.get('nav').get('ol').children().should('have.length', selector.breadcrumb.length)
+      cy.get('nav').find('ol').children().should('have.length', selector.breadcrumb.length)
       cy.get('nav')
-        .get('ol')
+        .find('ol')
         .children()
         .each((e, index) => {
           cy.wrap(e).should('contain.text', selector.breadcrumb[index])
@@ -33,7 +33,7 @@ describe('NamespaceDisplay', () => {
 
   it('should render properly an empty breadcrumb with an empty namespace', () => {
     cy.mountWithProviders(<NamespaceDisplay namespace={{}} />)
-    cy.get('nav').get('ol').children().should('have.length', 0)
+    cy.get('nav').find('ol').children().should('have.length', 0)
   })
 
   it('should be accessible', () => {

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/controls/GroupNodesControl.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/controls/GroupNodesControl.tsx
@@ -20,7 +20,9 @@ const GroupNodesControl: FC = () => {
   useOnSelectionChange({
     onChange: ({ nodes }) => {
       if (nodes.length >= 2)
-        setCurrentSelection(() => nodes.filter((e) => e.type === NodeTypes.ADAPTER_NODE && e.parentNode === undefined))
+        setCurrentSelection(() =>
+          nodes.filter((node) => node.type === NodeTypes.ADAPTER_NODE && node.parentNode === undefined)
+        )
       else setCurrentSelection([])
     },
   })

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeGroup.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeGroup.tsx
@@ -57,7 +57,9 @@ const NodeGroup: FC<NodeProps<Group>> = ({ id, data, selected, ...props }) => {
       })
     )
     onNodesChange([{ id, type: 'remove' } as NodeRemoveChange])
-    onEdgesChange(edges.filter((e) => e.source === id).map((e) => ({ id: e.id, type: 'remove' } as EdgeRemoveChange)))
+    onEdgesChange(
+      edges.filter((edge) => edge.source === id).map((e) => ({ id: e.id, type: 'remove' } as EdgeRemoveChange))
+    )
   }
 
   return (

--- a/hivemq-edge/src/frontend/src/utils/types.utils.spec.ts
+++ b/hivemq-edge/src/frontend/src/utils/types.utils.spec.ts
@@ -1,0 +1,10 @@
+import { describe, expect } from 'vitest'
+import { enumFromStringValue } from '@/utils/types.utils.ts'
+import { BehaviorPolicyType } from '@datahub/types.ts'
+
+describe('enumFromStringValue', () => {
+  it('should convert acceptable placeholders to HTML markup', async () => {
+    expect(enumFromStringValue(BehaviorPolicyType, 'fake')).toBeUndefined()
+    expect(enumFromStringValue(BehaviorPolicyType, 'Mqtt.events')).toEqual(BehaviorPolicyType.MQTT_EVENT)
+  })
+})


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/19466/details/

The PR adds support for user to edit the unique `id` of several types of nodes in the Designer
- `Data Policy` nodes
- `Behaviour Policy` nodes
- `Operation` nodes 

It dissociates the `id` of the ReactFlow node (`uuid`) from the user-facing `id` of the policy element. In effect, it acts as a name for the elements.

The `id` is mandatory and editable in the relevant side panel and serialised with the policies. They are bound to a uniqueness check, based on the type:
- Data Policy `id` must be unique among all published data policies
- Behaviour Policy  `id` must be unique among all published behaviour policies
- Operation `id` must be unique among the operations connected upstream in the given pipeline (i.e. it must not be used BEFORE in the pipeline but MIGHT be used in another pipeline of the same policy)

The main effect of the change is that policies are now listed with a more user-friendly name in the landing tables. 

### Out-of-scope
- allowing the editing of the id opens a lot of issues with "read-only" and the side panels. This will be dealt with in a separate ticket (https://hivemq.kanbanize.com/ctrl_board/57/cards/22182/details/)

### Before
![screenshot-localhost_3000-2024 04 12-09_52_44](https://github.com/hivemq/hivemq-edge/assets/2743481/59884d23-5bfb-450d-b15e-f8b6306dba77)

![screenshot-localhost_3000-2024 05 15-12_47_24](https://github.com/hivemq/hivemq-edge/assets/2743481/f70e8b30-a80f-4041-8c85-65bbc2272f39)

### After
![screenshot-localhost_3000-2024 05 15-12_54_13](https://github.com/hivemq/hivemq-edge/assets/2743481/c50e13d2-db05-4151-8202-a188e044f017)

![screenshot-localhost_3000-2024 05 15-12_46_55](https://github.com/hivemq/hivemq-edge/assets/2743481/2fa78e59-4ea5-42f9-b138-a2e79850126d)

![screenshot-localhost_3000-2024 05 15-12_46_35](https://github.com/hivemq/hivemq-edge/assets/2743481/6bd39481-c260-4d08-bdd7-3384d51cab69)

![screenshot-localhost_3000-2024 05 15-12_46_02](https://github.com/hivemq/hivemq-edge/assets/2743481/b068a529-bf68-469e-9504-3339a42c8b3a)



