### PR TITLE
fix(18935): Fix the verification of connectivity limits on handles

### DIFF
--- a/hivemq-edge/src/frontend/package.json
+++ b/hivemq-edge/src/frontend/package.json
@@ -81,7 +81,7 @@
     "react-i18next": "^14.1.1",
     "react-icons": "^5.0.1",
     "react-router-dom": "^6.11.2",
-    "reactflow": "^11.10.2",
+    "reactflow": "^11.11.3",
     "tippy.js": "^6.3.7",
     "uuid": "^9.0.1",
     "zustand": "^4.4.7"

--- a/hivemq-edge/src/frontend/pnpm-lock.yaml
+++ b/hivemq-edge/src/frontend/pnpm-lock.yaml
@@ -168,8 +168,8 @@ dependencies:
     specifier: ^6.11.2
     version: 6.11.2(react-dom@18.2.0)(react@18.2.0)
   reactflow:
-    specifier: ^11.10.2
-    version: 11.10.2(@types/react@18.0.28)(react-dom@18.2.0)(react@18.2.0)
+    specifier: ^11.11.3
+    version: 11.11.3(@types/react@18.0.28)(react-dom@18.2.0)(react@18.2.0)
   tippy.js:
     specifier: ^6.3.7
     version: 6.3.7
@@ -2999,13 +2999,13 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /@reactflow/background@11.3.7(@types/react@18.0.28)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-PhkvoFtO/NXJgFtBvfbPwdR/6/dl25egQlFhKWS3T4aYa7rh80dvf6dF3t6+JXJS4q5ToYJizD2/n8/qylo1yQ==}
+  /@reactflow/background@11.3.13(@types/react@18.0.28)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-hkvpVEhgvfTDyCvdlitw4ioKCYLaaiRXnuEG+1QM3Np+7N1DiWF1XOv5I8AFyNoJL07yXEkbECUTsHvkBvcG5A==}
     peerDependencies:
       react: '>=17'
       react-dom: '>=17'
     dependencies:
-      '@reactflow/core': 11.10.2(@types/react@18.0.28)(react-dom@18.2.0)(react@18.2.0)
+      '@reactflow/core': 11.11.3(@types/react@18.0.28)(react-dom@18.2.0)(react@18.2.0)
       classcat: 5.0.5
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
@@ -3015,13 +3015,13 @@ packages:
       - immer
     dev: false
 
-  /@reactflow/controls@11.2.7(@types/react@18.0.28)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-mugzVALH/SuKlVKk+JCRm1OXQ+p8e9+k8PCTIaqL+nBl+lPF8KA4uMm8ApsOvhuSAb2A80ezewpyvYHr0qSYVA==}
+  /@reactflow/controls@11.2.13(@types/react@18.0.28)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-3xgEg6ALIVkAQCS4NiBjb7ad8Cb3D8CtA7Vvl4Hf5Ar2PIVs6FOaeft9s2iDZGtsWP35ECDYId1rIFVhQL8r+A==}
     peerDependencies:
       react: '>=17'
       react-dom: '>=17'
     dependencies:
-      '@reactflow/core': 11.10.2(@types/react@18.0.28)(react-dom@18.2.0)(react@18.2.0)
+      '@reactflow/core': 11.11.3(@types/react@18.0.28)(react-dom@18.2.0)(react@18.2.0)
       classcat: 5.0.5
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
@@ -3031,8 +3031,8 @@ packages:
       - immer
     dev: false
 
-  /@reactflow/core@11.10.2(@types/react@18.0.28)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-/cbTxtFpfkIGReSVkcnQhS4Jx4VFY2AhPlJ5n0sbPtnR7OWowF9zodh5Yyzr4j1NOUoBgJ9h+UqGEwwY2dbAlw==}
+  /@reactflow/core@11.11.3(@types/react@18.0.28)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-+adHdUa7fJSEM93fWfjQwyWXeI92a1eLKwWbIstoCakHpL8UjzwhEh6sn+mN2h/59MlVI7Ehr1iGTt3MsfcIFA==}
     peerDependencies:
       react: '>=17'
       react-dom: '>=17'
@@ -3053,13 +3053,13 @@ packages:
       - immer
     dev: false
 
-  /@reactflow/minimap@11.7.7(@types/react@18.0.28)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-Pwqw31tJ663cJur6ypqyJU33nPckvTepmz96erdQZoHsfOyLmFj4nXT7afC30DJ48lp0nfNsw+028mlf7f/h4g==}
+  /@reactflow/minimap@11.7.13(@types/react@18.0.28)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-m2MvdiGSyOu44LEcERDEl1Aj6x//UQRWo3HEAejNU4HQTlJnYrSN8tgrYF8TxC1+c/9UdyzQY5VYgrTwW4QWdg==}
     peerDependencies:
       react: '>=17'
       react-dom: '>=17'
     dependencies:
-      '@reactflow/core': 11.10.2(@types/react@18.0.28)(react-dom@18.2.0)(react@18.2.0)
+      '@reactflow/core': 11.11.3(@types/react@18.0.28)(react-dom@18.2.0)(react@18.2.0)
       '@types/d3-selection': 3.0.10
       '@types/d3-zoom': 3.0.8
       classcat: 5.0.5
@@ -3073,13 +3073,13 @@ packages:
       - immer
     dev: false
 
-  /@reactflow/node-resizer@2.2.7(@types/react@18.0.28)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-BMBstmWNiklHnnAjHu8irkiPQ8/k8nnjzqlTql4acbVhD6Tsdxx/t/saOkELmfQODqGZNiPw9+pHcAHgtE6oNQ==}
+  /@reactflow/node-resizer@2.2.13(@types/react@18.0.28)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-X7ceQ2s3jFLgbkg03n2RYr4hm3jTVrzkW2W/8ANv/SZfuVmF8XJxlERuD8Eka5voKqLda0ywIZGAbw9GoHLfUQ==}
     peerDependencies:
       react: '>=17'
       react-dom: '>=17'
     dependencies:
-      '@reactflow/core': 11.10.2(@types/react@18.0.28)(react-dom@18.2.0)(react@18.2.0)
+      '@reactflow/core': 11.11.3(@types/react@18.0.28)(react-dom@18.2.0)(react@18.2.0)
       classcat: 5.0.5
       d3-drag: 3.0.0
       d3-selection: 3.0.0
@@ -3091,13 +3091,13 @@ packages:
       - immer
     dev: false
 
-  /@reactflow/node-toolbar@1.3.7(@types/react@18.0.28)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-75moEQKg23YKA3A2DNSFhq719ZPmby5mpwOD+NO7ZffJ88oMS/2eY8l8qpA3hvb1PTBHDxyKazhJirW+f4t0Wg==}
+  /@reactflow/node-toolbar@1.3.13(@types/react@18.0.28)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-aknvNICO10uWdthFSpgD6ctY/CTBeJUMV9co8T9Ilugr08Nb89IQ4uD0dPmr031ewMQxixtYIkw+sSDDzd2aaQ==}
     peerDependencies:
       react: '>=17'
       react-dom: '>=17'
     dependencies:
-      '@reactflow/core': 11.10.2(@types/react@18.0.28)(react-dom@18.2.0)(react@18.2.0)
+      '@reactflow/core': 11.11.3(@types/react@18.0.28)(react-dom@18.2.0)(react@18.2.0)
       classcat: 5.0.5
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
@@ -8710,18 +8710,18 @@ packages:
     dependencies:
       loose-envify: 1.4.0
 
-  /reactflow@11.10.2(@types/react@18.0.28)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-tqQJfPEiIkXonT3piVYf+F9CvABI5e28t5I6rpaLTnO8YVCAOh1h0f+ziDKz0Bx9Y2B/mFgyz+H7LZeUp/+lhQ==}
+  /reactflow@11.11.3(@types/react@18.0.28)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-wusd1Xpn1wgsSEv7UIa4NNraCwH9syBtubBy4xVNXg3b+CDKM+sFaF3hnMx0tr0et4km9urIDdNvwm34QiZong==}
     peerDependencies:
       react: '>=17'
       react-dom: '>=17'
     dependencies:
-      '@reactflow/background': 11.3.7(@types/react@18.0.28)(react-dom@18.2.0)(react@18.2.0)
-      '@reactflow/controls': 11.2.7(@types/react@18.0.28)(react-dom@18.2.0)(react@18.2.0)
-      '@reactflow/core': 11.10.2(@types/react@18.0.28)(react-dom@18.2.0)(react@18.2.0)
-      '@reactflow/minimap': 11.7.7(@types/react@18.0.28)(react-dom@18.2.0)(react@18.2.0)
-      '@reactflow/node-resizer': 2.2.7(@types/react@18.0.28)(react-dom@18.2.0)(react@18.2.0)
-      '@reactflow/node-toolbar': 1.3.7(@types/react@18.0.28)(react-dom@18.2.0)(react@18.2.0)
+      '@reactflow/background': 11.3.13(@types/react@18.0.28)(react-dom@18.2.0)(react@18.2.0)
+      '@reactflow/controls': 11.2.13(@types/react@18.0.28)(react-dom@18.2.0)(react@18.2.0)
+      '@reactflow/core': 11.11.3(@types/react@18.0.28)(react-dom@18.2.0)(react@18.2.0)
+      '@reactflow/minimap': 11.7.13(@types/react@18.0.28)(react-dom@18.2.0)(react@18.2.0)
+      '@reactflow/node-resizer': 2.2.13(@types/react@18.0.28)(react-dom@18.2.0)(react@18.2.0)
+      '@reactflow/node-toolbar': 1.3.13(@types/react@18.0.28)(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     transitivePeerDependencies:

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/DeleteListener.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/DeleteListener.tsx
@@ -1,7 +1,7 @@
 import { FC, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useHotkeys } from 'react-hotkeys-hook'
-import { NodeRemoveChange, EdgeRemoveChange } from 'reactflow'
+import { NodeRemoveChange, EdgeRemoveChange, getConnectedEdges } from 'reactflow'
 import { ListItem, Text, UnorderedList, useDisclosure, useToast, VStack } from '@chakra-ui/react'
 
 import ConfirmationDialog from '@/components/Modal/ConfirmationDialog.tsx'
@@ -74,7 +74,10 @@ const DeleteListener: FC = () => {
 
   const handleConfirmOnSubmit = () => {
     const { selectedNodes, selectedEdges } = selectedElements
-    onEdgesChange(selectedEdges.map<EdgeRemoveChange>((edge) => ({ id: edge.id, type: 'remove' })))
+    const allConnectedEdges = getConnectedEdges(selectedNodes, edges)
+    onEdgesChange(
+      [...selectedEdges, ...allConnectedEdges].map<EdgeRemoveChange>((edge) => ({ id: edge.id, type: 'remove' }))
+    )
     onNodesChange(selectedNodes.map<NodeRemoveChange>((node) => ({ id: node.id, type: 'remove' })))
     setStatus(status === DesignerStatus.DRAFT ? DesignerStatus.DRAFT : DesignerStatus.MODIFIED)
   }

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/ConnectionLine.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/ConnectionLine.tsx
@@ -5,6 +5,9 @@ import { Tag } from '@chakra-ui/react'
 import { getConnectedNodeFrom } from '@datahub/utils/node.utils.ts'
 import { NodeIcon } from '@datahub/components/helpers'
 
+const ICON_SIZE = 50
+const ICON_OFFSET = 20
+
 const ConnectionLine: FC<ConnectionLineComponentProps> = ({
   fromHandle,
   fromNode,
@@ -33,7 +36,12 @@ const ConnectionLine: FC<ConnectionLineComponentProps> = ({
     <g>
       <path fill="none" stroke="grey" strokeWidth={1.5} className="animated" d={d} />
       {props.connectionStatus === null && (
-        <foreignObject x={toX} y={toY - 20} width="50px" height="50px">
+        <foreignObject
+          x={toX - (props.fromPosition === 'left' ? ICON_SIZE : 0)}
+          y={toY - ICON_OFFSET}
+          width={`${ICON_SIZE}px`}
+          height={`${ICON_SIZE}px`}
+        >
           <Tag size="lg" colorScheme="gray" borderRadius="full" variant="outline">
             <NodeIcon type={droppedNode?.type} />
           </Tag>

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/CustomHandle.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/CustomHandle.tsx
@@ -1,9 +1,11 @@
 import { CSSProperties, FC, HTMLAttributes, useMemo } from 'react'
-import { getConnectedEdges, Handle, HandleProps, useNodeId } from 'reactflow'
+import { Handle, HandleProps, useNodeId } from 'reactflow'
 
 import useDataHubDraftStore from '../../hooks/useDataHubDraftStore.ts'
+import { isNodeHandleConnectable } from '@datahub/utils/node.utils.ts'
 
-interface CustomHandleProps extends Omit<HandleProps & Omit<HTMLAttributes<HTMLDivElement>, 'id'>, 'isConnectable'> {
+interface CustomHandleProps
+  extends Omit<HandleProps & Pick<HTMLAttributes<HTMLDivElement>, 'style' | 'className'>, 'isConnectable'> {
   isConnectable?: boolean | number
 }
 
@@ -12,22 +14,10 @@ export const CustomHandle: FC<CustomHandleProps> = (props) => {
   const nodeId = useNodeId()
 
   const isHandleConnectable = useMemo(() => {
-    if (typeof props.isConnectable === 'number') {
-      const node = nodes.find((node) => node.id === nodeId)
-      if (node) {
-        const connectedEdges = getConnectedEdges([node], edges)
-
-        const toHandle = connectedEdges.filter((edge) => {
-          const otherEnd = props.type === 'source' ? edge.sourceHandle : edge.targetHandle
-          return otherEnd === props.id
-        })
-
-        return toHandle.length < props.isConnectable
-      }
-      return false
-    }
-    return true
-  }, [edges, nodeId, nodes, props.id, props.isConnectable, props.type])
+    const node = nodes.find((node) => node.id === nodeId)
+    if (!node) return false
+    return isNodeHandleConnectable(props, node, edges)
+  }, [nodes.length, props, edges, nodeId])
 
   let transform: CSSProperties = {
     width: '12px',

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/CustomHandle.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/CustomHandle.tsx
@@ -17,6 +17,7 @@ export const CustomHandle: FC<CustomHandleProps> = (props) => {
     const node = nodes.find((node) => node.id === nodeId)
     if (!node) return false
     return isNodeHandleConnectable(props, node, edges)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [nodes.length, props, edges, nodeId])
 
   let transform: CSSProperties = {

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/operation/OperationNode.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/operation/OperationNode.tsx
@@ -54,13 +54,7 @@ export const OperationNode: FC<NodeProps<OperationData>> = (props) => {
       </NodeWrapper>
       <CustomHandle type="target" position={Position.Left} id={OperationData.Handle.INPUT} />
       {!metadata?.isTerminal && (
-        <CustomHandle
-          type="source"
-          position={Position.Right}
-          id={OperationData.Handle.OUTPUT}
-          // TODO[18935] bug with the isConnectable routine
-          // isConnectable={1}
-        />
+        <CustomHandle type="source" position={Position.Right} id={OperationData.Handle.OUTPUT} isConnectable={1} />
       )}
       {isSerialiser && <CustomHandle type="target" position={Position.Top} id={OperationData.Handle.SCHEMA} />}
       {isTransform && (

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/topic_filter/TopicFilterNode.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/topic_filter/TopicFilterNode.tsx
@@ -30,6 +30,7 @@ export const TopicFilterNode: FC<NodeProps<TopicFilterData>> = (props) => {
       {data.topics?.map((t, index) => (
         <CustomHandle
           type="source"
+          isConnectable={1}
           position={Position.Right}
           id={`${t}-${index}`}
           key={`${id}-${t}-${index}`}

--- a/hivemq-edge/src/frontend/src/extensions/datahub/utils/node.utils.spec.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/utils/node.utils.spec.ts
@@ -5,9 +5,11 @@ import { MOCK_DEFAULT_NODE } from '@/__test-utils__/react-flow/nodes.ts'
 import { DataPolicyValidator } from '@/api/__generated__'
 import { MOCK_JSONSCHEMA_SCHEMA } from '@datahub/__test-utils__/schema.mocks.ts'
 import {
+  ConnectableHandleProps,
   getAllParents,
   getNodeId,
   getNodePayload,
+  isNodeHandleConnectable,
   isValidPolicyConnection,
   reduceIdsFrom,
 } from '@datahub/utils/node.utils.ts'
@@ -335,5 +337,60 @@ describe('reduceIdsFrom', () => {
     expect(allNodes.reduce(reduceIdsFrom<DataPolicyData>(DataHubNodeType.DATA_POLICY, 'excluded-node-id'), [])).toEqual(
       ['first-id']
     )
+  })
+})
+
+describe('isNodeHandleConnectable', () => {
+  const nodes: Node[] = [
+    {
+      id: '1',
+      data: {},
+      position: { x: 0, y: 0 },
+    },
+    {
+      id: '2',
+      data: {},
+      position: { x: 0, y: 0 },
+    },
+    {
+      id: '3',
+      data: {},
+      position: { x: 0, y: 0 },
+    },
+    {
+      id: '3',
+      data: {},
+      position: { x: 0, y: 0 },
+    },
+  ]
+  const edges: Edge[] = [
+    { id: '1', source: '1', target: '3', sourceHandle: 'source1', targetHandle: 'target3' },
+    { id: '2', source: '2', target: '3', sourceHandle: 'source2', targetHandle: 'target3' },
+    { id: '3', source: '3', target: '4', sourceHandle: 'source3', targetHandle: 'target4' },
+  ]
+
+  it('should detect connectivity', async () => {
+    const handle: ConnectableHandleProps = { id: 'source', type: 'source', isConnectable: false }
+    expect(isNodeHandleConnectable(handle, nodes[0], edges)).toBeFalsy()
+    expect(isNodeHandleConnectable({ ...handle, isConnectable: undefined }, nodes[0], edges)).toBeFalsy()
+    expect(isNodeHandleConnectable({ ...handle, isConnectable: 1 }, nodes[0], edges)).toBeTruthy()
+  })
+
+  it('should detect connectivity', async () => {
+    const handle: ConnectableHandleProps = { id: 'target1', type: 'target', isConnectable: false }
+    expect(isNodeHandleConnectable({ ...handle, isConnectable: 1 }, nodes[0], edges)).toBeTruthy()
+  })
+
+  it('should detect connectivity', async () => {
+    const handle: ConnectableHandleProps = { id: 'source1', type: 'source', isConnectable: false }
+    expect(isNodeHandleConnectable({ ...handle, isConnectable: 1 }, nodes[0], edges)).toBeFalsy()
+    expect(isNodeHandleConnectable({ ...handle, isConnectable: 2 }, nodes[0], edges)).toBeTruthy()
+  })
+
+  it('should detect connectivity', async () => {
+    const handle: ConnectableHandleProps = { id: 'target3', type: 'target', isConnectable: false }
+    expect(isNodeHandleConnectable({ ...handle, isConnectable: 1 }, nodes[2], edges)).toBeFalsy()
+    expect(isNodeHandleConnectable({ ...handle, isConnectable: 2 }, nodes[2], edges)).toBeFalsy()
+    expect(isNodeHandleConnectable({ ...handle, isConnectable: 3 }, nodes[2], edges)).toBeTruthy()
   })
 })

--- a/hivemq-edge/src/frontend/src/extensions/datahub/utils/node.utils.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/utils/node.utils.ts
@@ -1,4 +1,4 @@
-import { Connection, Edge, getIncomers, getOutgoers, Node } from 'reactflow'
+import { Connection, Edge, getConnectedEdges, getIncomers, getOutgoers, HandleProps, Node } from 'reactflow'
 import { v4 as uuidv4 } from 'uuid'
 import { MOCK_JSONSCHEMA_SCHEMA } from '../__test-utils__/schema.mocks.ts'
 import i18n from '@/config/i18n.config.ts'
@@ -349,3 +349,20 @@ export const reduceIdsFrom =
     }
     return acc
   }
+
+interface ConnectableHandleProps extends Pick<HandleProps, 'id' | 'type'> {
+  isConnectable?: boolean | number
+}
+
+export const isNodeHandleConnectable = (props: ConnectableHandleProps, node: Node, edges: Edge[]) => {
+  if (typeof props.isConnectable === 'number') {
+    const connectedEdges = getConnectedEdges([node], edges)
+    const toHandle = connectedEdges.filter((edge) => {
+      return props.type === 'source'
+        ? edge.source === node.id && edge.sourceHandle === props.id
+        : edge.target === node.id && edge.targetHandle === props.id
+    })
+    return toHandle.length < props.isConnectable
+  }
+  return props.isConnectable
+}

--- a/hivemq-edge/src/frontend/src/extensions/datahub/utils/node.utils.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/utils/node.utils.ts
@@ -350,19 +350,19 @@ export const reduceIdsFrom =
     return acc
   }
 
-interface ConnectableHandleProps extends Pick<HandleProps, 'id' | 'type'> {
+export interface ConnectableHandleProps extends Pick<HandleProps, 'id' | 'type'> {
   isConnectable?: boolean | number
 }
 
-export const isNodeHandleConnectable = (props: ConnectableHandleProps, node: Node, edges: Edge[]) => {
-  if (typeof props.isConnectable === 'number') {
+export const isNodeHandleConnectable = (handle: ConnectableHandleProps, node: Node, edges: Edge[]) => {
+  if (typeof handle.isConnectable === 'number') {
     const connectedEdges = getConnectedEdges([node], edges)
     const toHandle = connectedEdges.filter((edge) => {
-      return props.type === 'source'
-        ? edge.source === node.id && edge.sourceHandle === props.id
-        : edge.target === node.id && edge.targetHandle === props.id
+      return handle.type === 'source'
+        ? edge.source === node.id && edge.sourceHandle === handle.id
+        : edge.target === node.id && edge.targetHandle === handle.id
     })
-    return toHandle.length < props.isConnectable
+    return toHandle.length < handle.isConnectable
   }
-  return props.isConnectable
+  return handle.isConnectable
 }


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/18935/details/

The PR fixes a bug with the computation of connecting edges to a handle, allowing correct restrictions on certain connections (e.g. Topic Filter's handles can only have one target)

The PR also fixes the rendering of the icon when dragging a connection from a handle

The PR finally fixes a bug when deleting nodes, whereas connected edges were not automatically deleted and stayed in the data store (not displayed but contributing to the connections count of a node)

### Before 
![screenshot-localhost_3000-2024 05 22-10_07_21](https://github.com/hivemq/hivemq-edge/assets/2743481/a6db1d2d-7942-4a09-ae86-de3f8e20955b)

![screenshot-localhost_3000-2024 05 22-10_06_33](https://github.com/hivemq/hivemq-edge/assets/2743481/5b8b2d01-327f-4fcb-a6df-36b392de7a2f)

### After 
![screenshot-localhost_3000-2024 05 22-10_05_02](https://github.com/hivemq/hivemq-edge/assets/2743481/6f35c2a8-9b7d-4c29-9f93-4c50fb9017a4)

![screenshot-localhost_3000-2024 05 22-10_05_19](https://github.com/hivemq/hivemq-edge/assets/2743481/5ab285b3-0f36-41bb-a8c2-9547dedfb73d)
