### PR TITLE
test(18841): Add tests for the different operations

### DIFF
--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/operation/OperationPanel.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/operation/OperationPanel.spec.cy.tsx
@@ -139,4 +139,39 @@ describe('OperationPanel', () => {
       cy.percySnapshot(`Component: OperationPanel > ${OperationData.Function.SYSTEM_LOG}`)
     })
   })
+
+  describe(OperationData.Function.DELIVERY_REDIRECT, () => {
+    const node: Node<OperationData> = {
+      id: 'my-node',
+      type: DataHubNodeType.TOPIC_FILTER,
+      position: { x: 0, y: 0 },
+      data: {
+        id: 'default-id',
+        functionId: OperationData.Function.DELIVERY_REDIRECT,
+        formData: { topic: 'a/simple/topic', applyPolicies: true },
+      },
+    }
+
+    it('should render the form', () => {
+      cy.mountWithProviders(<OperationPanel selectedNode="my-node" />, {
+        wrapper: getWrapperWith([node]),
+      })
+      cy.get('h2').should('contain.text', 'Delivery.redirectTo')
+      cy.get('label#root_formData_topic-label').should('contain.text', 'Topic')
+      cy.get('label#root_formData_topic-label + input').should('contain.value', 'a/simple/topic')
+      cy.get('label:has(> input#root_formData_applyPolicies) ')
+        .as('topic_Errors')
+        .should('contain.text', 'Apply Policies')
+        .should('have.attr', 'data-checked')
+    })
+
+    it('should be accessible', () => {
+      cy.injectAxe()
+      cy.mountWithProviders(<OperationPanel selectedNode="my-node" />, {
+        wrapper: getWrapperWith([node]),
+      })
+      cy.checkAccessibility()
+      cy.percySnapshot(`Component: OperationPanel > ${OperationData.Function.DELIVERY_REDIRECT}`)
+    })
+  })
 })

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/operation/OperationPanel.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/operation/OperationPanel.spec.cy.tsx
@@ -322,4 +322,37 @@ describe('OperationPanel', () => {
       cy.percySnapshot(`Component: OperationPanel > ${OperationData.Function.METRICS_COUNTER_INC}`)
     })
   })
+
+  describe(OperationData.Function.MQTT_DISCONNECT, () => {
+    const node: Node<OperationData> = {
+      id: 'my-node',
+      type: DataHubNodeType.OPERATION,
+      position: { x: 0, y: 0 },
+      data: {
+        id: 'default-id',
+        functionId: OperationData.Function.MQTT_DISCONNECT,
+        formData: {
+          metricName: 'metric-name',
+          incrementBy: 12,
+        },
+      },
+    }
+
+    it('should render the form', () => {
+      cy.mountWithProviders(<OperationPanel selectedNode="my-node" />, {
+        wrapper: getWrapperWith([node]),
+      })
+      cy.get('h2').should('contain.text', 'Mqtt.disconnect')
+      cy.get('[role="group"]:has(#root_formData__title) ').last().find('label').should('not.exist')
+    })
+
+    it('should be accessible', () => {
+      cy.injectAxe()
+      cy.mountWithProviders(<OperationPanel selectedNode="my-node" />, {
+        wrapper: getWrapperWith([node]),
+      })
+      cy.checkAccessibility()
+      cy.percySnapshot(`Component: OperationPanel > ${OperationData.Function.MQTT_DISCONNECT}`)
+    })
+  })
 })

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/operation/OperationPanel.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/operation/OperationPanel.spec.cy.tsx
@@ -174,4 +174,40 @@ describe('OperationPanel', () => {
       cy.percySnapshot(`Component: OperationPanel > ${OperationData.Function.DELIVERY_REDIRECT}`)
     })
   })
+
+  describe(OperationData.Function.MQTT_USER_PROPERTY, () => {
+    const node: Node<OperationData> = {
+      id: 'my-node',
+      type: DataHubNodeType.OPERATION,
+      position: { x: 0, y: 0 },
+      data: {
+        id: 'default-id',
+        functionId: OperationData.Function.MQTT_USER_PROPERTY,
+        formData: {
+          name: 'key',
+          value: 'value',
+        },
+      },
+    }
+
+    it('should render the form', () => {
+      cy.mountWithProviders(<OperationPanel selectedNode="my-node" />, {
+        wrapper: getWrapperWith([node]),
+      })
+      cy.get('h2').should('contain.text', 'Mqtt.UserProperties.add')
+      cy.get('label#root_formData_name-label').should('contain.text', 'Property Name')
+      cy.get('label#root_formData_name-label + input').should('contain.value', 'key')
+      cy.get('label#root_formData_value-label').should('contain.text', 'Property Value')
+      cy.get('label#root_formData_value-label + input').should('contain.value', 'value')
+    })
+
+    it('should be accessible', () => {
+      cy.injectAxe()
+      cy.mountWithProviders(<OperationPanel selectedNode="my-node" />, {
+        wrapper: getWrapperWith([node]),
+      })
+      cy.checkAccessibility()
+      cy.percySnapshot(`Component: OperationPanel > ${OperationData.Function.MQTT_USER_PROPERTY}`)
+    })
+  })
 })

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/operation/OperationPanel.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/operation/OperationPanel.spec.cy.tsx
@@ -1,41 +1,41 @@
 /// <reference types="cypress" />
 
+import { Node } from 'reactflow'
 import { Button } from '@chakra-ui/react'
 
 import { MockStoreWrapper } from '@datahub/__test-utils__/MockStoreWrapper.tsx'
-import { DataHubNodeType } from '@datahub/types.ts'
-import { getNodePayload } from '@datahub/utils/node.utils.ts'
 import { OperationPanel } from './OperationPanel.tsx'
 
-const wrapper: React.JSXElementConstructor<{ children: React.ReactNode }> = ({ children }) => (
-  <MockStoreWrapper
-    config={{
-      initialState: {
-        nodes: [
-          {
-            id: '3',
-            type: DataHubNodeType.OPERATION,
-            position: { x: 0, y: 0 },
-            data: getNodePayload(DataHubNodeType.OPERATION),
+const getWrapperWith = (initNodes: Node[]) => {
+  const Wrapper: React.JSXElementConstructor<{ children: React.ReactNode }> = ({ children }) => {
+    return (
+      <MockStoreWrapper
+        config={{
+          initialState: {
+            nodes: initNodes,
           },
-        ],
-      },
-    }}
-  >
-    {children}
-    <Button variant="primary" type="submit" form="datahub-node-form">
-      SUBMIT{' '}
-    </Button>
-  </MockStoreWrapper>
-)
+        }}
+      >
+        {children}
+        <Button variant="primary" type="submit" form="datahub-node-form">
+          SUBMIT
+        </Button>
+      </MockStoreWrapper>
+    )
+  }
+
+  return Wrapper
+}
 
 describe('OperationPanel', () => {
   beforeEach(() => {
     cy.viewport(800, 800)
   })
 
-  it('should render the fields for a Validator', () => {
-    cy.mountWithProviders(<OperationPanel selectedNode="3" />, { wrapper })
+  it('should render a validating form', () => {
+    cy.mountWithProviders(<OperationPanel selectedNode="0" onFormSubmit={cy.stub().as('submit')} />, {
+      wrapper: getWrapperWith([]),
+    })
 
     cy.get('label#root_id-label').should('contain.text', 'id')
     cy.get('#root_id').type('a123')
@@ -44,25 +44,50 @@ describe('OperationPanel', () => {
     cy.get('label#root_functionId-label').should('contain.text', 'Function')
     cy.get('label#root_functionId-label + div').should('contain.text', '')
     cy.get('label#root_functionId-label + div').click()
-    cy.get('label#root_functionId-label + div')
-      .find("[role='listbox']")
-      .find("[role='option']")
-      .eq(0)
-      .should('contain.text', 'System.log')
-    cy.get('label#root_functionId-label + div')
-      .find("[role='listbox']")
-      .find("[role='option']")
-      .eq(1)
-      .should('contain.text', 'Delivery.redirectTo')
+    cy.get('label#root_functionId-label + div').find("[role='listbox']").find("[role='option']").as('functionSelect')
 
-    // TODO[18841] Editors for the functions need to be tested
+    cy.get('@functionSelect').eq(0).should('contain.text', 'System.log')
+    cy.get('@functionSelect').eq(7).should('contain.text', 'Mqtt.drop')
+    cy.get('@functionSelect').eq(7).click()
+
+    cy.get('@submit').should('not.have.been.calledWith')
+    cy.get("button[type='submit']").click()
+    cy.get('@submit')
+      .should('have.been.calledWith', Cypress.sinon.match.object)
+      .its('firstCall.args.0')
+      .should('deep.include', {
+        edit: true,
+        status: 'submitted',
+      })
+      .its('formData')
+      .should('deep.include', { functionId: 'Mqtt.drop', id: 'a123' })
   })
 
-  it('should be accessible', () => {
-    cy.injectAxe()
-    cy.mountWithProviders(<OperationPanel selectedNode="3" />, { wrapper })
+  it('should render validation errors', () => {
+    cy.mountWithProviders(<OperationPanel selectedNode="0" onFormSubmit={cy.stub().as('submit')} />, {
+      wrapper: getWrapperWith([]),
+    })
 
-    cy.checkAccessibility()
-    cy.percySnapshot('Component: OperationPanel')
+    cy.get('label#root_functionId-label + div').click()
+    cy.get('label#root_functionId-label + div').find("[role='listbox']").find("[role='option']").as('functionSelect')
+
+    cy.get('@functionSelect').eq(1).click()
+
+    cy.get('p#root_formData_applyPolicies__description + label').should('have.text', 'Apply Policies').click()
+
+    cy.get('@submit').should('not.have.been.calledWith')
+    cy.get("button[type='submit']").click()
+    cy.get('@submit').should('not.have.been.calledWith')
+
+    cy.get('[role="group"]:has(> label#root_id-label) + [role="list"]').as('id_Errors')
+    cy.get('@id_Errors').should('contain.text', "must have required property 'id'")
+
+    cy.get('[role="group"]:has(> label#root_formData_topic-label) + [role="list"]').as('topic_Errors')
+    cy.get('@topic_Errors').should('contain.text', "must have required property 'Topic'")
+
+    cy.get('[role="alert"][data-status="error"]').should('be.visible')
+    cy.get('[role="alert"][data-status="error"] ul li').as('listErrors')
+    cy.get('@listErrors').eq(0).should('contain.text', "must have required property 'id'")
+    cy.get('@listErrors').eq(1).should('contain.text', "must have required property 'Topic'")
   })
 })

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/operation/OperationPanel.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/operation/OperationPanel.spec.cy.tsx
@@ -246,4 +246,40 @@ describe('OperationPanel', () => {
       cy.percySnapshot(`Component: OperationPanel > ${OperationData.Function.SERDES_DESERIALIZE}`)
     })
   })
+
+  describe(OperationData.Function.SERDES_SERIALIZE, () => {
+    const node: Node<OperationData> = {
+      id: 'my-node',
+      type: DataHubNodeType.OPERATION,
+      position: { x: 0, y: 0 },
+      data: {
+        id: 'default-id',
+        functionId: OperationData.Function.SERDES_SERIALIZE,
+        formData: {
+          schemaId: 'schema-id',
+          schemaVersion: 'version1',
+        },
+      },
+    }
+
+    it('should render the form', () => {
+      cy.mountWithProviders(<OperationPanel selectedNode="my-node" />, {
+        wrapper: getWrapperWith([node]),
+      })
+      cy.get('h2').should('contain.text', 'Serdes.serialize')
+      cy.get('label#root_formData_schemaId-label').should('contain.text', 'Schema ID')
+      cy.get('label#root_formData_schemaId-label + input').should('contain.value', 'schema-id')
+      cy.get('label#root_formData_schemaVersion-label').should('contain.text', 'Schema Version')
+      cy.get('label#root_formData_schemaVersion-label + input').should('contain.value', 'version1')
+    })
+
+    it('should be accessible', () => {
+      cy.injectAxe()
+      cy.mountWithProviders(<OperationPanel selectedNode="my-node" />, {
+        wrapper: getWrapperWith([node]),
+      })
+      cy.checkAccessibility()
+      cy.percySnapshot(`Component: OperationPanel > ${OperationData.Function.SERDES_SERIALIZE}`)
+    })
+  })
 })

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/operation/OperationPanel.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/operation/OperationPanel.spec.cy.tsx
@@ -331,10 +331,7 @@ describe('OperationPanel', () => {
       data: {
         id: 'default-id',
         functionId: OperationData.Function.MQTT_DISCONNECT,
-        formData: {
-          metricName: 'metric-name',
-          incrementBy: 12,
-        },
+        formData: {},
       },
     }
 
@@ -353,6 +350,36 @@ describe('OperationPanel', () => {
       })
       cy.checkAccessibility()
       cy.percySnapshot(`Component: OperationPanel > ${OperationData.Function.MQTT_DISCONNECT}`)
+    })
+  })
+
+  describe(OperationData.Function.MQTT_DROP, () => {
+    const node: Node<OperationData> = {
+      id: 'my-node',
+      type: DataHubNodeType.OPERATION,
+      position: { x: 0, y: 0 },
+      data: {
+        id: 'default-id',
+        functionId: OperationData.Function.MQTT_DROP,
+        formData: {},
+      },
+    }
+
+    it('should render the form', () => {
+      cy.mountWithProviders(<OperationPanel selectedNode="my-node" />, {
+        wrapper: getWrapperWith([node]),
+      })
+      cy.get('h2').should('contain.text', 'Mqtt.drop')
+      cy.get('[role="group"]:has(#root_formData__title) ').last().find('label').should('not.exist')
+    })
+
+    it('should be accessible', () => {
+      cy.injectAxe()
+      cy.mountWithProviders(<OperationPanel selectedNode="my-node" />, {
+        wrapper: getWrapperWith([node]),
+      })
+      cy.checkAccessibility()
+      cy.percySnapshot(`Component: OperationPanel > ${OperationData.Function.MQTT_DROP}`)
     })
   })
 })

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/operation/OperationPanel.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/operation/OperationPanel.spec.cy.tsx
@@ -282,4 +282,44 @@ describe('OperationPanel', () => {
       cy.percySnapshot(`Component: OperationPanel > ${OperationData.Function.SERDES_SERIALIZE}`)
     })
   })
+
+  describe(OperationData.Function.METRICS_COUNTER_INC, () => {
+    const node: Node<OperationData> = {
+      id: 'my-node',
+      type: DataHubNodeType.OPERATION,
+      position: { x: 0, y: 0 },
+      data: {
+        id: 'default-id',
+        functionId: OperationData.Function.METRICS_COUNTER_INC,
+        formData: {
+          metricName: 'metric-name',
+          incrementBy: 12,
+        },
+      },
+    }
+
+    it('should render the form', () => {
+      cy.mountWithProviders(<OperationPanel selectedNode="my-node" />, {
+        wrapper: getWrapperWith([node]),
+      })
+      cy.get('h2').should('contain.text', 'Metrics.Counter.increment')
+      cy.get('label#root_formData_metricName-label').should('contain.text', 'Metric Name')
+      cy.get('label#root_formData_metricName-label + div > div').should(
+        'contain.text',
+        'com.hivemq.com.data-hub.custom.counters.'
+      )
+      cy.get('label#root_formData_metricName-label + div > input').should('contain.value', 'metric-name')
+      cy.get('label[for="root_formData_incrementBy"]').should('contain.text', 'IncrementBy')
+      cy.get('label[for="root_formData_incrementBy"] + div >  input').should('contain.value', 12)
+    })
+
+    it('should be accessible', () => {
+      cy.injectAxe()
+      cy.mountWithProviders(<OperationPanel selectedNode="my-node" />, {
+        wrapper: getWrapperWith([node]),
+      })
+      cy.checkAccessibility()
+      cy.percySnapshot(`Component: OperationPanel > ${OperationData.Function.METRICS_COUNTER_INC}`)
+    })
+  })
 })

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/operation/OperationPanel.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/operation/OperationPanel.spec.cy.tsx
@@ -210,4 +210,40 @@ describe('OperationPanel', () => {
       cy.percySnapshot(`Component: OperationPanel > ${OperationData.Function.MQTT_USER_PROPERTY}`)
     })
   })
+
+  describe(OperationData.Function.SERDES_DESERIALIZE, () => {
+    const node: Node<OperationData> = {
+      id: 'my-node',
+      type: DataHubNodeType.OPERATION,
+      position: { x: 0, y: 0 },
+      data: {
+        id: 'default-id',
+        functionId: OperationData.Function.SERDES_DESERIALIZE,
+        formData: {
+          schemaId: 'schema-id',
+          schemaVersion: 'version1',
+        },
+      },
+    }
+
+    it('should render the form', () => {
+      cy.mountWithProviders(<OperationPanel selectedNode="my-node" />, {
+        wrapper: getWrapperWith([node]),
+      })
+      cy.get('h2').should('contain.text', 'Serdes.deserialize')
+      cy.get('label#root_formData_schemaId-label').should('contain.text', 'Schema ID')
+      cy.get('label#root_formData_schemaId-label + input').should('contain.value', 'schema-id')
+      cy.get('label#root_formData_schemaVersion-label').should('contain.text', 'Schema Version')
+      cy.get('label#root_formData_schemaVersion-label + input').should('contain.value', 'version1')
+    })
+
+    it('should be accessible', () => {
+      cy.injectAxe()
+      cy.mountWithProviders(<OperationPanel selectedNode="my-node" />, {
+        wrapper: getWrapperWith([node]),
+      })
+      cy.checkAccessibility()
+      cy.percySnapshot(`Component: OperationPanel > ${OperationData.Function.SERDES_DESERIALIZE}`)
+    })
+  })
 })

--- a/hivemq-edge/src/frontend/src/extensions/datahub/types.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/types.ts
@@ -234,7 +234,7 @@ export interface OperationData extends DataHubNodeData {
   id: string
   functionId?: string
   metadata?: FunctionDefinition
-  formData?: Record<string, string | number | string[]>
+  formData?: Record<string, string | number | string[] | boolean>
   core?: PolicyOperation
 }
 


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/18841/details/


The PR adds component tests for the configuration panel of every one of the Operation nodes supported in Data Hub: 
- `System.log`
- `Delivery.redirectTo`
- `Mqtt.UserProperties.add`
- `Serdes.deserialize`
- `Serdes.serialize`
- `Metrics.Counter.increment`
- `Mqtt.disconnect`
- `Mqtt.drop`
- `DataHub.transform`
