### PR TITLE
fix(hotfix): Prevent misdesigned subscriptions to be always treated as array

### DIFF
--- a/hivemq-edge/src/frontend/src/modules/Workspace/utils/topics-utils.ts
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/utils/topics-utils.ts
@@ -67,8 +67,13 @@ const getTopicsFromPath = (path: string, instance: RJSFSchema): string[] => {
   if (property === TOPIC_PATH_ITEMS_TOKEN) {
     const res: string[] = []
 
-    for (const item of instance as RJSFSchema[]) {
-      const topicsFromPath = getTopicsFromPath(rest.join('.'), item)
+    if (Array.isArray(instance)) {
+      for (const item of instance as RJSFSchema[]) {
+        const topicsFromPath = getTopicsFromPath(rest.join('.'), item)
+        res.push(...topicsFromPath)
+      }
+    } else {
+      const topicsFromPath = getTopicsFromPath(rest.join('.'), instance as RJSFSchema)
       res.push(...topicsFromPath)
     }
     return res


### PR DESCRIPTION
Fix an uncaught error with a subscription item expected to be an array when it's not