### PR TITLE
fix(22943): Fix bugs with the batch subscription mode

### DIFF
--- a/ext/hivemq-edge-openapi-2024.5.yaml
+++ b/ext/hivemq-edge-openapi-2024.5.yaml
@@ -4815,8 +4815,8 @@ components:
             description: The capabilities of this adapter
             enum:
               - READ
-              - WRITE
               - DISCOVER
+          uniqueItems: true
         category:
           $ref: '#/components/schemas/ProtocolAdapterCategory'
         configSchema:
@@ -5117,7 +5117,7 @@ components:
           description: The verifyHostname from the config
     TypeIdentifier:
       type: object
-      description: The type-identifier of the object who caused the event to be generated
+      description: The unique id of the event object
       properties:
         fullQualifiedIdentifier:
           type: string

--- a/hivemq-edge/src/frontend/src/api/__generated__/models/ProtocolAdapter.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/models/ProtocolAdapter.ts
@@ -17,7 +17,7 @@ export type ProtocolAdapter = {
     /**
      * The capabilities of this adapter
      */
-    capabilities?: Array<'READ' | 'WRITE' | 'DISCOVER'>;
+    capabilities?: Array<'READ' | 'DISCOVER'>;
     category?: ProtocolAdapterCategory;
     configSchema?: JsonNode;
     /**

--- a/hivemq-edge/src/frontend/src/api/__generated__/models/TypeIdentifier.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/models/TypeIdentifier.ts
@@ -4,7 +4,7 @@
 /* eslint-disable */
 
 /**
- * The type-identifier of the object who caused the event to be generated
+ * The unique id of the event object
  */
 export type TypeIdentifier = {
     fullQualifiedIdentifier?: string;

--- a/hivemq-edge/src/frontend/src/api/__generated__/schemas/$TypeIdentifier.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/schemas/$TypeIdentifier.ts
@@ -3,7 +3,7 @@
 /* tslint:disable */
 /* eslint-disable */
 export const $TypeIdentifier = {
-    description: `The type-identifier of the object who caused the event to be generated`,
+    description: `The unique id of the event object`,
     properties: {
         fullQualifiedIdentifier: {
             type: 'string',

--- a/hivemq-edge/src/frontend/src/components/rjsf/ArrayFieldTemplate.tsx
+++ b/hivemq-edge/src/frontend/src/components/rjsf/ArrayFieldTemplate.tsx
@@ -31,7 +31,8 @@ export const ArrayFieldTemplate: FC<ArrayFieldTemplateProps<unknown, RJSFSchema,
   const ArrayFieldItemTemplate = getTemplate<'ArrayFieldItemTemplate'>('ArrayFieldItemTemplate', registry, uiOptions)
   const ArrayFieldTitleTemplate = getTemplate<'ArrayFieldTitleTemplate'>('ArrayFieldTitleTemplate', registry, uiOptions)
 
-  const { onBatchUpload } = formContext || {}
+  const { onBatchUpload, isEditAdapter } = formContext || {}
+
   return (
     <Box>
       <ArrayFieldTitleTemplate
@@ -71,7 +72,7 @@ export const ArrayFieldTemplate: FC<ArrayFieldTemplateProps<unknown, RJSFSchema,
               uiSchema={uiSchema}
               registry={registry}
             />
-            {uiOptions.batchMode && onBatchUpload && (
+            {uiOptions.batchMode && onBatchUpload && isEditAdapter && (
               <BatchUploadButton idSchema={idSchema} schema={schema} onBatchUpload={onBatchUpload} />
             )}
           </HStack>

--- a/hivemq-edge/src/frontend/src/components/rjsf/BatchSubscription/components/DataSourceStep.tsx
+++ b/hivemq-edge/src/frontend/src/components/rjsf/BatchSubscription/components/DataSourceStep.tsx
@@ -19,10 +19,11 @@ const getDropZoneBorder = (color: string) => {
   }
 }
 
-const DataSourceStep: FC<StepRendererProps> = ({ onContinue }) => {
+const DataSourceStep: FC<StepRendererProps> = ({ onContinue, store }) => {
   const { t } = useTranslation('components')
   const toast = useToast()
   const [loading, setLoading] = useState(false)
+  const { fileName } = store
   const { getRootProps, getInputProps, isDragActive, open } = useDropzone({
     noClick: true,
     noKeyboard: true,
@@ -89,6 +90,7 @@ const DataSourceStep: FC<StepRendererProps> = ({ onContinue }) => {
       {loading && <Text>{t('rjsf.batchUpload.dropZone.loading')}</Text>}
       {!isDragActive && !loading && (
         <>
+          {fileName && <Text mb={4}>{t('rjsf.batchUpload.dropZone.currentlyLoaded', { fileName: fileName })}</Text>}
           <Text>{t('rjsf.batchUpload.dropZone.placeholder')}</Text>
           <Button onClick={open}>{t('rjsf.batchUpload.dropZone.selectFile')}</Button>
         </>

--- a/hivemq-edge/src/frontend/src/locales/en/components.json
+++ b/hivemq-edge/src/frontend/src/locales/en/components.json
@@ -107,6 +107,7 @@
         }
       },
       "dropZone": {
+        "currentlyLoaded": "File currently loaded : {{ fileName }}",
         "placeholder": "Upload a .xlsx, .xls or .csv file",
         "dropping": "Drop a file here ...",
         "loading": "Processing ...",

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/drawers/AdapterInstanceDrawer.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/drawers/AdapterInstanceDrawer.tsx
@@ -92,6 +92,7 @@ const AdapterInstanceDrawer: FC<AdapterInstanceDrawerProps> = ({
   }
 
   const context: AdapterContext = {
+    isEditAdapter: !isNewAdapter,
     onBatchUpload: (idSchema: IdSchema<unknown>, batch) => {
       const path = idSchema.$id.replace('root_', '/').replaceAll('_', '/') + '/-'
       const operations: JSONPatchDocument = batch.map<JSONPatchAdd>((value) => ({ op: 'add', path, value }))

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/types.ts
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/types.ts
@@ -44,4 +44,5 @@ export type AdapterConfig = NonNullable<Adapter['config']>
 export interface AdapterContext {
   // TODO[NVL] Is that good enough for ANY form data?
   onBatchUpload?: (idSchema: IdSchema<unknown>, batch: Record<string, unknown>[]) => void
+  isEditAdapter?: boolean
 }

--- a/hivemq-edge/src/main/resources/simulation-adapter-ui-schema.json
+++ b/hivemq-edge/src/main/resources/simulation-adapter-ui-schema.json
@@ -27,6 +27,7 @@
   },
   "subscriptions": {
     "items": {
+      "ui:batchMode": true,
       "ui:order": [ "destination", "qos", "*"],
       "ui:collapsable": {
         "titleKey": "destination"

--- a/modules/hivemq-edge-module-http/src/main/resources/http-adapter-ui-schema.json
+++ b/modules/hivemq-edge-module-http/src/main/resources/http-adapter-ui-schema.json
@@ -40,14 +40,5 @@
   "httpRequestBody": {
     "ui:widget": "textarea"
   },
-  "ui:order": ["id", "host", "port", "*"],
-  "subscriptions": {
-    "ui:batchMode": true,
-    "items": {
-      "ui:order": ["destination", "qos", "*"],
-      "ui:collapsable": {
-        "titleKey": "destination"
-      }
-    }
-  }
+  "ui:order": ["id", "*"]
 }


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/22943/details/

The PR fixes a few bugs detected during QA:
- both `HTTP` and `Simulated` adapter have their `uiSchema` fixed for missing  or extra information
- the batch upload button is not available for a newly created adapter, to prevent misconfiguration
- the dropzone now displays the name of the loaded file. File uploading can still be operated. 

The PR also updates the OpenAPI specs to `2024.5` and  the stubs.

### Out-of-scope
- A better Ux for the dropzone is to add a visualisation of the content of the loaded file. It will be part of a subsequent refinement, see https://hivemq.kanbanize.com/ctrl_board/57/cards/23054/details/

### Before
![screenshot-localhost_3000-2024 06 13-12_13_10](https://github.com/hivemq/hivemq-edge/assets/2743481/93c9a28d-1840-46be-bc06-5d53dd2f46be)

![screenshot-localhost_3000-2024 06 13-12_13_39](https://github.com/hivemq/hivemq-edge/assets/2743481/90079728-1d89-43ad-8c49-a19f2a04d252)

### After
![screenshot-localhost_3000-2024 06 13-12_12_33](https://github.com/hivemq/hivemq-edge/assets/2743481/dcdbe8bf-3cd2-46cb-bced-116756579694)

![screenshot-localhost_3000-2024 06 13-12_12_08](https://github.com/hivemq/hivemq-edge/assets/2743481/debce465-1125-41b2-9101-3966c2f6c5fd)

