### PR TITLE
fix(23330): Only include selectable options in the browser

### DIFF
--- a/hivemq-edge/src/frontend/src/components/rjsf/Widgets/AdapterTagSelect.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/components/rjsf/Widgets/AdapterTagSelect.spec.cy.tsx
@@ -63,19 +63,19 @@ describe('AdapterTagSelect', () => {
     cy.get('#react-select-dataPoint-container').click()
     cy.get('#react-select-dataPoint-listbox').should('be.visible')
     cy.get('#react-select-dataPoint-listbox').find('[role="option"]').as('options')
-    cy.get('@options').should('have.length', 11)
-    cy.get('@options').eq(0).find('[data-testid="dataPoint-name"]').should('have.text', 'Object')
-    cy.get('@options').eq(0).find('[data-testid="dataPoint-id"]').should('have.text', 'i=85')
+    cy.get('@options').should('have.length', 8)
+    cy.get('@options').eq(0).find('[data-testid="dataPoint-name"]').should('have.text', 'Constant')
+    cy.get('@options').eq(0).find('[data-testid="dataPoint-id"]').should('have.text', 'ns=3;i=1001')
     cy.get('@options')
       .eq(0)
       .find('[data-testid="dataPoint-description"]')
       .should(
         'have.text',
-        'The Apollotech B340 is an affordable wireless mouse with reliable connectivity, 12 months battery life and modern design'
+        'New range of formal shirts are designed keeping you in mind. With fits and styling that will make you stand apart'
       )
 
     cy.get('@options').eq(3).click()
-    cy.get('#react-select-dataPoint-container').should('contain.text', 'ns=3;i=1002')
+    cy.get('#react-select-dataPoint-container').should('contain.text', 'ns=3;i=1004')
   })
 
   it('should be accessible', () => {

--- a/hivemq-edge/src/frontend/src/components/rjsf/Widgets/AdapterTagSelect.tsx
+++ b/hivemq-edge/src/frontend/src/components/rjsf/Widgets/AdapterTagSelect.tsx
@@ -1,6 +1,9 @@
 import { ComponentType, FC, useCallback } from 'react'
+import { useTranslation } from 'react-i18next'
 import { getTemplate, labelValue, WidgetProps } from '@rjsf/utils'
-import { Code, FormControl, FormLabel, HStack, Text, VStack } from '@chakra-ui/react'
+import { getChakra } from '@rjsf/chakra-ui/lib/utils'
+import { RJSFSchema } from '@rjsf/utils/src/types.ts'
+import { Breadcrumb, BreadcrumbItem, Code, FormControl, FormLabel, HStack, Text, VStack } from '@chakra-ui/react'
 import {
   chakraComponents,
   createFilter,
@@ -10,14 +13,11 @@ import {
   Select,
   SingleValueProps,
 } from 'chakra-react-select'
-import { getChakra } from '@rjsf/chakra-ui/lib/utils'
-import { RJSFSchema } from '@rjsf/utils/src/types.ts'
-import { INode } from 'react-accessible-treeview'
 
 import { useGetDataPoints } from '@/api/hooks/useProtocolAdapters/useGetDataPoints.tsx'
-import { AdapterContext } from '@/modules/ProtocolAdapters/types.ts'
-import { FlatObjectNode } from '@/components/rjsf/Widgets/types.ts'
+import { FlatObjectNode, INode } from '@/components/rjsf/Widgets/types.ts'
 import { getAdapterTreeView } from '@/components/rjsf/Widgets/utils/treeview.utils.ts'
+import { AdapterContext } from '@/modules/ProtocolAdapters/types.ts'
 
 const Option: ComponentType<OptionProps<INode<FlatObjectNode>, false, GroupBase<INode<FlatObjectNode>>>> = (props) => {
   const { metadata } = props.data
@@ -33,9 +33,18 @@ const Option: ComponentType<OptionProps<INode<FlatObjectNode>, false, GroupBase<
           </Text>
           <Code data-testid="dataPoint-id">{id}</Code>
         </HStack>
-        <Text fontSize="xs" data-testid="dataPoint-description">
-          {description}
-        </Text>
+        <VStack width="inherit" alignItems="flex-start" gap={0} pl={4}>
+          <Breadcrumb separator=">" fontSize="xs">
+            {metadata?.breadcrumb?.slice(0, -1).map((crumb, index) => (
+              <BreadcrumbItem key={`${crumb}-${index}`}>
+                <Text>{crumb}</Text>
+              </BreadcrumbItem>
+            ))}
+          </Breadcrumb>
+          <Text fontSize="xs" data-testid="dataPoint-description">
+            {description}
+          </Text>
+        </VStack>
       </VStack>
     </chakraComponents.Option>
   )
@@ -69,7 +78,19 @@ const AdapterTagSelect: FC<WidgetProps<unknown, RJSFSchema, AdapterContext>> = (
     return <BaseInputTemplate {...props} />
   }
 
-  const options = getAdapterTreeView(data).filter((option) => option.parent !== null)
+  const flattenDataTree = getAdapterTreeView(data)
+  const options = flattenDataTree.filter((option) => option.parent !== null && option.metadata?.selectable === true)
+
+  function noOptionsMessage(obj: { inputValue: string }) {
+    const getErrorMessage = () => {
+      if (!flattenDataTree.length) return t('rjsf.AdapterTagSelect.select.noTags')
+      if (!options.length) return t('rjsf.AdapterTagSelect.select.noSelectable')
+
+      return t('rjsf.AdapterTagSelect.select.noOption', { count: obj.inputValue.length, value: obj.inputValue })
+    }
+
+    return <Text>{getErrorMessage()}</Text>
+  }
 
   return (
     <FormControl
@@ -96,8 +117,8 @@ const AdapterTagSelect: FC<WidgetProps<unknown, RJSFSchema, AdapterContext>> = (
         options={options}
         value={options.find((e) => e.metadata?.id === props.value)}
         onChange={onChange}
+        noOptionsMessage={noOptionsMessage}
         filterOption={createFilter({
-          // search in the name and description
           stringify: (option) => {
             return `${option.data.metadata?.name || ''}${option.data.metadata?.id || ''}`
           },

--- a/hivemq-edge/src/frontend/src/components/rjsf/Widgets/AdapterTagSelect.tsx
+++ b/hivemq-edge/src/frontend/src/components/rjsf/Widgets/AdapterTagSelect.tsx
@@ -59,6 +59,7 @@ const SingleValue = (props: SingleValueProps<INode<FlatObjectNode>>) => {
 }
 
 const AdapterTagSelect: FC<WidgetProps<unknown, RJSFSchema, AdapterContext>> = (props) => {
+  const { t } = useTranslation('components')
   const { formContext } = props
   const { isDiscoverable, adapterType, adapterId } = formContext || {}
   if (!adapterType || !adapterId) throw new Error('The adapter has not been added to the form context')

--- a/hivemq-edge/src/frontend/src/components/rjsf/Widgets/types.ts
+++ b/hivemq-edge/src/frontend/src/components/rjsf/Widgets/types.ts
@@ -1,3 +1,20 @@
 import type { ObjectNode } from '@/api/__generated__'
 
-export type FlatObjectNode = Omit<ObjectNode, 'children'>
+export interface FlatObjectNode extends Omit<ObjectNode, 'children'> {
+  breadcrumb?: string[]
+}
+
+export interface INode<M> {
+  /** A non-negative integer that uniquely identifies the node */
+  id: string
+  /** Used to match on key press */
+  name: string
+  /** An array with the ids of the children nodes */
+  children: string[]
+  /** The parent of the node; null for the root node */
+  parent: string | null
+  /** Used to indicated whether a node is branch to be able load async data onExpand*/
+  isBranch?: boolean
+  /** User-defined metadata */
+  metadata?: M
+}

--- a/hivemq-edge/src/frontend/src/components/rjsf/Widgets/utils/treeview.utils.spec.ts
+++ b/hivemq-edge/src/frontend/src/components/rjsf/Widgets/utils/treeview.utils.spec.ts
@@ -1,9 +1,8 @@
 import { describe, expect } from 'vitest'
-import { INode } from 'react-accessible-treeview'
 
 import { ObjectNode } from '@/api/__generated__'
 import { convertEdgeNode, getAdapterTreeView } from '@/components/rjsf/Widgets/utils/treeview.utils.ts'
-import { FlatObjectNode } from '@/components/rjsf/Widgets/types.ts'
+import { FlatObjectNode, INode } from '@/components/rjsf/Widgets/types.ts'
 
 interface TestEachSuite {
   parent: INode<FlatObjectNode>
@@ -39,6 +38,7 @@ describe('convertEdgeNode', () => {
             name: 'node1',
             description: 'the first node',
             nodeType: ObjectNode.nodeType.OBJECT,
+            breadcrumb: ['node1'],
             selectable: false,
           },
           name: 'node1',
@@ -82,6 +82,7 @@ describe('convertEdgeNode', () => {
             id: 'node1',
             name: 'node1',
             description: 'the first node',
+            breadcrumb: ['node1'],
             nodeType: ObjectNode.nodeType.OBJECT,
             selectable: false,
           },
@@ -97,6 +98,7 @@ describe('convertEdgeNode', () => {
             name: 'node2',
             description: 'the second node',
             nodeType: ObjectNode.nodeType.OBJECT,
+            breadcrumb: ['node1', 'node2'],
             selectable: false,
           },
           name: 'node2',
@@ -111,6 +113,7 @@ describe('convertEdgeNode', () => {
             name: 'node3',
             description: 'the third node',
             nodeType: ObjectNode.nodeType.OBJECT,
+            breadcrumb: ['node1', 'node3'],
             selectable: false,
           },
           name: 'node3',
@@ -154,6 +157,7 @@ describe('convertEdgeNode', () => {
             id: 'node1',
             name: 'node1',
             description: 'the first node',
+            breadcrumb: ['node1'],
             nodeType: ObjectNode.nodeType.OBJECT,
             selectable: false,
           },
@@ -168,6 +172,7 @@ describe('convertEdgeNode', () => {
             id: 'node2',
             name: 'node2',
             description: 'the second node',
+            breadcrumb: ['node1', 'node2'],
             nodeType: ObjectNode.nodeType.VALUE,
             selectable: false,
           },
@@ -183,6 +188,7 @@ describe('convertEdgeNode', () => {
             name: 'node3',
             description: 'the third node',
             nodeType: ObjectNode.nodeType.FOLDER,
+            breadcrumb: ['node1', 'node2', 'node3'],
             selectable: false,
           },
           name: 'node3',
@@ -250,6 +256,7 @@ describe('getAdapterTreeView', () => {
           name: 'node0',
           description: 'the root',
           nodeType: 'OBJECT',
+          breadcrumb: ['node0'],
           selectable: false,
         },
         name: 'node0',
@@ -264,6 +271,7 @@ describe('getAdapterTreeView', () => {
           name: 'node1',
           description: 'the first node',
           nodeType: 'OBJECT',
+          breadcrumb: ['node1'],
           selectable: false,
         },
         name: 'node1',
@@ -278,6 +286,7 @@ describe('getAdapterTreeView', () => {
           name: 'node2',
           description: 'the second node',
           nodeType: 'VALUE',
+          breadcrumb: ['node1', 'node2'],
           selectable: false,
         },
         name: 'node2',
@@ -292,6 +301,7 @@ describe('getAdapterTreeView', () => {
           name: 'node3',
           description: 'the third node',
           nodeType: 'FOLDER',
+          breadcrumb: ['node1', 'node2', 'node3'],
           selectable: false,
         },
         name: 'node3',

--- a/hivemq-edge/src/frontend/src/components/rjsf/Widgets/utils/treeview.utils.ts
+++ b/hivemq-edge/src/frontend/src/components/rjsf/Widgets/utils/treeview.utils.ts
@@ -1,19 +1,19 @@
-import { INode } from 'react-accessible-treeview'
 import { v4 as uuidv4 } from 'uuid'
 
 import { type ObjectNode, ValuesTree } from '@/api/__generated__'
-import { FlatObjectNode } from '@/components/rjsf/Widgets/types.ts'
+import { FlatObjectNode, INode } from '@/components/rjsf/Widgets/types.ts'
 
 export const convertEdgeNode = (parent: INode<FlatObjectNode>, node: ObjectNode): INode<FlatObjectNode>[] => {
   const { children, ...flatNode } = node
   const nodeId = uuidv4()
+  const breadcrumb = parent.metadata?.breadcrumb || []
 
   const newNode: INode<FlatObjectNode> = {
     id: nodeId,
     name: flatNode.name as string,
     parent: parent.id,
     isBranch: false,
-    metadata: flatNode,
+    metadata: { ...flatNode, breadcrumb: [...breadcrumb, flatNode.name as string] },
     children: [],
   }
 

--- a/hivemq-edge/src/frontend/src/locales/en/components.json
+++ b/hivemq-edge/src/frontend/src/locales/en/components.json
@@ -157,6 +157,15 @@
           "upload": "Upload records"
         }
       }
+    },
+    "AdapterTagSelect": {
+      "select": {
+        "noTags": "There are no tags available from your device",
+        "noSelectable": "None of the tags are selectable",
+        "noOption_zero": "No options",
+        "noOption_one": "No options matching {{ value }}",
+        "noOption_other": "No options matching {{ value }}"
+      }
     }
   }
 }


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/23330/details/

The PR corrects the logic of the tag browser, only allowing selectable options to be visible in the auto-complete options. 

The `selectable` flag is internal and received from the backend.

The PR also customises the error message when no options are visible, to identify the context (no options available, no selectable options available, no option matching filter)

The PR adds a "breadcrumb" representation of the path of an item in the tree. It could be used for rendering purposes, as an alternative to present a fully, non-accessible treeview

### Out-of-scope
- The application of the `selectable` flag might result in no options available, making the auto-complete component unworkable. An alternative UX, if non-discoverable configuration is still required, will be implemented in a different ticket

### Before
![screenshot-localhost_3000-2024 06 18-13_13_23](https://github.com/hivemq/hivemq-edge/assets/2743481/94e7f208-15ca-46fe-bb5e-22cc469c8620)

![screenshot-localhost_3000-2024 06 18-13_14_05](https://github.com/hivemq/hivemq-edge/assets/2743481/90faab47-7b21-4088-badd-785ef4136f4c)

### After
![screenshot-localhost_3000-2024 06 19-17_16_41](https://github.com/hivemq/hivemq-edge/assets/2743481/36becbda-45ae-4689-9377-0ad219ebdb89)

![screenshot-localhost_3000-2024 06 19-17_16_59](https://github.com/hivemq/hivemq-edge/assets/2743481/e1e29211-41b3-4e4e-bba2-67d4251a7050)
