### PR TITLE
fix(23881): Add fallback editor when Monaco is not loading

### DIFF
--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/forms/CodeEditor.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/forms/CodeEditor.tsx
@@ -1,14 +1,39 @@
-import { useMemo } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { labelValue, WidgetProps } from '@rjsf/utils'
-import { Editor } from '@monaco-editor/react'
-import { FormControl, FormLabel, VStack } from '@chakra-ui/react'
+import { Editor, useMonaco } from '@monaco-editor/react'
+import { FormControl, FormHelperText, FormLabel, VStack } from '@chakra-ui/react'
 import { getChakra } from '@rjsf/chakra-ui/lib/utils'
+import { generateWidgets } from '@rjsf/chakra-ui'
+
+import LoaderSpinner from '@/components/Chakra/LoaderSpinner.tsx'
+import { useTranslation } from 'react-i18next'
 
 const CodeEditor = (lng: string, props: WidgetProps) => {
+  const { t } = useTranslation('datahub')
   const chakraProps = getChakra({ uiSchema: props.uiSchema })
+  const monaco = useMonaco()
+  const [isLoaded, setIsLoaded] = useState(false)
+
+  const { TextareaWidget } = generateWidgets()
+
+  useEffect(() => {
+    if (monaco) {
+      setIsLoaded(true)
+    }
+  }, [monaco])
 
   const isReadOnly = useMemo(() => props.readonly || props.options.readonly, [props.readonly, props.options.readonly])
 
+  if (!isLoaded) {
+    const { options, ...rest } = props
+
+    return (
+      <>
+        <TextareaWidget {...rest} options={{ ...options, rows: 6 }} />
+        <FormHelperText>{t('workspace.codeEditor.loadingError')}</FormHelperText>
+      </>
+    )
+  }
   return (
     <FormControl
       {...chakraProps}
@@ -26,6 +51,7 @@ const CodeEditor = (lng: string, props: WidgetProps) => {
 
       <VStack gap={3} alignItems="flex-start" id={props.id}>
         <Editor
+          loading={<LoaderSpinner />}
           height="40vh"
           defaultLanguage={lng}
           defaultValue={props.value}
@@ -33,6 +59,7 @@ const CodeEditor = (lng: string, props: WidgetProps) => {
           onChange={(event) => props.onChange(event)}
           options={{ readOnly: isReadOnly }}
         />
+        )
       </VStack>
     </FormControl>
   )

--- a/hivemq-edge/src/frontend/src/extensions/datahub/locales/en/datahub.json
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/locales/en/datahub.json
@@ -187,6 +187,7 @@
       }
     },
     "codeEditor": {
+      "loadingError": "The advanced editor cannot be loaded. Syntax highlighting is not supported",
       "delete": "Delete this version",
       "test": "Test code"
     },


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/23881/details/

The Monaco Editor (https://github.com/suren-atoyan/monaco-react) relies on an external CDN to load all its components. When Edge is used "offline", the loading obviously fails. However, the visual feedback only shows a permanent "Loading ..." text, without any error message (in the dev console).

The PR provides a short-term solution for the problem by falling back on a standard `textarea` input.

### Design
- The fallback is created from the `textarea` widget provided by the React JSONSchema Form library, ensuring seamless integration
- A warning about the lack of syntax highlighting (and validation) is added below the form.
- The "loading" state of the Monaco Editor has been changed to the Edge's common spinner.
- The Monaco Editor doesn't seem to offer access to the loading errors. The fallback widget is therefore displayed FIRST while the editor is loading. Upon success, It will be replaced. This might result in a quick flicker 

### Out-of-scope
- An alternative to Monaco Editor, or at least an offline version of it, will be implemented in another ticket