### PR TITLE
fix(23934): Remove the "seletable" filter from the auto-complete selector

### DIFF
--- a/hivemq-edge/src/frontend/src/components/rjsf/Widgets/AdapterTagSelect.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/components/rjsf/Widgets/AdapterTagSelect.spec.cy.tsx
@@ -63,18 +63,18 @@ describe('AdapterTagSelect', () => {
     cy.get('#react-select-dataPoint-container').click()
     cy.get('#react-select-dataPoint-listbox').should('be.visible')
     cy.get('#react-select-dataPoint-listbox').find('[role="option"]').as('options')
-    cy.get('@options').should('have.length', 8)
-    cy.get('@options').eq(0).find('[data-testid="dataPoint-name"]').should('have.text', 'Constant')
-    cy.get('@options').eq(0).find('[data-testid="dataPoint-id"]').should('have.text', 'ns=3;i=1001')
+    cy.get('@options').should('have.length', 11)
+    cy.get('@options').eq(2).find('[data-testid="dataPoint-name"]').should('have.text', 'Constant')
+    cy.get('@options').eq(2).find('[data-testid="dataPoint-id"]').should('have.text', 'ns=3;i=1001')
     cy.get('@options')
-      .eq(0)
+      .eq(2)
       .find('[data-testid="dataPoint-description"]')
       .should(
         'have.text',
         'New range of formal shirts are designed keeping you in mind. With fits and styling that will make you stand apart'
       )
 
-    cy.get('@options').eq(3).click()
+    cy.get('@options').eq(5).click()
     cy.get('#react-select-dataPoint-container').should('contain.text', 'ns=3;i=1004')
   })
 

--- a/hivemq-edge/src/frontend/src/components/rjsf/Widgets/AdapterTagSelect.tsx
+++ b/hivemq-edge/src/frontend/src/components/rjsf/Widgets/AdapterTagSelect.tsx
@@ -80,7 +80,7 @@ const AdapterTagSelect: FC<WidgetProps<unknown, RJSFSchema, AdapterContext>> = (
   }
 
   const flattenDataTree = getAdapterTreeView(data)
-  const options = flattenDataTree.filter((option) => option.parent !== null && option.metadata?.selectable === true)
+  const options = flattenDataTree.filter((option) => option.parent !== null)
 
   function noOptionsMessage(obj: { inputValue: string }) {
     const getErrorMessage = () => {


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/23934/details/

This is a quick fix to the previous PR, which allows EVERY node discovered on the adapter to be selectable in the UI

### Design
- We have a significant ambiguity as to what makes a discovered node `selectable` in general
- Specifically, in `OPC-UA` the existing rule based on `VALUE` or `OBJECT` doesn't seem to be working
- The example given by one of our customers shows expected nodes that are `OBJECT` but `not selectable`
- We cannot make an informed decision of this treatment, based on our fake data. We need real-life expertise with real-life OPCA-UA devices deeding Edge
- The fix makes EVERY node selectable
  - users are not facing an empty list if their usable nodes are "unselectable"
  - if a wrong node is selected, the adapter will certainly fail and a relevant error message generated in the `event log`
  - the onus will be on the users to fix their mistake

### Before 
![screenshot-localhost_3000-2024 07 10-12_01_52](https://github.com/hivemq/hivemq-edge/assets/2743481/fa14f714-9a9b-496f-9076-33c32db40422)

For reference, this is the OPC-UA dummy :
![Screenshot 2024-07-10 at 12 02 25](https://github.com/hivemq/hivemq-edge/assets/2743481/d5c530b6-36ad-4d20-aeb2-8f705c374f2f)


### After
![screenshot-localhost_3000-2024 07 10-12_03_46](https://github.com/hivemq/hivemq-edge/assets/2743481/93e2916e-3d04-4516-8dd1-42ce4e128f30)

Note that it will affect EVERY adapter, including MODBUS, where the folder node will be displayed

![screenshot-localhost_3000-2024 07 10-12_04_46](https://github.com/hivemq/hivemq-edge/assets/2743481/bb746598-f7b3-4525-8fcf-a6d6c9915e11)
