### PR TITLE
feat(24144): Refactor the name of resources as displayed on their nodes in the Designer

### DIFF
--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/schema/SchemaNode.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/schema/SchemaNode.tsx
@@ -2,28 +2,17 @@ import { HStack, Text, VStack } from '@chakra-ui/react'
 import { FC, useMemo } from 'react'
 import { NodeProps, Position } from 'reactflow'
 import { useTranslation } from 'react-i18next'
-import { RJSFSchema } from '@rjsf/utils'
 
-import { DataHubNodeType, SchemaData, SchemaType } from '@datahub/types.ts'
+import { DataHubNodeType, SchemaData } from '@datahub/types.ts'
 import { CustomHandle, NodeWrapper } from '@datahub/components/nodes'
 import { NodeIcon, NodeParams } from '@datahub/components/helpers'
+import { renderResourceName } from '@datahub/utils/node.utils.ts'
 
 export const SchemaNode: FC<NodeProps<SchemaData>> = (props) => {
   const { t } = useTranslation('datahub')
   const { id, data, type } = props
 
-  const title = useMemo(() => {
-    if (!data.schemaSource) return undefined
-
-    if (data.type === SchemaType.PROTOBUF) return data.messageType
-
-    try {
-      const schema = JSON.parse(data.schemaSource) as RJSFSchema
-      return schema.title
-    } catch (error) {
-      return undefined
-    }
-  }, [data.messageType, data.schemaSource, data.type])
+  const title = useMemo(() => renderResourceName(data.name, data.version, t), [data.name, data.version, t])
 
   return (
     <>
@@ -33,7 +22,7 @@ export const SchemaNode: FC<NodeProps<SchemaData>> = (props) => {
           <Text data-testid="node-title"> {t('workspace.nodes.type', { context: type })}</Text>
           <VStack data-testid="node-model">
             <NodeParams value={data?.type || t('error.noSet.select')} />
-            <NodeParams value={title || t('error.noSet.select')} />
+            <NodeParams value={title} />
           </VStack>
         </HStack>
       </NodeWrapper>

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/script/FunctionNode.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/script/FunctionNode.tsx
@@ -1,15 +1,18 @@
-import { Code, HStack, Text, VStack } from '@chakra-ui/react'
-import { FC } from 'react'
+import { HStack, Text, VStack } from '@chakra-ui/react'
+import { FC, useMemo } from 'react'
 import { NodeProps, Position } from 'reactflow'
 import { useTranslation } from 'react-i18next'
 
 import { DataHubNodeType, FunctionData } from '@datahub/types.ts'
 import { CustomHandle, NodeWrapper } from '@datahub/components/nodes'
-import { NodeIcon } from '@datahub/components/helpers'
+import { NodeIcon, NodeParams } from '@datahub/components/helpers'
+import { renderResourceName } from '@datahub/utils/node.utils.ts'
 
 export const FunctionNode: FC<NodeProps<FunctionData>> = (props) => {
   const { t } = useTranslation('datahub')
   const { id, data, type } = props
+
+  const title = useMemo(() => renderResourceName(data.name, data.version, t), [data.name, data.version, t])
 
   return (
     <>
@@ -19,7 +22,7 @@ export const FunctionNode: FC<NodeProps<FunctionData>> = (props) => {
             <NodeIcon type={DataHubNodeType.FUNCTION} />
             <Text data-testid="node-title"> {t('workspace.nodes.type', { context: type })}</Text>
             <VStack data-testid="node-model">
-              <Code>{data?.name || t('error.noSet.select')}</Code>
+              <NodeParams value={title || t('error.noSet.select')} />
             </VStack>
           </HStack>
         </VStack>

--- a/hivemq-edge/src/frontend/src/extensions/datahub/locales/en/datahub.json
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/locales/en/datahub.json
@@ -155,7 +155,9 @@
       "type_OPERATION": "Operation",
       "type_TRANSITION": "Transition",
       "type_FUNCTION": "JS Function",
-      "type_EVENT": "Event"
+      "type_EVENT": "Event",
+      "status_DRAFT": "DRAFT",
+      "status_MODIFIED": "MODIFIED"
     },
     "handles": {
       "validation_onSuccess": "onSuccess",

--- a/hivemq-edge/src/frontend/src/extensions/datahub/utils/node.utils.spec.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/utils/node.utils.spec.ts
@@ -15,6 +15,7 @@ import {
   isNodeHandleConnectable,
   isValidPolicyConnection,
   reduceIdsFrom,
+  renderResourceName,
 } from '@datahub/utils/node.utils.ts'
 import {
   BehaviorPolicyData,
@@ -22,11 +23,13 @@ import {
   DataPolicyData,
   DesignerStatus,
   OperationData,
+  ResourceStatus,
   SchemaType,
   StrategyType,
   TransitionData,
   ValidDropConnection,
 } from '@datahub/types.ts'
+import i18n from '@/config/i18n.config.ts'
 
 describe('getNodeId', () => {
   it('should return the initial state of the store', async () => {
@@ -655,6 +658,42 @@ describe('getConnectedNodeFrom', () => {
     'should return a $result.type with $node + $handle',
     ({ node, handle, result }) => {
       expect(getConnectedNodeFrom(node, handle)).toStrictEqual(result ? expect.objectContaining(result) : undefined)
+    }
+  )
+})
+
+interface ResourceNameTest {
+  name?: string
+  version?: ResourceStatus.DRAFT | number | ResourceStatus.MODIFIED
+  result: string
+}
+
+const resourceNameTestSuite: ResourceNameTest[] = [
+  {
+    name: 'test',
+    version: 1,
+    result: 'test:1',
+  },
+  {
+    version: 1,
+    result: '< not set >',
+  },
+  {
+    name: 'test',
+    result: '< not set >',
+  },
+  {
+    name: 'test',
+    version: ResourceStatus.DRAFT,
+    result: 'test:DRAFT',
+  },
+]
+
+describe('renderResourceName', () => {
+  it.each<ResourceNameTest>(resourceNameTestSuite)(
+    'should return $result with $name and $version',
+    ({ name, version, result }) => {
+      expect(renderResourceName(name, version, i18n.t)).toStrictEqual(result)
     }
   )
 })

--- a/hivemq-edge/src/frontend/src/extensions/datahub/utils/node.utils.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/utils/node.utils.ts
@@ -24,6 +24,8 @@ import {
 } from '../types.ts'
 import { RiPassExpiredLine, RiPassPendingLine, RiPassValidLine } from 'react-icons/ri'
 import { DataPolicyValidator } from '@/api/__generated__'
+import { enumFromStringValue } from '@/utils/types.utils.ts'
+import type { TFunction } from 'i18next'
 
 export const getNodeId = (stub = 'node') => `${stub}_${uuidv4()}`
 
@@ -360,4 +362,17 @@ export const isNodeHandleConnectable = (handle: ConnectableHandleProps, node: No
     return toHandle.length < handle.isConnectable
   }
   return handle.isConnectable
+}
+
+export const renderResourceName = (
+  name: string | undefined,
+  version: ResourceStatus.DRAFT | number | ResourceStatus.MODIFIED | undefined,
+  t: TFunction
+) => {
+  if (!name || !version) return t('error.noSet.select', { ns: 'datahub' })
+
+  const isDraft = enumFromStringValue(ResourceStatus, version.toString())
+  const formatedVersion = !isDraft ? version : t('workspace.nodes.status', { context: version, ns: 'datahub' })
+
+  return `${name}:${formatedVersion}`
 }


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/24144/details/

The PR refactors the way the name of a resource (SCRIPT or SCHEMA) is rendered on the node itself. 

Previously, there was an inconsistent mix of internal names and schema's internal properties. 

The current refactoring consistently utilises the `name` and the `version` of the resource, as internally used in the API payload.

### Design
- The rendering uses the internal pattern `name:version`
- When a new resource is created, the version will be displayed as `DRAFT`
- When a new version of the resource is created, the version will be rendered as `MODIFIED`

### Before
![screenshot-localhost_3000-2024 07 11-16_40_35](https://github.com/hivemq/hivemq-edge/assets/2743481/e199d4dd-9163-4f2c-a66c-82d48907ba63)


### After
![screenshot-localhost_3000-2024 07 11-16_41_03](https://github.com/hivemq/hivemq-edge/assets/2743481/e49b52a7-6abc-41a4-b5ba-b037983a67a7)
