### PR TITLE
chore(CYPRESS): Enable videos and verbose output

### DIFF
--- a/.github/workflows/frontend-cli.yml
+++ b/.github/workflows/frontend-cli.yml
@@ -100,7 +100,7 @@ jobs:
           component: true
           start: pnpm preview
           working-directory: ./hivemq-edge/src/frontend/
-          quiet: true
+          quiet: false
 
       # after the test run completes store videos
       - name: 💾 Upload Component videos
@@ -136,7 +136,7 @@ jobs:
         with:
           start: pnpm preview --port 3000
           working-directory: ./hivemq-edge/src/frontend/
-          quiet: true
+          quiet: false
       - name: 💾 Upload E2E videos
         if: failure()
         uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4

--- a/hivemq-edge/src/frontend/cypress.config.ts
+++ b/hivemq-edge/src/frontend/cypress.config.ts
@@ -4,6 +4,7 @@ import installLogsPrinter from 'cypress-terminal-report/src/installLogsPrinter'
 export default defineConfig({
   retries: { runMode: 2, openMode: 0 },
   e2e: {
+    video: true,
     baseUrl: 'http://localhost:3000',
     setupNodeEvents(on) {
       installLogsPrinter(on, {
@@ -14,6 +15,8 @@ export default defineConfig({
   },
 
   component: {
+    video: true,
+
     setupNodeEvents(on) {
       installLogsPrinter(on, {
         printLogsToConsole: 'onFail',


### PR DESCRIPTION
To track the flaky component tests 