### PR TITLE
feat(24140): Add a context toolbar to the nodes on the Designer

### DIFF
--- a/hivemq-edge/src/frontend/package.json
+++ b/hivemq-edge/src/frontend/package.json
@@ -85,7 +85,7 @@
     "react-i18next": "^14.1.1",
     "react-icons": "^5.0.1",
     "react-router-dom": "^6.11.2",
-    "reactflow": "^11.11.3",
+    "reactflow": "^11.11.4",
     "tippy.js": "^6.3.7",
     "uuid": "^9.0.1",
     "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz",

--- a/hivemq-edge/src/frontend/pnpm-lock.yaml
+++ b/hivemq-edge/src/frontend/pnpm-lock.yaml
@@ -1,9 +1,5 @@
 lockfileVersion: '6.0'
 
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false
-
 dependencies:
   '@chakra-ui/anatomy':
     specifier: ^2.2.2
@@ -180,7 +176,7 @@ dependencies:
     specifier: ^6.11.2
     version: 6.11.2(react-dom@18.2.0)(react@18.2.0)
   reactflow:
-    specifier: ^11.11.3
+    specifier: ^11.11.4
     version: 11.11.4(@types/react@18.0.28)(react-dom@18.2.0)(react@18.2.0)
   tippy.js:
     specifier: ^6.3.7
@@ -10248,3 +10244,7 @@ packages:
     engines: {node: '>=0.8'}
     hasBin: true
     dev: false
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false

--- a/hivemq-edge/src/frontend/src/components/Chakra/ContextMenu.tsx
+++ b/hivemq-edge/src/frontend/src/components/Chakra/ContextMenu.tsx
@@ -1,0 +1,75 @@
+import { MutableRefObject, useCallback, useEffect, useRef, useState } from 'react'
+import { useEventListener, Portal, Menu, MenuButton, PortalProps, MenuButtonProps, MenuProps } from '@chakra-ui/react'
+
+export interface ContextMenuProps<T extends HTMLElement> {
+  renderMenu: () => JSX.Element | null
+  children: (ref: MutableRefObject<T | null>) => JSX.Element | null
+  menuProps?: Omit<MenuProps, 'children'> & { children?: React.ReactNode }
+  portalProps?: Omit<PortalProps, 'children'> & { children?: React.ReactNode }
+  menuButtonProps?: MenuButtonProps
+}
+
+export function ContextMenu<T extends HTMLElement = HTMLElement>(props: ContextMenuProps<T>) {
+  const [isOpen, setIsOpen] = useState(false)
+  const [isRendered, setIsRendered] = useState(false)
+  const [isDeferredOpen, setIsDeferredOpen] = useState(false)
+  const [position, setPosition] = useState<[number, number]>([0, 0])
+  const targetRef = useRef<T>(null)
+
+  useEffect(() => {
+    if (isOpen) {
+      setTimeout(() => {
+        setIsRendered(true)
+        setTimeout(() => {
+          setIsDeferredOpen(true)
+        })
+      })
+    } else {
+      setIsDeferredOpen(false)
+      const timeout = setTimeout(() => {
+        setIsRendered(isOpen)
+      }, 1000)
+      return () => clearTimeout(timeout)
+    }
+  }, [isOpen])
+
+  useEventListener('contextmenu', (e) => {
+    if (targetRef.current?.contains(e.target as any) || e.target === targetRef.current) {
+      e.preventDefault()
+      setIsOpen(true)
+      setPosition([e.pageX, e.pageY])
+    } else {
+      setIsOpen(false)
+    }
+  })
+
+  const onCloseHandler = useCallback(() => {
+    props.menuProps?.onClose?.()
+    setIsOpen(false)
+  }, [props.menuProps])
+
+  return (
+    <>
+      {props.children(targetRef)}
+      {isRendered && (
+        <Portal {...props.portalProps}>
+          <Menu isOpen={isDeferredOpen} gutter={0} {...props.menuProps} onClose={onCloseHandler}>
+            <MenuButton
+              aria-hidden={true}
+              w={1}
+              h={1}
+              style={{
+                position: 'absolute',
+                left: position[0],
+                top: position[1],
+                cursor: 'default',
+              }}
+              {...props.menuButtonProps}
+            />
+            {props.renderMenu()}
+          </Menu>
+        </Portal>
+      )}
+    </>
+  )
+}

--- a/hivemq-edge/src/frontend/src/components/Chakra/ContextMenu.tsx
+++ b/hivemq-edge/src/frontend/src/components/Chakra/ContextMenu.tsx
@@ -9,6 +9,10 @@ export interface ContextMenuProps<T extends HTMLElement> {
   menuButtonProps?: MenuButtonProps
 }
 
+/**
+ * From https://github.com/lukasbach/chakra-ui-contextmenu
+ * @deprecated Doesn't integrate well with React Flow (keyboard navigation) and ChakraUI (focus on first element)
+ */
 export function ContextMenu<T extends HTMLElement = HTMLElement>(props: ContextMenuProps<T>) {
   const [isOpen, setIsOpen] = useState(false)
   const [isRendered, setIsRendered] = useState(false)

--- a/hivemq-edge/src/frontend/src/components/Chakra/ContextMenu.tsx
+++ b/hivemq-edge/src/frontend/src/components/Chakra/ContextMenu.tsx
@@ -38,7 +38,7 @@ export function ContextMenu<T extends HTMLElement = HTMLElement>(props: ContextM
   }, [isOpen])
 
   useEventListener('contextmenu', (e) => {
-    if (targetRef.current?.contains(e.target as any) || e.target === targetRef.current) {
+    if (targetRef.current?.contains(e.target as never) || e.target === targetRef.current) {
       e.preventDefault()
       setIsOpen(true)
       setPosition([e.pageX, e.pageY])

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/NodeDatahubToolbar.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/NodeDatahubToolbar.spec.cy.tsx
@@ -1,0 +1,40 @@
+import NodeDatahubToolbar from '@datahub/components/nodes/NodeDatahubToolbar.tsx'
+import { mockReactFlow } from '@/__test-utils__/react-flow/providers.tsx'
+
+describe('NodeDatahubToolbar', () => {
+  beforeEach(() => {
+    cy.viewport(400, 400)
+  })
+
+  it('should render the toolbar', () => {
+    const mockOnEdit = cy.stub().as('editNode')
+    const mockOnDelete = cy.stub().as('deleteNode')
+    const mockOnCopy = cy.stub().as('copyNode')
+
+    cy.mountWithProviders(
+      mockReactFlow(<NodeDatahubToolbar onEdit={mockOnEdit} onCopy={mockOnCopy} onDelete={mockOnDelete} />)
+    )
+    cy.get('@editNode').should('not.have.been.called')
+    cy.get('@deleteNode').should('not.have.been.called')
+    cy.get('@copyNode').should('not.have.been.called')
+
+    cy.getByTestId('node-toolbar-edit').should('have.attr', 'aria-label', 'Edit')
+    cy.getByTestId('node-toolbar-edit').click()
+    cy.get('@editNode').should('have.been.called')
+
+    cy.getByTestId('node-toolbar-copy').should('have.attr', 'aria-label', 'Copy')
+    cy.getByTestId('node-toolbar-copy').click()
+    cy.get('@copyNode').should('have.been.called')
+
+    cy.getByTestId('node-toolbar-delete').should('have.attr', 'aria-label', 'Delete')
+    cy.getByTestId('node-toolbar-delete').click()
+    cy.get('@deleteNode').should('have.been.called')
+  })
+
+  it('should be accessible', () => {
+    cy.injectAxe()
+    cy.mountWithProviders(mockReactFlow(<NodeDatahubToolbar />))
+    cy.checkAccessibility()
+    cy.percySnapshot('Component: DataHub - NodeDatahubToolbar')
+  })
+})

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/NodeDatahubToolbar.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/NodeDatahubToolbar.tsx
@@ -1,0 +1,35 @@
+import { FC, useMemo } from 'react'
+import { NodeToolbar, Position } from 'reactflow'
+import { ButtonGroup, ButtonGroupProps } from '@chakra-ui/react'
+import { LuCopy, LuDelete, LuFileEdit } from 'react-icons/lu'
+
+import IconButton from '@/components/Chakra/IconButton.tsx'
+import useDataHubDraftStore from '@datahub/hooks/useDataHubDraftStore.ts'
+
+interface NodeToolbarProps extends ButtonGroupProps {
+  isVisible: boolean
+  onCopy?: (event: React.BaseSyntheticEvent) => void
+  onDelete?: (event: React.BaseSyntheticEvent) => void
+  onEdit?: (event: React.BaseSyntheticEvent) => void
+}
+
+const NodeDatahubToolbar: FC<NodeToolbarProps> = (props) => {
+  const { nodes } = useDataHubDraftStore()
+
+  const isSingleSelect = useMemo(() => {
+    const selectedNodes = nodes.filter((node) => node.selected)
+    return selectedNodes.length === 1
+  }, [nodes])
+
+  return (
+    <NodeToolbar isVisible={props.isVisible && isSingleSelect} position={Position.Top} offset={8}>
+      <ButtonGroup size="xs" variant="solid" colorScheme="gray" isAttached {...props}>
+        <IconButton icon={<LuFileEdit />} aria-label="Edit" onClick={props.onEdit} />
+        <IconButton icon={<LuCopy />} aria-label="Copy" onClick={props.onCopy} />
+        <IconButton icon={<LuDelete />} aria-label="Delete" colorScheme="red" onClick={props.onDelete} />
+      </ButtonGroup>
+    </NodeToolbar>
+  )
+}
+
+export default NodeDatahubToolbar

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/NodeDatahubToolbar.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/NodeDatahubToolbar.tsx
@@ -1,9 +1,10 @@
-import { FC } from 'react'
+import { FC, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { ButtonGroup, ButtonGroupProps } from '@chakra-ui/react'
 import { LuCopy, LuDelete, LuFileEdit } from 'react-icons/lu'
 
 import IconButton from '@/components/Chakra/IconButton.tsx'
+import { useStore } from 'reactflow'
 
 interface NodeToolbarProps extends ButtonGroupProps {
   onCopy?: (event: React.BaseSyntheticEvent) => void
@@ -13,9 +14,17 @@ interface NodeToolbarProps extends ButtonGroupProps {
 
 const NodeDatahubToolbar: FC<NodeToolbarProps> = (props) => {
   const { t } = useTranslation('datahub')
+  const zoomFactor = useStore((s) => s.transform[2])
+
+  const getToolbarSize = useMemo<string>(() => {
+    if (zoomFactor >= 1.5) return 'lg'
+    if (zoomFactor >= 1) return 'md'
+    if (zoomFactor >= 0.75) return 'sm'
+    return 'xs'
+  }, [zoomFactor])
 
   return (
-    <ButtonGroup size="xs" variant="solid" colorScheme="gray" isAttached {...props}>
+    <ButtonGroup size={getToolbarSize} variant="solid" colorScheme="gray" isAttached {...props}>
       <IconButton
         icon={<LuFileEdit />}
         data-testid="node-toolbar-edit"

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/NodeDatahubToolbar.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/NodeDatahubToolbar.tsx
@@ -1,4 +1,5 @@
 import { FC } from 'react'
+import { useTranslation } from 'react-i18next'
 import { ButtonGroup, ButtonGroupProps } from '@chakra-ui/react'
 import { LuCopy, LuDelete, LuFileEdit } from 'react-icons/lu'
 
@@ -11,11 +12,29 @@ interface NodeToolbarProps extends ButtonGroupProps {
 }
 
 const NodeDatahubToolbar: FC<NodeToolbarProps> = (props) => {
+  const { t } = useTranslation('datahub')
+
   return (
     <ButtonGroup size="xs" variant="solid" colorScheme="gray" isAttached {...props}>
-      <IconButton icon={<LuFileEdit />} aria-label="Edit" onClick={props.onEdit} />
-      <IconButton icon={<LuCopy />} aria-label="Copy" onClick={props.onCopy} />
-      <IconButton icon={<LuDelete />} aria-label="Delete" colorScheme="red" onClick={props.onDelete} />
+      <IconButton
+        icon={<LuFileEdit />}
+        data-testid="node-toolbar-edit"
+        aria-label={t('Listings.action.edit')}
+        onClick={props.onEdit}
+      />
+      <IconButton
+        icon={<LuCopy />}
+        data-testid="node-toolbar-copy"
+        aria-label={t('Listings.action.copy')}
+        onClick={props.onCopy}
+      />
+      <IconButton
+        icon={<LuDelete />}
+        data-testid="node-toolbar-delete"
+        aria-label={t('Listings.action.delete')}
+        colorScheme="red"
+        onClick={props.onDelete}
+      />
     </ButtonGroup>
   )
 }

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/NodeDatahubToolbar.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/NodeDatahubToolbar.tsx
@@ -1,34 +1,22 @@
-import { FC, useMemo } from 'react'
-import { NodeToolbar, Position } from 'reactflow'
+import { FC } from 'react'
 import { ButtonGroup, ButtonGroupProps } from '@chakra-ui/react'
 import { LuCopy, LuDelete, LuFileEdit } from 'react-icons/lu'
 
 import IconButton from '@/components/Chakra/IconButton.tsx'
-import useDataHubDraftStore from '@datahub/hooks/useDataHubDraftStore.ts'
 
 interface NodeToolbarProps extends ButtonGroupProps {
-  isVisible: boolean
   onCopy?: (event: React.BaseSyntheticEvent) => void
   onDelete?: (event: React.BaseSyntheticEvent) => void
   onEdit?: (event: React.BaseSyntheticEvent) => void
 }
 
 const NodeDatahubToolbar: FC<NodeToolbarProps> = (props) => {
-  const { nodes } = useDataHubDraftStore()
-
-  const isSingleSelect = useMemo(() => {
-    const selectedNodes = nodes.filter((node) => node.selected)
-    return selectedNodes.length === 1
-  }, [nodes])
-
   return (
-    <NodeToolbar isVisible={props.isVisible && isSingleSelect} position={Position.Top} offset={8}>
-      <ButtonGroup size="xs" variant="solid" colorScheme="gray" isAttached {...props}>
-        <IconButton icon={<LuFileEdit />} aria-label="Edit" onClick={props.onEdit} />
-        <IconButton icon={<LuCopy />} aria-label="Copy" onClick={props.onCopy} />
-        <IconButton icon={<LuDelete />} aria-label="Delete" colorScheme="red" onClick={props.onDelete} />
-      </ButtonGroup>
-    </NodeToolbar>
+    <ButtonGroup size="xs" variant="solid" colorScheme="gray" isAttached {...props}>
+      <IconButton icon={<LuFileEdit />} aria-label="Edit" onClick={props.onEdit} />
+      <IconButton icon={<LuCopy />} aria-label="Copy" onClick={props.onCopy} />
+      <IconButton icon={<LuDelete />} aria-label="Delete" colorScheme="red" onClick={props.onDelete} />
+    </ButtonGroup>
   )
 }
 

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/NodeWrapper.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/NodeWrapper.tsx
@@ -1,11 +1,13 @@
 import { FC, ReactNode, useEffect, useMemo, useState } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 import { NodeProps } from 'reactflow'
-
 import { Avatar, BoxProps, Card, CardBody, CardBodyProps, HStack } from '@chakra-ui/react'
-import { DataHubNodeData, PolicyDryRunStatus } from '@datahub/types.ts'
 
+import NodeDatahubToolbar from '@datahub/components/nodes/NodeDatahubToolbar.tsx'
+import { DataHubNodeData, PolicyDryRunStatus } from '@datahub/types.ts'
 import { getDryRunStatusIcon } from '@datahub/utils/node.utils.ts'
+import { parseHotkey } from '@datahub/utils/hotkeys.utils.ts'
+import { DATAHUB_HOTKEY } from '@datahub/utils/datahub.utils.ts'
 
 interface NodeWrapperProps extends NodeProps<DataHubNodeData> {
   children: ReactNode
@@ -24,6 +26,23 @@ export const NodeWrapper: FC<NodeWrapperProps> = ({ selected, children, route, w
     if (!selected) setInternalSelection(false)
   }, [selected])
 
+  const onHandleCopy = () => {
+    document.dispatchEvent(new KeyboardEvent('keydown', parseHotkey(DATAHUB_HOTKEY.COPY)))
+  }
+
+  const onHandleDelete = () => {
+    document.dispatchEvent(new KeyboardEvent('keydown', parseHotkey(DATAHUB_HOTKEY.DELETE)))
+  }
+
+  const onHandleEdit = (event: React.BaseSyntheticEvent) => {
+    if (internalSelection) {
+      navigate(route, { state: { origin: pathname } })
+      event.preventDefault()
+      event.stopPropagation()
+    }
+    setInternalSelection(true)
+  }
+
   const selectedStyle: Partial<BoxProps> = {
     boxShadow: 'var(--chakra-shadows-outline)',
   }
@@ -37,37 +56,41 @@ export const NodeWrapper: FC<NodeWrapperProps> = ({ selected, children, route, w
   }
 
   const isDryRun = data.dryRunStatus !== undefined && data.dryRunStatus !== PolicyDryRunStatus.IDLE
+  const isToolbarEnabled = import.meta.env.VITE_FLAG_DATAHUB_SHOW_TOOLBAR === 'true'
 
   return (
-    <Card
-      variant="elevated"
-      {...(data.dryRunStatus === PolicyDryRunStatus.FAILURE ? { ...errorStyle } : {})}
-      {...(data.dryRunStatus === PolicyDryRunStatus.SUCCESS ? { ...successStyle } : {})}
-      {...(selected ? { ...selectedStyle } : {})}
-      size="sm"
-      onClick={(event) => {
-        if (internalSelection) {
-          navigate(route, { state: { origin: pathname } })
-          event.preventDefault()
-          event.stopPropagation()
-        }
-        setInternalSelection(true)
-      }}
-    >
-      {isDryRun && (
-        <Avatar
-          position="absolute"
-          left="-1rem"
-          top="-1rem"
-          size="sm"
-          icon={<CheckIcon fontSize="1.2rem" />}
-          {...(data.dryRunStatus === PolicyDryRunStatus.FAILURE ? { ...errorStyle, background: 'red.500' } : {})}
-          {...(data.dryRunStatus === PolicyDryRunStatus.SUCCESS ? { ...successStyle, background: 'green.500' } : {})}
+    <>
+      {isToolbarEnabled && (
+        <NodeDatahubToolbar
+          isVisible={selected}
+          onCopy={onHandleCopy}
+          onDelete={onHandleDelete}
+          onEdit={onHandleEdit}
         />
       )}
-      <CardBody as={HStack} {...wrapperProps}>
-        {children}
-      </CardBody>
-    </Card>
+      <Card
+        variant="elevated"
+        {...(data.dryRunStatus === PolicyDryRunStatus.FAILURE ? { ...errorStyle } : {})}
+        {...(data.dryRunStatus === PolicyDryRunStatus.SUCCESS ? { ...successStyle } : {})}
+        {...(selected ? { ...selectedStyle } : {})}
+        size="sm"
+        onClick={onHandleEdit}
+      >
+        {isDryRun && (
+          <Avatar
+            position="absolute"
+            left="-1rem"
+            top="-1rem"
+            size="sm"
+            icon={<CheckIcon fontSize="1.2rem" />}
+            {...(data.dryRunStatus === PolicyDryRunStatus.FAILURE ? { ...errorStyle, background: 'red.500' } : {})}
+            {...(data.dryRunStatus === PolicyDryRunStatus.SUCCESS ? { ...successStyle, background: 'green.500' } : {})}
+          />
+        )}
+        <CardBody as={HStack} {...wrapperProps}>
+          {children}
+        </CardBody>
+      </Card>
+    </>
   )
 }

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/NodeWrapper.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/NodeWrapper.tsx
@@ -1,6 +1,6 @@
 import { FC, ReactNode, useEffect, useMemo, useState } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
-import { NodeProps } from 'reactflow'
+import { NodeProps, NodeToolbar, Position } from 'reactflow'
 import { Avatar, BoxProps, Card, CardBody, CardBodyProps, HStack } from '@chakra-ui/react'
 
 import NodeDatahubToolbar from '@datahub/components/nodes/NodeDatahubToolbar.tsx'
@@ -8,6 +8,7 @@ import { DataHubNodeData, PolicyDryRunStatus } from '@datahub/types.ts'
 import { getDryRunStatusIcon } from '@datahub/utils/node.utils.ts'
 import { parseHotkey } from '@datahub/utils/hotkeys.utils.ts'
 import { DATAHUB_HOTKEY } from '@datahub/utils/datahub.utils.ts'
+import useDataHubDraftStore from '@datahub/hooks/useDataHubDraftStore.ts'
 
 interface NodeWrapperProps extends NodeProps<DataHubNodeData> {
   children: ReactNode
@@ -16,6 +17,7 @@ interface NodeWrapperProps extends NodeProps<DataHubNodeData> {
 }
 
 export const NodeWrapper: FC<NodeWrapperProps> = ({ selected, children, route, wrapperProps, data }) => {
+  const { nodes } = useDataHubDraftStore()
   const [internalSelection, setInternalSelection] = useState(false)
   const navigate = useNavigate()
   const { pathname } = useLocation()
@@ -25,6 +27,11 @@ export const NodeWrapper: FC<NodeWrapperProps> = ({ selected, children, route, w
   useEffect(() => {
     if (!selected) setInternalSelection(false)
   }, [selected])
+
+  const isSingleSelect = useMemo(() => {
+    const selectedNodes = nodes.filter((node) => node.selected)
+    return selectedNodes.length === 1
+  }, [nodes])
 
   const onHandleCopy = () => {
     document.dispatchEvent(new KeyboardEvent('keydown', parseHotkey(DATAHUB_HOTKEY.COPY)))
@@ -61,12 +68,9 @@ export const NodeWrapper: FC<NodeWrapperProps> = ({ selected, children, route, w
   return (
     <>
       {isToolbarEnabled && (
-        <NodeDatahubToolbar
-          isVisible={selected}
-          onCopy={onHandleCopy}
-          onDelete={onHandleDelete}
-          onEdit={onHandleEdit}
-        />
+        <NodeToolbar isVisible={selected && isSingleSelect} position={Position.Top} offset={8}>
+          <NodeDatahubToolbar onCopy={onHandleCopy} onDelete={onHandleDelete} onEdit={onHandleEdit} />
+        </NodeToolbar>
       )}
       <Card
         variant="elevated"

--- a/hivemq-edge/src/frontend/src/extensions/datahub/locales/en/datahub.json
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/locales/en/datahub.json
@@ -33,7 +33,8 @@
       "edit": "Edit",
       "view": "View",
       "download": "Download",
-      "delete": "Delete"
+      "delete": "Delete",
+      "copy": "Copy"
     },
     "tabs": {
       "policy": {

--- a/hivemq-edge/src/frontend/src/extensions/datahub/utils/hotkeys.utils.spec.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/utils/hotkeys.utils.spec.ts
@@ -1,0 +1,26 @@
+import { describe, expect } from 'vitest'
+import { parseHotkey } from '@datahub/utils/hotkeys.utils.ts'
+
+interface ParseHotkeySuite {
+  hotKey: string
+  expected: KeyboardEventInit
+}
+
+describe('parseHotkey', () => {
+  test.each<ParseHotkeySuite>([
+    {
+      hotKey: 'undefined',
+      expected: { key: 'undefined' },
+    },
+    {
+      hotKey: 'Meta+C',
+      expected: { key: 'c', metaKey: true },
+    },
+    {
+      hotKey: 'Shift+FAKE',
+      expected: { key: 'fake', shiftKey: true },
+    },
+  ])('should return a keydown for $hotKey ', ({ hotKey, expected }) => {
+    expect(parseHotkey(hotKey)).toStrictEqual(expect.objectContaining({ ...expected }))
+  })
+})

--- a/hivemq-edge/src/frontend/src/extensions/datahub/utils/hotkeys.utils.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/utils/hotkeys.utils.ts
@@ -1,0 +1,57 @@
+/**
+ * Adapted from https://github.com/JohannesKlauss/react-hotkeys-hook/blob/main/src/parseHotkeys.ts
+ */
+
+const reservedModifierKeywords = ['shift', 'alt', 'meta', 'mod', 'ctrl']
+
+const mappedKeys: Record<string, string> = {
+  esc: 'escape',
+  return: 'enter',
+  '.': 'period',
+  ',': 'comma',
+  '-': 'slash',
+  ' ': 'space',
+  '`': 'backquote',
+  '#': 'backslash',
+  '+': 'bracketright',
+  ShiftLeft: 'shift',
+  ShiftRight: 'shift',
+  AltLeft: 'alt',
+  AltRight: 'alt',
+  MetaLeft: 'meta',
+  MetaRight: 'meta',
+  OSLeft: 'meta',
+  OSRight: 'meta',
+  ControlLeft: 'ctrl',
+  ControlRight: 'ctrl',
+}
+
+export function mapKey(key: string): string {
+  return (mappedKeys[key] || key)
+    .trim()
+    .toLowerCase()
+    .replace(/key|digit|numpad|arrow/, '')
+}
+
+export function parseHotkey(hotkey: string, combinationKey = '+'): KeyboardEventInit {
+  const keys = hotkey
+    .toLocaleLowerCase()
+    .split(combinationKey)
+    .map((k) => mapKey(k))
+
+  const modifiers: EventModifierInit = {
+    altKey: keys.includes('alt'),
+    ctrlKey: keys.includes('ctrl') || keys.includes('control'),
+    shiftKey: keys.includes('shift'),
+    metaKey: keys.includes('meta'),
+    modifierFn: keys.includes('mod'),
+  }
+
+  const singleCharKeys = keys.filter((k) => !reservedModifierKeywords.includes(k))
+
+  return {
+    ...modifiers,
+    // Not supporting combined Hot Key. Take only the first one
+    key: singleCharKeys[0],
+  }
+}

--- a/hivemq-edge/src/frontend/src/extensions/datahub/utils/hotkeys.utils.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/utils/hotkeys.utils.ts
@@ -26,7 +26,7 @@ const mappedKeys: Record<string, string> = {
   ControlRight: 'ctrl',
 }
 
-export function mapKey(key: string): string {
+function mapKey(key: string): string {
   return (mappedKeys[key] || key)
     .trim()
     .toLowerCase()
@@ -48,7 +48,6 @@ export function parseHotkey(hotkey: string, combinationKey = '+'): KeyboardEvent
   }
 
   const singleCharKeys = keys.filter((k) => !reservedModifierKeywords.includes(k))
-
   return {
     ...modifiers,
     // Not supporting combined Hot Key. Take only the first one


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/24140/details/

The PR adds a conditional toolbar to every node on the Designer, containing buttons for the main tasks associated with nodes: edit (open the side panel), copy and delete

### Design
- The toolbar is conditional to a node being selected. 
- The toolbar is associated with the node (top)
- If multiple nodes are selected (like for copy), no toolbar is displayed
- The toolbar's size changes based on the zoom factor of the canvas, maintaining a consistent visual

### Out-of-scope
- Multiple selections might benefit from a toolbar, associated with the first node for example, and applying the operation to every node. This might be exploited in a subsequent ticket
- Dispatching the COPY and DELETE hit keys trigger an uncaught error with ReactFlow. This will be explored after eventual upgrade to v12

### Before
![screenshot-localhost_3000-2024 07 16-13_44_40](https://github.com/user-attachments/assets/b79b05eb-b344-47a5-b9c0-e2ac63ee10ff)

### After
![screenshot-localhost_3000-2024 07 16-13_44_20](https://github.com/user-attachments/assets/7f913d0b-977c-45b9-9352-70efc8d6a523)
