### PR TITLE
fix(24361): Fix bug with deprecated error

### DIFF
--- a/hivemq-edge/src/frontend/src/api/hooks/useProtocolAdapters/useGetDataPoints.tsx
+++ b/hivemq-edge/src/frontend/src/api/hooks/useProtocolAdapters/useGetDataPoints.tsx
@@ -3,12 +3,17 @@ import { useHttpClient } from '@/api/hooks/useHttpClient/useHttpClient.ts'
 import { ApiError, ValuesTree } from '@/api/__generated__'
 import { QUERY_KEYS } from '@/api/utils.ts'
 
-export const useGetDataPoints = (isDiscoverable: boolean, adapterId: string, root?: string, depth?: number) => {
+export const useGetDataPoints = (
+  isDiscoverable: boolean,
+  adapterId: string | undefined,
+  root?: string,
+  depth?: number
+) => {
   const appClient = useHttpClient()
 
   return useQuery<ValuesTree, ApiError>({
     queryKey: [QUERY_KEYS.ADAPTERS, adapterId, QUERY_KEYS.DISCOVERY_POINTS, root, depth],
-    queryFn: () => appClient.protocolAdapters.discoverDataPoints(adapterId, root, depth),
-    enabled: isDiscoverable,
+    queryFn: () => appClient.protocolAdapters.discoverDataPoints(adapterId || '', root, depth),
+    enabled: Boolean(isDiscoverable && adapterId),
   })
 }

--- a/hivemq-edge/src/frontend/src/components/rjsf/Widgets/AdapterTagSelect.tsx
+++ b/hivemq-edge/src/frontend/src/components/rjsf/Widgets/AdapterTagSelect.tsx
@@ -62,7 +62,6 @@ const AdapterTagSelect: FC<WidgetProps<unknown, RJSFSchema, AdapterContext>> = (
   const { t } = useTranslation('components')
   const { formContext } = props
   const { isDiscoverable, adapterType, adapterId } = formContext || {}
-  if (!adapterType || !adapterId) throw new Error('The adapter has not been added to the form context')
   const { data, isLoading, isError } = useGetDataPoints(Boolean(isDiscoverable), adapterId)
   const chakraProps = getChakra({ uiSchema: props.uiSchema })
 


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/24361/details/

The PR removes a deprecated error throw. The case is dealt with by supporting an alternative field.

### Out-of-scope
- Since the discovery API requires an adapter `id` to work, it cannot be used when creating a new adapter. Without the discovery, there is no possible auto-complete. In such a case, the widget reverts to the default, uncontrolled, input. The issue was raised on the main PR. 