### PR TITLE
refactor(24369): Turn discovery browser off

### DIFF
--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/utils/uiSchema.utils.ts
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/utils/uiSchema.utils.ts
@@ -1,5 +1,4 @@
 import { RegistryWidgetsType, UiSchema } from '@rjsf/utils'
-import AdapterTagSelect from '@/components/rjsf/Widgets/AdapterTagSelect.tsx'
 
 export const getRequiredUiSchema = (uiSchema: UiSchema | undefined, isNewAdapter: boolean): UiSchema => {
   const { ['ui:submitButtonOptions']: submitButtonOptions, id, ...rest } = uiSchema || {}
@@ -19,5 +18,6 @@ export const getRequiredUiSchema = (uiSchema: UiSchema | undefined, isNewAdapter
 }
 
 export const adapterJSFWidgets: RegistryWidgetsType = {
-  'discovery:tagBrowser': AdapterTagSelect,
+  // @ts-ignore [24369] Turn discovery browser off (and replace by regular text input)
+  'discovery:tagBrowser': 'text',
 }


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/24369/details/

The PR turns the custom data point browser off and replace it with the standard text input. It will affect all adapters with the `DISCOVERY` feature and `discovery:tagBrowser` mapping in the `UiSchema`

### Before
![screenshot-localhost_3000-2024 07 18-10_26_40](https://github.com/user-attachments/assets/f2e3b7b8-6e12-4f94-88c5-11b03c3d6f01)


### After
![screenshot-localhost_3000-2024 07 18-10_28_35](https://github.com/user-attachments/assets/82acc8ff-f906-4bee-b2f1-70de1f63b666)
