### PR TITLE
feat(24592): Add the websocket configuration to the UI

### DIFF
--- a/ext/hivemq-edge-openapi-2024.7.yaml
+++ b/ext/hivemq-edge-openapi-2024.7.yaml
@@ -1,0 +1,5173 @@
+openapi: 3.0.1
+info:
+  contact:
+    url: https://www.hivemq.com
+  description: |
+    # Introduction
+    HiveMQ Edge's REST API provides endpoints for the following use cases:
+    - Authentication
+    - Health Checking
+    - Exploring Configuration
+    ## Errors
+    Conventional HTTP response codes are used to indicate the success or failure of an API request. Codes in the 2xx range generally indicate success. Codes in the 4xx range indicate an error that failed given the information provided (e.g., a required parameter was omitted). Codes in the 5xx range indicate an error on the server side.
+    For all errors a JSON response with additional details is returned in the format [Problem JSON](https://tools.ietf.org/html/rfc7807).
+    ## OpenAPI
+    HiveMQ's REST API provides an OpenAPI 3.0 schema definition that can imported into popular API tooling (e.g. Postman) or can be used to generate client-code for multiple programming languages.
+  title: HiveMQ Edge REST API
+  version: "2024.7"
+  x-logo:
+    url: https://www.hivemq.com/img/svg/hivemq-bee.svg
+tags:
+  - description: Services to obtain and validate security tokens with the HiveMQ Edge
+      API.
+    name: Authentication Endpoint
+  - description: Explore and interact with the Bridges configured on your Gateway.
+    name: Bridges
+  - description: Interact with the system event sub-system.
+    name: Events
+  - description: Services relating to the use of the portal.
+    name: Frontend
+  - description: Services to interact with the gateway configuration.
+    name: Gateway Endpoint
+  - description: Gain insight and system metrics.
+    name: Metrics Endpoint
+  - description: Interact with protocol adapters.
+    name: Protocol Adapters
+  - description: Configure Unified Namespace.
+    name: UNS
+  - description: This resource bundles endpoints for the available Finite State Machines
+      (FSMs) for Behavior Policies for the HiveMQ Data Hub. Currently this is limited
+      to getting the available FSMs.
+    name: Data Hub - FSM
+  - description: This resource bundles endpoints for the available Functions for the
+      HiveMQ Data Hub. Currently this is limited to getting the available Functions.
+    name: Data Hub - Functions
+  - description: |-
+      Policies describe how you want the HiveMQ broker to validate the behavior of MQTT clients.
+      Each policy has four sections:
+      
+      - Matching: Specifies which clients the policy engine validates.
+      - Deserialization: Specifies deserializers for different message payloads.
+      - Behavior: Specifies the behavior that is considered valid for matched clients.
+      - onTransitions: Specifies custom actions that are executed when a client transitions to a different state within the specified behavior model that is valid for that client.
+      These endpoints can be used to create, update, delete, and list behavior policies.
+      
+      For more information on all capabilities the HiveMQ Data Hub offers, see the [HiveMQ documentation](https://docs.hivemq.com/hivemq/latest/data-hub/index.html).
+    name: Data Hub - Behavior Policies
+  - description: |-
+      Data Policies describe how you want the HiveMQ broker to apply schemas to incoming MQTT message payload data and act on the validation results.
+      Each policy has four sections:
+      
+      - Matching: Specifies which packets the policy engine validates.
+      - Validation: Specifies how the packets are validated. For example, based on a JSON Schema.
+      - OnSuccess: Defines which actions are executed when the outcome of a validation is successful.
+      - OnFailure: Defines which actions are executed when the validation fails.
+      
+      These endpoints can be used to create, update, delete, and list data policies.
+      
+      For more information on all capabilities the HiveMQ Data Hub offers, see the [HiveMQ documentation](https://docs.hivemq.com/hivemq/latest/data-hub/index.html).
+    name: Data Hub - Data Policies
+  - description: |-
+      A schema defines the expected structure and format of incoming MQTT message payload data.
+      
+      This endpoint can be used to create, get, and delete schemas.
+      
+      Schemas can be enforced with the use of a policy.
+      
+      Currently, the following schema definitions are supported:
+      
+      - [JSON Schema](https://json-schema.org/)
+      - [Protocol Buffers (Protobuf)](https://protobuf.dev/)
+      
+      For more information on how to define and use a schema in HiveMQ, see [Schemas](https://docs.hivemq.com/hivemq/latest/data-hub/schemas.html).
+    name: Data Hub - Schemas
+  - description: |-
+      A script represents custom logic that can be executed in response to MQTT messages.
+      
+      This endpoint can be used to create, get, and delete scripts.
+      
+      For more information on how to define and use a script in HiveMQ, see [Scripts](https://docs.hivemq.com/hivemq/latest/data-hub/scripts.html).
+    name: Data Hub - Scripts
+  - description: |+
+      These endpoints can be used to retrieve states of clients for the Data Hub.
+
+    name: Data Hub - State
+paths:
+  /:
+    get:
+      operationId: getRoot
+      responses:
+        default:
+          content:
+            '*/*': {}
+          description: default response
+  /api/v1/auth/authenticate:
+    post:
+      description: Authorize the presented user to obtain a secure token for use on
+        the API.
+      operationId: authenticate
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UsernamePasswordCredentials'
+      responses:
+        "200":
+          content:
+            application/json:
+              examples:
+                example-authentication:
+                  description: Example Authentication configuration.
+                  summary: Example authentication
+                  value:
+                    token: eyJraWQiOiIwMDAwMSIsImFsZyI6IlJTMjU2In0.eyJqdGkiOiJpb09YbmdWQW1ncl9rSGxZMlRPNWx3IiwiaWF0IjoxNjg3OTQ2MzkwLCJhdWQiOiJIaXZlTVEtRWRnZS1BcGkiLCJpc3MiOiJIaXZlTVEtRWRnZSIsImV4cCI6MTY4Nzk0ODE5MCwibmJmIjoxNjg3OTQ2MjcwLCJzdWIiOiJhZG1pbiIsInJvbGVzIjpbImFkbWluIl19.F4fCJcLobUJXR8rcER_sXVR2l6LhGc6LrnpDlBfuCmVQI22UjLjh-GBYPJV_VF17at_ChBS0UePN9dF4U0i5SsuLcLbrl6QMyI3kmiDxvZCKPWPJGJfiqljVysbQS5vK2F8eJmVFWr0Bb5rXjTtClLIfDGTLEoETbUOMfmic5EzPdWwLN7i3NbuE3xl9u0RepJwVNf0eZrvwIQjpeLZ8vNx9eIVUeMhXpylrQGlDeikJn_F6K89hc1igl2hzN4aU9oT-WOLeQ82oRq7IhL1Rzi1K9NdKMS_xrpV951basq_419oyGyQ6zcxORyC7vsGLZPGi0sHsSJdQ-j12xhPsMg
+              schema:
+                $ref: '#/components/schemas/ApiBearerToken'
+          description: Username & Password Credentials to Authenticate as.
+        "401":
+          content:
+            application/json:
+              examples:
+                authentication-invalid:
+                  description: Unable to authenticate credentials
+                  summary: The requested credentials could not be authenticated
+                  value:
+                    title: Invalid username and/or password
+              schema:
+                $ref: '#/components/schemas/ApiErrorMessage'
+          description: The requested credentials could not be authenticated.
+      summary: Authorize the presented user to obtain a secure token for use on the
+        API.
+      tags:
+        - Authentication
+        - Authentication Endpoint
+  /api/v1/auth/refresh-token:
+    post:
+      description: Authorize the presented user to obtain a secure token for use on
+        the API.
+      operationId: refresh-token
+      responses:
+        "200":
+          content:
+            application/json:
+              examples:
+                example-authentication:
+                  description: Example Authentication configuration.
+                  summary: Example authentication
+                  value:
+                    token: eyJraWQiOiIwMDAwMSIsImFsZyI6IlJTMjU2In0.eyJqdGkiOiJpb09YbmdWQW1ncl9rSGxZMlRPNWx3IiwiaWF0IjoxNjg3OTQ2MzkwLCJhdWQiOiJIaXZlTVEtRWRnZS1BcGkiLCJpc3MiOiJIaXZlTVEtRWRnZSIsImV4cCI6MTY4Nzk0ODE5MCwibmJmIjoxNjg3OTQ2MjcwLCJzdWIiOiJhZG1pbiIsInJvbGVzIjpbImFkbWluIl19.F4fCJcLobUJXR8rcER_sXVR2l6LhGc6LrnpDlBfuCmVQI22UjLjh-GBYPJV_VF17at_ChBS0UePN9dF4U0i5SsuLcLbrl6QMyI3kmiDxvZCKPWPJGJfiqljVysbQS5vK2F8eJmVFWr0Bb5rXjTtClLIfDGTLEoETbUOMfmic5EzPdWwLN7i3NbuE3xl9u0RepJwVNf0eZrvwIQjpeLZ8vNx9eIVUeMhXpylrQGlDeikJn_F6K89hc1igl2hzN4aU9oT-WOLeQ82oRq7IhL1Rzi1K9NdKMS_xrpV951basq_419oyGyQ6zcxORyC7vsGLZPGi0sHsSJdQ-j12xhPsMg
+              schema:
+                $ref: '#/components/schemas/ApiBearerToken'
+          description: Obtain a new JWT from a previously authentication token.
+        "401":
+          content:
+            application/json:
+              examples:
+                authentication-invalid:
+                  description: Unable to authenticate credentials
+                  summary: The requested credentials could not be authenticated
+                  value:
+                    title: Invalid username and/or password
+              schema:
+                $ref: '#/components/schemas/ApiErrorMessage'
+          description: The requested credentials could not be authenticated.
+      summary: Obtain a fresh JWT for the previously authenticated user.
+      tags:
+        - Authentication
+        - Authentication Endpoint
+  /api/v1/auth/validate-token:
+    post:
+      description: Authorize the presented user to obtain a secure token for use on
+        the API.
+      operationId: validate-token
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ApiBearerToken'
+      responses:
+        "200":
+          description: The token was valid
+        "401":
+          description: The token was invalid
+      summary: Authorize the presented user to obtain a secure token for use on the
+        API.
+      tags:
+        - Authentication
+        - Authentication Endpoint
+  /api/v1/data-hub/behavior-validation/policies:
+    get:
+      description: "Get all policies. \n\n This endpoint returns the content of the\
+        \ policies with the content-type `application/json`. \n\n "
+      operationId: getAllBehaviorPolicies
+      parameters:
+        - description: "Comma-separated list of fields to include in the response. Allowed\
+          \ values are: id, createdAt, lastUpdatedAt, deserialization, matching, behavior,\
+          \ onTransitions"
+          example: "id,createdAt"
+          in: query
+          name: fields
+          schema:
+            type: string
+        - description: Comma-separated list of policy ids used for filtering. Multiple
+            filters can be applied together.
+          example: "policy1,policy2"
+          in: query
+          name: policyIds
+          schema:
+            type: string
+        - description: Comma-separated list of MQTT client identifiers that are used
+            for filtering. Client identifiers are matched by the retrieved policies.
+            Multiple filters can be applied together.
+          example: "client1,client2"
+          in: query
+          name: clientIds
+          schema:
+            type: string
+        - description: Specifies the page size for the returned results. Has to be between
+            10 and 500. Default page size is 50. Limit is ignored if the 'topic' query
+            parameter is set.
+          example: 100
+          in: query
+          name: limit
+          schema:
+            type: integer
+            format: int32
+        - description: The cursor that has been returned by the previous result page.
+            Do not pass this parameter if you want to fetch the first page.
+          in: query
+          name: cursor
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              examples:
+                list-response-a:
+                  description: Example response with multiple policies. No more pages
+                    left
+                  summary: "Multiple results, last page"
+                  value:
+                    items:
+                      - id: P18
+                        createdAt: 2023-07-28T07:27:24.531Z
+                        lastUpdatedAt: 2023-07-28T07:27:24.531Z
+                        matching:
+                          clientIdRegex: .*
+                        behavior:
+                          id: Mqtt.events
+                          arguments: {}
+                        onTransitions:
+                          - fromState: Any.*
+                            toState: Any.*
+                            Event.OnAny:
+                              pipeline:
+                                - id: log1
+                                  functionId: System.log
+                                  arguments:
+                                    level: INFO
+                                    message: transition happened
+                      - id: P19
+                        createdAt: 2023-07-28T07:27:24.532Z
+                        lastUpdatedAt: 2023-07-28T07:27:24.532Z
+                        matching:
+                          clientIdRegex: .*
+                        behavior:
+                          id: Mqtt.events
+                          arguments: {}
+                        onTransitions:
+                          - fromState: Any.*
+                            toState: Any.*
+                            Event.OnAny:
+                              pipeline:
+                                - id: log1
+                                  functionId: System.log
+                                  arguments:
+                                    level: INFO
+                                    message: transition happened
+                list-response-b:
+                  description: Example response with multiple policies. More pages
+                    left
+                  summary: "Multiple results, more pages left"
+                  value:
+                    items:
+                      - id: P0
+                        createdAt: 2023-07-28T07:44:35.382Z
+                        lastUpdatedAt: 2023-07-28T07:44:35.382Z
+                        matching:
+                          clientIdRegex: .*
+                        behavior:
+                          id: Mqtt.events
+                          arguments: {}
+                        onTransitions:
+                          - fromState: Any.*
+                            toState: Any.*
+                            Event.OnAny:
+                              pipeline:
+                                - id: log1
+                                  functionId: System.log
+                                  arguments:
+                                    level: INFO
+                                    message: transition happened
+                      - id: P1
+                        createdAt: 2023-07-28T07:44:35.405Z
+                        lastUpdatedAt: 2023-07-28T07:44:35.405Z
+                        matching:
+                          clientIdRegex: .*
+                        behavior:
+                          id: Mqtt.events
+                          arguments: {}
+                        onTransitions:
+                          - fromState: Any.*
+                            toState: Any.*
+                            Event.OnAny:
+                              pipeline:
+                                - id: log1
+                                  functionId: System.log
+                                  arguments:
+                                    level: INFO
+                                    message: transition happened
+                    _links:
+                      next: /api/v1/data-hub/behavior-validation/policies?cursor=a-Wva-QBoB5yAX_HJ0WRQ8ng==&limit=2
+                list-response-c:
+                  description: Example response with requested fields and multiple
+                    policies. More pages left
+                  summary: "Multiple results, requested 'id' field"
+                  value:
+                    items:
+                      - id: P0
+                      - id: P1
+                    _links:
+                      next: /api/v1/data-hub/behavior-validation/policies?cursor=a-Wva-QBoB5yAX_HZxWBM9mQ==&limit=2&fields=id
+                list-response-d:
+                  description: Example response with a single policy
+                  summary: Single Result
+                  value:
+                    items:
+                      - id: policy1
+                        createdAt: 2023-07-28T07:34:14.150Z
+                        lastUpdatedAt: 2023-07-28T07:34:14.150Z
+                        matching:
+                          clientIdRegex: .*
+                        behavior:
+                          id: Mqtt.events
+                          arguments: {}
+                        onTransitions:
+                          - fromState: Any.*
+                            toState: Any.*
+                            Event.OnAny:
+                              pipeline:
+                                - id: log1
+                                  functionId: System.log
+                                  arguments:
+                                    level: INFO
+                                    message: transition happened
+              schema:
+                $ref: '#/components/schemas/BehaviorPolicyList'
+          description: Success
+        "503":
+          content:
+            application/json:
+              examples:
+                version-check-failed:
+                  description: Version check failed
+                  summary: Version check failed
+                  value:
+                    errors:
+                      - title: Endpoint not active yet
+                        detail: "Not all cluster nodes support this endpoint yet, please\
+                        \ try again later"
+              schema:
+                $ref: '#/components/schemas/Errors'
+          description: Not all cluster nodes at minimum version
+      summary: Get all policies
+      tags:
+        - Data Hub - Behavior Policies
+    post:
+      description: |+
+        Create a behavior policy
+
+      operationId: createBehaviorPolicy
+      requestBody:
+        content:
+          application/json:
+            example:
+              id: wildcardLogBehaviorPolicy
+              createdAt: 2023-08-23T10:14:38.447Z
+              matching:
+                clientIdRegex: .*
+              deserialization:
+                publish:
+                  schema:
+                    schemaId: schema
+                    version: latest
+                will:
+                  schema:
+                    schemaId: schema
+                    version: latest
+              behavior:
+                id: Mqtt.events
+                arguments: {}
+              onTransitions:
+                - fromState: Any.*
+                  toState: Any.*
+                  Event.OnAny:
+                    pipeline:
+                      - id: log1
+                        functionId: System.log
+                        arguments:
+                          level: INFO
+                          message: transition happened
+            schema:
+              $ref: '#/components/schemas/BehaviorPolicy'
+        description: The policy that should be created.
+        required: true
+      responses:
+        "201":
+          content:
+            application/json:
+              examples:
+                response-example:
+                  description: Example response.
+                  summary: Policy was created successfully
+                  value:
+                    id: wildcardLogBehaviorPolicy
+                    createdAt: 2023-08-23T10:14:38.447Z
+                    lastUpdatedAt: 2023-08-23T10:14:38.447Z
+                    matching:
+                      clientIdRegex: .*
+                    deserialization:
+                      publish:
+                        schema:
+                          schemaId: schema
+                          version: latest
+                      will:
+                        schema:
+                          schemaId: schema
+                          version: latest
+                        arguments: {}
+                    behavior:
+                      id: Mqtt.events
+                      arguments: {}
+                    onTransitions:
+                      - fromState: Any.*
+                        toState: Any.*
+                        Event.OnAny:
+                          pipeline:
+                            - id: log1
+                              functionId: System.log
+                              arguments:
+                                level: INFO
+                                message: transition happened
+              schema:
+                $ref: '#/components/schemas/BehaviorPolicy'
+          description: Success
+        "400":
+          content:
+            application/json:
+              examples:
+                param-missing:
+                  description: Example response when a required parameter is missing.
+                  summary: Required URL parameter missing
+                  value:
+                    errors:
+                      - title: Required parameter missing
+                        detail: Required URL parameter 'parameterName' is missing
+                policy-id-already-in-use:
+                  description: Example response when the policy uses an already existing
+                    id.
+                  summary: The given policy ID is already in use
+                  value:
+                    errors:
+                      - title: Policy id already used
+                        detail: The given policy id 'policy-id' is already in use.
+                policy-not-parsable:
+                  description: Example response when the submitted policy could not
+                    be parsed as JSON.
+                  summary: The submitted policy cannot be parsed.
+                  value:
+                    errors:
+                      - title: Policy not parsable
+                        detail: The submitted policy 'policy' can not be parsed.
+                policy-not-valid:
+                  description: "Example response when the policy is invalid, because\
+                    \ a field is missing."
+                  summary: The submitted policy is not valid
+                  value:
+                    errors:
+                      - title: Policy is not valid
+                        detail: Required body entity parameter is missing
+              schema:
+                $ref: '#/components/schemas/Errors'
+          description: Bad request
+        "503":
+          content:
+            application/json:
+              examples:
+                referenced-incompatible-policy-functions:
+                  description: Example response when not all cluster nodes support
+                    the referenced script functions yet.
+                  summary: At least one referenced script function is not yet supported
+                    by all cluster nodes
+                  value:
+                    errors:
+                      - title: Incompatible policy
+                        detail: "The policy with id 'policy' could not be added because\
+                        \ its functions [fn:my-transform.js:1, fn:my-transform.js:2]\
+                        \ require at least HiveMQ version 4.23.0, but not all cluster\
+                        \ nodes have been updated to this version yet. Please try\
+                        \ again later."
+                temporarily-not-available:
+                  description: The endpoint is temporarily not available
+                  summary: Temporarily not available
+                  value:
+                    errors:
+                      - title: The endpoint is temporarily not available
+                        detail: "The endpoint is temporarily not available, please try\
+                        \ again later"
+                version-check-failed:
+                  description: Version check failed
+                  summary: Version check failed
+                  value:
+                    errors:
+                      - title: Endpoint not active yet
+                        detail: "Not all cluster nodes support this endpoint yet, please\
+                        \ try again later"
+              schema:
+                $ref: '#/components/schemas/Errors'
+          description: Temporarily not available
+      summary: Create a new policy
+      tags:
+        - Data Hub - Behavior Policies
+  /api/v1/data-hub/behavior-validation/policies/{policyId}:
+    delete:
+      description: "Deletes an existing policy. \n\n "
+      operationId: deleteBehaviorPolicy
+      parameters:
+        - description: The identifier of the policy to delete.
+          example: policy1
+          in: path
+          name: policyId
+          required: true
+          schema:
+            type: string
+      responses:
+        "204":
+          description: "Success, no response body"
+        "400":
+          content:
+            application/json:
+              examples:
+                param-missing:
+                  description: Bad request
+                  summary: Required URL parameter missing
+                  value:
+                    errors:
+                      - title: Required parameter missing
+                        detail: Required URL parameter 'parameterName' is missing
+              schema:
+                $ref: '#/components/schemas/Errors'
+          description: Bad request
+        "404":
+          content:
+            application/json:
+              examples:
+                not-found:
+                  description: Policy not found
+                  summary: Not found
+                  value:
+                    errors:
+                      - title: Resource not found
+                        detail: Resource with id 'my-resource-id' not found
+              schema:
+                $ref: '#/components/schemas/Errors'
+          description: Resource not found
+        "503":
+          content:
+            application/json:
+              examples:
+                version-check-failed:
+                  description: Version check failed
+                  summary: Version check failed
+                  value:
+                    errors:
+                      - title: Endpoint not active yet
+                        detail: "Not all cluster nodes support this endpoint yet, please\
+                        \ try again later"
+              schema:
+                $ref: '#/components/schemas/Errors'
+          description: Not all cluster nodes at minimum version
+      summary: Delete a behavior policy
+      tags:
+        - Data Hub - Behavior Policies
+    get:
+      description: "Get a specific policy. \n\n This endpoint returns the content\
+        \ of the policy with the content-type `application/json`. \n\n "
+      operationId: getBehaviorPolicy
+      parameters:
+        - description: The identifier of the policy.
+          example: policy1
+          in: path
+          name: policyId
+          required: true
+          schema:
+            type: string
+        - description: "Comma-separated list of fields to include in the response. Allowed\
+          \ values are: id, createdAt, lastUpdatedAt, deserialization, matching, behavior,\
+          \ onTransitions"
+          example: "id,createdAt"
+          in: query
+          name: fields
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              examples:
+                get-response:
+                  description: Get Policy
+                  summary: Get  Policy
+                  value:
+                    id: wildcardLogBehaviorPolicy
+                    createdAt: 2023-08-23T10:14:38.447Z
+                    lastUpdatedAt: 2023-08-23T10:14:38.447Z
+                    matching:
+                      clientIdRegex: .*
+                    deserialization:
+                      publish:
+                        schema:
+                          schemaId: schema
+                          version: latest
+                      will:
+                        schema:
+                          schemaId: schema
+                          version: latest
+                        arguments: {}
+                    behavior:
+                      id: Mqtt.events
+                      arguments: {}
+                    onTransitions:
+                      - fromState: Any.*
+                        toState: Any.*
+                        Event.OnAny:
+                          pipeline:
+                            - id: log1
+                              functionId: System.log
+                              arguments:
+                                level: INFO
+                                message: transition happened
+              schema:
+                $ref: '#/components/schemas/BehaviorPolicy'
+          description: Success
+        "400":
+          content:
+            application/json:
+              examples:
+                param-missing:
+                  description: Bad request
+                  summary: Required URL parameter missing
+                  value:
+                    errors:
+                      - title: Required parameter missing
+                        detail: Required URL parameter 'parameterName' is missing
+              schema:
+                $ref: '#/components/schemas/Errors'
+          description: Bad request
+        "404":
+          content:
+            application/json:
+              examples:
+                not-found:
+                  description: Resource not found
+                  summary: Not found
+                  value:
+                    errors:
+                      - title: Resource not found
+                        detail: Resource with id 'my-resource-id' not found
+              schema:
+                $ref: '#/components/schemas/Errors'
+          description: Resource not found
+      summary: Get a  policy
+      tags:
+        - Data Hub - Behavior Policies
+    put:
+      description: "Update a behavior policy\n\nThe path parameter 'policyId' must\
+        \ match the 'id' of the policy in the request body.\n "
+      operationId: updateBehaviorPolicy
+      parameters:
+        - description: The identifier of the policy.
+          example: policy1
+          in: path
+          name: policyId
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            example:
+              id: wildcardLogBehaviorPolicy
+              createdAt: 2023-08-23T10:14:38.447Z
+              matching:
+                clientIdRegex: .*
+              deserialization:
+                publish:
+                  schema:
+                    schemaId: schema
+                    version: latest
+                will:
+                  schema:
+                    schemaId: schema
+                    version: latest
+              behavior:
+                id: Mqtt.events
+                arguments: {}
+              onTransitions:
+                - fromState: Any.*
+                  toState: Any.*
+                  Event.OnAny:
+                    pipeline:
+                      - id: log1
+                        functionId: System.log
+                        arguments:
+                          level: INFO
+                          message: transition happened
+            schema:
+              $ref: '#/components/schemas/BehaviorPolicy'
+        description: The policy that should be updated.
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              examples:
+                response-example:
+                  description: Example response.
+                  summary: Policy was updated successfully
+                  value:
+                    id: wildcardLogBehaviorPolicy
+                    createdAt: 2023-08-23T10:14:38.447Z
+                    lastUpdatedAt: 2023-09-26T11:17:22.311Z
+                    matching:
+                      clientIdRegex: .*
+                    deserialization:
+                      publish:
+                        schema:
+                          schemaId: schema
+                          version: latest
+                      will:
+                        schema:
+                          schemaId: schema
+                          version: latest
+                        arguments: {}
+                    behavior:
+                      id: Mqtt.events
+                      arguments: {}
+                    onTransitions:
+                      - fromState: Any.*
+                        toState: Any.*
+                        Event.OnAny:
+                          pipeline:
+                            - id: log1
+                              functionId: System.log
+                              arguments:
+                                level: INFO
+                                message: transition happened
+              schema:
+                $ref: '#/components/schemas/BehaviorPolicy'
+          description: Success
+        "400":
+          content:
+            application/json:
+              examples:
+                param-missing:
+                  description: Example response when a required parameter is missing.
+                  summary: Required URL parameter missing
+                  value:
+                    errors:
+                      - title: Required parameter missing
+                        detail: Required URL parameter 'parameterName' is missing
+                policy-not-parsable:
+                  description: The submitted policy cannot be parsed.
+                  summary: The submitted policy can not be parsed
+                  value:
+                    errors:
+                      - title: Policy not parsable
+                        detail: The submitted policy 'policy' can not be parsed.
+                policy-not-valid:
+                  description: "Example response when the policy is invalid, because\
+                    \ a field is missing."
+                  summary: The submitted policy is not valid
+                  value:
+                    errors:
+                      - title: Policy is not valid
+                        detail: Required body entity parameter is missing
+              schema:
+                $ref: '#/components/schemas/Errors'
+          description: Bad request
+        "404":
+          content:
+            application/json:
+              examples:
+                not-found:
+                  description: Policy not found
+                  summary: Not found
+                  value:
+                    errors:
+                      - title: Referenced policy not found
+                        detail: The referenced policy with id 'policyId' was not found.
+              schema:
+                $ref: '#/components/schemas/Errors'
+          description: Policy not found
+        "412":
+          content:
+            application/json:
+              examples:
+                etag-not-matching:
+                  description: Precondition failed
+                  summary: Etag not matching
+                  value:
+                    errors:
+                      - title: Precondition Failed
+                        detail: Policy does not match the given etag '123456789'.
+              schema:
+                $ref: '#/components/schemas/Errors'
+          description: Precondition failed
+        "503":
+          content:
+            application/json:
+              examples:
+                referenced-incompatible-policy-functions:
+                  description: Example response when not all cluster nodes support
+                    the referenced script functions yet.
+                  summary: At least one referenced script function is not yet supported
+                    by all cluster nodes
+                  value:
+                    errors:
+                      - title: Incompatible policy
+                        detail: "The policy with id 'policy' could not be added because\
+                        \ its functions [fn:my-transform.js:1, fn:my-transform.js:2]\
+                        \ require at least HiveMQ version 4.23.0, but not all cluster\
+                        \ nodes have been updated to this version yet. Please try\
+                        \ again later."
+                version-check-failed:
+                  description: Version check failed
+                  summary: Version check failed
+                  value:
+                    errors:
+                      - title: Endpoint not active yet
+                        detail: "Not all cluster nodes support this endpoint yet, please\
+                        \ try again later"
+              schema:
+                $ref: '#/components/schemas/Errors'
+          description: Not all cluster nodes at minimum version
+      summary: Update an existing policy
+      tags:
+        - Data Hub - Behavior Policies
+  /api/v1/data-hub/behavior-validation/states/{clientId}:
+    get:
+      description: |+
+        Use this endpoint to get the stored state of a client for DataHub.
+
+      operationId: getClientState
+      parameters:
+        - description: The client identifier.
+          example: client1
+          in: path
+          name: clientId
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              examples:
+                get-response:
+                  description: Get client State
+                  summary: Get the state of a client
+                  value:
+                    items:
+                      - policyId: reallyCoolBehaviorPolicy
+                        behaviorId: Publish.quota
+                        stateType: INTERMEDIATE
+                        stateName: Connected
+                        firstSetAt: 2023-09-05T09:46:47.854Z
+                        arguments:
+                          minPublishes: 5
+                          maxPublishes: 10
+                        variables:
+                          minPublishes: "5"
+                          publishCount: "0"
+                          maxPublishes: "10"
+              schema:
+                $ref: '#/components/schemas/FsmStatesInformationListItem'
+          description: Success
+        "400":
+          content:
+            application/json:
+              examples:
+                param-missing:
+                  description: Bad request
+                  summary: Required URL parameter missing
+                  value:
+                    errors:
+                      - title: Required parameter missing
+                        detail: Required URL parameter 'parameterName' is missing
+              schema:
+                $ref: '#/components/schemas/Errors'
+          description: Bad request
+        "404":
+          content:
+            application/json:
+              examples:
+                client-disconnected:
+                  description: Example response when client is disconnected
+                  summary: "Target client is not connected at the moment, but a session\
+                    \ is present."
+                  value: |-
+                    {
+                      "errors": [
+                        {
+                          "title": "Client disconnected
+                          "detail": "The client 'client' is disconnected."
+                        }
+                      ]
+                    }
+                client-not-found:
+                  description: Example response when client identifier is unknown
+                    to the broker
+                  summary: "Target client is not known to the broker, because there\
+                    \ is no session present."
+                  value: |-
+                    {
+                      "errors": [
+                        {
+                          "title": "Client not found
+                          "detail": "The client '<clientId>' was not found."
+                        }
+                      ]
+                    }
+                not-found:
+                  description: Resource not found
+                  summary: Not found
+                  value:
+                    errors:
+                      - title: Resource not found
+                        detail: Resource with id 'my-resource-id' not found
+              schema:
+                $ref: '#/components/schemas/Errors'
+          description: Resource not found
+        "503":
+          content:
+            application/json:
+              examples:
+                temporarily-not-available:
+                  description: The endpoint is temporarily not available
+                  summary: Temporarily not available
+                  value:
+                    errors:
+                      - title: The endpoint is temporarily not available
+                        detail: "The endpoint is temporarily not available, please try\
+                        \ again later"
+              schema:
+                $ref: '#/components/schemas/Errors'
+          description: Temporarily not available
+      summary: Get the state of a client
+      tags:
+        - Data Hub - State
+  /api/v1/data-hub/data-validation/policies:
+    get:
+      description: "Get all data policies. \n\n This endpoint returns the content\
+        \ of the policies with the content-type `application/json`. \n\n "
+      operationId: getAllDataPolicies
+      parameters:
+        - description: "Comma-separated list of fields to include in the response. Allowed\
+          \ values are: id, createdAt, lastUpdatedAt, matching, validation, onSuccess,\
+          \ onFailure"
+          example: "id,createdAt"
+          in: query
+          name: fields
+          schema:
+            type: string
+        - description: Comma-separated list of policy IDs used for filtering. Multiple
+            filters can be applied together.
+          example: "policy1,policy2"
+          in: query
+          name: policyIds
+          schema:
+            type: string
+        - description: Comma-separated list of schema IDs used for filtering. Multiple
+            filters can be applied together.
+          example: "schema1,schema2"
+          in: query
+          name: schemaIds
+          schema:
+            type: string
+        - description: MQTT topic string that the retrieved policies must match. Returned
+            policies are sorted in the same way as they are applied to matching publishes.
+            'topic' filtering does not support pagination
+          example: topic/my-topic
+          in: query
+          name: topic
+          schema:
+            type: string
+        - description: Specifies the page size for the returned results. The value must
+            be between 10 and 500. The default page size is 50. The limit is ignored
+            if the 'topic' query parameter is set.
+          example: 100
+          in: query
+          name: limit
+          schema:
+            type: integer
+            format: int32
+        - description: The cursor that has been returned by the previous result page.
+            Do not pass this parameter if you want to fetch the first page.
+          in: query
+          name: cursor
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              examples:
+                list-response-a:
+                  description: Example response with multiple policies. No more pages
+                    left
+                  summary: "Multiple results, last page"
+                  value:
+                    items:
+                      - id: policy1
+                        createdAt: 2023-04-26T13:32:47.032Z
+                        lastUpdatedAt: 2023-04-26T13:32:47.032Z
+                        matching:
+                          topicFilter: topic1
+                        validation:
+                          validators:
+                            - type: schema
+                              arguments:
+                                strategy: ALL_OF
+                                schemas:
+                                  - schemaId: schema
+                                    version: "1"
+                        onSuccess:
+                          pipeline:
+                            - id: logSuccessOperation
+                              functionId: System.log
+                              arguments:
+                                level: DEBUG
+                                message: "${clientId} sent a publish on topic '${topic}'\
+                              \ with result '${validationResult}'"
+                        onFailure:
+                          pipeline:
+                            - id: logFailureOperation
+                              functionId: System.log
+                              arguments:
+                                level: WARN
+                                message: "${clientId} sent an invalid publish on topic\
+                              \ '${topic}' with result '${validationResult}'"
+                      - id: policy2
+                        createdAt: 2023-04-26T13:32:47.049Z
+                        lastUpdatedAt: 2023-04-26T13:32:47.049Z
+                        matching:
+                          topicFilter: topic2
+                        validation:
+                          validators:
+                            - type: schema
+                              arguments:
+                                strategy: ALL_OF
+                                schemas:
+                                  - schemaId: schema
+                                    version: "1"
+                        onSuccess:
+                          pipeline:
+                            - id: logSuccessOperation
+                              functionId: System.log
+                              arguments:
+                                level: DEBUG
+                                message: "${clientId} sent a publish on topic '${topic}'\
+                              \ with result '${validationResult}'"
+                        onFailure:
+                          pipeline:
+                            - id: logSuccessOperation
+                              functionId: System.log
+                              arguments:
+                                level: WARN
+                                message: "${clientId} sent an invalid publish on topic\
+                              \ '${topic}' with result '${validationResult}'"
+                list-response-b:
+                  description: Example response with multiple policies. More pages
+                    left
+                  summary: "Multiple results, more pages left"
+                  value:
+                    items:
+                      - id: policy1
+                        createdAt: 2023-04-26T13:32:47.032Z
+                        lastUpdatedAt: 2023-04-26T13:32:47.032Z
+                        matching:
+                          topicFilter: topic1
+                        validation:
+                          validators:
+                            - type: schema
+                              arguments:
+                                strategy: ALL_OF
+                                schemas:
+                                  - schemaId: schema
+                                    version: "1"
+                        onSuccess:
+                          pipeline:
+                            - id: logSuccessOperation
+                              functionId: System.log
+                              arguments:
+                                level: DEBUG
+                                message: $clientId sent a publish on topic '$topic' with
+                                  result '$validationResult'
+                        onFailure:
+                          pipeline:
+                            - id: logFailureOperation
+                              functionId: System.log
+                              arguments:
+                                level: WARN
+                                message: $clientId sent an invalid publish on topic '$topic'
+                                  with result '$validationResult'
+                      - id: policy2
+                        createdAt: 2023-04-26T13:32:47.049Z
+                        lastUpdatedAt: 2023-04-26T13:32:47.049Z
+                        matching:
+                          topicFilter: topic2
+                        validation:
+                          validators:
+                            - type: schema
+                              arguments:
+                                strategy: ALL_OF
+                                schemas:
+                                  - schemaId: schema
+                                    version: "1"
+                        onSuccess:
+                          pipeline:
+                            - id: logSuccessOperation
+                              functionId: System.log
+                              arguments:
+                                level: DEBUG
+                                message: $clientId sent a publish on topic '$topic' with
+                                  result '$validationResult'
+                        onFailure:
+                          pipeline:
+                            - id: logSuccessOperation
+                              functionId: System.log
+                              arguments:
+                                level: WARN
+                                message: $clientId sent an invalid publish on topic '$topic'
+                                  with result '$validationResult'
+                      - id: policy3
+                        createdAt: 2023-04-26T13:32:47.049Z
+                        lastUpdatedAt: 2023-04-26T13:32:47.049Z
+                        matching:
+                          topicFilter: topic3
+                        validation:
+                          validators:
+                            - type: schema
+                              arguments:
+                                strategy: ALL_OF
+                                schemas:
+                                  - schemaId: schema
+                                    version: "1"
+                        onSuccess:
+                          pipeline:
+                            - id: logSuccessOperation
+                              functionId: System.log
+                              arguments:
+                                level: DEBUG
+                                message: $clientId sent a publish on topic '$topic' with
+                                  result '$validationResult'
+                        onFailure:
+                          pipeline:
+                            - id: logSuccessOperation
+                              functionId: System.log
+                              arguments:
+                                level: WARN
+                                message: $clientId sent an invalid publish on topic '$topic'
+                                  with result '$validationResult'
+                    _links:
+                      next: /api/v1/data-validation/policies?cursor=a-eqj-GE9B5DkV-nhwVBk-nTL807ty&limit=3
+                list-response-c:
+                  description: Example response with requested fields and multiple
+                    policies. More pages left
+                  summary: "Multiple results, requested 'id' field"
+                  value:
+                    items:
+                      - id: policy1
+                      - id: policy2
+                      - id: policy3
+                    _links:
+                      next: /api/v1/data-validation/policies?cursor=a-eqj-GE9B5DkV-nhwVBk-nTL807ty&limit=3&fields=id
+                list-response-d:
+                  description: Example response with a single policy
+                  summary: Single Result
+                  value:
+                    items:
+                      - id: policy1
+                        createdAt: 2023-04-26T13:32:47.032Z
+                        lastUpdatedAt: 2023-04-26T13:32:47.032Z
+                        matching:
+                          topicFilter: topic1
+                        validation:
+                          validators:
+                            - type: schema
+                              arguments:
+                                strategy: ALL_OF
+                                schemas:
+                                  - schemaId: schema
+                                    version: "1"
+                        onSuccess:
+                          pipeline:
+                            - id: logSuccessOperation
+                              functionId: System.log
+                              arguments:
+                                level: DEBUG
+                                message: $clientId sent a publish on topic '$topic' with
+                                  result '$validationResult'
+                        onFailure:
+                          pipeline:
+                            - id: logFailureOperation
+                              functionId: System.log
+                              arguments:
+                                level: WARN
+                                message: $clientId sent an invalid publish on topic '$topic'
+                                  with result '$validationResult'
+              schema:
+                $ref: '#/components/schemas/DataPolicyList'
+          description: Success
+        "503":
+          content:
+            application/json:
+              examples:
+                version-check-failed:
+                  description: Version check failed
+                  summary: Version check failed
+                  value:
+                    errors:
+                      - title: Endpoint not active yet
+                        detail: "Not all cluster nodes support this endpoint yet, please\
+                        \ try again later"
+              schema:
+                $ref: '#/components/schemas/Errors'
+          description: Not all cluster nodes at minimum version
+      summary: Get all data policies
+      tags:
+        - Data Hub - Data Policies
+    post:
+      description: |+
+        Create a data policy
+
+      operationId: createDataPolicy
+      requestBody:
+        content:
+          application/json:
+            example:
+              id: policy1
+              matching:
+                topicFilter: topic/+
+              validation:
+                validators:
+                  - type: schema
+                    arguments:
+                      strategy: ALL_OF
+                      schemas:
+                        - schemaId: schema
+                          version: "1"
+              onSuccess:
+                pipeline:
+                  - id: logOperationSuccess
+                    functionId: System.log
+                    arguments:
+                      level: DEBUG
+                      message: "${clientId} sent a publish on topic '${topic}' with\
+                      \ result '${validationResult}'"
+              onFailure:
+                pipeline:
+                  - id: logOperationFailure
+                    functionId: System.log
+                    arguments:
+                      level: WARN
+                      message: "${clientId} sent an invalid publish on topic '${topic}'\
+                      \ with result '${validationResult}'"
+            schema:
+              $ref: '#/components/schemas/DataPolicy'
+        description: The data policy to create.
+        required: true
+      responses:
+        "201":
+          content:
+            application/json:
+              examples:
+                response-example:
+                  description: Example response.
+                  summary: Policy was created successfully
+                  value:
+                    id: policy1
+                    createdAt: 2023-04-19T13:35:00.930Z
+                    lastUpdatedAt: 2023-04-19T13:35:00.930Z
+                    matching:
+                      topicFilter: topic/+
+                    validation:
+                      validators:
+                        - type: schema
+                          arguments:
+                            strategy: ALL_OF
+                            schemas:
+                              - schemaId: schema1
+                                version: "1"
+                    onSuccess:
+                      pipeline:
+                        - id: logOperationSuccess
+                          functionId: System.log
+                          arguments:
+                            level: DEBUG
+                            message: "${clientId} sent a publish on topic '${topic}'\
+                            \ with result '${validationResult}'"
+                    onFailure:
+                      pipeline:
+                        - id: logOperationFailure
+                          functionId: System.log
+                          arguments:
+                            level: WARN
+                            message: "${clientId} sent an invalid publish on topic '${topic}'\
+                            \ with result '${validationResult}'"
+              schema:
+                $ref: '#/components/schemas/DataPolicy'
+          description: Success
+        "400":
+          content:
+            application/json:
+              examples:
+                param-missing:
+                  description: Example response when a required parameter is missing.
+                  summary: Required URL parameter missing
+                  value:
+                    errors:
+                      - title: Required parameter missing
+                        detail: Required URL parameter 'parameterName' is missing
+                policy-id-already-in-use:
+                  description: Example response when the policy uses an already existing
+                    id.
+                  summary: The given policy identifier is already in use
+                  value:
+                    errors:
+                      - title: Policy id already used
+                        detail: The given policy id 'policy-id' is already in use.
+                policy-not-parsable:
+                  description: Example response when the submitted policy could not
+                    be parsed as JSON.
+                  summary: The submitted policy can not be parsed
+                  value:
+                    errors:
+                      - title: Policy not parsable
+                        detail: The submitted policy 'policy' can not be parsed.
+                policy-not-valid:
+                  description: "Example response when the policy is invalid, because\
+                    \ a field is missing."
+                  summary: The submitted policy is not valid
+                  value:
+                    errors:
+                      - title: Policy is not valid
+                        detail: Required body entity parameter is missing
+                referenced-schema-does-not-exist:
+                  description: Example response when a referenced schema was not found.
+                  summary: A schema that is referenced in the policy does not exist
+                  value:
+                    errors:
+                      - title: Referenced schema does not exist
+                        detail: The referenced schema with id 'schema-id' does not exist.
+              schema:
+                $ref: '#/components/schemas/Errors'
+          description: Bad request
+        "503":
+          content:
+            application/json:
+              examples:
+                referenced-incompatible-policy-functions:
+                  description: Example response when not all cluster nodes support
+                    the referenced script functions yet.
+                  summary: At least one referenced script function is not yet supported
+                    by all cluster nodes
+                  value:
+                    errors:
+                      - title: Incompatible policy
+                        detail: "The policy with id 'policy' could not be added because\
+                        \ its functions [fn:my-transform.js:1, fn:my-transform.js:2]\
+                        \ require at least HiveMQ version 4.23.0, but not all cluster\
+                        \ nodes have been updated to this version yet. Please try\
+                        \ again later."
+                temporarily-not-available:
+                  description: The endpoint is temporarily not available
+                  summary: Temporarily not available
+                  value:
+                    errors:
+                      - title: The endpoint is temporarily not available
+                        detail: "The endpoint is temporarily not available, please try\
+                        \ again later"
+                version-check-failed:
+                  description: Version check failed
+                  summary: Version check failed
+                  value:
+                    errors:
+                      - title: Endpoint not active yet
+                        detail: "Not all cluster nodes support this endpoint yet, please\
+                        \ try again later"
+              schema:
+                $ref: '#/components/schemas/Errors'
+          description: Not all cluster nodes at minimum version
+      summary: Create a new data policy
+      tags:
+        - Data Hub - Data Policies
+  /api/v1/data-hub/data-validation/policies/{policyId}:
+    delete:
+      description: "Deletes an existing data policy. \n\n "
+      operationId: deleteDataPolicy
+      parameters:
+        - description: The identifier of the data policy to delete.
+          example: policy1
+          in: path
+          name: policyId
+          required: true
+          schema:
+            type: string
+      responses:
+        "204":
+          description: "Success, no response body"
+        "400":
+          content:
+            application/json:
+              examples:
+                param-missing:
+                  description: Bad request
+                  summary: Required URL parameter missing
+                  value:
+                    errors:
+                      - title: Required parameter missing
+                        detail: Required URL parameter 'parameterName' is missing
+              schema:
+                $ref: '#/components/schemas/Errors'
+          description: Bad request
+        "404":
+          content:
+            application/json:
+              examples:
+                not-found:
+                  description: Resource not found
+                  summary: Not found
+                  value:
+                    errors:
+                      - title: Resource not found
+                        detail: Resource with id 'my-resource-id' not found
+              schema:
+                $ref: '#/components/schemas/Errors'
+          description: Resource not found
+        "503":
+          content:
+            application/json:
+              examples:
+                version-check-failed:
+                  description: Version check failed
+                  summary: Version check failed
+                  value:
+                    errors:
+                      - title: Endpoint not active yet
+                        detail: "Not all cluster nodes support this endpoint yet, please\
+                        \ try again later"
+              schema:
+                $ref: '#/components/schemas/Errors'
+          description: Not all cluster nodes at minimum version
+      summary: Delete a data policy
+      tags:
+        - Data Hub - Data Policies
+    get:
+      description: "Get a specific data policy. \n\n This endpoint returns the content\
+        \ of the policy with the content-type `application/json`. \n\n "
+      operationId: getDataPolicy
+      parameters:
+        - description: The identifier of the policy.
+          example: policy1
+          in: path
+          name: policyId
+          required: true
+          schema:
+            type: string
+        - description: "Comma-separated list of fields to include in the response. Allowed\
+          \ values are: id, createdAt, lastUpdatedAt, matching, validation, onSuccess,\
+          \ onFailure"
+          example: "id,createdAt"
+          in: query
+          name: fields
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              examples:
+                get-response:
+                  description: Get Policy
+                  summary: Get Policy
+                  value:
+                    id: policy1
+                    createdAt: 2023-04-19T13:35:00.930Z
+                    lastUpdatedAt: 2023-04-19T13:35:00.930Z
+                    matching:
+                      topicFilter: topic/+
+                    validation:
+                      validators:
+                        - type: schema
+                          arguments:
+                            strategy: ALL_OF
+                            schemas:
+                              - schemaId: schema1
+                                version: "1"
+                    onSuccess:
+                      pipeline:
+                        - id: logOperationSuccess
+                          functionId: System.log
+                          arguments:
+                            level: DEBUG
+                            message: "${clientId} sent a publish on topic '${topic}'\
+                            \ with result '${validationResult}'"
+                    onFailure:
+                      pipeline:
+                        - id: logOperationFailure
+                          functionId: System.log
+                          arguments:
+                            level: WARN
+                            message: "${clientId} sent an invalid publish on topic '${topic}'\
+                            \ with result '${validationResult}'"
+              schema:
+                $ref: '#/components/schemas/DataPolicy'
+          description: Success
+        "400":
+          content:
+            application/json:
+              examples:
+                param-missing:
+                  description: Example response when a required parameter is missing.
+                  summary: Required URL parameter missing
+                  value:
+                    errors:
+                      - title: Required parameter missing
+                        detail: Required URL parameter 'parameterName' is missing
+              schema:
+                $ref: '#/components/schemas/Errors'
+          description: Bad request
+        "404":
+          content:
+            application/json:
+              examples:
+                not-found:
+                  description: Policy not found
+                  summary: Not found
+                  value:
+                    errors:
+                      - title: Resource not found
+                        detail: Resource with id 'my-resource-id' not found
+              schema:
+                $ref: '#/components/schemas/Errors'
+          description: Resource not found
+      summary: Get a data policy
+      tags:
+        - Data Hub - Data Policies
+    put:
+      description: "Update a data policy\n\nThe path parameter 'policyId' must match\
+        \ the 'id' of the policy in the request body.\n The matching part of policies\
+        \ cannot be changed with an update.\n "
+      operationId: updateDataPolicy
+      parameters:
+        - description: The identifier of the policy.
+          example: policy1
+          in: path
+          name: policyId
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            example:
+              id: policy1
+              matching:
+                topicFilter: topic/+
+              validation:
+                validators:
+                  - type: schema
+                    arguments:
+                      strategy: ALL_OF
+                      schemas:
+                        - schemaId: schema
+                          version: "1"
+              onSuccess:
+                pipeline:
+                  - id: logOperationSuccess
+                    functionId: System.log
+                    arguments:
+                      level: DEBUG
+                      message: "${clientId} sent a publish on topic '${topic}' with\
+                      \ result '${validationResult}'"
+              onFailure:
+                pipeline:
+                  - id: logOperationFailure
+                    functionId: System.log
+                    arguments:
+                      level: WARN
+                      message: "${clientId} sent an invalid publish on topic '${topic}'\
+                      \ with result '${validationResult}'"
+            schema:
+              $ref: '#/components/schemas/DataPolicy'
+        description: The data policy that should be updated.
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              examples:
+                response-example:
+                  description: Example response.
+                  summary: Policy was updated successfully
+                  value:
+                    id: policy1
+                    createdAt: 2023-04-19T13:35:00.930Z
+                    lastUpdatedAt: 2023-09-26T11:17:22.311Z
+                    matching:
+                      topicFilter: topic/+
+                    validation:
+                      validators:
+                        - type: schema
+                          arguments:
+                            strategy: ALL_OF
+                            schemas:
+                              - schemaId: schema1
+                                version: "1"
+                    onSuccess:
+                      pipeline:
+                        - id: logOperationSuccess
+                          functionId: System.log
+                          arguments:
+                            level: DEBUG
+                            message: "${clientId} sent a publish on topic '${topic}'\
+                            \ with result '${validationResult}'"
+                    onFailure:
+                      pipeline:
+                        - id: logOperationFailure
+                          functionId: System.log
+                          arguments:
+                            level: WARN
+                            message: "${clientId} sent an invalid publish on topic '${topic}'\
+                            \ with result '${validationResult}'"
+              schema:
+                $ref: '#/components/schemas/DataPolicy'
+          description: Success
+        "400":
+          content:
+            application/json:
+              examples:
+                param-missing:
+                  description: Example response when a required parameter is missing.
+                  summary: Required URL parameter missing
+                  value:
+                    errors:
+                      - title: Required parameter missing
+                        detail: Required URL parameter 'parameterName' is missing
+                policy-not-parsable:
+                  description: Example response when the submitted policy could not
+                    be parsed as JSON.
+                  summary: The submitted policy can not be parsed
+                  value:
+                    errors:
+                      - title: Policy not parsable
+                        detail: The submitted policy 'policy' can not be parsed.
+                policy-not-valid:
+                  description: "Example response when the policy is invalid, because\
+                    \ a field is missing."
+                  summary: The submitted policy is not valid
+                  value:
+                    errors:
+                      - title: Policy is not valid
+                        detail: Required body entity parameter is missing
+                policy-topic-filter-not-matching:
+                  description: Example response when the given topic filter does not
+                    match the present one.
+                  summary: The policy topic filter does not match
+                  value:
+                    errors:
+                      - title: Topic filter does not match
+                        detail: The policy with id 'policyId' has a topic filter 'my/topic/filter'
+                          that does not match the topic filter of the current policy.
+                referenced-schema-does-not-exist:
+                  description: Example response when a referenced schema was not found.
+                  summary: A schema that is referenced in the policy does not exist
+                  value:
+                    errors:
+                      - title: Referenced schema does not exist
+                        detail: The referenced schema with id 'schema-id' does not exist.
+              schema:
+                $ref: '#/components/schemas/Errors'
+          description: Bad request
+        "404":
+          content:
+            application/json:
+              examples:
+                not-found:
+                  description: Policy not found
+                  summary: Not found
+                  value:
+                    errors:
+                      - title: Referenced policy not found
+                        detail: The referenced policy with id 'policyId' was not found.
+              schema:
+                $ref: '#/components/schemas/Errors'
+          description: Policy not found
+        "412":
+          content:
+            application/json:
+              examples:
+                etag-not-matching:
+                  description: Precondition failed
+                  summary: Etag not matching
+                  value:
+                    errors:
+                      - title: Precondition Failed
+                        detail: Policy does not match the given etag '123456789'.
+              schema:
+                $ref: '#/components/schemas/Errors'
+          description: Precondition failed
+        "503":
+          content:
+            application/json:
+              examples:
+                referenced-incompatible-policy-functions:
+                  description: Example response when not all cluster nodes support
+                    the referenced script functions yet.
+                  summary: At least one referenced script function is not yet supported
+                    by all cluster nodes
+                  value:
+                    errors:
+                      - title: Incompatible policy
+                        detail: "The policy with id 'policy' could not be added because\
+                        \ its functions [fn:my-transform.js:1, fn:my-transform.js:2]\
+                        \ require at least HiveMQ version 4.23.0, but not all cluster\
+                        \ nodes have been updated to this version yet. Please try\
+                        \ again later."
+                version-check-failed:
+                  description: Version check failed
+                  summary: Version check failed
+                  value:
+                    errors:
+                      - title: Endpoint not active yet
+                        detail: "Not all cluster nodes support this endpoint yet, please\
+                        \ try again later"
+              schema:
+                $ref: '#/components/schemas/Errors'
+          description: Not all cluster nodes at minimum version
+      summary: Update an existing data policy
+      tags:
+        - Data Hub - Data Policies
+  /api/v1/data-hub/fsm:
+    get:
+      description: This endpoints provides the means to get information on the available
+        Finite State Machines (FSMs) for Behavior Policies for the HiveMQ Data Hub.
+        The information is provided in form of a Json Schema.
+      operationId: getFsms
+      responses:
+        "200":
+          content:
+            application/json:
+              examples:
+                get-response:
+                  description: Get FSMs
+                  summary: Get schema
+                  value:
+                    type: object
+                    required:
+                      - model
+                    properties:
+                      model:
+                        title: Behavior Model
+                        default: Mqtt.events
+                        enum:
+                          - Publish.quota
+                          - Mqtt.events
+                          - Publish.duplicate
+                    allOf:
+                      - if:
+                          type: object
+                          properties:
+                            model:
+                              const: Publish.quota
+                        then:
+                          type: object
+                          properties:
+                            arguments:
+                              title: Publish.quota options
+                              description: "When you configure a publish-quota model,\
+                              \ at least one of the available arguments must be present.\
+                              \ Data Hub uses the default value for the missing parameter.\\\
+                              nThe default value for minimum is 0. The default value\
+                              \ for maxPublishes is UNLIMITED."
+                              type: object
+                              required:
+                                - minPublishes
+                              properties:
+                                minPublishes:
+                                  type: number
+                                  title: minPublishes
+                                  description: Defines the minimal number of published
+                                    messages that must be reached
+                                maxPublishes:
+                                  type: number
+                                  title: maxPublishes
+                                  description: Defines the maximum number of published
+                                    messages that must be reached
+                      - if:
+                          type: object
+                          properties:
+                            model:
+                              const: Mqtt.events
+                        then:
+                          type: object
+                          properties:
+                            arguments:
+                              title: Mqtt.events
+                              description: This FSM does not require any arguments.
+                              type: object
+                              required: []
+                              properties: {}
+                      - if:
+                          type: object
+                          properties:
+                            model:
+                              const: Publish.duplicate
+                        then:
+                          type: object
+                          properties:
+                            arguments:
+                              title: Publish.duplicate options
+                              description: This FSM does not require any arguments.
+                              type: object
+                              required: []
+                              properties: {}
+              schema:
+                $ref: '#/components/schemas/JsonNode'
+          description: Success
+        "404":
+          content:
+            application/json:
+              examples:
+                not-found:
+                  description: Resource not found
+                  summary: Not found
+                  value:
+                    errors:
+                      - title: Resource not found
+                        detail: Resource with id 'my-resource-id' not found
+              schema:
+                $ref: '#/components/schemas/Errors'
+          description: Resource not found
+      summary: Get all FSMs as a JSON Schema
+      tags:
+        - Data Hub - FSM
+  /api/v1/data-hub/functions:
+    get:
+      description: This endpoints provides the means to get information on the available
+        Functions for the HiveMQ Data Hub. The information is provided in form of
+        a Json Schema.
+      operationId: getFunctions
+      responses:
+        "200":
+          content:
+            application/json:
+              examples:
+                get-response:
+                  description: Get Functions
+                  summary: Get Functions
+                  value:
+                    anyOf:
+                      - title: Mqtt.UserProperties.add
+                        description: Adds a user property to the MQTT message.
+                        type: object
+                        required:
+                          - name
+                          - value
+                        metaData:
+                          isTerminal: false
+                          isDataOnly: false
+                          hasArguments: true
+                        properties:
+                          name:
+                            type: string
+                            title: name
+                            description: Specifies the name of the user property. Multiple
+                              user properties with the same name are allowed.
+                          value:
+                            type: string
+                            title: value
+                            description: Specifies the value of the user property.
+                      - title: Delivery.redirectTo
+                        description: Redirects an MQTT PUBLISH message to a specified
+                          topic
+                        type: object
+                        required:
+                          - topic
+                        metaData:
+                          isTerminal: true
+                          isDataOnly: true
+                          hasArguments: true
+                        properties:
+                          topic:
+                            type: string
+                            title: topic
+                            description: The destination MQTT topic according to MQTT
+                              specification
+                          applyPolicies:
+                            type: string
+                            title: applyPolicies
+                            description: Defines whether policies are executed after
+                              publishing to a different topic.
+                      - title: Mqtt.drop
+                        description: Drops the MQTT packet that is currently processed
+                        type: object
+                        required: []
+                        metaData:
+                          isTerminal: false
+                          isDataOnly: false
+                          hasArguments: true
+                        properties:
+                          reasonString:
+                            type: string
+                            title: reasonString
+                            description: Specifies the reason string that is responded
+                              to MQTT5 clients.
+                      - title: System.log
+                        description: Logs a message on the given level
+                        type: object
+                        required:
+                          - level
+                          - message
+                        metaData:
+                          isTerminal: false
+                          isDataOnly: false
+                          hasArguments: true
+                        properties:
+                          level:
+                            type: string
+                            title: Log Level
+                            description: Specifies the log level of the function in
+                              the hivemq.log file
+                          message:
+                            type: string
+                            title: Message
+                            description: "Adds a user-defined string that prints to\
+                            \ the log file. For more information, see Example log\
+                            \ message"
+                      - title: Mqtt.disconnect
+                        description: Disconnects the client
+                        type: object
+                        required: []
+                        metaData:
+                          isTerminal: true
+                          isDataOnly: false
+                          hasArguments: false
+                        properties: {}
+                      - title: Serdes.deserialize
+                        description: Deserializes a binary MQTT message payload into
+                          a data object based on the configured JSON Schema or Protobuf
+                          schema.
+                        type: object
+                        required:
+                          - schemaId
+                          - schemaVersion
+                        metaData:
+                          isTerminal: false
+                          isDataOnly: false
+                          hasArguments: true
+                        properties:
+                          schemaId:
+                            type: string
+                            title: schemaId
+                            description: The identifier of the JSON Schema to be used
+                              for deserialization.
+                          schemaVersion:
+                            type: string
+                            title: schemaVersion
+                            description: The version of the schema to be used for deserialization.
+                      - title: Metrics.Counter.increment
+                        description: "Increments a metric of type counter, which can\
+                        \ be accessed with monitoring"
+                        type: object
+                        required:
+                          - metricName
+                          - incrementBy
+                        metaData:
+                          isTerminal: false
+                          isDataOnly: false
+                          hasArguments: true
+                        properties:
+                          metricName:
+                            type: string
+                            title: metricName
+                            description: Specifies the name of the metric to be incremented.
+                          incrementBy:
+                            type: string
+                            title: incrementBy
+                            description: Specifies the amount by which the counter should
+                              be incremented. Negative values are supported.
+                      - title: Serdes.serialize
+                        description: Serializes a data object into a binary MQTT message
+                          payload based on the configured JSON Schema (PROTOBUF currently
+                          not supported).
+                        type: object
+                        required:
+                          - schemaId
+                          - schemaVersion
+                        metaData:
+                          isTerminal: false
+                          isDataOnly: true
+                          hasArguments: true
+                        properties:
+                          schemaId:
+                            type: string
+                            title: schemaId
+                            description: The identifier of the JSON Schema to be used
+                              for serialization
+                          schemaVersion:
+                            type: string
+                            title: schemaVersion
+                            description: The version of the schema to be used for serialization.
+              schema:
+                $ref: '#/components/schemas/JsonNode'
+          description: Success
+        "404":
+          content:
+            application/json:
+              examples:
+                not-found:
+                  description: Resource not found
+                  summary: Not found
+                  value:
+                    errors:
+                      - title: Resource not found
+                        detail: Resource with id 'my-resource-id' not found
+              schema:
+                $ref: '#/components/schemas/Errors'
+          description: Resource not found
+      summary: Get all functions as a JSON Schema
+      tags:
+        - Data Hub - Functions
+  /api/v1/data-hub/schemas:
+    get:
+      description: "Get all schemas. \n\n This endpoint returns the content of the\
+        \ schemas with the content-type `application/json`. \n\n "
+      operationId: getAllSchemas
+      parameters:
+        - description: "Comma-separated list of fields to include in the response. Allowed\
+          \ values are: id, type, schemaDefinition, createdAt"
+          example: "id,createdAt"
+          in: query
+          name: fields
+          schema:
+            type: string
+        - description: Comma-separated list of schema types used for filtering. Multiple
+            filters can be applied together.
+          example: "JSON,PROTOBUF"
+          in: query
+          name: types
+          schema:
+            type: string
+        - description: Comma-separated list of schema ids used for filtering. Multiple
+            filters can be applied together.
+          example: "schema1,schema2"
+          in: query
+          name: schemaIds
+          schema:
+            type: string
+        - description: Specifies the page size for the returned results. Has to be between
+            10 and 500. Default page size is 50.
+          example: 100
+          in: query
+          name: limit
+          schema:
+            type: integer
+            format: int32
+        - description: The cursor that has been returned by the previous result page.
+            Do not pass this parameter if you want to fetch the first page.
+          in: query
+          name: cursor
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              examples:
+                list-response-a:
+                  description: Example response with multiple schemas. No more pages
+                    left
+                  summary: "Multiple results, last page"
+                  value:
+                    items:
+                      - id: schema1
+                        version: 1
+                        type: JSON
+                        schemaDefinition: ewogICIkaWQiOiAiaHR0cHM6Ly9leGFtcGxlLmNvbS9hZGRyZXNzLmpzb24iLAogICIkc2NoZW1hIjogImh0dHA6Ly9qc29uLXNjaGVtYS5vcmcvZHJhZnQtMDcvc2NoZW1hIiwKICAidHlwZSI6ICJvYmplY3QiLAogICJwcm9wZXJ0aWVzIjogewogICAgInN0cmVldF9hZGRyZXNzIjogeyAidHlwZSI6ICJzdHJpbmciIH0sCiAgICAiY2l0eSI6IHsgInR5cGUiOiAic3RyaW5nIiB9LAogICAgInN0YXRlIjogeyAidHlwZSI6ICJzdHJpbmciIH0KICB9LAogICJyZXF1aXJlZCI6IFsic3RyZWV0X2FkZHJlc3MiLCAiY2l0eSIsICJzdGF0ZSJdCn0=
+                        createdAt: 2023-03-01T13:28:35.164Z
+                      - id: schema2
+                        version: 1
+                        type: JSON
+                        schemaDefinition: ewogICIkaWQiOiAiaHR0cHM6Ly9leGFtcGxlLmNvbS9hZGRyZXNzLmpzb24iLAogICIkc2NoZW1hIjogImh0dHA6Ly9qc29uLXNjaGVtYS5vcmcvZHJhZnQtMDcvc2NoZW1hIiwKICAidHlwZSI6ICJvYmplY3QiLAogICJwcm9wZXJ0aWVzIjogewogICAgInN0cmVldF9hZGRyZXNzIjogeyAidHlwZSI6ICJzdHJpbmciIH0sCiAgICAiY2l0eSI6IHsgInR5cGUiOiAic3RyaW5nIiB9LAogICAgInN0YXRlIjogeyAidHlwZSI6ICJzdHJpbmciIH0KICB9LAogICJyZXF1aXJlZCI6IFsic3RyZWV0X2FkZHJlc3MiLCAiY2l0eSIsICJzdGF0ZSJdCn0=
+                        createdAt: 2023-03-01T13:38:35.164Z
+                      - id: schema3
+                        version: 1
+                        type: JSON
+                        schemaDefinition: ewogICIkaWQiOiAiaHR0cHM6Ly9leGFtcGxlLmNvbS9hZGRyZXNzLmpzb24iLAogICIkc2NoZW1hIjogImh0dHA6Ly9qc29uLXNjaGVtYS5vcmcvZHJhZnQtMDcvc2NoZW1hIiwKICAidHlwZSI6ICJvYmplY3QiLAogICJwcm9wZXJ0aWVzIjogewogICAgInN0cmVldF9hZGRyZXNzIjogeyAidHlwZSI6ICJzdHJpbmciIH0sCiAgICAiY2l0eSI6IHsgInR5cGUiOiAic3RyaW5nIiB9LAogICAgInN0YXRlIjogeyAidHlwZSI6ICJzdHJpbmciIH0KICB9LAogICJyZXF1aXJlZCI6IFsic3RyZWV0X2FkZHJlc3MiLCAiY2l0eSIsICJzdGF0ZSJdCn0=
+                        createdAt: 2023-03-01T13:48:35.164Z
+                list-response-b:
+                  description: Example response with multiple schemas. More pages
+                    left
+                  summary: "Multiple results, more pages left"
+                  value:
+                    items:
+                      - id: schema1
+                        version: 1
+                        type: JSON
+                        schemaDefinition: ewogICIkaWQiOiAiaHR0cHM6Ly9leGFtcGxlLmNvbS9hZGRyZXNzLmpzb24iLAogICIkc2NoZW1hIjogImh0dHA6Ly9qc29uLXNjaGVtYS5vcmcvZHJhZnQtMDcvc2NoZW1hIiwKICAidHlwZSI6ICJvYmplY3QiLAogICJwcm9wZXJ0aWVzIjogewogICAgInN0cmVldF9hZGRyZXNzIjogeyAidHlwZSI6ICJzdHJpbmciIH0sCiAgICAiY2l0eSI6IHsgInR5cGUiOiAic3RyaW5nIiB9LAogICAgInN0YXRlIjogeyAidHlwZSI6ICJzdHJpbmciIH0KICB9LAogICJyZXF1aXJlZCI6IFsic3RyZWV0X2FkZHJlc3MiLCAiY2l0eSIsICJzdGF0ZSJdCn0=
+                        createdAt: 2023-03-01T13:28:35.164Z
+                      - id: schema2
+                        version: 1
+                        type: JSON
+                        schemaDefinition: ewogICIkaWQiOiAiaHR0cHM6Ly9leGFtcGxlLmNvbS9hZGRyZXNzLmpzb24iLAogICIkc2NoZW1hIjogImh0dHA6Ly9qc29uLXNjaGVtYS5vcmcvZHJhZnQtMDcvc2NoZW1hIiwKICAidHlwZSI6ICJvYmplY3QiLAogICJwcm9wZXJ0aWVzIjogewogICAgInN0cmVldF9hZGRyZXNzIjogeyAidHlwZSI6ICJzdHJpbmciIH0sCiAgICAiY2l0eSI6IHsgInR5cGUiOiAic3RyaW5nIiB9LAogICAgInN0YXRlIjogeyAidHlwZSI6ICJzdHJpbmciIH0KICB9LAogICJyZXF1aXJlZCI6IFsic3RyZWV0X2FkZHJlc3MiLCAiY2l0eSIsICJzdGF0ZSJdCn0=
+                        createdAt: 2023-03-01T13:38:35.164Z
+                      - id: schema3
+                        version: 1
+                        type: JSON
+                        schemaDefinition: ewogICIkaWQiOiAiaHR0cHM6Ly9leGFtcGxlLmNvbS9hZGRyZXNzLmpzb24iLAogICIkc2NoZW1hIjogImh0dHA6Ly9qc29uLXNjaGVtYS5vcmcvZHJhZnQtMDcvc2NoZW1hIiwKICAidHlwZSI6ICJvYmplY3QiLAogICJwcm9wZXJ0aWVzIjogewogICAgInN0cmVldF9hZGRyZXNzIjogeyAidHlwZSI6ICJzdHJpbmciIH0sCiAgICAiY2l0eSI6IHsgInR5cGUiOiAic3RyaW5nIiB9LAogICAgInN0YXRlIjogeyAidHlwZSI6ICJzdHJpbmciIH0KICB9LAogICJyZXF1aXJlZCI6IFsic3RyZWV0X2FkZHJlc3MiLCAiY2l0eSIsICJzdGF0ZSJdCn0=
+                        createdAt: 2023-03-01T13:48:35.164Z
+                    _links:
+                      next: /api/v1/data-hub/schemas?cursor=a-eqj-GE9B5DkV-nhwVBk-nTL807ty&limit=3
+                list-response-c:
+                  description: Example response with requested fields and multiple
+                    schemas. More pages left
+                  summary: "Multiple results, requested 'id' field"
+                  value:
+                    items:
+                      - id: schema1
+                      - id: schema2
+                      - id: schema3
+                    _links:
+                      next: /api/v1/data-hub/schemas?cursor=a-eqj-GE9B5DkV-nhwVBk-nTL807ty&limit=3&fields=id
+                list-response-d:
+                  description: Example response with a single schema
+                  summary: Single Result
+                  value:
+                    items:
+                      - id: schema1
+                        version: 1
+                        type: JSON
+                        schemaDefinition: ewogICIkaWQiOiAiaHR0cHM6Ly9leGFtcGxlLmNvbS9hZGRyZXNzLmpzb24iLAogICIkc2NoZW1hIjogImh0dHA6Ly9qc29uLXNjaGVtYS5vcmcvZHJhZnQtMDcvc2NoZW1hIiwKICAidHlwZSI6ICJvYmplY3QiLAogICJwcm9wZXJ0aWVzIjogewogICAgInN0cmVldF9hZGRyZXNzIjogeyAidHlwZSI6ICJzdHJpbmciIH0sCiAgICAiY2l0eSI6IHsgInR5cGUiOiAic3RyaW5nIiB9LAogICAgInN0YXRlIjogeyAidHlwZSI6ICJzdHJpbmciIH0KICB9LAogICJyZXF1aXJlZCI6IFsic3RyZWV0X2FkZHJlc3MiLCAiY2l0eSIsICJzdGF0ZSJdCn0=
+                        createdAt: 2023-03-01T13:28:35.164Z
+                list-response-e:
+                  description: Example response with all versions of specific schema
+                    id.
+                  summary: "List versions of one schema, last page"
+                  value:
+                    items:
+                      - id: schema1
+                        version: 1
+                        type: JSON
+                        schemaDefinition: ewogICIkaWQiOiAiaHR0cHM6Ly9leGFtcGxlLmNvbS9hZGRyZXNzLmpzb24iLAogICIkc2NoZW1hIjogImh0dHA6Ly9qc29uLXNjaGVtYS5vcmcvZHJhZnQtMDcvc2NoZW1hIiwKICAidHlwZSI6ICJvYmplY3QiLAogICJwcm9wZXJ0aWVzIjogewogICAgInN0cmVldF9hZGRyZXNzIjogeyAidHlwZSI6ICJzdHJpbmciIH0sCiAgICAiY2l0eSI6IHsgInR5cGUiOiAic3RyaW5nIiB9LAogICAgInN0YXRlIjogeyAidHlwZSI6ICJzdHJpbmciIH0KICB9LAogICJyZXF1aXJlZCI6IFsic3RyZWV0X2FkZHJlc3MiLCAiY2l0eSIsICJzdGF0ZSJdCn0=
+                        createdAt: 2023-03-01T13:28:35.164Z
+                      - id: schema1
+                        version: 2
+                        type: JSON
+                        schemaDefinition: ewogICIkaWQiOiAiaHR0cHM6Ly9leGFtcGxlLmNvbS9hZGRyZXNzLmpzb24iLAogICIkc2NoZW1hIjogImh0dHA6Ly9qc29uLXNjaGVtYS5vcmcvZHJhZnQtMDcvc2NoZW1hIiwKICAidHlwZSI6ICJvYmplY3QiLAogICJwcm9wZXJ0aWVzIjogewogICAgInN0cmVldF9hZGRyZXNzIjogeyAidHlwZSI6ICJzdHJpbmciIH0sCiAgICAiY2l0eSI6IHsgInR5cGUiOiAic3RyaW5nIiB9LAogICAgInN0YXRlIjogeyAidHlwZSI6ICJzdHJpbmciIH0KICB9LAogICJyZXF1aXJlZCI6IFsic3RyZWV0X2FkZHJlc3MiLCAiY2l0eSIsICJzdGF0ZSJdCn0=
+                        createdAt: 2023-03-01T13:38:35.164Z
+                      - id: schema1
+                        version: 3
+                        type: JSON
+                        schemaDefinition: ewogICIkaWQiOiAiaHR0cHM6Ly9leGFtcGxlLmNvbS9hZGRyZXNzLmpzb24iLAogICIkc2NoZW1hIjogImh0dHA6Ly9qc29uLXNjaGVtYS5vcmcvZHJhZnQtMDcvc2NoZW1hIiwKICAidHlwZSI6ICJvYmplY3QiLAogICJwcm9wZXJ0aWVzIjogewogICAgInN0cmVldF9hZGRyZXNzIjogeyAidHlwZSI6ICJzdHJpbmciIH0sCiAgICAiY2l0eSI6IHsgInR5cGUiOiAic3RyaW5nIiB9LAogICAgInN0YXRlIjogeyAidHlwZSI6ICJzdHJpbmciIH0KICB9LAogICJyZXF1aXJlZCI6IFsic3RyZWV0X2FkZHJlc3MiLCAiY2l0eSIsICJzdGF0ZSJdCn0=
+                        createdAt: 2023-03-01T13:48:35.164Z
+              schema:
+                $ref: '#/components/schemas/SchemaList'
+          description: Success
+        "503":
+          content:
+            application/json:
+              examples:
+                version-check-failed:
+                  description: Version check failed
+                  summary: Version check failed
+                  value:
+                    errors:
+                      - title: Endpoint not active yet
+                        detail: "Not all cluster nodes support this endpoint yet, please\
+                        \ try again later"
+              schema:
+                $ref: '#/components/schemas/Errors'
+          description: Not all cluster nodes at minimum version
+      summary: Get all schemas
+      tags:
+        - Data Hub - Schemas
+    post:
+      description: |+
+        Creates a schema
+
+      operationId: createSchema
+      requestBody:
+        content:
+          application/json:
+            example:
+              id: schema
+              type: JSON
+              schemaDefinition: ewogICIkaWQiOiAiaHR0cHM6Ly9leGFtcGxlLmNvbS9hZGRyZXNzLmpzb24iLAogICIkc2NoZW1hIjogImh0dHA6Ly9qc29uLXNjaGVtYS5vcmcvZHJhZnQtMDcvc2NoZW1hIiwKICAidHlwZSI6ICJvYmplY3QiLAogICJwcm9wZXJ0aWVzIjogewogICAgInN0cmVldF9hZGRyZXNzIjogeyAidHlwZSI6ICJzdHJpbmciIH0sCiAgICAiY2l0eSI6IHsgInR5cGUiOiAic3RyaW5nIiB9LAogICAgInN0YXRlIjogeyAidHlwZSI6ICJzdHJpbmciIH0KICB9LAogICJyZXF1aXJlZCI6IFsic3RyZWV0X2FkZHJlc3MiLCAiY2l0eSIsICJzdGF0ZSJdCn0=
+            schema:
+              $ref: '#/components/schemas/Schema'
+        description: The schema that should be created.
+        required: true
+      responses:
+        "201":
+          content:
+            application/json:
+              examples:
+                response-example:
+                  description: Example response.
+                  summary: Schema was created successfully
+                  value:
+                    id: schema
+                    version: 1
+                    type: JSON
+                    schemaDefinition: ewogICIkaWQiOiAiaHR0cHM6Ly9leGFtcGxlLmNvbS9hZGRyZXNzLmpzb24iLAogICIkc2NoZW1hIjogImh0dHA6Ly9qc29uLXNjaGVtYS5vcmcvZHJhZnQtMDcvc2NoZW1hIiwKICAidHlwZSI6ICJvYmplY3QiLAogICJwcm9wZXJ0aWVzIjogewogICAgInN0cmVldF9hZGRyZXNzIjogeyAidHlwZSI6ICJzdHJpbmciIH0sCiAgICAiY2l0eSI6IHsgInR5cGUiOiAic3RyaW5nIiB9LAogICAgInN0YXRlIjogeyAidHlwZSI6ICJzdHJpbmciIH0KICB9LAogICJyZXF1aXJlZCI6IFsic3RyZWV0X2FkZHJlc3MiLCAiY2l0eSIsICJzdGF0ZSJdCn0=
+                    createdAt: 2023-03-01T13:28:35.164Z
+              schema:
+                $ref: '#/components/schemas/Schema'
+          description: Success
+        "400":
+          content:
+            application/json:
+              examples:
+                Schema-already-present:
+                  description: Example response when the schema is already present.
+                  summary: The given schema is already present as latest version
+                  value:
+                    errors:
+                      - title: Schema already present
+                        detail: The given schema is already present as the latest version
+                          for the schema id 'schemaId'.
+                param-missing:
+                  description: Example response when a required parameter is missing.
+                  summary: Required URL parameter missing
+                  value:
+                    errors:
+                      - title: Required parameter missing
+                        detail: Required URL parameter 'parameterName' is missing
+                schema-not-parsable:
+                  description: Example response when the submitted schema could not
+                    be parsed as JSON.
+                  summary: The submitted schema can not be parsed
+                  value:
+                    errors:
+                      - title: Schema not parsable
+                        detail: The submitted schema 'schema' can not be parsed.
+                schema-type-not-supported:
+                  description: Example response when the specified schema type is
+                    not supported.
+                  summary: The submitted schema type is not supported
+                  value:
+                    errors:
+                      - title: Schema type not supported
+                        detail: The submitted schema type 'schema-type' is not supported
+              schema:
+                $ref: '#/components/schemas/Errors'
+          description: Bad request
+        "503":
+          content:
+            application/json:
+              examples:
+                temporarily-not-available:
+                  description: The endpoint is temporarily not available
+                  summary: Temporarily not available
+                  value:
+                    errors:
+                      - title: The endpoint is temporarily not available
+                        detail: "The endpoint is temporarily not available, please try\
+                        \ again later"
+                version-check-failed:
+                  description: Version check failed
+                  summary: Version check failed
+                  value:
+                    errors:
+                      - title: Endpoint not active yet
+                        detail: "Not all cluster nodes support this endpoint yet, please\
+                        \ try again later"
+              schema:
+                $ref: '#/components/schemas/Errors'
+          description: Not all cluster nodes at minimum version
+      summary: Create a new schema
+      tags:
+        - Data Hub - Schemas
+  /api/v1/data-hub/schemas/{schemaId}:
+    delete:
+      description: "Deletes the selected schema and all associated versions of the\
+        \ schema. \n\n "
+      operationId: deleteSchema
+      parameters:
+        - description: The schema identifier of the schema versions to delete.
+          example: schema1
+          in: path
+          name: schemaId
+          required: true
+          schema:
+            type: string
+      responses:
+        "204":
+          description: "Success, no response body"
+        "400":
+          content:
+            application/json:
+              examples:
+                param-missing:
+                  description: Bad request
+                  summary: Required URL parameter missing
+                  value:
+                    errors:
+                      - title: Required parameter missing
+                        detail: Required URL parameter 'parameterName' is missing
+              schema:
+                $ref: '#/components/schemas/Errors'
+          description: Bad request
+        "404":
+          content:
+            application/json:
+              examples:
+                not-found:
+                  description: Resource not found
+                  summary: Not found
+                  value:
+                    errors:
+                      - title: Resource not found
+                        detail: Resource with id 'my-resource-id' not found
+              schema:
+                $ref: '#/components/schemas/Errors'
+          description: Resource not found
+        "503":
+          content:
+            application/json:
+              examples:
+                version-check-failed:
+                  description: Version check failed
+                  summary: Version check failed
+                  value:
+                    errors:
+                      - title: Endpoint not active yet
+                        detail: "Not all cluster nodes support this endpoint yet, please\
+                        \ try again later"
+              schema:
+                $ref: '#/components/schemas/Errors'
+          description: Not all cluster nodes at minimum version
+      summary: Delete all versions of the schema
+      tags:
+        - Data Hub - Schemas
+    get:
+      description: "Get a specific schema. \n\n This endpoint returns the content\
+        \ of the latest version of the schema with the content-type `application/json`.\
+        \ \n\n "
+      operationId: getSchema
+      parameters:
+        - description: The identifier of the schema.
+          example: schema1
+          in: path
+          name: schemaId
+          required: true
+          schema:
+            type: string
+        - description: "Comma-separated list of fields to include in the response. Allowed\
+          \ values are: id, type, schemaDefinition, createdAt"
+          example: "id,type"
+          in: query
+          name: fields
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              examples:
+                get-response:
+                  description: Get schema
+                  summary: Get schema
+                  value:
+                    id: schema
+                    version: 1
+                    type: JSON
+                    schemaDefinition: ewogICIkaWQiOiAiaHR0cHM6Ly9leGFtcGxlLmNvbS9hZGRyZXNzLmpzb24iLAogICIkc2NoZW1hIjogImh0dHA6Ly9qc29uLXNjaGVtYS5vcmcvZHJhZnQtMDcvc2NoZW1hIiwKICAidHlwZSI6ICJvYmplY3QiLAogICJwcm9wZXJ0aWVzIjogewogICAgInN0cmVldF9hZGRyZXNzIjogeyAidHlwZSI6ICJzdHJpbmciIH0sCiAgICAiY2l0eSI6IHsgInR5cGUiOiAic3RyaW5nIiB9LAogICAgInN0YXRlIjogeyAidHlwZSI6ICJzdHJpbmciIH0KICB9LAogICJyZXF1aXJlZCI6IFsic3RyZWV0X2FkZHJlc3MiLCAiY2l0eSIsICJzdGF0ZSJdCn0=
+                    createdAt: 2023-03-01T13:28:35.164Z
+              schema:
+                $ref: '#/components/schemas/Schema'
+          description: Success
+        "400":
+          content:
+            application/json:
+              examples:
+                param-missing:
+                  description: Bad request
+                  summary: Required URL parameter missing
+                  value:
+                    errors:
+                      - title: Required parameter missing
+                        detail: Required URL parameter 'parameterName' is missing
+              schema:
+                $ref: '#/components/schemas/Errors'
+          description: Bad request
+        "404":
+          content:
+            application/json:
+              examples:
+                not-found:
+                  description: Resource not found
+                  summary: Not found
+                  value:
+                    errors:
+                      - title: Resource not found
+                        detail: Resource with id 'my-resource-id' not found
+              schema:
+                $ref: '#/components/schemas/Errors'
+          description: Resource not found
+      summary: Get a schema
+      tags:
+        - Data Hub - Schemas
+  /api/v1/data-hub/scripts:
+    get:
+      description: Get all scripts.
+      operationId: getAllScripts
+      parameters:
+        - description: "Comma-separated list of fields to include in the response. Allowed\
+          \ values are: id, version, description, runtime, functionType, createdAt"
+          example: "id,createdAt,source"
+          in: query
+          name: fields
+          schema:
+            type: string
+        - description: Comma-separated list of function types used for filtering. Multiple
+            filters can be applied together.
+          example: TRANSFORMATION
+          in: query
+          name: functionTypes
+          schema:
+            type: string
+        - description: Comma-separated list of script ids used for filtering. Multiple
+            filters can be applied together.
+          example: "script1,script2"
+          in: query
+          name: scriptIds
+          schema:
+            type: string
+        - description: Specifies the page size for the returned results. Has to be between
+            10 and 500. Default page size is 50.
+          example: 100
+          in: query
+          name: limit
+          schema:
+            type: integer
+            format: int32
+        - description: The cursor that has been returned by the previous result page.
+            Do not pass this parameter if you want to fetch the first page.
+          in: query
+          name: cursor
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              examples:
+                list-response-1:
+                  description: Example response with a single script
+                  summary: Single Result
+                  value:
+                    items:
+                      - id: my-transform.js
+                        version: 1
+                        createdAt: 2023-11-21T13:08:09.898Z
+                        description: This script prefixes topics with 'transformed/'
+                        functionType: TRANSFORMATION
+                        source: ZnVuY3Rpb24gdHJhbnNmb3JtKHB1Ymxpc2gsIGNvbnRleHQpIHsKICAgcHVibGlzaC50b3BpYyA9ICJ0cmFuc2Zvcm1lZC8iICsgcHVibGlzaC50b3BpYzsKICAgcmV0dXJuIHB1Ymxpc2g7Cn0=
+                list-response-b:
+                  description: Example response with multiple sripts. More pages left
+                  summary: "Multiple results, more pages left"
+                  value:
+                    items:
+                      - id: my-transform.js
+                        version: 1
+                        createdAt: 2023-11-21T13:08:09.898Z
+                        description: This script prefixes topics with 'transformed/'
+                        functionType: TRANSFORMATION
+                        source: ZnVuY3Rpb24gdHJhbnNmb3JtKHB1Ymxpc2gsIGNvbnRleHQpIHsKICAgcHVibGlzaC50b3BpYyA9ICJ0cmFuc2Zvcm1lZC8iICsgcHVibGlzaC50b3BpYzsKICAgcmV0dXJuIHB1Ymxpc2g7Cn0=
+                      - id: my-transform-new.js
+                        version: 1
+                        createdAt: 2023-11-21T13:17:53.085Z
+                        description: "This script adds the user property ('foo', 'bar')\
+                        \ to a publish"
+                        functionType: TRANSFORMATION
+                        source: ZnVuY3Rpb24gdHJhbnNmb3JtKHB1Ymxpc2gsIGNvbnRleHQpIHsgcHVibGlzaC51c2VyUHJvcGVydGllcy5wdXNoKHtuYW1lOiAnZm9vJywgdmFsdWU6ICdiYXInfSk7IHJldHVybiBwdWJsaXNoOyB9
+                    _links:
+                      next: /api/v1/data-hub/scripts?cursor=a-WfW-QB4L4Q==&limit=3
+                list-response-c:
+                  description: Example response with requested fields and multiple
+                    scripts. More pages left
+                  summary: "Multiple results, requested 'id' field"
+                  value:
+                    items:
+                      - id: script1
+                      - id: script2
+                      - id: script3
+                    _links:
+                      next: /api/v1/data-hub/scripts?cursor=a-eqj-GE9B5DkV-nhwVBk-nTL807ty&limit=3&fields=id
+                list-response-e:
+                  description: Example response with all versions of specific script
+                    id.
+                  summary: "List versions of one script, last page"
+                  value:
+                    items:
+                      - id: my-transform.js
+                        version: 1
+                        createdAt: 2023-11-21T13:08:09.898Z
+                        description: This script prefixes topics with 'transformed/'
+                        functionType: TRANSFORMATION
+                        source: ZnVuY3Rpb24gdHJhbnNmb3JtKHB1Ymxpc2gsIGNvbnRleHQpIHsKICAgcHVibGlzaC50b3BpYyA9ICJ0cmFuc2Zvcm1lZC8iICsgcHVibGlzaC50b3BpYzsKICAgcmV0dXJuIHB1Ymxpc2g7Cn0=
+                      - id: my-transform.js
+                        version: 2
+                        createdAt: 2023-11-21T13:17:53.085Z
+                        description: This script prefixes topics with 'transformed/'
+                        functionType: TRANSFORMATION
+                        source: ZnVuY3Rpb24gdHJhbnNmb3JtKHB1Ymxpc2gsIGNvbnRleHQpIHsgcHVibGlzaC51c2VyUHJvcGVydGllcy5wdXNoKHtuYW1lOiAnZm9vJywgdmFsdWU6ICdiYXInfSk7IHJldHVybiBwdWJsaXNoOyB9
+                list-response-many:
+                  description: Example response with multiple scripts
+                  summary: Multiple results
+                  value:
+                    items:
+                      - id: my-transform.js
+                        version: 1
+                        createdAt: 2023-11-21T13:08:09.898Z
+                        description: This script prefixes topics with 'transformed/'
+                        functionType: TRANSFORMATION
+                        source: ZnVuY3Rpb24gdHJhbnNmb3JtKHB1Ymxpc2gsIGNvbnRleHQpIHsKICAgcHVibGlzaC50b3BpYyA9ICJ0cmFuc2Zvcm1lZC8iICsgcHVibGlzaC50b3BpYzsKICAgcmV0dXJuIHB1Ymxpc2g7Cn0=
+                      - id: my-transform-new.js
+                        version: 1
+                        createdAt: 2023-11-21T13:17:53.085Z
+                        description: "This script adds the user property ('foo', 'bar')\
+                        \ to a publish"
+                        functionType: TRANSFORMATION
+                        source: ZnVuY3Rpb24gdHJhbnNmb3JtKHB1Ymxpc2gsIGNvbnRleHQpIHsgcHVibGlzaC51c2VyUHJvcGVydGllcy5wdXNoKHtuYW1lOiAnZm9vJywgdmFsdWU6ICdiYXInfSk7IHJldHVybiBwdWJsaXNoOyB9
+              schema:
+                $ref: '#/components/schemas/ScriptList'
+          description: Success
+        "503":
+          content:
+            application/json:
+              examples:
+                version-check-failed:
+                  description: Version check failed
+                  summary: Version check failed
+                  value:
+                    errors:
+                      - title: Endpoint not active yet
+                        detail: "Not all cluster nodes support this endpoint yet, please\
+                        \ try again later"
+              schema:
+                $ref: '#/components/schemas/Errors'
+          description: Not all cluster nodes at minimum version
+      summary: Get all scripts
+      tags:
+        - Data Hub - Scripts
+    post:
+      description: Creates a script
+      operationId: createScript
+      requestBody:
+        content:
+          application/json:
+            example:
+              id: my-transform.js
+              description: This script prefixes topics with 'transformed/'
+              functionType: TRANSFORMATION
+              source: ZnVuY3Rpb24gdHJhbnNmb3JtKHB1Ymxpc2gsIGNvbnRleHQpIHsKICAgcHVibGlzaC50b3BpYyA9ICJ0cmFuc2Zvcm1lZC8iICsgcHVibGlzaC50b3BpYzsKICAgcmV0dXJuIHB1Ymxpc2g7Cn0=
+            schema:
+              $ref: '#/components/schemas/Script'
+        description: The script that should be created.
+        required: true
+      responses:
+        "201":
+          content:
+            application/json:
+              examples:
+                response-example:
+                  description: Example response.
+                  summary: Script was created successfully
+                  value:
+                    id: my-transform.js
+                    version: 1
+                    createdAt: 2023-11-21T13:08:09.898Z
+                    description: This script prefixes topics with 'transformed/'
+                    functionType: TRANSFORMATION
+                    source: ZnVuY3Rpb24gdHJhbnNmb3JtKHB1Ymxpc2gsIGNvbnRleHQpIHsKICAgcHVibGlzaC50b3BpYyA9ICJ0cmFuc2Zvcm1lZC8iICsgcHVibGlzaC50b3BpYzsKICAgcmV0dXJuIHB1Ymxpc2g7Cn0=
+              schema:
+                $ref: '#/components/schemas/Script'
+          description: Success
+        "400":
+          content:
+            application/json:
+              examples:
+                input-cannot-be-parsed:
+                  description: Example response when input cannot be parsed.
+                  summary: Unable to parse JSON body
+                  value:
+                    errors:
+                      - title: Invalid input
+                        detail: Unable to parse JSON body
+                script-already-present:
+                  description: Example response when the script is already present.
+                  summary: The given script is identical to the latest version
+                  value:
+                    errors:
+                      - title: Script already present
+                        detail: The given script is identical to the latest version
+                          of the script with id 'scriptId'.
+              schema:
+                $ref: '#/components/schemas/Errors'
+          description: Bad request
+        "503":
+          content:
+            application/json:
+              examples:
+                version-check-failed:
+                  description: Version check failed
+                  summary: Version check failed
+                  value:
+                    errors:
+                      - title: Endpoint not active yet
+                        detail: "Not all cluster nodes support this endpoint yet, please\
+                        \ try again later"
+              schema:
+                $ref: '#/components/schemas/Errors'
+          description: Not all cluster nodes at minimum version
+      summary: Create a new script
+      tags:
+        - Data Hub - Scripts
+  /api/v1/data-hub/scripts/{scriptId}:
+    delete:
+      description: Deletes the selected script.
+      operationId: deleteScript
+      parameters:
+        - description: The script identifier of the script to delete.
+          example: hello_world_function
+          in: path
+          name: scriptId
+          required: true
+          schema:
+            type: string
+      responses:
+        "204":
+          description: "Success, no response body"
+        "400":
+          content:
+            application/json:
+              examples:
+                param-missing:
+                  description: Bad request
+                  summary: Required URL parameter missing
+                script-referenced:
+                  description: Bad request
+                  summary: Script was referenced recently
+              schema:
+                $ref: '#/components/schemas/Errors'
+          description: Bad request
+        "404":
+          content:
+            application/json:
+              examples:
+                not-found:
+                  description: Resource not found
+                  summary: Not found
+                  value:
+                    errors:
+                      - title: Resource not found
+                        detail: Resource with id 'my-resource-id' not found
+              schema:
+                $ref: '#/components/schemas/Errors'
+          description: Resource not found
+        "503":
+          content:
+            application/json:
+              examples:
+                version-check-failed:
+                  description: Version check failed
+                  summary: Version check failed
+                  value:
+                    errors:
+                      - title: Endpoint not active yet
+                        detail: "Not all cluster nodes support this endpoint yet, please\
+                        \ try again later"
+              schema:
+                $ref: '#/components/schemas/Errors'
+          description: Not all cluster nodes at minimum version
+      summary: Delete a script
+      tags:
+        - Data Hub - Scripts
+    get:
+      description: Get a specific script.
+      operationId: getScript
+      parameters:
+        - description: The identifier of the script.
+          example: hello_world_function
+          in: path
+          name: scriptId
+          required: true
+          schema:
+            type: string
+        - description: "Comma-separated list of fields to include in the response. Allowed\
+          \ values are: id, version, description, runtime, functionType, createdAt"
+          example: "id,createdAt,source"
+          in: query
+          name: fields
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              examples:
+                get-response:
+                  description: Get script
+                  summary: Get script
+                  value:
+                    id: my-transform.js
+                    version: 1
+                    createdAt: 2023-11-21T13:08:09.898Z
+                    description: This script prefixes topics with 'transformed/'
+                    functionType: TRANSFORMATION
+                    source: ZnVuY3Rpb24gdHJhbnNmb3JtKHB1Ymxpc2gsIGNvbnRleHQpIHsKICAgcHVibGlzaC50b3BpYyA9ICJ0cmFuc2Zvcm1lZC8iICsgcHVibGlzaC50b3BpYzsKICAgcmV0dXJuIHB1Ymxpc2g7Cn0=
+              schema:
+                $ref: '#/components/schemas/Script'
+          description: Success
+        "400":
+          content:
+            application/json:
+              examples:
+                param-missing:
+                  description: Bad request
+                  summary: Required URL parameter missing
+                  value:
+                    errors:
+                      - title: Required parameter missing
+                        detail: Required URL parameter 'parameterName' is missing
+              schema:
+                $ref: '#/components/schemas/Errors'
+          description: Bad request
+        "404":
+          content:
+            application/json:
+              examples:
+                not-found:
+                  description: Resource not found
+                  summary: Not found
+                  value:
+                    errors:
+                      - title: Resource not found
+                        detail: Resource with id 'my-resource-id' not found
+              schema:
+                $ref: '#/components/schemas/Errors'
+          description: Resource not found
+      summary: Get a script
+      tags:
+        - Data Hub - Scripts
+  /api/v1/frontend/capabilities:
+    get:
+      description: Obtain gateway capabilities.
+      operationId: get-capabilities
+      responses:
+        "200":
+          content:
+            application/json:
+              examples:
+                capabilities:
+                  description: An example capability list.
+                  summary: Example capabilities
+                  value: |-
+                    {
+                        "items": [
+                            {
+                                "id": "test-capability"
+                                "displayName": "Super useful Capability"
+                                "description": "This capability is really useful for so many reasons."
+                            }
+                        ]
+                    }
+              schema:
+                $ref: '#/components/schemas/CapabilityList'
+          description: Success
+      summary: Obtain Capabilities of the HiveMQ Edge Installation
+      tags:
+        - Frontend
+  /api/v1/frontend/configuration:
+    get:
+      description: Obtain configuration.
+      operationId: get-configuration
+      responses:
+        "200":
+          content:
+            application/json:
+              examples:
+                default-configuration:
+                  description: An example default gateway configuration.
+                  summary: Example gateway configuration
+                  value:
+                    environment:
+                      properties:
+                        environment-type: TEST
+                    cloudLink:
+                      displayText: HiveMQ Cloud
+                      url: https://hivemq.com/cloud
+                      description: "Lorem ipsum dolor sit amet, consetetur sadipscing\
+                        \ elitr, sed diam nonumy eirmod tempor invidunt ut labore\
+                        \ et dolore magna aliquyam erat, sed diam voluptua. At vero\
+                        \ eos et accusam et justo duo dolores et ea rebum. Stet clita\
+                        \ kasd gubergren,"
+                      external: true
+                    gitHubLink:
+                      displayText: GitHub
+                      url: https://github.com/hivemq/hivemq-edge
+                      description: "Lorem ipsum dolor sit amet, consetetur sadipscing\
+                        \ elitr, sed diam nonumy eirmod tempor invidunt ut labore\
+                        \ et dolore magna aliquyam erat, sed diam voluptua. At vero\
+                        \ eos et accusam et justo duo dolores et ea rebum. Stet clita\
+                        \ kasd gubergren,"
+                      external: true
+                    documentationLink:
+                      displayText: Documentation
+                      url: https://github.com/hivemq/hivemq-edge/README.MD
+                      description: "Lorem ipsum dolor sit amet, consetetur sadipscing\
+                        \ elitr, sed diam nonumy eirmod tempor invidunt ut labore\
+                        \ et dolore magna aliquyam erat, sed diam voluptua. At vero\
+                        \ eos et accusam et justo duo dolores et ea rebum. Stet clita\
+                        \ kasd gubergren,"
+                      external: true
+                    firstUseInformation:
+                      firstUse: false
+                      prefillUsername: admin
+                      prefillPassword: password
+                      firstUseTitle: Welcome To HiveMQ Edge
+                      firstUseDescription: "Lorem ipsum dolor sit amet, consetetur\
+                        \ sadipscing elitr, sed diam nonumy eirmod tempor invidunt\
+                        \ ut labore et dolore magna aliquyam erat, sed diam voluptua.\
+                        \ At vero eos et accusam et justo duo dolores et ea rebum.\
+                        \ Stet clita kasd gubergren, no sea takimata sanctus est Lorem\
+                        \ ipsum dolor sit amet."
+                    ctas:
+                      items:
+                        - displayText: Connect My First Device
+                          url: ./protocol-adapters?from=dashboard-cta
+                          description: "Lorem ipsum dolor sit amet, consetetur sadipscing\
+                          \ elitr, sed diam nonumy eirmod tempor invidunt ut labore\
+                          \ et dolore magna aliquyam erat, sed diam voluptua. At vero\
+                          \ eos et accusam et justo duo dolores et ea rebum. Stet\
+                          \ clita kasd gubergren,"
+                          external: false
+                        - displayText: Connect To My MQTT Broker
+                          url: ./bridges?from=dashboard-cta
+                          description: "Lorem ipsum dolor sit amet, consetetur sadipscing\
+                          \ elitr, sed diam nonumy eirmod tempor invidunt ut labore\
+                          \ et dolore magna aliquyam erat, sed diam voluptua. At vero\
+                          \ eos et accusam et justo duo dolores et ea rebum. Stet\
+                          \ clita kasd gubergren,"
+                          external: false
+                        - displayText: Learn More
+                          url: resources?from=dashboard-cta
+                          description: "Lorem ipsum dolor sit amet, consetetur sadipscing\
+                          \ elitr, sed diam nonumy eirmod tempor invidunt ut labore\
+                          \ et dolore magna aliquyam erat, sed diam voluptua. At vero\
+                          \ eos et accusam et justo duo dolores et ea rebum. Stet\
+                          \ clita kasd gubergren,"
+                          external: false
+                    resources:
+                      items:
+                        - displayText: Power Of Smart Manufacturing
+                          url: https://www.hivemq.com/articles/power-of-iot-data-management-in-smart-manufacturing/
+                          description: ""
+                          target: ""
+                          imageUrl: ""
+                          external: true
+                        - displayText: Power Of Smart Manufacturing
+                          url: https://www.hivemq.com/articles/power-of-iot-data-management-in-smart-manufacturing/
+                          description: ""
+                          target: ""
+                          imageUrl: ""
+                          external: true
+                    modules:
+                      items: []
+                    extensions:
+                      items:
+                        - id: extension-1
+                          version: 1.0.0
+                          name: My First Extension
+                          description: Some extension description here which could span
+                            multiple lines
+                          author: HiveMQ
+                          priority: 0
+                        - id: hivemq-allow-all-extension
+                          version: 1.0.0
+                          name: Allow All Extension
+                          author: HiveMQ
+                          priority: 0
+                          installed: true
+              schema:
+                $ref: '#/components/schemas/GatewayConfiguration'
+          description: Success
+      summary: Obtain frontend configuration
+      tags:
+        - Frontend
+  /api/v1/frontend/notifications:
+    get:
+      description: Obtain gateway notifications.
+      operationId: get-notifications
+      responses:
+        "200":
+          content:
+            application/json:
+              examples:
+                notifications:
+                  description: An example notification list.
+                  summary: Example notifications
+                  value:
+                    items:
+                      - level: WARNING
+                        title: Default Credentials Need Changing!
+                        description: Your gateway access is configured to use the default
+                          username/password combination. This is a security risk. Please
+                          ensure you modify your access credentials in your configuration.xml
+                          file.
+              schema:
+                $ref: '#/components/schemas/NotificationList'
+          description: Success
+      summary: Obtain Notifications
+      tags:
+        - Frontend
+  /api/v1/gateway/configuration:
+    get:
+      description: Obtain gateway configuration.
+      operationId: get-xml-configuration
+      responses:
+        "200":
+          content:
+            application/xml:
+              schema:
+                type: string
+          description: Success
+        "405":
+          content:
+            application/xml:
+              examples:
+                export-not-allowed:
+                  description: Export is not allowed from gateway
+                  summary: Example export disabled
+                  value:
+                    message: An unknown error occurred processing your request
+                    cause: xml export not allowed
+              schema:
+                $ref: '#/components/schemas/ApiErrorMessage'
+          description: Error - function not supported
+      summary: Obtain HiveMQ Edge Configuration
+      tags:
+        - Gateway Endpoint
+  /api/v1/gateway/listeners:
+    get:
+      description: Obtain listener.
+      operationId: get-listeners
+      responses:
+        "200":
+          content:
+            application/json:
+              examples:
+                listener-configuration:
+                  description: A list of listeners configured in the gateway
+                  summary: Listener configuration
+                  value:
+                    items:
+                      - name: tcp-listener-1883
+                        hostName: localhost
+                        port: 1883
+                      - name: udp-listener-2442
+                        hostName: localhost
+                        port: 2442
+              schema:
+                $ref: '#/components/schemas/ListenerList'
+          description: Success
+      summary: 'Obtain the listeners configured '
+      tags:
+        - Gateway Endpoint
+  /api/v1/health/liveness:
+    get:
+      description: Endpoint to determine whether the gateway is considered UP.
+      operationId: liveness
+      responses:
+        "200":
+          content:
+            application/json:
+              examples:
+                success-health:
+                  description: An example success health response.
+                  value:
+                    status: UP
+              schema:
+                $ref: '#/components/schemas/HealthStatus'
+          description: Success
+      summary: Endpoint to determine whether the gateway is considered UP
+  /api/v1/health/readiness:
+    get:
+      description: Endpoint to determine whether the gateway is considered ready.
+      operationId: readiness
+      responses:
+        "200":
+          content:
+            application/json:
+              examples:
+                success-health:
+                  description: An example success health response.
+                  value:
+                    status: UP
+              schema:
+                $ref: '#/components/schemas/HealthStatus'
+          description: Success
+      summary: Endpoint to determine whether the gateway is considered ready
+  /api/v1/management/bridges:
+    get:
+      description: Get all bridges configured in the system.
+      operationId: getBridges
+      responses:
+        "200":
+          content:
+            application/json:
+              examples:
+                bridge-list-result:
+                  description: Example response with several bridges.
+                  summary: Bridge List result
+                  value:
+                    items:
+                      - id: cloud
+                        host: REDACTED.cloud
+                        port: 8883
+                        clientId: cloud
+                        keepAlive: 60
+                        sessionExpiry: 3600
+                        cleanStart: false
+                        username: username
+                        password: '*****'
+                        loopPreventionEnabled: true
+                        loopPreventionHopCount: 1
+                        remoteSubscriptions: []
+                        localSubscriptions:
+                          - filters:
+                              - '#'
+                            destination: "prefix/{#}/bridge/${bridge.name}"
+                            excludes: []
+                            customUserProperties:
+                              - key: test1
+                                value: test2
+                            preserveRetain: true
+                            maxQoS: 0
+                        tlsConfiguration:
+                          enabled: true
+                          keystorePassword: ""
+                          privateKeyPassword: ""
+                          truststorePassword: ""
+                          protocols: []
+                          cipherSuites: []
+                          keystoreType: JKS
+                          truststoreType: JKS
+                          verifyHostname: true
+                          handshakeTimeout: 10
+                        bridgeRuntimeInformation:
+                          connectionStatus:
+                            status: CONNECTED
+                            id: cloud
+                            type: bridge
+              schema:
+                $ref: '#/components/schemas/BridgeList'
+          description: Success
+      summary: List all bridges in the system
+      tags:
+        - Bridges
+    post:
+      description: Add bridge configured in the system.
+      operationId: addBridge
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Bridge'
+        description: The new bridge.
+        required: true
+      responses:
+        "200":
+          description: Success
+      summary: Add a new Bridge
+      tags:
+        - Bridges
+  /api/v1/management/bridges/status:
+    get:
+      description: Obtain the details.
+      operationId: get-bridges-status
+      responses:
+        "200":
+          content:
+            application/json:
+              examples:
+                example-connection-status:
+                  description: Example connection status list.
+                  summary: Example connection status
+                  value:
+                    items:
+                      - status: CONNECTED
+                        id: cloud
+                        type: bridge
+              schema:
+                $ref: '#/components/schemas/StatusList'
+          description: The Connection Details Verification Result.
+      summary: Get the status of all the bridges in the system.
+      tags:
+        - Bridges
+  /api/v1/management/bridges/{bridgeId}:
+    delete:
+      description: Remove bridge configured in the system.
+      operationId: removeBridge
+      parameters:
+        - description: The id of the bridge to delete.
+          in: path
+          name: bridgeId
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Success
+      summary: Remove a Bridge
+      tags:
+        - Bridges
+    get:
+      description: Get a bridge by ID.
+      operationId: getBridgeByName
+      parameters:
+        - description: The id of the bridge to query.
+          in: path
+          name: bridgeId
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              examples:
+                bridge-get-result:
+                  description: Example Bridge.
+                  summary: Get Bridge Result
+                  value:
+                    id: cloud
+                    host: REDACTED.cloud
+                    port: 8883
+                    clientId: cloud
+                    keepAlive: 60
+                    sessionExpiry: 3600
+                    cleanStart: false
+                    username: username
+                    password: password
+                    loopPreventionEnabled: true
+                    loopPreventionHopCount: 1
+                    remoteSubscriptions: []
+                    localSubscriptions:
+                      - filters:
+                          - '#'
+                        destination: "prefix/{#}/bridge/${bridge.name}"
+                        excludes: []
+                        customUserProperties:
+                          - key: test1
+                            value: test2
+                        preserveRetain: true
+                        maxQoS: 0
+                    tlsConfiguration:
+                      enabled: true
+                      keystorePassword: ""
+                      privateKeyPassword: ""
+                      truststorePassword: ""
+                      protocols: []
+                      cipherSuites: []
+                      keystoreType: JKS
+                      truststoreType: JKS
+                      verifyHostname: true
+                      handshakeTimeout: 10
+                    bridgeRuntimeInformation:
+                      connectionStatus:
+                        status: CONNECTED
+                        id: simons-cloud
+                        type: bridge
+              schema:
+                $ref: '#/components/schemas/Bridge'
+          description: Success
+      summary: Get a bridge by ID
+      tags:
+        - Bridges
+    put:
+      description: Update bridge configured in the system.
+      operationId: updateBridge
+      parameters:
+        - description: The bridge to update.
+          in: path
+          name: bridgeId
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Bridge'
+      responses:
+        "200":
+          description: Success
+      summary: Update a Bridge
+      tags:
+        - Bridges
+  /api/v1/management/bridges/{bridgeId}/connection-status:
+    get:
+      description: Get the up to date status of a bridge.
+      operationId: get-bridge-status
+      parameters:
+        - description: The name of the bridge to query.
+          in: path
+          name: bridgeId
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              examples:
+                bridge-connection-status-result:
+                  description: Example response with CONNECTED status.
+                  summary: Bridge Connection Status Result
+                  value:
+                    status: CONNECTED
+                    id: cloud
+                    type: bridge
+              schema:
+                $ref: '#/components/schemas/Status'
+          description: Success
+      summary: Get the up to date status of a bridge
+      tags:
+        - Bridges
+  /api/v1/management/bridges/{bridgeId}/status:
+    put:
+      description: Transition the connection status of a bridge.
+      operationId: transition-bridge-status
+      parameters:
+        - description: The id of the bridge whose runtime-status will change.
+          in: path
+          name: bridgeId
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/StatusTransitionCommand'
+        description: The command to transition the bridge runtime status.
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              examples:
+                transition-status-result:
+                  description: Example response with PENDING status.
+                  summary: Bridge Connection Transition Result
+                  value:
+                    status: PENDING
+                    callbackTimeoutMillis: 1000
+              schema:
+                $ref: '#/components/schemas/StatusTransitionResult'
+          description: Success
+      summary: Transition the runtime status of a bridge
+      tags:
+        - Bridges
+  /api/v1/management/events:
+    get:
+      description: Get all bridges configured in the system.
+      operationId: getEvents
+      parameters:
+        - description: Obtain all events since the specified epoch.
+          in: query
+          name: limit
+          schema:
+            type: integer
+            format: int32
+            default: 100
+        - description: Obtain all events since the specified epoch.
+          in: query
+          name: since
+          schema:
+            type: integer
+            format: int64
+      responses:
+        "200":
+          content:
+            application/json:
+              examples:
+                event-list-result:
+                  description: Example response with several events.
+                  summary: Event List result
+                  value: {}
+              schema:
+                $ref: '#/components/schemas/EventList'
+          description: Success
+      summary: List most recent events in the system
+      tags:
+        - Events
+  /api/v1/management/protocol-adapters/adapters:
+    get:
+      description: Obtain a list of configured adapters.
+      operationId: getAdapters
+      responses:
+        "200":
+          content:
+            application/json:
+              examples:
+                adapter-list:
+                  description: An example adapter list.
+                  value:
+                    items:
+                      - id: test-simulation-server
+                        type: simulation
+                        config:
+                          id: test-simulation-server
+                          port: 5021
+                          host: 127.0.0.1
+                          pollingIntervalMillis: 1000
+                          subscriptions:
+                            - filter: my-simulation-server/my-simulation-path-100
+                              destination: test
+                              qos: 0
+                        adapterRuntimeInformation:
+                          lastStartedAttemptTime: 2023-06-28T10:57:18.707+01
+                          numberOfDaemonProcesses: 1
+                          connectionStatus:
+                            status: CONNECTED
+                            id: test-simulation-server
+                            type: adapter
+              schema:
+                $ref: '#/components/schemas/AdaptersList'
+          description: Success
+      summary: Obtain a list of configured adapters
+      tags:
+        - Protocol Adapters
+  /api/v1/management/protocol-adapters/adapters/{adapterId}:
+    delete:
+      description: Delete adapter configured in the system.
+      operationId: deleteAdapter
+      parameters:
+        - description: The adapter Id.
+          in: path
+          name: adapterId
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Success
+      summary: Delete an adapter
+      tags:
+        - Protocol Adapters
+    get:
+      description: Obtain the details for a configured adapter for the specified type".
+      operationId: getAdapter
+      parameters:
+        - description: The adapter Id.
+          in: path
+          name: adapterId
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              examples:
+                adapter:
+                  description: An example adapter.
+                  value:
+                    id: test-simulation-server
+                    type: simulation
+                    config:
+                      id: test-simulation-server
+                      port: 5021
+                      host: 127.0.0.1
+                      pollingIntervalMillis: 1000
+                      subscriptions:
+                        - filter: my-simulation-server/my-simulation-path-100
+                          destination: test
+                          qos: 0
+                    adapterRuntimeInformation:
+                      lastStartedAttemptTime: 2023-06-28T10:57:18.707+01
+                      numberOfDaemonProcesses: 1
+                      connectionStatus:
+                        status: CONNECTED
+                        id: test-simulation-server
+                        type: adapter
+              schema:
+                $ref: '#/components/schemas/Adapter'
+          description: Success
+      summary: Obtain the details for a configured adapter for the specified type
+      tags:
+        - Protocol Adapters
+    put:
+      description: Update adapter configured in the system.
+      operationId: updateAdapter
+      parameters:
+        - description: The adapter Id.
+          in: path
+          name: adapterId
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Adapter'
+      responses:
+        "200":
+          description: Success
+      summary: Update an adapter
+      tags:
+        - Protocol Adapters
+  /api/v1/management/protocol-adapters/adapters/{adapterId}/discover:
+    get:
+      description: Obtain a list of available values accessible via this protocol
+        adapter.
+      operationId: discoverDataPoints
+      parameters:
+        - description: The adapter Id.
+          in: path
+          name: adapterId
+          required: true
+          schema:
+            type: string
+        - description: The root to browse.
+          in: query
+          name: root
+          schema:
+            type: string
+        - description: The recursive depth to include. Must be larger than 0.
+          in: query
+          name: depth
+          schema:
+            type: integer
+            format: int32
+      responses:
+        "200":
+          content:
+            application/json:
+              examples:
+                discover:
+                  description: An example discovery request.
+                  value:
+                    items:
+                      - id: holding-registers
+                        name: Holding Registers
+                        description: Holding Registers
+                        nodeType: FOLDER
+                        selectable: false
+                        children:
+                          - id: grouping-1
+                            name: Addresses 1-16
+                            description: ""
+                            nodeType: FOLDER
+                            selectable: false
+                            children:
+                              - id: address-location-1
+                                name: "1"
+                                description: ""
+                                nodeType: VALUE
+                                selectable: true
+                                children: []
+              schema:
+                $ref: '#/components/schemas/ValuesTree'
+          description: Success
+        "400":
+          description: Protocol adapter does not support discovery
+      summary: Discover a list of available data points
+      tags:
+        - Protocol Adapters
+  /api/v1/management/protocol-adapters/adapters/{adapterId}/status:
+    get:
+      description: Get the up to date status an adapter.
+      operationId: get-adapter-status
+      parameters:
+        - description: The name of the adapter to query.
+          in: path
+          name: adapterId
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              examples:
+                example-connection-status:
+                  description: Example connection status.
+                  summary: Example connection status
+                  value:
+                    status: CONNECTED
+                    id: cloud
+                    type: bridge
+              schema:
+                $ref: '#/components/schemas/Status'
+          description: Success
+      summary: Get the up to date status of an adapter
+      tags:
+        - Protocol Adapters
+    put:
+      description: Transition the runtime status of an adapter.
+      operationId: transition-adapter-status
+      parameters:
+        - description: The id of the adapter whose runtime status will change.
+          in: path
+          name: adapterId
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/StatusTransitionCommand'
+        description: The command to transition the adapter runtime status.
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              examples:
+                transition-status-result:
+                  description: Example response with PENDING status.
+                  summary: Adapter Connection Transition Result
+                  value:
+                    status: PENDING
+                    callbackTimeoutMillis: 1000
+              schema:
+                $ref: '#/components/schemas/StatusTransitionResult'
+          description: Success
+      summary: Transition the runtime status of an adapter
+      tags:
+        - Protocol Adapters
+  /api/v1/management/protocol-adapters/adapters/{adapterType}:
+    post:
+      description: Add adapter to the system.
+      operationId: addAdapter
+      parameters:
+        - description: The adapter type.
+          in: path
+          name: adapterType
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Adapter'
+        description: The new adapter.
+        required: true
+      responses:
+        "200":
+          description: Success
+      summary: Add a new Adapter
+      tags:
+        - Protocol Adapters
+  /api/v1/management/protocol-adapters/status:
+    get:
+      description: Obtain the details.
+      operationId: get-adapters-status
+      responses:
+        "200":
+          content:
+            application/json:
+              examples:
+                example-connection-status:
+                  description: Example connection status list.
+                  summary: Example connection status
+                  value:
+                    items:
+                      - status: CONNECTED
+                        id: cloud
+                        type: bridge
+              schema:
+                $ref: '#/components/schemas/StatusList'
+          description: The Connection Details Verification Result.
+      summary: Get the status of all the adapters in the system.
+      tags:
+        - Protocol Adapters
+  /api/v1/management/protocol-adapters/types:
+    get:
+      description: Obtain a list of available protocol adapter types.
+      operationId: getAdapterTypes
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProtocolAdaptersList'
+          description: Success
+      summary: Obtain a list of available protocol adapter types
+      tags:
+        - Protocol Adapters
+  /api/v1/management/protocol-adapters/types/{adapterType}:
+    get:
+      description: Obtain a list of configured adapters for the specified type.
+      operationId: getAdaptersForType
+      parameters:
+        - description: The adapter type.
+          in: path
+          name: adapterType
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              examples:
+                filtered-adapters:
+                  description: An example filtered adapter list.
+                  value:
+                    items:
+                      - id: test-simulation-server
+                        type: simulation
+                        config:
+                          id: test-simulation-server
+                          port: 5021
+                          host: 127.0.0.1
+                          pollingIntervalMillis: 1000
+                          subscriptions:
+                            - filter: my-simulation-server/my-simulation-path-100
+                              destination: test
+                              qos: 0
+                        adapterRuntimeInformation:
+                          lastStartedAttemptTime: 2023-06-28T10:57:18.707+01
+                          numberOfDaemonProcesses: 1
+                          connectionStatus:
+                            status: CONNECTED
+                            id: test-simulation-server
+                            type: adapter
+              schema:
+                $ref: '#/components/schemas/AdaptersList'
+          description: Success
+      summary: Obtain a list of configured adapters for the specified type
+      tags:
+        - Protocol Adapters
+  /api/v1/management/uns/isa95:
+    get:
+      description: Obtain isa95 config.
+      operationId: get-isa95
+      responses:
+        "200":
+          content:
+            application/json:
+              examples:
+                default-configuration:
+                  description: An example ISA 95 config.
+                  summary: Example configuration
+                  value:
+                    enabled: true
+                    prefixAllTopics: true
+                    enterprise: enterprise
+                    site: site
+                    area: area
+                    productionLine: production-line
+                    workCell: work-cell
+              schema:
+                $ref: '#/components/schemas/ISA95ApiBean'
+          description: Success
+      summary: Obtain isa95 config
+      tags:
+        - UNS
+    post:
+      description: Set isa95 config.
+      operationId: set-isa95
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ISA95ApiBean'
+        description: The updated isa95 configuration.
+        required: true
+      responses:
+        "200":
+          description: Success
+      summary: Set isa95 config
+      tags:
+        - UNS
+  /api/v1/metrics:
+    get:
+      description: Obtain the latest sample for the metric requested.
+      operationId: getMetrics
+      responses:
+        "200":
+          content:
+            application/json:
+              examples:
+                metrics-list-sample:
+                  description: Example response with metrics listed.
+                  summary: List Metrics
+                  value:
+                    items:
+                      - name: com.hivemq.edge.bridge.simons-cloud.local.publish.count
+                      - name: simulation
+                      - name: com.hivemq.edge.messages.dropped.count
+                      - name: com.hivemq.edge.mqtt.connection.not-writable.current
+                      - name: com.hivemq.edge.bridge.simons-cloud.forward.publish.count
+                      - name: com.hivemq.edge.bridge.simons-cloud.local.publish.received.count
+                      - name: com.hivemq.edge.messages.outgoing.publish.count
+                      - name: com.hivemq.edge.sessions.overall.current
+                      - name: com.hivemq.edge.bridge.simons-cloud.forward.publish.failed.count
+                      - name: com.hivemq.edge.networking.bytes.read.total
+                      - name: com.hivemq.edge.messages.outgoing.total.count
+                      - name: com.hivemq.messages.governance.count
+                      - name: com.hivemq.edge.bridge.simons-cloud.local.publish.failed.count
+                      - name: com.hivemq.edge.networking.connections.current
+                      - name: com.hivemq.edge.persistence.retained-messages.in-memory.total-size
+                      - name: com.hivemq.edge.bridge.simons-cloud.forward.publish.loop-hops-exceeded.count
+                      - name: com.hivemq.edge.messages.incoming.connect.count
+                      - name: com.hivemq.edge.bridge.simons-cloud.local.publish.no-subscriber-present.count
+                      - name: com.hivemq.edge.messages.incoming.publish.count
+                      - name: com.hivemq.edge.messages.incoming.total.count
+                      - name: com.hivemq.edge.messages.will.count.current
+                      - name: com.hivemq.edge.messages.will.published.count.total
+                      - name: com.hivemq.edge.persistence.client-session.subscriptions.in-memory.total-size
+                      - name: com.hivemq.edge.bridge.simons-cloud.remote.publish.loop-hops-exceeded.count
+                      - name: com.hivemq.edge.networking.bytes.write.total
+                      - name: com.hivemq.edge.bridge.simons-cloud.forward.publish.excluded.count
+                      - name: com.hivemq.edge.networking.connections-closed.total.count
+                      - name: com.hivemq.edge.bridge.simons-cloud.remote.publish.received.count
+                      - name: com.hivemq.edge.subscriptions.overall.current
+                      - name: com.hivemq.edge.persistence.queued-messages.in-memory.total-size
+                      - name: com.hivemq.edge.persistence.client-sessions.in-memory.total-size
+                      - name: com.hivemq.edge.messages.retained.current
+              schema:
+                $ref: '#/components/schemas/MetricList'
+          description: Success
+      summary: Obtain a list of available metrics
+      tags:
+        - Metrics
+        - Metrics Endpoint
+  /api/v1/metrics/{metricName}/latest:
+    get:
+      description: Obtain the latest sample for the metric requested.
+      operationId: getSample
+      parameters:
+        - description: The metric to search for.
+          in: path
+          name: metricName
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              examples:
+                metric-sample:
+                  description: Example response with metrics listed.
+                  summary: Metric Sample
+                  value:
+                    sampleTime: 2023-06-28T11:39:12.789+01
+                    value: 0
+              schema:
+                $ref: '#/components/schemas/DataPoint'
+          description: Success
+      summary: Obtain the latest sample for the metric requested
+      tags:
+        - Metrics
+        - Metrics Endpoint
+components:
+  schemas:
+    Adapter:
+      type: object
+      properties:
+        config:
+          type: object
+          additionalProperties:
+            type: object
+            description: The adapter configuration associated with this instance
+          description: The adapter configuration associated with this instance
+        id:
+          type: string
+          format: string
+          description: "The adapter id, must be unique and only contain alpha numeric\
+            \ characters with spaces and hyphens."
+          maxLength: 500
+          minLength: 1
+          pattern: "^([a-zA-Z_0-9-_])*$"
+        status:
+          $ref: '#/components/schemas/Status'
+        type:
+          type: string
+          description: The adapter type associated with this instance
+      required:
+        - id
+    AdaptersList:
+      type: object
+      properties:
+        items:
+          type: array
+          description: List of result items that are returned by this endpoint
+          items:
+            $ref: '#/components/schemas/Adapter'
+    ApiBearerToken:
+      type: object
+      properties:
+        token:
+          type: string
+          description: The token associated a set of authenticated credentials
+    ApiErrorMessage:
+      type: object
+      properties:
+        detail:
+          type: string
+          description: Detailed contextual description of this error
+        fieldName:
+          type: string
+          description: Application Error Code associate with this field
+        title:
+          type: string
+          description: The title of this error
+    BehaviorPolicy:
+      type: object
+      description: A policy which is used to validate and execute certain actions
+        based on the validation result.
+      properties:
+        behavior:
+          $ref: '#/components/schemas/BehaviorPolicyBehavior'
+        createdAt:
+          type: string
+          format: date-time
+          description: The formatted UTC timestamp indicating when the policy was
+            created.
+          readOnly: true
+        deserialization:
+          $ref: '#/components/schemas/BehaviorPolicyDeserialization'
+        id:
+          type: string
+          description: The unique identifier of the policy.
+        lastUpdatedAt:
+          type: string
+          format: date-time
+          description: The formatted UTC timestamp indicating when the policy was
+            updated the last time.
+          readOnly: true
+        matching:
+          $ref: '#/components/schemas/BehaviorPolicyMatching'
+        onTransitions:
+          type: array
+          items:
+            $ref: '#/components/schemas/BehaviorPolicyOnTransition'
+      required:
+        - behavior
+        - id
+        - matching
+    BehaviorPolicyBehavior:
+      type: object
+      description: "The behavior referenced by the policy, that is validated by the\
+        \ policy."
+      properties:
+        arguments:
+          type: object
+          description: The  arguments that the referenced validator type requires.
+        id:
+          type: string
+          description: The unique identifier of a pre-defined behavior.
+      required:
+        - id
+    BehaviorPolicyDeserialization:
+      type: object
+      description: The deserializers used by the policy for particular message and/or
+        payload types.
+      properties:
+        publish:
+          $ref: '#/components/schemas/BehaviorPolicyDeserializer'
+        will:
+          $ref: '#/components/schemas/BehaviorPolicyDeserializer'
+    BehaviorPolicyDeserializer:
+      type: object
+      description: The deserializer applied to a particular message or payload type.
+      properties:
+        schema:
+          $ref: '#/components/schemas/SchemaReference'
+      required:
+        - schema
+    BehaviorPolicyList:
+      type: object
+      description: A listing of behavior policies.
+      properties:
+        _links:
+          $ref: '#/components/schemas/PaginationCursor'
+        items:
+          type: array
+          description: List of result items that are returned by this endpoint
+          items:
+            $ref: '#/components/schemas/BehaviorPolicy'
+    BehaviorPolicyMatching:
+      type: object
+      description: The matching rules the policy applies.
+      properties:
+        clientIdRegex:
+          type: string
+          description: The regex pattern to match the client id against.
+      required:
+        - clientIdRegex
+    BehaviorPolicyOnEvent:
+      type: object
+      description: "One or more operations that are triggered on the event. When this\
+        \ field is empty, the transition does not trigger any operations."
+      properties:
+        pipeline:
+          type: array
+          items:
+            $ref: '#/components/schemas/PolicyOperation'
+      required:
+        - pipeline
+    BehaviorPolicyOnTransition:
+      type: object
+      description: The actions that are executed for the specified transition.
+      properties:
+        Connection.OnDisconnect:
+          $ref: '#/components/schemas/BehaviorPolicyOnEvent'
+        Event.OnAny:
+          $ref: '#/components/schemas/BehaviorPolicyOnEvent'
+        Mqtt.OnInboundConnect:
+          $ref: '#/components/schemas/BehaviorPolicyOnEvent'
+        Mqtt.OnInboundDisconnect:
+          $ref: '#/components/schemas/BehaviorPolicyOnEvent'
+        Mqtt.OnInboundPublish:
+          $ref: '#/components/schemas/BehaviorPolicyOnEvent'
+        Mqtt.OnInboundSubscribe:
+          $ref: '#/components/schemas/BehaviorPolicyOnEvent'
+        fromState:
+          type: string
+          description: The exact state from which the transition happened. Alternatively
+            a state filter can be used.
+        toState:
+          type: string
+          description: The exact state to which the transition happened. Alternatively
+            a state filter can be used.
+      required:
+        - fromState
+        - toState
+    Bridge:
+      type: object
+      properties:
+        cleanStart:
+          type: boolean
+          format: boolean
+          default: true
+          description: The cleanStart value associated the the MQTT connection.
+        clientId:
+          type: string
+          format: string
+          description: The client identifier associated the the MQTT connection.
+          example: my-example-client-id
+          maxLength: 65535
+          nullable: true
+        host:
+          type: string
+          description: "The host the bridge connects to - a well formed hostname,\
+            \ ipv4 or ipv6 value."
+          maxLength: 255
+        id:
+          type: string
+          format: string
+          description: "The bridge id, must be unique and only contain alpha numeric\
+            \ characters with spaces and hyphens."
+          maxLength: 500
+          minLength: 1
+          pattern: "^([a-zA-Z_0-9-_])*$"
+        keepAlive:
+          type: integer
+          format: int32
+          default: 240
+          description: The keepAlive associated the the MQTT connection.
+          maximum: 65535
+          minimum: 0
+        localSubscriptions:
+          type: array
+          description: localSubscriptions associated with the bridge
+          items:
+            $ref: '#/components/schemas/LocalBridgeSubscription'
+        loopPreventionEnabled:
+          type: boolean
+          format: boolean
+          default: true
+          description: Is loop prevention enabled on the connection
+        loopPreventionHopCount:
+          type: integer
+          format: int32
+          default: 1
+          description: Loop prevention hop count
+          maximum: 100
+          minimum: 0
+        password:
+          type: string
+          format: string
+          description: The password value associated the the MQTT connection.
+          maxLength: 65535
+          nullable: true
+        persist:
+          type: boolean
+          description: "If this flag is set to true, any outgoing mqtt messages with\
+            \ QoS-1 or QoS-2 will be persisted on disc in case disc persistence is\
+            \ active.If this flag is set to false, the QoS of any outgoing mqtt messages\
+            \ will be set to QoS-0 and no traffic will be persisted on disc."
+          nullable: true
+        port:
+          type: integer
+          format: int32
+          description: The port number to connect to
+          maximum: 65535
+          minimum: 1
+        remoteSubscriptions:
+          type: array
+          description: remoteSubscriptions associated with the bridge
+          items:
+            $ref: '#/components/schemas/BridgeSubscription'
+        sessionExpiry:
+          type: integer
+          format: int32
+          default: 3600
+          description: The sessionExpiry associated the the MQTT connection.
+          maximum: 4294967295
+          minimum: 0
+        status:
+          $ref: '#/components/schemas/Status'
+        tlsConfiguration:
+          $ref: '#/components/schemas/TlsConfiguration'
+        username:
+          type: string
+          format: string
+          description: The username value associated the the MQTT connection.
+          maxLength: 65535
+          nullable: true
+        websocketConfiguration:
+          $ref: '#/components/schemas/WebsocketConfiguration'
+      required:
+        - cleanStart
+        - host
+        - id
+        - keepAlive
+        - port
+        - sessionExpiry
+    BridgeCustomUserProperty:
+      type: object
+      description: The customUserProperties for this subscription
+      properties:
+        key:
+          type: string
+          format: string
+          description: The key the from the property
+        value:
+          type: string
+          format: string
+          description: The value the from the property
+      required:
+        - key
+        - value
+    BridgeList:
+      type: object
+      properties:
+        items:
+          type: array
+          description: List of result items that are returned by this endpoint
+          items:
+            $ref: '#/components/schemas/Bridge'
+    BridgeSubscription:
+      type: object
+      description: remoteSubscriptions associated with the bridge
+      properties:
+        customUserProperties:
+          type: array
+          description: The customUserProperties for this subscription
+          items:
+            $ref: '#/components/schemas/BridgeCustomUserProperty'
+        destination:
+          type: string
+          description: The destination topic for this filter set.
+          example: some/topic/value
+        filters:
+          type: array
+          description: The filters for this subscription.
+          example: some/topic/value
+          items:
+            type: string
+            description: The filters for this subscription.
+            example: some/topic/value
+        maxQoS:
+          type: integer
+          format: int32
+          default: 0
+          description: The maxQoS for this subscription.
+          enum:
+            - 0
+            - 1
+            - 2
+          maximum: 2
+          minimum: 0
+        preserveRetain:
+          type: boolean
+          description: The preserveRetain for this subscription
+      required:
+        - destination
+        - filters
+        - maxQoS
+    Capability:
+      type: object
+      description: List of result items that are returned by this endpoint
+      properties:
+        description:
+          type: string
+          description: A description for the capability
+        displayName:
+          type: string
+          description: "A human readable name, intended to be used to display at front\
+            \ end."
+        id:
+          type: string
+          description: The identifier of this capability
+    CapabilityList:
+      type: object
+      properties:
+        items:
+          type: array
+          description: List of result items that are returned by this endpoint
+          items:
+            $ref: '#/components/schemas/Capability'
+    DataPoint:
+      type: object
+      properties:
+        sampleTime:
+          type: string
+          format: date-time
+          description: Time the data-point was generated
+          nullable: true
+        value:
+          type: integer
+          format: int64
+          description: The value of the data point
+    DataPolicy:
+      type: object
+      description: A data policy which is used to validate and execute certain actions
+        based on the validation result.
+      properties:
+        createdAt:
+          type: string
+          format: date-time
+          description: The formatted UTC timestamp indicating when the policy was
+            created.
+          readOnly: true
+        id:
+          type: string
+          description: The unique identifier of the policy.
+        lastUpdatedAt:
+          type: string
+          format: date-time
+          description: The formatted UTC timestamp indicating when the policy was
+            updated the last time.
+          readOnly: true
+        matching:
+          $ref: '#/components/schemas/DataPolicyMatching'
+        onFailure:
+          $ref: '#/components/schemas/DataPolicyAction'
+        onSuccess:
+          $ref: '#/components/schemas/DataPolicyAction'
+        validation:
+          $ref: '#/components/schemas/DataPolicyValidation'
+      required:
+        - id
+        - matching
+    DataPolicyAction:
+      type: object
+      description: "One or more operations the outcome of the validation triggers.\
+        \  When this field is empty, the outcome of the policy validation does not\
+        \ trigger any operations."
+      properties:
+        pipeline:
+          type: array
+          description: "The pipeline to execute, when this action is triggered. The\
+            \ operations in the pipeline are executed in-order."
+          items:
+            $ref: '#/components/schemas/PolicyOperation'
+    DataPolicyList:
+      type: object
+      description: A listing of data policies.
+      properties:
+        _links:
+          $ref: '#/components/schemas/PaginationCursor'
+        items:
+          type: array
+          description: List of result items that are returned by this endpoint
+          items:
+            $ref: '#/components/schemas/DataPolicy'
+    DataPolicyMatching:
+      type: object
+      description: The matching rules the policy applies.
+      properties:
+        topicFilter:
+          type: string
+          description: The topic filter for which the policy is matched.
+      required:
+        - topicFilter
+    DataPolicyValidation:
+      type: object
+      description: "The section of the policy that defines how incoming MQTT messages\
+        \ are validated. If this section is empty, the result of the policy validation\
+        \ is always successful."
+      properties:
+        validators:
+          type: array
+          description: The validators of the policy.
+          items:
+            $ref: '#/components/schemas/DataPolicyValidator'
+    DataPolicyValidator:
+      type: object
+      description: A policy validator which executes the defined validation.
+      properties:
+        arguments:
+          type: object
+          description: The required arguments of the referenced validator type.
+        type:
+          type: string
+          description: The type of the validator.
+          enum:
+            - SCHEMA
+      required:
+        - arguments
+        - type
+    EnvironmentProperties:
+      type: object
+      description: A map of properties relating to the installation
+      nullable: true
+      properties:
+        properties:
+          type: object
+          additionalProperties:
+            type: string
+            description: Map of properties that are returned by this endpoint
+          description: Map of properties that are returned by this endpoint
+    Error:
+      type: object
+      properties:
+        detail:
+          type: string
+          description: Detailed contextual description of this error
+        title:
+          type: string
+          description: The type of this error
+    Errors:
+      type: object
+      properties:
+        errors:
+          type: array
+          items:
+            $ref: '#/components/schemas/Error'
+    Event:
+      type: object
+      description: List of result items that are returned by this endpoint
+      properties:
+        associatedObject:
+          $ref: '#/components/schemas/TypeIdentifier'
+        created:
+          type: string
+          format: date-time
+          description: Time the event was in date format
+        identifier:
+          $ref: '#/components/schemas/TypeIdentifier'
+        message:
+          type: string
+          description: The message associated with the event. A message will be no
+            more than 1024 characters in length
+        payload:
+          $ref: '#/components/schemas/Payload'
+        severity:
+          type: string
+          description: The severity that this log is considered to be
+          enum:
+            - INFO
+            - WARN
+            - ERROR
+            - CRITICAL
+        source:
+          $ref: '#/components/schemas/TypeIdentifier'
+        timestamp:
+          type: integer
+          format: int64
+          description: Time the event was generated in epoch format
+      required:
+        - created
+        - identifier
+        - message
+        - severity
+        - timestamp
+    EventList:
+      type: object
+      properties:
+        items:
+          type: array
+          description: List of result items that are returned by this endpoint
+          items:
+            $ref: '#/components/schemas/Event'
+    Extension:
+      type: object
+      description: List of result items that are returned by this endpoint
+      properties:
+        author:
+          type: string
+          description: The extension author
+        description:
+          type: string
+          description: The extension description
+          nullable: true
+        id:
+          type: string
+          description: A mandatory ID associated with the Extension
+        installed:
+          type: boolean
+          description: Is the extension installed
+          nullable: true
+        link:
+          $ref: '#/components/schemas/Link'
+        name:
+          type: string
+          description: The extension name
+        priority:
+          type: integer
+          format: int32
+          description: The extension priority
+        version:
+          type: string
+          description: The extension version
+    ExtensionList:
+      type: object
+      description: The extensions available for installation
+      properties:
+        items:
+          type: array
+          description: List of result items that are returned by this endpoint
+          items:
+            $ref: '#/components/schemas/Extension'
+    FirstUseInformation:
+      type: object
+      description: Information relating to the firstuse experience
+      properties:
+        firstUse:
+          type: boolean
+          description: A mandatory Boolean indicating if the gateway is in firstUse
+            mode
+        firstUseDescription:
+          type: string
+          description: A description string to use when firstUse = true.
+          nullable: true
+        firstUseTitle:
+          type: string
+          description: A header string to use when firstUse = true.
+          nullable: true
+        prefillPassword:
+          type: string
+          description: A String indicating if the prefill data for the username/password
+            page.
+          nullable: true
+        prefillUsername:
+          type: string
+          description: A String indicating if the prefill data for the username/password
+            page.
+          nullable: true
+      required:
+        - firstUse
+    FsmStateInformationItem:
+      type: object
+      description: List of result items that are returned by this endpoint
+      properties:
+        arguments:
+          $ref: '#/components/schemas/JsonNode'
+        behaviorId:
+          type: string
+          description: The unique identifier of the policy.
+        firstSetAt:
+          type: string
+          description: The timestamp when this state was set the first time.
+        policyId:
+          type: string
+          description: The unique identifier of the policy.
+        stateName:
+          type: string
+          description: The name of the fsm state.
+        stateType:
+          type: string
+          description: The type of the fsm state.
+        variables:
+          type: object
+          additionalProperties:
+            type: string
+            description: The variables for this fsm.
+          description: The variables for this fsm.
+    FsmStatesInformationListItem:
+      type: object
+      properties:
+        items:
+          type: array
+          description: List of result items that are returned by this endpoint
+          items:
+            $ref: '#/components/schemas/FsmStateInformationItem'
+    GatewayConfiguration:
+      type: object
+      properties:
+        cloudLink:
+          $ref: '#/components/schemas/Link'
+        ctas:
+          $ref: '#/components/schemas/LinkList'
+        documentationLink:
+          $ref: '#/components/schemas/Link'
+        environment:
+          $ref: '#/components/schemas/EnvironmentProperties'
+        extensions:
+          $ref: '#/components/schemas/ExtensionList'
+        firstUseInformation:
+          $ref: '#/components/schemas/FirstUseInformation'
+        gitHubLink:
+          $ref: '#/components/schemas/Link'
+        hivemqId:
+          type: string
+          description: The current id of hivemq edge. Changes at restart.
+        modules:
+          $ref: '#/components/schemas/ModuleList'
+        resources:
+          $ref: '#/components/schemas/LinkList'
+        trackingAllowed:
+          type: boolean
+          description: Is the tracking of user actions allowed.
+    HealthStatus:
+      type: object
+      properties:
+        status:
+          type: string
+    ISA95ApiBean:
+      type: object
+      properties:
+        area:
+          type: string
+          description: The area
+          nullable: true
+          pattern: "^[a-zA-Z0-9 -_]*$"
+        enabled:
+          type: boolean
+          description: Should UNS be available
+        enterprise:
+          type: string
+          description: The enterprise
+          nullable: true
+          pattern: "^[a-zA-Z0-9 -_]*"
+        prefixAllTopics:
+          type: boolean
+          description: Should all topics be prefixed with UNS placeholders
+        productionLine:
+          type: string
+          description: The productionLine
+          nullable: true
+          pattern: "^[a-zA-Z0-9 -_]*$"
+        site:
+          type: string
+          description: The site
+          nullable: true
+          pattern: "^[a-zA-Z0-9 -_]*$"
+        workCell:
+          type: string
+          description: The workCell
+          nullable: true
+          pattern: "^[a-zA-Z0-9 -_]*$"
+    JsonNode:
+      type: object
+      description: The arguments of the fsm derived from the behavior policy.
+    Link:
+      type: object
+      description: An associated link
+      nullable: true
+      properties:
+        description:
+          type: string
+          description: The optional link display description
+          nullable: true
+        displayText:
+          type: string
+          description: The link display text
+          nullable: true
+        external:
+          type: boolean
+          description: A mandatory Boolean indicating if the link is internal to the
+            context or an external webLink
+        imageUrl:
+          type: string
+          description: An optional imageUrl associated with the Link
+          nullable: true
+        target:
+          type: string
+          description: An optional target associated with the Link
+          nullable: true
+        url:
+          type: string
+          description: A mandatory URL associated with the Link
+      required:
+        - url
+    LinkList:
+      type: object
+      description: A list of resources to render
+      properties:
+        items:
+          type: array
+          description: List of result items that are returned by this endpoint
+          items:
+            $ref: '#/components/schemas/Link'
+    Listener:
+      type: object
+      description: List of result items that are returned by this endpoint
+      properties:
+        description:
+          type: string
+          description: The extension description
+          nullable: true
+        externalHostname:
+          type: string
+          description: The external hostname
+          nullable: true
+        hostName:
+          type: string
+          description: A mandatory ID hostName with the Listener
+        name:
+          type: string
+          description: The listener name
+        port:
+          type: integer
+          format: int32
+          description: The listener port
+        protocol:
+          type: string
+          description: A protocol that this listener services
+          nullable: true
+        transport:
+          type: string
+          description: The underlying transport that this listener uses
+          enum:
+            - TCP
+            - UDP
+            - DCCP
+            - SCTP
+            - RSVP
+            - QUIC
+          nullable: true
+    ListenerList:
+      type: object
+      properties:
+        items:
+          type: array
+          description: List of result items that are returned by this endpoint
+          items:
+            $ref: '#/components/schemas/Listener'
+    LocalBridgeSubscription:
+      type: object
+      description: localSubscriptions associated with the bridge
+      properties:
+        customUserProperties:
+          type: array
+          description: The customUserProperties for this subscription
+          items:
+            $ref: '#/components/schemas/BridgeCustomUserProperty'
+        destination:
+          type: string
+          description: The destination topic for this filter set.
+          example: some/topic/value
+        excludes:
+          type: array
+          description: The exclusion patterns
+          items:
+            type: string
+            description: The exclusion patterns
+            nullable: true
+          nullable: true
+        filters:
+          type: array
+          description: The filters for this subscription.
+          example: some/topic/value
+          items:
+            type: string
+            description: The filters for this subscription.
+            example: some/topic/value
+        maxQoS:
+          type: integer
+          format: int32
+          default: 0
+          description: The maxQoS for this subscription.
+          enum:
+            - 0
+            - 1
+            - 2
+          maximum: 2
+          minimum: 0
+        preserveRetain:
+          type: boolean
+          description: The preserveRetain for this subscription
+        queueLimit:
+          type: integer
+          format: int64
+          description: The limit of this bridge for QoS-1 and QoS-2 messages.
+          nullable: true
+      required:
+        - destination
+        - filters
+        - maxQoS
+    Metric:
+      type: object
+      description: List of result items that are returned by this endpoint
+      properties:
+        name:
+          type: string
+          description: The name of the metric
+    MetricList:
+      type: object
+      properties:
+        items:
+          type: array
+          description: List of result items that are returned by this endpoint
+          items:
+            $ref: '#/components/schemas/Metric'
+    Module:
+      type: object
+      description: List of result items that are returned by this endpoint
+      properties:
+        author:
+          type: string
+          description: The module author
+        description:
+          type: string
+          description: The module description
+          nullable: true
+        documentationLink:
+          $ref: '#/components/schemas/Link'
+        id:
+          type: string
+          description: A mandatory ID associated with the Module
+        installed:
+          type: boolean
+          description: Is the module installed
+          nullable: true
+        logoUrl:
+          $ref: '#/components/schemas/Link'
+        moduleType:
+          type: string
+          description: The type of the module
+          nullable: true
+        name:
+          type: string
+          description: The module name
+        priority:
+          type: integer
+          format: int32
+          description: The module priority
+        provisioningLink:
+          $ref: '#/components/schemas/Link'
+        version:
+          type: string
+          description: The module version
+    ModuleList:
+      type: object
+      description: The modules available for installation
+      properties:
+        items:
+          type: array
+          description: List of result items that are returned by this endpoint
+          items:
+            $ref: '#/components/schemas/Module'
+    Notification:
+      type: object
+      description: List of result items that are returned by this endpoint
+      properties:
+        description:
+          type: string
+          description: The notification description
+          nullable: true
+        level:
+          type: string
+          description: The notification level
+          enum:
+            - NOTICE
+            - WARNING
+            - ERROR
+        link:
+          $ref: '#/components/schemas/Link'
+        title:
+          type: string
+          description: The notification title
+    NotificationList:
+      type: object
+      properties:
+        items:
+          type: array
+          description: List of result items that are returned by this endpoint
+          items:
+            $ref: '#/components/schemas/Notification'
+    ObjectNode:
+      type: object
+      description: List of result items that are returned by this endpoint
+      properties:
+        children:
+          type: array
+          items:
+            $ref: '#/components/schemas/ObjectNode'
+        description:
+          type: string
+        id:
+          type: string
+        name:
+          type: string
+        nodeType:
+          type: string
+          enum:
+            - FOLDER
+            - OBJECT
+            - VALUE
+        selectable:
+          type: boolean
+        value:
+          type: string
+    PaginationCursor:
+      type: object
+      description: Links for pagination
+      nullable: true
+      properties:
+        next:
+          type: string
+    Payload:
+      type: object
+      description: Object to denote the payload of the event
+      properties:
+        content:
+          type: string
+          description: The content of the payload encoded as a string
+        contentType:
+          type: string
+          description: The content type of the payload that the event contains
+          enum:
+            - JSON
+            - PLAIN_TEXT
+            - XML
+            - CSV
+      required:
+        - contentType
+    PolicyOperation:
+      type: object
+      description: The pipeline to execute when this action is triggered. The operations
+        in the pipeline are executed in order.
+      properties:
+        arguments:
+          type: object
+          description: The required arguments of the referenced function.
+        functionId:
+          type: string
+          description: The unique id of the referenced function to execute in this
+            operation.
+        id:
+          type: string
+          description: The unique id of the operation in the pipeline.
+      required:
+        - arguments
+        - functionId
+        - id
+    ProtocolAdapter:
+      type: object
+      description: List of result items that are returned by this endpoint
+      properties:
+        author:
+          type: string
+          description: The author of the adapter
+        capabilities:
+          type: array
+          description: The capabilities of this adapter
+          items:
+            type: string
+            description: The capabilities of this adapter
+            enum:
+              - READ
+              - DISCOVER
+          uniqueItems: true
+        category:
+          $ref: '#/components/schemas/ProtocolAdapterCategory'
+        configSchema:
+          $ref: '#/components/schemas/JsonNode'
+        description:
+          type: string
+          description: The description
+        id:
+          type: string
+          description: The id assigned to the protocol adapter type
+        installed:
+          type: boolean
+          description: Is the adapter installed?
+        logoUrl:
+          type: string
+          description: The logo of the adapter
+        name:
+          type: string
+          description: The name of the adapter
+        protocol:
+          type: string
+          description: The supported protocol
+        provisioningUrl:
+          type: string
+          description: The provisioning url of the adapter
+        tags:
+          type: array
+          description: The search tags associated with this adapter
+          items:
+            type: string
+            description: The search tags associated with this adapter
+        uiSchema:
+          $ref: '#/components/schemas/JsonNode'
+        url:
+          type: string
+          description: The url of the adapter
+        version:
+          type: string
+          description: The installed version of the adapter
+    ProtocolAdapterCategory:
+      type: object
+      description: The category of the adapter
+      properties:
+        description:
+          type: string
+          format: string
+          description: The description associated with the category.
+        displayName:
+          type: string
+          format: string
+          description: The display name of the category to be used in HCIs.
+          minLength: 1
+        image:
+          type: string
+          format: string
+          description: The image associated with the category.
+        name:
+          type: string
+          format: string
+          description: The unique name of the category to be used in API communication.
+          maxLength: 256
+          minLength: 1
+          pattern: "^[A-Za-z0-9-_](?:[A-Za-z0-9_ -]*[A-Za-z0-9_-])$"
+      required:
+        - displayName
+        - name
+    ProtocolAdaptersList:
+      type: object
+      properties:
+        items:
+          type: array
+          description: List of result items that are returned by this endpoint
+          items:
+            $ref: '#/components/schemas/ProtocolAdapter'
+    Schema:
+      type: object
+      properties:
+        arguments:
+          type: object
+          additionalProperties:
+            type: string
+            description: The schema type dependent arguments.
+          description: The schema type dependent arguments.
+        createdAt:
+          type: string
+          description: The formatted UTC timestamp when the schema was created.
+          readOnly: true
+        id:
+          type: string
+          description: The unique identifier of the schema.
+        schemaDefinition:
+          type: string
+          description: The base64 encoded schema definition.
+        type:
+          type: string
+          description: The type of the schema.
+        version:
+          type: integer
+          format: int32
+          description: The version of the schema.
+          readOnly: true
+      required:
+        - id
+        - schemaDefinition
+        - type
+    SchemaList:
+      type: object
+      description: A listing of schemas.
+      properties:
+        _links:
+          $ref: '#/components/schemas/PaginationCursor'
+        items:
+          type: array
+          description: List of result items that are returned by this endpoint
+          items:
+            $ref: '#/components/schemas/Schema'
+    SchemaReference:
+      type: object
+      description: A schema reference is a unique identifier for a schema.
+      properties:
+        schemaId:
+          type: string
+          description: The identifier of the schema.
+        version:
+          type: string
+          description: The version of the schema. The value "latest" may be used to
+            always refer to the latest schema.
+      required:
+        - schemaId
+        - version
+    Script:
+      type: object
+      properties:
+        createdAt:
+          type: string
+          description: The formatted UTC timestamp when the script was created.
+          readOnly: true
+        description:
+          type: string
+          description: A string of free-form text describing the function.
+        functionType:
+          type: string
+          description: The type of the function.
+          enum:
+            - TRANSFORMATION
+        id:
+          type: string
+          description: The unique identifier of the script.
+        source:
+          type: string
+          description: The base64 encoded function source code.
+        version:
+          type: integer
+          format: int32
+          description: The version of the script.
+          readOnly: true
+      required:
+        - functionType
+        - id
+        - source
+    ScriptList:
+      type: object
+      description: A listing of scripts.
+      properties:
+        _links:
+          $ref: '#/components/schemas/PaginationCursor'
+        items:
+          type: array
+          description: List of result items that are returned by this endpoint
+          items:
+            $ref: '#/components/schemas/Script'
+    Status:
+      type: object
+      description: Information associated with the runtime of this adapter
+      properties:
+        connection:
+          type: string
+          description: A mandatory connection status field.
+          enum:
+            - CONNECTED
+            - DISCONNECTED
+            - STATELESS
+            - UNKNOWN
+            - ERROR
+        id:
+          type: string
+          description: The identifier of the object
+        lastActivity:
+          type: string
+          format: date-time
+          description: The datetime of the last activity through this connection
+        message:
+          type: string
+          description: A message associated with the state of a connection
+        runtime:
+          type: string
+          description: A object status field.
+          enum:
+            - STARTED
+            - STOPPED
+        startedAt:
+          type: string
+          format: date-time
+          description: The datetime the object was 'started' in the system.
+        type:
+          type: string
+          description: The type of the object
+    StatusList:
+      type: object
+      properties:
+        items:
+          type: array
+          description: List of result items that are returned by this endpoint
+          items:
+            $ref: '#/components/schemas/Status'
+    StatusTransitionCommand:
+      type: object
+      properties:
+        command:
+          type: string
+          description: The command to perform on the target connection.
+          enum:
+            - START
+            - STOP
+            - RESTART
+    StatusTransitionResult:
+      type: object
+      properties:
+        callbackTimeoutMillis:
+          type: integer
+          format: int32
+          description: The callback timeout specifies the minimum amount of time (in
+            milliseconds) that the API advises the client to backoff before rechecking
+            the (runtime or connection) status of this object. This is only applicable
+            when the status is 'PENDING'.
+        identifier:
+          type: string
+          description: The identifier of the object in transition
+        status:
+          type: string
+          description: The status to perform on the target connection.
+          enum:
+            - PENDING
+            - COMPLETE
+        type:
+          type: string
+          description: The type of the object in transition
+    TlsConfiguration:
+      type: object
+      description: tlsConfiguration associated with the bridge
+      nullable: true
+      properties:
+        cipherSuites:
+          type: array
+          description: The cipherSuites from the config
+          items:
+            type: string
+            description: The cipherSuites from the config
+        enabled:
+          type: boolean
+          description: If TLS is used
+        handshakeTimeout:
+          type: integer
+          format: int32
+          description: The handshakeTimeout from the config
+        keystorePassword:
+          type: string
+          description: The keystorePassword from the config
+        keystorePath:
+          type: string
+          description: The keystorePath from the config
+          nullable: true
+        keystoreType:
+          type: string
+          description: The keystoreType from the config
+        privateKeyPassword:
+          type: string
+          description: The privateKeyPassword from the config
+        protocols:
+          type: array
+          description: The protocols from the config
+          items:
+            type: string
+            description: The protocols from the config
+        truststorePassword:
+          type: string
+          description: The truststorePassword from the config
+        truststorePath:
+          type: string
+          description: The truststorePath from the config
+          nullable: true
+        truststoreType:
+          type: string
+          description: The truststoreType from the config
+        verifyHostname:
+          type: boolean
+          default: false
+          description: The verifyHostname from the config
+    TypeIdentifier:
+      type: object
+      description: The unique id of the event object
+      properties:
+        fullQualifiedIdentifier:
+          type: string
+        identifier:
+          type: string
+          description: "The identifier associated with the object, a combination of\
+            \ type and identifier is used to uniquely identify an object in the system"
+        type:
+          type: string
+          description: The type of the associated object/entity
+          enum:
+            - BRIDGE
+            - ADAPTER
+            - ADAPTER_TYPE
+            - EVENT
+            - USER
+      required:
+        - type
+    UsernamePasswordCredentials:
+      type: object
+      properties:
+        password:
+          type: string
+          description: The password associated with the user
+        userName:
+          type: string
+          description: The userName associated with the user
+    ValuesTree:
+      type: object
+      properties:
+        items:
+          type: array
+          description: List of result items that are returned by this endpoint
+          items:
+            $ref: '#/components/schemas/ObjectNode'
+    WebsocketConfiguration:
+      type: object
+      description: websocketConfiguration associated with the bridge
+      nullable: true
+      properties:
+        enabled:
+          type: boolean
+          description: If Websockets are used
+        serverPath:
+          type: string
+          description: The server path from the config
+        subProtocol:
+          type: string
+          description: The subProtocol from the config

--- a/ext/hivemq-edge-openapi-2024.7.yaml
+++ b/ext/hivemq-edge-openapi-2024.7.yaml
@@ -5164,10 +5164,15 @@ components:
       properties:
         enabled:
           type: boolean
+          default: false
           description: If Websockets are used
         serverPath:
           type: string
-          description: The server path from the config
+          default: /mqtt
+          description: The server path used by the bridge client. This must be setup
+            as path at the remote broker
         subProtocol:
           type: string
-          description: The subProtocol from the config
+          default: mqtt
+          description: The sub-protocol used by the bridge client. This must be supported
+            by the remote broker

--- a/hivemq-edge/src/frontend/package.json
+++ b/hivemq-edge/src/frontend/package.json
@@ -11,7 +11,7 @@
     "lint:prettier:write": "prettier --write .",
     "lint:stylelint": "stylelint './src/**/*.css'",
     "lint:all": "eslint src --ext ts,tsx --report-unused-disable-directives --max-warnings 0 && prettier --check .",
-    "dev:openAPI": "openapi --input '../../../../hivemq-edge/ext/hivemq-edge-openapi-2024.6.yaml' -o ./src/api/__generated__ -c axios --name HiveMqClient --exportSchemas true",
+    "dev:openAPI": "openapi --input '../../../../hivemq-edge/ext/hivemq-edge-openapi-2024.7.yaml' -o ./src/api/__generated__ -c axios --name HiveMqClient --exportSchemas true",
     "dev:chakra:types": "chakra-cli tokens './src/modules/Theme/themeHiveMQ.ts' --out 'node_modules/.pnpm/@chakra-ui+styled-system@2.9.2/node_modules/@chakra-ui/styled-system/dist/theming.types.d.ts'",
     "cypress:open": "cypress open",
     "cypress:open:component": "cypress open --component --browser chrome",

--- a/hivemq-edge/src/frontend/src/api/__generated__/HiveMqClient.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/HiveMqClient.ts
@@ -53,7 +53,7 @@ export class HiveMqClient {
     constructor(config?: Partial<OpenAPIConfig>, HttpRequest: HttpRequestConstructor = AxiosHttpRequest) {
         this.request = new HttpRequest({
             BASE: config?.BASE ?? '',
-            VERSION: config?.VERSION ?? '2024.6',
+            VERSION: config?.VERSION ?? '2024.7',
             WITH_CREDENTIALS: config?.WITH_CREDENTIALS ?? false,
             CREDENTIALS: config?.CREDENTIALS ?? 'include',
             TOKEN: config?.TOKEN,

--- a/hivemq-edge/src/frontend/src/api/__generated__/core/OpenAPI.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/core/OpenAPI.ts
@@ -21,7 +21,7 @@ export type OpenAPIConfig = {
 
 export const OpenAPI: OpenAPIConfig = {
     BASE: '',
-    VERSION: '2024.6',
+    VERSION: '2024.7',
     WITH_CREDENTIALS: false,
     CREDENTIALS: 'include',
     TOKEN: undefined,

--- a/hivemq-edge/src/frontend/src/api/__generated__/index.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/index.ts
@@ -80,6 +80,7 @@ export type { TlsConfiguration } from './models/TlsConfiguration';
 export { TypeIdentifier } from './models/TypeIdentifier';
 export type { UsernamePasswordCredentials } from './models/UsernamePasswordCredentials';
 export type { ValuesTree } from './models/ValuesTree';
+export type { WebsocketConfiguration } from './models/WebsocketConfiguration';
 
 export { $Adapter } from './schemas/$Adapter';
 export { $AdaptersList } from './schemas/$AdaptersList';
@@ -151,6 +152,7 @@ export { $TlsConfiguration } from './schemas/$TlsConfiguration';
 export { $TypeIdentifier } from './schemas/$TypeIdentifier';
 export { $UsernamePasswordCredentials } from './schemas/$UsernamePasswordCredentials';
 export { $ValuesTree } from './schemas/$ValuesTree';
+export { $WebsocketConfiguration } from './schemas/$WebsocketConfiguration';
 
 export { AuthenticationService } from './services/AuthenticationService';
 export { AuthenticationEndpointService } from './services/AuthenticationEndpointService';

--- a/hivemq-edge/src/frontend/src/api/__generated__/models/Bridge.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/models/Bridge.ts
@@ -7,6 +7,7 @@ import type { BridgeSubscription } from './BridgeSubscription';
 import type { LocalBridgeSubscription } from './LocalBridgeSubscription';
 import type { Status } from './Status';
 import type { TlsConfiguration } from './TlsConfiguration';
+import type { WebsocketConfiguration } from './WebsocketConfiguration';
 
 export type Bridge = {
     /**
@@ -67,5 +68,6 @@ export type Bridge = {
      * The username value associated the the MQTT connection.
      */
     username?: string | null;
+    websocketConfiguration?: WebsocketConfiguration;
 };
 

--- a/hivemq-edge/src/frontend/src/api/__generated__/models/WebsocketConfiguration.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/models/WebsocketConfiguration.ts
@@ -12,11 +12,11 @@ export type WebsocketConfiguration = {
      */
     enabled?: boolean;
     /**
-     * The server path from the config
+     * The server path used by the bridge client. This must be setup as path at the remote broker
      */
     serverPath?: string;
     /**
-     * The subProtocol from the config
+     * The sub-protocol used by the bridge client. This must be supported by the remote broker
      */
     subProtocol?: string;
 };

--- a/hivemq-edge/src/frontend/src/api/__generated__/models/WebsocketConfiguration.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/models/WebsocketConfiguration.ts
@@ -1,0 +1,23 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * websocketConfiguration associated with the bridge
+ */
+export type WebsocketConfiguration = {
+    /**
+     * If Websockets are used
+     */
+    enabled?: boolean;
+    /**
+     * The server path from the config
+     */
+    serverPath?: string;
+    /**
+     * The subProtocol from the config
+     */
+    subProtocol?: string;
+};
+

--- a/hivemq-edge/src/frontend/src/api/__generated__/schemas/$Bridge.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/schemas/$Bridge.ts
@@ -102,5 +102,8 @@ export const $Bridge = {
             format: 'string',
             maxLength: 65535,
         },
+        websocketConfiguration: {
+            type: 'WebsocketConfiguration',
+        },
     },
 } as const;

--- a/hivemq-edge/src/frontend/src/api/__generated__/schemas/$WebsocketConfiguration.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/schemas/$WebsocketConfiguration.ts
@@ -1,0 +1,22 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $WebsocketConfiguration = {
+    description: `websocketConfiguration associated with the bridge`,
+    properties: {
+        enabled: {
+            type: 'boolean',
+            description: `If Websockets are used`,
+        },
+        serverPath: {
+            type: 'string',
+            description: `The server path from the config`,
+        },
+        subProtocol: {
+            type: 'string',
+            description: `The subProtocol from the config`,
+        },
+    },
+    isNullable: true,
+} as const;

--- a/hivemq-edge/src/frontend/src/api/__generated__/schemas/$WebsocketConfiguration.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/schemas/$WebsocketConfiguration.ts
@@ -11,11 +11,11 @@ export const $WebsocketConfiguration = {
         },
         serverPath: {
             type: 'string',
-            description: `The server path from the config`,
+            description: `The server path used by the bridge client. This must be setup as path at the remote broker`,
         },
         subProtocol: {
             type: 'string',
-            description: `The subProtocol from the config`,
+            description: `The sub-protocol used by the bridge client. This must be supported by the remote broker`,
         },
     },
     isNullable: true,

--- a/hivemq-edge/src/frontend/src/locales/en/translation.json
+++ b/hivemq-edge/src/frontend/src/locales/en/translation.json
@@ -340,6 +340,12 @@
         "helper": "Select to store MQTT Traffic greater than QoS 0 on disk."
       }
     },
+    "websocket": {
+      "description": "Websocket configuration associated with the bridge",
+      "enabled": { "label": "Enabled", "helper": "If Websockets are used" },
+      "serverPath": { "label": "Server Path", "helper": "The server path from the config" },
+      "subProtocol": { "label": "Subprotocols", "helper": "The subProtocol from the config" }
+    },
     "noDataWarning": {
       "title": "No bridges currently installed",
       "description": "Configure Bridges to start sending data to your enterprise MQTT broker."
@@ -353,7 +359,8 @@
       "connection": "Connection details",
       "broker": "Broker Configuration",
       "security": "Security",
-      "persistence": "Persistence"
+      "persistence": "Persistence",
+      "websocket": "Websocket"
     },
     "stepper": {
       "description": "Create a new bridge to a broker",

--- a/hivemq-edge/src/frontend/src/locales/en/translation.json
+++ b/hivemq-edge/src/frontend/src/locales/en/translation.json
@@ -344,7 +344,7 @@
       "description": "Websocket configuration associated with the bridge",
       "enabled": { "label": "Enabled", "helper": "If Websockets are used" },
       "serverPath": { "label": "Server Path", "helper": "The server path from the config" },
-      "subProtocol": { "label": "Subprotocols", "helper": "The subProtocol from the config" }
+      "subProtocol": { "label": "Subprotocol", "helper": "The Subprotocol from the config" }
     },
     "noDataWarning": {
       "title": "No bridges currently installed",

--- a/hivemq-edge/src/frontend/src/locales/en/translation.json
+++ b/hivemq-edge/src/frontend/src/locales/en/translation.json
@@ -343,8 +343,14 @@
     "websocket": {
       "description": "Websocket configuration associated with the bridge",
       "enabled": { "label": "Enabled", "helper": "If Websockets are used" },
-      "serverPath": { "label": "Server Path", "helper": "The server path from the config" },
-      "subProtocol": { "label": "Subprotocol", "helper": "The Subprotocol from the config" }
+      "serverPath": {
+        "label": "Server Path",
+        "helper": "The server path used by the bridge client. This must be setup as path at the remote broker."
+      },
+      "subProtocol": {
+        "label": "Sub-protocol",
+        "helper": "The sub-protocol used by the bridge client. This must be supported by the remote broker"
+      }
     },
     "noDataWarning": {
       "title": "No bridges currently installed",

--- a/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/BridgeMainDrawer.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/BridgeMainDrawer.tsx
@@ -29,6 +29,7 @@ import SubscriptionsPanel from '../panels/SubscriptionsPanel.tsx'
 import SecurityPanel from '../panels/SecurityPanel.tsx'
 import PersistencePanel from '../panels/PersistencePanel.tsx'
 import { useBridgeSetup } from '../../hooks/useBridgeConfig.tsx'
+import WebSocketPanel from '@/modules/Bridges/components/panels/WebSocketPanel.tsx'
 
 interface BridgeMainDrawerProps {
   isNewBridge?: boolean
@@ -90,6 +91,7 @@ const BridgeMainDrawer: FC<BridgeMainDrawerProps> = ({
                   <Tab>{t('bridge.drawer.connection')}</Tab>
                   <Tab>{t('bridge.drawer.broker')}</Tab>
                   <Tab>{t('bridge.drawer.security')}</Tab>
+                  <Tab>{t('bridge.drawer.websocket')}</Tab>
                   {hasPersistence && <Tab>{t('bridge.drawer.persistence')}</Tab>}
                 </TabList>
 
@@ -120,6 +122,10 @@ const BridgeMainDrawer: FC<BridgeMainDrawerProps> = ({
 
                   <TabPanel>
                     <SecurityPanel form={form} />
+                  </TabPanel>
+
+                  <TabPanel>
+                    <WebSocketPanel form={form} />
                   </TabPanel>
 
                   {hasPersistence && (

--- a/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/WebSocketPanel.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/WebSocketPanel.spec.cy.tsx
@@ -35,12 +35,17 @@ describe('WebSocketPanel', () => {
     cy.viewport(800, 800)
   })
 
-  it('should render properly', () => {
+  it.only('should render properly', () => {
     const mockOnSubmit = cy.stub().as('onSubmit')
     cy.mountWithProviders(<TestingComponent onSubmit={mockOnSubmit} defaultValues={mockBridge} />)
 
+    cy.getByTestId('form-websocket-serverPath').should('have.value', '/mqtt')
+    cy.getByTestId('form-websocket-subProtocol').should('have.value', 'mqtt')
+
     cy.getByTestId('form-websocket-enabled').click()
+    cy.getByTestId('form-websocket-serverPath').clear()
     cy.getByTestId('form-websocket-serverPath').type('1234')
+    cy.getByTestId('form-websocket-subProtocol').clear()
     cy.getByTestId('form-websocket-subProtocol').type('5678')
 
     cy.getByTestId('form-submit').click()

--- a/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/WebSocketPanel.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/WebSocketPanel.spec.cy.tsx
@@ -1,0 +1,62 @@
+/// <reference types="cypress" />
+import { useForm } from 'react-hook-form'
+import { FC } from 'react'
+import { Button } from '@chakra-ui/react'
+
+import { Bridge } from '@/api/__generated__'
+import { mockBridge } from '@/api/hooks/useGetBridges/__handlers__'
+import WebSocketPanel from '@/modules/Bridges/components/panels/WebSocketPanel.tsx'
+
+interface TestingComponentProps {
+  onSubmit: (data: Bridge) => void
+  defaultValues: Bridge
+}
+
+const TestingComponent: FC<TestingComponentProps> = ({ onSubmit, defaultValues }) => {
+  const form = useForm<Bridge>({
+    mode: 'all',
+    criteriaMode: 'all',
+    defaultValues: defaultValues,
+  })
+  return (
+    <div>
+      <form id="bridge-form" onSubmit={form.handleSubmit(onSubmit)}>
+        <WebSocketPanel form={form} />
+      </form>
+      <Button variant="primary" type="submit" form="bridge-form" data-testid="form-submit" mt={8}>
+        Submit
+      </Button>
+    </div>
+  )
+}
+
+describe('WebSocketPanel', () => {
+  beforeEach(() => {
+    cy.viewport(800, 800)
+  })
+
+  it('should render properly', () => {
+    const mockOnSubmit = cy.stub().as('onSubmit')
+    cy.mountWithProviders(<TestingComponent onSubmit={mockOnSubmit} defaultValues={mockBridge} />)
+
+    cy.getByTestId('form-websocket-enabled').click()
+    cy.getByTestId('form-websocket-serverPath').type('1234')
+    cy.getByTestId('form-websocket-subProtocol').type('5678')
+
+    cy.getByTestId('form-submit').click()
+    cy.get('@onSubmit').should(
+      'have.been.calledWith',
+      Cypress.sinon.match({
+        ...mockBridge,
+        websocketConfiguration: { enabled: true, serverPath: '1234', subProtocol: '5678' },
+      })
+    )
+  })
+
+  it('should be accessible', () => {
+    cy.injectAxe()
+    cy.mountWithProviders(<TestingComponent onSubmit={cy.stub} defaultValues={mockBridge} />)
+    cy.checkAccessibility()
+    cy.percySnapshot('Component: WebSocketPanel')
+  })
+})

--- a/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/WebSocketPanel.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/WebSocketPanel.tsx
@@ -15,7 +15,9 @@ const WebSocketPanel: FC<BridgePanelType> = ({ form }) => {
     <FormControl variant="hivemq" flexGrow={1} display="flex" flexDirection="column" gap={4} as="fieldset">
       <Text>{t('bridge.websocket.description')}</Text>
       <FormControl isInvalid={!!errors.websocketConfiguration?.enabled}>
-        <Checkbox {...register('websocketConfiguration.enabled')}>{t('bridge.websocket.enabled.label')}</Checkbox>
+        <Checkbox {...register('websocketConfiguration.enabled')} data-testid="form-websocket-enabled">
+          {t('bridge.websocket.enabled.label')}
+        </Checkbox>
         <FormHelperText>{t('bridge.websocket.enabled.helper')}</FormHelperText>
         <FormErrorMessage>
           {errors.websocketConfiguration?.enabled && errors.websocketConfiguration.enabled.message}
@@ -23,7 +25,9 @@ const WebSocketPanel: FC<BridgePanelType> = ({ form }) => {
       </FormControl>
 
       <FormControl as="fieldset" variant="hivemq">
-        <FormLabel htmlFor="serverPath">{t('bridge.websocket.serverPath.label')}</FormLabel>
+        <FormLabel htmlFor="serverPath" data-testid="form-websocket-serverPath">
+          {t('bridge.websocket.serverPath.label')}
+        </FormLabel>
         <Input
           autoFocus
           id="serverPath"
@@ -35,7 +39,9 @@ const WebSocketPanel: FC<BridgePanelType> = ({ form }) => {
       </FormControl>
 
       <FormControl as="fieldset" variant="hivemq">
-        <FormLabel htmlFor="subProtocol">{t('bridge.websocket.subProtocol.label')}</FormLabel>
+        <FormLabel htmlFor="subProtocol" data-testid="form-websocket-subProtocol">
+          {t('bridge.websocket.subProtocol.label')}
+        </FormLabel>
         <Input
           autoFocus
           id="subProtocol"

--- a/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/WebSocketPanel.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/WebSocketPanel.tsx
@@ -15,7 +15,7 @@ const WebSocketPanel: FC<BridgePanelType> = ({ form }) => {
     <FormControl variant="hivemq" flexGrow={1} display="flex" flexDirection="column" gap={4} as="fieldset">
       <Text>{t('bridge.websocket.description')}</Text>
       <FormControl isInvalid={!!errors.websocketConfiguration?.enabled}>
-        <Checkbox {...register('persist')}>{t('bridge.websocket.enabled.label')}</Checkbox>
+        <Checkbox {...register('websocketConfiguration.enabled')}>{t('bridge.websocket.enabled.label')}</Checkbox>
         <FormHelperText>{t('bridge.websocket.enabled.helper')}</FormHelperText>
         <FormErrorMessage>
           {errors.websocketConfiguration?.enabled && errors.websocketConfiguration.enabled.message}
@@ -23,7 +23,7 @@ const WebSocketPanel: FC<BridgePanelType> = ({ form }) => {
       </FormControl>
 
       <FormControl as="fieldset" variant="hivemq">
-        <FormLabel htmlFor="name">{t('bridge.websocket.serverPath.label')}</FormLabel>
+        <FormLabel htmlFor="serverPath">{t('bridge.websocket.serverPath.label')}</FormLabel>
         <Input
           autoFocus
           id="serverPath"
@@ -35,10 +35,10 @@ const WebSocketPanel: FC<BridgePanelType> = ({ form }) => {
       </FormControl>
 
       <FormControl as="fieldset" variant="hivemq">
-        <FormLabel htmlFor="name">{t('bridge.websocket.subProtocol.label')}</FormLabel>
+        <FormLabel htmlFor="subProtocol">{t('bridge.websocket.subProtocol.label')}</FormLabel>
         <Input
           autoFocus
-          id="serverPath"
+          id="subProtocol"
           type="text"
           autoComplete="name"
           {...register('websocketConfiguration.subProtocol')}

--- a/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/WebSocketPanel.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/WebSocketPanel.tsx
@@ -25,10 +25,9 @@ const WebSocketPanel: FC<BridgePanelType> = ({ form }) => {
       </FormControl>
 
       <FormControl as="fieldset" variant="hivemq">
-        <FormLabel htmlFor="serverPath" data-testid="form-websocket-serverPath">
-          {t('bridge.websocket.serverPath.label')}
-        </FormLabel>
+        <FormLabel htmlFor="serverPath">{t('bridge.websocket.serverPath.label')}</FormLabel>
         <Input
+          data-testid="form-websocket-serverPath"
           autoFocus
           id="serverPath"
           type="text"
@@ -40,10 +39,9 @@ const WebSocketPanel: FC<BridgePanelType> = ({ form }) => {
       </FormControl>
 
       <FormControl as="fieldset" variant="hivemq">
-        <FormLabel htmlFor="subProtocol" data-testid="form-websocket-subProtocol">
-          {t('bridge.websocket.subProtocol.label')}
-        </FormLabel>
+        <FormLabel htmlFor="subProtocol">{t('bridge.websocket.subProtocol.label')}</FormLabel>
         <Input
+          data-testid="form-websocket-subProtocol"
           autoFocus
           id="subProtocol"
           type="text"

--- a/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/WebSocketPanel.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/WebSocketPanel.tsx
@@ -1,0 +1,52 @@
+import { FC } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Checkbox, FormControl, FormErrorMessage, FormHelperText, FormLabel, Input, Text } from '@chakra-ui/react'
+
+import { BridgePanelType } from '../../types.ts'
+
+const WebSocketPanel: FC<BridgePanelType> = ({ form }) => {
+  const { t } = useTranslation()
+  const {
+    register,
+    formState: { errors },
+  } = form
+
+  return (
+    <FormControl variant="hivemq" flexGrow={1} display="flex" flexDirection="column" gap={4} as="fieldset">
+      <Text>{t('bridge.websocket.description')}</Text>
+      <FormControl isInvalid={!!errors.websocketConfiguration?.enabled}>
+        <Checkbox {...register('persist')}>{t('bridge.websocket.enabled.label')}</Checkbox>
+        <FormHelperText>{t('bridge.websocket.enabled.helper')}</FormHelperText>
+        <FormErrorMessage>
+          {errors.websocketConfiguration?.enabled && errors.websocketConfiguration.enabled.message}
+        </FormErrorMessage>
+      </FormControl>
+
+      <FormControl as="fieldset" variant="hivemq">
+        <FormLabel htmlFor="name">{t('bridge.websocket.serverPath.label')}</FormLabel>
+        <Input
+          autoFocus
+          id="serverPath"
+          type="text"
+          autoComplete="name"
+          {...register('websocketConfiguration.serverPath')}
+        />
+        <FormHelperText>{t('bridge.websocket.serverPath.helper')}</FormHelperText>
+      </FormControl>
+
+      <FormControl as="fieldset" variant="hivemq">
+        <FormLabel htmlFor="name">{t('bridge.websocket.subProtocol.label')}</FormLabel>
+        <Input
+          autoFocus
+          id="serverPath"
+          type="text"
+          autoComplete="name"
+          {...register('websocketConfiguration.subProtocol')}
+        />
+        <FormHelperText>{t('bridge.websocket.subProtocol.helper')}</FormHelperText>
+      </FormControl>
+    </FormControl>
+  )
+}
+
+export default WebSocketPanel

--- a/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/WebSocketPanel.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/WebSocketPanel.tsx
@@ -32,7 +32,8 @@ const WebSocketPanel: FC<BridgePanelType> = ({ form }) => {
           autoFocus
           id="serverPath"
           type="text"
-          autoComplete="name"
+          autoComplete="serverPath"
+          defaultValue="/mqtt"
           {...register('websocketConfiguration.serverPath')}
         />
         <FormHelperText>{t('bridge.websocket.serverPath.helper')}</FormHelperText>
@@ -46,7 +47,8 @@ const WebSocketPanel: FC<BridgePanelType> = ({ form }) => {
           autoFocus
           id="subProtocol"
           type="text"
-          autoComplete="name"
+          autoComplete="subProtocol"
+          defaultValue="mqtt"
           {...register('websocketConfiguration.subProtocol')}
         />
         <FormHelperText>{t('bridge.websocket.subProtocol.helper')}</FormHelperText>


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/24592/details/

The PR adds a new tab to the `Bridge` configuration panel, allowing users to enable websockets and their options

### Design
- Both `serverpath` and `subprotocol` are open string input, without any validation

### Out-of-scope
- There are now 5 tabs in the configuration panel, reaching a good-practice limit. Reorganising the options should be part of a subsequent ticket


### Before
![screenshot-localhost_3000-2024 08 06-11_09_36](https://github.com/user-attachments/assets/31138684-e449-4ab5-a0da-1f7e25c37e4e)

### After
![screenshot-localhost_3000-2024 08 06-14_55_49](https://github.com/user-attachments/assets/b3618acd-8834-4c76-9c92-92642801c4d9)

