### PR TITLE
fix(24988): Fix the drag-select creation of group

### DIFF
--- a/hivemq-edge/src/frontend/src/__test-utils__/react-flow/ReactFlowTesting.tsx
+++ b/hivemq-edge/src/frontend/src/__test-utils__/react-flow/ReactFlowTesting.tsx
@@ -29,15 +29,15 @@ export const ReactFlowTesting: FC<ReactFlowTestingProps> = ({ children, dashboar
     const { initialState } = config
     if (initialState?.nodes)
       onAddNodes(
-        initialState.nodes.map((n) => ({
-          item: n,
+        initialState.nodes.map((node) => ({
+          item: node,
           type: 'add',
         }))
       )
     if (initialState?.edges)
       onAddEdges(
-        initialState.edges.map((e) => ({
-          item: e,
+        initialState.edges.map((edge) => ({
+          item: edge,
           type: 'add',
         }))
       )

--- a/hivemq-edge/src/frontend/src/__test-utils__/react-flow/ReactFlowTesting.tsx
+++ b/hivemq-edge/src/frontend/src/__test-utils__/react-flow/ReactFlowTesting.tsx
@@ -1,0 +1,61 @@
+import { type FC, type ReactNode, useEffect } from 'react'
+import { ReactFlowProvider } from 'reactflow'
+
+import useWorkspaceStore from '@/modules/Workspace/hooks/useWorkspaceStore.ts'
+import { EdgeFlowProvider } from '@/modules/Workspace/hooks/FlowContext.tsx'
+import { type WorkspaceState } from '@/modules/Workspace/types.ts'
+import { Card, CardBody, CardHeader } from '@chakra-ui/react'
+
+type Optional<T, K extends keyof T> = Pick<Partial<T>, K> & Omit<T, K>
+interface ReactFlowTestingConfig {
+  initialState?: Optional<WorkspaceState, 'nodes' | 'edges'>
+}
+
+interface MockStoreWrapperProps {
+  children: ReactNode
+  dashboard?: ReactNode
+  showDashboard?: boolean
+  config: ReactFlowTestingConfig
+}
+
+export const ReactFlowTesting: FC<MockStoreWrapperProps> = ({ children, dashboard, showDashboard = false, config }) => {
+  const { reset, onAddNodes, onAddEdges } = useWorkspaceStore()
+
+  useEffect(() => {
+    reset()
+  }, [reset])
+
+  useEffect(() => {
+    const { initialState } = config
+    if (initialState?.nodes)
+      onAddNodes(
+        initialState.nodes.map((n) => ({
+          item: n,
+          type: 'add',
+        }))
+      )
+    if (initialState?.edges)
+      onAddEdges(
+        initialState.edges.map((e) => ({
+          item: e,
+          type: 'add',
+        }))
+      )
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  return (
+    <EdgeFlowProvider>
+      <ReactFlowProvider>
+        {children}
+        {dashboard && showDashboard && (
+          <Card mt={50} size="sm" variant="filled" colorScheme="red">
+            <CardHeader>Testing Dashboard</CardHeader>
+            <CardBody>{dashboard}</CardBody>
+          </Card>
+        )}
+      </ReactFlowProvider>
+    </EdgeFlowProvider>
+  )
+}

--- a/hivemq-edge/src/frontend/src/__test-utils__/react-flow/ReactFlowTesting.tsx
+++ b/hivemq-edge/src/frontend/src/__test-utils__/react-flow/ReactFlowTesting.tsx
@@ -11,14 +11,14 @@ interface ReactFlowTestingConfig {
   initialState?: Optional<WorkspaceState, 'nodes' | 'edges'>
 }
 
-interface MockStoreWrapperProps {
+interface ReactFlowTestingProps {
   children: ReactNode
   dashboard?: ReactNode
   showDashboard?: boolean
   config: ReactFlowTestingConfig
 }
 
-export const ReactFlowTesting: FC<MockStoreWrapperProps> = ({ children, dashboard, showDashboard = false, config }) => {
+export const ReactFlowTesting: FC<ReactFlowTestingProps> = ({ children, dashboard, showDashboard = false, config }) => {
   const { reset, onAddNodes, onAddEdges } = useWorkspaceStore()
 
   useEffect(() => {

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/controls/GroupNodesControl.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/controls/GroupNodesControl.spec.cy.tsx
@@ -1,0 +1,106 @@
+import { Checkbox, Stack, Text } from '@chakra-ui/react'
+import { MOCK_NODE_ADAPTER, MOCK_NODE_BRIDGE } from '@/__test-utils__/react-flow/nodes.ts'
+import { ReactFlowTesting } from '@/__test-utils__/react-flow/ReactFlowTesting.tsx'
+import useWorkspaceStore from '@/modules/Workspace/hooks/useWorkspaceStore.ts'
+
+import GroupNodesControl from '@/modules/Workspace/components/controls/GroupNodesControl.tsx'
+
+const Wrapper: React.JSXElementConstructor<{ children: React.ReactNode; showDashboard?: boolean }> = ({
+  children,
+  showDashboard = true,
+}) => {
+  const { nodes, onNodesChange } = useWorkspaceStore()
+
+  return (
+    <ReactFlowTesting
+      config={{
+        initialState: {
+          nodes: [
+            { ...MOCK_NODE_ADAPTER, position: { x: 0, y: 0 } },
+            { ...MOCK_NODE_ADAPTER, id: 'idAdapter2', position: { x: 0, y: 0 } },
+            { ...MOCK_NODE_BRIDGE, position: { x: 0, y: 0 } },
+          ],
+        },
+      }}
+      showDashboard={showDashboard}
+      dashboard={
+        <Stack direction="column">
+          {nodes.map((e) => (
+            <Checkbox
+              size="sm"
+              key={e.id}
+              isChecked={e.selected}
+              onChange={() => {
+                onNodesChange([{ id: e.id, type: 'select', selected: !e.selected }])
+              }}
+              data-testid="node-checked"
+            >
+              <Text as="span" data-testid="node-type">
+                {e.type}
+              </Text>{' '}
+              <Text as="span" data-testid="node-group">
+                {e.parentNode || e.parentId ? 'Grouped' : ''}
+              </Text>{' '}
+              <Text as="span" data-testid="node-id">
+                ({e.id})
+              </Text>
+            </Checkbox>
+          ))}
+        </Stack>
+      }
+    >
+      {children}
+    </ReactFlowTesting>
+  )
+}
+
+const WrapperLight: React.JSXElementConstructor<{ children: React.ReactNode }> = ({ children }) => (
+  <Wrapper showDashboard={false}>{children}</Wrapper>
+)
+
+describe('GroupNodesControl', () => {
+  beforeEach(() => {
+    cy.viewport(500, 400)
+  })
+
+  it('should render properly', () => {
+    cy.mountWithProviders(<GroupNodesControl />, { wrapper: Wrapper })
+
+    cy.getByAriaLabel('Group the selected entities').should('be.disabled')
+    cy.getByTestId('node-checked').should('have.length', 3)
+
+    cy.getByTestId('node-checked').eq(0).should('not.have.attr', 'data-checked')
+    cy.getByTestId('node-checked').eq(0).click()
+    cy.getByTestId('node-checked').eq(0).should('have.attr', 'data-checked')
+    cy.getByTestId('node-checked').eq(0).should('not.contain.text', 'Grouped')
+    cy.getByTestId('node-checked').eq(2).click()
+    cy.getByTestId('node-checked').eq(2).should('have.attr', 'data-checked')
+
+    cy.getByAriaLabel('Group the selected entities').should('be.disabled')
+    cy.getByTestId('node-checked').eq(1).click()
+    cy.getByTestId('node-checked').eq(1).should('have.attr', 'data-checked')
+    cy.getByTestId('node-checked').eq(1).should('not.contain.text', 'Grouped')
+
+    cy.getByAriaLabel('Group the selected entities').should('not.be.disabled')
+
+    cy.getByAriaLabel('Group the selected entities').click()
+
+    cy.getByTestId('node-checked').should('have.length', 4)
+
+    cy.getByTestId('node-checked').eq(0).should('contain.text', 'CLUSTER_NODE')
+    cy.getByTestId('node-checked').eq(0).should('not.have.attr', 'data-checked')
+    cy.getByTestId('node-checked').eq(1).should('not.have.attr', 'data-checked')
+    cy.getByTestId('node-checked').eq(1).should('contain.text', 'Grouped')
+    cy.getByTestId('node-checked').eq(2).should('not.have.attr', 'data-checked')
+    cy.getByTestId('node-checked').eq(1).should('contain.text', 'Grouped')
+    cy.getByTestId('node-checked').eq(3).should('have.attr', 'data-checked')
+  })
+
+  it('should be accessible', () => {
+    cy.injectAxe()
+    cy.mountWithProviders(<GroupNodesControl />, { wrapper: WrapperLight })
+
+    cy.checkAccessibility()
+    cy.percySnapshot('Component: GroupNodesControl')
+  })
+})

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/controls/GroupNodesControl.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/controls/GroupNodesControl.spec.cy.tsx
@@ -25,24 +25,24 @@ const Wrapper: React.JSXElementConstructor<{ children: React.ReactNode; showDash
       showDashboard={showDashboard}
       dashboard={
         <Stack direction="column">
-          {nodes.map((e) => (
+          {nodes.map((node) => (
             <Checkbox
               size="sm"
-              key={e.id}
-              isChecked={e.selected}
+              key={node.id}
+              isChecked={node.selected}
               onChange={() => {
-                onNodesChange([{ id: e.id, type: 'select', selected: !e.selected }])
+                onNodesChange([{ id: node.id, type: 'select', selected: !node.selected }])
               }}
               data-testid="node-checked"
             >
               <Text as="span" data-testid="node-type">
-                {e.type}
+                {node.type}
               </Text>{' '}
               <Text as="span" data-testid="node-group">
-                {e.parentNode || e.parentId ? 'Grouped' : ''}
+                {node.parentNode || node.parentId ? 'Grouped' : ''}
               </Text>{' '}
               <Text as="span" data-testid="node-id">
-                ({e.id})
+                ({node.id})
               </Text>
             </Checkbox>
           ))}

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/controls/GroupNodesControl.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/controls/GroupNodesControl.tsx
@@ -1,31 +1,30 @@
-import { FC, useState } from 'react'
-import { Edge, MarkerType, Node, Panel, useOnSelectionChange } from 'reactflow'
+import { FC, useEffect, useState } from 'react'
+import { Edge, MarkerType, Node, Panel } from 'reactflow'
 import { useTranslation } from 'react-i18next'
 import { Icon, useTheme } from '@chakra-ui/react'
 import { ImMakeGroup } from 'react-icons/im'
 
 import { Adapter, Status } from '@/api/__generated__'
-import { EdgeTypes, Group, IdStubs, NodeTypes } from '../../types.ts'
-import useWorkspaceStore from '../../hooks/useWorkspaceStore.ts'
-import { getThemeForStatus } from '../../utils/status-utils.ts'
-import { getGroupLayout } from '../../utils/group.utils.ts'
 import IconButton from '@/components/Chakra/IconButton.tsx'
+import useWorkspaceStore from '@/modules/Workspace/hooks/useWorkspaceStore.ts'
+import { EdgeTypes, Group, IdStubs, NodeTypes } from '@/modules/Workspace/types.ts'
+import { getGroupLayout } from '@/modules/Workspace/utils/group.utils.ts'
+import { getThemeForStatus } from '@/modules/Workspace/utils/status-utils.ts'
 
 const GroupNodesControl: FC = () => {
   const { t } = useTranslation()
-  const { onInsertGroupNode } = useWorkspaceStore()
+  const { onInsertGroupNode, nodes } = useWorkspaceStore()
   const [currentSelection, setCurrentSelection] = useState<Node[]>([])
   const theme = useTheme()
 
-  useOnSelectionChange({
-    onChange: ({ nodes }) => {
-      if (nodes.length >= 2)
-        setCurrentSelection(() =>
-          nodes.filter((node) => node.type === NodeTypes.ADAPTER_NODE && node.parentNode === undefined)
-        )
-      else setCurrentSelection([])
-    },
-  })
+  useEffect(() => {
+    const selectedNodes = nodes.filter((node) => node.selected)
+    if (selectedNodes.length >= 2)
+      setCurrentSelection(() =>
+        selectedNodes.filter((node) => node.type === NodeTypes.ADAPTER_NODE && node.parentNode === undefined)
+      )
+    else setCurrentSelection([])
+  }, [nodes])
 
   const onCreateGroup = () => {
     const groupId = `${IdStubs.GROUP_NODE}@${currentSelection.map((e) => e.data.id).join('+')}`


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/24988/details/

The PR corrects a misbehaviour when creating groups., by allowing drag-and-select to indicate nodes that need to be grouped. 

The current approach was only considering nodes that were click-and-selected. 


### Before
![screenshot-localhost_3000-2024 08 14-18_25_13](https://github.com/user-attachments/assets/2c0ae999-2025-4da4-a1d4-63317c87f94a)

### After

![screenshot-localhost_3000-2024 08 14-18_24_50](https://github.com/user-attachments/assets/cfcdca98-4ebf-47ba-96e8-22fc64ad8e1f)
