### PR TITLE
refactor(25468): Refactor adapter routes to expose the adapter type

### DIFF
--- a/hivemq-edge/src/frontend/src/api/hooks/useEvents/__handlers__/index.ts
+++ b/hivemq-edge/src/frontend/src/api/hooks/useEvents/__handlers__/index.ts
@@ -4,6 +4,7 @@ import { Event, EventList, Payload, TypeIdentifier } from '@/api/__generated__'
 import { DateTime } from 'luxon'
 import { mockBridge } from '@/api/hooks/useGetBridges/__handlers__'
 
+const MOCK_ID_SHIFT = 100
 const makeID = (type: TypeIdentifier.type, inc: number): TypeIdentifier => ({
   identifier: `${type}-${inc}`,
   type: type,
@@ -49,7 +50,7 @@ export const mockEdgeEvent = (n = maxEvents): Event[] =>
     payload: contentType[x % 3],
 
     source: makeID(sourceKeys[x % sourceKeys.length] as TypeIdentifier.type, x),
-    associatedObject: makeID(sourceKeys[x % sourceKeys.length] as TypeIdentifier.type, x + 100),
+    associatedObject: makeID(sourceKeys[x % sourceKeys.length] as TypeIdentifier.type, x + MOCK_ID_SHIFT),
     created: DateTime.fromISO('2023-10-13T11:51:24.234')
       .plus({ minutes: x % 100 })
       .toISO({ format: 'basic' }) as string,

--- a/hivemq-edge/src/frontend/src/api/hooks/useEvents/__handlers__/index.ts
+++ b/hivemq-edge/src/frontend/src/api/hooks/useEvents/__handlers__/index.ts
@@ -49,7 +49,7 @@ export const mockEdgeEvent = (n = maxEvents): Event[] =>
     payload: contentType[x % 3],
 
     source: makeID(sourceKeys[x % sourceKeys.length] as TypeIdentifier.type, x),
-    associatedObject: makeID(sourceKeys[x % sourceKeys.length] as TypeIdentifier.type, x),
+    associatedObject: makeID(sourceKeys[x % sourceKeys.length] as TypeIdentifier.type, x + 100),
     created: DateTime.fromISO('2023-10-13T11:51:24.234')
       .plus({ minutes: x % 100 })
       .toISO({ format: 'basic' }) as string,

--- a/hivemq-edge/src/frontend/src/modules/App/routes.tsx
+++ b/hivemq-edge/src/frontend/src/modules/App/routes.tsx
@@ -70,7 +70,7 @@ export const routes = createBrowserRouter(
           element: <EdgeFlowPage />,
           children: [
             {
-              path: ':nodeType/:nodeId',
+              path: ':nodeType/:device?/:adapter?/:nodeId',
               element: <NodePanelController />,
             },
           ],

--- a/hivemq-edge/src/frontend/src/modules/App/routes.tsx
+++ b/hivemq-edge/src/frontend/src/modules/App/routes.tsx
@@ -52,15 +52,15 @@ export const routes = createBrowserRouter(
           element: <ProtocolAdapterPage />,
           children: [
             {
-              path: 'new',
+              path: 'new/:type',
               element: <AdapterController isNew />,
             },
             {
-              path: ':adapterId',
+              path: 'edit/:type/:adapterId',
               element: <AdapterController />,
             },
             {
-              path: ':adapterId/export',
+              path: 'edit/:type/:adapterId/export',
               element: <ExportDrawer />,
             },
           ],

--- a/hivemq-edge/src/frontend/src/modules/EventLog/components/SourceLink.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/EventLog/components/SourceLink.spec.cy.tsx
@@ -16,10 +16,12 @@ describe('SourceLink', () => {
   })
 
   it('should render the adapter component', () => {
-    cy.mountWithProviders(<SourceLink source={mockEdgeEvent(5)[1].source} />)
+    cy.mountWithProviders(
+      <SourceLink source={mockEdgeEvent(5)[1].source} type={mockEdgeEvent(5)[1].associatedObject} />
+    )
 
     cy.get('a').should('contain.text', 'ADAPTER-1')
-    cy.get('a').should('have.attr', 'href', '/protocol-adapters/ADAPTER-1')
+    cy.get('a').should('have.attr', 'href', '/protocol-adapters/edit/ADAPTER-101/ADAPTER-1')
   })
 
   it('should render the adapter type component', () => {

--- a/hivemq-edge/src/frontend/src/modules/EventLog/components/SourceLink.tsx
+++ b/hivemq-edge/src/frontend/src/modules/EventLog/components/SourceLink.tsx
@@ -12,40 +12,38 @@ interface SourceLinkProps {
   type?: TypeIdentifier | undefined
 }
 
-interface LinkWrapperProps {
-  Icon: JSX.Element
-  To?: (id: string) => string | undefined
-  State?: (id: string) => AdapterNavigateState
-}
-
-const LinkWrapper: Record<TypeIdentifier.type, LinkWrapperProps> = {
-  [TypeIdentifier.type.ADAPTER]: {
-    Icon: <Icon as={PiPlugsConnectedFill} mr={2} />,
-    State: (id: string) => ({
-      protocolAdapterTabIndex: ProtocolAdapterTabIndex.ADAPTERS,
-      protocolAdapterType: id,
-    }),
-    To: (id: string) => `/protocol-adapters/${id}`,
-  },
-  [TypeIdentifier.type.ADAPTER_TYPE]: {
-    Icon: <Icon as={PiPlugsConnectedFill} mr={2} />,
-  },
-  [TypeIdentifier.type.BRIDGE]: {
-    Icon: <Icon as={PiBridgeThin} fontSize="20px" mr={2} />,
-    To: (id: string) => `/mqtt-bridges/${id}`,
-  },
-  [TypeIdentifier.type.EVENT]: {
-    Icon: <Icon as={MdOutlineEventNote} mr={2} />,
-  },
-  [TypeIdentifier.type.USER]: {
-    Icon: <Icon as={PiUserFill} mr={2} />,
-  },
-}
-
 const SourceLink: FC<SourceLinkProps> = ({ source, type }) => {
-  const SourceType = source?.type && LinkWrapper[source?.type]
+  let icon: JSX.Element | undefined
+  let to: string | undefined
+  let state: AdapterNavigateState | undefined
 
-  if (!SourceType?.To)
+  switch (source?.type) {
+    case TypeIdentifier.type.ADAPTER:
+      icon = <Icon as={PiPlugsConnectedFill} mr={2} />
+      state = {
+        protocolAdapterTabIndex: ProtocolAdapterTabIndex.ADAPTERS,
+        protocolAdapterType: type?.identifier,
+      }
+      to = `/protocol-adapters/edit/${type?.identifier}/${source.identifier}`
+      break
+    case TypeIdentifier.type.ADAPTER_TYPE:
+      icon = <Icon as={PiPlugsConnectedFill} mr={2} />
+      break
+    case TypeIdentifier.type.BRIDGE:
+      icon = <Icon as={PiBridgeThin} fontSize="20px" mr={2} />
+      to = `/mqtt-bridges/${source.identifier}`
+      break
+    case TypeIdentifier.type.EVENT:
+      icon = <Icon as={MdOutlineEventNote} mr={2} />
+      break
+    case TypeIdentifier.type.USER:
+      icon = <Icon as={PiUserFill} mr={2} />
+      break
+    default:
+      break
+  }
+
+  if (!to)
     return (
       <Box whiteSpace="nowrap" display="inline-flex">
         {source?.identifier}
@@ -53,14 +51,8 @@ const SourceLink: FC<SourceLinkProps> = ({ source, type }) => {
     )
 
   return (
-    <ChakraLink
-      as={ReactRouterLink}
-      to={source?.identifier && SourceType.To?.(source.identifier)}
-      state={type?.identifier && SourceType.State?.(type?.identifier)}
-      whiteSpace="nowrap"
-      display="inline-flex"
-    >
-      {source?.type && SourceType.Icon}
+    <ChakraLink as={ReactRouterLink} to={to} state={state} whiteSpace="nowrap" display="inline-flex">
+      {Boolean(icon) && icon}
       {source?.identifier}
     </ChakraLink>
   )

--- a/hivemq-edge/src/frontend/src/modules/EventLog/components/panel/EventDrawer.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/EventLog/components/panel/EventDrawer.spec.cy.tsx
@@ -17,11 +17,11 @@ describe('EventDrawer', () => {
 
     cy.get('[data-status]').should('contain.text', 'INFO')
     cy.getByTestId('event-title-created').should('contain.text', 'Created')
-    cy.getByTestId('event-value-created').should('contain.text', 'Friday, 13 October 2023 at 11:51:24.234')
+    cy.getByTestId('event-value-created').should('contain.text', 'Friday 13 October 2023 at 11:51:24.234')
     cy.getByTestId('event-title-source').should('contain.text', 'Source')
     cy.getByTestId('event-value-source').should('contain.text', 'BRIDGE-0')
     cy.getByTestId('event-title-associatedObject').should('contain.text', 'Associated Object')
-    cy.getByTestId('event-value-associatedObject').should('contain.text', 'BRIDGE-0')
+    cy.getByTestId('event-value-associatedObject').should('contain.text', 'BRIDGE-100')
 
     cy.getByTestId('event-value-message').should('contain.text', 'Lorem ipsum dolor sit amet')
     cy.getByTestId('event-title-payload').should('contain.text', 'Payload')

--- a/hivemq-edge/src/frontend/src/modules/EventLog/components/panel/EventDrawer.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/EventLog/components/panel/EventDrawer.spec.cy.tsx
@@ -17,7 +17,7 @@ describe('EventDrawer', () => {
 
     cy.get('[data-status]').should('contain.text', 'INFO')
     cy.getByTestId('event-title-created').should('contain.text', 'Created')
-    cy.getByTestId('event-value-created').should('contain.text', 'Friday 13 October 2023 at 11:51:24.234')
+    cy.getByTestId('event-value-created').should('contain.text', 'Friday, 13 October 2023 at 11:51:24.234')
     cy.getByTestId('event-title-source').should('contain.text', 'Source')
     cy.getByTestId('event-value-source').should('contain.text', 'BRIDGE-0')
     cy.getByTestId('event-title-associatedObject').should('contain.text', 'Associated Object')

--- a/hivemq-edge/src/frontend/src/modules/EventLog/components/panel/EventDrawer.tsx
+++ b/hivemq-edge/src/frontend/src/modules/EventLog/components/panel/EventDrawer.tsx
@@ -67,7 +67,7 @@ const EventDrawer: FC<BridgeMainDrawerProps> = ({ event, isOpen, onClose }) => {
                       <Text>{t('eventLog.table.header.source')}</Text>
                     </GridItem>
                     <GridItem data-testid="event-value-source">
-                      <SourceLink source={event?.source} />
+                      <SourceLink source={event?.source} type={event?.associatedObject} />
                     </GridItem>
                     <GridItem data-testid="event-title-associatedObject">
                       <Text>{t('eventLog.table.header.associatedObject')}</Text>

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/panels/ProtocolAdapters.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/panels/ProtocolAdapters.tsx
@@ -76,7 +76,7 @@ const ProtocolAdapters: FC = () => {
         protocolAdapterTabIndex: ProtocolAdapterTabIndex.ADAPTERS,
         protocolAdapterType: type,
       }
-      navigate('/protocol-adapters/new', { state: adapterNavigateState })
+      navigate(`/protocol-adapters/new/${type}`, { state: adapterNavigateState })
     }
 
     const handleEditInstance = (adapterId: string, type: string) => {
@@ -84,7 +84,7 @@ const ProtocolAdapters: FC = () => {
         protocolAdapterTabIndex: ProtocolAdapterTabIndex.ADAPTERS,
         protocolAdapterType: type,
       }
-      if (adapterId) navigate(`/protocol-adapters/${adapterId}`, { state: adapterNavigateState })
+      if (adapterId) navigate(`/protocol-adapters/edit/${type}/${adapterId}`, { state: adapterNavigateState })
     }
 
     const handleOnDelete = (adapterId: string) => {
@@ -96,8 +96,8 @@ const ProtocolAdapters: FC = () => {
       if (adapterId) navigate(`/edge-flow`, { state: { selectedAdapter: { adapterId, type } } })
     }
 
-    const handleExport = (adapterId: string) => {
-      if (adapterId) navigate(`/protocol-adapters/${adapterId}/export`)
+    const handleExport = (adapterId: string, type: string) => {
+      if (adapterId) navigate(`/protocol-adapters/edit/${type}/${adapterId}/export`)
     }
 
     return [

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/panels/ProtocolIntegrationStore.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/panels/ProtocolIntegrationStore.tsx
@@ -33,7 +33,7 @@ const ProtocolIntegrationStore: FC = () => {
       protocolAdapterType: adapterId,
       // selectedActiveAdapter: { isNew: false, isOpen: false, adapterId: (selected?.data as Adapter).id },
     }
-    navigate('/protocol-adapters/new', {
+    navigate(`/protocol-adapters/new/${adapterId}`, {
       state: adapterNavigateState,
     })
   }

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/controls/NodePanelController.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/controls/NodePanelController.tsx
@@ -56,14 +56,13 @@ const NodePanelController: FC = () => {
         protocolAdapterType: (selectedNode?.data as Adapter).type,
         selectedActiveAdapter: { isNew: false, isOpen: false, adapterId: (selectedNode?.data as Adapter).id },
       }
-      navigate(
-        `/protocol-adapters/edit/${(selectedNode?.data as Adapter).type}/${(selectedNode?.data as Adapter).id}`,
-        {
-          state: adapterNavigateState,
-        }
-      )
+      const { id, type } = selectedNode?.data as Adapter
+      navigate(`/protocol-adapters/edit/${type}/${id}`, {
+        state: adapterNavigateState,
+      })
     } else if (selectedNode?.type === NodeTypes.BRIDGE_NODE) {
-      navigate(`/mqtt-bridges/${(selectedNode?.data as Bridge).id}`)
+      const { id } = selectedNode?.data as Bridge
+      navigate(`/mqtt-bridges/${id}`)
     }
   }
 

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/controls/NodePanelController.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/controls/NodePanelController.tsx
@@ -56,9 +56,12 @@ const NodePanelController: FC = () => {
         protocolAdapterType: (selectedNode?.data as Adapter).type,
         selectedActiveAdapter: { isNew: false, isOpen: false, adapterId: (selectedNode?.data as Adapter).id },
       }
-      navigate(`/protocol-adapters/${(selectedNode?.data as Adapter).id}`, {
-        state: adapterNavigateState,
-      })
+      navigate(
+        `/protocol-adapters/edit/${(selectedNode?.data as Adapter).type}/${(selectedNode?.data as Adapter).id}`,
+        {
+          state: adapterNavigateState,
+        }
+      )
     } else if (selectedNode?.type === NodeTypes.BRIDGE_NODE) {
       navigate(`/mqtt-bridges/${(selectedNode?.data as Bridge).id}`)
     }

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeAdapter.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeAdapter.tsx
@@ -23,7 +23,7 @@ const NodeAdapter: FC<NodeProps<Adapter>> = ({ id, data: adapter, selected }) =>
     if (!adapter.config) return []
     return discoverAdapterTopics(adapterProtocol, adapter.config).map((e) => ({ topic: e }))
   }, [adapter.config, adapterProtocol])
-  const { onContextMenu } = useContextMenu(id, selected, '/edge-flow/node')
+  const { onContextMenu } = useContextMenu(id, selected, `/edge-flow/node/adapter/${adapter.type}`)
 
   return (
     <>

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeBridge.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeBridge.tsx
@@ -17,7 +17,7 @@ const NodeBridge: FC<NodeProps<Bridge>> = ({ id, selected, data: bridge }) => {
   const { t } = useTranslation()
   const topics = getBridgeTopics(bridge)
   const { options } = useEdgeFlowContext()
-  const { onContextMenu } = useContextMenu(id, selected, '/edge-flow/node')
+  const { onContextMenu } = useContextMenu(id, selected, '/edge-flow/node/bridge')
 
   return (
     <>


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/25468/details/

The PR is a quick fix to change the router for adapters
- The routes are now including the `type` of the adapter
- The children's routes are rewritten to avoid conflicts

### Before
![Screenshot 2024-08-22 at 17 32 07](https://github.com/user-attachments/assets/882eb44c-e4d2-49f4-bebe-bc3a4e1bf048)

### After
![Screenshot 2024-08-22 at 17 31 43](https://github.com/user-attachments/assets/042ccb89-55ba-48dc-b160-4a48629aec9c)
