### PR TITLE
fix(25622): fix bug with compact table

### DIFF
--- a/hivemq-edge/src/frontend/src/components/rjsf/Fields/CompactArrayField.tsx
+++ b/hivemq-edge/src/frontend/src/components/rjsf/Fields/CompactArrayField.tsx
@@ -12,7 +12,7 @@ import { CompactArrayFieldItemTemplate } from '@/components/rjsf/Templates/Compa
 const CompactArrayField: FC<FieldProps<unknown, RJSFSchema, AdapterContext>> = (props) => {
   const { registry } = props
 
-  registry.templates = {
+  const template = {
     ...registry.templates,
     ArrayFieldTemplate: CompactArrayFieldTemplate,
     ArrayFieldItemTemplate: CompactArrayFieldItemTemplate,
@@ -20,8 +20,9 @@ const CompactArrayField: FC<FieldProps<unknown, RJSFSchema, AdapterContext>> = (
     BaseInputTemplate: CompactBaseInputTemplate,
     ObjectFieldTemplate: CompactObjectFieldTemplate,
   }
+  const compactRegistry = { ...registry, template: template }
 
-  return <props.registry.fields.ArrayField {...props} />
+  return <props.registry.fields.ArrayField {...props} registry={compactRegistry} />
 }
 
 export default CompactArrayField


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/25622/details/

The fix prevents the `RJSC` registry, which contains templates and widgets, to be permanently modified for the overrides needed by the compact table  