### PR TITLE
fix(25622): remove compact table from adapter's UISchema

### DIFF
--- a/hivemq-edge/src/main/resources/simulation-adapter-ui-schema.json
+++ b/hivemq-edge/src/main/resources/simulation-adapter-ui-schema.json
@@ -31,9 +31,6 @@
       "ui:order": [ "destination", "qos", "*"],
       "ui:collapsable": {
         "titleKey": "destination"
-      },
-      "userProperties": {
-        "ui:field": "compactTable"
       }
     }
   }

--- a/modules/hivemq-edge-module-http/src/main/resources/http-adapter-ui-schema.json
+++ b/modules/hivemq-edge-module-http/src/main/resources/http-adapter-ui-schema.json
@@ -40,8 +40,5 @@
   "httpRequestBody": {
     "ui:widget": "textarea"
   },
-  "httpHeaders": {
-    "ui:field": "compactTable"
-  },
   "ui:order": ["id", "*"]
 }

--- a/modules/hivemq-edge-module-modbus/src/main/resources/modbus-adapter-ui-schema.json
+++ b/modules/hivemq-edge-module-modbus/src/main/resources/modbus-adapter-ui-schema.json
@@ -37,9 +37,6 @@
         "startIdx": {
           "ui:widget": "discovery:tagBrowser"
         }
-      },
-      "userProperties": {
-        "ui:field": "compactTable"
       }
     }
   }

--- a/modules/hivemq-edge-module-opcua/src/main/resources/opcua-adapter-ui-schema.json
+++ b/modules/hivemq-edge-module-opcua/src/main/resources/opcua-adapter-ui-schema.json
@@ -34,9 +34,6 @@
       },
       "node": {
         "ui:widget": "discovery:tagBrowser"
-      },
-      "userProperties": {
-        "ui:field": "compactTable"
       }
     }
   },

--- a/modules/hivemq-edge-module-plc4x/src/main/resources/s7-adapter-ui-schema.json
+++ b/modules/hivemq-edge-module-plc4x/src/main/resources/s7-adapter-ui-schema.json
@@ -45,9 +45,6 @@
       "ui:order": ["node", "mqtt-topic", "destination", "qos", "*"],
       "ui:collapsable": {
         "titleKey": "destination"
-      },
-      "userProperties": {
-        "ui:field": "compactTable"
       }
     }
   }


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/25622/details/

The PR prevents a significant bug with the compact table widget, removing the mapping from the existing adapters. 

### Out-of-scope
- the code for te RJSF widgets and templates is still in the frontend. It will be refactored to remove the unexpected side effect in a further ticket. 
