### PR TITLE
feat(25881): Add Device Tag management to the workspace

### DIFF
--- a/hivemq-edge/src/frontend/src/api/__generated__/services/ProtocolAdaptersService.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/services/ProtocolAdaptersService.ts
@@ -238,11 +238,13 @@ export class ProtocolAdaptersService {
      * Get the domain tags for the device connected through this adapter
      * Get the domain tags for the device connected through this adapter
      * @param adapterId The name of the adapter to query.
+     * @param adapterType The name of the adapter to query. (DEV ONLY - will be regenerated)
      * @returns DomainTagList Success
      * @throws ApiError
      */
     public getAdapterDomainTags(
         adapterId: string,
+        adapterType?: string
     ): CancelablePromise<DomainTagList> {
         return this.httpRequest.request({
             method: 'GET',
@@ -250,6 +252,9 @@ export class ProtocolAdaptersService {
             path: {
                 'adapterId': adapterId,
             },
+            query: {
+                'type': adapterType,
+          },
         });
     }
 

--- a/hivemq-edge/src/frontend/src/api/__generated__/services/ProtocolAdaptersService.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/services/ProtocolAdaptersService.ts
@@ -329,4 +329,28 @@ export class ProtocolAdaptersService {
         });
     }
 
+  /**
+   * Update a domain tag
+   * Update the domain tag of an adapter
+   * @param adapterId The adapter Id.
+   * @param tagId The tag id.
+   * @param requestBody
+   * @returns any Success
+   * @throws ApiError
+   */
+  public updateAdapterAllDomainTags(
+      adapterId: string,
+      requestBody?: DomainTagList,
+  ): CancelablePromise<any> {
+    return this.httpRequest.request({
+      method: 'PUT',
+      url: '/api/v1/management/protocol-adapters/adapters/{adapterId}/tags',
+      path: {
+        'adapterId': adapterId,
+      },
+      body: requestBody,
+      mediaType: 'application/json',
+    });
+  }
+
 }

--- a/hivemq-edge/src/frontend/src/api/hooks/useProtocolAdapters/__handlers__/index.ts
+++ b/hivemq-edge/src/frontend/src/api/hooks/useProtocolAdapters/__handlers__/index.ts
@@ -6,6 +6,7 @@ import { MOCK_ADAPTER_ID } from '@/__test-utils__/mocks.ts'
 import {
   Adapter,
   AdaptersList,
+  type DeviceDataPoint,
   type DomainTag,
   type DomainTagList,
   JsonNode,
@@ -655,13 +656,16 @@ export const mockDataPointOPCUA: ValuesTree = {
   ],
 }
 
+export const MOCK_DEVICE_TAG_ADDRESS_MODBUS: DeviceDataPoint = { startIdx: 0, endIdx: 1 }
+export const MOCK_DEVICE_TAG_ADDRESS_OPCUA: DeviceDataPoint = { node: 'ns=3;i=1002' }
+
 export const MOCK_DEVICE_TAGS = (adapterId: string, type?: string | null): DomainTag[] => {
   switch (type) {
     case MockAdapterType.MODBUS:
-      return [{ tag: `${adapterId}/alert`, dataPoint: { startIdx: 0, endIdx: 1 } }]
+      return [{ tag: `${adapterId}/alert`, dataPoint: MOCK_DEVICE_TAG_ADDRESS_MODBUS }]
     case MockAdapterType.OPC_UA:
       return [
-        { tag: `${adapterId}/power/off`, dataPoint: { node: 'ns=3;i=1002' } },
+        { tag: `${adapterId}/power/off`, dataPoint: MOCK_DEVICE_TAG_ADDRESS_OPCUA },
         { tag: `${adapterId}/log/event`, dataPoint: { node: 'ns=3;i=1008' } },
       ]
     default:
@@ -722,6 +726,10 @@ export const deviceHandlers = [
   }),
 
   http.put('*/protocol-adapters/adapters/:adapterId/tags/:tagId', () => {
+    return HttpResponse.json({}, { status: 200 })
+  }),
+
+  http.put('*/protocol-adapters/adapters/:adapterId/tags', () => {
     return HttpResponse.json({}, { status: 200 })
   }),
 ]

--- a/hivemq-edge/src/frontend/src/api/hooks/useProtocolAdapters/__handlers__/index.ts
+++ b/hivemq-edge/src/frontend/src/api/hooks/useProtocolAdapters/__handlers__/index.ts
@@ -510,8 +510,11 @@ export const mockAdapter_OPCUA: Adapter = {
   id: 'opcua-1',
   type: 'opcua',
   config: {
+    // @ts-ignore TODO[26764] bug with backend, https://hivemq.kanbanize.com/ctrl_board/57/cards/26764/details/
     id: 'opcua-1',
+    // @ts-ignore TODO[26764] bug with backend, https://hivemq.kanbanize.com/ctrl_board/57/cards/26764/details/
     uri: 'opc.tcp://test.host.local:53530/OPCUA/Server',
+    // @ts-ignore TODO[26764] bug with backend, https://hivemq.kanbanize.com/ctrl_board/57/cards/26764/details/
     overrideUri: false,
     tls: {
       enabled: false,

--- a/hivemq-edge/src/frontend/src/api/hooks/useProtocolAdapters/__handlers__/index.ts
+++ b/hivemq-edge/src/frontend/src/api/hooks/useProtocolAdapters/__handlers__/index.ts
@@ -15,6 +15,7 @@ import {
   Status,
   type ValuesTree,
 } from '@/api/__generated__'
+import { MockAdapterType } from '@/__test-utils__/adapters/types.ts'
 
 export const mockUISchema: UiSchema = {
   'ui:tabs': [
@@ -217,6 +218,265 @@ export const mockProtocolAdapter: ProtocolAdapter = {
   tags: ['tag1', 'tag2', 'tag3'],
 }
 
+export const mockProtocolAdapter_OPCUA: ProtocolAdapter = {
+  id: 'opcua',
+  protocol: 'OPC UA',
+  name: 'OPC UA to MQTT Protocol Adapter',
+  description:
+    'Connects HiveMQ Edge to existing OPC UA services as a client and enables a seamless exchange of data between MQTT and OPC-UA.',
+  url: 'https://docs.hivemq.com/hivemq-edge/protocol-adapters.html#opc-ua-adapter',
+  version: 'Development Version',
+  logoUrl: '/module/images/opc-ua-icon.jpg',
+  author: 'HiveMQ',
+  installed: true,
+  capabilities: ['DISCOVER', 'READ'],
+  category: {
+    name: 'INDUSTRIAL',
+    displayName: 'Industrial',
+    description: 'Industrial, typically field bus protocols.',
+  },
+  configSchema: {
+    $schema: 'https://json-schema.org/draft/2020-12/schema',
+    type: 'object',
+    properties: {
+      auth: {
+        type: 'object',
+        properties: {
+          basic: {
+            type: 'object',
+            properties: {
+              password: {
+                type: 'string',
+                title: 'Password',
+                description: 'Password for basic authentication',
+              },
+              username: {
+                type: 'string',
+                title: 'Username',
+                description: 'Username for basic authentication',
+              },
+            },
+            title: 'Basic Authentication',
+            description: 'Username / password based authentication',
+          },
+          x509: {
+            type: 'object',
+            properties: {
+              enabled: {
+                type: 'boolean',
+                title: 'Enable X509',
+                description: 'Enables X509 auth',
+              },
+            },
+            title: 'X509 Authentication',
+            description: 'Authentication based on certificate / private key',
+          },
+        },
+      },
+      id: {
+        type: 'string',
+        title: 'Identifier',
+        description: 'Unique identifier for this protocol adapter',
+        minLength: 1,
+        maxLength: 1024,
+        format: 'identifier',
+        pattern: '^([a-zA-Z_0-9-_])*$',
+      },
+      opcuaToMqtt: {
+        type: 'object',
+        properties: {
+          opcuaToMqttMappings: {
+            title: 'opcuaToMqttMappings',
+            description: 'Map your sensor data to MQTT Topics',
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                messageExpiryInterval: {
+                  type: 'integer',
+                  title: 'MQTT message expiry interval [s]',
+                  description: 'Time in seconds until an MQTT publish message expires',
+                  minimum: 1,
+                  maximum: 4294967295,
+                },
+                mqttQos: {
+                  type: 'integer',
+                  title: 'MQTT QoS',
+                  description: 'MQTT quality of service level',
+                  default: 0,
+                  minimum: 0,
+                  maximum: 2,
+                },
+                mqttTopic: {
+                  type: 'string',
+                  title: 'Destination MQTT topic',
+                  description: 'The MQTT topic to publish to',
+                  format: 'mqtt-topic',
+                },
+                node: {
+                  type: 'string',
+                  title: 'Source Node ID',
+                  description: 'identifier of the node on the OPC UA server. Example: "ns=3;s=85/0:Temperature"',
+                },
+                publishingInterval: {
+                  type: 'integer',
+                  title: 'OPC UA publishing interval [ms]',
+                  description: 'OPC UA publishing interval in milliseconds for this subscription on the server',
+                  default: 1000,
+                  minimum: 1,
+                },
+                serverQueueSize: {
+                  type: 'integer',
+                  title: 'OPC UA server queue size',
+                  description: 'OPC UA queue size for this subscription on the server',
+                  default: 1,
+                  minimum: 1,
+                },
+              },
+              required: ['mqttTopic', 'node'],
+            },
+          },
+        },
+        title: 'OpcUA To MQTT Config',
+        description: 'The configuration for a data stream from OpcUA to MQTT',
+      },
+      overrideUri: {
+        type: 'boolean',
+        title: 'Override server returned endpoint URI',
+        description:
+          'Overrides the endpoint URI returned from the OPC UA server with the hostname and port from the specified URI.',
+        default: false,
+        format: 'boolean',
+      },
+      security: {
+        type: 'object',
+        properties: {
+          policy: {
+            type: 'string',
+            enum: [
+              'NONE',
+              'BASIC128RSA15',
+              'BASIC256',
+              'BASIC256SHA256',
+              'AES128_SHA256_RSAOAEP',
+              'AES256_SHA256_RSAPSS',
+            ],
+            title: 'OPC UA security policy',
+            description: 'Security policy to use for communication with the server.',
+          },
+        },
+      },
+      tls: {
+        type: 'object',
+        properties: {
+          enabled: {
+            type: 'boolean',
+            title: 'Enable TLS',
+            description: 'Enables TLS encrypted connection',
+            default: true,
+          },
+          keystore: {
+            type: 'object',
+            properties: {
+              password: {
+                type: 'string',
+                title: 'Keystore password',
+                description: 'Password to open the keystore.',
+              },
+              path: {
+                type: 'string',
+                title: 'Keystore path',
+                description: 'Path on the local file system to the keystore.',
+              },
+              privateKeyPassword: {
+                type: 'string',
+                title: 'Private key password',
+                description: 'Password to access the private key.',
+              },
+            },
+            required: ['password', 'path', 'privateKeyPassword'],
+            title: 'Keystore',
+            description:
+              'Keystore that contains the client certificate including the chain. Required for X509 authentication.',
+          },
+          truststore: {
+            type: 'object',
+            properties: {
+              password: {
+                type: 'string',
+                title: 'Truststore password',
+                description: 'Password to open the truststore.',
+              },
+              path: {
+                type: 'string',
+                title: 'Truststore path',
+                description: 'Path on the local file system to the truststore.',
+              },
+            },
+            required: ['password', 'path'],
+            title: 'Truststore',
+            description: 'Truststore wich contains the trusted server certificates or trusted intermediates.',
+          },
+        },
+      },
+      uri: {
+        type: 'string',
+        title: 'OPC UA Server URI',
+        description: 'URI of the OPC UA server to connect to',
+        format: 'uri',
+      },
+    },
+    required: ['id', 'opcuaToMqtt', 'uri'],
+  },
+  uiSchema: {
+    'ui:tabs': [
+      {
+        id: 'coreFields',
+        title: 'Connection',
+        properties: ['id', 'uri', 'overrideUri'],
+      },
+      {
+        id: 'subFields',
+        title: 'OPC UA to MQTT',
+        properties: ['opcuaToMqtt'],
+      },
+      {
+        id: 'security',
+        title: 'Security',
+        properties: ['security', 'tls'],
+      },
+      {
+        id: 'authentication',
+        title: 'Authentication',
+        properties: ['auth'],
+      },
+    ],
+    id: {
+      'ui:disabled': true,
+    },
+    'ui:order': ['id', 'uri', '*'],
+    opcuaToMqtt: {
+      'ui:batchMode': true,
+      opcuaToMqttMappings: {
+        items: {
+          'ui:order': ['node', 'mqttTopic', 'mqttQos', '*'],
+          'ui:collapsable': {
+            titleKey: 'mqttTopic',
+          },
+          node: {
+            'ui:widget': 'discovery:tagBrowser',
+          },
+        },
+      },
+    },
+    auth: {
+      basic: {
+        'ui:order': ['username', 'password', '*'],
+      },
+    },
+  },
+}
+
 export const mockAdapterConfig: GenericObjectType = {
   minValue: 0,
   maxValue: 1000,
@@ -243,6 +503,43 @@ export const mockAdapter: Adapter = {
   status: {
     startedAt: '2023-08-21T11:51:24.234+01',
     connection: Status.connection.CONNECTED,
+  },
+}
+
+export const mockAdapter_OPCUA: Adapter = {
+  id: 'opcua-1',
+  type: 'opcua',
+  config: {
+    id: 'opcua-1',
+    uri: 'opc.tcp://test.host.local:53530/OPCUA/Server',
+    overrideUri: false,
+    tls: {
+      enabled: false,
+    },
+    opcuaToMqtt: {
+      opcuaToMqttMappings: [
+        {
+          node: 'ns=3;s=85/0:Temperature',
+          mqttTopic: 'generator/group1/energy',
+          publishingInterval: 1000,
+          serverQueueSize: 1,
+          mqttQos: 0,
+          messageExpiryInterval: 4294967295,
+        },
+      ],
+    },
+    security: {
+      policy: 'NONE',
+    },
+  },
+  status: {
+    runtime: Status.runtime.STOPPED,
+    connection: Status.connection.ERROR,
+    id: 'opcua-1',
+    type: 'adapter',
+    startedAt: '2024-10-08T10:34:21.692+01',
+    message:
+      "com.hivemq.edge.adapters.opcua.OpcUaException: OPC UA subscription failed for nodeId `NodeId{ns=3, id=85/0:Temperature}`: Bad_NodeIdUnknown,The node id refers to a node that does not exist in the server address space. (status 'StatusCode{name=Bad_NodeIdUnknown, value=0x80340000, quality=bad}')",
   },
 }
 
@@ -355,11 +652,19 @@ export const mockDataPointOPCUA: ValuesTree = {
   ],
 }
 
-export const MOCK_DEVICE_TAGS = (adapterId: string): DomainTag[] => [
-  { tag: `${adapterId}/power-management/alert`, dataPoint: { node: 'ns=3;i=1002' } },
-  { tag: `${adapterId}/power-management/off`, dataPoint: { node: 'ns=3;i=1003' } },
-  { tag: `${adapterId}/log/event`, dataPoint: { node: 'ns=3;i=1008' } },
-]
+export const MOCK_DEVICE_TAGS = (adapterId: string, type?: string | null): DomainTag[] => {
+  switch (type) {
+    case MockAdapterType.MODBUS:
+      return [{ tag: `${adapterId}/alert`, dataPoint: { startIdx: 0, endIdx: 1 } }]
+    case MockAdapterType.OPC_UA:
+      return [
+        { tag: `${adapterId}/power/off`, dataPoint: { node: 'ns=3;i=1002' } },
+        { tag: `${adapterId}/log/event`, dataPoint: { node: 'ns=3;i=1008' } },
+      ]
+    default:
+      return [{ tag: `${adapterId}/log/event`, dataPoint: {} }]
+  }
+}
 
 export const handlers = [
   http.get('*/protocol-adapters/types', () => {
@@ -397,10 +702,14 @@ export const handlers = [
 ]
 
 export const deviceHandlers = [
-  http.get('*/protocol-adapters/adapters/:adapterId/tags', ({ params }) => {
+  http.get('*/protocol-adapters/adapters/:adapterId/tags', ({ params, request }) => {
     const { adapterId } = params
+    const url = new URL(request.url)
+    const type = url.searchParams.get('type')
 
-    return HttpResponse.json<DomainTagList>({ items: MOCK_DEVICE_TAGS(adapterId as string) }, { status: 200 })
+    console.log('XX')
+
+    return HttpResponse.json<DomainTagList>({ items: MOCK_DEVICE_TAGS(adapterId as string, type) }, { status: 200 })
   }),
 
   http.post('*/protocol-adapters/adapters/:adapterId/tags', () => {

--- a/hivemq-edge/src/frontend/src/api/hooks/useProtocolAdapters/__handlers__/index.ts
+++ b/hivemq-edge/src/frontend/src/api/hooks/useProtocolAdapters/__handlers__/index.ts
@@ -710,8 +710,6 @@ export const deviceHandlers = [
     const url = new URL(request.url)
     const type = url.searchParams.get('type')
 
-    console.log('XX')
-
     return HttpResponse.json<DomainTagList>({ items: MOCK_DEVICE_TAGS(adapterId as string, type) }, { status: 200 })
   }),
 

--- a/hivemq-edge/src/frontend/src/api/hooks/useProtocolAdapters/useGetDomainTags.spec.ts
+++ b/hivemq-edge/src/frontend/src/api/hooks/useProtocolAdapters/useGetDomainTags.spec.ts
@@ -7,6 +7,7 @@ import { SimpleWrapper as wrapper } from '@/__test-utils__/hooks/SimpleWrapper.t
 import { deviceHandlers } from './__handlers__'
 import { useGetDomainTags } from '@/api/hooks/useProtocolAdapters/useGetDomainTags.tsx'
 import type { DomainTagList } from '@/api/__generated__'
+import { MockAdapterType } from '@/__test-utils__/adapters/types.ts'
 
 describe('useGetDomainTags', () => {
   beforeEach(() => {
@@ -17,8 +18,8 @@ describe('useGetDomainTags', () => {
     server.resetHandlers()
   })
 
-  it('should load the data', async () => {
-    const { result } = renderHook(() => useGetDomainTags('adapterId'), { wrapper })
+  it('should load the data for OPCUA', async () => {
+    const { result } = renderHook(() => useGetDomainTags('adapterId', MockAdapterType.OPC_UA), { wrapper })
     await waitFor(() => {
       expect(result.current.isLoading).toBeFalsy()
       expect(result.current.isSuccess).toBeTruthy()
@@ -29,18 +30,45 @@ describe('useGetDomainTags', () => {
           dataPoint: {
             node: 'ns=3;i=1002',
           },
-          tag: 'adapterId/power-management/alert',
-        },
-        {
-          dataPoint: {
-            node: 'ns=3;i=1003',
-          },
-          tag: 'adapterId/power-management/off',
+          tag: 'adapterId/power/off',
         },
         {
           dataPoint: {
             node: 'ns=3;i=1008',
           },
+          tag: 'adapterId/log/event',
+        },
+      ],
+    })
+  })
+  it('should load the data for MODBUS', async () => {
+    const { result } = renderHook(() => useGetDomainTags('adapterId', MockAdapterType.MODBUS), { wrapper })
+    await waitFor(() => {
+      expect(result.current.isLoading).toBeFalsy()
+      expect(result.current.isSuccess).toBeTruthy()
+    })
+    expect(result.current.data).toStrictEqual<DomainTagList>({
+      items: [
+        {
+          dataPoint: {
+            endIdx: 1,
+            startIdx: 0,
+          },
+          tag: 'adapterId/alert',
+        },
+      ],
+    })
+  })
+  it('should load the data for others', async () => {
+    const { result } = renderHook(() => useGetDomainTags('adapterId', MockAdapterType.SIMULATION), { wrapper })
+    await waitFor(() => {
+      expect(result.current.isLoading).toBeFalsy()
+      expect(result.current.isSuccess).toBeTruthy()
+    })
+    expect(result.current.data).toStrictEqual<DomainTagList>({
+      items: [
+        {
+          dataPoint: {},
           tag: 'adapterId/log/event',
         },
       ],

--- a/hivemq-edge/src/frontend/src/api/hooks/useProtocolAdapters/useGetDomainTags.tsx
+++ b/hivemq-edge/src/frontend/src/api/hooks/useProtocolAdapters/useGetDomainTags.tsx
@@ -3,12 +3,18 @@ import { useHttpClient } from '@/api/hooks/useHttpClient/useHttpClient.ts'
 import { ApiError, type DomainTagList } from '@/api/__generated__'
 import { QUERY_KEYS } from '@/api/utils.ts'
 
-export const useGetDomainTags = (adapterId: string | undefined) => {
+/**
+ * @deprecated This is a mock-based, will be reverted
+ * @param adapterId
+ * @param adapterType This is part of the mock, in order to identify the adapter
+ */
+export const useGetDomainTags = (adapterId: string | undefined, adapterType?: string) => {
   const appClient = useHttpClient()
 
   return useQuery<DomainTagList, ApiError>({
+    // eslint-disable-next-line @tanstack/query/exhaustive-deps
     queryKey: [QUERY_KEYS.ADAPTERS, adapterId, QUERY_KEYS.DISCOVERY_TAGS],
-    queryFn: () => appClient.protocolAdapters.getAdapterDomainTags(adapterId || ''),
-    enabled: Boolean(adapterId),
+    queryFn: () => appClient.protocolAdapters.getAdapterDomainTags(adapterId || '', adapterType),
+    enabled: Boolean(adapterId && adapterType),
   })
 }

--- a/hivemq-edge/src/frontend/src/api/hooks/useProtocolAdapters/useUpdateAllDomainTags.spec.ts
+++ b/hivemq-edge/src/frontend/src/api/hooks/useProtocolAdapters/useUpdateAllDomainTags.spec.ts
@@ -1,0 +1,33 @@
+import { expect } from 'vitest'
+import { act, renderHook, waitFor } from '@testing-library/react'
+
+import { server } from '@/__test-utils__/msw/mockServer.ts'
+import { SimpleWrapper as wrapper } from '@/__test-utils__/hooks/SimpleWrapper.tsx'
+
+import { deviceHandlers, MOCK_DEVICE_TAGS } from './__handlers__'
+import { useUpdateAllDomainTags } from '@/api/hooks/useProtocolAdapters/useUpdateAllDomainTags.ts'
+import { MockAdapterType } from '@/__test-utils__/adapters/types.ts'
+
+describe('useUpdateAllDomainTags', () => {
+  afterEach(() => {
+    server.resetHandlers()
+  })
+
+  it('should load the data', async () => {
+    server.use(...deviceHandlers)
+
+    const { result } = renderHook(useUpdateAllDomainTags, { wrapper })
+
+    expect(result.current.isSuccess).toBeFalsy()
+    act(() => {
+      result.current.mutateAsync({
+        adapterId: 'my-adapter',
+        requestBody: { items: MOCK_DEVICE_TAGS('my-adapter', MockAdapterType.MODBUS) },
+      })
+    })
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBeTruthy()
+      expect(result.current.data).toStrictEqual({})
+    })
+  })
+})

--- a/hivemq-edge/src/frontend/src/api/hooks/useProtocolAdapters/useUpdateAllDomainTags.ts
+++ b/hivemq-edge/src/frontend/src/api/hooks/useProtocolAdapters/useUpdateAllDomainTags.ts
@@ -1,0 +1,26 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { ApiError, type DomainTagList } from '../../__generated__'
+
+import { useHttpClient } from '@/api/hooks/useHttpClient/useHttpClient.ts'
+import { QUERY_KEYS } from '@/api/utils.ts'
+
+interface UpdateAllDomainTagsProps {
+  adapterId: string
+  requestBody: DomainTagList
+}
+
+export const useUpdateAllDomainTags = () => {
+  const appClient = useHttpClient()
+  const queryClient = useQueryClient()
+
+  const updateAdapterDomainTags = ({ adapterId, requestBody }: UpdateAllDomainTagsProps) => {
+    return appClient.protocolAdapters.updateAdapterAllDomainTags(adapterId, requestBody)
+  }
+
+  return useMutation<UpdateAllDomainTagsProps, ApiError, UpdateAllDomainTagsProps>({
+    mutationFn: updateAdapterDomainTags,
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.ADAPTERS, data.adapterId, QUERY_KEYS.DISCOVERY_TAGS] })
+    },
+  })
+}

--- a/hivemq-edge/src/frontend/src/components/ErrorMessage.tsx
+++ b/hivemq-edge/src/frontend/src/components/ErrorMessage.tsx
@@ -1,14 +1,15 @@
 import { FC } from 'react'
-import { Alert, AlertDescription, AlertIcon, AlertTitle } from '@chakra-ui/react'
+import { Alert, AlertDescription, AlertIcon, type AlertStatus, AlertTitle } from '@chakra-ui/react'
 
 interface ErrorMessageProps {
   type?: string | number
   message?: string
+  status?: AlertStatus
 }
 
-const ErrorMessage: FC<ErrorMessageProps> = ({ type, message }) => {
+const ErrorMessage: FC<ErrorMessageProps> = ({ type, message, status = 'error' }) => {
   return (
-    <Alert status="error">
+    <Alert status={status}>
       <AlertIcon />
       <div>
         <AlertTitle>{type || ''}</AlertTitle>

--- a/hivemq-edge/src/frontend/src/components/rjsf/Fields/MqttTransformationField.tsx
+++ b/hivemq-edge/src/frontend/src/components/rjsf/Fields/MqttTransformationField.tsx
@@ -65,7 +65,7 @@ export const MqttTransformationField: FC<FieldProps<OutwardMapping[], RJSFSchema
   if (!subsData) return null
 
   return (
-    <Accordion defaultIndex={0} index={selectedItem === undefined ? 0 : 1}>
+    <Accordion defaultIndex={0} index={selectedItem === undefined ? 0 : 1} data-testid="mapping-editor-switch">
       <AccordionItem isDisabled={selectedItem !== undefined}>
         <AccordionButton>
           <Box as="span" flex="1" textAlign="left">

--- a/hivemq-edge/src/frontend/src/components/rjsf/MqttTransformation/components/EntitySelector.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/components/rjsf/MqttTransformation/components/EntitySelector.spec.cy.tsx
@@ -40,9 +40,9 @@ describe('SelectSourceTopics', () => {
         <SelectDestinationTag adapterId={mockAdapterId} values={['tag/test1']} onChange={cy.stub()} />
       )
 
-      // Loading
-      cy.get('#mapping-select-destination').should('contain.text', 'Loading...')
-      cy.get('#mapping-select-destination').should('not.contain.text', 'Loading...')
+      // // Loading
+      // cy.get('#mapping-select-destination').should('contain.text', 'Loading...')
+      // cy.get('#mapping-select-destination').should('not.contain.text', 'Loading...')
 
       cy.get('#mapping-select-destination').should('contain.text', 'tag/test1')
     })

--- a/hivemq-edge/src/frontend/src/locales/en/translation.json
+++ b/hivemq-edge/src/frontend/src/locales/en/translation.json
@@ -600,7 +600,12 @@
           "delete": {
             "title": "Delete Tag",
             "description_success": "The tag has been deleted from the device",
-            "description_error": "The tag has been deleted from the device"
+            "description_error": "The tag could not be deleted"
+          },
+          "updateList": {
+            "title": "Edit the tags",
+            "description_success": "The tags has been modified on the device",
+            "description_error": "The list of tags could not be updated on the device"
           }
         }
       },
@@ -612,6 +617,7 @@
       }
     },
     "errors": {
+      "noFormSchema": "The form cannot be created, due to internal errors",
       "noAdapter": "The protocol adapter for this device cannot be found",
       "noMetadataLoaded": "No metadata loaded for the device",
       "noTagLoaded": "Cannot load the tags",

--- a/hivemq-edge/src/frontend/src/locales/en/translation.json
+++ b/hivemq-edge/src/frontend/src/locales/en/translation.json
@@ -579,6 +579,17 @@
       }
     }
   },
+  "device": {
+    "drawer": {
+      "tagPanel": {
+        "title": "List of Device Tags"
+      }
+    },
+    "errors": {
+      "noMetadataLoaded": "No metadata loaded for the device"
+    }
+  },
+
   "articles": {
     "title": "Articles",
     "description": "Some reading for your understanding of HiveMQ Edge",

--- a/hivemq-edge/src/frontend/src/locales/en/translation.json
+++ b/hivemq-edge/src/frontend/src/locales/en/translation.json
@@ -63,6 +63,9 @@
     },
     "wip": {
       "message": "This is a work in progress. Be patient with us"
+    },
+    "rjsf": {
+      "validation": "Some validation errors in the form"
     }
   },
   "login": {
@@ -591,6 +594,14 @@
         "title": "List of Device Tags",
         "cta": {
           "edit": "Edit tags"
+        },
+        "toast": {
+          "description_loading": "Processing the request",
+          "delete": {
+            "title": "Delete Tag",
+            "description_success": "The tag has been deleted from the device",
+            "description_error": "The tag has been deleted from the device"
+          }
         }
       },
       "tagEditor": {
@@ -601,6 +612,7 @@
       }
     },
     "errors": {
+      "noAdapter": "The protocol adapter for this device cannot be found",
       "noMetadataLoaded": "No metadata loaded for the device",
       "noTagLoaded": "Cannot load the tags",
       "noTagCreated": "There is no tag created yet"

--- a/hivemq-edge/src/frontend/src/locales/en/translation.json
+++ b/hivemq-edge/src/frontend/src/locales/en/translation.json
@@ -567,6 +567,7 @@
         "status_success": "Adapter {{ name }} successfully downloaded "
       },
       "error": {
+        "noAdapterConfig": "No adapter configuration exists",
         "noMapping": "No mapping could be found in the adapter configuration",
         "noSchema": "There are no valid schema defining the extracted mappings",
         "notValid": "The data collected from the adapter is not valid"

--- a/hivemq-edge/src/frontend/src/locales/en/translation.json
+++ b/hivemq-edge/src/frontend/src/locales/en/translation.json
@@ -595,6 +595,9 @@
         "cta": {
           "edit": "Edit tags"
         },
+        "formatter": {
+          "unknownFormat": "< unknown format >"
+        },
         "toast": {
           "description_loading": "Processing the request",
           "delete": {

--- a/hivemq-edge/src/frontend/src/locales/en/translation.json
+++ b/hivemq-edge/src/frontend/src/locales/en/translation.json
@@ -605,7 +605,7 @@
             "description_success": "The tag has been deleted from the device",
             "description_error": "The tag could not be deleted"
           },
-          "updateList": {
+          "updateCollection": {
             "title": "Edit the tags",
             "description_success": "The tags has been modified on the device",
             "description_error": "The list of tags could not be updated on the device"

--- a/hivemq-edge/src/frontend/src/locales/en/translation.json
+++ b/hivemq-edge/src/frontend/src/locales/en/translation.json
@@ -581,12 +581,28 @@
   },
   "device": {
     "drawer": {
-      "tagPanel": {
-        "title": "List of Device Tags"
+      "metadataPanel": {
+        "cta": {
+          "load": "Load Metadata"
+        }
+      },
+      "tagList": {
+        "title": "List of Device Tags",
+        "cta": {
+          "edit": "Edit tags"
+        }
+      },
+      "tagEditor": {
+        "title": "Edit the tags",
+        "cta": {
+          "edit": "Edit tags"
+        }
       }
     },
     "errors": {
-      "noMetadataLoaded": "No metadata loaded for the device"
+      "noMetadataLoaded": "No metadata loaded for the device",
+      "noTagLoaded": "Cannot load the tags",
+      "noTagCreated": "There is no tag created yet"
     }
   },
 

--- a/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/WebSocketPanel.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/WebSocketPanel.spec.cy.tsx
@@ -35,7 +35,7 @@ describe('WebSocketPanel', () => {
     cy.viewport(800, 800)
   })
 
-  it.only('should render properly', () => {
+  it('should render properly', () => {
     const mockOnSubmit = cy.stub().as('onSubmit')
     cy.mountWithProviders(<TestingComponent onSubmit={mockOnSubmit} defaultValues={mockBridge} />)
 

--- a/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/WebSocketPanel.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Bridges/components/panels/WebSocketPanel.tsx
@@ -31,7 +31,7 @@ const WebSocketPanel: FC<BridgePanelType> = ({ form }) => {
           autoFocus
           id="serverPath"
           type="text"
-          autoComplete="serverPath"
+          autoComplete="on"
           defaultValue="/mqtt"
           {...register('websocketConfiguration.serverPath')}
         />
@@ -45,7 +45,7 @@ const WebSocketPanel: FC<BridgePanelType> = ({ form }) => {
           autoFocus
           id="subProtocol"
           type="text"
-          autoComplete="subProtocol"
+          autoComplete="on"
           defaultValue="mqtt"
           {...register('websocketConfiguration.subProtocol')}
         />

--- a/hivemq-edge/src/frontend/src/modules/Device/components/DeviceMetadataViewer.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Device/components/DeviceMetadataViewer.spec.cy.tsx
@@ -1,0 +1,21 @@
+/// <reference types="cypress" />
+
+import { mockProtocolAdapter } from '@/api/hooks/useProtocolAdapters/__handlers__'
+import DeviceMetadataViewer from '@/modules/Device/components/DeviceMetadataViewer.tsx'
+
+describe('DeviceMetadataViewer', () => {
+  beforeEach(() => {
+    cy.viewport(800, 800)
+  })
+
+  it('should render the form', () => {
+    cy.mountWithProviders(<DeviceMetadataViewer protocolAdapter={mockProtocolAdapter} />)
+
+    cy.getByTestId('device-metadata-header').should('be.visible')
+    cy.getByTestId('device-metadata-header').find('h2').should('contain.text', 'simulation')
+    cy.getByTestId('device-metadata-header').find('h2 + p').should('contain.text', 'Industrial')
+
+    cy.get('[role="alert"]').should('contain.text', 'No metadata loaded for the device')
+    cy.get('[role="alert"]').should('have.attr', 'data-status', 'info')
+  })
+})

--- a/hivemq-edge/src/frontend/src/modules/Device/components/DeviceMetadataViewer.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Device/components/DeviceMetadataViewer.tsx
@@ -43,7 +43,7 @@ const DeviceMetadataViewer: FC<DeviceMetadataProps> = ({ protocolAdapter }) => {
       <CardBody>
         <Alert status="error">
           <AlertIcon />
-          <AlertDescription>{t('XXXX no metadata loaded for the device')}</AlertDescription>
+          <AlertDescription>{t('device.errors.noMetadataLoaded')}</AlertDescription>
         </Alert>
       </CardBody>
     </Card>

--- a/hivemq-edge/src/frontend/src/modules/Device/components/DeviceMetadataViewer.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Device/components/DeviceMetadataViewer.tsx
@@ -28,10 +28,9 @@ const DeviceMetadataViewer: FC<DeviceMetadataProps> = ({ protocolAdapter }) => {
   return (
     <Card size="sm">
       <CardHeader>
-        <Flex gap="4">
+        <Flex>
           <Flex flex="1" gap="4" alignItems="center" flexWrap="wrap">
             <Avatar src={protocolAdapter?.logoUrl} />
-
             <Box>
               <Heading size="sm">{protocolAdapter?.id}</Heading>
               <Text>{protocolAdapter?.category?.displayName}</Text>

--- a/hivemq-edge/src/frontend/src/modules/Device/components/DeviceMetadataViewer.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Device/components/DeviceMetadataViewer.tsx
@@ -37,7 +37,7 @@ const DeviceMetadataViewer: FC<DeviceMetadataProps> = ({ protocolAdapter }) => {
               <Text>{protocolAdapter?.category?.displayName}</Text>
             </Box>
           </Flex>
-          <IconButton aria-label="Load Metadata" icon={<LuUpload />} isDisabled />
+          <IconButton aria-label={t('device.drawer.metadataPanel.cta.load')} icon={<LuUpload />} isDisabled />
         </Flex>
       </CardHeader>
       <CardBody>

--- a/hivemq-edge/src/frontend/src/modules/Device/components/DeviceMetadataViewer.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Device/components/DeviceMetadataViewer.tsx
@@ -28,7 +28,7 @@ const DeviceMetadataViewer: FC<DeviceMetadataProps> = ({ protocolAdapter }) => {
   return (
     <Card size="sm">
       <CardHeader>
-        <Flex>
+        <Flex data-testid="device-metadata-header">
           <Flex flex="1" gap="4" alignItems="center" flexWrap="wrap">
             <Avatar src={protocolAdapter?.logoUrl} />
             <Box>

--- a/hivemq-edge/src/frontend/src/modules/Device/components/DeviceMetadataViewer.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Device/components/DeviceMetadataViewer.tsx
@@ -40,7 +40,7 @@ const DeviceMetadataViewer: FC<DeviceMetadataProps> = ({ protocolAdapter }) => {
         </Flex>
       </CardHeader>
       <CardBody>
-        <Alert status="error">
+        <Alert status="info">
           <AlertIcon />
           <AlertDescription>{t('device.errors.noMetadataLoaded')}</AlertDescription>
         </Alert>

--- a/hivemq-edge/src/frontend/src/modules/Device/components/DeviceMetadataViewer.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Device/components/DeviceMetadataViewer.tsx
@@ -1,0 +1,53 @@
+import { FC } from 'react'
+import { useTranslation } from 'react-i18next'
+import {
+  Alert,
+  AlertDescription,
+  AlertIcon,
+  Avatar,
+  Box,
+  Card,
+  CardBody,
+  CardHeader,
+  Flex,
+  Heading,
+  Text,
+} from '@chakra-ui/react'
+import { LuUpload } from 'react-icons/lu'
+
+import IconButton from '@/components/Chakra/IconButton.tsx'
+import { DeviceMetadata } from '@/modules/Workspace/types.ts'
+
+interface DeviceMetadataProps {
+  protocolAdapter?: DeviceMetadata
+}
+
+const DeviceMetadataViewer: FC<DeviceMetadataProps> = ({ protocolAdapter }) => {
+  const { t } = useTranslation()
+
+  return (
+    <Card size="sm">
+      <CardHeader>
+        <Flex gap="4">
+          <Flex flex="1" gap="4" alignItems="center" flexWrap="wrap">
+            <Avatar src={protocolAdapter?.logoUrl} />
+
+            <Box>
+              <Heading size="sm">{protocolAdapter?.id}</Heading>
+              <Text>{protocolAdapter?.category?.displayName}</Text>
+            </Box>
+          </Flex>
+          <IconButton aria-label="Load Metadata" icon={<LuUpload />} isDisabled />
+        </Flex>
+      </CardHeader>
+      <CardBody>
+        <Alert status="error">
+          <AlertIcon />
+          <AlertDescription>{t('XXXX no metadata loaded for the device')}</AlertDescription>
+        </Alert>
+      </CardBody>
+    </Card>
+  )
+}
+
+export default DeviceMetadataViewer

--- a/hivemq-edge/src/frontend/src/modules/Device/components/DeviceTagDrawer.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Device/components/DeviceTagDrawer.spec.cy.tsx
@@ -1,0 +1,34 @@
+/// <reference types="cypress" />
+
+import DeviceTagDrawer from '@/modules/Device/components/DeviceTagDrawer.tsx'
+
+describe('DeviceTagDrawer', () => {
+  beforeEach(() => {
+    cy.viewport(800, 800)
+  })
+
+  it('should render in disabled state', () => {
+    cy.mountWithProviders(<DeviceTagDrawer context={{}} isDisabled />, {
+      routerProps: { initialEntries: [`/node/wrong-adapter`] },
+    })
+    cy.getByAriaLabel('Edit tags').should('be.visible').should('be.disabled')
+    cy.get('[role="dialog"]').should('not.exist')
+  })
+
+  it('should properly', () => {
+    const onSubmit = cy.stub().as('onSubmit')
+    cy.mountWithProviders(<DeviceTagDrawer context={{}} onSubmit={onSubmit} />, {
+      routerProps: { initialEntries: [`/node/wrong-adapter`] },
+    })
+
+    cy.getByAriaLabel('Edit tags').should('be.visible').should('not.be.disabled')
+    cy.getByAriaLabel('Edit tags').click()
+
+    cy.get('[role="dialog"]').should('be.visible')
+    cy.get('header').should('contain.text', 'Edit the tags')
+
+    cy.get('button[type="submit"]').should('contain.text', 'Submit')
+    cy.injectAxe()
+    cy.checkAccessibility()
+  })
+})

--- a/hivemq-edge/src/frontend/src/modules/Device/components/DeviceTagDrawer.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Device/components/DeviceTagDrawer.tsx
@@ -1,0 +1,60 @@
+import { FC } from 'react'
+import {
+  Button,
+  Drawer,
+  DrawerBody,
+  DrawerCloseButton,
+  DrawerContent,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerOverlay,
+  Text,
+  useDisclosure,
+} from '@chakra-ui/react'
+import IconButton from '@/components/Chakra/IconButton.tsx'
+import { LuFileCog } from 'react-icons/lu'
+import { useTranslation } from 'react-i18next'
+import DeviceTagForm from '@/modules/Device/components/DeviceTagForm.tsx'
+import { Adapter } from '@/api/__generated__'
+
+interface DeviceTagDrawerProps {
+  adapter?: Adapter
+}
+
+const DeviceTagDrawer: FC<DeviceTagDrawerProps> = ({ adapter }) => {
+  const { t } = useTranslation()
+  const { isOpen, onOpen, onClose } = useDisclosure()
+
+  return (
+    <>
+      <IconButton
+        variant="primary"
+        aria-label={t('device.drawer.tagList.cta.edit')}
+        icon={<LuFileCog />}
+        isDisabled={false}
+        onClick={onOpen}
+      />
+      <Drawer isOpen={isOpen} placement="right" size="md" onClose={onClose} closeOnOverlayClick={false}>
+        <DrawerOverlay />
+        <DrawerContent>
+          <DrawerCloseButton />
+          <DrawerHeader>
+            <Text> {t('device.drawer.tagEditor.title')}</Text>
+          </DrawerHeader>
+
+          <DrawerBody>
+            <DeviceTagForm adapterId={adapter?.id as string} adapterType={adapter?.type} />
+          </DrawerBody>
+
+          <DrawerFooter>
+            <Button variant="primary" type="submit" form="namespace-form">
+              {t('unifiedNamespace.submit.label')}
+            </Button>
+          </DrawerFooter>
+        </DrawerContent>
+      </Drawer>
+    </>
+  )
+}
+
+export default DeviceTagDrawer

--- a/hivemq-edge/src/frontend/src/modules/Device/components/DeviceTagDrawer.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Device/components/DeviceTagDrawer.tsx
@@ -1,4 +1,5 @@
 import { FC } from 'react'
+import { useTranslation } from 'react-i18next'
 import {
   Button,
   Drawer,
@@ -11,20 +12,27 @@ import {
   Text,
   useDisclosure,
 } from '@chakra-ui/react'
-import IconButton from '@/components/Chakra/IconButton.tsx'
 import { LuFileCog } from 'react-icons/lu'
-import { useTranslation } from 'react-i18next'
+
+import { DomainTagList } from '@/api/__generated__'
+import IconButton from '@/components/Chakra/IconButton.tsx'
 import DeviceTagForm from '@/modules/Device/components/DeviceTagForm.tsx'
-import { Adapter } from '@/api/__generated__'
+import { ManagerContextType } from '@/modules/Mappings/types.ts'
 
 interface DeviceTagDrawerProps {
-  adapter?: Adapter
   isDisabled?: boolean
+  context: ManagerContextType
+  onSubmit?: (data: DomainTagList | undefined) => void
 }
 
-const DeviceTagDrawer: FC<DeviceTagDrawerProps> = ({ adapter, isDisabled = false }) => {
+const DeviceTagDrawer: FC<DeviceTagDrawerProps> = ({ context, onSubmit, isDisabled = false }) => {
   const { t } = useTranslation()
   const { isOpen, onOpen, onClose } = useDisclosure()
+
+  const onHandleSubmit = (data: DomainTagList | undefined) => {
+    onSubmit?.(data)
+    onClose()
+  }
 
   return (
     <>
@@ -44,11 +52,11 @@ const DeviceTagDrawer: FC<DeviceTagDrawerProps> = ({ adapter, isDisabled = false
           </DrawerHeader>
 
           <DrawerBody>
-            <DeviceTagForm adapterId={adapter?.id as string} adapterType={adapter?.type} />
+            <DeviceTagForm context={context} onSubmit={onHandleSubmit} />
           </DrawerBody>
 
           <DrawerFooter>
-            <Button variant="primary" type="submit" form="adapter-instance-form">
+            <Button variant="primary" type="submit" form="domainTags-instance-form">
               {t('unifiedNamespace.submit.label')}
             </Button>
           </DrawerFooter>

--- a/hivemq-edge/src/frontend/src/modules/Device/components/DeviceTagDrawer.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Device/components/DeviceTagDrawer.tsx
@@ -19,9 +19,10 @@ import { Adapter } from '@/api/__generated__'
 
 interface DeviceTagDrawerProps {
   adapter?: Adapter
+  isDisabled?: boolean
 }
 
-const DeviceTagDrawer: FC<DeviceTagDrawerProps> = ({ adapter }) => {
+const DeviceTagDrawer: FC<DeviceTagDrawerProps> = ({ adapter, isDisabled = false }) => {
   const { t } = useTranslation()
   const { isOpen, onOpen, onClose } = useDisclosure()
 
@@ -31,7 +32,7 @@ const DeviceTagDrawer: FC<DeviceTagDrawerProps> = ({ adapter }) => {
         variant="primary"
         aria-label={t('device.drawer.tagList.cta.edit')}
         icon={<LuFileCog />}
-        isDisabled={false}
+        isDisabled={isDisabled}
         onClick={onOpen}
       />
       <Drawer isOpen={isOpen} placement="right" size="md" onClose={onClose} closeOnOverlayClick={false}>
@@ -47,7 +48,7 @@ const DeviceTagDrawer: FC<DeviceTagDrawerProps> = ({ adapter }) => {
           </DrawerBody>
 
           <DrawerFooter>
-            <Button variant="primary" type="submit" form="namespace-form">
+            <Button variant="primary" type="submit" form="adapter-instance-form">
               {t('unifiedNamespace.submit.label')}
             </Button>
           </DrawerFooter>

--- a/hivemq-edge/src/frontend/src/modules/Device/components/DeviceTagForm.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Device/components/DeviceTagForm.spec.cy.tsx
@@ -18,7 +18,7 @@ describe('AdapterSubscriptionManager', () => {
     cy.intercept('/api/v1/management/protocol-adapters/adapters', { statusCode: 404 })
     cy.intercept('/api/v1/management/protocol-adapters/adapters/*/tags?*', { statusCode: 404 })
 
-    cy.mountWithProviders(<DeviceTagForm adapterId="my-id" adapterType="my-type" />, {
+    cy.mountWithProviders(<DeviceTagForm context={{}} />, {
       routerProps: { initialEntries: [`/node/wrong-adapter`] },
     })
     cy.getByTestId('loading-spinner').should('be.visible')
@@ -40,7 +40,7 @@ describe('AdapterSubscriptionManager', () => {
     }
     cy.intercept('/api/v1/management/protocol-adapters/adapters/*/tags*', mockResponse).as('getTags')
 
-    cy.mountWithProviders(<DeviceTagForm adapterId={mockAdapter_OPCUA_ID} adapterType={mockProtocolAdapter_OPCUA_ID} />)
+    cy.mountWithProviders(<DeviceTagForm context={{}} />)
     cy.getByTestId('loading-spinner').should('be.visible')
 
     cy.wait(['@getProtocols', '@getAdapters', '@getTags'])

--- a/hivemq-edge/src/frontend/src/modules/Device/components/DeviceTagForm.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Device/components/DeviceTagForm.spec.cy.tsx
@@ -1,0 +1,65 @@
+/// <reference types="cypress" />
+
+import DeviceTagForm from '@/modules/Device/components/DeviceTagForm.tsx'
+import {
+  MOCK_DEVICE_TAGS,
+  mockAdapter_OPCUA,
+  mockProtocolAdapter_OPCUA,
+} from '@/api/hooks/useProtocolAdapters/__handlers__'
+import { DomainTagList } from '@/api/__generated__'
+
+describe('AdapterSubscriptionManager', () => {
+  beforeEach(() => {
+    cy.viewport(800, 800)
+  })
+
+  it('should render the errors', () => {
+    cy.intercept('/api/v1/management/protocol-adapters/types', { statusCode: 404 })
+    cy.intercept('/api/v1/management/protocol-adapters/adapters', { statusCode: 404 })
+    cy.intercept('/api/v1/management/protocol-adapters/adapters/*/tags?*', { statusCode: 404 })
+
+    cy.mountWithProviders(<DeviceTagForm adapterId="my-id" adapterType="my-type" />, {
+      routerProps: { initialEntries: [`/node/wrong-adapter`] },
+    })
+    cy.getByTestId('loading-spinner').should('be.visible')
+
+    cy.get('[role="alert"')
+      .should('have.attr', 'data-status', 'error')
+      .should('contain.text', 'We cannot load your adapters for the time being. Please try again later')
+  })
+
+  it.only('should render the form', () => {
+    const mockProtocolAdapter_OPCUA_ID = mockProtocolAdapter_OPCUA?.id as string
+    const mockAdapter_OPCUA_ID = mockAdapter_OPCUA.id as string
+    cy.intercept('/api/v1/management/protocol-adapters/types', { items: [mockProtocolAdapter_OPCUA] }).as(
+      'getProtocols'
+    )
+    cy.intercept('/api/v1/management/protocol-adapters/adapters', { items: [mockAdapter_OPCUA] }).as('getAdapters')
+    const mockResponse: DomainTagList = {
+      items: MOCK_DEVICE_TAGS(mockProtocolAdapter_OPCUA_ID, mockAdapter_OPCUA_ID),
+    }
+    cy.intercept('/api/v1/management/protocol-adapters/adapters/*/tags*', mockResponse).as('getTags')
+
+    cy.mountWithProviders(<DeviceTagForm adapterId={mockAdapter_OPCUA_ID} adapterType={mockProtocolAdapter_OPCUA_ID} />)
+    cy.getByTestId('loading-spinner').should('be.visible')
+
+    cy.wait(['@getProtocols', '@getAdapters', '@getTags'])
+
+    cy.get('#root_tags__title').should('contain.text', 'List of tags')
+    cy.get('#root_tags__title + p').should('contain.text', 'The list of all tags defined in the device')
+    cy.get('#root_tags__title + p + [role="list"]').as('tagList').should('be.visible')
+    cy.get('@tagList').find('[role="listitem"]').should('have.length', 1)
+
+    cy.get('@tagList').eq(0).find('[role="toolbar"] button').eq(0).should('have.attr', 'aria-label', 'Remove')
+    cy.get('#root_tags_0__title').should('have.text', 'tags-0')
+
+    cy.get('@tagList').eq(0).find('[role="group"] > label').eq(0).should('contain.text', 'Tag Name')
+    cy.get('@tagList')
+      .eq(0)
+      .find('[role="group"] > input')
+      .eq(0)
+      .should('contain.value', `${mockProtocolAdapter_OPCUA_ID}/log/event`)
+
+    cy.get('#root_tags__title + p + [role="list"] + div button').should('contain.text', 'Add Item')
+  })
+})

--- a/hivemq-edge/src/frontend/src/modules/Device/components/DeviceTagForm.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Device/components/DeviceTagForm.spec.cy.tsx
@@ -33,12 +33,6 @@ describe('DeviceTagForm', () => {
               test: 'ns=3;i=1002',
             },
           },
-          // {
-          //   tag: 'opcua-generator/log/event',
-          //   dataPoint: {
-          //     test: 'ns=3;i=1008',
-          //   },
-          // },
         ],
       },
     }

--- a/hivemq-edge/src/frontend/src/modules/Device/components/DeviceTagForm.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Device/components/DeviceTagForm.tsx
@@ -2,6 +2,7 @@ import { FC, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { IChangeEvent } from '@rjsf/core'
 import Form from '@rjsf/chakra-ui'
+import debug from 'debug'
 
 import { useGetDomainTags } from '@/api/hooks/useProtocolAdapters/useGetDomainTags.tsx'
 import LoaderSpinner from '@/components/Chakra/LoaderSpinner.tsx'
@@ -14,11 +15,14 @@ import { ArrayFieldItemTemplate } from '@/components/rjsf/ArrayFieldItemTemplate
 import { customFormatsValidator } from '@/modules/ProtocolAdapters/utils/validation-utils.ts'
 import { adapterJSFFields, adapterJSFWidgets } from '@/modules/ProtocolAdapters/utils/uiSchema.utils.ts'
 import { useMappingManager } from '@/modules/Mappings/hooks/useMappingManager.tsx'
+import { DomainTagList } from '@/api/__generated__'
 
 interface DeviceTagFormProps {
   adapterId: string
   adapterType?: string
 }
+
+const rjsfLog = debug('RJSF:DeviceTagForm')
 
 const DeviceTagForm: FC<DeviceTagFormProps> = ({ adapterId, adapterType }) => {
   const { t } = useTranslation()
@@ -58,7 +62,7 @@ const DeviceTagForm: FC<DeviceTagFormProps> = ({ adapterId, adapterType }) => {
         ArrayFieldTemplate,
         ArrayFieldItemTemplate,
       }}
-      onError={(errors) => console.log('XXXXX', errors)}
+      onError={(errors) => rjsfLog(t('error.rjsf.validation'), errors)}
     />
   )
 }

--- a/hivemq-edge/src/frontend/src/modules/Device/components/DeviceTagForm.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Device/components/DeviceTagForm.tsx
@@ -4,8 +4,7 @@ import type { IChangeEvent } from '@rjsf/core'
 import Form from '@rjsf/chakra-ui'
 import debug from 'debug'
 
-import { useGetDomainTags } from '@/api/hooks/useProtocolAdapters/useGetDomainTags.tsx'
-import LoaderSpinner from '@/components/Chakra/LoaderSpinner.tsx'
+import { DomainTagList } from '@/api/__generated__'
 import ErrorMessage from '@/components/ErrorMessage.tsx'
 import { ObjectFieldTemplate } from '@/components/rjsf/ObjectFieldTemplate.tsx'
 import { FieldTemplate } from '@/components/rjsf/FieldTemplate.tsx'
@@ -14,42 +13,36 @@ import { ArrayFieldTemplate } from '@/components/rjsf/ArrayFieldTemplate.tsx'
 import { ArrayFieldItemTemplate } from '@/components/rjsf/ArrayFieldItemTemplate.tsx'
 import { customFormatsValidator } from '@/modules/ProtocolAdapters/utils/validation-utils.ts'
 import { adapterJSFFields, adapterJSFWidgets } from '@/modules/ProtocolAdapters/utils/uiSchema.utils.ts'
-import { useMappingManager } from '@/modules/Mappings/hooks/useMappingManager.tsx'
-import { DomainTagList } from '@/api/__generated__'
+import { ManagerContextType } from '@/modules/Mappings/types.ts'
 
 interface DeviceTagFormProps {
-  adapterId: string
-  adapterType?: string
+  context: ManagerContextType
+  onSubmit?: (data: DomainTagList | undefined) => void
 }
 
 const rjsfLog = debug('RJSF:DeviceTagForm')
 
-const DeviceTagForm: FC<DeviceTagFormProps> = ({ adapterId, adapterType }) => {
+const DeviceTagForm: FC<DeviceTagFormProps> = ({ context, onSubmit }) => {
   const { t } = useTranslation()
-  const { tagsManager, isLoading } = useMappingManager(adapterId)
-  const { data: tags, isError, isLoading: isLoadingTags } = useGetDomainTags(adapterId, adapterType)
 
   const onFormSubmit = useCallback(
-    (data: IChangeEvent) => {
-      const subscriptions = data.formData?.subscriptions
-      tagsManager?.onSubmit?.(subscriptions.tags)
+    (data: IChangeEvent<DomainTagList>) => {
+      onSubmit?.(data.formData)
     },
-    [tagsManager]
+    [onSubmit]
   )
 
-  if (isLoadingTags || isLoading) return <LoaderSpinner />
-  if (!tagsManager || isError || tagsManager.errors)
-    return <ErrorMessage message={t('protocolAdapter.error.loading')} />
+  if (!context.schema) return <ErrorMessage message={t('device.errors.noFormSchema')} />
 
   return (
     <Form
-      id="adapter-instance-form"
-      schema={tagsManager.schema}
-      uiSchema={tagsManager.uiSchema}
-      formData={{ tags: tags?.items }}
+      id="domainTags-instance-form"
+      schema={context.schema}
+      uiSchema={context.uiSchema}
+      formData={context.formData}
       liveValidate
       noHtml5Validate
-      // focusOnFirstError
+      focusOnFirstError
       onSubmit={onFormSubmit}
       validator={customFormatsValidator}
       showErrorList="bottom"

--- a/hivemq-edge/src/frontend/src/modules/Device/components/DeviceTagForm.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Device/components/DeviceTagForm.tsx
@@ -34,7 +34,8 @@ const DeviceTagForm: FC<DeviceTagFormProps> = ({ adapterId, adapterType }) => {
   )
 
   if (isLoadingTags || isLoading) return <LoaderSpinner />
-  if (!tagsManager || isError) return <ErrorMessage message={t('protocolAdapter.error.loading')} />
+  if (!tagsManager || isError || tagsManager.errors)
+    return <ErrorMessage message={t('protocolAdapter.error.loading')} />
 
   return (
     <Form

--- a/hivemq-edge/src/frontend/src/modules/Device/components/DeviceTagForm.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Device/components/DeviceTagForm.tsx
@@ -1,0 +1,65 @@
+import { FC, useCallback } from 'react'
+import { useTranslation } from 'react-i18next'
+import type { IChangeEvent } from '@rjsf/core'
+import Form from '@rjsf/chakra-ui'
+
+import { useGetDomainTags } from '@/api/hooks/useProtocolAdapters/useGetDomainTags.tsx'
+import LoaderSpinner from '@/components/Chakra/LoaderSpinner.tsx'
+import ErrorMessage from '@/components/ErrorMessage.tsx'
+import { ObjectFieldTemplate } from '@/components/rjsf/ObjectFieldTemplate.tsx'
+import { FieldTemplate } from '@/components/rjsf/FieldTemplate.tsx'
+import { BaseInputTemplate } from '@/components/rjsf/BaseInputTemplate.tsx'
+import { ArrayFieldTemplate } from '@/components/rjsf/ArrayFieldTemplate.tsx'
+import { ArrayFieldItemTemplate } from '@/components/rjsf/ArrayFieldItemTemplate.tsx'
+import { customFormatsValidator } from '@/modules/ProtocolAdapters/utils/validation-utils.ts'
+import { adapterJSFFields, adapterJSFWidgets } from '@/modules/ProtocolAdapters/utils/uiSchema.utils.ts'
+import { useMappingManager } from '@/modules/Mappings/hooks/useMappingManager.tsx'
+
+interface DeviceTagFormProps {
+  adapterId: string
+  adapterType?: string
+}
+
+const DeviceTagForm: FC<DeviceTagFormProps> = ({ adapterId, adapterType }) => {
+  const { t } = useTranslation()
+  const { tagsManager, isLoading } = useMappingManager(adapterId)
+  const { data: tags, isError, isLoading: isLoadingTags } = useGetDomainTags(adapterId, adapterType)
+
+  const onFormSubmit = useCallback(
+    (data: IChangeEvent) => {
+      const subscriptions = data.formData?.subscriptions
+      tagsManager?.onSubmit?.(subscriptions.tags)
+    },
+    [tagsManager]
+  )
+
+  if (isLoadingTags || isLoading) return <LoaderSpinner />
+  if (!tagsManager || isError) return <ErrorMessage message={t('protocolAdapter.error.loading')} />
+
+  return (
+    <Form
+      id="adapter-instance-form"
+      schema={tagsManager.schema}
+      uiSchema={tagsManager.uiSchema}
+      formData={{ tags: tags?.items }}
+      liveValidate
+      noHtml5Validate
+      // focusOnFirstError
+      onSubmit={onFormSubmit}
+      validator={customFormatsValidator}
+      showErrorList="bottom"
+      widgets={adapterJSFWidgets}
+      fields={adapterJSFFields}
+      templates={{
+        ObjectFieldTemplate,
+        FieldTemplate,
+        BaseInputTemplate,
+        ArrayFieldTemplate,
+        ArrayFieldItemTemplate,
+      }}
+      onError={(errors) => console.log('XXXXX', errors)}
+    />
+  )
+}
+
+export default DeviceTagForm

--- a/hivemq-edge/src/frontend/src/modules/Device/components/DeviceTagList.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Device/components/DeviceTagList.spec.cy.tsx
@@ -1,0 +1,65 @@
+/// <reference types="cypress" />
+
+import {
+  MOCK_DEVICE_TAGS,
+  mockAdapter_OPCUA,
+  mockProtocolAdapter_OPCUA,
+} from '@/api/hooks/useProtocolAdapters/__handlers__'
+import DeviceTagList from '@/modules/Device/components/DeviceTagList.tsx'
+
+describe('DeviceTagList', () => {
+  beforeEach(() => {
+    cy.viewport(800, 800)
+    cy.intercept('/api/v1/management/protocol-adapters/types', { items: [mockProtocolAdapter_OPCUA] }).as(
+      'getProtocols'
+    )
+    cy.intercept('/api/v1/management/protocol-adapters/adapters', { items: [mockAdapter_OPCUA] }).as('getAdapters')
+  })
+
+  it('should render the errors', () => {
+    cy.intercept('/api/v1/management/protocol-adapters/adapters/*/tags?*', { statusCode: 404 }).as('getTags')
+
+    cy.mountWithProviders(<DeviceTagList adapter={mockAdapter_OPCUA} />)
+    cy.getByTestId('loading-spinner').should('be.visible')
+    cy.get('[role="alert"').should('have.attr', 'data-status', 'error').should('contain.text', 'Cannot load the tags')
+    cy.getByAriaLabel('Edit tags').should('be.visible').should('be.disabled')
+  })
+
+  it('should render an empty list', () => {
+    cy.intercept('/api/v1/management/protocol-adapters/adapters/*/tags?*', { items: [] }).as('getTags')
+
+    cy.mountWithProviders(<DeviceTagList adapter={mockAdapter_OPCUA} />)
+    cy.getByTestId('loading-spinner').should('be.visible')
+
+    cy.get('[role="alert"')
+      .should('have.attr', 'data-status', 'info')
+      .should('contain.text', 'There is no tag created yet')
+
+    cy.getByAriaLabel('Edit tags').should('be.visible').should('not.be.disabled')
+  })
+
+  it('should render properly', () => {
+    cy.intercept('/api/v1/management/protocol-adapters/adapters/*/tags?*', {
+      items: MOCK_DEVICE_TAGS('opcua-1', 'opcua'),
+    }).as('getTags')
+
+    cy.mountWithProviders(<DeviceTagList adapter={mockAdapter_OPCUA} />)
+    cy.getByTestId('loading-spinner').should('be.visible')
+
+    cy.get('h2').should('have.text', 'List of Device Tags')
+    cy.getByAriaLabel('Edit tags').should('be.visible').should('not.be.disabled')
+
+    cy.getByTestId('device-tags-list').should('be.visible')
+    cy.getByTestId('device-tags-list').find('li').should('have.length', 2)
+  })
+
+  it('should be accessible', () => {
+    cy.intercept('/api/v1/management/protocol-adapters/adapters/*/tags?*', {
+      items: MOCK_DEVICE_TAGS('opcua-1', 'opcua'),
+    }).as('getTags')
+
+    cy.mountWithProviders(<DeviceTagList adapter={mockAdapter_OPCUA} />)
+    cy.injectAxe()
+    cy.checkAccessibility()
+  })
+})

--- a/hivemq-edge/src/frontend/src/modules/Device/components/DeviceTagList.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Device/components/DeviceTagList.tsx
@@ -1,12 +1,14 @@
 import { FC } from 'react'
-import { Card, CardBody, CardHeader, Code, Heading, HStack, List, ListItem } from '@chakra-ui/react'
-import LoaderSpinner from '@/components/Chakra/LoaderSpinner.tsx'
-import { useGetDomainTags } from '@/api/hooks/useProtocolAdapters/useGetDomainTags.tsx'
-import { Adapter } from '@/api/__generated__'
-import { PLCTag } from '@/components/MQTT/EntityTag.tsx'
-import { formatTagDataPoint } from '@/modules/Device/utils/tags.utils.ts'
-import ErrorMessage from '@/components/ErrorMessage.tsx'
 import { useTranslation } from 'react-i18next'
+import { Card, CardBody, CardHeader, Code, Flex, Heading, HStack, List, ListItem } from '@chakra-ui/react'
+
+import { Adapter } from '@/api/__generated__'
+import { useGetDomainTags } from '@/api/hooks/useProtocolAdapters/useGetDomainTags.tsx'
+import LoaderSpinner from '@/components/Chakra/LoaderSpinner.tsx'
+import ErrorMessage from '@/components/ErrorMessage.tsx'
+import { PLCTag } from '@/components/MQTT/EntityTag.tsx'
+import DeviceTagDrawer from '@/modules/Device/components/DeviceTagDrawer.tsx'
+import { formatTagDataPoint } from '@/modules/Device/utils/tags.utils.ts'
 
 interface DeviceTagListProps {
   adapter?: Adapter
@@ -19,13 +21,19 @@ const DeviceTagList: FC<DeviceTagListProps> = ({ adapter }) => {
   return (
     <Card size="sm">
       <CardHeader>
-        <Heading size="sm">{t('device.drawer.tagPanel.title')}</Heading>
+        <Flex>
+          <Flex flex="1" alignItems="center" flexWrap="wrap">
+            <Heading size="sm">{t('device.drawer.tagList.title')}</Heading>
+          </Flex>
+          <DeviceTagDrawer adapter={adapter} />
+        </Flex>
       </CardHeader>
       <CardBody>
         {isLoading && <LoaderSpinner />}
-        {isError && <ErrorMessage message="XXXX Cannot load the tags" />}
-        {!isError && !data?.items?.length && <ErrorMessage message="XXXX No tag defined" status="info" />}
+        {isError && <ErrorMessage message={t('device.errors.noTagLoaded')} />}
+        {!isError && !data?.items?.length && <ErrorMessage message={t('device.errors.noTagCreated')} status="info" />}
         {!isError && data && (
+          // TODO[NVL] Too simple. Use a paginated table
           <List>
             {data.items?.map((e) => (
               <ListItem key={e.tag} m={1} display="flex" justifyContent="space-between">

--- a/hivemq-edge/src/frontend/src/modules/Device/components/DeviceTagList.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Device/components/DeviceTagList.tsx
@@ -2,7 +2,7 @@ import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Card, CardBody, CardHeader, Code, Flex, Heading, HStack, List, ListItem } from '@chakra-ui/react'
 
-import { Adapter } from '@/api/__generated__'
+import { Adapter, DomainTagList } from '@/api/__generated__'
 import LoaderSpinner from '@/components/Chakra/LoaderSpinner.tsx'
 import ErrorMessage from '@/components/ErrorMessage.tsx'
 import { PLCTag } from '@/components/MQTT/EntityTag.tsx'
@@ -16,7 +16,11 @@ interface DeviceTagListProps {
 
 const DeviceTagList: FC<DeviceTagListProps> = ({ adapter }) => {
   const { t } = useTranslation()
-  const { data, isLoading, isError } = useTagManager(adapter?.id)
+  const { data, isLoading, isError, context, onUpdateList } = useTagManager(adapter?.id)
+
+  const onHandleSubmit = (data: DomainTagList | undefined) => {
+    if (data) onUpdateList(data)
+  }
 
   return (
     <Card size="sm">
@@ -25,7 +29,7 @@ const DeviceTagList: FC<DeviceTagListProps> = ({ adapter }) => {
           <Flex flex="1" alignItems="center" flexWrap="wrap">
             <Heading size="sm">{t('device.drawer.tagList.title')}</Heading>
           </Flex>
-          <DeviceTagDrawer adapter={adapter} isDisabled={isLoading || isError} />
+          <DeviceTagDrawer isDisabled={isLoading || isError} context={context} onSubmit={onHandleSubmit} />
         </Flex>
       </CardHeader>
       <CardBody>

--- a/hivemq-edge/src/frontend/src/modules/Device/components/DeviceTagList.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Device/components/DeviceTagList.tsx
@@ -1,0 +1,47 @@
+import { FC } from 'react'
+import { Card, CardBody, CardHeader, Code, Heading, HStack, List, ListItem } from '@chakra-ui/react'
+import LoaderSpinner from '@/components/Chakra/LoaderSpinner.tsx'
+import { useGetDomainTags } from '@/api/hooks/useProtocolAdapters/useGetDomainTags.tsx'
+import { Adapter } from '@/api/__generated__'
+import { PLCTag } from '@/components/MQTT/EntityTag.tsx'
+import { formatTagDataPoint } from '@/modules/Device/utils/tags.utils.ts'
+import ErrorMessage from '@/components/ErrorMessage.tsx'
+import { useTranslation } from 'react-i18next'
+
+interface DeviceTagListProps {
+  adapter?: Adapter
+}
+
+const DeviceTagList: FC<DeviceTagListProps> = ({ adapter }) => {
+  const { t } = useTranslation()
+  const { data, isLoading, isError } = useGetDomainTags(adapter?.id, adapter?.type)
+
+  return (
+    <Card size="sm">
+      <CardHeader>
+        <Heading size="sm">{t('XXXXX List of Device Tags')}</Heading>
+      </CardHeader>
+      <CardBody>
+        {isLoading && <LoaderSpinner />}
+        {isError && <ErrorMessage message="XXXX Cannot load the tags" />}
+        {!isError && !data?.items?.length && <ErrorMessage message="XXXX No tag defined" status="info" />}
+        {!isError && data && (
+          <List>
+            {data.items?.map((e) => (
+              <ListItem key={e.tag} m={1} display="flex" justifyContent="space-between">
+                <HStack w="100%" justifyContent="space-between">
+                  <PLCTag tagTitle={e.tag} />{' '}
+                  <Code size="xs" textAlign="end">
+                    {formatTagDataPoint(e.dataPoint)}
+                  </Code>
+                </HStack>
+              </ListItem>
+            ))}
+          </List>
+        )}
+      </CardBody>
+    </Card>
+  )
+}
+
+export default DeviceTagList

--- a/hivemq-edge/src/frontend/src/modules/Device/components/DeviceTagList.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Device/components/DeviceTagList.tsx
@@ -3,12 +3,12 @@ import { useTranslation } from 'react-i18next'
 import { Card, CardBody, CardHeader, Code, Flex, Heading, HStack, List, ListItem } from '@chakra-ui/react'
 
 import { Adapter } from '@/api/__generated__'
-import { useGetDomainTags } from '@/api/hooks/useProtocolAdapters/useGetDomainTags.tsx'
 import LoaderSpinner from '@/components/Chakra/LoaderSpinner.tsx'
 import ErrorMessage from '@/components/ErrorMessage.tsx'
 import { PLCTag } from '@/components/MQTT/EntityTag.tsx'
 import DeviceTagDrawer from '@/modules/Device/components/DeviceTagDrawer.tsx'
 import { formatTagDataPoint } from '@/modules/Device/utils/tags.utils.ts'
+import { useTagManager } from '@/modules/Mappings/hooks/useTagManager.tsx'
 
 interface DeviceTagListProps {
   adapter?: Adapter
@@ -16,7 +16,7 @@ interface DeviceTagListProps {
 
 const DeviceTagList: FC<DeviceTagListProps> = ({ adapter }) => {
   const { t } = useTranslation()
-  const { data, isLoading, isError } = useGetDomainTags(adapter?.id, adapter?.type)
+  const { data, isLoading, isError } = useTagManager(adapter?.id)
 
   return (
     <Card size="sm">
@@ -31,8 +31,10 @@ const DeviceTagList: FC<DeviceTagListProps> = ({ adapter }) => {
       <CardBody>
         {isLoading && <LoaderSpinner />}
         {isError && <ErrorMessage message={t('device.errors.noTagLoaded')} />}
-        {!isError && !data?.items?.length && <ErrorMessage message={t('device.errors.noTagCreated')} status="info" />}
-        {!isError && data && (
+        {!isError && !isLoading && !data?.items?.length && (
+          <ErrorMessage message={t('device.errors.noTagCreated')} status="info" />
+        )}
+        {!isError && !isLoading && data && (
           // TODO[NVL] Too simple. Use a paginated table
           <List>
             {data.items?.map((e) => (

--- a/hivemq-edge/src/frontend/src/modules/Device/components/DeviceTagList.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Device/components/DeviceTagList.tsx
@@ -40,7 +40,7 @@ const DeviceTagList: FC<DeviceTagListProps> = ({ adapter }) => {
         )}
         {!isError && !isLoading && data && (
           // TODO[NVL] Too simple. Use a paginated table
-          <List>
+          <List data-testid="device-tags-list">
             {data.items?.map((e) => (
               <ListItem key={e.tag} m={1} display="flex" justifyContent="space-between">
                 <HStack w="100%" justifyContent="space-between">

--- a/hivemq-edge/src/frontend/src/modules/Device/components/DeviceTagList.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Device/components/DeviceTagList.tsx
@@ -19,7 +19,7 @@ const DeviceTagList: FC<DeviceTagListProps> = ({ adapter }) => {
   return (
     <Card size="sm">
       <CardHeader>
-        <Heading size="sm">{t('XXXXX List of Device Tags')}</Heading>
+        <Heading size="sm">{t('device.drawer.tagPanel.title')}</Heading>
       </CardHeader>
       <CardBody>
         {isLoading && <LoaderSpinner />}

--- a/hivemq-edge/src/frontend/src/modules/Device/components/DeviceTagList.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Device/components/DeviceTagList.tsx
@@ -25,7 +25,7 @@ const DeviceTagList: FC<DeviceTagListProps> = ({ adapter }) => {
           <Flex flex="1" alignItems="center" flexWrap="wrap">
             <Heading size="sm">{t('device.drawer.tagList.title')}</Heading>
           </Flex>
-          <DeviceTagDrawer adapter={adapter} />
+          <DeviceTagDrawer adapter={adapter} isDisabled={isLoading || isError} />
         </Flex>
       </CardHeader>
       <CardBody>

--- a/hivemq-edge/src/frontend/src/modules/Device/components/DeviceTagList.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Device/components/DeviceTagList.tsx
@@ -16,10 +16,10 @@ interface DeviceTagListProps {
 
 const DeviceTagList: FC<DeviceTagListProps> = ({ adapter }) => {
   const { t } = useTranslation()
-  const { data, isLoading, isError, context, onUpdateList } = useTagManager(adapter?.id)
+  const { data, isLoading, isError, context, onupdateCollection } = useTagManager(adapter?.id)
 
   const onHandleSubmit = (data: DomainTagList | undefined) => {
-    if (data) onUpdateList(data)
+    if (data) onupdateCollection(data)
   }
 
   return (

--- a/hivemq-edge/src/frontend/src/modules/Device/utils/tags.utils.spec.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Device/utils/tags.utils.spec.tsx
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest'
+import { createSchema, formatTagDataPoint } from '@/modules/Device/utils/tags.utils.ts'
+import { MOCK_DEVICE_TAG_ADDRESS_MODBUS } from '@/api/hooks/useProtocolAdapters/__handlers__'
+
+describe('formatTagDataPoint', () => {
+  it('should return a warning when no data schema given', () => {
+    expect(formatTagDataPoint()).toBe('< unknown format >')
+  })
+
+  it('should return a formatted payload', () => {
+    expect(formatTagDataPoint(MOCK_DEVICE_TAG_ADDRESS_MODBUS)).toBe(
+      JSON.stringify(MOCK_DEVICE_TAG_ADDRESS_MODBUS, null, 4)
+    )
+  })
+})
+
+describe('createSchema', () => {
+  it('should return a wrong schema if items not defined', () => {
+    expect(createSchema({ fakeProperty: 'my-property' })).toStrictEqual(
+      expect.objectContaining({
+        definitions: expect.objectContaining({
+          DeviceDataPoint: expect.objectContaining({
+            properties: {},
+          }),
+          DomainTag: expect.objectContaining({}),
+        }),
+        properties: expect.objectContaining({}),
+      })
+    )
+  })
+
+  it('should return a correct schema', () => {
+    expect(
+      createSchema({
+        properties: {
+          fake: {
+            type: 'string',
+          },
+        },
+      })
+    ).toStrictEqual(
+      expect.objectContaining({
+        definitions: expect.objectContaining({
+          DeviceDataPoint: expect.objectContaining({
+            properties: {
+              fake: {
+                type: 'string',
+              },
+            },
+          }),
+          DomainTag: expect.objectContaining({}),
+        }),
+        properties: expect.objectContaining({}),
+      })
+    )
+  })
+
+  it('should return a filtered schema', () => {
+    expect(
+      createSchema({
+        properties: {
+          fake: {
+            type: 'string',
+          },
+          mqttTopic: {
+            type: 'string',
+          },
+        },
+      })
+    ).toStrictEqual(
+      expect.objectContaining({
+        definitions: expect.objectContaining({
+          DeviceDataPoint: expect.objectContaining({
+            properties: {
+              fake: {
+                type: 'string',
+              },
+            },
+          }),
+          DomainTag: expect.objectContaining({}),
+        }),
+        properties: expect.objectContaining({}),
+      })
+    )
+  })
+})

--- a/hivemq-edge/src/frontend/src/modules/Device/utils/tags.utils.spec.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Device/utils/tags.utils.spec.tsx
@@ -16,16 +16,8 @@ describe('formatTagDataPoint', () => {
 
 describe('createSchema', () => {
   it('should return a wrong schema if items not defined', () => {
-    expect(createSchema({ fakeProperty: 'my-property' })).toStrictEqual(
-      expect.objectContaining({
-        definitions: expect.objectContaining({
-          DeviceDataPoint: expect.objectContaining({
-            properties: {},
-          }),
-          DomainTag: expect.objectContaining({}),
-        }),
-        properties: expect.objectContaining({}),
-      })
+    expect(() => createSchema({ fakeProperty: 'my-property' })).toThrowError(
+      'The form cannot be created, due to internal errors'
     )
   })
 

--- a/hivemq-edge/src/frontend/src/modules/Device/utils/tags.utils.ts
+++ b/hivemq-edge/src/frontend/src/modules/Device/utils/tags.utils.ts
@@ -16,9 +16,12 @@ const omit = (obj: JsonNode, ...props: string[]) => {
 
 /**
  * @deprecated This is a mock, missing support for tags
+ * Note that the stubs generated from the OpenAPI include schemas (see src/api/__generated__/schemas) but they are not usable
+ * due to the lack of connection between the instances.
+ * TheLibrary is not supported anymore; it needs replacement, see https://hivemq.kanbanize.com/ctrl_board/57/cards/24980/details/
  */
 export const createSchema = (items: RJSFSchema) => {
-  // This is totally wrong. The DeviceDataPoint schema should be clearly indicated in the
+  // TODO[NVL] This is total rubbish. The DeviceDataPoint schema should be self-extracted from the OpenAPI specs rather than second-guessed
   const sourceProperties = omit(
     items.properties as JsonNode,
     'mqttQos',
@@ -37,6 +40,8 @@ export const createSchema = (items: RJSFSchema) => {
     definitions: {
       DeviceDataPoint: {
         type: 'object',
+        title: 'Tag Address',
+        description: `The address of the data-point on the device.`,
         properties: sourceProperties,
       },
       DomainTag: {
@@ -45,6 +50,7 @@ export const createSchema = (items: RJSFSchema) => {
         properties: {
           tag: {
             type: 'string',
+            title: 'Tag Name',
             description: `The Tag associated with the data-point.`,
           },
           dataPoint: {
@@ -56,6 +62,8 @@ export const createSchema = (items: RJSFSchema) => {
     properties: {
       tags: {
         type: 'array',
+        title: 'List of tags',
+        description: 'The list of all tags defined in the device',
         items: {
           $ref: '#/definitions/DomainTag',
         },

--- a/hivemq-edge/src/frontend/src/modules/Device/utils/tags.utils.ts
+++ b/hivemq-edge/src/frontend/src/modules/Device/utils/tags.utils.ts
@@ -1,6 +1,65 @@
-import type { DeviceDataPoint } from '@/api/__generated__'
+import { DeviceDataPoint, JsonNode } from '@/api/__generated__'
+import { RJSFSchema } from '@rjsf/utils'
 
 export const formatTagDataPoint = (data?: DeviceDataPoint) => {
   if (data) return JSON.stringify(data, null, 4)
   return '< unknown format >'
+}
+
+const omit = (obj: JsonNode, ...props: string[]) => {
+  const result = { ...obj }
+  props.forEach(function (prop) {
+    delete result[prop]
+  })
+  return result
+}
+
+/**
+ * @deprecated This is a mock, missing support for tags
+ */
+export const createSchema = (items: RJSFSchema) => {
+  // This is totally wrong. The DeviceDataPoint schema should be clearly indicated in the
+  const sourceProperties = omit(
+    items.properties as JsonNode,
+    'mqttQos',
+    'mqttTopic',
+    'messageExpiryInterval',
+    'publishingInterval',
+    'serverQueueSize',
+    'includeTagNames',
+    'includeTimestamp',
+    'messageHandlingOptions',
+    'mqttUserProperties'
+  )
+
+  return {
+    // $schema: 'https://json-schema.org/draft/2020-12/schema',
+    definitions: {
+      DeviceDataPoint: {
+        type: 'object',
+        properties: sourceProperties,
+      },
+      DomainTag: {
+        description: `A tag associated with a data point on a device connected to the adapter`,
+        required: ['tag'],
+        properties: {
+          tag: {
+            type: 'string',
+            description: `The Tag associated with the data-point.`,
+          },
+          dataPoint: {
+            $ref: '#/definitions/DeviceDataPoint',
+          },
+        },
+      },
+    },
+    properties: {
+      tags: {
+        type: 'array',
+        items: {
+          $ref: '#/definitions/DomainTag',
+        },
+      },
+    },
+  } as RJSFSchema
 }

--- a/hivemq-edge/src/frontend/src/modules/Device/utils/tags.utils.ts
+++ b/hivemq-edge/src/frontend/src/modules/Device/utils/tags.utils.ts
@@ -1,0 +1,6 @@
+import type { DeviceDataPoint } from '@/api/__generated__'
+
+export const formatTagDataPoint = (data?: DeviceDataPoint) => {
+  if (data) return JSON.stringify(data, null, 4)
+  return '< unknown format >'
+}

--- a/hivemq-edge/src/frontend/src/modules/Device/utils/tags.utils.ts
+++ b/hivemq-edge/src/frontend/src/modules/Device/utils/tags.utils.ts
@@ -1,9 +1,11 @@
 import { DeviceDataPoint, JsonNode } from '@/api/__generated__'
 import { RJSFSchema } from '@rjsf/utils'
 
+import i18n from '@/config/i18n.config.ts'
+
 export const formatTagDataPoint = (data?: DeviceDataPoint) => {
   if (data) return JSON.stringify(data, null, 4)
-  return '< unknown format >'
+  return i18n.t('device.drawer.tagList.formatter.unknownFormat')
 }
 
 const omit = (obj: JsonNode, ...props: string[]) => {

--- a/hivemq-edge/src/frontend/src/modules/Device/utils/tags.utils.ts
+++ b/hivemq-edge/src/frontend/src/modules/Device/utils/tags.utils.ts
@@ -60,7 +60,7 @@ export const createSchema = (items: RJSFSchema) => {
       },
     },
     properties: {
-      tags: {
+      items: {
         type: 'array',
         title: 'List of tags',
         description: 'The list of all tags defined in the device',

--- a/hivemq-edge/src/frontend/src/modules/Device/utils/tags.utils.ts
+++ b/hivemq-edge/src/frontend/src/modules/Device/utils/tags.utils.ts
@@ -36,6 +36,7 @@ export const createSchema = (items: RJSFSchema) => {
     'messageHandlingOptions',
     'mqttUserProperties'
   )
+  if (!Object.keys(sourceProperties).length) throw new Error(i18n.t('device.errors.noFormSchema'))
 
   return {
     // $schema: 'https://json-schema.org/draft/2020-12/schema',

--- a/hivemq-edge/src/frontend/src/modules/Mappings/components/MappingForm.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/components/MappingForm.spec.cy.tsx
@@ -1,0 +1,25 @@
+/// <reference types="cypress" />
+
+import { mockAdapter_OPCUA, mockProtocolAdapter_OPCUA } from '@/api/hooks/useProtocolAdapters/__handlers__'
+import MappingForm from '@/modules/Mappings/components/MappingForm.tsx'
+import { MappingType } from '@/modules/Mappings/types.ts'
+
+describe('MappingForm', () => {
+  beforeEach(() => {
+    cy.viewport(800, 800)
+    cy.intercept('/api/v1/management/protocol-adapters/types', { items: [mockProtocolAdapter_OPCUA] }).as('getProtocol')
+    cy.intercept('/api/v1/management/protocol-adapters/adapters', { items: [mockAdapter_OPCUA] }).as('getAdapter')
+    cy.intercept('/api/v1/management/bridges', { items: [] })
+    cy.intercept('http://json-schema.org/draft/2020-12/schema', { statusCode: 404 })
+  })
+
+  it('should render properly', () => {
+    cy.mountWithProviders(<MappingForm adapterId={mockAdapter_OPCUA.id} type={MappingType.OUTWARD} />, {
+      routerProps: { initialEntries: [`/node/wrong-adapter`] },
+    })
+
+    cy.getByTestId('mapping-editor-switch').should('be.visible')
+
+    // TODO[NVL] To do after validation and array template updated
+  })
+})

--- a/hivemq-edge/src/frontend/src/modules/Mappings/components/MappingForm.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/components/MappingForm.tsx
@@ -2,6 +2,7 @@ import { type FC, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import Form from '@rjsf/chakra-ui'
 import { type IChangeEvent } from '@rjsf/core'
+import debug from 'debug'
 
 import ErrorMessage from '@/components/ErrorMessage.tsx'
 import { ObjectFieldTemplate } from '@/components/rjsf/ObjectFieldTemplate.tsx'
@@ -20,6 +21,8 @@ interface MappingFormProps {
   adapterType?: string
   type: MappingType
 }
+
+const rjsfLog = debug('RJSF:MappingForm')
 
 // TODO[NVL] Should replicate the config from the adapter form; share component?
 const MappingForm: FC<MappingFormProps> = ({ adapterId, adapterType, type }) => {
@@ -57,7 +60,7 @@ const MappingForm: FC<MappingFormProps> = ({ adapterId, adapterType, type }) => 
       onSubmit={onFormSubmit}
       validator={customFormatsValidator}
       showErrorList="bottom"
-      onError={(errors) => console.log('XXXXXXX', errors)}
+      onError={(errors) => rjsfLog(t('error.rjsf.validation'), errors)}
       formData={mappingManager.formData}
       widgets={adapterJSFWidgets}
       fields={adapterJSFFields}

--- a/hivemq-edge/src/frontend/src/modules/Mappings/hooks/useMappingManager.spec.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/hooks/useMappingManager.spec.tsx
@@ -79,6 +79,7 @@ describe('useMappingManager', () => {
       inwardManager: undefined,
       isLoading: false,
       outwardManager: undefined,
+      tagsManager: undefined,
     })
   })
 

--- a/hivemq-edge/src/frontend/src/modules/Mappings/hooks/useMappingManager.spec.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/hooks/useMappingManager.spec.tsx
@@ -95,7 +95,7 @@ describe('useMappingManager', () => {
 
     const { formData, schema, uiSchema } = inwardManager as MappingManagerType
     expect(formData).not.toBeUndefined()
-    expect(formData.simulationToMqtt).toStrictEqual(
+    expect(formData?.simulationToMqtt).toStrictEqual(
       expect.objectContaining({
         simulationToMqttMappings: [
           {

--- a/hivemq-edge/src/frontend/src/modules/Mappings/hooks/useMappingManager.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/hooks/useMappingManager.tsx
@@ -75,15 +75,18 @@ export const useMappingManager = (adapterId: string) => {
   const tagsManager = useMemo<MappingManagerType | undefined>(() => {
     if (!adapterInfo) return undefined
 
-    const schema = getInwardMappingSchema(adapterInfo.selectedProtocol)
-
-    return {
-      schema: createSchema(schema.items as RJSFSchema),
-      uiSchema: {
-        'ui:submitButtonOptions': {
-          norender: true,
+    try {
+      const schema = getInwardMappingSchema(adapterInfo.selectedProtocol)
+      return {
+        schema: createSchema(schema.items as RJSFSchema),
+        uiSchema: {
+          'ui:submitButtonOptions': {
+            norender: true,
+          },
         },
-      },
+      }
+    } catch (e) {
+      return { schema: {}, uiSchema: {}, errors: (e as Error).message }
     }
   }, [adapterInfo])
 

--- a/hivemq-edge/src/frontend/src/modules/Mappings/hooks/useMappingManager.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/hooks/useMappingManager.tsx
@@ -1,5 +1,4 @@
 import { useMemo } from 'react'
-import { type JSONSchema7 } from 'json-schema'
 import { type RJSFSchema, type UiSchema } from '@rjsf/utils'
 
 import { MOCK_MAPPING_DATA, MOCK_OUTWARD_MAPPING_OPCUA } from '@/__test-utils__/adapters/mapping.utils.ts'
@@ -7,7 +6,12 @@ import { useGetAdapterTypes } from '@/api/hooks/useProtocolAdapters/useGetAdapte
 import { useListProtocolAdapters } from '@/api/hooks/useProtocolAdapters/useListProtocolAdapters.ts'
 import { type MappingManagerType } from '@/modules/Mappings/types.ts'
 import { getMainRootFromPath, getTopicPaths } from '@/modules/Workspace/utils/topics-utils.ts'
-import { getInwardMappingRootProperty, isBidirectional } from '@/modules/Workspace/utils/adapter.utils.ts'
+import {
+  getInwardMappingRootProperty,
+  getInwardMappingSchema,
+  isBidirectional,
+} from '@/modules/Workspace/utils/adapter.utils.ts'
+import { createSchema } from '@/modules/Device/utils/tags.utils.ts'
 
 export const useMappingManager = (adapterId: string) => {
   const { data: allProtocols, isLoading: isProtocolLoading } = useGetAdapterTypes()
@@ -27,7 +31,7 @@ export const useMappingManager = (adapterId: string) => {
     if (!adapterInfo) return undefined
     const { selectedProtocol, selectedAdapter } = adapterInfo
 
-    const { properties } = selectedProtocol?.configSchema as JSONSchema7
+    const { properties } = selectedProtocol?.configSchema as RJSFSchema
     if (!properties) return undefined
 
     // TODO[NVL] This is still a hack; backend needs to provide identification of subscription properties
@@ -68,7 +72,22 @@ export const useMappingManager = (adapterId: string) => {
     }
   }, [adapterInfo])
 
+  const tagsManager = useMemo<MappingManagerType | undefined>(() => {
+    if (!adapterInfo) return undefined
+
+    const schema = getInwardMappingSchema(adapterInfo.selectedProtocol)
+
+    return {
+      schema: createSchema(schema.items as RJSFSchema),
+      uiSchema: {
+        'ui:submitButtonOptions': {
+          norender: true,
+        },
+      },
+    }
+  }, [adapterInfo])
+
   const isLoading = isAdapterLoading || isProtocolLoading
 
-  return { isLoading, inwardManager, outwardManager }
+  return { isLoading, inwardManager, outwardManager, tagsManager }
 }

--- a/hivemq-edge/src/frontend/src/modules/Mappings/hooks/useMappingManager.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/hooks/useMappingManager.tsx
@@ -12,6 +12,7 @@ import {
   isBidirectional,
 } from '@/modules/Workspace/utils/adapter.utils.ts'
 import { createSchema } from '@/modules/Device/utils/tags.utils.ts'
+import { DomainTagList } from '@/api/__generated__'
 
 export const useMappingManager = (adapterId: string) => {
   const { data: allProtocols, isLoading: isProtocolLoading } = useGetAdapterTypes()
@@ -72,8 +73,12 @@ export const useMappingManager = (adapterId: string) => {
     }
   }, [adapterInfo])
 
-  const tagsManager = useMemo<MappingManagerType | undefined>(() => {
+  const tagsManager = useMemo<MappingManagerType<DomainTagList> | undefined>(() => {
     if (!adapterInfo) return undefined
+
+    const handleOnError = (e: Error) => {
+      console.error(e.message)
+    }
 
     try {
       const schema = getInwardMappingSchema(adapterInfo.selectedProtocol)
@@ -84,8 +89,10 @@ export const useMappingManager = (adapterId: string) => {
             norender: true,
           },
         },
+        onSubmit: (e) => console.log('XXXXXXXX', e),
       }
     } catch (e) {
+      handleOnError(e as Error)
       return { schema: {}, uiSchema: {}, errors: (e as Error).message }
     }
   }, [adapterInfo])

--- a/hivemq-edge/src/frontend/src/modules/Mappings/hooks/useTagManager.spec.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/hooks/useTagManager.spec.tsx
@@ -1,0 +1,160 @@
+/// <reference types="cypress" />
+
+import { beforeEach, expect } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { ReactFlowProvider } from 'reactflow'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { http, HttpResponse } from 'msw'
+
+import { server } from '@/__test-utils__/msw/mockServer.ts'
+import {
+  mockAdapter,
+  mockAdapter_OPCUA,
+  mockProtocolAdapter,
+  mockProtocolAdapter_OPCUA,
+} from '@/api/hooks/useProtocolAdapters/__handlers__'
+import { Adapter, AdaptersList, type DomainTagList, ProtocolAdapter, ProtocolAdaptersList } from '@/api/__generated__'
+import { AuthProvider } from '@/modules/Auth/AuthProvider.tsx'
+import { useTagManager } from '@/modules/Mappings/hooks/useTagManager.tsx'
+import { MOCK_ADAPTER_ID } from '@/__test-utils__/mocks.ts'
+
+const wrapper: React.JSXElementConstructor<{ children: React.ReactElement }> = ({ children }) => (
+  <QueryClientProvider
+    client={
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            retry: false,
+          },
+        },
+      })
+    }
+  >
+    <AuthProvider>
+      <ReactFlowProvider>
+        <MemoryRouter>{children}</MemoryRouter>
+      </ReactFlowProvider>
+    </AuthProvider>
+  </QueryClientProvider>
+)
+
+const customHandlers = (
+  types: Array<ProtocolAdapter> | undefined,
+  adapters?: Array<Adapter> | undefined,
+  tags?: DomainTagList
+) => [
+  http.get('**/protocol-adapters/types', () => {
+    return types
+      ? HttpResponse.json<ProtocolAdaptersList>({ items: types }, { status: 200 })
+      : new HttpResponse(null, { status: 500 })
+  }),
+
+  http.get('**/protocol-adapters/adapters', () => {
+    return adapters
+      ? HttpResponse.json<AdaptersList>({ items: adapters }, { status: 200 })
+      : new HttpResponse(null, {
+          status: 500,
+        })
+  }),
+
+  http.get('**/protocol-adapters/adapters/**/tags', () => {
+    return tags
+      ? HttpResponse.json<DomainTagList>(tags, { status: 200 })
+      : new HttpResponse(null, {
+          status: 500,
+        })
+  }),
+]
+
+describe('useTagManager', () => {
+  beforeEach(() => {
+    server.use(...customHandlers([mockProtocolAdapter], [mockAdapter]))
+  })
+
+  it('should return errors for wrong adapter', async () => {
+    const { result } = renderHook(() => useTagManager('wrong-adapter'), { wrapper })
+    expect(result.current.isLoading).toBeTruthy()
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBeFalsy()
+    })
+    expect(result.current).toStrictEqual(
+      expect.objectContaining({
+        context: {
+          formData: undefined,
+          schema: undefined,
+          uiSchema: {},
+        },
+        data: undefined,
+        error: 'The protocol adapter for this device cannot be found',
+        isError: true,
+        isLoading: false,
+        isPending: false,
+      })
+    )
+  })
+
+  it('should return errors for missing tags', async () => {
+    const { result } = renderHook(() => useTagManager(MOCK_ADAPTER_ID), { wrapper })
+    expect(result.current.isLoading).toBeTruthy()
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBeFalsy()
+    })
+    expect(result.current).toStrictEqual(
+      expect.objectContaining({
+        context: {
+          formData: undefined,
+          schema: undefined,
+          uiSchema: {},
+        },
+        data: undefined,
+        error: 'The form cannot be created, due to internal errors',
+
+        isError: true,
+        isLoading: false,
+        isPending: false,
+      })
+    )
+  })
+
+  it('should return the manager', async () => {
+    server.use(...customHandlers([mockProtocolAdapter_OPCUA], [mockAdapter_OPCUA], { items: [] }))
+    const { result } = renderHook(() => useTagManager('opcua-1'), { wrapper })
+    expect(result.current.isLoading).toBeTruthy()
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBeFalsy()
+    })
+    expect(result.current).toStrictEqual(
+      expect.objectContaining({
+        context: {
+          formData: {
+            items: [],
+          },
+          schema: expect.objectContaining({
+            definitions: expect.objectContaining({
+              DeviceDataPoint: expect.objectContaining({
+                properties: expect.objectContaining({
+                  node: expect.objectContaining({
+                    title: 'Source Node ID',
+                  }),
+                }),
+              }),
+              DomainTag: expect.objectContaining({}),
+            }),
+          }),
+          uiSchema: {},
+        },
+        data: {
+          items: [],
+        },
+        error: null,
+        isError: false,
+        isLoading: false,
+        isPending: false,
+      })
+    )
+  })
+})

--- a/hivemq-edge/src/frontend/src/modules/Mappings/hooks/useTagManager.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/hooks/useTagManager.tsx
@@ -1,0 +1,109 @@
+import { useMemo } from 'react'
+import type { RJSFSchema } from '@rjsf/utils'
+import { useToast } from '@chakra-ui/react'
+import { useTranslation } from 'react-i18next'
+
+import type { DomainTag, DomainTagList } from '@/api/__generated__'
+import { useGetDomainTags } from '@/api/hooks/useProtocolAdapters/useGetDomainTags.tsx'
+import { useCreateDomainTags } from '@/api/hooks/useProtocolAdapters/useCreateDomainTags.ts'
+import { useDeleteDomainTags } from '@/api/hooks/useProtocolAdapters/useDeleteDomainTags.ts'
+import { useUpdateAllDomainTags } from '@/api/hooks/useProtocolAdapters/useUpdateAllDomainTags.ts'
+import { useUpdateDomainTags } from '@/api/hooks/useProtocolAdapters/useUpdateDomainTags.ts'
+import useGetAdapterInfo from '@/modules/ProtocolAdapters/hooks/useGetAdapterInfo.ts'
+import { getInwardMappingSchema } from '@/modules/Workspace/utils/adapter.utils.ts'
+import { createSchema } from '@/modules/Device/utils/tags.utils.ts'
+
+interface TagManagerSchema {
+  isError?: boolean
+  error?: string
+  data?: RJSFSchema
+}
+
+export const useTagManager = (adapterId: string | undefined) => {
+  const { t } = useTranslation()
+  const toast = useToast()
+
+  const { protocol, isLoading: protocolLoad } = useGetAdapterInfo(adapterId)
+  const { data: tagSchema } = useMemo<TagManagerSchema>(() => {
+    try {
+      if (!protocol) return { isError: true, error: t('device.errors.noAdapter') }
+
+      const schema = getInwardMappingSchema(protocol)
+      const tagSchema = createSchema(schema.items as RJSFSchema)
+      return { data: tagSchema }
+    } catch (e) {
+      return { isError: true, error: (e as Error).message }
+    }
+  }, [protocol, t])
+
+  const { data: tagList, isLoading, isError: isTagError, error: tagError } = useGetDomainTags(adapterId, protocol?.id)
+  const { error, isError } = useMemo(() => {
+    if (!adapterId) return { error: t('device.errors.noAdapter'), isError: true }
+    return { error: tagError, isError: isTagError }
+  }, [adapterId, isTagError, t, tagError])
+
+  const createMutator = useCreateDomainTags()
+  const deleteMutator = useDeleteDomainTags()
+  const updateMutator = useUpdateDomainTags()
+  const updateListMutator = useUpdateAllDomainTags()
+
+  const formatToast = (operation: string) => ({
+    success: {
+      title: t(`device.drawer.tagList.toast.${operation}.title`),
+      description: t(`device.drawer.tagList.toast.${operation}.description`, { context: 'success' }),
+    },
+    error: {
+      title: t(`device.drawer.tagList.toast.${operation}.title`),
+      description: t(`device.drawer.tagList.toast.${operation}.description`, { context: 'error' }),
+    },
+    loading: {
+      title: t(`device.drawer.tagList.toast.${operation}.title`),
+      description: t('device.drawer.tagList.toast.description', { context: 'loading' }),
+    },
+  })
+
+  const onDelete = (tagId: string) => {
+    if (!adapterId) return
+    toast.promise(
+      deleteMutator.mutateAsync({ adapterId: adapterId, tagId: encodeURIComponent(tagId) }),
+      formatToast('delete')
+    )
+  }
+
+  const onCreate = (tag: DomainTag) => {
+    if (!adapterId) return
+    toast.promise(createMutator.mutateAsync({ adapterId: adapterId, requestBody: tag }), formatToast('create'))
+  }
+
+  const onUpdate = (tagId: string, tag: DomainTag) => {
+    if (!adapterId) return
+    toast.promise(
+      updateMutator.mutateAsync({ adapterId: adapterId, tagId: encodeURIComponent(tagId), requestBody: tag }),
+      formatToast('update')
+    )
+  }
+
+  const onUpdateList = (tags: DomainTagList) => {
+    if (!adapterId) return
+    toast.promise(updateListMutator.mutateAsync({ adapterId: adapterId, requestBody: tags }), formatToast('update'))
+  }
+
+  return {
+    // The context of the operations
+    context: {
+      tagSchema,
+      uiSchema: {},
+    },
+    // The CRUD operations
+    data: tagList,
+    onUpdateList,
+    onCreate,
+    onDelete,
+    onUpdate,
+    // The state (as in ReactQuery)
+    isLoading: isLoading || protocolLoad,
+    isError,
+    error,
+    isPending: createMutator.isPending || updateMutator.isPending || deleteMutator.isPending, // assuming only one operation at a time
+  }
+}

--- a/hivemq-edge/src/frontend/src/modules/Mappings/hooks/useTagManager.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/hooks/useTagManager.tsx
@@ -86,7 +86,7 @@ export const useTagManager = (adapterId: string | undefined) => {
 
   const onUpdateList = (tags: DomainTagList) => {
     if (!adapterId) return
-    toast.promise(updateListMutator.mutateAsync({ adapterId: adapterId, requestBody: tags }), formatToast('update'))
+    toast.promise(updateListMutator.mutateAsync({ adapterId: adapterId, requestBody: tags }), formatToast('updateList'))
   }
 
   const context: ManagerContextType = {
@@ -108,6 +108,7 @@ export const useTagManager = (adapterId: string | undefined) => {
     isLoading: isLoading || protocolLoad,
     isError,
     error,
-    isPending: createMutator.isPending || updateMutator.isPending || deleteMutator.isPending, // assuming only one operation at a time
+    isPending:
+      createMutator.isPending || updateMutator.isPending || deleteMutator.isPending || updateListMutator.isPending, // assuming only one operation at a time
   }
 }

--- a/hivemq-edge/src/frontend/src/modules/Mappings/hooks/useTagManager.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/hooks/useTagManager.tsx
@@ -12,6 +12,7 @@ import { useUpdateDomainTags } from '@/api/hooks/useProtocolAdapters/useUpdateDo
 import useGetAdapterInfo from '@/modules/ProtocolAdapters/hooks/useGetAdapterInfo.ts'
 import { getInwardMappingSchema } from '@/modules/Workspace/utils/adapter.utils.ts'
 import { createSchema } from '@/modules/Device/utils/tags.utils.ts'
+import { ManagerContextType } from '@/modules/Mappings/types.ts'
 
 interface TagManagerSchema {
   isError?: boolean
@@ -88,12 +89,15 @@ export const useTagManager = (adapterId: string | undefined) => {
     toast.promise(updateListMutator.mutateAsync({ adapterId: adapterId, requestBody: tags }), formatToast('update'))
   }
 
+  const context: ManagerContextType = {
+    schema: tagSchema,
+    uiSchema: {},
+    formData: tagList,
+  }
+
   return {
     // The context of the operations
-    context: {
-      tagSchema,
-      uiSchema: {},
-    },
+    context,
     // The CRUD operations
     data: tagList,
     onUpdateList,

--- a/hivemq-edge/src/frontend/src/modules/Mappings/hooks/useTagManager.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/hooks/useTagManager.tsx
@@ -25,7 +25,8 @@ export const useTagManager = (adapterId: string | undefined) => {
   const toast = useToast()
 
   const { protocol, isLoading: protocolLoad } = useGetAdapterInfo(adapterId)
-  const { data: tagSchema } = useMemo<TagManagerSchema>(() => {
+  const { data: tagList, isLoading, isError: isTagError, error: tagError } = useGetDomainTags(adapterId, protocol?.id)
+  const tagManager = useMemo<TagManagerSchema>(() => {
     try {
       if (!protocol) return { isError: true, error: t('device.errors.noAdapter') }
 
@@ -37,11 +38,12 @@ export const useTagManager = (adapterId: string | undefined) => {
     }
   }, [protocol, t])
 
-  const { data: tagList, isLoading, isError: isTagError, error: tagError } = useGetDomainTags(adapterId, protocol?.id)
+  // TODO[NVL] Error formats differ too much. ProblemDetails!
   const { error, isError } = useMemo(() => {
     if (!adapterId) return { error: t('device.errors.noAdapter'), isError: true }
+    if (tagManager.isError) return { error: tagManager.error, isError: true }
     return { error: tagError, isError: isTagError }
-  }, [adapterId, isTagError, t, tagError])
+  }, [adapterId, isTagError, t, tagError, tagManager.error, tagManager.isError])
 
   const createMutator = useCreateDomainTags()
   const deleteMutator = useDeleteDomainTags()
@@ -90,7 +92,7 @@ export const useTagManager = (adapterId: string | undefined) => {
   }
 
   const context: ManagerContextType = {
-    schema: tagSchema,
+    schema: tagManager.data,
     uiSchema: {},
     formData: tagList,
   }

--- a/hivemq-edge/src/frontend/src/modules/Mappings/types.ts
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/types.ts
@@ -6,11 +6,12 @@ export enum MappingType {
   OUTWARD = 'OUTWARD',
 }
 
-export interface MappingManagerType {
+export interface MappingManagerType<T = any> {
   schema: RJSFSchema
   formData?: GenericObjectType
   uiSchema: UiSchema
-  onSubmit?: (data: unknown) => void
+  onSubmit?: (data: T) => void
+  onError?: (e: Error) => void
   errors?: string
 }
 

--- a/hivemq-edge/src/frontend/src/modules/Mappings/types.ts
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/types.ts
@@ -8,7 +8,7 @@ export enum MappingType {
 
 export interface MappingManagerType {
   schema: RJSFSchema
-  formData: GenericObjectType
+  formData?: GenericObjectType
   uiSchema: UiSchema
   onSubmit?: (data: unknown) => void
 }

--- a/hivemq-edge/src/frontend/src/modules/Mappings/types.ts
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/types.ts
@@ -12,6 +12,7 @@ export enum MappingType {
   OUTWARD = 'OUTWARD',
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export interface MappingManagerType<T = any> {
   schema: RJSFSchema
   formData?: GenericObjectType

--- a/hivemq-edge/src/frontend/src/modules/Mappings/types.ts
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/types.ts
@@ -1,6 +1,12 @@
 import { GenericObjectType, type RJSFSchema, type UiSchema } from '@rjsf/utils'
 import { AlertProps } from '@chakra-ui/react'
 
+export interface ManagerContextType {
+  schema?: RJSFSchema
+  formData?: GenericObjectType
+  uiSchema?: UiSchema
+}
+
 export enum MappingType {
   INWARD = 'INWARD',
   OUTWARD = 'OUTWARD',

--- a/hivemq-edge/src/frontend/src/modules/Mappings/types.ts
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/types.ts
@@ -11,6 +11,7 @@ export interface MappingManagerType {
   formData?: GenericObjectType
   uiSchema: UiSchema
   onSubmit?: (data: unknown) => void
+  errors?: string
 }
 
 /**

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/drawers/AdapterInstanceDrawer.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/drawers/AdapterInstanceDrawer.spec.cy.tsx
@@ -79,7 +79,7 @@ describe('AdapterInstanceDrawer', () => {
   })
 
   describe('Custom Templates', () => {
-    it.only('should render expandable array items', () => {
+    it('should render expandable array items', () => {
       cy.mountWithProviders(
         <AdapterInstanceDrawer
           adapterType={mockProtocolAdapter.id}

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/drawers/AdapterInstanceDrawer.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/drawers/AdapterInstanceDrawer.tsx
@@ -4,6 +4,7 @@ import { useParams } from 'react-router-dom'
 import { IChangeEvent } from '@rjsf/core'
 import { IdSchema, RJSFSchema } from '@rjsf/utils'
 import { RJSFValidationError } from '@rjsf/utils/src/types.ts'
+import debug from 'debug'
 import Form from '@rjsf/chakra-ui'
 import {
   Button,
@@ -53,6 +54,7 @@ interface AdapterInstanceDrawerProps {
 }
 
 const FLAG_POST_VALIDATE = false
+const rjsfLog = debug('RJSF:AdapterInstanceDrawer')
 
 const AdapterInstanceDrawer: FC<AdapterInstanceDrawerProps> = ({
   adapterType,
@@ -159,7 +161,7 @@ const AdapterInstanceDrawer: FC<AdapterInstanceDrawerProps> = ({
                   onSubmit={onValidate}
                   validator={customFormatsValidator}
                   showErrorList="bottom"
-                  onError={(errors) => console.log('XXXXXXX', errors)}
+                  onError={(errors) => rjsfLog(t('error.rjsf.validation'), errors)}
                   formData={defaultValues}
                   customValidate={customValidate(schema, allAdapters, t)}
                   transformErrors={filterUnboundErrors}

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/drawers/DevicePropertyDrawer.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/drawers/DevicePropertyDrawer.spec.cy.tsx
@@ -1,12 +1,51 @@
-/// <reference types="cypress" />
-
-import { MOCK_NODE_DEVICE } from '@/__test-utils__/react-flow/nodes.ts'
+import { Edge, Node } from 'reactflow'
+import { MOCK_NODE_ADAPTER, MOCK_NODE_DEVICE } from '@/__test-utils__/react-flow/nodes.ts'
+import { ReactFlowTesting } from '@/__test-utils__/react-flow/ReactFlowTesting.tsx'
+import { mockAdapter, mockProtocolAdapter } from '@/api/hooks/useProtocolAdapters/__handlers__'
 import DevicePropertyDrawer from '@/modules/Workspace/components/drawers/DevicePropertyDrawer.tsx'
+
+const getWrapperWith = (initialNodes?: Node[], initialEdges?: Edge[]) => {
+  const Wrapper: React.JSXElementConstructor<{ children: React.ReactNode }> = ({ children }) => {
+    return (
+      <ReactFlowTesting
+        config={{
+          initialState: {
+            nodes: initialNodes,
+            edges: initialEdges,
+          },
+        }}
+      >
+        {children}
+      </ReactFlowTesting>
+    )
+  }
+
+  return Wrapper
+}
 
 describe('DevicePropertyDrawer', () => {
   beforeEach(() => {
     cy.viewport(800, 800)
-    cy.intercept('/api/v1/management/protocol-adapters/types', { statusCode: 404 })
+    cy.intercept('/api/v1/management/protocol-adapters/types', { items: [mockProtocolAdapter] }).as('getProtocols')
+    cy.intercept('api/v1/management/protocol-adapters/adapters', { items: [mockAdapter] }).as('getAdapters')
+    cy.intercept('/api/v1/management/protocol-adapters/adapters/my-adapter/tags?type=simulation', { statusCode: 404 })
+  })
+
+  it('should render an error message', () => {
+    cy.mountWithProviders(
+      <DevicePropertyDrawer
+        nodeId="adapter@fgffgf"
+        selectedNode={{ ...MOCK_NODE_DEVICE, position: { x: 50, y: 100 } }}
+        isOpen={true}
+        onClose={cy.stub}
+        onEditEntity={cy.stub}
+      />,
+      { wrapper: getWrapperWith() }
+    )
+
+    cy.get('[role="alert"]')
+      .should('have.attr', 'data-status', 'error')
+      .should('contain.text', 'The protocol adapter for this device cannot be found')
   })
 
   it('should render properly', () => {
@@ -19,7 +58,16 @@ describe('DevicePropertyDrawer', () => {
         isOpen={true}
         onClose={onClose}
         onEditEntity={onEditEntity}
-      />
+      />,
+      {
+        wrapper: getWrapperWith(
+          [
+            { ...MOCK_NODE_DEVICE, position: { x: 50, y: 100 } },
+            { ...MOCK_NODE_ADAPTER, position: { x: 50, y: 100 } },
+          ],
+          [{ id: 'e1', source: 'idAdapter', target: 'idDevice' }]
+        ),
+      }
     )
 
     cy.get('@onClose').should('not.have.been.called')
@@ -27,5 +75,7 @@ describe('DevicePropertyDrawer', () => {
     cy.get('@onClose').should('have.been.calledOnce')
 
     cy.get('header').should('contain.text', 'Device Overview')
+    cy.get('h2').eq(0).should('contain.text', 'simulation')
+    cy.get('h2').eq(1).should('contain.text', 'List of Device Tags')
   })
 })

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/drawers/DevicePropertyDrawer.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/drawers/DevicePropertyDrawer.tsx
@@ -34,12 +34,12 @@ const DevicePropertyDrawer: FC<DevicePropertyDrawerProps> = ({ isOpen, selectedN
   const { data, isError, isLoading } = useGetAdapterTypes()
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const [adapterNode] = getIncomers<Adapter, any>(selectedNode, nodes, edges)
-
-  const protocol = data?.items?.find((e) => e.id === adapterNode.data.type)
+  const incomers = getIncomers<Adapter, any>(selectedNode, nodes, edges)
+  const adapter = incomers.find(Boolean)?.data
+  const protocol = data?.items?.find((e) => e.id === adapter?.type)
 
   if (isLoading) return <LoaderSpinner />
-  if (isError) return <ErrorMessage message={t('device.errors.noAdapter')} />
+  if (isError || !adapter || !protocol) return <ErrorMessage message={t('device.errors.noAdapter')} />
 
   return (
     <Drawer isOpen={isOpen} placement="right" size="md" onClose={onClose} variant="hivemq">
@@ -52,7 +52,7 @@ const DevicePropertyDrawer: FC<DevicePropertyDrawerProps> = ({ isOpen, selectedN
         <DrawerBody display="flex" flexDirection="column" gap={6}>
           <DrawerBody display="flex" flexDirection="column" gap={6}>
             <DeviceMetadataViewer protocolAdapter={protocol} />
-            <DeviceTagList adapter={adapterNode.data} />
+            <DeviceTagList adapter={adapter} />
           </DrawerBody>
         </DrawerBody>
       </DrawerContent>

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/drawers/DevicePropertyDrawer.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/drawers/DevicePropertyDrawer.tsx
@@ -1,17 +1,23 @@
 import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Node } from 'reactflow'
+import { getIncomers, Node } from 'reactflow'
 import {
   Drawer,
   DrawerBody,
   DrawerCloseButton,
   DrawerContent,
-  DrawerFooter,
   DrawerHeader,
   DrawerOverlay,
   Text,
 } from '@chakra-ui/react'
 
+import { Adapter } from '@/api/__generated__'
+import { useGetAdapterTypes } from '@/api/hooks/useProtocolAdapters/useGetAdapterTypes.ts'
+import LoaderSpinner from '@/components/Chakra/LoaderSpinner.tsx'
+import ErrorMessage from '@/components/ErrorMessage.tsx'
+import DeviceMetadataViewer from '@/modules/Device/components/DeviceMetadataViewer.tsx'
+import DeviceTagList from '@/modules/Device/components/DeviceTagList.tsx'
+import useWorkspaceStore from '@/modules/Workspace/hooks/useWorkspaceStore.ts'
 import { DeviceMetadata } from '@/modules/Workspace/types.ts'
 
 interface DevicePropertyDrawerProps {
@@ -24,6 +30,15 @@ interface DevicePropertyDrawerProps {
 
 const DevicePropertyDrawer: FC<DevicePropertyDrawerProps> = ({ isOpen, selectedNode, onClose }) => {
   const { t } = useTranslation()
+  const { nodes, edges } = useWorkspaceStore()
+  const { data, isError, isLoading } = useGetAdapterTypes()
+
+  const [adapterNode] = getIncomers<Adapter, any>(selectedNode, nodes, edges)
+
+  const protocol = data?.items?.find((e) => e.id === adapterNode.data.type)
+
+  if (isLoading) return <LoaderSpinner />
+  if (isError) return <ErrorMessage message="XXXX Cannot load the protocols" />
 
   return (
     <Drawer isOpen={isOpen} placement="right" size="md" onClose={onClose} variant="hivemq">
@@ -33,8 +48,12 @@ const DevicePropertyDrawer: FC<DevicePropertyDrawerProps> = ({ isOpen, selectedN
         <DrawerHeader>
           <Text> {t('workspace.property.header', { context: selectedNode.type })}</Text>
         </DrawerHeader>
-        <DrawerBody display="flex" flexDirection="column" gap={6}></DrawerBody>
-        <DrawerFooter borderTopWidth="1px"></DrawerFooter>
+        <DrawerBody display="flex" flexDirection="column" gap={6}>
+          <DrawerBody display="flex" flexDirection="column" gap={6}>
+            <DeviceMetadataViewer protocolAdapter={protocol} />
+            <DeviceTagList adapter={adapterNode.data} />
+          </DrawerBody>
+        </DrawerBody>
       </DrawerContent>
     </Drawer>
   )

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/drawers/DevicePropertyDrawer.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/drawers/DevicePropertyDrawer.tsx
@@ -33,6 +33,7 @@ const DevicePropertyDrawer: FC<DevicePropertyDrawerProps> = ({ isOpen, selectedN
   const { nodes, edges } = useWorkspaceStore()
   const { data, isError, isLoading } = useGetAdapterTypes()
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const [adapterNode] = getIncomers<Adapter, any>(selectedNode, nodes, edges)
 
   const protocol = data?.items?.find((e) => e.id === adapterNode.data.type)

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/drawers/DevicePropertyDrawer.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/drawers/DevicePropertyDrawer.tsx
@@ -39,7 +39,7 @@ const DevicePropertyDrawer: FC<DevicePropertyDrawerProps> = ({ isOpen, selectedN
   const protocol = data?.items?.find((e) => e.id === adapterNode.data.type)
 
   if (isLoading) return <LoaderSpinner />
-  if (isError) return <ErrorMessage message="XXXX Cannot load the protocols" />
+  if (isError) return <ErrorMessage message={t('device.errors.noAdapter')} />
 
   return (
     <Drawer isOpen={isOpen} placement="right" size="md" onClose={onClose} variant="hivemq">

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/ContextualToolbar.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/ContextualToolbar.tsx
@@ -136,15 +136,13 @@ const ContextualToolbar: FC<ContextualToolbarProps> = ({
         >
           <ToolbarButtonGroup>
             <IconButton
-              size="sm"
               data-testid="node-group-toolbar-panel"
-              icon={<LuPanelRightOpen />}
-              aria-label={t('workspace.toolbar.command.overview')}
-              onClick={onOpenPanel}
-            />
-          </ToolbarButtonGroup>
-        </NodeToolbar>
-      )}
+            icon={<LuPanelRightOpen />}
+            aria-label={t('workspace.toolbar.command.overview')}
+            onClick={onOpenPanel}
+          />
+        </ToolbarButtonGroup>
+      </NodeToolbar>)}
       {(children || isGroupable) && (
         <NodeToolbar
           isVisible={Boolean(mainNodes?.id === id && !dragging)}

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeAdapter.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeAdapter.tsx
@@ -6,6 +6,7 @@ import { Box, HStack, Icon, Image, SkeletonText, Text, VStack } from '@chakra-ui
 
 import { type Adapter } from '@/api/__generated__'
 import { useGetAdapterTypes } from '@/api/hooks/useProtocolAdapters/useGetAdapterTypes.ts'
+import { useGetDomainTags } from '@/api/hooks/useProtocolAdapters/useGetDomainTags.tsx'
 import IconButton from '@/components/Chakra/IconButton.tsx'
 import { ConnectionStatusBadge } from '@/components/ConnectionStatusBadge'
 import ToolbarButtonGroup from '@/components/react-flow/ToolbarButtonGroup.tsx'
@@ -32,6 +33,7 @@ const NodeAdapter: FC<NodeProps<Adapter>> = ({ id, data: adapter, selected, drag
   const { onContextMenu } = useContextMenu(id, selected, `/workspace/node/adapter/${adapter.type}`)
   const navigate = useNavigate()
   const showSkeleton = useStore(selectorIsSkeletonZoom)
+  const { data } = useGetDomainTags(adapter.id)
 
   const HACK_BIDIRECTIONAL = isBidirectional(adapterProtocol)
   const adapterNavPath = `/workspace/node/adapter/${adapter.type}/${id}`
@@ -63,7 +65,7 @@ const NodeAdapter: FC<NodeProps<Adapter>> = ({ id, data: adapter, selected, drag
       >
         {!showSkeleton && (
           <VStack>
-            {HACK_BIDIRECTIONAL && <MappingBadge destinations={['topic/mock/todo']} isTag />}
+            {HACK_BIDIRECTIONAL && <MappingBadge destinations={data?.items?.map((e) => e.tag) || []} isTag />}
 
             <HStack>
               <Image aria-label={adapter.type} boxSize="20px" objectFit="scale-down" src={adapterProtocol?.logoUrl} />

--- a/hivemq-edge/src/frontend/src/modules/Workspace/utils/adapter.utils.ts
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/utils/adapter.utils.ts
@@ -1,3 +1,4 @@
+import { type RJSFSchema } from '@rjsf/utils'
 import { type IconType } from 'react-icons'
 import { TbSettingsAutomation } from 'react-icons/tb'
 import { FaIndustry } from 'react-icons/fa6'
@@ -9,9 +10,12 @@ import { isMockAdapterTypeBidirectional } from '@/__test-utils__/adapters/types.
 import { type ProtocolAdapter, Status } from '@/api/__generated__'
 import { HmInput, HmOutput } from '@/components/react-icons/hm'
 
+import i18n from '@/config/i18n.config.ts'
+
 const MQTT_PROPERTY_STUB = {
   inward: 'ToMqtt',
   outward: 'mqttTo',
+  mapping: 'Mappings',
 }
 
 const capitalize = (s: string) => s && s[0].toUpperCase() + s.slice(1)
@@ -22,6 +26,19 @@ export const getOutwardMappingRootProperty = (adapterType: string) =>
 
 export const isBidirectional = (adapter: ProtocolAdapter | undefined) => {
   return Boolean(adapter?.capabilities?.includes('WRITE') || isMockAdapterTypeBidirectional(adapter?.id))
+}
+
+export const getInwardMappingSchema = (adapter: ProtocolAdapter | undefined): RJSFSchema => {
+  if (!adapter || !adapter.id) throw new Error(i18n.t('protocolAdapter.export.error.noAdapterConfig'))
+  const root = getInwardMappingRootProperty(adapter.id)
+  const { properties } = adapter.configSchema as RJSFSchema
+  if (!properties) throw new Error(i18n.t('protocolAdapter.export.error.noMapping'))
+
+  const mapping = (properties as RJSFSchema)[root] as RJSFSchema
+  const mappingProps = mapping.properties as RJSFSchema
+  if (!mappingProps) throw new Error(i18n.t('protocolAdapter.export.error.notValid'))
+
+  return mappingProps[`${root}${MQTT_PROPERTY_STUB.mapping}`]
 }
 
 /**


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/25881/details/

This PR is part of the bi-directional epic and introduces basic management for the Device Tags in the `workspace` 

Device Tags are the first level of abstraction of the device-to-MQTT mapping flow, in which users create a unique name (the "tag") for a specific address of a data point on the device. 

### Design
- The tag management has been moved to the devices on the `workspace` It is available by clicking on the device node or on the CTA, opening the configuration side panel
- The side panel is intended to provide all information pertinent to its contextualization, including the tags
- The `tag name` is expected to be unique across the Edge instance and to follow the segment pattern used for topics
- The `tag address` will differ from device to device but will be a list of attribute values that uniquely define a data point on this device
  - `{ node: 'ns=3;i=1008' } `  for `opc-ua`
  - `{ startIdx: 0, index: 1 }` for `modbus`
 - The management of tags is split into two distinct operations:
    - visualisation of the existing tags in a list
    - management of the tags (creation, modification, deletion) in a separate, JSONSchema-based form
 
### Out-of-scope
- The schema of the `tag address` is extracted through "magic" from the JSON-Schema of the adapter config. This is neither safe nor sustainable and it should be provided by a refactored payload, see https://hivemq.kanbanize.com/ctrl_board/57/cards/26668/details/.
- The devices don't exist as an Edge entity and therefore don't provide any pertinent information to display (the few information points are inferred from their adapter). The panel contains a "metadata" viewer that is a non-interactive placeholder. It will be refactored in further tickets (and initiatives) 
- There is a design flaw in the two-form (list + editor) approach of tag management, in which the editor redisplays the list of tags differently. There is a need for a better widget/template for RJSF that splits the list from the individual editors. Several CRUD-related management will benefit from a reusable pattern (see mapping editor). This will be dealt with in further tickets

### Before

![screenshot-localhost_3000-2024_10_09-16_03_07](https://github.com/user-attachments/assets/d6ac9294-279f-4f7e-8ee1-2dcd747657c6)

### After

![screenshot-localhost_3000-2024_10_08-11_35_59](https://github.com/user-attachments/assets/f0aea505-ca77-4ac8-bbd9-252b7c5a13ca)

![screenshot-localhost_3000-2024_10_08-11_19_50](https://github.com/user-attachments/assets/26cfe480-ee72-495b-a1c7-528de00db052)

![screenshot-localhost_3000-2024_10_08-11_20_23](https://github.com/user-attachments/assets/5c199257-3862-44f5-8f84-5e0042537040)

![screenshot-localhost_3000-2024_10_09-15_57_30](https://github.com/user-attachments/assets/474c5389-09cd-47d2-ad50-4fb3ff31db75)

