### PR TITLE
Switch to using the CachedConnectionManager

### DIFF
--- a/modules/hivemq-edge-module-plc4x/build.gradle.kts
+++ b/modules/hivemq-edge-module-plc4x/build.gradle.kts
@@ -42,6 +42,7 @@ dependencies {
     implementation(libs.plc4j.s7)
     implementation(libs.plc4j.ads)
     implementation(libs.plc4j.api)
+    implementation(libs.plc4j.connection.cache)
     implementation(libs.plc4j.transport.raw.socket)
 }
 

--- a/modules/hivemq-edge-module-plc4x/gradle/libs.versions.toml
+++ b/modules/hivemq-edge-module-plc4x/gradle/libs.versions.toml
@@ -15,6 +15,7 @@ hivemq-edge-adapterSdk = { module = "com.hivemq:hivemq-edge-adapter-sdk", versio
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit-jupiter" }
 mockito-junitJupiter = { module = "org.mockito:mockito-junit-jupiter", version.ref = "mockito" }
 plc4j-api = { module = "org.apache.plc4x:plc4j-api", version.ref = "apache-plc4x" }
+plc4j-connection-cache = { module = "org.apache.plc4x:plc4j-connection-cache", version.ref = "apache-plc4x" }
 plc4j-s7 = { module = "org.apache.plc4x:plc4j-driver-s7", version.ref = "apache-plc4x" }
 plc4j-ads = { module = "org.apache.plc4x:plc4j-driver-ads", version.ref = "apache-plc4x" }
 plc4j-transport-raw-socket = { module = "org.apache.plc4x:plc4j-transport-raw-socket", version.ref = "apache-plc4x" }

--- a/modules/hivemq-edge-module-plc4x/src/main/java/com/hivemq/edge/adapters/plc4x/impl/AbstractPlc4xAdapter.java
+++ b/modules/hivemq-edge-module-plc4x/src/main/java/com/hivemq/edge/adapters/plc4x/impl/AbstractPlc4xAdapter.java
@@ -38,6 +38,7 @@ import org.apache.plc4x.java.api.messages.PlcReadResponse;
 import org.apache.plc4x.java.api.types.PlcResponseCode;
 import org.apache.plc4x.java.api.value.PlcValue;
 import org.apache.plc4x.java.spi.messages.DefaultPlcReadResponse;
+import org.apache.plc4x.java.utils.cache.CachedPlcConnectionManager;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
@@ -65,6 +66,7 @@ public abstract class AbstractPlc4xAdapter<T extends Plc4xAdapterConfig<?>, C ex
     protected static final String TAG_ADDRESS_TYPE_SEP = ":";
     private final Logger log = LoggerFactory.getLogger(getClass());
     protected final static @NotNull PlcDriverManager driverManager = PlcDriverManager.getDefault();
+    protected final static @NotNull CachedPlcConnectionManager cachedConnectionManager = CachedPlcConnectionManager.getBuilder().build();
     private final @NotNull Object lock = new Object();
     private final @NotNull ProtocolAdapterInformation adapterInformation;
     protected final @NotNull T adapterConfig;
@@ -178,6 +180,7 @@ public abstract class AbstractPlc4xAdapter<T extends Plc4xAdapterConfig<?>, C ex
 
     protected @NotNull Plc4xConnection<T> createConnection() throws Plc4xException {
         return new Plc4xConnection<>(driverManager,
+                cachedConnectionManager,
                 adapterConfig,
                 plc4xAdapterConfig -> Plc4xDataUtils.createQueryString(createQueryStringParams(plc4xAdapterConfig),
                         true)) {

--- a/modules/hivemq-edge-module-plc4x/src/main/java/com/hivemq/edge/adapters/plc4x/impl/Plc4xConnection.java
+++ b/modules/hivemq-edge-module-plc4x/src/main/java/com/hivemq/edge/adapters/plc4x/impl/Plc4xConnection.java
@@ -19,6 +19,7 @@ import com.hivemq.edge.adapters.plc4x.Plc4xException;
 import com.hivemq.edge.adapters.plc4x.config.Plc4xAdapterConfig;
 import com.hivemq.edge.adapters.plc4x.config.Plc4xToMqttMapping;
 import org.apache.plc4x.java.api.PlcConnection;
+import org.apache.plc4x.java.api.PlcConnectionManager;
 import org.apache.plc4x.java.api.PlcDriverManager;
 import org.apache.plc4x.java.api.exceptions.PlcConnectionException;
 import org.apache.plc4x.java.api.messages.PlcReadRequest;
@@ -41,17 +42,20 @@ public abstract class Plc4xConnection<T extends Plc4xAdapterConfig<?>> {
 
     private final Object lock = new Object();
     protected final @NotNull PlcDriverManager plcDriverManager;
+    protected final @NotNull PlcConnectionManager plcConnectionManager;
     protected final @NotNull T config;
     protected final @NotNull Plc4xConnectionQueryStringProvider<T> connectionQueryStringProvider;
     protected volatile @NotNull PlcConnection plcConnection;
 
     public Plc4xConnection(
             final @NotNull PlcDriverManager plcDriverManager,
+            final @NotNull PlcConnectionManager plcConnectionManager,
             final @NotNull T config,
             final @NotNull Plc4xConnectionQueryStringProvider<T> connectionQueryStringProvider) throws Plc4xException {
         this.plcDriverManager = plcDriverManager;
         this.config = config;
         this.connectionQueryStringProvider = connectionQueryStringProvider;
+        this.plcConnectionManager = plcConnectionManager;
         if (!validConfiguration(config)) {
             if (log.isTraceEnabled()) {
                 log.trace("Configuration provided to PLC4X, connection was considered invalid by implementation");
@@ -83,7 +87,7 @@ public abstract class Plc4xConnection<T extends Plc4xAdapterConfig<?>> {
                         if (log.isTraceEnabled()) {
                             log.trace("Connecting via PLC4X to {}.", connectionString);
                         }
-                        plcConnection = plcDriverManager.getConnectionManager().getConnection(connectionString);
+                        plcConnection = plcConnectionManager.getConnection(connectionString);
                     }
                 }
             }


### PR DESCRIPTION
**Motivation**

Resolves #26848

We saw issues with S7 which were (probably) related to restarts/reloads.

**Changes**

Replace the connection manager with the cached version.

This was outlined in another issue which ran into a similar problem: https://github.com/apache/streampipes/issues/2944
