### PR TITLE
refactor(26909): Refactor device toolbar

### DIFF
--- a/hivemq-edge/src/frontend/src/locales/en/translation.json
+++ b/hivemq-edge/src/frontend/src/locales/en/translation.json
@@ -718,10 +718,13 @@
       "command": {
         "overview": "Open the overview panel",
         "group": "Group the selected adapters",
+        "device": {
+          "metadata": "Edit device tags"
+        },
         "mappings": {
           "common": "Manage mappings of the device",
-          "inward": "Inward mappings",
-          "outward": "Outward mappings"
+          "inward": "Edit inward mappings",
+          "outward": "Edit outward mappings"
         }
       }
     },

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/ContextualToolbar.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/ContextualToolbar.tsx
@@ -27,9 +27,16 @@ type SelectedNodeProps = Pick<NodeProps, 'id' | `dragging`> & Pick<NodeToolbarPr
 interface ContextualToolbarProps extends SelectedNodeProps {
   onOpenPanel?: MouseEventHandler | undefined
   children?: React.ReactNode
+  hasNoOverview?: boolean
 }
 
-const ContextualToolbar: FC<ContextualToolbarProps> = ({ id, onOpenPanel, children, dragging }) => {
+const ContextualToolbar: FC<ContextualToolbarProps> = ({
+  id,
+  onOpenPanel,
+  children,
+  hasNoOverview = false,
+  dragging,
+}) => {
   const { t } = useTranslation()
   const { onInsertGroupNode, nodes, edges } = useWorkspaceStore()
   const theme = useTheme()
@@ -120,22 +127,23 @@ const ContextualToolbar: FC<ContextualToolbarProps> = ({ id, onOpenPanel, childr
 
   return (
     <>
-      <NodeToolbar
-        isVisible={Boolean(mainNodes?.id === id && !dragging)}
-        position={Position.Right}
-        role="toolbar"
-        aria-label={t('workspace.toolbar.container.right')}
-      >
-        <ToolbarButtonGroup>
-          <IconButton
-            size="sm"
+      {!hasNoOverview && (
+        <NodeToolbar
+          isVisible={Boolean(mainNodes?.id === id && !dragging)}
+          position={Position.Right}
+          role="toolbar"
+          aria-label={t('workspace.toolbar.container.right')}
+        >
+          <ToolbarButtonGroup>
+            <IconButton
+              size="sm"
             data-testid="node-group-toolbar-panel"
             icon={<LuPanelRightOpen />}
             aria-label={t('workspace.toolbar.command.overview')}
             onClick={onOpenPanel}
           />
         </ToolbarButtonGroup>
-      </NodeToolbar>
+      </NodeToolbar>)}
       {(children || isGroupable) && (
         <NodeToolbar
           isVisible={Boolean(mainNodes?.id === id && !dragging)}

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/ContextualToolbar.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/ContextualToolbar.tsx
@@ -137,13 +137,14 @@ const ContextualToolbar: FC<ContextualToolbarProps> = ({
           <ToolbarButtonGroup>
             <IconButton
               size="sm"
-            data-testid="node-group-toolbar-panel"
-            icon={<LuPanelRightOpen />}
-            aria-label={t('workspace.toolbar.command.overview')}
-            onClick={onOpenPanel}
-          />
-        </ToolbarButtonGroup>
-      </NodeToolbar>)}
+              data-testid="node-group-toolbar-panel"
+              icon={<LuPanelRightOpen />}
+              aria-label={t('workspace.toolbar.command.overview')}
+              onClick={onOpenPanel}
+            />
+          </ToolbarButtonGroup>
+        </NodeToolbar>
+      )}
       {(children || isGroupable) && (
         <NodeToolbar
           isVisible={Boolean(mainNodes?.id === id && !dragging)}

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeAdapter.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeAdapter.spec.cy.tsx
@@ -48,7 +48,7 @@ describe('NodeAdapter', () => {
     cy.getByTestId('adapter-node-name').should('contain', MOCK_ADAPTER_ID)
     cy.get('[role="toolbar"] button').should('have.length', 2)
     cy.get('[role="toolbar"] button').eq(0).should('have.attr', 'aria-label', 'Open the overview panel')
-    cy.get('[role="toolbar"] button').eq(1).should('have.attr', 'aria-label', 'Inward mappings')
+    cy.get('[role="toolbar"] button').eq(1).should('have.attr', 'aria-label', 'Edit inward mappings')
   })
 
   it('should render the toolbar for bi-directional adapter', () => {
@@ -68,8 +68,8 @@ describe('NodeAdapter', () => {
     cy.getByTestId('adapter-node-name').should('contain', MOCK_ADAPTER_ID)
     cy.get('[role="toolbar"] button').should('have.length', 3)
     cy.get('[role="toolbar"] button').eq(0).should('have.attr', 'aria-label', 'Open the overview panel')
-    cy.get('[role="toolbar"] button').eq(1).should('have.attr', 'aria-label', 'Outward mappings')
-    cy.get('[role="toolbar"] button').eq(2).should('have.attr', 'aria-label', 'Inward mappings')
+    cy.get('[role="toolbar"] button').eq(1).should('have.attr', 'aria-label', 'Edit outward mappings')
+    cy.get('[role="toolbar"] button').eq(2).should('have.attr', 'aria-label', 'Edit inward mappings')
   })
 
   it('should render the toolbar for multiple selected', () => {
@@ -102,7 +102,7 @@ describe('NodeAdapter', () => {
     cy.getByTestId('adapter-node-name').should('contain', MOCK_ADAPTER_ID)
     cy.get('[role="toolbar"] button').should('have.length', 3)
     cy.get('[role="toolbar"] button').eq(0).should('have.attr', 'aria-label', 'Open the overview panel')
-    cy.get('[role="toolbar"] button').eq(1).should('have.attr', 'aria-label', 'Inward mappings')
+    cy.get('[role="toolbar"] button').eq(1).should('have.attr', 'aria-label', 'Edit inward mappings')
     cy.get('[role="toolbar"] button').eq(2).should('have.attr', 'aria-label', 'Group the selected adapters')
   })
 

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeDevice.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeDevice.spec.cy.tsx
@@ -32,7 +32,7 @@ describe('NodeDevice', () => {
     )
     cy.getByTestId('device-description').should('contain', 'Simulation')
     cy.get('[role="toolbar"] button').should('have.length', 1)
-    cy.get('[role="toolbar"] button').eq(0).should('have.attr', 'aria-label', 'Open the overview panel')
+    cy.get('[role="toolbar"] button').eq(0).should('have.attr', 'aria-label', 'Edit device tags')
 
     cy.getByTestId('test-navigate-pathname').should('have.text', '/')
     cy.get('[role="toolbar"] button').eq(0).click()

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeDevice.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeDevice.tsx
@@ -13,15 +13,27 @@ import { useContextMenu } from '@/modules/Workspace/hooks/useContextMenu.ts'
 import ContextualToolbar from '@/modules/Workspace/components/nodes/ContextualToolbar.tsx'
 import { CONFIG_ADAPTER_WIDTH } from '@/modules/Workspace/utils/nodes-utils.ts'
 import { selectorIsSkeletonZoom } from '@/modules/Workspace/utils/react-flow.utils.ts'
+import ToolbarButtonGroup from '@/components/react-flow/ToolbarButtonGroup.tsx'
+import IconButton from '@/components/Chakra/IconButton.tsx'
+import { useTranslation } from 'react-i18next'
 
 const NodeDevice: FC<NodeProps<DeviceMetadata>> = ({ id, selected, data, dragging }) => {
+  const { t } = useTranslation()
   const { onContextMenu } = useContextMenu(id, selected, '/workspace/node')
   const { category, capabilities } = data
   const showSkeleton = useStore(selectorIsSkeletonZoom)
 
   return (
     <>
-      <ContextualToolbar id={id} onOpenPanel={onContextMenu} dragging={dragging} />
+      <ContextualToolbar id={id} onOpenPanel={onContextMenu} dragging={dragging} hasNoOverview>
+        <ToolbarButtonGroup>
+          <IconButton
+            icon={<Icon as={deviceCapabilityIcon['READ']} />}
+            aria-label={t('workspace.toolbar.command.device.metadata')}
+            onClick={onContextMenu}
+          />
+        </ToolbarButtonGroup>
+      </ContextualToolbar>
       <NodeWrapper
         isSelected={selected}
         wordBreak="break-word"
@@ -29,8 +41,6 @@ const NodeDevice: FC<NodeProps<DeviceMetadata>> = ({ id, selected, data, draggin
         p={3}
         w={CONFIG_ADAPTER_WIDTH}
         borderTopRadius={30}
-        onDoubleClick={onContextMenu}
-        onContextMenu={onContextMenu}
       >
         <VStack>
           {!showSkeleton && (


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/26909/details/

This PR is part of the bi-directional epic and fixes a consistency issue with node toolbars on the workspace. 

The Device toolbar, to manage tags, is now on the left-hand side, consistent with the mapping toolbar for the adapter nodes 

### Out-of-scope 
- The device node remains underspecified (no information about devices in the system)
- The "overview" CTA on the right-hand side is non-existent. It also means the device node doesn't react to double-click or right-click like the other node. There is no visual feedback to support differences between the two states. This will be dealt with in a subsequent ticket.

### Before
![screenshot-localhost_3000-2024_10_11-12_51_10](https://github.com/user-attachments/assets/de7aad8a-7a01-433e-ba47-5bc164cac331)

![screenshot-localhost_3000-2024_10_11-12_50_56](https://github.com/user-attachments/assets/2e364096-242c-4032-9589-0c6ff3b6e199)


### After

![screenshot-localhost_3000-2024_10_11-12_51_45](https://github.com/user-attachments/assets/b8acfc30-bf09-43b7-b87c-20493017686d)

