### PR TITLE
fix(): Fixes the form ordering and captions for file input adapter

### DIFF
--- a/modules/hivemq-edge-module-file/src/main/resources/file-adapter-ui-schema.json
+++ b/modules/hivemq-edge-module-file/src/main/resources/file-adapter-ui-schema.json
@@ -10,7 +10,7 @@
     },
     {
       "id" : "subFields",
-      "title" : "File 2 MQTT",
+      "title" : "File to MQTT",
       "properties" : [
         "fileToMqtt"
       ]
@@ -26,9 +26,9 @@
   "fileToMqtt" : {
     "ui:batchMode" : true,
     "ui:order" : [
+      "fileToMqttMappings",
       "maxPollingErrorsBeforeRemoval",
       "pollingIntervalMillis",
-      "fileToMqttMappings",
       "*"
     ],
     "fileToMqttMappings" : {
@@ -36,11 +36,11 @@
       "items": {
         "ui:order" : [
           "mqttTopic",
+          "filePath",
+          "contentType",
           "mqttQos",
           "*",
-          "mqttUserProperties",
-          "filePath",
-          "dataType"
+          "mqttUserProperties"
         ],
         "ui:collapsable" : {
           "titleKey" : "mqttTopic"


### PR DESCRIPTION
This PR fixes ordering and caption of the fields in the config dialog for the file-input adapter.

![image](https://github.com/user-attachments/assets/011e9cab-d96e-44dc-a488-7b0979a32ecf)