### PR TITLE
fix(27781): Fix extraction of mapping schema

### DIFF
--- a/hivemq-edge/src/frontend/src/api/hooks/useProtocolAdapters/__handlers__/index.ts
+++ b/hivemq-edge/src/frontend/src/api/hooks/useProtocolAdapters/__handlers__/index.ts
@@ -1,5 +1,6 @@
 import { http, HttpResponse } from 'msw'
 import { GenericObjectType, UiSchema } from '@rjsf/utils'
+import { JSONSchema7 } from 'json-schema'
 
 import { MOCK_TOPIC_REF1, MOCK_TOPIC_REF2 } from '@/__test-utils__/react-flow/topics.ts'
 import { MOCK_ADAPTER_ID } from '@/__test-utils__/mocks.ts'
@@ -9,7 +10,6 @@ import {
   type DeviceDataPoint,
   type DomainTag,
   type DomainTagList,
-  JsonNode,
   ObjectNode,
   ProtocolAdapter,
   ProtocolAdaptersList,
@@ -57,10 +57,10 @@ export const mockUISchema: UiSchema = {
   },
 }
 
-export const mockJSONSchema: JsonNode = {
+export const mockJSONSchema: JSONSchema7 = {
   $schema: 'https://json-schema.org/draft/2020-12/schema',
   type: 'object',
-  properties: {
+  $defs: {
     minValue: {
       type: 'integer',
       title: 'Min. Generated Value',
@@ -68,12 +68,22 @@ export const mockJSONSchema: JsonNode = {
       default: 0,
       minimum: 0,
     },
+  },
+  definitions: {
     maxValue: {
       type: 'integer',
       title: 'Max. Generated Value (Excl.)',
       description: 'Maximum value of the generated decimal number (excluded)',
       default: 1000,
       maximum: 1000,
+    },
+  },
+  properties: {
+    minValue: {
+      $ref: '#/$defs/minValue',
+    },
+    maxValue: {
+      $ref: '#/definitions/maxValue',
     },
     simulationToMqtt: {
       type: 'object',
@@ -119,6 +129,7 @@ export const mockJSONSchema: JsonNode = {
                 description:
                   'This setting defines the format of the resulting MQTT message, either a message per changed tag or a message per subscription that may include multiple data points per sample',
                 default: 'MQTTMessagePerTag',
+                // @ts-ignore TODO[NVL] enumNames not officially supported
                 enumNames: [
                   'MQTT Message Per Device Tag',
                   'MQTT Message Per Subscription (Potentially Multiple Data Points Per Sample)',

--- a/hivemq-edge/src/frontend/src/api/types/json-schema.ts
+++ b/hivemq-edge/src/frontend/src/api/types/json-schema.ts
@@ -1,3 +1,4 @@
 export const CustomFormat = {
   MQTT_TOPIC: 'mqtt-topic',
+  MQTT_TOPIC_FILTER: 'mqtt-topic-filter',
 }

--- a/hivemq-edge/src/frontend/src/modules/Mappings/hooks/useMappingManager.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/hooks/useMappingManager.tsx
@@ -53,7 +53,7 @@ export const useMappingManager = (adapterId: string) => {
     if (!adapterInfo) return undefined
     const { selectedProtocol, selectedAdapter } = adapterInfo
 
-    const { properties } = selectedProtocol?.configSchema as RJSFSchema
+    const { properties, $defs, definitions } = selectedProtocol?.configSchema as RJSFSchema
     if (!properties) return undefined
 
     if (!selectedProtocol?.id) return undefined
@@ -67,11 +67,14 @@ export const useMappingManager = (adapterId: string) => {
 
     const schema: RJSFSchema = {
       type: 'object',
+      $defs: $defs,
+      definitions: definitions,
       properties: {
         [mappingPropName]: mappingProperties,
       },
     }
     const { ['ui:tabs']: tabs, ...rest } = selectedProtocol.uiSchema as UiSchema
+
     return {
       schema,
       formData: { [mappingPropName]: formData },

--- a/hivemq-edge/src/frontend/src/modules/Workspace/utils/topics-utils.ts
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/utils/topics-utils.ts
@@ -56,12 +56,12 @@ export const getMainRootFromPath = (paths: string[]): string | undefined => {
   return root
 }
 
-export const getTopicPaths = (configSchema: RJSFSchema) => {
+export const getTopicPaths = (configSchema: RJSFSchema, format = CustomFormat.MQTT_TOPIC) => {
   const flattenSchema = flattenObject(configSchema)
   return (
     Object.entries(flattenSchema)
       // Only interested in topics, internally defined by the string format `format: 'mqtt-topic'`
-      .filter(([k, v]) => k.endsWith('format') && v === CustomFormat.MQTT_TOPIC)
+      .filter(([k, v]) => k.endsWith('format') && v === format)
       .map(([path]) =>
         path
           // A `type: 'array'` property will have a `items: { properties: {}}` pattern [?]
@@ -117,9 +117,13 @@ const getTopicsFromPath = (path: string, instance: GenericObjectType): string[] 
   return getTopicsFromPath(rest.join('.'), instance?.[property])
 }
 
-export const discoverAdapterTopics = (protocol: ProtocolAdapter, instance: GenericObjectType): string[] => {
+export const discoverAdapterTopics = (
+  protocol: ProtocolAdapter,
+  instance: GenericObjectType,
+  format = CustomFormat.MQTT_TOPIC
+): string[] => {
   // TODO[138] review nullable for protocol
-  const paths = getTopicPaths(protocol?.configSchema || {})
+  const paths = getTopicPaths(protocol?.configSchema || {}, format)
   const topics: string[] = []
 
   paths.forEach((path) => {


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/27781/details/

The PR fixes a bug with the extraction of mapping schemas from the main config schema, whereas potential definitions were not extracted. The fix takes care of both `definitions` and `$defs` syntax for the JSONSchema element.

The PR also fixed two small issues:
- the visual rendering of status on the links to devices in the workspace has been corrected to reflect the creation of outward mappings.
- the topics used for outward mappings are now displayed on the top-side of the adapter node, replicating the pattern introduced with inward mappings. 
  It is worth noting that the display is a temporary placeholder, using a "tag" rendering while in fact it shows the source topic filter. This is to create an expected placeholder, while the tag/topic mapping is being introduced

### Before 
![screenshot-localhost_3000-2024_11_11-10_00_34](https://github.com/user-attachments/assets/d7d52880-4e2a-45b5-a4b6-ed5907791ac9)

### After
![screenshot-localhost_3000-2024_11_11-10_00_08](https://github.com/user-attachments/assets/d1ef9fa3-9042-4cbd-a33a-19ae832b58f1)
