### PR TITLE
fix(27867): add device node to every adapter in the workspace

### DIFF
--- a/hivemq-edge/src/frontend/src/__test-utils__/react-flow/nodes.ts
+++ b/hivemq-edge/src/frontend/src/__test-utils__/react-flow/nodes.ts
@@ -5,6 +5,7 @@ import { mockBridge } from '@/api/hooks/useGetBridges/__handlers__'
 import { mockClientSubscription } from '@/api/hooks/useClientSubscriptions/__handlers__'
 import { mockMqttListener } from '@/api/hooks/useGateway/__handlers__'
 import { DeviceMetadata, Group, NodeTypes } from '@/modules/Workspace/types.ts'
+import { MOCK_ADAPTER_ID } from '@/__test-utils__/mocks.ts'
 
 export const MOCK_DEFAULT_NODE = {
   selected: false,
@@ -58,7 +59,7 @@ export const MOCK_NODE_GROUP: NodeProps<Group> = {
 export const MOCK_NODE_DEVICE: NodeProps<DeviceMetadata> = {
   id: 'idDevice',
   type: NodeTypes.DEVICE_NODE,
-  data: mockProtocolAdapter,
+  data: { ...mockProtocolAdapter, sourceAdapterId: MOCK_ADAPTER_ID },
   ...MOCK_DEFAULT_NODE,
 }
 

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeAdapter.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeAdapter.tsx
@@ -105,7 +105,7 @@ const NodeAdapter: FC<NodeProps<Adapter>> = ({ id, data: adapter, selected, drag
         )}
       </NodeWrapper>
       <Handle type="source" position={Position.Bottom} id="Bottom" isConnectable={false} />
-      {bidirectional && <Handle type="source" position={Position.Top} id="Top" isConnectable={false} />}
+      <Handle type="source" position={Position.Top} id="Top" isConnectable={false} />
     </>
   )
 }

--- a/hivemq-edge/src/frontend/src/modules/Workspace/hooks/useWorkspaceStore.spec.ts
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/hooks/useWorkspaceStore.spec.ts
@@ -7,6 +7,7 @@ import useWorkspaceStore from './useWorkspaceStore.ts'
 import {
   MOCK_NODE_ADAPTER,
   MOCK_NODE_BRIDGE,
+  MOCK_NODE_DEVICE,
   MOCK_NODE_EDGE,
   MOCK_NODE_GROUP,
 } from '@/__test-utils__/react-flow/nodes.ts'
@@ -140,13 +141,20 @@ describe('useWorkspaceStore', () => {
     expect(result.current.edges).toHaveLength(0)
 
     act(() => {
-      const { onNodesChange } = result.current
+      const { onNodesChange, onAddEdges } = result.current
       const item: Node = { ...MOCK_NODE_ADAPTER, position: { x: 0, y: 0 } }
-      onNodesChange([{ item, type: 'add' }])
+      const device: Node = { ...MOCK_NODE_DEVICE, position: { x: 0, y: 0 } }
+      const link: Edge = { id: '1-2', source: 'idAdapter', target: 'idDevice' }
+
+      onNodesChange([
+        { item, type: 'add' },
+        { item: device, type: 'add' },
+      ])
+      onAddEdges([{ item: link, type: 'add' } as EdgeAddChange])
     })
 
-    expect(result.current.nodes).toHaveLength(1)
-    expect(result.current.edges).toHaveLength(0)
+    expect(result.current.nodes).toHaveLength(2)
+    expect(result.current.edges).toHaveLength(1)
 
     act(() => {
       const { onDeleteNode } = result.current
@@ -154,7 +162,7 @@ describe('useWorkspaceStore', () => {
     })
 
     expect(result.current.nodes).toHaveLength(0)
-    expect(result.current.edges).toHaveLength(0)
+    expect(result.current.edges).toHaveLength(1)
   })
 
   it('should toggle a group', async () => {

--- a/hivemq-edge/src/frontend/src/modules/Workspace/hooks/useWorkspaceStore.ts
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/hooks/useWorkspaceStore.ts
@@ -9,7 +9,7 @@ import {
   applyNodeChanges,
   applyEdgeChanges,
 } from 'reactflow'
-import { Group, NodeTypes, WorkspaceState, WorkspaceAction } from '@/modules/Workspace/types.ts'
+import { Group, NodeTypes, WorkspaceState, WorkspaceAction, DeviceMetadata } from '@/modules/Workspace/types.ts'
 import { persist, createJSONStorage } from 'zustand/middleware'
 import { Adapter } from '@/api/__generated__'
 
@@ -81,8 +81,12 @@ const useWorkspaceStore = create<WorkspaceState & WorkspaceAction>()(
       },
       onDeleteNode: (type: NodeTypes, adapterId: string) => {
         set({
-          nodes: get().nodes.filter((e) => {
-            return !(e.type === type && (e.data as Adapter).id === adapterId)
+          nodes: get().nodes.filter((node) => {
+            const isThisTheAdapter = node.type === type && (node.data as Adapter).id === adapterId
+            const isThisTheDevice =
+              node.type === NodeTypes.DEVICE_NODE && (node.data as DeviceMetadata).sourceAdapterId == adapterId
+
+            return !isThisTheAdapter && !isThisTheDevice
           }),
         })
       },

--- a/hivemq-edge/src/frontend/src/modules/Workspace/types.ts
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/types.ts
@@ -78,7 +78,6 @@ export interface TopicTreeMetadata {
   count: number
 }
 
-/**
- * @deprecated This is a mock, will need to be replaced by OpenAPI specs when available
- */
-export type DeviceMetadata = ProtocolAdapter
+export interface DeviceMetadata extends ProtocolAdapter {
+  sourceAdapterId?: string
+}

--- a/hivemq-edge/src/frontend/src/modules/Workspace/utils/nodes-utils.spec.ts
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/utils/nodes-utils.spec.ts
@@ -8,7 +8,7 @@ import { mockBridge } from '@/api/hooks/useGetBridges/__handlers__'
 import { mockMqttListener } from '@/api/hooks/useGateway/__handlers__'
 import { mockAdapter, mockProtocolAdapter } from '@/api/hooks/useProtocolAdapters/__handlers__'
 
-import { IdStubs, NodeTypes } from '../types.ts'
+import { DeviceMetadata, IdStubs, NodeTypes } from '../types.ts'
 import {
   createAdapterNode,
   createBridgeNode,
@@ -160,7 +160,9 @@ describe('createAdapterNode', () => {
     const actual = createAdapterNode(mockProtocolAdapter, mockAdapter, 1, 2, MOCK_THEME)
     const expected: {
       nodeAdapter: Node<Bridge, NodeTypes.ADAPTER_NODE>
+      nodeDevice: Node<DeviceMetadata, NodeTypes.DEVICE_NODE>
       edgeConnector: Edge
+      deviceConnector: Edge
     } = {
       nodeAdapter: expect.objectContaining({
         id: `adapter@${MOCK_ADAPTER_ID}`,
@@ -172,6 +174,17 @@ describe('createAdapterNode', () => {
         source: `adapter@${MOCK_ADAPTER_ID}`,
         animated: true,
         target: 'edge',
+      }),
+      nodeDevice: expect.objectContaining({
+        id: 'device@adapter@my-adapter',
+        targetPosition: Position.Top,
+        type: NodeTypes.DEVICE_NODE,
+      }),
+      deviceConnector: expect.objectContaining({
+        id: 'connect-device@adapter@my-adapter',
+        source: 'adapter@my-adapter',
+        animated: true,
+        target: 'device@adapter@my-adapter',
       }),
     }
 

--- a/hivemq-edge/src/frontend/src/modules/Workspace/utils/nodes-utils.ts
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/utils/nodes-utils.ts
@@ -8,7 +8,6 @@ import { Adapter, Bridge, Status, Listener, ProtocolAdapter, ClientFilter } from
 import { EdgeTypes, IdStubs, NodeTypes } from '../types.ts'
 import { getBridgeTopics, discoverAdapterTopics } from '../utils/topics-utils.ts'
 import { getThemeForStatus } from '@/modules/Workspace/utils/status-utils.ts'
-import { isBidirectional } from '@/modules/Workspace/utils/adapter.utils.ts'
 
 export const CONFIG_ADAPTER_WIDTH = 245
 
@@ -201,37 +200,35 @@ export const createAdapterNode = (
   let nodeDevice: Node<ProtocolAdapter, NodeTypes.DEVICE_NODE> | undefined = undefined
   let deviceConnector: Edge | undefined = undefined
 
-  if (isBidirectional(type)) {
-    const idBAdapterDevice = `${IdStubs.DEVICE_NODE}@${idAdapter}`
-    nodeDevice = {
-      id: idBAdapterDevice,
-      type: NodeTypes.DEVICE_NODE,
-      targetPosition: Position.Top,
-      data: type,
-      position: positionStorage?.[idBAdapterDevice] ?? {
-        x: nodeAdapter.position.x,
-        y: nodeAdapter.position.y + gluedNodeDefinition[NodeTypes.ADAPTER_NODE][1],
-      },
-    }
+  const idBAdapterDevice = `${IdStubs.DEVICE_NODE}@${idAdapter}`
+  nodeDevice = {
+    id: idBAdapterDevice,
+    type: NodeTypes.DEVICE_NODE,
+    targetPosition: Position.Top,
+    data: type,
+    position: positionStorage?.[idBAdapterDevice] ?? {
+      x: nodeAdapter.position.x,
+      y: nodeAdapter.position.y + gluedNodeDefinition[NodeTypes.ADAPTER_NODE][1],
+    },
+  }
 
-    deviceConnector = {
-      id: `${IdStubs.CONNECTOR}-${IdStubs.DEVICE_NODE}@${idAdapter}`,
-      target: idBAdapterDevice,
-      sourceHandle: 'Top',
-      source: idAdapter,
-      focusable: false,
-      markerEnd: {
-        type: MarkerType.ArrowClosed,
-        width: 20,
-        height: 20,
-        color: getThemeForStatus(theme, adapter.status),
-      },
-      animated: isConnected && !!topics.length,
-      style: {
-        strokeWidth: 1.5,
-        stroke: getThemeForStatus(theme, adapter.status),
-      },
-    }
+  deviceConnector = {
+    id: `${IdStubs.CONNECTOR}-${IdStubs.DEVICE_NODE}@${idAdapter}`,
+    target: idBAdapterDevice,
+    sourceHandle: 'Top',
+    source: idAdapter,
+    focusable: false,
+    markerEnd: {
+      type: MarkerType.ArrowClosed,
+      width: 20,
+      height: 20,
+      color: getThemeForStatus(theme, adapter.status),
+    },
+    animated: isConnected && !!topics.length,
+    style: {
+      strokeWidth: 1.5,
+      stroke: getThemeForStatus(theme, adapter.status),
+    },
   }
 
   return { nodeAdapter, edgeConnector, nodeDevice, deviceConnector }

--- a/hivemq-edge/src/frontend/src/modules/Workspace/utils/nodes-utils.ts
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/utils/nodes-utils.ts
@@ -5,7 +5,7 @@ import { GenericObjectType } from '@rjsf/utils'
 
 import { Adapter, Bridge, Status, Listener, ProtocolAdapter, ClientFilter } from '@/api/__generated__'
 
-import { EdgeTypes, IdStubs, NodeTypes } from '../types.ts'
+import { DeviceMetadata, EdgeTypes, IdStubs, NodeTypes } from '../types.ts'
 import { getBridgeTopics, discoverAdapterTopics } from '../utils/topics-utils.ts'
 import { getThemeForStatus } from '@/modules/Workspace/utils/status-utils.ts'
 
@@ -197,7 +197,7 @@ export const createAdapterNode = (
     },
   }
 
-  let nodeDevice: Node<ProtocolAdapter, NodeTypes.DEVICE_NODE> | undefined = undefined
+  let nodeDevice: Node<DeviceMetadata, NodeTypes.DEVICE_NODE> | undefined = undefined
   let deviceConnector: Edge | undefined = undefined
 
   const idBAdapterDevice = `${IdStubs.DEVICE_NODE}@${idAdapter}`
@@ -205,7 +205,7 @@ export const createAdapterNode = (
     id: idBAdapterDevice,
     type: NodeTypes.DEVICE_NODE,
     targetPosition: Position.Top,
-    data: type,
+    data: { ...type, sourceAdapterId: adapter.id },
     position: positionStorage?.[idBAdapterDevice] ?? {
       x: nodeAdapter.position.x,
       y: nodeAdapter.position.y + gluedNodeDefinition[NodeTypes.ADAPTER_NODE][1],


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/27867/details/

A simple fix to enable the `workspace` to show the `device` node of every `adapter` created. 

Initially, `devices` were only added for adapters supporting bi-directionality. 

However, the generalisation of `tags` for mapping, regardless of direction, enabled the co-location of the `tags` within the `device` namespace, and the necessity of their presence on the `workspace`.

The PR also fixes a bug with the `device` node not being deleted when their `adapter` is.

### Out-of-scope
- Content of the `device` nodes is still not accurate but will be delivered in subsequent tickets

### Before
![screenshot-localhost_3000-2024_11_12-15_39_00](https://github.com/user-attachments/assets/f439d762-de00-45f6-93e2-01113dbbcb1e)


### After
![screenshot-localhost_3000-2024_11_12-15_38_15](https://github.com/user-attachments/assets/b75ff037-a6a6-4426-b5a4-5ada30812912)