### PR TITLE
feat(26339): Improve errors display in RJSF forms and handle focus on hidden widget

### DIFF
--- a/hivemq-edge/src/frontend/src/components/rjsf/ArrayFieldItemTemplate.tsx
+++ b/hivemq-edge/src/frontend/src/components/rjsf/ArrayFieldItemTemplate.tsx
@@ -1,4 +1,4 @@
-import { FC, useMemo } from 'react'
+import { FC, useEffect, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { ArrayFieldTemplateItemType, getTemplate, getUiOptions } from '@rjsf/utils'
 import { Box, ButtonGroup, FormControl, HStack, useDisclosure, VStack } from '@chakra-ui/react'
@@ -6,6 +6,7 @@ import { LuPanelTopClose, LuPanelTopOpen } from 'react-icons/lu'
 
 import IconButton from '@/components/Chakra/IconButton.tsx'
 import { CopyButton, MoveDownButton, MoveUpButton, RemoveButton } from '@/components/rjsf/__internals/IconButton.tsx'
+import { useFormControlStore } from '@/components/rjsf/Form/useFormControlStore.ts'
 
 // TODO[NVL] Need a better handling of the custom UISchema property, for the Adapter SDK
 interface ArrayFieldItemCollapsableUISchema {
@@ -32,10 +33,13 @@ export const ArrayFieldItemTemplate: FC<ArrayFieldTemplateItemType> = (props) =>
   } = props
   const { t } = useTranslation('components')
   const uiOptions = getUiOptions(uiSchema)
+  const { expandItems } = useFormControlStore()
+
   const collapsableItems: ArrayFieldItemCollapsableUISchema | undefined = useMemo(() => {
     return uiOptions.collapsable as ArrayFieldItemCollapsableUISchema | undefined
   }, [uiOptions.collapsable])
-  const { isOpen, onToggle, getButtonProps, getDisclosureProps } = useDisclosure({
+
+  const { isOpen, onToggle, getButtonProps, getDisclosureProps, onOpen } = useDisclosure({
     defaultIsOpen:
       !collapsableItems ||
       !collapsableItems?.titleKey ||
@@ -48,6 +52,10 @@ export const ArrayFieldItemTemplate: FC<ArrayFieldTemplateItemType> = (props) =>
     if (childrenFormData) return `${children.props.name} - ${childrenFormData}`
     return children.props.name
   }, [children.props.formData, children.props.name, collapsableItems?.titleKey])
+
+  useEffect(() => {
+    if (props.children.props.idSchema.$id === expandItems.join('_')) onOpen()
+  }, [expandItems, onOpen, props.children.props.idSchema.$id])
 
   const onCopyClick = useMemo(() => onCopyIndexClick(index), [index, onCopyIndexClick])
   const onRemoveClick = useMemo(() => onDropIndexClick(index), [index, onDropIndexClick])

--- a/hivemq-edge/src/frontend/src/components/rjsf/Form/ChakraRJSForm.tsx
+++ b/hivemq-edge/src/frontend/src/components/rjsf/Form/ChakraRJSForm.tsx
@@ -16,8 +16,8 @@ import { ArrayFieldItemTemplate } from '@/components/rjsf/ArrayFieldItemTemplate
 import { ChakraRJSFormContext } from '@/components/rjsf/Form/types.ts'
 import { customFormatsValidator } from '@/modules/ProtocolAdapters/utils/validation-utils.ts'
 import { adapterJSFFields, adapterJSFWidgets } from '@/modules/ProtocolAdapters/utils/uiSchema.utils.ts'
-import { TitleFieldTemplate } from '@/components/rjsf/Templates/TitleFieldTemplate.tsx'
 import { customFocusError } from '@/components/rjsf/Form/error-focus.utils.ts'
+import { TitleFieldTemplate } from '@/components/rjsf/Templates/TitleFieldTemplate.tsx'
 import { ErrorListTemplate } from '@/components/rjsf/Templates/ErrorListTemplate.tsx'
 
 interface CustomFormProps<T>
@@ -72,7 +72,7 @@ const ChakraRJSForm: FC<CustomFormProps<unknown>> = ({
 
       setBatchData(operations)
     },
-    focusOnError: customFocusError(ref, uiSchema),
+    focusOnError: customFocusError(ref),
   }
 
   const rjsfLog = debug(`RJSF:${id}`)
@@ -102,7 +102,7 @@ const ChakraRJSForm: FC<CustomFormProps<unknown>> = ({
       liveValidate
       // TODO[NVL] Removing HTML validation; see https://rjsf-team.github.io/react-jsonschema-form/docs/usage/validation/#html5-validation
       noHtml5Validate
-      focusOnFirstError={customFocusError(ref, uiSchema)}
+      focusOnFirstError={customFocusError(ref)}
       onSubmit={onValidate}
       validator={customFormatsValidator}
       customValidate={customValidate}

--- a/hivemq-edge/src/frontend/src/components/rjsf/Form/ChakraRJSForm.tsx
+++ b/hivemq-edge/src/frontend/src/components/rjsf/Form/ChakraRJSForm.tsx
@@ -40,6 +40,7 @@ const ChakraRJSForm: FC<CustomFormProps<unknown>> = ({
   readonly,
 }) => {
   const { t } = useTranslation()
+  const ref = useRef(null)
   const [batchData, setBatchData] = useState<JSONPatchDocument | undefined>(undefined)
   const defaultValues = useMemo(() => {
     if (batchData) {
@@ -79,6 +80,7 @@ const ChakraRJSForm: FC<CustomFormProps<unknown>> = ({
 
   return (
     <Form
+      ref={ref}
       id={id}
       readonly={readonly}
       schema={unspecifiedSchema}

--- a/hivemq-edge/src/frontend/src/components/rjsf/Form/ChakraRJSForm.tsx
+++ b/hivemq-edge/src/frontend/src/components/rjsf/Form/ChakraRJSForm.tsx
@@ -100,7 +100,7 @@ const ChakraRJSForm: FC<CustomFormProps<unknown>> = ({
       liveValidate
       // TODO[NVL] Removing HTML validation; see https://rjsf-team.github.io/react-jsonschema-form/docs/usage/validation/#html5-validation
       noHtml5Validate
-      focusOnFirstError
+      focusOnFirstError={customFocusError(ref, uiSchema)}
       onSubmit={onValidate}
       validator={customFormatsValidator}
       customValidate={customValidate}

--- a/hivemq-edge/src/frontend/src/components/rjsf/Form/ChakraRJSForm.tsx
+++ b/hivemq-edge/src/frontend/src/components/rjsf/Form/ChakraRJSForm.tsx
@@ -1,4 +1,4 @@
-import { FC, useCallback, useMemo, useState } from 'react'
+import { FC, useCallback, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import debug from 'debug'
 import { immutableJSONPatch, JSONPatchAdd, JSONPatchDocument } from 'immutable-json-patch'
@@ -13,11 +13,12 @@ import { DescriptionFieldTemplate } from '@/components/rjsf/Templates/Descriptio
 import { BaseInputTemplate } from '@/components/rjsf/BaseInputTemplate.tsx'
 import { ArrayFieldTemplate } from '@/components/rjsf/ArrayFieldTemplate.tsx'
 import { ArrayFieldItemTemplate } from '@/components/rjsf/ArrayFieldItemTemplate.tsx'
-import { ErrorListTemplate } from '@/components/rjsf/Templates/ErrorListTemplate.tsx'
 import { ChakraRJSFormContext } from '@/components/rjsf/Form/types.ts'
 import { customFormatsValidator } from '@/modules/ProtocolAdapters/utils/validation-utils.ts'
 import { adapterJSFFields, adapterJSFWidgets } from '@/modules/ProtocolAdapters/utils/uiSchema.utils.ts'
 import { TitleFieldTemplate } from '@/components/rjsf/Templates/TitleFieldTemplate.tsx'
+import { customFocusError } from '@/components/rjsf/Form/error-focus.utils.ts'
+import { ErrorListTemplate } from '@/components/rjsf/Templates/ErrorListTemplate.tsx'
 
 interface CustomFormProps<T>
   extends Pick<
@@ -71,6 +72,7 @@ const ChakraRJSForm: FC<CustomFormProps<unknown>> = ({
 
       setBatchData(operations)
     },
+    focusOnError: customFocusError(ref, uiSchema),
   }
 
   const rjsfLog = debug(`RJSF:${id}`)

--- a/hivemq-edge/src/frontend/src/components/rjsf/Form/ChakraRJSForm.tsx
+++ b/hivemq-edge/src/frontend/src/components/rjsf/Form/ChakraRJSForm.tsx
@@ -1,4 +1,4 @@
-import { FC, useCallback, useMemo, useRef, useState } from 'react'
+import { FC, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import debug from 'debug'
 import { immutableJSONPatch, JSONPatchAdd, JSONPatchDocument } from 'immutable-json-patch'
@@ -19,6 +19,7 @@ import { adapterJSFFields, adapterJSFWidgets } from '@/modules/ProtocolAdapters/
 import { customFocusError } from '@/components/rjsf/Form/error-focus.utils.ts'
 import { TitleFieldTemplate } from '@/components/rjsf/Templates/TitleFieldTemplate.tsx'
 import { ErrorListTemplate } from '@/components/rjsf/Templates/ErrorListTemplate.tsx'
+import { useFormControlStore } from '@/components/rjsf/Form/useFormControlStore.ts'
 
 interface CustomFormProps<T>
   extends Pick<
@@ -41,6 +42,7 @@ const ChakraRJSForm: FC<CustomFormProps<unknown>> = ({
   readonly,
 }) => {
   const { t } = useTranslation()
+  const { setTabIndex } = useFormControlStore()
   const ref = useRef(null)
   const [batchData, setBatchData] = useState<JSONPatchDocument | undefined>(undefined)
   const defaultValues = useMemo(() => {
@@ -55,6 +57,15 @@ const ChakraRJSForm: FC<CustomFormProps<unknown>> = ({
       onSubmit?.(data)
     },
     [onSubmit]
+  )
+
+  useEffect(
+    () => {
+      setTabIndex(0)
+      return () => setTabIndex(0)
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
   )
 
   const context: ChakraRJSFormContext = {
@@ -99,17 +110,17 @@ const ChakraRJSForm: FC<CustomFormProps<unknown>> = ({
         ErrorListTemplate,
         TitleFieldTemplate,
       }}
+      widgets={adapterJSFWidgets}
+      fields={adapterJSFFields}
+      onSubmit={onValidate}
       liveValidate
       // TODO[NVL] Removing HTML validation; see https://rjsf-team.github.io/react-jsonschema-form/docs/usage/validation/#html5-validation
       noHtml5Validate
-      focusOnFirstError={customFocusError(ref)}
-      onSubmit={onValidate}
       validator={customFormatsValidator}
       customValidate={customValidate}
-      widgets={adapterJSFWidgets}
-      fields={adapterJSFFields}
       onError={(errors) => rjsfLog(t('error.rjsf.validation'), errors)}
       showErrorList="bottom"
+      focusOnFirstError={context.focusOnError}
     />
   )
 }

--- a/hivemq-edge/src/frontend/src/components/rjsf/Form/error-focus.utils.spec.ts
+++ b/hivemq-edge/src/frontend/src/components/rjsf/Form/error-focus.utils.spec.ts
@@ -1,0 +1,183 @@
+import { expect } from 'vitest'
+
+import {
+  _toPath,
+  deepGet,
+  isNumeric,
+  isPropertyBehindCollapsedElement,
+  isPropertyBehindTab,
+} from '@/components/rjsf/Form/error-focus.utils.ts'
+
+describe('_toPath', () => {
+  it.each([
+    {
+      path: '',
+      value: null,
+    },
+    {
+      path: 'a.b.c',
+      value: ['a', 'b', 'c'],
+    },
+    {
+      path: 'a[0].b.c',
+      value: ['a', '0', 'b', 'c'],
+    },
+  ])('should return $value for $path', ({ path, value }) => {
+    expect(_toPath(path)).toStrictEqual(value)
+  })
+})
+
+describe('isNumeric', () => {
+  it.each(['1', '1000'])('$item should be a number', (item) => {
+    expect(isNumeric(item)).toStrictEqual(true)
+  })
+  it.each(['1.', '1.5', '-1'])('$item should not be a number', (item) => {
+    expect(isNumeric(item)).toStrictEqual(false)
+  })
+})
+
+const MOCK_OBJECT = {
+  foo: {
+    foz: [1, 2, 3],
+    bar: {
+      baz: ['a', 'b', 'c'],
+    },
+  },
+}
+
+describe('deepGet', () => {
+  it('should return null for an empty object', async () => {
+    expect(deepGet({}, [1])).toStrictEqual(null)
+  })
+
+  it('should return null for an empty key', async () => {
+    expect(deepGet(MOCK_OBJECT, [])).toStrictEqual(null)
+  })
+
+  it.each([
+    {
+      keys: ['foo', 'bar'],
+      value: {
+        baz: ['a', 'b', 'c'],
+      },
+    },
+    { keys: ['foo', 'foz', 2], value: 3 },
+    { keys: ['foo', 'bar', 'baz', 1], value: 'b' },
+    { keys: ['foo', 'bar', 'baz', 8, 'foz'], value: null },
+  ])('should return $value for $keys', ({ keys, value }) => {
+    expect(deepGet(MOCK_OBJECT, keys)).toStrictEqual(value)
+  })
+})
+
+describe('isPropertyBehindCollapsedElement', () => {
+  it.each([
+    {
+      property: '',
+    },
+    {
+      property: 'id',
+    },
+    {
+      property: '.property',
+    },
+    {
+      property: '.property.without.any.array',
+    },
+  ])('should be undefined for $property', ({ property }) => {
+    expect(isPropertyBehindCollapsedElement(property, {})).toStrictEqual(undefined)
+  })
+
+  it.each([
+    {
+      property: '.property.0.with_no_items',
+      uiSchema: {
+        property: {},
+      },
+      value: undefined,
+    },
+    {
+      property: '.property.0.item.without_collapsable_tag',
+      uiSchema: {
+        property: {
+          items: {
+            'ui:title': 'ss',
+          },
+        },
+      },
+      value: undefined,
+    },
+    {
+      property: '.property.0.item.with_collapsable_tag',
+      uiSchema: {
+        property: {
+          items: {
+            'ui:title': 'ss',
+            'ui:collapsable': 'ss',
+          },
+        },
+      },
+      value: ['root', 'property', '0'],
+    },
+    {
+      property: '.property.0.subProp.1.another.level.2.item',
+      uiSchema: {
+        property: {
+          items: {
+            'ui:title': 'ss',
+            'ui:collapsable': 'ss',
+          },
+        },
+      },
+      value: ['root', 'property', '0'],
+    },
+  ])('should return $value for $property', ({ property, uiSchema, value }) => {
+    expect(isPropertyBehindCollapsedElement(property, uiSchema)).toStrictEqual(value)
+  })
+})
+
+describe('isPropertyBehindTab', () => {
+  it('should return undefined if tabs are not defined', async () => {
+    expect(isPropertyBehindTab('whatever.the.property.path', { test: 1 })).toStrictEqual(undefined)
+    expect(isPropertyBehindTab('whatever.the.property.path', { 'ui:tabs': 1 })).toStrictEqual(undefined)
+  })
+
+  it('should return undefined if property is not defined', async () => {
+    expect(isPropertyBehindTab('', { 'ui:tabs': [] })).toStrictEqual(undefined)
+  })
+
+  it('should return undefined if property is not in the tabs', async () => {
+    expect(isPropertyBehindTab('.test.property', { 'ui:tabs': [] })).toStrictEqual(undefined)
+  })
+
+  it('should return undefined if property is not in the tabs', async () => {
+    expect(isPropertyBehindTab('.test.property', { 'ui:tabs': [{ wrongProperties: '' }] })).toStrictEqual(undefined)
+  })
+  it('should return undefined if property is not in the tabs', async () => {
+    const mockUISchema = { 'ui:tabs': [{ id: 'tab1', title: 'tab 1', properties: ['prop1', 'prop2'] }] }
+    expect(isPropertyBehindTab('.test.property', mockUISchema)).toStrictEqual(undefined)
+  })
+  it('should return tab1 if property is in the tab', async () => {
+    const mockUISchema = { 'ui:tabs': [{ id: 'tab1', title: 'tab 1', properties: ['test', 'prop2'] }] }
+    expect(isPropertyBehindTab('.test.property', mockUISchema)).toStrictEqual({
+      id: 'tab1',
+      title: 'tab 1',
+      properties: ['test', 'prop2'],
+      index: 0,
+    })
+  })
+  it('should return rab2 if property is in the tab', async () => {
+    const mockUISchema = {
+      'ui:tabs': [
+        { id: 'tab1', title: 'tab 1', properties: ['prop123'] },
+        { id: 'tab2', title: 'tab 2', properties: ['prop456', 'test'] },
+        { id: 'tab3', title: 'tab 3', properties: ['prop789'] },
+      ],
+    }
+    expect(isPropertyBehindTab('.test.property', mockUISchema)).toStrictEqual({
+      id: 'tab2',
+      title: 'tab 2',
+      properties: ['prop456', 'test'],
+      index: 1,
+    })
+  })
+})

--- a/hivemq-edge/src/frontend/src/components/rjsf/Form/error-focus.utils.ts
+++ b/hivemq-edge/src/frontend/src/components/rjsf/Form/error-focus.utils.ts
@@ -26,12 +26,10 @@ const focusOnError = (formElement: HTMLFormElement, error: RJSFValidationError) 
   }
 
   const elementId = path.join(idSeparator)
-  // let field = formElement.elements[elementId]
   let field = formElement.querySelector(`#${elementId}`) as HTMLElement
 
   if (!field) {
     // if not an exact match, try finding an input starting with the element id (like radio buttons or checkboxes)
-    // field = this.formElement.current.querySelector(`input[id^="${elementId}"`)
     field = formElement.querySelector(`input[id^="${elementId}"`) as HTMLElement
   }
   if (field instanceof HTMLDivElement) {
@@ -90,7 +88,6 @@ export const isPropertyBehindTab = (
   uiSchema: UiSchema<unknown, RJSFSchema, ChakraRJSFormContext>
 ) => {
   const { 'ui:tabs': tabs } = uiSchema
-  if (!tabs) return undefined
   if (!Array.isArray(tabs)) return undefined
 
   const root = property.split('.')[1] || property
@@ -102,6 +99,5 @@ export const isPropertyBehindTab = (
     if (properties && properties.includes(root)) inTab = { ...tab, index }
   }
 
-  if (inTab) return inTab
-  return undefined
+  return inTab ? inTab : undefined
 }

--- a/hivemq-edge/src/frontend/src/components/rjsf/Form/error-focus.utils.ts
+++ b/hivemq-edge/src/frontend/src/components/rjsf/Form/error-focus.utils.ts
@@ -1,0 +1,57 @@
+import { MutableRefObject } from 'react'
+import Form from '@rjsf/core'
+import { RJSFValidationError, UiSchema } from '@rjsf/utils'
+
+// From RJSF
+const focusOnError = (formElement: HTMLFormElement, error: RJSFValidationError) => {
+  // const { idPrefix = 'root', idSeparator = '_' } = props;
+  const idPrefix = 'root',
+    idSeparator = '_'
+
+  const { property } = error
+  if (!property) return
+
+  // WARNING: This is not a drop in replacement solution and
+  // it might not work for some edge cases. Test your code!
+  const _toPath = (path: string) => path?.match(/([^[.\]])+/g)
+
+  const path = _toPath(property)
+  if (!path) return
+  if (path[0] === '') {
+    // Most of the time the `.foo` property results in the first element being empty, so replace it with the idPrefix
+    path[0] = 'root'
+  } else {
+    // Otherwise insert the idPrefix into the first location using unshift
+    path.unshift(idPrefix)
+  }
+
+  //
+  const elementId = path.join(idSeparator)
+  // let field = formElement.elements[elementId]
+  let field = formElement.querySelector(`#${elementId}`) as HTMLElement
+
+  if (!field) {
+    // if not an exact match, try finding an input starting with the element id (like radio buttons or checkboxes)
+    // field = this.formElement.current.querySelector(`input[id^="${elementId}"`)
+    field = formElement.querySelector(`input[id^="${elementId}"`) as HTMLElement
+  }
+  if (field instanceof HTMLDivElement) {
+    // if the field is a select or other wrapper, find the nested input
+    field = formElement.querySelector<HTMLDivElement>(`#${elementId} input`) as HTMLElement
+    console.log('XXX', field)
+  }
+
+  if (field) {
+    field.focus()
+  }
+}
+
+export const customFocusError =
+  (wrapperRef: MutableRefObject<null>, uiSchema?: UiSchema) => (error: RJSFValidationError) => {
+    if (!wrapperRef.current) return
+
+    const rjsForm = wrapperRef.current as Form
+
+    console.log('I need to handle focusing on this error', rjsForm, uiSchema, error)
+    focusOnError(rjsForm.formElement.current, error)
+  }

--- a/hivemq-edge/src/frontend/src/components/rjsf/Form/error-focus.utils.ts
+++ b/hivemq-edge/src/frontend/src/components/rjsf/Form/error-focus.utils.ts
@@ -1,6 +1,6 @@
 import { MutableRefObject } from 'react'
 import Form from '@rjsf/core'
-import { RJSFValidationError, UiSchema } from '@rjsf/utils'
+import { RJSFValidationError } from '@rjsf/utils'
 
 // From RJSF
 const focusOnError = (formElement: HTMLFormElement, error: RJSFValidationError) => {
@@ -38,7 +38,6 @@ const focusOnError = (formElement: HTMLFormElement, error: RJSFValidationError) 
   if (field instanceof HTMLDivElement) {
     // if the field is a select or other wrapper, find the nested input
     field = formElement.querySelector<HTMLDivElement>(`#${elementId} input`) as HTMLElement
-    console.log('XXX', field)
   }
 
   if (field) {
@@ -46,12 +45,10 @@ const focusOnError = (formElement: HTMLFormElement, error: RJSFValidationError) 
   }
 }
 
-export const customFocusError =
-  (wrapperRef: MutableRefObject<null>, uiSchema?: UiSchema) => (error: RJSFValidationError) => {
-    if (!wrapperRef.current) return
+export const customFocusError = (wrapperRef: MutableRefObject<null>) => (error: RJSFValidationError) => {
+  if (!wrapperRef.current) return
 
-    const rjsForm = wrapperRef.current as Form
+  const rjsForm = wrapperRef.current as Form
 
-    console.log('I need to handle focusing on this error', rjsForm, uiSchema, error)
-    focusOnError(rjsForm.formElement.current, error)
-  }
+  focusOnError(rjsForm.formElement.current, error)
+}

--- a/hivemq-edge/src/frontend/src/components/rjsf/Form/types.ts
+++ b/hivemq-edge/src/frontend/src/components/rjsf/Form/types.ts
@@ -10,3 +10,13 @@ export interface ChakraRJSFormContext extends FormContextType {
   onBatchUpload?: (idSchema: IdSchema<unknown>, batch: Record<string, unknown>[]) => void
   focusOnError?: (error: RJSFValidationError) => void
 }
+
+export interface UITab {
+  id: string
+  title: string
+  properties: string[]
+}
+
+export interface UITabIndexed extends UITab {
+  index: number
+}

--- a/hivemq-edge/src/frontend/src/components/rjsf/Form/types.ts
+++ b/hivemq-edge/src/frontend/src/components/rjsf/Form/types.ts
@@ -1,5 +1,6 @@
-import { FormContextType, IdSchema } from '@rjsf/utils'
+import { FormContextType, IdSchema, RJSFValidationError } from '@rjsf/utils'
 
 export interface ChakraRJSFormContext extends FormContextType {
   onBatchUpload?: (idSchema: IdSchema<unknown>, batch: Record<string, unknown>[]) => void
+  focusOnError?: (error: RJSFValidationError) => void
 }

--- a/hivemq-edge/src/frontend/src/components/rjsf/Form/types.ts
+++ b/hivemq-edge/src/frontend/src/components/rjsf/Form/types.ts
@@ -1,10 +1,17 @@
 import { FormContextType, IdSchema, RJSFValidationError } from '@rjsf/utils'
 
-export type FormControlStore = {
+export type FormControlState = {
   tabIndex: number
-  setTabIndex: (n: number) => void
-  clearController: () => void
+  expandItems: string[]
 }
+
+export type FormControlAction = {
+  reset: () => void
+  setTabIndex: (n: number) => void
+  setExpandItems: (items: string[]) => void
+}
+
+export type FormControlStore = FormControlState & FormControlAction
 
 export interface ChakraRJSFormContext extends FormContextType {
   onBatchUpload?: (idSchema: IdSchema<unknown>, batch: Record<string, unknown>[]) => void

--- a/hivemq-edge/src/frontend/src/components/rjsf/Form/types.ts
+++ b/hivemq-edge/src/frontend/src/components/rjsf/Form/types.ts
@@ -1,5 +1,11 @@
 import { FormContextType, IdSchema, RJSFValidationError } from '@rjsf/utils'
 
+export type FormControlStore = {
+  tabIndex: number
+  setTabIndex: (n: number) => void
+  clearController: () => void
+}
+
 export interface ChakraRJSFormContext extends FormContextType {
   onBatchUpload?: (idSchema: IdSchema<unknown>, batch: Record<string, unknown>[]) => void
   focusOnError?: (error: RJSFValidationError) => void

--- a/hivemq-edge/src/frontend/src/components/rjsf/Form/useFormControlStore.spec.ts
+++ b/hivemq-edge/src/frontend/src/components/rjsf/Form/useFormControlStore.spec.ts
@@ -1,0 +1,75 @@
+import { expect } from 'vitest'
+import { act, renderHook } from '@testing-library/react'
+
+import { useFormControlStore } from '@/components/rjsf/Form/useFormControlStore.ts'
+import { FormControlStore } from '@/components/rjsf/Form/types.ts'
+
+describe('useWorkspaceStore', () => {
+  beforeEach(() => {
+    const { result } = renderHook<FormControlStore, undefined>(useFormControlStore)
+    act(() => {
+      result.current.reset()
+    })
+  })
+
+  it('should start with a default store', async () => {
+    const { result } = renderHook<FormControlStore, undefined>(useFormControlStore)
+
+    expect(result.current.expandItems).toStrictEqual([])
+    expect(result.current.tabIndex).toStrictEqual(0)
+  })
+
+  it('should change the selected tab', async () => {
+    const { result } = renderHook<FormControlStore, undefined>(useFormControlStore)
+
+    expect(result.current.expandItems).toStrictEqual([])
+    expect(result.current.tabIndex).toStrictEqual(0)
+
+    act(() => {
+      const { setTabIndex } = result.current
+      setTabIndex(2)
+    })
+
+    expect(result.current.expandItems).toStrictEqual([])
+    expect(result.current.tabIndex).toStrictEqual(2)
+  })
+
+  it('should change the list of collapsed items', async () => {
+    const { result } = renderHook<FormControlStore, undefined>(useFormControlStore)
+
+    expect(result.current.expandItems).toStrictEqual([])
+    expect(result.current.tabIndex).toStrictEqual(0)
+
+    act(() => {
+      const { setExpandItems } = result.current
+      setExpandItems(['first', 'second'])
+    })
+
+    expect(result.current.expandItems).toStrictEqual(['first', 'second'])
+    expect(result.current.tabIndex).toStrictEqual(0)
+  })
+
+  it('should reset the store', async () => {
+    const { result } = renderHook<FormControlStore, undefined>(useFormControlStore)
+
+    expect(result.current.expandItems).toStrictEqual([])
+    expect(result.current.tabIndex).toStrictEqual(0)
+
+    act(() => {
+      const { setExpandItems, setTabIndex } = result.current
+      setExpandItems(['first', 'second'])
+      setTabIndex(2)
+    })
+
+    expect(result.current.expandItems).toStrictEqual(['first', 'second'])
+    expect(result.current.tabIndex).toStrictEqual(2)
+
+    act(() => {
+      const { reset } = result.current
+      reset()
+    })
+
+    expect(result.current.expandItems).toStrictEqual([])
+    expect(result.current.tabIndex).toStrictEqual(0)
+  })
+})

--- a/hivemq-edge/src/frontend/src/components/rjsf/Form/useFormControlStore.ts
+++ b/hivemq-edge/src/frontend/src/components/rjsf/Form/useFormControlStore.ts
@@ -1,0 +1,8 @@
+import { create } from 'zustand'
+import { FormControlStore } from '@/components/rjsf/Form/types.ts'
+
+export const useFormControlStore = create<FormControlStore>()((set) => ({
+  tabIndex: 0,
+  setTabIndex: (n: number) => set(() => ({ tabIndex: n })),
+  clearController: () => set(() => ({ tabIndex: 0 })),
+}))

--- a/hivemq-edge/src/frontend/src/components/rjsf/Form/useFormControlStore.ts
+++ b/hivemq-edge/src/frontend/src/components/rjsf/Form/useFormControlStore.ts
@@ -1,8 +1,16 @@
 import { create } from 'zustand'
-import { FormControlStore } from '@/components/rjsf/Form/types.ts'
+import { FormControlState, FormControlStore } from '@/components/rjsf/Form/types.ts'
+
+const initialState: FormControlState = {
+  tabIndex: 0,
+  expandItems: [],
+}
 
 export const useFormControlStore = create<FormControlStore>()((set) => ({
-  tabIndex: 0,
+  ...initialState,
+  reset: () => {
+    set(initialState)
+  },
   setTabIndex: (n: number) => set(() => ({ tabIndex: n })),
-  clearController: () => set(() => ({ tabIndex: 0 })),
+  setExpandItems: (items: string[]) => set(() => ({ expandItems: items })),
 }))

--- a/hivemq-edge/src/frontend/src/components/rjsf/ObjectFieldTemplate.tsx
+++ b/hivemq-edge/src/frontend/src/components/rjsf/ObjectFieldTemplate.tsx
@@ -8,7 +8,7 @@ import {
   titleId,
 } from '@rjsf/utils'
 import { Box, Tab, TabList, TabPanel, TabPanels, Tabs } from '@chakra-ui/react'
-import { UITab } from '@/modules/ProtocolAdapters/types.ts'
+import { UITab } from '@/components/rjsf/Form/types.ts'
 import { useFormControlStore } from '@/components/rjsf/Form/useFormControlStore.ts'
 
 export const ObjectFieldTemplate = <

--- a/hivemq-edge/src/frontend/src/components/rjsf/ObjectFieldTemplate.tsx
+++ b/hivemq-edge/src/frontend/src/components/rjsf/ObjectFieldTemplate.tsx
@@ -9,6 +9,7 @@ import {
 } from '@rjsf/utils'
 import { Box, Tab, TabList, TabPanel, TabPanels, Tabs } from '@chakra-ui/react'
 import { UITab } from '@/modules/ProtocolAdapters/types.ts'
+import { useFormControlStore } from '@/components/rjsf/Form/useFormControlStore.ts'
 
 export const ObjectFieldTemplate = <
   T = never,
@@ -20,6 +21,7 @@ export const ObjectFieldTemplate = <
   const { registry, properties, title, description, uiSchema, required, schema, idSchema } = props
   const options = getUiOptions<T, S, F>(uiSchema)
   const TitleFieldTemplate = getTemplate<'TitleFieldTemplate', T, S, F>('TitleFieldTemplate', registry, options)
+  const { tabIndex, setTabIndex } = useFormControlStore()
 
   // @ts-ignore Type will need to be corrected
   const { tabs }: { tabs: UITab[] } = options
@@ -51,7 +53,7 @@ export const ObjectFieldTemplate = <
 
   return (
     <>
-      <Tabs>
+      <Tabs index={tabIndex} onChange={setTabIndex}>
         <TabList>
           {tabs.map((e) => {
             const filteredProps = properties.filter((property) => e.properties.includes(property.name))

--- a/hivemq-edge/src/frontend/src/components/rjsf/Templates/ErrorListTemplate.tsx
+++ b/hivemq-edge/src/frontend/src/components/rjsf/Templates/ErrorListTemplate.tsx
@@ -1,20 +1,87 @@
-import { ErrorListProps, RJSFSchema, StrictRJSFSchema, TranslatableString } from '@rjsf/utils'
-import { Alert, AlertTitle, List, ListIcon, ListItem } from '@chakra-ui/react'
+import { FC, useMemo } from 'react'
+import { ErrorListProps, RJSFSchema, TranslatableString, UiSchema } from '@rjsf/utils'
+import {
+  Alert,
+  AlertTitle,
+  Box,
+  Button,
+  HStack,
+  Icon,
+  IconButton,
+  List,
+  ListIcon,
+  ListItem,
+  Text,
+} from '@chakra-ui/react'
 import { WarningIcon } from '@chakra-ui/icons'
+import { IoLink } from 'react-icons/io5'
+import { RJSFValidationError } from '@rjsf/utils/src/types.ts'
 
-export const ErrorListTemplate = <T = unknown, S extends StrictRJSFSchema = RJSFSchema>({
-  errors,
-  registry,
-}: ErrorListProps<T, S>) => {
+import { AdapterConfig, UITab } from '@/modules/ProtocolAdapters/types.ts'
+import { ChakraRJSFormContext } from '@/components/rjsf/Form/types.ts'
+import { useTranslation } from 'react-i18next'
+
+interface RJSFValidationErrorRef extends RJSFValidationError {
+  tab?: UITab
+}
+
+export const ErrorListTemplate: FC<ErrorListProps<unknown, RJSFSchema, ChakraRJSFormContext>> = (props) => {
+  const { t } = useTranslation('components')
+  const { uiSchema, errors, registry, formContext } = props
+
+  const linkedErrors = useMemo(() => {
+    return errors.map<RJSFValidationErrorRef>((error) => {
+      const { 'ui:tabs': tabs } = uiSchema as UiSchema<AdapterConfig>
+      const { property } = error
+      if (!tabs) return error
+
+      const root = property?.split('.')[1] || property
+
+      let inTab: UITab | null = null
+      for (const tab of tabs) {
+        const { properties } = tab as UITab
+        if (properties && root && properties.includes(root)) inTab = tab
+      }
+
+      if (inTab) return { ...error, tab: inTab }
+      return error
+    })
+  }, [errors, uiSchema])
+
   const { translateString } = registry
+
   return (
     <Alert flexDirection="column" alignItems="flex-start" gap={3} status="error" mt={4}>
       <AlertTitle>{translateString(TranslatableString.ErrorsLabel)}</AlertTitle>
       <List>
-        {errors.map((error, i) => (
+        {linkedErrors.map((error, i) => (
           <ListItem key={i}>
-            <ListIcon as={WarningIcon} color="red.500" />
-            {error.stack}
+            <HStack>
+              <ListIcon as={WarningIcon} color="red.500" />
+              <Box>
+                {error.tab && (
+                  <>
+                    <Button
+                      colorScheme="red"
+                      variant="link"
+                      color="red.700"
+                      onClick={() => formContext?.focusOnError?.(error)}
+                    >
+                      {error.tab?.title}
+                    </Button>{' '}
+                  </>
+                )}
+                <Text as="span">{error.stack}</Text>{' '}
+                <IconButton
+                  icon={<Icon as={IoLink} />}
+                  variant="link"
+                  aria-label={t('rjsf.ErrorListTemplate.focusOnError.aria-label')}
+                  color="red.700"
+                  size="sm"
+                  onClick={() => formContext?.focusOnError?.(error)}
+                />
+              </Box>
+            </HStack>
           </ListItem>
         ))}
       </List>

--- a/hivemq-edge/src/frontend/src/locales/en/components.json
+++ b/hivemq-edge/src/frontend/src/locales/en/components.json
@@ -111,6 +111,11 @@
         "expanded_false": "Expand Item"
       }
     },
+    "ErrorListTemplate": {
+      "focusOnError": {
+        "aria-label": "Jump to error"
+      }
+    },
     "batchUpload": {
       "button": "Upload",
       "modal": {

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/types.ts
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/types.ts
@@ -20,12 +20,6 @@ export interface ProtocolFacetType {
   filter?: { key: keyof ProtocolAdapter; value: string } | null
 }
 
-export interface UITab {
-  id: string
-  title: string
-  properties: string[]
-}
-
 export enum ProtocolAdapterTabIndex {
   PROTOCOLS,
   ADAPTERS,


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/26339/details/

The PR significantly improves the rendering of the error summary in all the RJSF-based forms. The main problem was error messages mentioning an input field that might be on a grouping tab not currently active or within a "collapsed" item in an array. In such situations, not only would the field with the property not be visible to the users, but its location would not even be mentioned.  

### Design
- The warning in the browser for trying to focus on a hidden DOM element has been removed by disabling HTML5 validation that was already creating conflict with the form-based validation
- The error list has been redesigned to include two elements on each item
   - If an error is in a tab, the name of the tab is displayed before the error message
   - a "link" to the field in question is added after the error message
- Both items are clickable buttons and will shift the focus to the relevant field
- If the tab containing the button is not active, it will be activated first before the focus is shifting

### Out-of-scope
- The errors in the form are all itemised, potentially resulting in a very long list. Filtering and grouping could help error management but will be handled in a different ticket


### Before 
![screenshot-localhost_3000-2024_11_21-11_21_30](https://github.com/user-attachments/assets/386c2b2e-2776-4850-b776-9b5bc1425873)

### After
![screenshot-localhost_3000-2024_11_21-11_22_18](https://github.com/user-attachments/assets/019d9e4c-bd8e-42c7-ad32-2a96595a11bf)

