### PR TITLE
Fixing issues with the new userflow where a missing mqttTo-config causes NPEs

### DIFF
--- a/ext/hivemq-edge-openapi-2024.8-SNAPSHOT.yaml
+++ b/ext/hivemq-edge-openapi-2024.8-SNAPSHOT.yaml
@@ -3343,6 +3343,36 @@ paths:
       summary: List most recent events in the system
       tags:
       - Events
+  /api/v1/management/protocol-adapters/adapterconfigs/{adaptertype}/{adaptername}:
+    put:
+      description: Add an adapter and all related parts like e.g. tags to the system.
+      operationId: create-complete-adapter
+      parameters:
+      - description: The adapter type.
+        in: path
+        name: adaptertype
+        required: true
+        schema:
+          type: string
+      - description: The adapter name.
+        in: path
+        name: adaptername
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AdapterConfigModel'
+        description: The new adapter.
+        required: true
+      responses:
+        "200":
+          description: Success
+      summary: Add a new Adapter and all related parts like e.g. tags
+      tags:
+      - Protocol Adapters
   /api/v1/management/protocol-adapters/adapters:
     get:
       description: Obtain a list of configured adapters.
@@ -4310,6 +4340,16 @@ components:
           description: The adapter type associated with this instance
       required:
       - id
+    AdapterConfigModel:
+      type: object
+      properties:
+        config:
+          $ref: '#/components/schemas/Adapter'
+        tags:
+          type: array
+          description: The tags defined for this adapter
+          items:
+            $ref: '#/components/schemas/DomainTag'
     AdaptersList:
       type: object
       properties:

--- a/hivemq-edge/src/main/java/com/hivemq/api/adapters/AdapterConfigModel.java
+++ b/hivemq-edge/src/main/java/com/hivemq/api/adapters/AdapterConfigModel.java
@@ -1,5 +1,19 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hivemq.api.adapters;
-
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/hivemq-edge/src/main/java/com/hivemq/api/adapters/AdapterConfigModel.java
+++ b/hivemq-edge/src/main/java/com/hivemq/api/adapters/AdapterConfigModel.java
@@ -1,0 +1,61 @@
+package com.hivemq.api.adapters;
+
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.hivemq.api.model.adapters.Adapter;
+import com.hivemq.api.model.tags.DomainTagModel;
+import com.hivemq.extension.sdk.api.annotations.NotNull;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+import java.util.Objects;
+
+public class AdapterConfigModel {
+
+    @JsonProperty("config")
+    @Schema(name = "config",
+            description = "The adapter configuration")
+    private final @NotNull Adapter adapter;
+
+
+    @JsonProperty("tags")
+    @Schema(name = "tags",
+            description = "The tags defined for this adapter")
+    private final @NotNull List<DomainTagModel> domainTagModels;
+
+    @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+    public AdapterConfigModel(
+            @JsonProperty("config") final @NotNull Adapter adapter,
+            @JsonProperty("tags") final @NotNull List<DomainTagModel> domainTagModels) {
+        this.adapter = adapter;
+        this.domainTagModels = domainTagModels;
+    }
+
+    public @NotNull Adapter getAdapter() {
+        return adapter;
+    }
+
+    public @NotNull List<DomainTagModel> getDomainTagModels() {
+        return domainTagModels;
+    }
+
+    @Override
+    public String toString() {
+        return "FullAdapter{" + "adapter" +
+                "=" + adapter + ", domainTagModels=" + domainTagModels + '}';
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        final AdapterConfigModel that = (AdapterConfigModel) o;
+        return Objects.equals(adapter, that.adapter) && Objects.equals(domainTagModels, that.domainTagModels);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(adapter, domainTagModels);
+    }
+}

--- a/hivemq-edge/src/main/java/com/hivemq/api/resources/ProtocolAdaptersApi.java
+++ b/hivemq-edge/src/main/java/com/hivemq/api/resources/ProtocolAdaptersApi.java
@@ -16,6 +16,7 @@
 package com.hivemq.api.resources;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.hivemq.api.adapters.AdapterConfigModel;
 import com.hivemq.api.model.adapters.Adapter;
 import com.hivemq.api.model.adapters.AdaptersList;
 import com.hivemq.api.model.adapters.ProtocolAdaptersList;
@@ -114,6 +115,28 @@ public interface ProtocolAdaptersApi {
                                 description = "The new adapter.",
                                 required = true,
                                 in = ParameterIn.DEFAULT) Adapter adapter);
+
+    @PUT
+    @Path("/adapterconfigs/{adaptertype}/{adaptername}")
+    @Operation(summary = "Add a new Adapter and all related parts like e.g. tags",
+               operationId = "create-complete-adapter",
+               description = "Add an adapter and all related parts like e.g. tags to the system.",
+               responses = {
+                       @ApiResponse(responseCode = "200", description = "Success")})
+    @NotNull
+    Response addCompleteAdapter(
+            @NotNull @Parameter(name = "adaptertype",
+                                description = "The adapter type.",
+                                required = true,
+                                in = ParameterIn.PATH) @PathParam("adaptertype") String adapterType,
+            @NotNull @Parameter(name = "adaptername",
+                                description = "The adapter name.",
+                                required = true,
+                                in = ParameterIn.PATH) @PathParam("adaptername") String adapterName,
+            @NotNull @Parameter(name = "adapter",
+                                description = "The new adapter.",
+                                required = true,
+                                in = ParameterIn.DEFAULT) AdapterConfigModel adapter);
 
     @GET
     @Path("/adapters/")

--- a/hivemq-edge/src/main/java/com/hivemq/api/resources/impl/ProtocolAdaptersResourceImpl.java
+++ b/hivemq-edge/src/main/java/com/hivemq/api/resources/impl/ProtocolAdaptersResourceImpl.java
@@ -602,13 +602,11 @@ public class ProtocolAdaptersResourceImpl extends AbstractApi implements Protoco
         final Optional<ProtocolAdapterWrapper<? extends com.hivemq.adapter.sdk.api.ProtocolAdapter>> instance =
                 protocolAdapterManager.getAdapterById(adapterId);
         if (instance.isPresent()) {
-            System.out.println("FU1");
             ApiErrorUtils.addValidationError(errorMessages, "id", "Adapter ID must be unique in system");
             return ApiErrorUtils.badRequest(errorMessages);
         }
         validateAdapterSchema(errorMessages, adapter.getAdapter());
         if (ApiErrorUtils.hasRequestErrors(errorMessages)) {
-            System.out.println("FU2");
             return ApiErrorUtils.badRequest(errorMessages);
         }
         try {
@@ -623,19 +621,15 @@ public class ProtocolAdaptersResourceImpl extends AbstractApi implements Protoco
                     .map(dtm -> DomainTag.fromDomainTagEntity(dtm, adapterId))
                     .map(DomainTag::toTagMap)
                     .collect(Collectors.toList());
-
-            System.out.println(config);
-            System.out.println(domainTags);
             protocolAdapterManager.addAdapter(adapterType, adapterId, config, domainTags);
         } catch (final IllegalArgumentException e) {
             if (e.getCause() instanceof UnrecognizedPropertyException) {
-                e.printStackTrace();
                 ApiErrorUtils.addValidationError(errorMessages,
                         ((UnrecognizedPropertyException) e.getCause()).getPropertyName(),
                         "Unknown field on adapter configuration");
+            } else {
+                log.error("Error processing incoming request", e);
             }
-            e.printStackTrace();
-            System.out.println("FU3");
             return ApiErrorUtils.badRequest(errorMessages);
         }
         if (logger.isDebugEnabled()) {

--- a/hivemq-edge/src/main/java/com/hivemq/api/resources/impl/ProtocolAdaptersResourceImpl.java
+++ b/hivemq-edge/src/main/java/com/hivemq/api/resources/impl/ProtocolAdaptersResourceImpl.java
@@ -26,6 +26,7 @@ import com.hivemq.adapter.sdk.api.discovery.ProtocolAdapterDiscoveryInput;
 import com.hivemq.adapter.sdk.api.services.ProtocolAdapterWritingService;
 import com.hivemq.adapter.sdk.api.writing.WritingProtocolAdapter;
 import com.hivemq.api.AbstractApi;
+import com.hivemq.api.adapters.AdapterConfigModel;
 import com.hivemq.api.json.CustomConfigSchemaGenerator;
 import com.hivemq.api.model.ApiConstants;
 import com.hivemq.api.model.ApiErrorMessages;
@@ -584,5 +585,62 @@ public class ProtocolAdaptersResourceImpl extends AbstractApi implements Protoco
                 return Response.serverError().build();
             }
         }
+    }
+
+    @Override
+    public Response addCompleteAdapter(
+            final String adapterType,
+            final String adapterName,
+            final AdapterConfigModel adapter) {
+        final Optional<ProtocolAdapterInformation> protocolAdapterType =
+                protocolAdapterManager.getAdapterTypeById(adapterType);
+        if (protocolAdapterType.isEmpty()) {
+            return ApiErrorUtils.notFound("Adapter Type not found by adapterType");
+        }
+        final ApiErrorMessages errorMessages = ApiErrorUtils.createErrorContainer();
+        final String adapterId = adapter.getAdapter().getId();
+        final Optional<ProtocolAdapterWrapper<? extends com.hivemq.adapter.sdk.api.ProtocolAdapter>> instance =
+                protocolAdapterManager.getAdapterById(adapterId);
+        if (instance.isPresent()) {
+            System.out.println("FU1");
+            ApiErrorUtils.addValidationError(errorMessages, "id", "Adapter ID must be unique in system");
+            return ApiErrorUtils.badRequest(errorMessages);
+        }
+        validateAdapterSchema(errorMessages, adapter.getAdapter());
+        if (ApiErrorUtils.hasRequestErrors(errorMessages)) {
+            System.out.println("FU2");
+            return ApiErrorUtils.badRequest(errorMessages);
+        }
+        try {
+
+            //TODO: we need to move all these conversions into a common place
+            final Map<String, Object> config =
+                    objectMapper.convertValue(adapter.getAdapter(), new TypeReference<>() {
+                    });
+
+            final List<Map<String, Object>> domainTags = adapter.getDomainTagModels()
+                    .stream()
+                    .map(dtm -> DomainTag.fromDomainTagEntity(dtm, adapterId))
+                    .map(DomainTag::toTagMap)
+                    .collect(Collectors.toList());
+
+            System.out.println(config);
+            System.out.println(domainTags);
+            protocolAdapterManager.addAdapter(adapterType, adapterId, config, domainTags);
+        } catch (final IllegalArgumentException e) {
+            if (e.getCause() instanceof UnrecognizedPropertyException) {
+                e.printStackTrace();
+                ApiErrorUtils.addValidationError(errorMessages,
+                        ((UnrecognizedPropertyException) e.getCause()).getPropertyName(),
+                        "Unknown field on adapter configuration");
+            }
+            e.printStackTrace();
+            System.out.println("FU3");
+            return ApiErrorUtils.badRequest(errorMessages);
+        }
+        if (logger.isDebugEnabled()) {
+            logger.debug("Added protocol adapter of type {} with ID {}.", adapterType, adapter.getAdapter().getId());
+        }
+        return Response.ok().build();
     }
 }

--- a/modules/hivemq-edge-module-etherip/src/main/java/com/hivemq/edge/adapters/etherip/config/EipAdapterConfig.java
+++ b/modules/hivemq-edge-module-etherip/src/main/java/com/hivemq/edge/adapters/etherip/config/EipAdapterConfig.java
@@ -74,7 +74,7 @@ public class EipAdapterConfig implements ProtocolAdapterConfig {
     @ModuleConfigField(title = "Ethernet IP To MQTT Config",
                        description = "The configuration for a data stream from Ethernet IP to MQTT",
                        required = true)
-    private final @NotNull EipToMqttConfig eipToMqttConfig;
+    private final @Nullable EipToMqttConfig eipToMqttConfig;
 
     @JsonCreator
     public EipAdapterConfig(
@@ -83,7 +83,7 @@ public class EipAdapterConfig implements ProtocolAdapterConfig {
             @JsonProperty(value = "host", required = true) final @NotNull String host,
             @JsonProperty(value = "backplane") final @Nullable Integer backplane,
             @JsonProperty(value = "slot") final @Nullable Integer slot,
-            @JsonProperty(value = "eipToMqtt", required = true) final @NotNull EipToMqttConfig eipToMqttConfig) {
+            @JsonProperty(value = "eipToMqtt") final @Nullable EipToMqttConfig eipToMqttConfig) {
         this.id = id;
         this.host = host;
         this.port = port;
@@ -98,7 +98,11 @@ public class EipAdapterConfig implements ProtocolAdapterConfig {
 
     @Override
     public @NotNull Set<String> calculateAllUsedTags() {
-        return eipToMqttConfig.getMappings().stream().map(EipToMqttMapping::getTagName).collect(Collectors.toSet());
+        if(eipToMqttConfig != null) {
+            return eipToMqttConfig.getMappings().stream().map(EipToMqttMapping::getTagName).collect(Collectors.toSet());
+        } else {
+            return Set.of();
+        }
     }
 
     public @NotNull String getHost() {
@@ -117,7 +121,7 @@ public class EipAdapterConfig implements ProtocolAdapterConfig {
         return slot;
     }
 
-    public @NotNull EipToMqttConfig getEipToMqttConfig() {
+    public @Nullable EipToMqttConfig getEipToMqttConfig() {
         return eipToMqttConfig;
     }
 }

--- a/modules/hivemq-edge-module-file/src/main/java/com/hivemq/edge/adapters/file/FilePollingProtocolAdapter.java
+++ b/modules/hivemq-edge-module-file/src/main/java/com/hivemq/edge/adapters/file/FilePollingProtocolAdapter.java
@@ -57,7 +57,11 @@ public class FilePollingProtocolAdapter implements PollingProtocolAdapter<FileTo
         this.adapterConfig = input.getConfig();
         this.tags = input.getTags();
         this.protocolAdapterState = input.getProtocolAdapterState();
-        this.pollingContext = adapterConfig.getFileToMqttConfig().getMappings();
+        if(adapterConfig.getFileToMqttConfig() != null) {
+            this.pollingContext = adapterConfig.getFileToMqttConfig().getMappings();
+        } else {
+            this.pollingContext = List.of();
+        }
     }
 
     @Override

--- a/modules/hivemq-edge-module-file/src/main/java/com/hivemq/edge/adapters/file/config/FileAdapterConfig.java
+++ b/modules/hivemq-edge-module-file/src/main/java/com/hivemq/edge/adapters/file/config/FileAdapterConfig.java
@@ -47,11 +47,11 @@ public class FileAdapterConfig implements ProtocolAdapterConfig {
     @ModuleConfigField(title = "File To MQTT Config",
                        description = "The configuration for a data stream from File to MQTT",
                        required = true)
-    private final @NotNull FileToMqttConfig fileToMqttConfig;
+    private final @Nullable FileToMqttConfig fileToMqttConfig;
 
     public FileAdapterConfig(
             @JsonProperty(value = "id", required = true) final @NotNull String id,
-            @JsonProperty(value = "fileToMqtt", required = true) final @NotNull FileToMqttConfig fileToMqttConfig) {
+            @JsonProperty(value = "fileToMqtt") final @Nullable FileToMqttConfig fileToMqttConfig) {
         this.id = id;
         this.fileToMqttConfig = fileToMqttConfig;
     }
@@ -63,7 +63,11 @@ public class FileAdapterConfig implements ProtocolAdapterConfig {
 
     @Override
     public @NotNull Set<String> calculateAllUsedTags() {
-        return fileToMqttConfig.getMappings().stream().map(FileToMqttMapping::getTagName).collect(Collectors.toSet());
+        if(fileToMqttConfig != null && fileToMqttConfig.getMappings() != null) {
+            return fileToMqttConfig.getMappings().stream().map(FileToMqttMapping::getTagName).collect(Collectors.toSet());
+        } else {
+            return Set.of();
+        }
     }
 
     public @NotNull FileToMqttConfig getFileToMqttConfig() {

--- a/modules/hivemq-edge-module-file/src/main/java/com/hivemq/edge/adapters/file/config/FileToMqttConfig.java
+++ b/modules/hivemq-edge-module-file/src/main/java/com/hivemq/edge/adapters/file/config/FileToMqttConfig.java
@@ -65,6 +65,7 @@ public class FileToMqttConfig {
     }
 
     public @NotNull List<FileToMqttMapping> getMappings() {
+        System.out.println("MAPPING2 " + mappings);
         return mappings;
     }
 }

--- a/modules/hivemq-edge-module-file/src/main/java/com/hivemq/edge/adapters/file/config/FileToMqttConfig.java
+++ b/modules/hivemq-edge-module-file/src/main/java/com/hivemq/edge/adapters/file/config/FileToMqttConfig.java
@@ -65,7 +65,6 @@ public class FileToMqttConfig {
     }
 
     public @NotNull List<FileToMqttMapping> getMappings() {
-        System.out.println("MAPPING2 " + mappings);
         return mappings;
     }
 }

--- a/modules/hivemq-edge-module-http/src/main/java/com/hivemq/edge/adapters/http/HttpProtocolAdapter.java
+++ b/modules/hivemq-edge-module-http/src/main/java/com/hivemq/edge/adapters/http/HttpProtocolAdapter.java
@@ -282,7 +282,11 @@ public class HttpProtocolAdapter
 
     @Override
     public @NotNull List<HttpToMqttMapping> getPollingContexts() {
-        return List.copyOf(adapterConfig.getHttpToMqttConfig().getMappings());
+        if(adapterConfig.getHttpToMqttConfig() != null){
+            return List.copyOf(adapterConfig.getHttpToMqttConfig().getMappings());
+        } else {
+            return List.of();
+        }
     }
 
     @Override

--- a/modules/hivemq-edge-module-modbus/src/main/java/com/hivemq/edge/adapters/modbus/ModbusProtocolAdapter.java
+++ b/modules/hivemq-edge-module-modbus/src/main/java/com/hivemq/edge/adapters/modbus/ModbusProtocolAdapter.java
@@ -129,7 +129,11 @@ public class ModbusProtocolAdapter implements PollingProtocolAdapter<ModbusToMqt
 
     @Override
     public @NotNull List<ModbusToMqttMapping> getPollingContexts() {
-        return new ArrayList<>(adapterConfig.getModbusToMQTTConfig().getMappings());
+        if (adapterConfig.getModbusToMQTTConfig() != null) {
+            return List.copyOf(adapterConfig.getModbusToMQTTConfig().getMappings());
+        } else {
+            return List.of();
+        }
     }
 
     @Override

--- a/modules/hivemq-edge-module-modbus/src/main/java/com/hivemq/edge/adapters/modbus/config/ModbusAdapterConfig.java
+++ b/modules/hivemq-edge-module-modbus/src/main/java/com/hivemq/edge/adapters/modbus/config/ModbusAdapterConfig.java
@@ -74,7 +74,7 @@ public class ModbusAdapterConfig implements ProtocolAdapterConfig {
     @ModuleConfigField(title = "Modbus To MQTT Config",
                        description = "The configuration for a data stream from Modbus to MQTT",
                        required = true)
-    private final @NotNull ModbusToMqttConfig modbusToMQTTConfig;
+    private final @Nullable ModbusToMqttConfig modbusToMQTTConfig;
 
     @JsonCreator
     public ModbusAdapterConfig(
@@ -82,7 +82,7 @@ public class ModbusAdapterConfig implements ProtocolAdapterConfig {
             @JsonProperty(value = "port", required = true) final int port,
             @JsonProperty(value = "host", required = true) final @NotNull String host,
             @JsonProperty(value = "timeoutMillis") final @Nullable Integer timeoutMillis,
-            @JsonProperty(value = "modbusToMqtt", required = true) final @NotNull ModbusToMqttConfig modbusToMQTTConfig) {
+            @JsonProperty(value = "modbusToMqtt") final @NotNull ModbusToMqttConfig modbusToMQTTConfig) {
         this.id = id;
         this.port = port;
         this.host = host;
@@ -111,7 +111,7 @@ public class ModbusAdapterConfig implements ProtocolAdapterConfig {
         return timeoutMillis;
     }
 
-    public @NotNull ModbusToMqttConfig getModbusToMQTTConfig() {
+    public @Nullable ModbusToMqttConfig getModbusToMQTTConfig() {
         return modbusToMQTTConfig;
     }
 }

--- a/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/OpcUaClientWrapper.java
+++ b/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/OpcUaClientWrapper.java
@@ -291,12 +291,16 @@ public class OpcUaClientWrapper {
                         Optional.of(new JsonToOpcUAConverter(opcUaClient));
                 final Optional<JsonSchemaGenerator> jsonSchemaGeneratorOpt =
                         Optional.of(new JsonSchemaGenerator(opcUaClient, new ObjectMapper()));
-                return opcUaSubscriptionLifecycle.subscribeAll(adapterConfig.getOpcuaToMqttConfig()
-                                .getOpcuaToMqttMappings())
-                        .thenApply(ignored -> new OpcUaClientWrapper(opcUaClient,
-                                opcUaSubscriptionLifecycle,
-                                jsonToOpcUAConverterOpt,
-                                jsonSchemaGeneratorOpt));
+                if (adapterConfig.getOpcuaToMqttConfig() != null) {
+                    return opcUaSubscriptionLifecycle.subscribeAll(adapterConfig.getOpcuaToMqttConfig()
+                                    .getOpcuaToMqttMappings())
+                            .thenApply(ignored -> new OpcUaClientWrapper(opcUaClient,
+                                    opcUaSubscriptionLifecycle,
+                                    jsonToOpcUAConverterOpt,
+                                    jsonSchemaGeneratorOpt));
+                } else {
+                    return CompletableFuture.completedFuture(null);
+                }
             } catch (final UaException e) {
                 log.error("Unable to create the converters for writing.", e);
                 output.failStart(e, "Unable to create the converters for writing.");

--- a/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/config/OpcUaAdapterConfig.java
+++ b/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/config/OpcUaAdapterConfig.java
@@ -73,7 +73,7 @@ public class OpcUaAdapterConfig implements ProtocolAdapterConfig {
     @JsonProperty(value = "opcuaToMqtt")
     @ModuleConfigField(title = "OPC UA To MQTT Config",
                        description = "The configuration for a data stream from OPC UA to MQTT")
-    private final @NotNull OpcUaToMqttConfig opcuaToMqttConfig;
+    private final @Nullable OpcUaToMqttConfig opcuaToMqttConfig;
 
     @JsonCreator
     public OpcUaAdapterConfig(
@@ -115,7 +115,7 @@ public class OpcUaAdapterConfig implements ProtocolAdapterConfig {
         return security;
     }
 
-    public @NotNull OpcUaToMqttConfig getOpcuaToMqttConfig() {
+    public @Nullable OpcUaToMqttConfig getOpcuaToMqttConfig() {
         return opcuaToMqttConfig;
     }
 
@@ -125,6 +125,10 @@ public class OpcUaAdapterConfig implements ProtocolAdapterConfig {
     
     @Override
     public @NotNull Set<String> calculateAllUsedTags() {
-        return opcuaToMqttConfig.getOpcuaToMqttMappings().stream().map(OpcUaToMqttMapping::getTagName).collect(Collectors.toSet());
+        if(opcuaToMqttConfig != null) {
+            return opcuaToMqttConfig.getOpcuaToMqttMappings().stream().map(OpcUaToMqttMapping::getTagName).collect(Collectors.toSet());
+        } else {
+            return Set.of();
+        }
     }
 }

--- a/modules/hivemq-edge-module-plc4x/src/main/java/com/hivemq/edge/adapters/plc4x/config/Plc4xAdapterConfig.java
+++ b/modules/hivemq-edge-module-plc4x/src/main/java/com/hivemq/edge/adapters/plc4x/config/Plc4xAdapterConfig.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.hivemq.adapter.sdk.api.annotations.ModuleConfigField;
 import com.hivemq.adapter.sdk.api.config.ProtocolAdapterConfig;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public abstract class Plc4xAdapterConfig<T extends Plc4xToMqttConfig> implements ProtocolAdapterConfig {
 
@@ -75,7 +76,7 @@ public abstract class Plc4xAdapterConfig<T extends Plc4xToMqttConfig> implements
         return host;
     }
 
-    @NotNull
+    @Nullable
     @JsonIgnore
     public abstract T getPlc4xToMqttConfig();
 }

--- a/modules/hivemq-edge-module-plc4x/src/main/java/com/hivemq/edge/adapters/plc4x/impl/AbstractPlc4xAdapter.java
+++ b/modules/hivemq-edge-module-plc4x/src/main/java/com/hivemq/edge/adapters/plc4x/impl/AbstractPlc4xAdapter.java
@@ -132,7 +132,11 @@ public abstract class AbstractPlc4xAdapter<T extends Plc4xAdapterConfig<?>, C ex
     @Override
     public @NotNull List<C> getPollingContexts() {
         if (getReadType() == ReadType.Read) {
-            return (List<C>) adapterConfig.getPlc4xToMqttConfig().getMappings();
+            if(adapterConfig.getPlc4xToMqttConfig() != null) {
+                return (List<C>) adapterConfig.getPlc4xToMqttConfig().getMappings();
+            } else {
+                return List.of();
+            }
         } else {
             return List.of();
         }
@@ -220,11 +224,13 @@ public abstract class AbstractPlc4xAdapter<T extends Plc4xAdapterConfig<?>, C ex
     }
 
     protected void subscribeAllInternal(@NotNull final Plc4xConnection<T> connection) throws RuntimeException {
-        for (final Plc4xToMqttMapping mapping : adapterConfig.getPlc4xToMqttConfig().getMappings()) {
-            try {
-                subscribeInternal(connection, mapping);
-            } catch (final Plc4xException e) {
-                throw new RuntimeException(e);
+        if(adapterConfig.getPlc4xToMqttConfig() != null) {
+            for (final Plc4xToMqttMapping mapping : adapterConfig.getPlc4xToMqttConfig().getMappings()) {
+                try {
+                    subscribeInternal(connection, mapping);
+                } catch (final Plc4xException e) {
+                    throw new RuntimeException(e);
+                }
             }
         }
     }
@@ -251,7 +257,7 @@ public abstract class AbstractPlc4xAdapter<T extends Plc4xAdapterConfig<?>, C ex
         boolean publishData = true;
         final String tagAddress = plc4xTag.getDefinition().getTagAddress();
 
-        if (adapterConfig.getPlc4xToMqttConfig().getPublishChangedDataOnly()) {
+        if (adapterConfig.getPlc4xToMqttConfig() != null && adapterConfig.getPlc4xToMqttConfig().getPublishChangedDataOnly()) {
             final ProtocolAdapterDataSample previousSample = lastSamples.put(tagAddress, data);
             if (previousSample != null) {
                 final List<DataPoint> dataPoints = previousSample.getDataPoints();
@@ -341,11 +347,19 @@ public abstract class AbstractPlc4xAdapter<T extends Plc4xAdapterConfig<?>, C ex
 
     @Override
     public int getPollingIntervalMillis() {
-        return adapterConfig.getPlc4xToMqttConfig().getPollingIntervalMillis();
+        if (adapterConfig.getPlc4xToMqttConfig() != null) {
+            return adapterConfig.getPlc4xToMqttConfig().getPollingIntervalMillis();
+        } else {
+            return 1000;
+        }
     }
 
     @Override
     public int getMaxPollingErrorsBeforeRemoval() {
-        return adapterConfig.getPlc4xToMqttConfig().getMaxPollingErrorsBeforeRemoval();
+        if (adapterConfig.getPlc4xToMqttConfig() != null) {
+            return adapterConfig.getPlc4xToMqttConfig().getMaxPollingErrorsBeforeRemoval();
+        } else {
+            return 5;
+        }
     }
 }

--- a/modules/hivemq-edge-module-plc4x/src/main/java/com/hivemq/edge/adapters/plc4x/types/ads/config/ADSAdapterConfig.java
+++ b/modules/hivemq-edge-module-plc4x/src/main/java/com/hivemq/edge/adapters/plc4x/types/ads/config/ADSAdapterConfig.java
@@ -79,7 +79,7 @@ public class ADSAdapterConfig extends Plc4xAdapterConfig<ADSToMqttConfig> {
     @ModuleConfigField(title = "ADS To MQTT Config",
                        description = "The configuration for a data stream from ADS to MQTT",
                        required = true)
-    private final @NotNull ADSToMqttConfig adsToMqttConfig;
+    private final @Nullable ADSToMqttConfig adsToMqttConfig;
 
     @JsonCreator
     public ADSAdapterConfig(
@@ -90,7 +90,7 @@ public class ADSAdapterConfig extends Plc4xAdapterConfig<ADSToMqttConfig> {
             @JsonProperty(value = "sourceAmsPort", required = true) final int sourceAmsPort,
             @JsonProperty(value = "targetAmsNetId", required = true) final @NotNull String targetAmsNetId,
             @JsonProperty(value = "sourceAmsNetId", required = true) final @NotNull String sourceAmsNetId,
-            @JsonProperty(value = "adsToMqtt", required = true) final @NotNull ADSToMqttConfig adsToMqttConfig) {
+            @JsonProperty(value = "adsToMqtt") final @Nullable ADSToMqttConfig adsToMqttConfig) {
         super(id, port, host);
         this.port = port;
         this.targetAmsPort = targetAmsPort;
@@ -123,12 +123,16 @@ public class ADSAdapterConfig extends Plc4xAdapterConfig<ADSToMqttConfig> {
     }
 
     @Override
-    public @NotNull ADSToMqttConfig getPlc4xToMqttConfig() {
+    public @Nullable ADSToMqttConfig getPlc4xToMqttConfig() {
         return adsToMqttConfig;
     }
 
     @Override
     public @NotNull Set<String> calculateAllUsedTags() {
-        return adsToMqttConfig.getMappings().stream().map(Plc4xToMqttMapping::getTagName).collect(Collectors.toSet());
+        if(adsToMqttConfig != null) {
+            return adsToMqttConfig.getMappings().stream().map(Plc4xToMqttMapping::getTagName).collect(Collectors.toSet());
+        } else {
+            return Set.of();
+        }
     }
 }

--- a/modules/hivemq-edge-module-plc4x/src/main/java/com/hivemq/edge/adapters/plc4x/types/siemens/S7ProtocolAdapter.java
+++ b/modules/hivemq-edge-module-plc4x/src/main/java/com/hivemq/edge/adapters/plc4x/types/siemens/S7ProtocolAdapter.java
@@ -116,7 +116,7 @@ public class S7ProtocolAdapter extends AbstractPlc4xAdapter<S7AdapterConfig, Plc
         map.put(REMOTE_TSAP, nullSafe(config.getRemoteTsap()));
 
         //ping if polling interval greater than default read timeout - 1s grace
-        if (config.getPlc4xToMqttConfig().getPollingIntervalMillis() >= 7000) {
+        if (config.getPlc4xToMqttConfig() != null && config.getPlc4xToMqttConfig().getPollingIntervalMillis() >= 7000) {
             map.put(PING, "true");
             map.put(PING_TIME, "4");
         }

--- a/modules/hivemq-edge-module-plc4x/src/main/java/com/hivemq/edge/adapters/plc4x/types/siemens/config/S7AdapterConfig.java
+++ b/modules/hivemq-edge-module-plc4x/src/main/java/com/hivemq/edge/adapters/plc4x/types/siemens/config/S7AdapterConfig.java
@@ -93,7 +93,7 @@ public class S7AdapterConfig extends Plc4xAdapterConfig<Plc4xToMqttConfig> {
     @ModuleConfigField(title = "S7 To MQTT Config",
                        description = "The configuration for a data stream from S7 to MQTT",
                        required = true)
-    private final @NotNull S7ToMqttConfig s7ToMqttConfig;
+    private final @Nullable S7ToMqttConfig s7ToMqttConfig;
 
     @JsonCreator
     public S7AdapterConfig(
@@ -106,7 +106,7 @@ public class S7AdapterConfig extends Plc4xAdapterConfig<Plc4xToMqttConfig> {
             @JsonProperty(value = "remoteSlot") final @Nullable Integer remoteSlot,
             @JsonProperty(value = "remoteSlot2") final @Nullable Integer remoteSlot2,
             @JsonProperty(value = "remoteTsap") final @Nullable Integer remoteTsap,
-            @JsonProperty(value = "s7ToMqtt", required = true) final @NotNull S7ToMqttConfig s7ToMqttConfig) {
+            @JsonProperty(value = "s7ToMqtt") final @Nullable S7ToMqttConfig s7ToMqttConfig) {
         super(id, port, host);
         this.port = port;
         this.controllerType = controllerType;
@@ -149,12 +149,16 @@ public class S7AdapterConfig extends Plc4xAdapterConfig<Plc4xToMqttConfig> {
     }
 
     @Override
-    public @NotNull Plc4xToMqttConfig getPlc4xToMqttConfig() {
+    public @Nullable Plc4xToMqttConfig getPlc4xToMqttConfig() {
         return s7ToMqttConfig;
     }
 
     @Override
     public @NotNull Set<String> calculateAllUsedTags() {
-        return s7ToMqttConfig.getMappings().stream().map(Plc4xToMqttMapping::getTagName).collect(Collectors.toSet());
+        if(s7ToMqttConfig != null) {
+            return s7ToMqttConfig.getMappings().stream().map(Plc4xToMqttMapping::getTagName).collect(Collectors.toSet());
+        } else {
+            return Set.of();
+        }
     }
 }


### PR DESCRIPTION
**Motivation**

Resolves #27907

**Changes**
When introducing the new userflow (first creating the config, then the tags + mappings) the changes didn't reflect through to all config objects.
Several places had NotNull-annotations and others relied on the values not being null.
