### PR TITLE
Retrieving empty lists of domaintags gave a null body instead of an empty list

### DIFF
--- a/hivemq-edge/src/main/java/com/hivemq/api/resources/impl/ProtocolAdaptersResourceImpl.java
+++ b/hivemq-edge/src/main/java/com/hivemq/api/resources/impl/ProtocolAdaptersResourceImpl.java
@@ -430,12 +430,11 @@ public class ProtocolAdaptersResourceImpl extends AbstractApi implements Protoco
     public @NotNull Response getDomainTagsForAdapter(final @NotNull String adapterId) {
         return protocolAdapterManager.getTagsForAdapter(adapterId).map(tags -> {
             if (tags.isEmpty()) {
-                return Response.ok().build();
+                return Response.ok(new DomainTagModelList(List.of())).build();
             } else {
                 final List<DomainTagModel> domainTagModels =
                         tags.stream().map(DomainTagModel::fromDomainTag).collect(Collectors.toList());
-                final DomainTagModelList domainTagModelList = new DomainTagModelList(domainTagModels);
-                return Response.ok().entity(domainTagModelList).build();
+                return Response.ok(new DomainTagModelList(domainTagModels)).build();
             }
         }).orElse(Response.status(Response.Status.NOT_FOUND).build());
     }


### PR DESCRIPTION
**Motivation**

Resolves #<28589>

**Changes**
The call to retrieve  the list of fomain-tags for an existing adapter which doesn't have configured tags now returns an empty object instead of null.