### PR TITLE
refactoring(28441): Aligning mappings UX to backend

### DIFF
--- a/hivemq-edge/src/frontend/src/__test-utils__/msw/handlers.ts
+++ b/hivemq-edge/src/frontend/src/__test-utils__/msw/handlers.ts
@@ -4,16 +4,15 @@ import { handlers as ConnectionStatusHandlers } from '@/api/hooks/useConnection/
 import { handlers as BridgeHandlers } from '@/api/hooks/useGetBridges/__handlers__'
 import { handlers as ProtocolAdapterHandlers } from '@/api/hooks/useProtocolAdapters/__handlers__'
 import { handlers as ListenerHandlers } from '@/api/hooks/useGateway/__handlers__'
-import { handlers as TopicFilterHandlers } from '@/api/hooks/useTopicFilters/__handlers__'
 
 import { handlers as DataHubDataPoliciesService } from '@/extensions/datahub/api/hooks/DataHubDataPoliciesService/__handlers__'
 import { handlers as DataHubBehaviorPoliciesService } from '@/extensions/datahub/api/hooks/DataHubBehaviorPoliciesService/__handlers__'
 import { handlers as DataHubSchemasService } from '@/extensions/datahub/api/hooks/DataHubSchemasService/__handlers__'
 import { handlers as DataHubScriptsService } from '@/extensions/datahub/api/hooks/DataHubScriptsService/__handlers__'
 
-import { deviceHandlers as DeviceHandlers } from '@/api/hooks/useProtocolAdapters/__handlers__'
-import { schemaHandlers } from '@/api/hooks/useDomainModel/__handlers__'
+import { safeTopicSchemaHandlers } from '@/api/hooks/useDomainModel/__handlers__'
 import { MQTTSample } from '@/hooks/usePrivateMqttClient/type.ts'
+import { safeWritingSchemaHandlers } from '@/api/hooks/useProtocolAdapters/__handlers__/mapping.mocks.ts'
 
 export const handlers = [
   ...useFrontendServices,
@@ -30,12 +29,15 @@ export const handlers = [
 ]
 
 export const createHandlersWithMQTTClient = (
-  onSampling?: (topicFilter: string) => Promise<MQTTSample[]> | undefined
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  _onSampling?: (topicFilter: string) => Promise<MQTTSample[]> | undefined
 ) => {
   return [
-    ...DeviceHandlers,
-    ...TopicFilterHandlers,
+    // ...DeviceHandlers,
+    // ...TopicFilterHandlers,
     // Domain & Schemas
-    ...schemaHandlers(onSampling),
+    // ...schemaHandlers(onSampling),
+    ...safeTopicSchemaHandlers,
+    ...safeWritingSchemaHandlers,
   ]
 }

--- a/hivemq-edge/src/frontend/src/__test-utils__/msw/handlers.ts
+++ b/hivemq-edge/src/frontend/src/__test-utils__/msw/handlers.ts
@@ -12,7 +12,6 @@ import { handlers as DataHubScriptsService } from '@/extensions/datahub/api/hook
 
 import { safeTopicSchemaHandlers } from '@/api/hooks/useDomainModel/__handlers__'
 import { MQTTSample } from '@/hooks/usePrivateMqttClient/type.ts'
-import { safeWritingSchemaHandlers } from '@/api/hooks/useProtocolAdapters/__handlers__/mapping.mocks.ts'
 
 export const handlers = [
   ...useFrontendServices,
@@ -38,6 +37,6 @@ export const createHandlersWithMQTTClient = (
     // Domain & Schemas
     // ...schemaHandlers(onSampling),
     ...safeTopicSchemaHandlers,
-    ...safeWritingSchemaHandlers,
+    // ...safeWritingSchemaHandlers,
   ]
 }

--- a/hivemq-edge/src/frontend/src/api/__generated__/models/Metadata.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/models/Metadata.ts
@@ -7,9 +7,10 @@ import type { JsonNode } from './JsonNode';
 
 /**
  * Metadata for the whole mapping
+ * TODO[28498] Changed manually until backend fixed
  */
 export type Metadata = {
-    destination: JsonNode;
-    source: JsonNode;
+    destination?: JsonNode;
+    source?: JsonNode;
 };
 

--- a/hivemq-edge/src/frontend/src/api/__generated__/models/TopicFilter.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/models/TopicFilter.ts
@@ -12,6 +12,10 @@ export type TopicFilter = {
      */
     description?: string;
     /**
+     * The optional json schema for this topic filter in the data uri format.
+     */
+    schema?: string;
+    /**
      * The topic filter according to the MQTT specification.
      */
     topicFilter: string;

--- a/hivemq-edge/src/frontend/src/api/__generated__/schemas/$TopicFilter.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/schemas/$TopicFilter.ts
@@ -9,6 +9,10 @@ export const $TopicFilter = {
             type: 'string',
             description: `The name for this topic filter.`,
         },
+        schema: {
+            type: 'string',
+            description: `The optional json schema for this topic filter in the data uri format.`,
+        },
         topicFilter: {
             type: 'string',
             description: `The topic filter according to the MQTT specification.`,

--- a/hivemq-edge/src/frontend/src/api/hooks/useDomainModel/__handlers__/index.ts
+++ b/hivemq-edge/src/frontend/src/api/hooks/useDomainModel/__handlers__/index.ts
@@ -187,3 +187,17 @@ export const schemaHandlers = (onSampling?: (topicFilter: string) => Promise<MQT
     }),
   ]
 }
+
+export const safeTopicSchemaHandlers = [
+  http.get<{ topic: string }>('**/management/sampling/schema/:topic', ({ params }) => {
+    const { topic } = params
+
+    if (topic === MOCK_DEVICE_TAG_FAKE)
+      return HttpResponse.json<ProblemDetails>(
+        { title: 'The schema for the tags cannot be found', status: 404 },
+        { status: 404 }
+      )
+
+    return HttpResponse.json<JsonNode>(GENERATE_DATA_MODELS(true, topic), { status: 200 })
+  }),
+]

--- a/hivemq-edge/src/frontend/src/api/hooks/useDomainModel/__handlers__/index.ts
+++ b/hivemq-edge/src/frontend/src/api/hooks/useDomainModel/__handlers__/index.ts
@@ -104,7 +104,7 @@ export const handlers = [
     const { tagName } = params
 
     try {
-      const realTag = atob(tagName)
+      const realTag = decodeURIComponent(tagName)
       if (realTag === MOCK_DEVICE_TAG_FAKE)
         return HttpResponse.json<ProblemDetails>({ title: 'The tag is not found', status: 404 }, { status: 404 })
       return HttpResponse.json<DomainTag>(

--- a/hivemq-edge/src/frontend/src/api/hooks/useDomainModel/useGetDomainTag.ts
+++ b/hivemq-edge/src/frontend/src/api/hooks/useDomainModel/useGetDomainTag.ts
@@ -9,6 +9,6 @@ export const useGetDomainTag = (tagName: string) => {
 
   return useQuery<DomainTag, ApiError>({
     queryKey: [QUERY_KEYS.DISCOVERY_TAGS, tagName],
-    queryFn: () => appClient.protocolAdapters.getDomainTag(btoa(tagName)),
+    queryFn: () => appClient.protocolAdapters.getDomainTag(encodeURIComponent(tagName)),
   })
 }

--- a/hivemq-edge/src/frontend/src/api/hooks/useDomainModel/useGetSamplesForTopic.ts
+++ b/hivemq-edge/src/frontend/src/api/hooks/useDomainModel/useGetSamplesForTopic.ts
@@ -9,7 +9,7 @@ export const useGetSamplesForTopic = (topic: string, hasBeenStarted = false) => 
 
   return useQuery<PayloadSampleList, ApiError>({
     queryKey: [QUERY_KEYS.DISCOVERY_PAYLOADS, topic],
-    queryFn: () => appClient.payloadSampling.getSamplesForTopic(btoa(topic)),
+    queryFn: () => appClient.payloadSampling.getSamplesForTopic(encodeURIComponent(topic)),
     enabled: hasBeenStarted,
     retry: 1,
   })

--- a/hivemq-edge/src/frontend/src/api/hooks/useDomainModel/useGetSchemaForTopic.spec.ts
+++ b/hivemq-edge/src/frontend/src/api/hooks/useDomainModel/useGetSchemaForTopic.spec.ts
@@ -25,7 +25,7 @@ describe('useGetSchemaForTopic', () => {
     })
     expect(result.current.data).toStrictEqual<JsonNode>(
       expect.objectContaining({
-        title: 'dGVzdC90b3BpYzE=',
+        title: encodeURIComponent('test/topic1'),
         type: 'object',
       })
     )

--- a/hivemq-edge/src/frontend/src/api/hooks/useDomainModel/useGetSchemaForTopic.ts
+++ b/hivemq-edge/src/frontend/src/api/hooks/useDomainModel/useGetSchemaForTopic.ts
@@ -9,7 +9,7 @@ export const useGetSchemaForTopic = (topic: string, hasBeenStarted = false) => {
 
   return useQuery<JsonNode, ApiError>({
     queryKey: [QUERY_KEYS.DISCOVERY_PAYLOADS, topic, QUERY_KEYS.DISCOVERY_SCHEMAS],
-    queryFn: () => appClient.payloadSampling.getSchemaForTopic(btoa(topic)),
+    queryFn: () => appClient.payloadSampling.getSchemaForTopic(encodeURIComponent(topic)),
     enabled: hasBeenStarted,
     retry: 1,
   })

--- a/hivemq-edge/src/frontend/src/api/hooks/useDomainModel/useSamplingForTopic.spec.ts
+++ b/hivemq-edge/src/frontend/src/api/hooks/useDomainModel/useSamplingForTopic.spec.ts
@@ -27,7 +27,7 @@ describe('useSamplingForTopic', () => {
 
     expect(result.current.data).toStrictEqual<JsonNode>(
       expect.objectContaining({
-        title: 'dG9waWMvdGVzdA==',
+        title: encodeURIComponent(mockTopic),
         type: 'object',
       })
     )

--- a/hivemq-edge/src/frontend/src/api/hooks/useDomainModel/useStartSamplingForTopic.spec.ts
+++ b/hivemq-edge/src/frontend/src/api/hooks/useDomainModel/useStartSamplingForTopic.spec.ts
@@ -27,7 +27,7 @@ describe('useStartSamplingForTopic', () => {
       expect(result.current.isSuccess).toBeTruthy()
     })
     expect(result.current.data).toStrictEqual({
-      topic: 'dGVzdC9kYXRh',
+      topic: encodeURIComponent('test/data'),
     })
   })
 })

--- a/hivemq-edge/src/frontend/src/api/hooks/useDomainModel/useStartSamplingForTopic.ts
+++ b/hivemq-edge/src/frontend/src/api/hooks/useDomainModel/useStartSamplingForTopic.ts
@@ -7,7 +7,7 @@ export const useStartSamplingForTopic = () => {
   const appClient = useHttpClient()
 
   const createAdapterDomainTags = (topic: string) => {
-    return appClient.payloadSampling.startSamplingForTopic(btoa(topic))
+    return appClient.payloadSampling.startSamplingForTopic(encodeURIComponent(topic))
   }
 
   return useMutation<string, ApiError, string>({

--- a/hivemq-edge/src/frontend/src/api/hooks/useProtocolAdapters/__handlers__/mapping.mocks.ts
+++ b/hivemq-edge/src/frontend/src/api/hooks/useProtocolAdapters/__handlers__/mapping.mocks.ts
@@ -80,3 +80,13 @@ export const mappingHandlers = [
     }
   ),
 ]
+
+export const safeWritingSchemaHandlers = [
+  http.get<{ adapterId: string; tagName: string }>(
+    '*/management/protocol-adapters/writing-schema/:adapterId/:tagName',
+    ({ params }) => {
+      const { tagName } = params
+      return HttpResponse.json<JsonNode>(GENERATE_DATA_MODELS(true, tagName), { status: 200 })
+    }
+  ),
+]

--- a/hivemq-edge/src/frontend/src/api/hooks/useProtocolAdapters/useCreateDomainTags.ts
+++ b/hivemq-edge/src/frontend/src/api/hooks/useProtocolAdapters/useCreateDomainTags.ts
@@ -17,10 +17,10 @@ export const useCreateDomainTags = () => {
     return appClient.protocolAdapters.addAdapterDomainTags(adapterId, requestBody)
   }
 
-  return useMutation<CreateDomainTagsProps, ApiError, CreateDomainTagsProps>({
+  return useMutation<unknown, ApiError, CreateDomainTagsProps>({
     mutationFn: createAdapterDomainTags,
-    onSuccess: (data) => {
-      queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.ADAPTERS, data.adapterId, QUERY_KEYS.DISCOVERY_TAGS] })
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.ADAPTERS, variables.adapterId, QUERY_KEYS.DISCOVERY_TAGS] })
     },
   })
 }

--- a/hivemq-edge/src/frontend/src/api/hooks/useProtocolAdapters/useDeleteDomainTags.ts
+++ b/hivemq-edge/src/frontend/src/api/hooks/useProtocolAdapters/useDeleteDomainTags.ts
@@ -17,10 +17,10 @@ export const useDeleteDomainTags = () => {
     return appClient.protocolAdapters.deleteAdapterDomainTags(adapterId, tagId)
   }
 
-  return useMutation<DeleteDomainTagsProps, ApiError, DeleteDomainTagsProps>({
+  return useMutation<unknown, ApiError, DeleteDomainTagsProps>({
     mutationFn: deleteAdapterDomainTags,
-    onSuccess: (data) => {
-      queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.ADAPTERS, data.adapterId, QUERY_KEYS.DISCOVERY_TAGS] })
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.ADAPTERS, variables.adapterId, QUERY_KEYS.DISCOVERY_TAGS] })
     },
   })
 }

--- a/hivemq-edge/src/frontend/src/api/hooks/useProtocolAdapters/useGetWritingSchema.spec.ts
+++ b/hivemq-edge/src/frontend/src/api/hooks/useProtocolAdapters/useGetWritingSchema.spec.ts
@@ -25,7 +25,7 @@ describe('useGetWritingSchema', () => {
     expect(result.current.data).toStrictEqual(
       expect.objectContaining({
         description: 'A simple form example.',
-        title: btoa('my-tag'),
+        title: encodeURIComponent('my-tag'),
         properties: expect.objectContaining({
           age: expect.objectContaining({}),
           array: expect.objectContaining({}),

--- a/hivemq-edge/src/frontend/src/api/hooks/useProtocolAdapters/useGetWritingSchema.ts
+++ b/hivemq-edge/src/frontend/src/api/hooks/useProtocolAdapters/useGetWritingSchema.ts
@@ -9,6 +9,6 @@ export const useGetWritingSchema = (adapterId: string, tagName: string) => {
 
   return useQuery<TagSchema, ApiError>({
     queryKey: [QUERY_KEYS.ADAPTERS, adapterId, QUERY_KEYS.DISCOVERY_TAGS, tagName],
-    queryFn: () => appClient.protocolAdapters.getWritingSchema(adapterId, btoa(tagName)),
+    queryFn: () => appClient.protocolAdapters.getWritingSchema(adapterId, encodeURIComponent(tagName)),
   })
 }

--- a/hivemq-edge/src/frontend/src/api/hooks/useProtocolAdapters/useUpdateAllDomainTags.ts
+++ b/hivemq-edge/src/frontend/src/api/hooks/useProtocolAdapters/useUpdateAllDomainTags.ts
@@ -17,10 +17,10 @@ export const useUpdateAllDomainTags = () => {
     return appClient.protocolAdapters.updateAdapterDomainTags(adapterId, requestBody)
   }
 
-  return useMutation<UpdateAllDomainTagsProps, ApiError, UpdateAllDomainTagsProps>({
+  return useMutation<unknown, ApiError, UpdateAllDomainTagsProps>({
     mutationFn: updateAdapterDomainTags,
-    onSuccess: (data) => {
-      queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.ADAPTERS, data.adapterId, QUERY_KEYS.DISCOVERY_TAGS] })
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.ADAPTERS, variables.adapterId, QUERY_KEYS.DISCOVERY_TAGS] })
     },
   })
 }

--- a/hivemq-edge/src/frontend/src/api/hooks/useProtocolAdapters/useUpdateDomainTags.ts
+++ b/hivemq-edge/src/frontend/src/api/hooks/useProtocolAdapters/useUpdateDomainTags.ts
@@ -18,10 +18,10 @@ export const useUpdateDomainTags = () => {
     return appClient.protocolAdapters.updateAdapterDomainTag(adapterId, tagId, requestBody)
   }
 
-  return useMutation<UpdateDomainTagsProps, ApiError, UpdateDomainTagsProps>({
+  return useMutation<unknown, ApiError, UpdateDomainTagsProps>({
     mutationFn: updateAdapterDomainTags,
-    onSuccess: (data) => {
-      queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.ADAPTERS, data.adapterId, QUERY_KEYS.DISCOVERY_TAGS] })
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.ADAPTERS, variables.adapterId, QUERY_KEYS.DISCOVERY_TAGS] })
     },
   })
 }

--- a/hivemq-edge/src/frontend/src/api/hooks/useProtocolAdapters/useUpdateNorthboundMappings.ts
+++ b/hivemq-edge/src/frontend/src/api/hooks/useProtocolAdapters/useUpdateNorthboundMappings.ts
@@ -16,10 +16,12 @@ export const useUpdateNorthboundMappings = () => {
     return appClient.protocolAdapters.updateAdapterNorthboundMappings(adapterId, requestBody)
   }
 
-  return useMutation<UpdateNorthboundMappingsProps, ApiError, UpdateNorthboundMappingsProps>({
+  return useMutation<unknown, ApiError, UpdateNorthboundMappingsProps>({
     mutationFn: updateProtocolAdapter,
-    onSuccess: (data) => {
-      queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.ADAPTERS, data.adapterId, QUERY_KEYS.NORTHBOUND_MAPPINGS] })
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: [QUERY_KEYS.ADAPTERS, variables.adapterId, QUERY_KEYS.NORTHBOUND_MAPPINGS],
+      })
     },
   })
 }

--- a/hivemq-edge/src/frontend/src/api/hooks/useProtocolAdapters/useUpdateSouthboundMappings.ts
+++ b/hivemq-edge/src/frontend/src/api/hooks/useProtocolAdapters/useUpdateSouthboundMappings.ts
@@ -16,10 +16,12 @@ export const useUpdateSouthboundMappings = () => {
     return appClient.protocolAdapters.updateAdapterSouthboundMappings(adapterId, requestBody)
   }
 
-  return useMutation<UpdateSouthboundMappingsProps, ApiError, UpdateSouthboundMappingsProps>({
+  return useMutation<unknown, ApiError, UpdateSouthboundMappingsProps>({
     mutationFn: updateProtocolAdapter,
-    onSuccess: (data) => {
-      queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.ADAPTERS, data.adapterId, QUERY_KEYS.SOUTHBOUND_MAPPINGS] })
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: [QUERY_KEYS.ADAPTERS, variables.adapterId, QUERY_KEYS.SOUTHBOUND_MAPPINGS],
+      })
     },
   })
 }

--- a/hivemq-edge/src/frontend/src/api/hooks/useTopicFilters/useTopicFilterOperations.ts
+++ b/hivemq-edge/src/frontend/src/api/hooks/useTopicFilters/useTopicFilterOperations.ts
@@ -95,6 +95,9 @@ export const useTopicFilterOperations = () => {
         'ui:title': 'Topic Filters',
         items: {
           'ui:order': ['topicFilter', '*'],
+          schema: {
+            'ui:widget': 'hidden',
+          },
         },
       },
     },

--- a/hivemq-edge/src/frontend/src/api/schemas/northbound.json-schema.ts
+++ b/hivemq-edge/src/frontend/src/api/schemas/northbound.json-schema.ts
@@ -36,6 +36,11 @@ export const northboundMappingListSchema: JSONSchema7 = {
             'This setting defines the format of the resulting MQTT message, either a message per changed tag or a message per subscription that may include multiple data points per sample',
           default: 'MQTTMessagePerTag',
         },
+        messageExpiryInterval: {
+          type: 'number',
+          description: `The message expiry interval.`,
+          format: 'int64',
+        },
         maxQoS: {
           $ref: '#/definitions/QoS',
         },

--- a/hivemq-edge/src/frontend/src/api/schemas/southbound.json-schema.ts
+++ b/hivemq-edge/src/frontend/src/api/schemas/southbound.json-schema.ts
@@ -38,11 +38,11 @@ export const southboundMappingListSchema: JSONSchema7 = {
       properties: {
         destination: {
           type: 'string',
-          // readOnly: true,
+          format: 'data-url',
         },
         source: {
           type: 'string',
-          // readOnly: true,
+          format: 'data-url',
         },
       },
     },

--- a/hivemq-edge/src/frontend/src/api/schemas/southbound.json-schema.ts
+++ b/hivemq-edge/src/frontend/src/api/schemas/southbound.json-schema.ts
@@ -37,12 +37,14 @@ export const southboundMappingListSchema: JSONSchema7 = {
       description: `Metadata for the whole mapping`,
       properties: {
         destination: {
-          type: 'string',
-          format: 'data-url',
+          type: 'object',
+          // type: 'string',
+          // format: 'data-url',
         },
         source: {
-          type: 'string',
-          format: 'data-url',
+          type: 'object',
+          // type: 'string',
+          // format: 'data-url',
         },
       },
     },

--- a/hivemq-edge/src/frontend/src/api/schemas/southbound.ui-schema.ts
+++ b/hivemq-edge/src/frontend/src/api/schemas/southbound.ui-schema.ts
@@ -2,11 +2,8 @@ import { UiSchema } from '@rjsf/utils'
 
 /* istanbul ignore next -- @preserve */
 const metadataWidget: UiSchema = {
-  'ui:widget': 'data-url',
-  // 'ui:widget': 'textarea',
-  // 'ui:widget': 'application/schema+json',
+  // 'ui:widget': 'data-url',
   'ui:options': {
-    // readonly: true,
     accept: '.json',
   },
 }
@@ -20,6 +17,7 @@ export const southboundMappingListUISchema: UiSchema = {
   items: {
     'ui:title': 'List of Southbound mappings',
     'ui:description': 'The list of all the mappings delivering messages from Edge to the device',
+    'ui:field': 'mqtt:transform',
     items: {
       'ui:order': ['topicFilter', 'tagName', '*'],
       'ui:collapsable': {

--- a/hivemq-edge/src/frontend/src/components/Chakra/RadioButton.tsx
+++ b/hivemq-edge/src/frontend/src/components/Chakra/RadioButton.tsx
@@ -1,0 +1,35 @@
+import { FC } from 'react'
+import { UseRadioProps, Box, useRadio, Text } from '@chakra-ui/react'
+
+interface RadioButtonProps extends UseRadioProps {
+  children: React.ReactNode
+}
+
+export const RadioButton: FC<RadioButtonProps> = ({ children, ...rest }) => {
+  const { getInputProps, getRadioProps } = useRadio(rest)
+
+  return (
+    <Box as="label">
+      <input {...getInputProps()} />
+      <Box
+        {...getRadioProps()}
+        cursor="pointer"
+        borderWidth="1px"
+        borderRadius="md"
+        boxShadow="md"
+        _checked={{
+          bg: 'teal.600',
+          color: 'white',
+          borderColor: 'teal.600',
+        }}
+        _focus={{
+          boxShadow: 'outline',
+        }}
+        px={5}
+        py={1}
+      >
+        <Text>{children}</Text>
+      </Box>
+    </Box>
+  )
+}

--- a/hivemq-edge/src/frontend/src/components/rjsf/Fields/MqttTransformationField.tsx
+++ b/hivemq-edge/src/frontend/src/components/rjsf/Fields/MqttTransformationField.tsx
@@ -60,7 +60,7 @@ export const MqttTransformationField: FC<FieldProps<SouthboundMapping[], RJSFSch
     ])
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const handleChange = (id: keyof SouthboundMapping, v: any) => {
     if (selectedItem === undefined) return
     setSubsData((old) => {

--- a/hivemq-edge/src/frontend/src/components/rjsf/Fields/MqttTransformationField.tsx
+++ b/hivemq-edge/src/frontend/src/components/rjsf/Fields/MqttTransformationField.tsx
@@ -51,21 +51,24 @@ export const MqttTransformationField: FC<FieldProps<SouthboundMapping[], RJSFSch
         maxQoS: MOCK_MAX_QOS,
         fieldMapping: {
           instructions: [],
+          metadata: {
+            source: {},
+            destination: {},
+          },
         },
       },
     ])
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars
-  const handleChange = (_id: keyof SouthboundMapping, _v: any) => {
+  const handleChange = (id: keyof SouthboundMapping, v: any) => {
     if (selectedItem === undefined) return
     setSubsData((old) => {
-      // const currentItem = old?.[selectedItem]
-      // TODO[⚠ 28441 ⚠] This will not work anymore because of nested structure. DO NOT MERGE AND FIX
-      // if (currentItem) {
-      //   // @ts-ignore
-      //   currentItem[id] = v
-      // }
+      const currentItem = old?.[selectedItem]
+      if (currentItem) {
+        // @ts-ignore
+        currentItem[id] = v
+      }
       return [...(old || [])]
     })
   }

--- a/hivemq-edge/src/frontend/src/components/rjsf/Form/ChakraRJSForm.tsx
+++ b/hivemq-edge/src/frontend/src/components/rjsf/Form/ChakraRJSForm.tsx
@@ -7,7 +7,6 @@ import { FormProps, IChangeEvent } from '@rjsf/core'
 import { IdSchema } from '@rjsf/utils'
 import validator from '@rjsf/validator-ajv8'
 
-import { ObjectFieldTemplate } from '@/components/rjsf/ObjectFieldTemplate.tsx'
 import { FieldTemplate } from '@/components/rjsf/FieldTemplate.tsx'
 import { DescriptionFieldTemplate } from '@/components/rjsf/Templates/DescriptionFieldTemplate.tsx'
 import { BaseInputTemplate } from '@/components/rjsf/BaseInputTemplate.tsx'
@@ -15,11 +14,12 @@ import { ArrayFieldTemplate } from '@/components/rjsf/ArrayFieldTemplate.tsx'
 import { ArrayFieldItemTemplate } from '@/components/rjsf/ArrayFieldItemTemplate.tsx'
 import { ChakraRJSFormContext } from '@/components/rjsf/Form/types.ts'
 import { customFormatsValidator } from '@/components/rjsf/Form/validation.utils.ts'
-import { adapterJSFFields, adapterJSFWidgets } from '@/modules/ProtocolAdapters/utils/uiSchema.utils.ts'
 import { customFocusError } from '@/components/rjsf/Form/error-focus.utils.ts'
 import { TitleFieldTemplate } from '@/components/rjsf/Templates/TitleFieldTemplate.tsx'
 import { ErrorListTemplate } from '@/components/rjsf/Templates/ErrorListTemplate.tsx'
 import { useFormControlStore } from '@/components/rjsf/Form/useFormControlStore.ts'
+import { MqttTransformationField } from '@/components/rjsf/Fields'
+import { adapterJSFWidgets } from '@/modules/ProtocolAdapters/utils/uiSchema.utils.ts'
 
 interface CustomFormProps<T>
   extends Pick<
@@ -27,6 +27,7 @@ interface CustomFormProps<T>
     'id' | 'schema' | 'uiSchema' | 'formData' | 'formContext' | 'customValidate' | 'readonly'
   > {
   onSubmit: (data: IChangeEvent) => void
+  showNativeWidgets?: boolean
 }
 
 const FLAG_POST_VALIDATE = false
@@ -40,6 +41,7 @@ const ChakraRJSForm: FC<CustomFormProps<unknown>> = ({
   formContext,
   customValidate,
   readonly,
+  showNativeWidgets = false,
 }) => {
   const { t } = useTranslation()
   const { setTabIndex } = useFormControlStore()
@@ -101,7 +103,8 @@ const ChakraRJSForm: FC<CustomFormProps<unknown>> = ({
       formData={defaultValues}
       formContext={context}
       templates={{
-        ObjectFieldTemplate,
+        // TODO[NVL] This override was mostly for the tabs (not used in this context) but is wrongly rendering additionalProperties
+        // ObjectFieldTemplate,
         FieldTemplate,
         BaseInputTemplate,
         ArrayFieldTemplate,
@@ -110,8 +113,14 @@ const ChakraRJSForm: FC<CustomFormProps<unknown>> = ({
         ErrorListTemplate,
         TitleFieldTemplate,
       }}
-      widgets={adapterJSFWidgets}
-      fields={adapterJSFFields}
+      widgets={{
+        ...(!showNativeWidgets && adapterJSFWidgets),
+      }}
+      fields={{
+        ...(!showNativeWidgets && {
+          'mqtt:transform': MqttTransformationField,
+        }),
+      }}
       onSubmit={onValidate}
       liveValidate
       // TODO[NVL] Removing HTML validation; see https://rjsf-team.github.io/react-jsonschema-form/docs/usage/validation/#html5-validation

--- a/hivemq-edge/src/frontend/src/components/rjsf/MqttTransformation/components/DataModelSources.tsx
+++ b/hivemq-edge/src/frontend/src/components/rjsf/MqttTransformation/components/DataModelSources.tsx
@@ -1,4 +1,4 @@
-import { FC, useMemo } from 'react'
+import { FC, useEffect, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { JSONSchema7 } from 'json-schema'
 import { Card, CardBody, CardHeader, CardProps, Heading, HStack } from '@chakra-ui/react'
@@ -9,12 +9,14 @@ import IconButton from '@/components/Chakra/IconButton.tsx'
 import JsonSchemaBrowser from '@/components/rjsf/MqttTransformation/JsonSchemaBrowser.tsx'
 import LoaderSpinner from '@/components/Chakra/LoaderSpinner.tsx'
 import ErrorMessage from '@/components/ErrorMessage.tsx'
+import { JsonNode } from '@/api/__generated__'
 
-interface DataModelSourcesProps extends CardProps {
+interface DataModelSourcesProps extends Omit<CardProps, 'onChange'> {
   topic: string
+  onChange?: (v: JsonNode | undefined) => void
 }
 
-const DataModelSources: FC<DataModelSourcesProps> = ({ topic, ...props }) => {
+const DataModelSources: FC<DataModelSourcesProps> = ({ topic, onChange, ...props }) => {
   const { t } = useTranslation()
   const { schema, isLoading, isError, error } = useSamplingForTopic(topic)
 
@@ -22,6 +24,10 @@ const DataModelSources: FC<DataModelSourcesProps> = ({ topic, ...props }) => {
     if (!schema) return [] as JSONSchema7[]
     return [{ ...schema, title: topic }] as JSONSchema7[]
   }, [schema, topic])
+
+  useEffect(() => {
+    onChange?.(schema)
+  }, [onChange, schema])
 
   return (
     <Card {...props} size="sm">

--- a/hivemq-edge/src/frontend/src/components/rjsf/MqttTransformation/components/ListMappings.tsx
+++ b/hivemq-edge/src/frontend/src/components/rjsf/MqttTransformation/components/ListMappings.tsx
@@ -32,7 +32,7 @@ const ListMappings: FC<ListSubscriptionsProps> = ({ items, onEdit, onDelete, onA
         header: t('rjsf.MqttTransformationField.listing.sources'),
       },
       {
-        accessorKey: 'tag',
+        accessorKey: 'tagName',
         cell: (info) => {
           const val = info.getValue<string>()
           return val ? <PLCTag tagTitle={val} /> : <Text>{t('rjsf.MqttTransformationField.unset')}</Text>

--- a/hivemq-edge/src/frontend/src/components/rjsf/MqttTransformation/components/MappingContainer.tsx
+++ b/hivemq-edge/src/frontend/src/components/rjsf/MqttTransformation/components/MappingContainer.tsx
@@ -89,7 +89,8 @@ const MappingContainer: FC<SubscriptionContainerProps> = ({ adapterId, adapterTy
                 if (!mappings) {
                   return
                 }
-                onChange('fieldMapping', mappings)
+                console.log('XXXXXX item.fieldMapping?.instructions', item.fieldMapping?.instructions)
+                onChange('fieldMapping', { instructions: [...(item.fieldMapping?.instructions || []), ...mappings] })
               }}
               onSchemaReady={onSchemaReadyHandler}
             />

--- a/hivemq-edge/src/frontend/src/components/rjsf/MqttTransformation/components/MappingDrawer.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/components/rjsf/MqttTransformation/components/MappingDrawer.spec.cy.tsx
@@ -27,10 +27,13 @@ describe('MappingDrawer', () => {
       items: MOCK_DEVICE_TAGS(mockAdapterId, MockAdapterType.OPC_UA),
     }).as('getTags')
 
-    cy.intercept(`/api/v1/management/protocol-adapters/writing-schema/${mockAdapterId}/${btoa('my/tag')}`, {
-      configSchema: GENERATE_DATA_MODELS(true, 'mockTopic'),
-      protocolId: 'my-type',
-    })
+    cy.intercept(
+      `/api/v1/management/protocol-adapters/writing-schema/${mockAdapterId}/${encodeURIComponent('my/tag')}`,
+      {
+        configSchema: GENERATE_DATA_MODELS(true, 'mockTopic'),
+        protocolId: 'my-type',
+      }
+    )
 
     cy.intercept('/api/v1/management/sampling/topic/**', { items: [] })
     cy.intercept('/api/v1/management/sampling/schema/*', GENERATE_DATA_MODELS(true, 'my-topic'))

--- a/hivemq-edge/src/frontend/src/locales/en/translation.json
+++ b/hivemq-edge/src/frontend/src/locales/en/translation.json
@@ -867,6 +867,7 @@
     }
   },
   "modals": {
+    "native": "Native UX",
     "generics": {
       "confirmation": "Are you sure? You can't undo this action afterward."
     },

--- a/hivemq-edge/src/frontend/src/locales/en/translation.json
+++ b/hivemq-edge/src/frontend/src/locales/en/translation.json
@@ -583,6 +583,14 @@
       },
       "actions": {
         "submit": "Submit"
+      },
+      "toast": {
+        "description_loading": "Processing the request",
+        "updateCollection": {
+          "title": "Edit the mappings",
+          "description_success": "The mappings have been modified on the adapter",
+          "description_error": "The list of mappings could not be updated on the adapter"
+        }
       }
     }
   },

--- a/hivemq-edge/src/frontend/src/modules/Device/components/DeviceMetadataViewer.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Device/components/DeviceMetadataViewer.spec.cy.tsx
@@ -14,8 +14,5 @@ describe('DeviceMetadataViewer', () => {
     cy.getByTestId('device-metadata-header').should('be.visible')
     cy.getByTestId('device-metadata-header').find('h2').should('contain.text', 'simulation')
     cy.getByTestId('device-metadata-header').find('h2 + p').should('contain.text', 'Simulation')
-
-    cy.get('[role="alert"]').should('contain.text', 'Uploading device metadata is not yet supported')
-    cy.get('[role="alert"]').should('have.attr', 'data-status', 'warning')
   })
 })

--- a/hivemq-edge/src/frontend/src/modules/Device/components/DeviceMetadataViewer.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Device/components/DeviceMetadataViewer.tsx
@@ -1,21 +1,5 @@
 import { FC } from 'react'
-import { useTranslation } from 'react-i18next'
-import {
-  Alert,
-  AlertDescription,
-  AlertIcon,
-  Avatar,
-  Box,
-  Card,
-  CardBody,
-  CardHeader,
-  Flex,
-  Heading,
-  Text,
-} from '@chakra-ui/react'
-import { LuUpload } from 'react-icons/lu'
-
-import IconButton from '@/components/Chakra/IconButton.tsx'
+import { Avatar, Box, Card, CardHeader, Flex, Heading, Text } from '@chakra-ui/react'
 import { DeviceMetadata } from '@/modules/Workspace/types.ts'
 
 interface DeviceMetadataProps {
@@ -23,8 +7,6 @@ interface DeviceMetadataProps {
 }
 
 const DeviceMetadataViewer: FC<DeviceMetadataProps> = ({ protocolAdapter }) => {
-  const { t } = useTranslation()
-
   return (
     <Card size="sm">
       <CardHeader>
@@ -36,15 +18,8 @@ const DeviceMetadataViewer: FC<DeviceMetadataProps> = ({ protocolAdapter }) => {
               <Text>{protocolAdapter?.category?.displayName}</Text>
             </Box>
           </Flex>
-          <IconButton aria-label={t('device.drawer.metadataPanel.cta.load')} icon={<LuUpload />} isDisabled />
         </Flex>
       </CardHeader>
-      <CardBody>
-        <Alert status="warning">
-          <AlertIcon />
-          <AlertDescription>{t('device.errors.noMetadataLoaded')}</AlertDescription>
-        </Alert>
-      </CardBody>
     </Card>
   )
 }

--- a/hivemq-edge/src/frontend/src/modules/Mappings/AdapterMappingManager.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/AdapterMappingManager.tsx
@@ -11,10 +11,15 @@ import {
   DrawerFooter,
   DrawerHeader,
   DrawerOverlay,
+  FormControl,
+  FormLabel,
+  Switch,
   Text,
   useBoolean,
   useDisclosure,
 } from '@chakra-ui/react'
+
+import config from '@/config'
 
 import type { Adapter } from '@/api/__generated__'
 import DrawerExpandButton from '@/components/Chakra/DrawerExpandButton.tsx'
@@ -55,6 +60,8 @@ const AdapterMappingManager: FC<AdapterMappingManagerProps> = ({ type }) => {
   const adapterId = selectedNode?.data.id
   const manager = type === MappingType.NORTHBOUND ? useNorthboundMappingManager : useSouthboundMappingManager
 
+  const [showNativeWidgets, setShowNativeWidgets] = useBoolean()
+
   return (
     <Drawer isOpen={isOpen} placement="right" size={isExpanded ? 'full' : 'lg'} onClose={handleClose} variant="hivemq">
       <DrawerOverlay />
@@ -73,10 +80,19 @@ const AdapterMappingManager: FC<AdapterMappingManagerProps> = ({ type }) => {
               onSubmit={handleClose}
               useManager={manager}
               type={type}
+              showNativeWidgets={showNativeWidgets}
             />
           )}
         </DrawerBody>
         <DrawerFooter>
+          {config.environment === 'development' && (
+            <FormControl display="flex" alignItems="center">
+              <FormLabel htmlFor="email-alerts" mb="0">
+                {t('modals.native')}
+              </FormLabel>
+              <Switch id="email-alerts" isChecked={showNativeWidgets} onChange={setShowNativeWidgets.toggle} />
+            </FormControl>
+          )}
           <Button variant="primary" type="submit" form="adapter-mapping-form">
             {t('protocolAdapter.mapping.actions.submit')}
           </Button>

--- a/hivemq-edge/src/frontend/src/modules/Mappings/components/MappingForm.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/components/MappingForm.tsx
@@ -26,9 +26,10 @@ const MappingForm: FC<MappingFormProps> = ({ adapterId, adapterType, useManager,
 
   const onFormSubmit = useCallback(
     (data: IChangeEvent<unknown>) => {
-      onUpdateCollection(data.formData)
+      const promise = onUpdateCollection(data.formData)
+      promise?.then(onSubmit)
     },
-    [onUpdateCollection]
+    [onSubmit, onUpdateCollection]
   )
 
   if (!context.schema) return <ErrorMessage message={t('protocolAdapter.export.error.noSchema')} />

--- a/hivemq-edge/src/frontend/src/modules/Mappings/components/MappingForm.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/components/MappingForm.tsx
@@ -16,9 +16,10 @@ interface MappingFormProps {
   onSubmit: () => void
   useManager: (adapterId: string) => MappingManagerType
   type: MappingType
+  showNativeWidgets?: boolean
 }
 
-const MappingForm: FC<MappingFormProps> = ({ adapterId, adapterType, useManager, type }) => {
+const MappingForm: FC<MappingFormProps> = ({ adapterId, adapterType, useManager, type, showNativeWidgets = false }) => {
   const { t } = useTranslation()
   const { context, onUpdateCollection } = useManager(adapterId)
   const validationSchemas = useState<FlatJSONSchema7[]>()
@@ -42,6 +43,7 @@ const MappingForm: FC<MappingFormProps> = ({ adapterId, adapterType, useManager,
 
   return (
     <ChakraRJSForm
+      showNativeWidgets={showNativeWidgets}
       id="adapter-mapping-form"
       schema={context.schema}
       uiSchema={context.uiSchema}

--- a/hivemq-edge/src/frontend/src/modules/Mappings/components/MappingForm.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/components/MappingForm.tsx
@@ -19,7 +19,14 @@ interface MappingFormProps {
   showNativeWidgets?: boolean
 }
 
-const MappingForm: FC<MappingFormProps> = ({ adapterId, adapterType, useManager, type, showNativeWidgets = false }) => {
+const MappingForm: FC<MappingFormProps> = ({
+  adapterId,
+  adapterType,
+  useManager,
+  type,
+  showNativeWidgets = false,
+  onSubmit,
+}) => {
   const { t } = useTranslation()
   const { context, onUpdateCollection } = useManager(adapterId)
   const validationSchemas = useState<FlatJSONSchema7[]>()

--- a/hivemq-edge/src/frontend/src/modules/Mappings/hooks/useNorthboundMappingManager.ts
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/hooks/useNorthboundMappingManager.ts
@@ -5,14 +5,17 @@ import { type NorthboundMappingList } from '@/api/__generated__'
 import { useListNorthboundMappings } from '@/api/hooks/useProtocolAdapters/useListNorthboundMappings.ts'
 import { useUpdateNorthboundMappings } from '@/api/hooks/useProtocolAdapters/useUpdateNorthboundMappings.ts'
 
-import { ManagerContextType, MappingManagerType } from '@/modules/Mappings/types.ts'
 import { northboundMappingListSchema } from '@/api/schemas/northbound.json-schema.ts'
 import { northboundMappingListUISchema } from '@/api/schemas/northbound.ui-schema.ts'
+import { DEFAULT_TOAST_OPTION } from '@/hooks/useEdgeToast/toast-utils.ts'
+import { ManagerContextType, MappingManagerType } from '@/modules/Mappings/types.ts'
 
 export const useNorthboundMappingManager = (adapterId: string): MappingManagerType<NorthboundMappingList> => {
   const { t } = useTranslation()
-  const toast = useToast()
-
+  const toast = useToast({
+    duration: DEFAULT_TOAST_OPTION.duration,
+    isClosable: DEFAULT_TOAST_OPTION.isClosable,
+  })
   const { data, isError, isLoading, error } = useListNorthboundMappings(adapterId)
 
   const updateCollectionMutator = useUpdateNorthboundMappings()
@@ -33,11 +36,10 @@ export const useNorthboundMappingManager = (adapterId: string): MappingManagerTy
   })
 
   const onUpdateCollection = (tags: NorthboundMappingList) => {
-    if (!adapterId) return
-    toast.promise(
-      updateCollectionMutator.mutateAsync({ adapterId: adapterId, requestBody: tags }),
-      formatToast('updateCollection')
-    )
+    if (!adapterId) return undefined
+    const promise = updateCollectionMutator.mutateAsync({ adapterId: adapterId, requestBody: tags })
+    toast.promise(promise, formatToast('updateCollection'))
+    return promise
   }
 
   const context: ManagerContextType = {
@@ -52,6 +54,7 @@ export const useNorthboundMappingManager = (adapterId: string): MappingManagerTy
     // The CRUD operations
     data: data,
     onUpdateCollection,
+    onClose: () => toast.closeAll(),
     // The state (as in ReactQuery)
     isLoading: isLoading,
     isError: isError,

--- a/hivemq-edge/src/frontend/src/modules/Mappings/hooks/useNorthboundMappingManager.ts
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/hooks/useNorthboundMappingManager.ts
@@ -17,19 +17,18 @@ export const useNorthboundMappingManager = (adapterId: string): MappingManagerTy
 
   const updateCollectionMutator = useUpdateNorthboundMappings()
 
-  // TODO[NVL] Insert Edge-wide toast configuration (need refactoring)
   const formatToast = (operation: string) => ({
     success: {
-      title: t(`device.drawer.tagList.toast.${operation}.title`),
-      description: t(`device.drawer.tagList.toast.${operation}.description`, { context: 'success' }),
+      title: t(`protocolAdapter.mapping.toast.${operation}.title`),
+      description: t(`protocolAdapter.mapping.toast.${operation}.description`, { context: 'success' }),
     },
     error: {
-      title: t(`device.drawer.tagList.toast.${operation}.title`),
-      description: t(`device.drawer.tagList.toast.${operation}.description`, { context: 'error' }),
+      title: t(`protocolAdapter.mapping.toast.${operation}.title`),
+      description: t(`protocolAdapter.mapping.toast.${operation}.description`, { context: 'error' }),
     },
     loading: {
-      title: t(`device.drawer.tagList.toast.${operation}.title`),
-      description: t('device.drawer.tagList.toast.description', { context: 'loading' }),
+      title: t(`protocolAdapter.mapping.toast.${operation}.title`),
+      description: t('protocolAdapter.mapping.toast.description', { context: 'loading' }),
     },
   })
 

--- a/hivemq-edge/src/frontend/src/modules/Mappings/hooks/useSouthboundMappingManager.ts
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/hooks/useSouthboundMappingManager.ts
@@ -8,10 +8,14 @@ import { useUpdateSouthboundMappings } from '@/api/hooks/useProtocolAdapters/use
 import { ManagerContextType, MappingManagerType } from '@/modules/Mappings/types.ts'
 import { southboundMappingListSchema } from '@/api/schemas/southbound.json-schema.ts'
 import { southboundMappingListUISchema } from '@/api/schemas/southbound.ui-schema.ts'
+import { DEFAULT_TOAST_OPTION } from '@/hooks/useEdgeToast/toast-utils.ts'
 
 export const useSouthboundMappingManager = (adapterId: string): MappingManagerType<SouthboundMappingList> => {
   const { t } = useTranslation()
-  const toast = useToast()
+  const toast = useToast({
+    duration: DEFAULT_TOAST_OPTION.duration,
+    isClosable: DEFAULT_TOAST_OPTION.isClosable,
+  })
 
   const { data, isError, isLoading, error } = useListSouthboundMappings(adapterId)
 
@@ -34,10 +38,9 @@ export const useSouthboundMappingManager = (adapterId: string): MappingManagerTy
 
   const onUpdateCollection = (tags: SouthboundMappingList) => {
     if (!adapterId) return
-    toast.promise(
-      updateCollectionMutator.mutateAsync({ adapterId: adapterId, requestBody: tags }),
-      formatToast('updateCollection')
-    )
+    const promise = updateCollectionMutator.mutateAsync({ adapterId: adapterId, requestBody: tags })
+    toast.promise(promise, formatToast('updateCollection'))
+    return promise
   }
 
   const context: ManagerContextType = {
@@ -52,6 +55,7 @@ export const useSouthboundMappingManager = (adapterId: string): MappingManagerTy
     // The CRUD operations
     data: data,
     onUpdateCollection,
+    onClose: () => toast.closeAll(),
     // The state (as in ReactQuery)
     isLoading: isLoading,
     isError: isError,

--- a/hivemq-edge/src/frontend/src/modules/Mappings/hooks/useSouthboundMappingManager.ts
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/hooks/useSouthboundMappingManager.ts
@@ -17,19 +17,18 @@ export const useSouthboundMappingManager = (adapterId: string): MappingManagerTy
 
   const updateCollectionMutator = useUpdateSouthboundMappings()
 
-  // TODO[NVL] Insert Edge-wide toast configuration (need refactoring)
   const formatToast = (operation: string) => ({
     success: {
-      title: t(`device.drawer.tagList.toast.${operation}.title`),
-      description: t(`device.drawer.tagList.toast.${operation}.description`, { context: 'success' }),
+      title: t(`protocolAdapter.mapping.toast.${operation}.title`),
+      description: t(`protocolAdapter.mapping.toast.${operation}.description`, { context: 'success' }),
     },
     error: {
-      title: t(`device.drawer.tagList.toast.${operation}.title`),
-      description: t(`device.drawer.tagList.toast.${operation}.description`, { context: 'error' }),
+      title: t(`protocolAdapter.mapping.toast.${operation}.title`),
+      description: t(`protocolAdapter.mapping.toast.${operation}.description`, { context: 'error' }),
     },
     loading: {
-      title: t(`device.drawer.tagList.toast.${operation}.title`),
-      description: t('device.drawer.tagList.toast.description', { context: 'loading' }),
+      title: t(`protocolAdapter.mapping.toast.${operation}.title`),
+      description: t('protocolAdapter.mapping.toast.description', { context: 'loading' }),
     },
   })
 

--- a/hivemq-edge/src/frontend/src/modules/Mappings/types.ts
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/types.ts
@@ -17,7 +17,8 @@ export enum MappingType {
 export interface MappingManagerType<T = any> {
   context: ManagerContextType
   data: T | undefined
-  onUpdateCollection: (tags: T) => void
+  onUpdateCollection: (tags: T) => Promise<unknown> | undefined
+  onClose: () => void
   isLoading: boolean
   isError: boolean
   isPending: boolean


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/28441/details/

This Pr is the third and last alignment with the backend, following the refactoring of the mapping flow.
- fixes the northbound mapping UX
- fixes bugs with the tag management, allowing full creation 
- fixes the southbound mapping UX

The PR also removes the placeholders in the "device" panel 

### Out-of-scope
- Southbound mapping metadata are not saved with the mapping request. The behaviour will need to be updated 

### Before 
![screenshot-localhost_3000-2024_12_05-14_13_35](https://github.com/user-attachments/assets/e25139b3-6ee0-4ea0-a8d6-e54d0e0532ad)


### After

![screenshot-localhost_3000-2024_12_05-14_13_09](https://github.com/user-attachments/assets/19df6cd8-5d33-414d-b61e-05073a84f49b)

![screenshot-localhost_3000-2024_12_05-13_17_14](https://github.com/user-attachments/assets/b8a36e85-cce5-401e-a74e-ea9677de2774)

![screenshot-localhost_3000-2024_12_05-13_27_12](https://github.com/user-attachments/assets/d7668956-aa9a-4243-a089-9c3b253b111c)

![screenshot-localhost_3000-2024_12_05-13_27_50](https://github.com/user-attachments/assets/6abda9ed-684e-4f9e-bacf-4df5b2a9c591)
