### PR TITLE
feat(28664): Add schema management for the topic filters

### DIFF
--- a/hivemq-edge/src/frontend/src/api/hooks/useTopicFilters/__handlers__/index.ts
+++ b/hivemq-edge/src/frontend/src/api/hooks/useTopicFilters/__handlers__/index.ts
@@ -1,9 +1,14 @@
 import { http, HttpResponse } from 'msw'
 import { type TopicFilter, type TopicFilterList } from '@/api/__generated__'
 
+export const MOCK_TOPIC_FILTER_SCHEMA_INVALID = 'data:application/json;base64,ewogICJ0ZXN0IjogMQp9Cg=='
+export const MOCK_TOPIC_FILTER_SCHEMA_VALID =
+  'data:application/json;base64,ewogICJ0eXBlIjogIm9iamVjdCIsCiAgInRpdGxlIjogIlRoaXMgaXMgYSBzaW1wbGUgc2NoZW1hIiwKICAicHJvcGVydGllcyI6IHsKICAgICJkZXNjcmlwdGlvbiI6IHsKICAgICAgInR5cGUiOiAic3RyaW5nIiwKICAgICAgInRpdGxlIjogImRlc2NyaXB0aW9uIiwKICAgICAgImRlc2NyaXB0aW9uIjogIlRoZSBkZXNjcmlwdGlvbiBvZiB0aGUgaXRlbSIKICAgIH0sCiAgICAibmFtZSI6IHsKICAgICAgInR5cGUiOiAic3RyaW5nIiwKICAgICAgInRpdGxlIjogIm5hbWUiLAogICAgICAiZGVzY3JpcHRpb24iOiAiVGhlIG5hbWUgb2YgdGhlIGl0ZW0iCiAgICB9CiAgfSwKICAicmVxdWlyZWQiOiBbCiAgICAiZGVzY3JpcHRpb24iLAogICAgIm5hbWUiCiAgXQp9Cg=='
+
 export const MOCK_TOPIC_FILTER: TopicFilter = {
   topicFilter: 'a/topic/+/filter',
   description: 'This is a topic filter',
+  schema: MOCK_TOPIC_FILTER_SCHEMA_VALID,
 }
 
 export const handlers = [

--- a/hivemq-edge/src/frontend/src/api/hooks/useTopicFilters/useListTopicFilters.spec.ts
+++ b/hivemq-edge/src/frontend/src/api/hooks/useTopicFilters/useListTopicFilters.spec.ts
@@ -5,7 +5,7 @@ import { server } from '@/__test-utils__/msw/mockServer.ts'
 import { SimpleWrapper as wrapper } from '@/__test-utils__/hooks/SimpleWrapper.tsx'
 import type { TopicFilterList } from '@/api/__generated__'
 import { useListTopicFilters } from '@/api/hooks/useTopicFilters/useListTopicFilters.ts'
-import { handlers } from '@/api/hooks/useTopicFilters/__handlers__'
+import { handlers, MOCK_TOPIC_FILTER_SCHEMA_VALID } from '@/api/hooks/useTopicFilters/__handlers__'
 
 describe('useListTopicFilters', () => {
   beforeEach(() => {
@@ -27,6 +27,7 @@ describe('useListTopicFilters', () => {
         {
           description: 'This is a topic filter',
           topicFilter: 'a/topic/+/filter',
+          schema: MOCK_TOPIC_FILTER_SCHEMA_VALID,
         },
       ],
     })

--- a/hivemq-edge/src/frontend/src/locales/en/translation.json
+++ b/hivemq-edge/src/frontend/src/locales/en/translation.json
@@ -1028,6 +1028,7 @@
     },
     "schema": {
       "header": "Manage the schemas of the topic filter",
+      "title": "Topic Filter:",
       "prompt": "You can upload a schema or try to automatically infer a schema from the MQTT traffic on your installation",
       "actions": {
         "remove": "Remove assigned schema",

--- a/hivemq-edge/src/frontend/src/locales/en/translation.json
+++ b/hivemq-edge/src/frontend/src/locales/en/translation.json
@@ -1030,6 +1030,12 @@
       "header": "Manage the schemas of the topic filter",
       "submit": {
         "label": "OK"
+      },
+      "status": {
+        "success": "Your topic filter is currently assigned a valid schema",
+        "missing": "Your topic filter is currently not assigned a schema",
+        "invalid": "Your topic filter is currently assigned a schema that is not valid",
+        "internalError": "Internal error - cannot extract your schema"
       }
     },
     "error": {

--- a/hivemq-edge/src/frontend/src/locales/en/translation.json
+++ b/hivemq-edge/src/frontend/src/locales/en/translation.json
@@ -1034,7 +1034,18 @@
     },
     "error": {
       "loading": "We cannot load the topic filters. Please try again later.",
-      "noSchemaSampled": "No schema could be inferred from the traffic on this topic filter. Please try again later."
+      "noSchemaSampled": "No schema could be inferred from the traffic on this topic filter. Please try again later.",
+      "schema": {
+        "noDataUri": "Not a valid data-url encoded JSONSchema",
+        "noScheme": "No scheme defined in the URI",
+        "noSchemeData": "The scheme of the uri is not defined as 'data'",
+        "noJsonSchemaMimeType": "The media types doesn't include the mandatory `application/schema+json`",
+        "noBase64MediaType": "The media types doesn't include the mandatory `base64`",
+        "noBase64Data": "The data is not properly encoded as a `base64` string",
+        "noJSON": "The data is not properly encoded as a `JSON` object",
+        "ajvValidationFails": "Internal validation error",
+        "ajvNoProperties": "Not a valid JSONSchema: `properties` is missing"
+      }
     },
     "toast": {
       "description_loading": "Processing the request",

--- a/hivemq-edge/src/frontend/src/locales/en/translation.json
+++ b/hivemq-edge/src/frontend/src/locales/en/translation.json
@@ -1028,6 +1028,17 @@
     },
     "schema": {
       "header": "Manage the schemas of the topic filter",
+      "prompt": "You can upload a schema or try to automatically infer a schema from the MQTT traffic on your installation",
+      "actions": {
+        "remove": "Remove assigned schema",
+        "assign": "Assign schema",
+        "upload": "Upload a JSON-Schema file"
+      },
+      "tabs": {
+        "current": "Current Schema",
+        "upload": "Upload a new schema",
+        "infer": "Infer a schema"
+      },
       "submit": {
         "label": "OK"
       },

--- a/hivemq-edge/src/frontend/src/locales/en/translation.json
+++ b/hivemq-edge/src/frontend/src/locales/en/translation.json
@@ -1071,6 +1071,11 @@
         "description_success": "The Topic Filter has been deleted from the Edge",
         "description_error": "The Topic Filter could not be deleted"
       },
+      "update": {
+        "title": "Update Topic Filter",
+        "description_success": "The Topic Filter has been updated on the Edge",
+        "description_error": "The Topic Filter could not be updated"
+      },
       "updateCollection": {
         "title": "Edit the Topic Filters",
         "description_success": "The Topic Filters have been modified on the Edge",

--- a/hivemq-edge/src/frontend/src/locales/en/translation.json
+++ b/hivemq-edge/src/frontend/src/locales/en/translation.json
@@ -1022,7 +1022,7 @@
           "aria-label": "Delete Topic Filter"
         },
         "add": {
-          "aria-label": "Add a new Topic Filter"
+          "aria-label": "Edit the topic Filters"
         }
       }
     },

--- a/hivemq-edge/src/frontend/src/modules/TopicFilters/TopicFilterManager.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/TopicFilters/TopicFilterManager.spec.cy.tsx
@@ -1,6 +1,5 @@
 import TopicFilterManager from '@/modules/TopicFilters/TopicFilterManager.tsx'
-import { MOCK_TOPIC_FILTER } from '@/api/hooks/useTopicFilters/__handlers__'
-import { GENERATE_DATA_MODELS } from '@/api/hooks/useDomainModel/__handlers__'
+import { MOCK_TOPIC_FILTER, MOCK_TOPIC_FILTER_SCHEMA_INVALID } from '@/api/hooks/useTopicFilters/__handlers__'
 
 describe('TopicFilterManager', () => {
   beforeEach(() => {
@@ -11,18 +10,10 @@ describe('TopicFilterManager', () => {
         {
           topicFilter: 'another/filter',
           description: 'This is a topic filter',
+          schema: MOCK_TOPIC_FILTER_SCHEMA_INVALID,
         },
       ],
     }).as('getTopicFilters')
-
-    cy.intercept('/api/v1/management/sampling/schema/**', (req) => {
-      if (req.url.includes(btoa('another/filter'))) req.reply({ statusCode: 400 })
-      else req.reply(GENERATE_DATA_MODELS(true, req.query.topics as string))
-    })
-
-    cy.intercept('/api/v1/management/sampling/topic/**', (req) => {
-      req.reply({ items: [] })
-    })
   })
 
   // TODO[NVL] There is a problem with re-rendering in Cypress. Redesign the component
@@ -45,7 +36,7 @@ describe('TopicFilterManager', () => {
     cy.get('@body').find('td').eq(0).should('have.text', 'a / topic / + / filter')
     cy.get('@body').find('td').eq(1).should('have.text', 'This is a topic filter')
     cy.get('@body').find('td').eq(2).children().should('have.attr', 'data-status', 'success')
-    cy.get('@body').find('td').eq(6).children().should('have.attr', 'data-status', 'success')
+    cy.get('@body').find('td').eq(6).children().should('have.attr', 'data-status', 'error')
 
     cy.get('@body').find('td').eq(3).find('button').as('topicActions')
 

--- a/hivemq-edge/src/frontend/src/modules/TopicFilters/TopicFilterManager.tsx
+++ b/hivemq-edge/src/frontend/src/modules/TopicFilters/TopicFilterManager.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { ColumnDef } from '@tanstack/react-table'
 import { Button, ButtonGroup, Card, CardBody, Text, useDisclosure } from '@chakra-ui/react'
-import { LuPencil, LuPlus, LuTrash, LuView } from 'react-icons/lu'
+import { LuClipboardEdit, LuPencil, LuTrash, LuView } from 'react-icons/lu'
 
 import { TopicFilter, TopicFilterList } from '@/api/__generated__'
 import { useTopicFilterManager } from '@/modules/TopicFilters/hooks/useTopicFilterManager.ts'
@@ -100,7 +100,7 @@ const TopicFilterManager: FC = () => {
               }}
               trigger={({ onOpen: onOpenArrayDrawer }) => (
                 <ButtonGroup isAttached size="sm">
-                  <Button leftIcon={<LuPlus />} onClick={onOpenArrayDrawer}>
+                  <Button leftIcon={<LuClipboardEdit />} onClick={onOpenArrayDrawer}>
                     {t('topicFilter.listing.action.add.aria-label')}
                   </Button>
                 </ButtonGroup>

--- a/hivemq-edge/src/frontend/src/modules/TopicFilters/components/SchemaSampler.tsx
+++ b/hivemq-edge/src/frontend/src/modules/TopicFilters/components/SchemaSampler.tsx
@@ -1,18 +1,21 @@
 import { FC, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { JSONSchema7 } from 'json-schema'
+import { Button, Card, CardBody, CardFooter } from '@chakra-ui/react'
 
 import { TopicFilter } from '@/api/__generated__'
 import { useSamplingForTopic } from '@/api/hooks/useDomainModel/useSamplingForTopic.ts'
 import LoaderSpinner from '@/components/Chakra/LoaderSpinner.tsx'
 import ErrorMessage from '@/components/ErrorMessage.tsx'
 import JsonSchemaBrowser from '@/components/rjsf/MqttTransformation/JsonSchemaBrowser.tsx'
+import { encodeDataUriJsonSchema } from '@/modules/TopicFilters/utils/topic-filter.schema.ts'
 
 interface SchemaManagerProps {
   topicFilter: TopicFilter
+  onUpload: (s: string) => void
 }
 
-const SchemaManager: FC<SchemaManagerProps> = ({ topicFilter }) => {
+const SchemaSampler: FC<SchemaManagerProps> = ({ topicFilter, onUpload }) => {
   const { t } = useTranslation()
   const { schema, isLoading, isError, error } = useSamplingForTopic(topicFilter.topicFilter)
 
@@ -24,7 +27,21 @@ const SchemaManager: FC<SchemaManagerProps> = ({ topicFilter }) => {
   if (isError && error) return <ErrorMessage message={error.message} />
   if (!isSchemaValid) return <ErrorMessage message={t('topicFilter.error.noSchemaSampled')} />
 
-  return <JsonSchemaBrowser schema={schema as JSONSchema7} />
+  return (
+    <Card>
+      <CardBody>
+        <JsonSchemaBrowser schema={schema as JSONSchema7} />
+      </CardBody>
+      <CardFooter justifyContent="flex-end">
+        <Button
+          data-testid="schema-sampler-upload"
+          onClick={() => onUpload(encodeDataUriJsonSchema(schema as JSONSchema7))}
+        >
+          {t('topicFilter.schema.actions.assign')}
+        </Button>
+      </CardFooter>
+    </Card>
+  )
 }
 
-export default SchemaManager
+export default SchemaSampler

--- a/hivemq-edge/src/frontend/src/modules/TopicFilters/components/SchemaUploader.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/TopicFilters/components/SchemaUploader.spec.cy.tsx
@@ -1,0 +1,16 @@
+import SchemaUploader from '@/modules/TopicFilters/components/SchemaUploader.tsx'
+
+describe('SchemaUploader', () => {
+  beforeEach(() => {
+    cy.viewport(800, 800)
+  })
+
+  it('should render properly', () => {
+    const onUpload = cy.stub().as('onUpload')
+    cy.mountWithProviders(<SchemaUploader onUpload={onUpload} />)
+
+    cy.get('#dropzone').as('dropzone')
+    cy.get('#dropzone p').should('have.text', 'Upload a JSON-Schema file')
+    cy.get('#dropzone button').should('have.text', 'Select file')
+  })
+})

--- a/hivemq-edge/src/frontend/src/modules/TopicFilters/components/SchemaUploader.tsx
+++ b/hivemq-edge/src/frontend/src/modules/TopicFilters/components/SchemaUploader.tsx
@@ -8,7 +8,6 @@ import { getDropZoneBorder } from '@/modules/Theme/utils.ts'
 import { ACCEPT_JSON_SCHEMA } from '@/modules/TopicFilters/utils/topic-filter.schema.ts'
 
 interface SchemaUploaderProps {
-  id?: string
   onUpload: (s: string) => void
 }
 
@@ -58,7 +57,7 @@ const SchemaUploader: FC<SchemaUploaderProps> = ({ onUpload }) => {
       alignItems="center"
       id="dropzone"
     >
-      <input {...getInputProps()} data-testid="batch-load-dropzone" />
+      <input {...getInputProps()} data-testid="schema-dropzone" />
       {isDragActive && <Text>{t('rjsf.batchUpload.dropZone.dropping', { ns: 'components' })}</Text>}
       {loading && <Text>{t('rjsf.batchUpload.dropZone.loading', { ns: 'components' })}</Text>}
       {!isDragActive && !loading && (

--- a/hivemq-edge/src/frontend/src/modules/TopicFilters/components/SchemaUploader.tsx
+++ b/hivemq-edge/src/frontend/src/modules/TopicFilters/components/SchemaUploader.tsx
@@ -1,7 +1,7 @@
 import { FC, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useDropzone } from 'react-dropzone'
-import { AlertStatus, Button, Text, useToast, VStack } from '@chakra-ui/react'
+import { AlertStatus, Button, Card, CardBody, Text, useToast } from '@chakra-ui/react'
 
 import { DEFAULT_TOAST_OPTION } from '@/hooks/useEdgeToast/toast-utils.ts'
 import { getDropZoneBorder } from '@/modules/Theme/utils.ts'
@@ -48,25 +48,28 @@ const SchemaUploader: FC<SchemaUploaderProps> = ({ onUpload }) => {
   })
 
   return (
-    <VStack
-      {...getRootProps()}
-      {...getDropZoneBorder('blue.500')}
-      minHeight="calc(250px - 2rem)"
-      display="flex"
-      justifyContent="center"
-      alignItems="center"
-      id="dropzone"
-    >
-      <input {...getInputProps()} data-testid="schema-dropzone" />
-      {isDragActive && <Text>{t('rjsf.batchUpload.dropZone.dropping', { ns: 'components' })}</Text>}
-      {loading && <Text>{t('rjsf.batchUpload.dropZone.loading', { ns: 'components' })}</Text>}
-      {!isDragActive && !loading && (
-        <>
-          <Text>{t('topicFilter.schema.actions.upload')}</Text>
-          <Button onClick={open}>{t('rjsf.batchUpload.dropZone.selectFile', { ns: 'components' })}</Button>
-        </>
-      )}
-    </VStack>
+    <Card variant="filled">
+      <CardBody
+        {...getRootProps()}
+        {...getDropZoneBorder('blue.500')}
+        minHeight="calc(250px - 2rem)"
+        display="flex"
+        flexDirection="column"
+        justifyContent="center"
+        alignItems="center"
+        id="dropzone"
+      >
+        <input {...getInputProps()} data-testid="schema-dropzone" />
+        {isDragActive && <Text>{t('rjsf.batchUpload.dropZone.dropping', { ns: 'components' })}</Text>}
+        {loading && <Text>{t('rjsf.batchUpload.dropZone.loading', { ns: 'components' })}</Text>}
+        {!isDragActive && !loading && (
+          <>
+            <Text>{t('topicFilter.schema.actions.upload')}</Text>
+            <Button onClick={open}>{t('rjsf.batchUpload.dropZone.selectFile', { ns: 'components' })}</Button>
+          </>
+        )}
+      </CardBody>
+    </Card>
   )
 }
 

--- a/hivemq-edge/src/frontend/src/modules/TopicFilters/components/SchemaUploader.tsx
+++ b/hivemq-edge/src/frontend/src/modules/TopicFilters/components/SchemaUploader.tsx
@@ -1,0 +1,74 @@
+import { FC, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useDropzone } from 'react-dropzone'
+import { AlertStatus, Button, Text, useToast, VStack } from '@chakra-ui/react'
+
+import { DEFAULT_TOAST_OPTION } from '@/hooks/useEdgeToast/toast-utils.ts'
+import { getDropZoneBorder } from '@/modules/Theme/utils.ts'
+import { ACCEPT_JSON_SCHEMA } from '@/modules/TopicFilters/utils/topic-filter.schema.ts'
+
+interface SchemaUploaderProps {
+  id?: string
+  onUpload: (s: string) => void
+}
+
+const SchemaUploader: FC<SchemaUploaderProps> = ({ onUpload }) => {
+  const [loading, setLoading] = useState(false)
+  const { t } = useTranslation()
+  const toast = useToast()
+
+  const { getRootProps, getInputProps, isDragActive, open } = useDropzone({
+    noClick: true,
+    noKeyboard: true,
+    maxFiles: 1,
+    accept: ACCEPT_JSON_SCHEMA,
+    onDropRejected: (fileRejections) => {
+      const status: AlertStatus = 'error'
+      setLoading(false)
+      fileRejections.forEach((fileRejection) => {
+        toast({
+          ...DEFAULT_TOAST_OPTION,
+          status,
+          title: t('rjsf.batchUpload.dropZone.status', {
+            ns: 'components',
+            context: status,
+            fileName: fileRejection.file.name,
+          }),
+          description: fileRejection.errors[0].message,
+        })
+      })
+    },
+    onDropAccepted: async (files) => {
+      const [file] = files
+      const reader = new FileReader()
+      reader.readAsDataURL(file)
+      reader.onload = () => {
+        if (typeof reader.result === 'string') onUpload(reader.result as string)
+      }
+    },
+  })
+
+  return (
+    <VStack
+      {...getRootProps()}
+      {...getDropZoneBorder('blue.500')}
+      minHeight="calc(250px - 2rem)"
+      display="flex"
+      justifyContent="center"
+      alignItems="center"
+      id="dropzone"
+    >
+      <input {...getInputProps()} data-testid="batch-load-dropzone" />
+      {isDragActive && <Text>{t('rjsf.batchUpload.dropZone.dropping', { ns: 'components' })}</Text>}
+      {loading && <Text>{t('rjsf.batchUpload.dropZone.loading', { ns: 'components' })}</Text>}
+      {!isDragActive && !loading && (
+        <>
+          <Text>{t('topicFilter.schema.actions.upload')}</Text>
+          <Button onClick={open}>{t('rjsf.batchUpload.dropZone.selectFile', { ns: 'components' })}</Button>
+        </>
+      )}
+    </VStack>
+  )
+}
+
+export default SchemaUploader

--- a/hivemq-edge/src/frontend/src/modules/TopicFilters/components/SchemaValidationMark.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/TopicFilters/components/SchemaValidationMark.spec.cy.tsx
@@ -1,21 +1,14 @@
 import { MOCK_TOPIC_FILTER } from '@/api/hooks/useTopicFilters/__handlers__'
-import { GENERATE_DATA_MODELS } from '@/api/hooks/useDomainModel/__handlers__'
 import SchemaValidationMark from '@/modules/TopicFilters/components/SchemaValidationMark.tsx'
 
 describe('SchemaValidationMark', () => {
   beforeEach(() => {
     cy.viewport(800, 800)
-    cy.intercept('/api/v1/management/sampling/topic/**', { items: [] }).as('getTopic')
-
-    cy.intercept('/api/v1/management/sampling/schema/**', GENERATE_DATA_MODELS(true, MOCK_TOPIC_FILTER.topicFilter)).as(
-      'getSchema'
-    )
   })
 
   it('should render properly', () => {
     cy.mountWithProviders(<SchemaValidationMark topicFilter={MOCK_TOPIC_FILTER} />)
 
-    cy.getByTestId('validation-loading').should('be.visible')
     cy.get('[role="alert"]').should('have.attr', 'data-status', 'success')
   })
 })

--- a/hivemq-edge/src/frontend/src/modules/TopicFilters/components/SchemaValidationMark.tsx
+++ b/hivemq-edge/src/frontend/src/modules/TopicFilters/components/SchemaValidationMark.tsx
@@ -1,23 +1,21 @@
 import { FC, useMemo } from 'react'
-import { Alert, AlertIcon, Spinner } from '@chakra-ui/react'
+import { Alert, AlertIcon } from '@chakra-ui/react'
 
 import { TopicFilter } from '@/api/__generated__'
-import { useSamplingForTopic } from '@/api/hooks/useDomainModel/useSamplingForTopic.ts'
+import { SchemaHandler, validateSchemaFromDataURI } from '@/modules/TopicFilters/utils/topic-filter.schema.ts'
 
 interface SchemaValidationMarkProps {
   topicFilter: TopicFilter
 }
 
 const SchemaValidationMark: FC<SchemaValidationMarkProps> = ({ topicFilter }) => {
-  const { schema, isLoading } = useSamplingForTopic(topicFilter.topicFilter)
+  const schemaHandler = useMemo<SchemaHandler>(
+    () => validateSchemaFromDataURI(topicFilter.schema),
+    [topicFilter.schema]
+  )
 
-  const isSchemaValid = useMemo(() => {
-    return schema && Object.keys(schema).length !== 0 && schema.constructor === Object
-  }, [schema])
-
-  if (isLoading) return <Spinner size="xs" data-testid="validation-loading" />
   return (
-    <Alert status={isSchemaValid ? 'success' : 'error'} size="xs" py={1} pl={2}>
+    <Alert status={schemaHandler.status} size="xs" py={1} pl={2} w={10}>
       <AlertIcon />
     </Alert>
   )

--- a/hivemq-edge/src/frontend/src/modules/TopicFilters/components/TopicSchemaDrawer.tsx
+++ b/hivemq-edge/src/frontend/src/modules/TopicFilters/components/TopicSchemaDrawer.tsx
@@ -19,7 +19,7 @@ import {
 
 import { TopicFilter } from '@/api/__generated__'
 import { Topic } from '@/components/MQTT/EntityTag.tsx'
-import SchemaManager from '@/modules/TopicFilters/components/SchemaManager.tsx'
+import TopicSchemaManager from '@/modules/TopicFilters/components/TopicSchemaManager.tsx'
 
 interface TopicSchemaDrawerProps {
   topicFilter: TopicFilter
@@ -39,7 +39,7 @@ const TopicSchemaDrawer: FC<TopicSchemaDrawerProps> = ({ topicFilter, trigger })
   return (
     <>
       {trigger(props)}
-      <Drawer isOpen={isOpen} placement="right" size="md" onClose={onClose} closeOnOverlayClick={false}>
+      <Drawer isOpen={isOpen} placement="right" size="lg" onClose={onClose} closeOnOverlayClick={false}>
         <DrawerOverlay />
         <DrawerContent>
           <DrawerCloseButton />
@@ -48,12 +48,12 @@ const TopicSchemaDrawer: FC<TopicSchemaDrawerProps> = ({ topicFilter, trigger })
           </DrawerHeader>
 
           <DrawerBody>
-            <Card>
+            <Card size="sm">
               <CardHeader>
-                <Topic tagTitle={topicFilter.topicFilter} mr={3} />
+                Topic Filter: <Topic tagTitle={topicFilter.topicFilter} mr={3} />
               </CardHeader>
               <CardBody>
-                <SchemaManager topicFilter={topicFilter} />
+                <TopicSchemaManager topicFilter={topicFilter} />
               </CardBody>
             </Card>
           </DrawerBody>

--- a/hivemq-edge/src/frontend/src/modules/TopicFilters/components/TopicSchemaDrawer.tsx
+++ b/hivemq-edge/src/frontend/src/modules/TopicFilters/components/TopicSchemaDrawer.tsx
@@ -50,7 +50,8 @@ const TopicSchemaDrawer: FC<TopicSchemaDrawerProps> = ({ topicFilter, trigger })
           <DrawerBody>
             <Card size="sm">
               <CardHeader>
-                Topic Filter: <Topic tagTitle={topicFilter.topicFilter} mr={3} />
+                <Text as="span">{t('topicFilter.schema.title')}</Text>{' '}
+                <Topic tagTitle={topicFilter.topicFilter} mr={3} />
               </CardHeader>
               <CardBody>
                 <TopicSchemaManager topicFilter={topicFilter} />

--- a/hivemq-edge/src/frontend/src/modules/TopicFilters/components/TopicSchemaManager.tsx
+++ b/hivemq-edge/src/frontend/src/modules/TopicFilters/components/TopicSchemaManager.tsx
@@ -40,6 +40,10 @@ const TopicSchemaManager: FC<CurrentSchemaProps> = ({ topicFilter }) => {
     onUpdate(topicFilter.topicFilter, { ...topicFilter, schema: dataUri })
   }
 
+  const onHandleClear = () => {
+    onUpdate(topicFilter.topicFilter, { ...topicFilter, schema: undefined })
+  }
+
   return (
     <VStack>
       <ErrorMessage message={schemaHandler.error} status={schemaHandler.status} type={schemaHandler.message} />
@@ -64,7 +68,9 @@ const TopicSchemaManager: FC<CurrentSchemaProps> = ({ topicFilter }) => {
                       <JsonSchemaBrowser schema={schemaHandler.schema} />
                     </CardBody>
                     <CardFooter justifyContent="flex-end">
-                      <Button isDisabled>{t('topicFilter.schema.actions.remove')}</Button>
+                      <Button isDisabled={Boolean(!topicFilter.schema)} onClick={onHandleClear}>
+                        {t('topicFilter.schema.actions.remove')}
+                      </Button>
                     </CardFooter>
                   </Card>
                 )}

--- a/hivemq-edge/src/frontend/src/modules/TopicFilters/components/TopicSchemaManager.tsx
+++ b/hivemq-edge/src/frontend/src/modules/TopicFilters/components/TopicSchemaManager.tsx
@@ -67,7 +67,7 @@ const TopicSchemaManager: FC<CurrentSchemaProps> = ({ topicFilter }) => {
                     {schemaHandler.error && (
                       <ErrorMessage message={schemaHandler.error} status={schemaHandler.status} />
                     )}
-                    {schemaHandler.schema && <JsonSchemaBrowser schema={schemaHandler.schema} />}
+                    {schemaHandler.schema && <JsonSchemaBrowser schema={schemaHandler.schema} hasExamples />}
                   </CardBody>
                   <CardFooter justifyContent="flex-end">
                     <Button isDisabled={Boolean(!topicFilter.schema)} onClick={onHandleClear}>

--- a/hivemq-edge/src/frontend/src/modules/TopicFilters/components/TopicSchemaManager.tsx
+++ b/hivemq-edge/src/frontend/src/modules/TopicFilters/components/TopicSchemaManager.tsx
@@ -19,7 +19,7 @@ import { TopicFilter } from '@/api/__generated__'
 import JsonSchemaBrowser from '@/components/rjsf/MqttTransformation/JsonSchemaBrowser.tsx'
 import ErrorMessage from '@/components/ErrorMessage.tsx'
 import SchemaUploader from '@/modules/TopicFilters/components/SchemaUploader.tsx'
-import SchemaManager from '@/modules/TopicFilters/components/SchemaManager.tsx'
+import SchemaSampler from '@/modules/TopicFilters/components/SchemaSampler.tsx'
 import { useTopicFilterManager } from '@/modules/TopicFilters/hooks/useTopicFilterManager.ts'
 import { SchemaHandler, validateSchemaFromDataURI } from '@/modules/TopicFilters/utils/topic-filter.schema.ts'
 import { useTranslation } from 'react-i18next'
@@ -46,7 +46,7 @@ const TopicSchemaManager: FC<CurrentSchemaProps> = ({ topicFilter }) => {
 
   return (
     <VStack>
-      <ErrorMessage message={schemaHandler.error} status={schemaHandler.status} type={schemaHandler.message} />
+      <ErrorMessage status={schemaHandler.status} type={schemaHandler.message} />
 
       <Card size="sm">
         <CardHeader>
@@ -56,39 +56,31 @@ const TopicSchemaManager: FC<CurrentSchemaProps> = ({ topicFilter }) => {
           <Tabs isLazy>
             <TabList>
               <Tab>{t('topicFilter.schema.tabs.current')}</Tab>
-              <Tab>{t('topicFilter.schema.tabs.upload')}</Tab>
               <Tab>{t('topicFilter.schema.tabs.infer')}</Tab>
+              <Tab>{t('topicFilter.schema.tabs.upload')}</Tab>
             </TabList>
 
             <TabPanels>
               <TabPanel>
-                {schemaHandler.schema && (
-                  <Card>
-                    <CardBody>
-                      <JsonSchemaBrowser schema={schemaHandler.schema} />
-                    </CardBody>
-                    <CardFooter justifyContent="flex-end">
-                      <Button isDisabled={Boolean(!topicFilter.schema)} onClick={onHandleClear}>
-                        {t('topicFilter.schema.actions.remove')}
-                      </Button>
-                    </CardFooter>
-                  </Card>
-                )}
-              </TabPanel>
-              <TabPanel>
-                <Card>
-                  <SchemaUploader onUpload={onHandleUpload} />
-                </Card>
-              </TabPanel>
-              <TabPanel>
                 <Card>
                   <CardBody>
-                    <SchemaManager topicFilter={topicFilter} />
+                    {schemaHandler.error && (
+                      <ErrorMessage message={schemaHandler.error} status={schemaHandler.status} />
+                    )}
+                    {schemaHandler.schema && <JsonSchemaBrowser schema={schemaHandler.schema} />}
                   </CardBody>
                   <CardFooter justifyContent="flex-end">
-                    <Button isDisabled>{t('topicFilter.schema.actions.assign')}</Button>
+                    <Button isDisabled={Boolean(!topicFilter.schema)} onClick={onHandleClear}>
+                      {t('topicFilter.schema.actions.remove')}
+                    </Button>
                   </CardFooter>
                 </Card>
+              </TabPanel>
+              <TabPanel>
+                <SchemaSampler topicFilter={topicFilter} onUpload={onHandleUpload} />
+              </TabPanel>
+              <TabPanel>
+                <SchemaUploader onUpload={onHandleUpload} />
               </TabPanel>
             </TabPanels>
           </Tabs>

--- a/hivemq-edge/src/frontend/src/modules/TopicFilters/components/TopicSchemaManager.tsx
+++ b/hivemq-edge/src/frontend/src/modules/TopicFilters/components/TopicSchemaManager.tsx
@@ -1,0 +1,95 @@
+import { FC, useMemo } from 'react'
+import {
+  Button,
+  Card,
+  CardBody,
+  CardFooter,
+  CardHeader,
+  Tab,
+  TabList,
+  TabPanel,
+  TabPanels,
+  Tabs,
+  Text,
+  VStack,
+} from '@chakra-ui/react'
+
+import { TopicFilter } from '@/api/__generated__'
+
+import JsonSchemaBrowser from '@/components/rjsf/MqttTransformation/JsonSchemaBrowser.tsx'
+import ErrorMessage from '@/components/ErrorMessage.tsx'
+import SchemaUploader from '@/modules/TopicFilters/components/SchemaUploader.tsx'
+import SchemaManager from '@/modules/TopicFilters/components/SchemaManager.tsx'
+import { useTopicFilterManager } from '@/modules/TopicFilters/hooks/useTopicFilterManager.ts'
+import { SchemaHandler, validateSchemaFromDataURI } from '@/modules/TopicFilters/utils/topic-filter.schema.ts'
+import { useTranslation } from 'react-i18next'
+
+interface CurrentSchemaProps {
+  topicFilter: TopicFilter
+}
+
+const TopicSchemaManager: FC<CurrentSchemaProps> = ({ topicFilter }) => {
+  const { t } = useTranslation()
+  const schemaHandler = useMemo<SchemaHandler>(
+    () => validateSchemaFromDataURI(topicFilter.schema),
+    [topicFilter.schema]
+  )
+  const { onUpdate } = useTopicFilterManager()
+
+  const onHandleUpload = (dataUri: string) => {
+    onUpdate(topicFilter.topicFilter, { ...topicFilter, schema: dataUri })
+  }
+
+  return (
+    <VStack>
+      <ErrorMessage message={schemaHandler.error} status={schemaHandler.status} type={schemaHandler.message} />
+
+      <Card size="sm">
+        <CardHeader>
+          <Text>{t('topicFilter.schema.prompt')}</Text>
+        </CardHeader>
+        <CardBody>
+          <Tabs isLazy>
+            <TabList>
+              <Tab>{t('topicFilter.schema.tabs.current')}</Tab>
+              <Tab>{t('topicFilter.schema.tabs.upload')}</Tab>
+              <Tab>{t('topicFilter.schema.tabs.infer')}</Tab>
+            </TabList>
+
+            <TabPanels>
+              <TabPanel>
+                {schemaHandler.schema && (
+                  <Card>
+                    <CardBody>
+                      <JsonSchemaBrowser schema={schemaHandler.schema} />
+                    </CardBody>
+                    <CardFooter justifyContent="flex-end">
+                      <Button isDisabled>{t('topicFilter.schema.actions.remove')}</Button>
+                    </CardFooter>
+                  </Card>
+                )}
+              </TabPanel>
+              <TabPanel>
+                <Card>
+                  <SchemaUploader onUpload={onHandleUpload} />
+                </Card>
+              </TabPanel>
+              <TabPanel>
+                <Card>
+                  <CardBody>
+                    <SchemaManager topicFilter={topicFilter} />
+                  </CardBody>
+                  <CardFooter justifyContent="flex-end">
+                    <Button isDisabled>{t('topicFilter.schema.actions.assign')}</Button>
+                  </CardFooter>
+                </Card>
+              </TabPanel>
+            </TabPanels>
+          </Tabs>
+        </CardBody>
+      </Card>
+    </VStack>
+  )
+}
+
+export default TopicSchemaManager

--- a/hivemq-edge/src/frontend/src/modules/TopicFilters/hooks/useTopicFilterManager.spec.ts
+++ b/hivemq-edge/src/frontend/src/modules/TopicFilters/hooks/useTopicFilterManager.spec.ts
@@ -4,7 +4,7 @@ import { renderHook, waitFor } from '@testing-library/react'
 import { server } from '@/__test-utils__/msw/mockServer.ts'
 import { SimpleWrapper as wrapper } from '@/__test-utils__/hooks/SimpleWrapper.tsx'
 import { useTopicFilterManager } from '@/modules/TopicFilters/hooks/useTopicFilterManager.ts'
-import { handlers } from '@/api/hooks/useTopicFilters/__handlers__'
+import { handlers, MOCK_TOPIC_FILTER_SCHEMA_VALID } from '@/api/hooks/useTopicFilters/__handlers__'
 
 import '@/config/i18n.config.ts'
 
@@ -27,6 +27,7 @@ describe('useTopicFilterManager', () => {
             {
               description: 'This is a topic filter',
               topicFilter: 'a/topic/+/filter',
+              schema: MOCK_TOPIC_FILTER_SCHEMA_VALID,
             },
           ],
         },

--- a/hivemq-edge/src/frontend/src/modules/TopicFilters/hooks/useTopicFilterManager.ts
+++ b/hivemq-edge/src/frontend/src/modules/TopicFilters/hooks/useTopicFilterManager.ts
@@ -56,15 +56,15 @@ export const useTopicFilterManager = () => {
   // TODO[NVL] Insert Edge-wide toast configuration (need refactoring)
   const formatToast = (operation: string) => ({
     success: {
-      title: t(`device.drawer.tagList.toast.${operation}.title`),
+      title: t(`topicFilter.toast.${operation}.title`),
       description: t(`topicFilter.toast.${operation}.description`, { context: 'success' }),
     },
     error: {
-      title: t(`device.drawer.tagList.toast.${operation}.title`),
+      title: t(`topicFilter.toast.${operation}.title`),
       description: t(`topicFilter.toast.${operation}.description`, { context: 'error' }),
     },
     loading: {
-      title: t(`device.drawer.tagList.toast.${operation}.title`),
+      title: t(`topicFilter.toast.${operation}.title`),
       description: t('topicFilter.toast.description', { context: 'loading' }),
     },
   })

--- a/hivemq-edge/src/frontend/src/modules/TopicFilters/utils/topic-filter.schema.spec.ts
+++ b/hivemq-edge/src/frontend/src/modules/TopicFilters/utils/topic-filter.schema.spec.ts
@@ -1,0 +1,35 @@
+import { describe, expect } from 'vitest'
+import { decodeDataUriJsonSchema } from '@/modules/TopicFilters/utils/topic-filter.schema.ts'
+
+interface Suite {
+  data: string
+  error: string
+}
+
+describe('decodeDataUriJsonSchema', () => {
+  const tests: Suite[] = [
+    { data: '', error: 'Not a valid data-url encoded JSONSchema' },
+    { data: '123', error: 'Not a valid data-url encoded JSONSchema' },
+    { data: '123,456', error: 'No scheme defined in the URI' },
+    { data: '123:test,456', error: "The scheme of the uri is not defined as 'data'" },
+    { data: 'data:test,456', error: "The media types doesn't include the mandatory `application/schema+json`" },
+    { data: 'data:application/json,456', error: "The media types doesn't include the mandatory `base64`" },
+    { data: 'data:application/json;base64,456', error: 'The data is not properly encoded as a `base64` string' },
+    {
+      data: 'data:application/json;base64,ewogICJ0ZXN0IjogMQp9Cg==',
+      error: 'Not a valid JSONSchema: `properties` is missing',
+    },
+  ]
+
+  it.each<Suite>(tests)('$data should throw $error', ({ data, error }) => {
+    expect(() => decodeDataUriJsonSchema(data)).toThrowError(error)
+  })
+
+  it('should return a valid json object', () => {
+    expect(
+      decodeDataUriJsonSchema(
+        'data:application/json;base64,IHsKICAgICJ0eXBlIiA6ICJvYmplY3QiLAogICAgInByb3BlcnRpZXMiIDogewogICAgICAiZGVmaW5pdGlvbiIgOiB7CiAgICAgICAgInR5cGUiIDogIm9iamVjdCIsCiAgICAgICAgInByb3BlcnRpZXMiIDogewogICAgICAgICAgImRhdGFUeXBlIiA6IHsKICAgICAgICAgICAgInR5cGUiIDogInN0cmluZyIsCiAgICAgICAgICAgICJlbnVtIiA6IFsgIk5VTEwiLCAiQk9PTCIsICJCWVRFIiwgIldPUkQiLCAiRFdPUkQiLCAiTFdPUkQiLCAiVVNJTlQiLCAiVUlOVCIsICJVRElOVCIsICJVTElOVCIsICJTSU5UIiwgIklOVCIsICJESU5UIiwgIkxJTlQiLCAiUkVBTCIsICJMUkVBTCIsICJDSEFSIiwgIldDSEFSIiwgIlNUUklORyIsICJXU1RSSU5HIiwgIlRJTUUiLCAiTFRJTUUiLCAiREFURSIsICJMREFURSIsICJUSU1FX09GX0RBWSIsICJMVElNRV9PRl9EQVkiLCAiREFURV9BTkRfVElNRSIsICJMREFURV9BTkRfVElNRSIsICJSQVdfQllURV9BUlJBWSIgXSwKICAgICAgICAgICAgInRpdGxlIiA6ICJEYXRhIFR5cGUiLAogICAgICAgICAgICAiZGVzY3JpcHRpb24iIDogIlRoZSBleHBlY3RlZCBkYXRhIHR5cGUgb2YgdGhlIHRhZyIsCiAgICAgICAgICAgICJlbnVtTmFtZXMiIDogWyAiTnVsbCIsICJCb29sZWFuIiwgIkJ5dGUiLCAiV29yZCAodW5pdCAxNikiLCAiRFdvcmQgKHVpbnQgMzIpIiwgIkxXb3JkICh1aW50IDY0KSIsICJVU2ludCAodWludCA4KSIsICJVaW50ICh1aW50IDE2KSIsICJVRGludCAodWludCAzMikiLCAiVUxpbnQgKHVpbnQgNjQpIiwgIlNpbnQgKGludCA4KSIsICJJbnQgKGludCAxNikiLCAiRGludCAoaW50IDMyKSIsICJMaW50IChpbnQgNjQpIiwgIlJlYWwgKGZsb2F0IDMyKSIsICJMUmVhbCAoZG91YmxlIDY0KSIsICJDaGFyICgxIGJ5dGUgY2hhcikiLCAiV0NoYXIgKDIgYnl0ZSBjaGFyKSIsICJTdHJpbmciLCAiV1N0cmluZyIsICJUaW1pbmcgKER1cmF0aW9uIG1zKSIsICJMb25nIFRpbWluZyAoRHVyYXRpb24gbnMpIiwgIkRhdGUgKERhdGVTdGFtcCkiLCAiTG9uZyBEYXRlIChEYXRlU3RhbXApIiwgIlRpbWUgT2YgRGF5IChUaW1lU3RhbXApIiwgIkxvbmcgVGltZSBPZiBEYXkgKFRpbWVTdGFtcCkiLCAiRGF0ZSBUaW1lIChEYXRlVGltZVN0YW1wKSIsICJMb25nIERhdGUgVGltZSAoRGF0ZVRpbWVTdGFtcCkiLCAiUmF3IEJ5dGUgQXJyYXkiIF0KICAgICAgICAgIH0sCiAgICAgICAgICAidGFnQWRkcmVzcyIgOiB7CiAgICAgICAgICAgICJ0eXBlIiA6ICJzdHJpbmciLAogICAgICAgICAgICAidGl0bGUiIDogIlRhZyBBZGRyZXNzIiwKICAgICAgICAgICAgImRlc2NyaXB0aW9uIiA6ICJUaGUgd2VsbCBmb3JtZWQgYWRkcmVzcyBvZiB0aGUgdGFnIHRvIHJlYWQiCiAgICAgICAgICB9CiAgICAgICAgfSwKICAgICAgICAicmVxdWlyZWQiIDogWyAiZGF0YVR5cGUiLCAidGFnQWRkcmVzcyIgXSwKICAgICAgICAidGl0bGUiIDogImRlZmluaXRpb24iLAogICAgICAgICJkZXNjcmlwdGlvbiIgOiAiVGhlIGFjdHVhbCBkZWZpbml0aW9uIG9mIHRoZSB0YWcgb24gdGhlIGRldmljZSIKICAgICAgfSwKICAgICAgImRlc2NyaXB0aW9uIiA6IHsKICAgICAgICAidHlwZSIgOiAic3RyaW5nIiwKICAgICAgICAidGl0bGUiIDogImRlc2NyaXB0aW9uIiwKICAgICAgICAiZGVzY3JpcHRpb24iIDogIkEgaHVtYW4gcmVhZGFibGUgZGVzY3JpcHRpb24gb2YgdGhlIHRhZyIKICAgICAgfSwKICAgICAgIm5hbWUiIDogewogICAgICAgICJ0eXBlIiA6ICJzdHJpbmciLAogICAgICAgICJ0aXRsZSIgOiAibmFtZSIsCiAgICAgICAgImRlc2NyaXB0aW9uIiA6ICJuYW1lIG9mIHRoZSB0YWcgdG8gYmUgdXNlZCBpbiBtYXBwaW5ncyIKICAgICAgfQogICAgfSwKICAgICJyZXF1aXJlZCIgOiBbICJkZWZpbml0aW9uIiwgImRlc2NyaXB0aW9uIiwgIm5hbWUiIF0KICB9Cg=='
+      )
+    ).toBeFalsy
+  })
+})

--- a/hivemq-edge/src/frontend/src/modules/TopicFilters/utils/topic-filter.schema.spec.ts
+++ b/hivemq-edge/src/frontend/src/modules/TopicFilters/utils/topic-filter.schema.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect } from 'vitest'
 import {
   decodeDataUriJsonSchema,
+  encodeDataUriJsonSchema,
   SchemaHandler,
   validateSchemaFromDataURI,
 } from '@/modules/TopicFilters/utils/topic-filter.schema.ts'
@@ -20,10 +21,6 @@ describe('decodeDataUriJsonSchema', () => {
     { data: 'data:test,456', error: "The media types doesn't include the mandatory `application/schema+json`" },
     { data: 'data:application/json,456', error: "The media types doesn't include the mandatory `base64`" },
     { data: 'data:application/json;base64,456', error: 'The data is not properly encoded as a `base64` string' },
-    {
-      data: 'data:application/json;base64,ewogICJ0ZXN0IjogMQp9Cg==',
-      error: 'Not a valid JSONSchema: `properties` is missing',
-    },
   ]
 
   it.each<Suite>(tests)('$data should throw $error', ({ data, error }) => {
@@ -35,21 +32,20 @@ describe('decodeDataUriJsonSchema', () => {
   })
 })
 
+describe('encodeDataUriJsonSchema', () => {
+  it('should return a data-url', () => {
+    const schema = { test: 1 }
+    expect(encodeDataUriJsonSchema(schema)).toStrictEqual<string>(
+      `data:application/json;base64,${btoa(JSON.stringify(schema))}`
+    )
+  })
+})
+
 describe('validateSchemaFromDataURI', () => {
   it('should return a warning if not assigned', () => {
     expect(validateSchemaFromDataURI(undefined)).toStrictEqual<SchemaHandler>({
       status: 'warning',
       message: expect.stringContaining(''),
-    })
-  })
-
-  it('should return an error', () => {
-    expect(
-      validateSchemaFromDataURI('data:application/json;base64,ewogICJ0ZXN0IjogMQp9Cg==')
-    ).toStrictEqual<SchemaHandler>({
-      error: 'Not a valid JSONSchema: `properties` is missing',
-      message: expect.stringContaining(''),
-      status: 'error',
     })
   })
 

--- a/hivemq-edge/src/frontend/src/modules/TopicFilters/utils/topic-filter.schema.spec.ts
+++ b/hivemq-edge/src/frontend/src/modules/TopicFilters/utils/topic-filter.schema.spec.ts
@@ -1,5 +1,10 @@
 import { describe, expect } from 'vitest'
-import { decodeDataUriJsonSchema } from '@/modules/TopicFilters/utils/topic-filter.schema.ts'
+import {
+  decodeDataUriJsonSchema,
+  SchemaHandler,
+  validateSchemaFromDataURI,
+} from '@/modules/TopicFilters/utils/topic-filter.schema.ts'
+import { MOCK_TOPIC_FILTER_SCHEMA_VALID } from '@/api/hooks/useTopicFilters/__handlers__'
 
 interface Suite {
   data: string
@@ -26,10 +31,33 @@ describe('decodeDataUriJsonSchema', () => {
   })
 
   it('should return a valid json object', () => {
+    expect(decodeDataUriJsonSchema(MOCK_TOPIC_FILTER_SCHEMA_VALID)).toBeFalsy
+  })
+})
+
+describe('validateSchemaFromDataURI', () => {
+  it('should return a warning if not assigned', () => {
+    expect(validateSchemaFromDataURI(undefined)).toStrictEqual<SchemaHandler>({
+      status: 'warning',
+      message: expect.stringContaining(''),
+    })
+  })
+
+  it('should return an error', () => {
     expect(
-      decodeDataUriJsonSchema(
-        'data:application/json;base64,IHsKICAgICJ0eXBlIiA6ICJvYmplY3QiLAogICAgInByb3BlcnRpZXMiIDogewogICAgICAiZGVmaW5pdGlvbiIgOiB7CiAgICAgICAgInR5cGUiIDogIm9iamVjdCIsCiAgICAgICAgInByb3BlcnRpZXMiIDogewogICAgICAgICAgImRhdGFUeXBlIiA6IHsKICAgICAgICAgICAgInR5cGUiIDogInN0cmluZyIsCiAgICAgICAgICAgICJlbnVtIiA6IFsgIk5VTEwiLCAiQk9PTCIsICJCWVRFIiwgIldPUkQiLCAiRFdPUkQiLCAiTFdPUkQiLCAiVVNJTlQiLCAiVUlOVCIsICJVRElOVCIsICJVTElOVCIsICJTSU5UIiwgIklOVCIsICJESU5UIiwgIkxJTlQiLCAiUkVBTCIsICJMUkVBTCIsICJDSEFSIiwgIldDSEFSIiwgIlNUUklORyIsICJXU1RSSU5HIiwgIlRJTUUiLCAiTFRJTUUiLCAiREFURSIsICJMREFURSIsICJUSU1FX09GX0RBWSIsICJMVElNRV9PRl9EQVkiLCAiREFURV9BTkRfVElNRSIsICJMREFURV9BTkRfVElNRSIsICJSQVdfQllURV9BUlJBWSIgXSwKICAgICAgICAgICAgInRpdGxlIiA6ICJEYXRhIFR5cGUiLAogICAgICAgICAgICAiZGVzY3JpcHRpb24iIDogIlRoZSBleHBlY3RlZCBkYXRhIHR5cGUgb2YgdGhlIHRhZyIsCiAgICAgICAgICAgICJlbnVtTmFtZXMiIDogWyAiTnVsbCIsICJCb29sZWFuIiwgIkJ5dGUiLCAiV29yZCAodW5pdCAxNikiLCAiRFdvcmQgKHVpbnQgMzIpIiwgIkxXb3JkICh1aW50IDY0KSIsICJVU2ludCAodWludCA4KSIsICJVaW50ICh1aW50IDE2KSIsICJVRGludCAodWludCAzMikiLCAiVUxpbnQgKHVpbnQgNjQpIiwgIlNpbnQgKGludCA4KSIsICJJbnQgKGludCAxNikiLCAiRGludCAoaW50IDMyKSIsICJMaW50IChpbnQgNjQpIiwgIlJlYWwgKGZsb2F0IDMyKSIsICJMUmVhbCAoZG91YmxlIDY0KSIsICJDaGFyICgxIGJ5dGUgY2hhcikiLCAiV0NoYXIgKDIgYnl0ZSBjaGFyKSIsICJTdHJpbmciLCAiV1N0cmluZyIsICJUaW1pbmcgKER1cmF0aW9uIG1zKSIsICJMb25nIFRpbWluZyAoRHVyYXRpb24gbnMpIiwgIkRhdGUgKERhdGVTdGFtcCkiLCAiTG9uZyBEYXRlIChEYXRlU3RhbXApIiwgIlRpbWUgT2YgRGF5IChUaW1lU3RhbXApIiwgIkxvbmcgVGltZSBPZiBEYXkgKFRpbWVTdGFtcCkiLCAiRGF0ZSBUaW1lIChEYXRlVGltZVN0YW1wKSIsICJMb25nIERhdGUgVGltZSAoRGF0ZVRpbWVTdGFtcCkiLCAiUmF3IEJ5dGUgQXJyYXkiIF0KICAgICAgICAgIH0sCiAgICAgICAgICAidGFnQWRkcmVzcyIgOiB7CiAgICAgICAgICAgICJ0eXBlIiA6ICJzdHJpbmciLAogICAgICAgICAgICAidGl0bGUiIDogIlRhZyBBZGRyZXNzIiwKICAgICAgICAgICAgImRlc2NyaXB0aW9uIiA6ICJUaGUgd2VsbCBmb3JtZWQgYWRkcmVzcyBvZiB0aGUgdGFnIHRvIHJlYWQiCiAgICAgICAgICB9CiAgICAgICAgfSwKICAgICAgICAicmVxdWlyZWQiIDogWyAiZGF0YVR5cGUiLCAidGFnQWRkcmVzcyIgXSwKICAgICAgICAidGl0bGUiIDogImRlZmluaXRpb24iLAogICAgICAgICJkZXNjcmlwdGlvbiIgOiAiVGhlIGFjdHVhbCBkZWZpbml0aW9uIG9mIHRoZSB0YWcgb24gdGhlIGRldmljZSIKICAgICAgfSwKICAgICAgImRlc2NyaXB0aW9uIiA6IHsKICAgICAgICAidHlwZSIgOiAic3RyaW5nIiwKICAgICAgICAidGl0bGUiIDogImRlc2NyaXB0aW9uIiwKICAgICAgICAiZGVzY3JpcHRpb24iIDogIkEgaHVtYW4gcmVhZGFibGUgZGVzY3JpcHRpb24gb2YgdGhlIHRhZyIKICAgICAgfSwKICAgICAgIm5hbWUiIDogewogICAgICAgICJ0eXBlIiA6ICJzdHJpbmciLAogICAgICAgICJ0aXRsZSIgOiAibmFtZSIsCiAgICAgICAgImRlc2NyaXB0aW9uIiA6ICJuYW1lIG9mIHRoZSB0YWcgdG8gYmUgdXNlZCBpbiBtYXBwaW5ncyIKICAgICAgfQogICAgfSwKICAgICJyZXF1aXJlZCIgOiBbICJkZWZpbml0aW9uIiwgImRlc2NyaXB0aW9uIiwgIm5hbWUiIF0KICB9Cg=='
-      )
-    ).toBeFalsy
+      validateSchemaFromDataURI('data:application/json;base64,ewogICJ0ZXN0IjogMQp9Cg==')
+    ).toStrictEqual<SchemaHandler>({
+      error: 'Not a valid JSONSchema: `properties` is missing',
+      message: expect.stringContaining(''),
+      status: 'error',
+    })
+  })
+
+  it('should return a schema', () => {
+    expect(validateSchemaFromDataURI(MOCK_TOPIC_FILTER_SCHEMA_VALID)).toStrictEqual<SchemaHandler>({
+      message: expect.stringContaining(''),
+      status: 'success',
+      schema: expect.objectContaining({}),
+    })
   })
 })

--- a/hivemq-edge/src/frontend/src/modules/TopicFilters/utils/topic-filter.schema.ts
+++ b/hivemq-edge/src/frontend/src/modules/TopicFilters/utils/topic-filter.schema.ts
@@ -57,6 +57,10 @@ export const decodeDataUriJsonSchema = (dataUrl: string) => {
   }
 }
 
+export const encodeDataUriJsonSchema = (schema: RJSFSchema) => {
+  return `data:${MIMETYPE_JSON};base64,${btoa(JSON.stringify(schema))}`
+}
+
 export interface SchemaHandler {
   schema?: JSONSchema7
   error?: string

--- a/hivemq-edge/src/frontend/src/modules/TopicFilters/utils/topic-filter.schema.ts
+++ b/hivemq-edge/src/frontend/src/modules/TopicFilters/utils/topic-filter.schema.ts
@@ -1,0 +1,56 @@
+// data:content/type;base64,
+import { RJSFSchema } from '@rjsf/utils'
+import { Accept } from 'react-dropzone'
+import validator from '@rjsf/validator-ajv8'
+
+import i18n from '@/config/i18n.config.ts'
+
+export const MIMETYPE_JSON = 'application/json'
+export const MIMETYPE_JSON_SCHEMA = 'application/schema+json'
+export const ACCEPT_JSON_SCHEMA: Accept = {
+  [MIMETYPE_JSON_SCHEMA]: ['.json'],
+}
+const DECODE_HEADER_SEPARATOR = ','
+const DECODE_SCHEME_SEPARATOR = ':'
+const DECODE_MEDIA_TYPES_SEPARATOR = ';'
+const DECODE_DATA = 'data'
+const DECODE_BASE64 = 'base64'
+
+export interface UriInfo {
+  mimeType: string
+  options?: string[]
+  body: RJSFSchema
+}
+
+export const decodeDataUriJsonSchema = (dataUrl: string) => {
+  const [header, data] = dataUrl.split(DECODE_HEADER_SEPARATOR)
+  if (!data || !header) throw new Error(i18n.t('topicFilter.error.schema.noDataUri'))
+
+  const [scheme, mediaTypes] = header.split(DECODE_SCHEME_SEPARATOR)
+  if (!mediaTypes) throw new Error(i18n.t('topicFilter.error.schema.noScheme'))
+  if (scheme !== DECODE_DATA) throw new Error(i18n.t('topicFilter.error.schema.noSchemeData'))
+
+  const options = mediaTypes.split(DECODE_MEDIA_TYPES_SEPARATOR)
+  if (!options.includes(MIMETYPE_JSON)) throw new Error(i18n.t('topicFilter.error.schema.noJsonSchemaMimeType'))
+  if (!options.includes(DECODE_BASE64)) throw new Error(i18n.t('topicFilter.error.schema.noBase64MediaType'))
+
+  try {
+    const decoded = atob(data)
+    const json: RJSFSchema = JSON.parse(decoded)
+
+    // This will take care of some of the basic json error but not of a valid JSONSchema
+    const validate = validator.ajv.compile(json)
+    if (validate.errors?.length) throw new Error(i18n.t('topicFilter.error.schema.ajvValidationFails'))
+    // const valid = validate({})
+
+    const { properties } = json
+
+    if (!properties) throw new Error(i18n.t('topicFilter.error.schema.ajvNoProperties'))
+
+    return { mimeType: MIMETYPE_JSON, options, body: json } as UriInfo
+  } catch (error) {
+    if (error instanceof SyntaxError) throw new Error(i18n.t('topicFilter.error.schema.noBase64Data'))
+    if (error instanceof DOMException) throw new Error(i18n.t('topicFilter.error.schema.noJSON'))
+    if (error instanceof Error) throw new Error(error.message)
+  }
+}

--- a/hivemq-edge/src/frontend/src/modules/TopicFilters/utils/topic-filter.schema.ts
+++ b/hivemq-edge/src/frontend/src/modules/TopicFilters/utils/topic-filter.schema.ts
@@ -4,6 +4,8 @@ import { Accept } from 'react-dropzone'
 import validator from '@rjsf/validator-ajv8'
 
 import i18n from '@/config/i18n.config.ts'
+import type { JSONSchema7 } from 'json-schema'
+import type { AlertStatus } from '@chakra-ui/react'
 
 export const MIMETYPE_JSON = 'application/json'
 export const MIMETYPE_JSON_SCHEMA = 'application/schema+json'
@@ -52,5 +54,40 @@ export const decodeDataUriJsonSchema = (dataUrl: string) => {
     if (error instanceof SyntaxError) throw new Error(i18n.t('topicFilter.error.schema.noBase64Data'))
     if (error instanceof DOMException) throw new Error(i18n.t('topicFilter.error.schema.noJSON'))
     if (error instanceof Error) throw new Error(error.message)
+  }
+}
+
+export interface SchemaHandler {
+  schema?: JSONSchema7
+  error?: string
+  status: AlertStatus
+  message: string
+}
+
+export const validateSchemaFromDataURI = (topicFilterSchema: string | undefined): SchemaHandler => {
+  if (!topicFilterSchema)
+    return {
+      status: 'warning',
+      message: i18n.t('topicFilter.schema.status.missing'),
+    }
+  try {
+    const schema = decodeDataUriJsonSchema(topicFilterSchema)
+    if (!schema?.body)
+      return {
+        error: 'no body from the base64 payload',
+        status: 'error',
+        message: i18n.t('topicFilter.schema.status.internalError'),
+      }
+    return {
+      schema: schema.body,
+      status: 'success',
+      message: i18n.t('topicFilter.schema.status.success'),
+    }
+  } catch (e) {
+    return {
+      error: (e as Error).message,
+      status: 'error',
+      message: i18n.t('topicFilter.schema.status.success'),
+    }
   }
 }

--- a/hivemq-edge/src/frontend/src/modules/TopicFilters/utils/topic-filter.schema.ts
+++ b/hivemq-edge/src/frontend/src/modules/TopicFilters/utils/topic-filter.schema.ts
@@ -41,19 +41,19 @@ export const decodeDataUriJsonSchema = (dataUrl: string) => {
     const json: RJSFSchema = JSON.parse(decoded)
 
     // This will take care of some of the basic json error but not of a valid JSONSchema
-    const validate = validator.ajv.compile(json)
-    if (validate.errors?.length) throw new Error(i18n.t('topicFilter.error.schema.ajvValidationFails'))
-    // const valid = validate({})
+    validator.ajv.compile(json)
 
+    // TODO[NVL] We need to decide what we want to require on the schema
     const { properties } = json
-
     if (!properties) throw new Error(i18n.t('topicFilter.error.schema.ajvNoProperties'))
 
     return { mimeType: MIMETYPE_JSON, options, body: json } as UriInfo
   } catch (error) {
     if (error instanceof SyntaxError) throw new Error(i18n.t('topicFilter.error.schema.noBase64Data'))
     if (error instanceof DOMException) throw new Error(i18n.t('topicFilter.error.schema.noJSON'))
-    if (error instanceof Error) throw new Error(error.message)
+    if (error instanceof Error) {
+      throw new Error(`${error.message}`)
+    }
   }
 }
 
@@ -91,7 +91,7 @@ export const validateSchemaFromDataURI = (topicFilterSchema: string | undefined)
     return {
       error: (e as Error).message,
       status: 'error',
-      message: i18n.t('topicFilter.schema.status.success'),
+      message: i18n.t('topicFilter.schema.status.invalid'),
     }
   }
 }


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/28664/details/

This PR creates a new UX for managing the schema associated with topic filters. It refactors the secondary editor flow in the main list of topic filters (accessible through the  "manage schema" CTA on every item).

The flow is based on three distinct operations:
- the "current schema", if already present, is displayed using the generic rendering paradigm. It is possible to remove it.
- a schema can be "uploaded" using a drag-and-drop interface or a file selector. The file is expected to be a JSON document, valid with JSON-Schema specification 
- a schema can be "inferred" from the traffic on the current Edge instance. If matching topics exist, all their schemas are displayed, for one of them to be selected for replacing the current schema

The three operations are rendered in tabs on a dedicated side panel.

### Out-of-scope
- JSON-Schema has a very relaxed validation process, to deal with a lot of cases. The `properties` are not even a mandatory part of the schema. The basic validation (`RJSF` + `AJV`) will only address structural errors (e.g. wrong JSON). Custom rules and restrictions on acceptable schemas should be considered. 
- the uploaded schema is expected to be a `data-url` bundle (https://www.rfc-editor.org/rfc/rfc2397) and is stored as such with its topic filter. This assumption might have to be reassessed 
- When uploading a schema, the file is directly updated on the relevant item in the list, by way of the `PUT` request. The `GET` cache is therefore updated and the `React` lifecycle automatically updates the DOM. The result is that the schema editor is closed abruptly. This behaviour might be considered too brusque for a proper UX and will be looked at in the subsequent ticket

### Before
![screenshot-localhost_3000-2024_12_09-15_11_00](https://github.com/user-attachments/assets/d212023d-43ed-4041-8fa6-e7eeab81add4)
![screenshot-localhost_3000-2024_12_09-15_11_13](https://github.com/user-attachments/assets/32517ea1-b297-4b72-b6b2-e0fcc88a602a)


### After
![screenshot-localhost_3000-2024_12_09-15_09_36](https://github.com/user-attachments/assets/6455f64d-cfd0-4385-9dab-76d531bf2670)


![screenshot-localhost_3000-2024_12_09-15_09_55](https://github.com/user-attachments/assets/3e07d59b-72da-437e-8d39-3b751a9894a5)

![screenshot-localhost_3000-2024_12_09-15_10_03](https://github.com/user-attachments/assets/4c874bf5-61b3-4a9d-941b-77e0ae31b394)

![screenshot-localhost_3000-2024_12_09-15_10_11](https://github.com/user-attachments/assets/86939736-dcb0-4604-a541-1076285e2b8e)

![screenshot-localhost_3000-2024_12_09-15_10_30](https://github.com/user-attachments/assets/6320d083-b6c9-43c9-8d1b-98fef407639d)

