### PR TITLE
feat(26143): add installation instructions

### DIFF
--- a/hivemq-edge/src/frontend/src/locales/en/translation.json
+++ b/hivemq-edge/src/frontend/src/locales/en/translation.json
@@ -409,7 +409,8 @@
     "overview": {
       "type": "Type:",
       "author": "Author:",
-      "documentation": "Documentation:"
+      "documentation": "Documentation:",
+      "installation": "This adapter needs to be installed separately. Check the instructions"
     },
     "error": {
       "loading": "We cannot load your adapters for the time being. Please try again later"

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/IntegrationStore/ProtocolsBrowser.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/IntegrationStore/ProtocolsBrowser.spec.cy.tsx
@@ -138,6 +138,11 @@ describe('ProtocolsBrowser', () => {
     )
     cy.getByTestId('protocol-name').should('have.length', 3)
     cy.getByTestId('protocol-create-adapter').should('have.length', 2)
+
+    cy.get('[role="listitem"')
+      .eq(2)
+      .find('a[data-testid="protocol-install-adapter"]')
+      .should('contain', 'This adapter needs to be installed separately. Check the instructions')
   })
 
   it('should be accessible', () => {

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/IntegrationStore/ProtocolsBrowser.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/IntegrationStore/ProtocolsBrowser.tsx
@@ -1,6 +1,6 @@
 import { FC, useMemo } from 'react'
-import { Box, Button, Card, CardBody, CardFooter, SimpleGrid, Skeleton } from '@chakra-ui/react'
-import { ArrowForwardIcon } from '@chakra-ui/icons'
+import { Box, Button, Card, CardBody, CardFooter, Link, SimpleGrid, Skeleton } from '@chakra-ui/react'
+import { ArrowForwardIcon, ExternalLinkIcon } from '@chakra-ui/icons'
 import { useTranslation } from 'react-i18next'
 
 import { ProtocolAdapter } from '@/api/__generated__'
@@ -61,6 +61,11 @@ const ProtocolsBrowser: FC<ProtocolsBrowserProps> = ({ items, facet, onCreate, i
                 >
                   {t('protocolAdapter.action.createInstance')}
                 </Button>
+              )}
+              {!e.installed && (
+                <Link href={e.url} isExternal data-testid="protocol-install-adapter">
+                  {t('protocolAdapter.overview.installation')} <ExternalLinkIcon />
+                </Link>
               )}
             </Skeleton>
           </CardFooter>


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/26143/details/

The PR adds a link to installation instructions when an adapter is not installed locally.
- installation is determined by the `installed` property of the adapter
- the link is the same as the documentation (from the `url` property)

### Before 
![screenshot-localhost_3000-2024_12_10-13_27_07](https://github.com/user-attachments/assets/ef24e3ba-1e23-4343-baaf-0689f61deaab)



### After

![screenshot-localhost_3000-2024_12_10-13_26_46](https://github.com/user-attachments/assets/d1ff6c0a-260c-4c9a-b8d6-759a371a41d9)
