### PR TITLE
Modbus was internall casting a PollingContext to the wrong object when trying to determine deltas, breaking delta sending

### DIFF
--- a/modules/hivemq-edge-module-modbus/src/main/java/com/hivemq/edge/adapters/modbus/util/AdapterDataUtils.java
+++ b/modules/hivemq-edge-module-modbus/src/main/java/com/hivemq/edge/adapters/modbus/util/AdapterDataUtils.java
@@ -19,29 +19,25 @@ import com.hivemq.adapter.sdk.api.data.DataPoint;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 public class AdapterDataUtils {
-    public static boolean matches(final @NotNull DataPoint point, final @NotNull List<DataPoint> list) {
-        return list.stream().filter(dp -> dp.getTagName().equals(point.getTagName())) // First filter by tagName
-                .anyMatch(dp -> dp.getTagValue().equals(point.getTagValue())); // Then check for tagValue
-    }
 
     public static @NotNull List<DataPoint> mergeChangedSamples(
             final @Nullable List<DataPoint> historicalSamples, final @NotNull List<DataPoint> currentSamples) {
         if (historicalSamples == null) {
             return currentSamples;
         }
-        List<DataPoint> delta = new ArrayList<>();
-        for (int i = 0; i < currentSamples.size(); i++) {
-            DataPoint currentSample = currentSamples.get(i);
-            // If the current sample does not match any in the historical samples, it has changed
-            if (!matches(currentSample, historicalSamples)) {
-                historicalSamples.set(i, currentSample);
-                delta.add(currentSample);
-            }
-        }
-        return delta;
+
+        final Map<String, DataPoint> historicalSamplesMap = historicalSamples.stream()
+                .collect(Collectors.toMap(DataPoint::getTagName, Function.identity()));
+
+        return currentSamples.stream()
+                .filter(sample ->
+                        !(historicalSamplesMap.containsKey(sample.getTagName()) && historicalSamplesMap.get(sample.getTagName()).getTagValue().equals(sample.getTagValue())))
+                .collect(Collectors.toList());
     }
 }

--- a/modules/hivemq-edge-module-modbus/src/test/java/com/hivemq/edge/adapters/modbus/ModbusProtocolAdapterTest.java
+++ b/modules/hivemq-edge-module-modbus/src/test/java/com/hivemq/edge/adapters/modbus/ModbusProtocolAdapterTest.java
@@ -21,11 +21,13 @@ import com.hivemq.edge.adapters.modbus.config.ModbusToMqttMapping;
 import com.hivemq.edge.adapters.modbus.model.ModBusData;
 import com.hivemq.edge.adapters.modbus.util.AdapterDataUtils;
 import com.hivemq.edge.modules.adapters.data.DataPointImpl;
+import org.assertj.core.groups.Tuple;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.stream.IntStream;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class ModbusProtocolAdapterTest {
@@ -51,11 +53,13 @@ class ModbusProtocolAdapterTest {
         final ModBusData data2 = createSampleData();
         data2.getDataPoints().set(5, new DataPointImpl("register-5", 777));
 
-        AdapterDataUtils.mergeChangedSamples(data1.getDataPoints(), data2.getDataPoints());
+        final List<DataPoint> dataPoints =
+                AdapterDataUtils.mergeChangedSamples(data1.getDataPoints(), data2.getDataPoints());
 
-        assertEquals(777,
-                ((DataPoint) data1.getDataPoints().get(5)).getTagValue(),
-                "Merged data should contain new value");
+        assertThat(dataPoints)
+                .hasSize(1)
+                .extracting(DataPoint::getTagValue, DataPoint::getTagName)
+                .containsExactly(Tuple.tuple(777, "register-5"));
     }
 
     protected static ModBusData createSampleData() {


### PR DESCRIPTION
**Motivation**

Resolves #28848

**Changes**
ModbusAdapter was casting the incoming PolingContext to the wrong type.
Since this was only used for delta-calculations it broke only those. 