### PR TITLE
refactor(28810): flip icons

### DIFF
--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeAdapter.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeAdapter.spec.cy.tsx
@@ -68,8 +68,8 @@ describe('NodeAdapter', () => {
     cy.getByTestId('adapter-node-name').should('contain', MOCK_ADAPTER_ID)
     cy.get('[role="toolbar"] button').should('have.length', 3)
     cy.get('[role="toolbar"] button').eq(0).should('have.attr', 'aria-label', 'Open the overview panel')
-    cy.get('[role="toolbar"] button').eq(1).should('have.attr', 'aria-label', 'Edit Southbound mappings')
-    cy.get('[role="toolbar"] button').eq(2).should('have.attr', 'aria-label', 'Edit Northbound mappings')
+    cy.get('[role="toolbar"] button').eq(1).should('have.attr', 'aria-label', 'Edit Northbound mappings')
+    cy.get('[role="toolbar"] button').eq(2).should('have.attr', 'aria-label', 'Edit Southbound mappings')
   })
 
   it('should render the toolbar for multiple selected', () => {
@@ -128,13 +128,13 @@ describe('NodeAdapter', () => {
       `/workspace/node/adapter/opc-ua-client/${MOCK_NODE_ADAPTER.id}`
     )
 
-    cy.get('[role="toolbar"] button').eq(1).click()
+    cy.get('[role="toolbar"] button').eq(2).click()
     cy.getByTestId('test-navigate-pathname').should(
       'have.text',
       `/workspace/node/adapter/opc-ua-client/${MOCK_NODE_ADAPTER.id}/southbound`
     )
 
-    cy.get('[role="toolbar"] button').eq(2).click()
+    cy.get('[role="toolbar"] button').eq(1).click()
     cy.getByTestId('test-navigate-pathname').should(
       'have.text',
       `/workspace/node/adapter/opc-ua-client/${MOCK_NODE_ADAPTER.id}/northbound`

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeAdapter.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeAdapter.tsx
@@ -47,6 +47,11 @@ const NodeAdapter: FC<NodeProps<Adapter>> = ({ id, data: adapter, selected, drag
     <>
       <ContextualToolbar id={id} dragging={dragging} onOpenPanel={onContextMenu}>
         <ToolbarButtonGroup>
+          <IconButton
+            icon={<Icon as={deviceCapabilityIcon['READ']} />}
+            aria-label={t('workspace.toolbar.command.mappings.northbound')}
+            onClick={() => navigate(`${adapterNavPath}/northbound`)}
+          />
           {bidirectional && (
             <IconButton
               icon={<Icon as={deviceCapabilityIcon['WRITE']} />}
@@ -54,11 +59,6 @@ const NodeAdapter: FC<NodeProps<Adapter>> = ({ id, data: adapter, selected, drag
               onClick={() => navigate(`${adapterNavPath}/southbound`)}
             />
           )}
-          <IconButton
-            icon={<Icon as={deviceCapabilityIcon['READ']} />}
-            aria-label={t('workspace.toolbar.command.mappings.northbound')}
-            onClick={() => navigate(`${adapterNavPath}/northbound`)}
-          />
         </ToolbarButtonGroup>
       </ContextualToolbar>
       <NodeWrapper


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/28810/details/

Change order of the CTAs on the adapter toolbar