### PR TITLE
fix(28866): Fix the configuration flags of the adapter nodes

### DIFF
--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeAdapter.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeAdapter.spec.cy.tsx
@@ -1,9 +1,6 @@
-/// <reference types="cypress" />
-
 import { mockReactFlow } from '@/__test-utils__/react-flow/providers.tsx'
 import { CustomNodeTesting } from '@/__test-utils__/react-flow/CustomNodeTesting.tsx'
 import { MOCK_NODE_ADAPTER } from '@/__test-utils__/react-flow/nodes.ts'
-import { MOCK_TOPIC_REF1, MOCK_TOPIC_REF2 } from '@/__test-utils__/react-flow/topics.ts'
 import { MOCK_ADAPTER_ID } from '@/__test-utils__/mocks.ts'
 
 import { mockProtocolAdapter } from '@/api/hooks/useProtocolAdapters/__handlers__'
@@ -11,6 +8,10 @@ import { formatTopicString } from '@/components/MQTT/topic-utils.ts'
 import { NodeTypes } from '@/modules/Workspace/types.ts'
 
 import NodeAdapter from './NodeAdapter.tsx'
+import {
+  MOCK_NORTHBOUND_MAPPING,
+  MOCK_SOUTHBOUND_MAPPING,
+} from '@/api/hooks/useProtocolAdapters/__handlers__/mapping.mocks.ts'
 
 describe('NodeAdapter', () => {
   beforeEach(() => {
@@ -25,6 +26,14 @@ describe('NodeAdapter', () => {
         },
       ],
     })
+
+    cy.intercept('/api/v1/management/protocol-adapters/adapters/*/northboundMappings', {
+      items: [MOCK_NORTHBOUND_MAPPING],
+    }).as('getNorthboundMappings')
+
+    cy.intercept('/api/v1/management/protocol-adapters/adapters/*/southboundMappings', {
+      items: [MOCK_SOUTHBOUND_MAPPING],
+    }).as('getSouthboundMappings')
   })
 
   it('should render properly', () => {
@@ -32,10 +41,7 @@ describe('NodeAdapter', () => {
 
     cy.getByTestId('adapter-node-name').should('contain', MOCK_ADAPTER_ID)
     cy.getByTestId('connection-status').should('contain.text', 'Connected')
-    cy.getByTestId('topics-container')
-      .should('be.visible')
-      .should('contain.text', formatTopicString(MOCK_TOPIC_REF1))
-      .should('contain.text', formatTopicString(MOCK_TOPIC_REF2))
+    cy.getByTestId('topics-container').should('be.visible').should('contain.text', formatTopicString('my/topic'))
   })
 
   it('should render the selected adapter properly', () => {

--- a/hivemq-edge/src/frontend/src/modules/Workspace/utils/status-utils.spec.ts
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/utils/status-utils.spec.ts
@@ -237,7 +237,7 @@ describe('getEdgeStatus', () => {
       },
     },
   ])('should return the correct style for $isConnected and $hasTopics', ({ isConnected, hasTopics, expected }) => {
-    const edgeStyle = getEdgeStatus(isConnected, hasTopics, color)
+    const edgeStyle = getEdgeStatus(isConnected, hasTopics, true, color)
     expect(edgeStyle).toStrictEqual(expected)
   })
 })

--- a/hivemq-edge/src/frontend/src/modules/Workspace/utils/topics-utils.ts
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/utils/topics-utils.ts
@@ -110,6 +110,9 @@ const getTopicsFromPath = (path: string, instance: GenericObjectType): string[] 
   return getTopicsFromPath(rest.join('.'), instance?.[property])
 }
 
+/**
+ * @deprecated This is not in use anymore; check the north and south mappings
+ */
 export const discoverAdapterTopics = (
   protocol: ProtocolAdapter,
   instance: GenericObjectType,


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/28866/details/

The PR updates the old "topic tag" in the adapter node with the new mapping paradigm. 

- They cannot be called "tags" anymore since we now have "Device Tags" in the mapping
- As they are basically labels to the link handles on a node, they could be termed "configuration labels"
-  Northbound mappings provides the topics for the labels to the connection with the Edge node
- Southbound mappings provides the topics filters for the labels to the connection with the Device node

The PR also fixes the connection status of an adapter, as rendered by the colour of the links between the nodes. Bi-directionality is rendered by an arrowed link to the Device node, by contract to a plain link when uni-directional,

### Before
![screenshot-localhost_3000-2024_12_12-10_59_13](https://github.com/user-attachments/assets/ae1b98dd-5d32-4dff-a339-74abc1a2677b)

### After

![screenshot-localhost_3000-2024_12_12-10_57_46](https://github.com/user-attachments/assets/fbf2d85c-c0d4-4df9-ad34-aee2de10fa16)
