### PR TITLE
feat(27875): Redesign the workspace toolbars

### DIFF
--- a/hivemq-edge/src/frontend/src/components/react-flow/ToolbarButtonGroup.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/components/react-flow/ToolbarButtonGroup.spec.cy.tsx
@@ -21,7 +21,7 @@ describe('ToolbarButtonGroup', () => {
       }
     )
 
-    cy.get('[role="group"]').should('have.attr', 'data-orientation', 'vertical')
+    cy.get('[role="group"]').should('have.attr', 'data-orientation', 'horizontal')
     cy.getByAriaLabel('second button').should('be.visible')
     cy.getByAriaLabel('first button').should('be.visible')
   })

--- a/hivemq-edge/src/frontend/src/components/react-flow/ToolbarButtonGroup.tsx
+++ b/hivemq-edge/src/frontend/src/components/react-flow/ToolbarButtonGroup.tsx
@@ -1,31 +1,10 @@
-import { FC, useMemo } from 'react'
-import { useStore } from 'reactflow'
+import { FC } from 'react'
 import { ButtonGroup, ButtonGroupProps } from '@chakra-ui/react'
 
 // TODO[NVL] ChakraUI Theme doesn't support ButtonGroup
 const ToolbarButtonGroup: FC<ButtonGroupProps> = ({ children, ...rest }) => {
-  const zoomFactor = useStore((s) => s.transform[2])
-
-  const getToolbarSize = useMemo<string>(() => {
-    if (zoomFactor >= 1.5) return 'lg'
-    if (zoomFactor >= 1) return 'md'
-    if (zoomFactor >= 0.75) return 'sm'
-    return 'xs'
-  }, [zoomFactor])
-
   return (
-    <ButtonGroup
-      size={getToolbarSize}
-      variant="solid"
-      colorScheme="gray"
-      orientation="vertical"
-      isAttached
-      sx={{
-        boxShadow: '0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19)',
-        backgroundColor: 'rgba(0, 0, 0, 0.19)',
-      }}
-      {...rest}
-    >
+    <ButtonGroup size="sm" variant="solid" colorScheme="gray" isAttached {...rest}>
       {children}
     </ButtonGroup>
   )

--- a/hivemq-edge/src/frontend/src/locales/en/translation.json
+++ b/hivemq-edge/src/frontend/src/locales/en/translation.json
@@ -773,8 +773,7 @@
     },
     "toolbar": {
       "container": {
-        "left": "First Toolbar",
-        "right": "Second Toolbar"
+        "label": "Node toolbar"
       },
       "command": {
         "overview": "Open the overview panel",

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/ContextualToolbar.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/ContextualToolbar.tsx
@@ -10,9 +10,10 @@ import {
   getOutgoers,
 } from 'reactflow'
 import { useTranslation } from 'react-i18next'
-import { useTheme } from '@chakra-ui/react'
+import { Divider, HStack, Icon, Text, useTheme } from '@chakra-ui/react'
 import { LuPanelRightOpen } from 'react-icons/lu'
 import { ImMakeGroup } from 'react-icons/im'
+import { BsGripVertical } from 'react-icons/bs'
 
 import { Adapter, Status } from '@/api/__generated__'
 import { EdgeTypes, Group, IdStubs, NodeTypes } from '@/modules/Workspace/types.ts'
@@ -28,10 +29,12 @@ interface ContextualToolbarProps extends SelectedNodeProps {
   onOpenPanel?: MouseEventHandler | undefined
   children?: React.ReactNode
   hasNoOverview?: boolean
+  title?: string
 }
 
 const ContextualToolbar: FC<ContextualToolbarProps> = ({
   id,
+  title,
   onOpenPanel,
   children,
   hasNoOverview = false,
@@ -126,46 +129,62 @@ const ContextualToolbar: FC<ContextualToolbarProps> = ({
   const isGroupable = selectedGroupCandidates
 
   return (
-    <>
-      {!hasNoOverview && (
-        <NodeToolbar
-          isVisible={Boolean(mainNodes?.id === id && !dragging)}
-          position={Position.Right}
-          role="toolbar"
-          aria-label={t('workspace.toolbar.container.right')}
-        >
-          <ToolbarButtonGroup>
-            <IconButton
-              data-testid="node-group-toolbar-panel"
-              icon={<LuPanelRightOpen />}
-              aria-label={t('workspace.toolbar.command.overview')}
-              onClick={onOpenPanel}
-            />
-          </ToolbarButtonGroup>
-        </NodeToolbar>
-      )}
-      {(children || isGroupable) && (
-        <NodeToolbar
-          isVisible={Boolean(mainNodes?.id === id && !dragging)}
-          position={Position.Left}
-          role="toolbar"
-          aria-label={t('workspace.toolbar.container.left')}
-          style={{ display: 'flex', gap: '4px', flexDirection: 'column' }}
-        >
-          {children}
-          {isGroupable && (
+    <NodeToolbar
+      isVisible={Boolean(mainNodes?.id === id && !dragging)}
+      position={Position.Top}
+      role="toolbar"
+      aria-label={t('workspace.toolbar.container.right')}
+    >
+      <HStack
+        sx={{
+          borderColor: 'var(--chakra-colors-chakra-border-color)',
+          _dark: {
+            borderWidth: 1,
+          },
+          // paddingLeft: 2,
+          paddingRight: 2,
+          borderRadius: 'var(--chakra-radii-md)',
+          backgroundColor: 'var(--chakra-colors-chakra-body-bg)',
+          boxShadow:
+            'rgba(17, 17, 26, 0.1) 0px 4px 16px, rgba(17, 17, 26, 0.1) 0px 8px 24px, rgba(17, 17, 26, 0.1) 0px 16px 56px;',
+        }}
+        height="50px"
+      >
+        <Icon as={BsGripVertical} boxSize={7} />
+        <Text>{title || id}</Text>
+        {children && (
+          <>
+            <Divider orientation="vertical" />
+            {children}
+          </>
+        )}
+
+        <Divider orientation="vertical" />
+        <ToolbarButtonGroup>
+          <IconButton
+            isDisabled={!isGroupable}
+            data-testid="node-group-toolbar-group"
+            icon={<ImMakeGroup />}
+            aria-label={t('workspace.toolbar.command.group')}
+            onClick={onCreateGroup}
+          />
+        </ToolbarButtonGroup>
+
+        {!hasNoOverview && (
+          <>
+            <Divider orientation="vertical" />
             <ToolbarButtonGroup>
               <IconButton
-                data-testid="node-group-toolbar-group"
-                icon={<ImMakeGroup />}
-                aria-label={t('workspace.toolbar.command.group')}
-                onClick={onCreateGroup}
+                data-testid="node-group-toolbar-panel"
+                icon={<LuPanelRightOpen />}
+                aria-label={t('workspace.toolbar.command.overview')}
+                onClick={onOpenPanel}
               />
             </ToolbarButtonGroup>
-          )}
-        </NodeToolbar>
-      )}
-    </>
+          </>
+        )}
+      </HStack>
+    </NodeToolbar>
   )
 }
 

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/ContextualToolbar.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/ContextualToolbar.tsx
@@ -133,7 +133,7 @@ const ContextualToolbar: FC<ContextualToolbarProps> = ({
       isVisible={Boolean(mainNodes?.id === id && !dragging)}
       position={Position.Top}
       role="toolbar"
-      aria-label={t('workspace.toolbar.container.right')}
+      aria-label={t('workspace.toolbar.container.label')}
     >
       <HStack
         sx={{
@@ -150,8 +150,8 @@ const ContextualToolbar: FC<ContextualToolbarProps> = ({
         }}
         height="50px"
       >
-        <Icon as={BsGripVertical} boxSize={7} />
-        <Text>{title || id}</Text>
+        <Icon as={BsGripVertical} boxSize={7} aria-hidden={true} />
+        <Text data-testid="toolbar-title">{title || id}</Text>
         {children && (
           <>
             <Divider orientation="vertical" />

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeAdapter.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeAdapter.spec.cy.tsx
@@ -52,9 +52,10 @@ describe('NodeAdapter', () => {
       />
     )
     cy.getByTestId('adapter-node-name').should('contain', MOCK_ADAPTER_ID)
-    cy.get('[role="toolbar"] button').should('have.length', 2)
-    cy.get('[role="toolbar"] button').eq(0).should('have.attr', 'aria-label', 'Open the overview panel')
-    cy.get('[role="toolbar"] button').eq(1).should('have.attr', 'aria-label', 'Edit Northbound mappings')
+    cy.get('[role="toolbar"] button').should('have.length', 3)
+    cy.get('[role="toolbar"] button').eq(0).should('have.attr', 'aria-label', 'Edit Northbound mappings')
+    cy.get('[role="toolbar"] button').eq(1).should('have.attr', 'aria-label', 'Group the selected adapters')
+    cy.get('[role="toolbar"] button').eq(2).should('have.attr', 'aria-label', 'Open the overview panel')
   })
 
   it('should render the toolbar for bi-directional adapter', () => {
@@ -72,10 +73,11 @@ describe('NodeAdapter', () => {
       />
     )
     cy.getByTestId('adapter-node-name').should('contain', MOCK_ADAPTER_ID)
-    cy.get('[role="toolbar"] button').should('have.length', 3)
-    cy.get('[role="toolbar"] button').eq(0).should('have.attr', 'aria-label', 'Open the overview panel')
-    cy.get('[role="toolbar"] button').eq(1).should('have.attr', 'aria-label', 'Edit Northbound mappings')
-    cy.get('[role="toolbar"] button').eq(2).should('have.attr', 'aria-label', 'Edit Southbound mappings')
+    cy.get('[role="toolbar"] button').should('have.length', 4)
+    cy.get('[role="toolbar"] button').eq(0).should('have.attr', 'aria-label', 'Edit Northbound mappings')
+    cy.get('[role="toolbar"] button').eq(1).should('have.attr', 'aria-label', 'Edit Southbound mappings')
+    cy.get('[role="toolbar"] button').eq(2).should('have.attr', 'aria-label', 'Group the selected adapters')
+    cy.get('[role="toolbar"] button').eq(3).should('have.attr', 'aria-label', 'Open the overview panel')
   })
 
   it('should render the toolbar for multiple selected', () => {
@@ -107,9 +109,9 @@ describe('NodeAdapter', () => {
     )
     cy.getByTestId('adapter-node-name').should('contain', MOCK_ADAPTER_ID)
     cy.get('[role="toolbar"] button').should('have.length', 3)
-    cy.get('[role="toolbar"] button').eq(0).should('have.attr', 'aria-label', 'Open the overview panel')
-    cy.get('[role="toolbar"] button').eq(1).should('have.attr', 'aria-label', 'Edit Northbound mappings')
-    cy.get('[role="toolbar"] button').eq(2).should('have.attr', 'aria-label', 'Group the selected adapters')
+    cy.get('[role="toolbar"] button').eq(0).should('have.attr', 'aria-label', 'Edit Northbound mappings')
+    cy.get('[role="toolbar"] button').eq(1).should('have.attr', 'aria-label', 'Group the selected adapters')
+    cy.get('[role="toolbar"] button').eq(2).should('have.attr', 'aria-label', 'Open the overview panel')
   })
 
   it('should render the toolbar properly', () => {
@@ -128,19 +130,19 @@ describe('NodeAdapter', () => {
     )
 
     cy.getByTestId('test-navigate-pathname').should('have.text', '/')
-    cy.get('[role="toolbar"] button').eq(0).click()
+    cy.get('[role="toolbar"] button').eq(3).click()
     cy.getByTestId('test-navigate-pathname').should(
       'have.text',
       `/workspace/node/adapter/opc-ua-client/${MOCK_NODE_ADAPTER.id}`
     )
 
-    cy.get('[role="toolbar"] button').eq(2).click()
+    cy.get('[role="toolbar"] button').eq(1).click()
     cy.getByTestId('test-navigate-pathname').should(
       'have.text',
       `/workspace/node/adapter/opc-ua-client/${MOCK_NODE_ADAPTER.id}/southbound`
     )
 
-    cy.get('[role="toolbar"] button').eq(1).click()
+    cy.get('[role="toolbar"] button').eq(0).click()
     cy.getByTestId('test-navigate-pathname').should(
       'have.text',
       `/workspace/node/adapter/opc-ua-client/${MOCK_NODE_ADAPTER.id}/northbound`

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeAdapter.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeAdapter.tsx
@@ -47,7 +47,7 @@ const NodeAdapter: FC<NodeProps<Adapter>> = ({ id, data: adapter, selected, drag
 
   return (
     <>
-      <ContextualToolbar id={id} dragging={dragging} onOpenPanel={onContextMenu}>
+      <ContextualToolbar id={id} title={adapter.id} dragging={dragging} onOpenPanel={onContextMenu}>
         <ToolbarButtonGroup>
           <IconButton
             icon={<Icon as={deviceCapabilityIcon['READ']} />}

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeBridge.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeBridge.tsx
@@ -25,7 +25,7 @@ const NodeBridge: FC<NodeProps<Bridge>> = ({ id, selected, data: bridge, draggin
 
   return (
     <>
-      <ContextualToolbar id={id} dragging={dragging} onOpenPanel={onContextMenu} />
+      <ContextualToolbar id={id} title={bridge.id} dragging={dragging} onOpenPanel={onContextMenu} />
       <NodeWrapper
         isSelected={selected}
         onDoubleClick={onContextMenu}

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeDevice.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeDevice.spec.cy.tsx
@@ -30,7 +30,7 @@ describe('NodeDevice', () => {
       />
     )
     cy.getByTestId('device-description').should('contain', 'Simulation')
-    cy.get('[role="toolbar"] button').should('have.length', 1)
+    cy.get('[role="toolbar"] button').should('have.length', 2)
     cy.get('[role="toolbar"] button').eq(0).should('have.attr', 'aria-label', 'Edit device tags')
 
     cy.getByTestId('test-navigate-pathname').should('have.text', '/')

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeDevice.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeDevice.tsx
@@ -26,7 +26,7 @@ const NodeDevice: FC<NodeProps<DeviceMetadata>> = ({ id, selected, data, draggin
 
   return (
     <>
-      <ContextualToolbar id={id} onOpenPanel={onContextMenu} dragging={dragging} hasNoOverview>
+      <ContextualToolbar id={id} title={data.protocol} onOpenPanel={onContextMenu} dragging={dragging} hasNoOverview>
         <ToolbarButtonGroup>
           <IconButton
             icon={<PLCTagIcon />}

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeEdge.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeEdge.tsx
@@ -1,7 +1,9 @@
 import { FC } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { Handle, Position, NodeProps } from 'reactflow'
 import { useTranslation } from 'react-i18next'
 import { Icon, Image } from '@chakra-ui/react'
+import { LuInspect } from 'react-icons/lu'
 
 import logo from '@/assets/edge/05-icon-industrial-hivemq-edge.svg'
 import ToolbarButtonGroup from '@/components/react-flow/ToolbarButtonGroup.tsx'
@@ -10,7 +12,6 @@ import { TopicIcon } from '@/components/Icons/TopicIcon.tsx'
 import NodeWrapper from '@/modules/Workspace/components/parts/NodeWrapper.tsx'
 import { useContextMenu } from '@/modules/Workspace/hooks/useContextMenu.ts'
 import ContextualToolbar from '@/modules/Workspace/components/nodes/ContextualToolbar.tsx'
-import { useNavigate } from 'react-router-dom'
 
 const NodeEdge: FC<NodeProps> = (props) => {
   const { t } = useTranslation()
@@ -19,7 +20,12 @@ const NodeEdge: FC<NodeProps> = (props) => {
 
   return (
     <>
-      <ContextualToolbar id={props.id} dragging={props.dragging} onOpenPanel={onContextMenu}>
+      <ContextualToolbar
+        id={props.id}
+        title={t('branding.appName')}
+        dragging={props.dragging}
+        onOpenPanel={onContextMenu}
+      >
         <ToolbarButtonGroup>
           <IconButton
             icon={<Icon as={TopicIcon} />}

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeEdge.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeEdge.tsx
@@ -3,7 +3,6 @@ import { useNavigate } from 'react-router-dom'
 import { Handle, Position, NodeProps } from 'reactflow'
 import { useTranslation } from 'react-i18next'
 import { Icon, Image } from '@chakra-ui/react'
-import { LuInspect } from 'react-icons/lu'
 
 import logo from '@/assets/edge/05-icon-industrial-hivemq-edge.svg'
 import ToolbarButtonGroup from '@/components/react-flow/ToolbarButtonGroup.tsx'

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeGroup.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeGroup.spec.cy.tsx
@@ -37,7 +37,7 @@ describe('NodeGroup', () => {
 
     cy.get(`#node-group-${MOCK_NODE_GROUP.id}`).should('contain.text', 'The group title')
 
-    cy.get('[role="toolbar"]').should('have.length', 2)
+    cy.get('[role="toolbar"]').should('have.length', 1)
 
     cy.getByTestId('test-navigate-pathname').should('have.text', '/')
     cy.get(`#node-group-${MOCK_NODE_GROUP.id}`).rightclick()
@@ -52,27 +52,27 @@ describe('NodeGroup', () => {
       />
     )
 
-    // cy.getByTestId('node-group-toolbar-expand').should('not.exist')
-
     cy.get(`#node-group-${MOCK_NODE_GROUP.id}`)
       .should('contain.text', 'The group title')
       .should('have.attr', 'data-groupopen', 'true')
 
-    cy.get('[role="toolbar"] button').should('have.length', 3)
-    cy.get('[role="toolbar"] button').eq(0).should('have.attr', 'aria-label', 'Open the overview panel')
-    cy.get('[role="toolbar"] button').eq(1).should('have.attr', 'aria-label', 'Collapse group')
-    cy.get('[role="toolbar"] button').eq(2).should('have.attr', 'aria-label', 'Ungroup')
+    cy.get('[role="toolbar"] button').should('have.length', 4)
+    cy.get('[role="toolbar"] button').eq(0).should('have.attr', 'aria-label', 'Collapse group')
+    cy.get('[role="toolbar"] button').eq(1).should('have.attr', 'aria-label', 'Ungroup')
+    cy.get('[role="toolbar"] button').eq(2).should('have.attr', 'aria-label', 'Group the selected adapters')
 
-    cy.get('[role="toolbar"] button').eq(1).click()
+    cy.get('[role="toolbar"] button').eq(3).should('have.attr', 'aria-label', 'Open the overview panel')
+
+    cy.get('[role="toolbar"] button').eq(0).click()
     cy.get(`#node-group-${MOCK_NODE_GROUP.id}`).should('have.attr', 'data-groupopen', 'false')
 
     cy.get('[role="alertdialog"]').should('not.exist')
-    cy.get('[role="toolbar"] button').eq(2).click()
+    cy.get('[role="toolbar"] button').eq(1).click()
     cy.get('[role="alertdialog"]').should('contain.text', 'Ungroup the adapters')
     cy.getByTestId('confirmation-cancel').click()
 
     cy.getByTestId('test-navigate-pathname').should('have.text', '/')
-    cy.get('[role="toolbar"] button').eq(0).click()
+    cy.get('[role="toolbar"] button').eq(3).click()
     cy.getByTestId('test-navigate-pathname').should('have.text', `/workspace/group/${MOCK_NODE_GROUP.id}`)
   })
 

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeGroup.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeGroup.tsx
@@ -65,7 +65,7 @@ const NodeGroup: FC<NodeProps<Group>> = ({ id, data, selected, ...props }) => {
 
   return (
     <>
-      <ContextualToolbar id={id} dragging={props.dragging} onOpenPanel={onContextMenu}>
+      <ContextualToolbar id={id} title={data.title} dragging={props.dragging} onOpenPanel={onContextMenu}>
         <ToolbarButtonGroup isAttached={false}>
           <IconButton
             data-testid="node-group-toolbar-expand"


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/27875/details/

The PR replaces the unconvincing side CTAs with a common toolbar with a more consistent content. The toolbar is also used to display the name of the node, which can prove helpful when used in a small zoom factor.

### Before 
![screenshot-localhost_3000-2024_12_16-08_02_56](https://github.com/user-attachments/assets/537630f6-23e3-4675-8be0-1703a0312376)

### After
![screenshot-localhost_3000-2024_12_16-07_59_23](https://github.com/user-attachments/assets/5572ee8b-0b8a-4e7f-b6c9-92420b0df054)

![screenshot-localhost_3000-2024_12_16-07_59_35](https://github.com/user-attachments/assets/40a2b22a-51b1-43f9-8587-ed250fd9c7f3)


