### PR TITLE
fix(28701): fix style of folder array items when error

### DIFF
--- a/hivemq-edge/src/frontend/src/components/rjsf/ArrayFieldItemTemplate.tsx
+++ b/hivemq-edge/src/frontend/src/components/rjsf/ArrayFieldItemTemplate.tsx
@@ -57,6 +57,10 @@ export const ArrayFieldItemTemplate: FC<ArrayFieldTemplateItemType> = (props) =>
     if (props.children.props.idSchema.$id === expandItems.join('_')) onOpen()
   }, [expandItems, onOpen, props.children.props.idSchema.$id])
 
+  const hasErrors = Boolean(props.children.props.errorSchema)
+  const errorStyle =
+    hasErrors && collapsableItems && !isOpen ? { borderColor: '#E53E3E', boxShadow: '0 0 0 1px #E53E3E' } : undefined
+
   const onCopyClick = useMemo(() => onCopyIndexClick(index), [index, onCopyIndexClick])
   const onRemoveClick = useMemo(() => onDropIndexClick(index), [index, onDropIndexClick])
   const onArrowUpClick = useMemo(() => onReorderClick(index, index - 1), [index, onReorderClick])
@@ -65,7 +69,7 @@ export const ArrayFieldItemTemplate: FC<ArrayFieldTemplateItemType> = (props) =>
   const renderCollapsed = () => {
     const TitleFieldTemplate = getTemplate<'TitleFieldTemplate'>('TitleFieldTemplate', registry, uiOptions)
     return (
-      <FormControl variant="hivemq">
+      <FormControl variant="hivemq" sx={errorStyle}>
         <TitleFieldTemplate
           title={name}
           id={children.props.name}


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/28701/details/

The PR fixes a major usability issue, by styling array items with the common "red" border when a validation error is generated but the item is "folded" and doesn't materialise the error 

### Before 
![screenshot-localhost_3000-2024_12_16-07_58_51](https://github.com/user-attachments/assets/a3d8e02e-5ae9-425c-b471-1ef8f8d032de)


### After
![screenshot-localhost_3000-2024_12_16-07_57_54](https://github.com/user-attachments/assets/893fea65-b0e5-4e08-98b1-73104f940a5a)
