### PR TITLE
fix(28713): change generated name for array items

### DIFF
--- a/hivemq-edge/src/frontend/src/api/schemas/northbound.ui-schema.ts
+++ b/hivemq-edge/src/frontend/src/api/schemas/northbound.ui-schema.ts
@@ -15,6 +15,7 @@ export const northboundMappingListUISchema: UiSchema = {
       'ui:order': ['tagName', 'topic', '*'],
       'ui:collapsable': {
         titleKey: 'tagName',
+        name: 'Mapping',
       },
       tagName: {
         'ui:widget': registerEntitySelectWidget(CustomFormat.MQTT_TAG),

--- a/hivemq-edge/src/frontend/src/components/rjsf/ArrayFieldItemTemplate.tsx
+++ b/hivemq-edge/src/frontend/src/components/rjsf/ArrayFieldItemTemplate.tsx
@@ -52,7 +52,7 @@ export const ArrayFieldItemTemplate: FC<ArrayFieldTemplateItemType> = (props) =>
       ? children.props.formData[collapsableItems?.titleKey]
       : undefined
 
-    return formatItemName(collapsableItems?.name as string, children.props.index, childrenFormData)
+    return formatItemName(collapsableItems?.name, children.props.index, childrenFormData)
   }, [children.props.formData, children.props.index, collapsableItems?.name, collapsableItems?.titleKey])
 
   useEffect(() => {
@@ -87,7 +87,7 @@ export const ArrayFieldItemTemplate: FC<ArrayFieldTemplateItemType> = (props) =>
   // This is to override the hardcoded rendering of the item's indexed names
   const childrenWithCustomTitle = {
     ...children,
-    props: { ...children.props, title: formatItemName(collapsableItems?.name as string, children.props.index) },
+    props: { ...children.props, title: formatItemName(collapsableItems?.name, children.props.index) },
   }
 
   return (

--- a/hivemq-edge/src/frontend/src/components/rjsf/ArrayFieldItemTemplate.tsx
+++ b/hivemq-edge/src/frontend/src/components/rjsf/ArrayFieldItemTemplate.tsx
@@ -7,10 +7,12 @@ import { LuPanelTopClose, LuPanelTopOpen } from 'react-icons/lu'
 import IconButton from '@/components/Chakra/IconButton.tsx'
 import { CopyButton, MoveDownButton, MoveUpButton, RemoveButton } from '@/components/rjsf/__internals/IconButton.tsx'
 import { useFormControlStore } from '@/components/rjsf/Form/useFormControlStore.ts'
+import { formatItemName } from '@/components/rjsf/utils/array-items.utils.ts'
 
 // TODO[NVL] Need a better handling of the custom UISchema property, for the Adapter SDK
 interface ArrayFieldItemCollapsableUISchema {
   titleKey: string
+  name: string
 }
 
 // TODO[NVL] This is driven by subscription handling; use uiSchema to allow configuration for individual array property
@@ -49,9 +51,9 @@ export const ArrayFieldItemTemplate: FC<ArrayFieldTemplateItemType> = (props) =>
     const childrenFormData = collapsableItems?.titleKey
       ? children.props.formData[collapsableItems?.titleKey]
       : undefined
-    if (childrenFormData) return `${children.props.name} - ${childrenFormData}`
-    return children.props.name
-  }, [children.props.formData, children.props.name, collapsableItems?.titleKey])
+
+    return formatItemName(collapsableItems?.name as string, children.props.index, childrenFormData)
+  }, [children.props.formData, children.props.index, collapsableItems?.name, collapsableItems?.titleKey])
 
   useEffect(() => {
     if (props.children.props.idSchema.$id === expandItems.join('_')) onOpen()
@@ -81,6 +83,12 @@ export const ArrayFieldItemTemplate: FC<ArrayFieldTemplateItemType> = (props) =>
     )
   }
   const { hidden, ...rest } = getDisclosureProps()
+
+  // This is to override the hardcoded rendering of the item's indexed names
+  const childrenWithCustomTitle = {
+    ...children,
+    props: { ...children.props, title: formatItemName(collapsableItems?.name as string, children.props.index) },
+  }
 
   return (
     <HStack flexDirection="row-reverse" alignItems="flex-start" py={1} role="listitem">
@@ -136,7 +144,7 @@ export const ArrayFieldItemTemplate: FC<ArrayFieldTemplateItemType> = (props) =>
       )}
 
       <Box w="100%" {...rest}>
-        {!collapsableItems || isOpen ? children : renderCollapsed()}
+        {!collapsableItems || isOpen ? childrenWithCustomTitle : renderCollapsed()}
       </Box>
     </HStack>
   )

--- a/hivemq-edge/src/frontend/src/components/rjsf/utils/array-items.utils.spec.ts
+++ b/hivemq-edge/src/frontend/src/components/rjsf/utils/array-items.utils.spec.ts
@@ -5,6 +5,12 @@ import { formatItemName } from '@/components/rjsf/utils/array-items.utils.ts'
 describe('formatItemName', () => {
   it.each([
     {
+      stub: undefined,
+      index: 1,
+      content: undefined,
+      result: 'item #1',
+    },
+    {
       stub: 'item',
       index: 1,
       content: undefined,

--- a/hivemq-edge/src/frontend/src/components/rjsf/utils/array-items.utils.spec.ts
+++ b/hivemq-edge/src/frontend/src/components/rjsf/utils/array-items.utils.spec.ts
@@ -1,0 +1,22 @@
+import { expect } from 'vitest'
+
+import { formatItemName } from '@/components/rjsf/utils/array-items.utils.ts'
+
+describe('formatItemName', () => {
+  it.each([
+    {
+      stub: 'item',
+      index: 1,
+      content: undefined,
+      result: 'item #1',
+    },
+    {
+      stub: 'item',
+      index: 1,
+      content: 'the full name',
+      result: 'item #1 - the full name',
+    },
+  ])('should return $value for $path', ({ stub, index, content, result }) => {
+    expect(formatItemName(stub, index, content)).toStrictEqual(result)
+  })
+})

--- a/hivemq-edge/src/frontend/src/components/rjsf/utils/array-items.utils.ts
+++ b/hivemq-edge/src/frontend/src/components/rjsf/utils/array-items.utils.ts
@@ -1,0 +1,7 @@
+const FORMAT_INDEX_MARKER = '#'
+const FORMAT_SEPARATOR = '-'
+
+export const formatItemName = (stub: string, index: number, description?: string) => {
+  if (!description) return `${stub} ${FORMAT_INDEX_MARKER}${index}`
+  return `${stub} ${FORMAT_INDEX_MARKER}${index} ${FORMAT_SEPARATOR} ${description}`
+}

--- a/hivemq-edge/src/frontend/src/components/rjsf/utils/array-items.utils.ts
+++ b/hivemq-edge/src/frontend/src/components/rjsf/utils/array-items.utils.ts
@@ -1,7 +1,10 @@
 const FORMAT_INDEX_MARKER = '#'
 const FORMAT_SEPARATOR = '-'
 
-export const formatItemName = (stub: string, index: number, description?: string) => {
-  if (!description) return `${stub} ${FORMAT_INDEX_MARKER}${index}`
-  return `${stub} ${FORMAT_INDEX_MARKER}${index} ${FORMAT_SEPARATOR} ${description}`
+import i18n from '@/config/i18n.config.ts'
+
+export const formatItemName = (stub: string | undefined, index: number, description?: string) => {
+  const token = stub || i18n.t('rjsf.ArrayFieldItem.item', { ns: 'components' })
+  if (!description) return `${token} ${FORMAT_INDEX_MARKER}${index}`
+  return `${token} ${FORMAT_INDEX_MARKER}${index} ${FORMAT_SEPARATOR} ${description}`
 }

--- a/hivemq-edge/src/frontend/src/locales/en/components.json
+++ b/hivemq-edge/src/frontend/src/locales/en/components.json
@@ -118,6 +118,7 @@
       }
     },
     "ArrayFieldItem": {
+      "item": "item",
       "Buttons": {
         "expanded_true": "Collapse Item",
         "expanded_false": "Expand Item"


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/28713/details/

The PR change the pattern of the default name for items in a `RJSF` form. 
- the pattern in used is more readable: `name #1 - content`
- the default name is `item`
- if a `ui:title` is given, then it replaces the name

Note that the fix involves overriding a name that is hardcoded by the `RJSF` library. It might not be resilient to code updates.

### Before
![screenshot-localhost_3000-2024_12_16-09_13_30](https://github.com/user-attachments/assets/17f1fcf8-1deb-4938-af1a-03b662640032)

### After
![screenshot-localhost_3000-2024_12_16-09_12_58](https://github.com/user-attachments/assets/7c94710b-4e23-42cc-97d2-b14092e2f69a)
