### PR TITLE
fix(28963): reintroduce batch upload in northbound mappings

### DIFF
--- a/hivemq-edge/src/frontend/src/api/schemas/northbound.ui-schema.ts
+++ b/hivemq-edge/src/frontend/src/api/schemas/northbound.ui-schema.ts
@@ -11,6 +11,7 @@ export const northboundMappingListUISchema: UiSchema = {
   items: {
     'ui:title': 'List of northbound mappings',
     'ui:description': 'The list of all the mappings delivering messages from this adapter onto the Edge',
+    'ui:batchMode': true,
     items: {
       'ui:order': ['tagName', 'topic', '*'],
       'ui:collapsable': {


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/28963/details/

The PR re-introduces the `batch upload` functionality for northbound mappings

### Out-of-scope
- The batch upload requires `tags` to be defined BEFORE the mappings are created. There is no way to verify this and there is no way to extend the batch process to create requirements and dependencies on the fly. The feature will need to be investigated in a further epic.

### Before 
![screenshot-localhost_3000-2024_12_16-10_11_54](https://github.com/user-attachments/assets/4966ee08-2ea6-4354-9aa4-bd0751065a0f)

### After 
![screenshot-localhost_3000-2024_12_16-10_08_56](https://github.com/user-attachments/assets/42bd1f57-935c-416a-8079-3d6c22b41cea)
