### PR TITLE
refactor(28703): Add the source of a side panel into its header

### DIFF
--- a/hivemq-edge/src/frontend/src/components/ExpandableDrawer/ExpandableDrawer.tsx
+++ b/hivemq-edge/src/frontend/src/components/ExpandableDrawer/ExpandableDrawer.tsx
@@ -14,9 +14,10 @@ import DrawerExpandButton from '@/components/Chakra/DrawerExpandButton.tsx'
 
 interface ExpandableDrawerProps extends DrawerProps {
   header: string
+  subHeader?: JSX.Element
 }
 
-const ExpandableDrawer: FC<ExpandableDrawerProps> = ({ header, ...props }) => {
+const ExpandableDrawer: FC<ExpandableDrawerProps> = ({ header, subHeader, ...props }) => {
   // TODO[NVL] use  local storage
   const [isExpanded, setExpanded] = useBoolean(true)
 
@@ -28,6 +29,7 @@ const ExpandableDrawer: FC<ExpandableDrawerProps> = ({ header, ...props }) => {
         <DrawerExpandButton isExpanded={isExpanded} toggle={setExpanded.toggle} />
         <DrawerHeader>
           <Text>{header}</Text>
+          {subHeader}
         </DrawerHeader>
         <DrawerBody display="flex" flexDirection="column" gap={6}>
           {props.children}

--- a/hivemq-edge/src/frontend/src/locales/en/translation.json
+++ b/hivemq-edge/src/frontend/src/locales/en/translation.json
@@ -765,7 +765,9 @@
     "device": {
       "type_ADAPTER_NODE": "adapter",
       "type_BRIDGE_NODE": "bridge",
-      "type_EDGE_NODE": "edge"
+      "type_EDGE_NODE": "edge",
+      "type_DEVICE_NODE": "device",
+      "type_CLUSTER_NODE": "Group"
     },
     "layout": {
       "HORIZONTAL": "Horizontal",

--- a/hivemq-edge/src/frontend/src/modules/Mappings/AdapterMappingManager.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/AdapterMappingManager.tsx
@@ -30,6 +30,8 @@ import { NodeTypes } from '@/modules/Workspace/types.ts'
 import useWorkspaceStore from '@/modules/Workspace/hooks/useWorkspaceStore.ts'
 import { useSouthboundMappingManager } from '@/modules/Mappings/hooks/useSouthboundMappingManager.ts'
 import { MappingType } from './types'
+import NodeNameCard from '@/modules/Workspace/components/parts/NodeNameCard.tsx'
+import { useGetAdapterTypes } from '@/api/hooks/useProtocolAdapters/useGetAdapterTypes.ts'
 
 interface AdapterMappingManagerProps {
   type: MappingType
@@ -47,6 +49,12 @@ const AdapterMappingManager: FC<AdapterMappingManagerProps> = ({ type }) => {
   const selectedNode = useMemo(() => {
     return nodes.find((node) => node.id === nodeId && node.type === NodeTypes.ADAPTER_NODE) as Node<Adapter> | undefined
   }, [nodeId, nodes])
+
+  const { data: protocols } = useGetAdapterTypes()
+  const adapterProtocol =
+    selectedNode?.type === NodeTypes.ADAPTER_NODE
+      ? protocols?.items?.find((e) => e.id === (selectedNode as Node<Adapter>).data.type)
+      : undefined
 
   const handleClose = () => {
     onClose()
@@ -70,6 +78,12 @@ const AdapterMappingManager: FC<AdapterMappingManagerProps> = ({ type }) => {
         <DrawerExpandButton isExpanded={isExpanded} toggle={setExpanded.toggle} />
         <DrawerHeader>
           <Text>{t('protocolAdapter.mapping.manager.header', { context: type })}</Text>
+          <NodeNameCard
+            name={selectedNode?.data.id}
+            type={selectedNode?.type as NodeTypes}
+            icon={adapterProtocol?.logoUrl}
+            description={adapterProtocol?.name}
+          />
         </DrawerHeader>
         <DrawerBody display="flex" flexDirection="column" gap={6}>
           {!adapterId && <ErrorMessage message={t('protocolAdapter.error.loading')} />}

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/drawers/AdapterInstanceDrawer.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/drawers/AdapterInstanceDrawer.tsx
@@ -14,8 +14,6 @@ import {
   DrawerHeader,
   DrawerOverlay,
   Flex,
-  HStack,
-  Image,
   Text,
 } from '@chakra-ui/react'
 
@@ -29,6 +27,8 @@ import { getRequiredUiSchema } from '@/modules/ProtocolAdapters/utils/uiSchema.u
 import { AdapterContext } from '@/modules/ProtocolAdapters/types.ts'
 
 import ChakraRJSForm from '@/components/rjsf/Form/ChakraRJSForm.tsx'
+import NodeNameCard from '@/modules/Workspace/components/parts/NodeNameCard.tsx'
+import { NodeTypes } from '@/modules/Workspace/types.ts'
 
 interface AdapterInstanceDrawerProps {
   adapterType?: string
@@ -96,12 +96,7 @@ const AdapterInstanceDrawer: FC<AdapterInstanceDrawerProps> = ({
               <Text>
                 {isNewAdapter ? t('protocolAdapter.drawer.title.create') : t('protocolAdapter.drawer.title.update')}
               </Text>
-              <HStack>
-                <Image boxSize="30px" objectFit="scale-down" src={logo} aria-label={name} />
-                <Text fontSize="md" fontWeight="500">
-                  {name}
-                </Text>
-              </HStack>
+              <NodeNameCard name={name} type={NodeTypes.ADAPTER_NODE} icon={logo} />
             </DrawerHeader>
             <DrawerBody>
               {schema && (

--- a/hivemq-edge/src/frontend/src/modules/TopicFilters/TopicFilterManager.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/TopicFilters/TopicFilterManager.spec.cy.tsx
@@ -22,7 +22,7 @@ describe('TopicFilterManager', () => {
 
     cy.mountWithProviders(<TopicFilterManager />)
 
-    cy.get('header').should('have.text', 'Manage topic filters')
+    cy.get('header > p').should('have.text', 'Manage topic filters')
     cy.get('table').should('be.visible')
 
     cy.get('table').as('table').should('have.attr', 'aria-label', 'List of topic filters')

--- a/hivemq-edge/src/frontend/src/modules/TopicFilters/TopicFilterManager.tsx
+++ b/hivemq-edge/src/frontend/src/modules/TopicFilters/TopicFilterManager.tsx
@@ -16,6 +16,8 @@ import PaginatedTable from '@/components/PaginatedTable/PaginatedTable.tsx'
 import ArrayItemDrawer from '@/components/rjsf/SplitArrayEditor/components/ArrayItemDrawer.tsx'
 import TopicSchemaDrawer from '@/modules/TopicFilters/components/TopicSchemaDrawer.tsx'
 import SchemaValidationMark from '@/modules/TopicFilters/components/SchemaValidationMark.tsx'
+import NodeNameCard from '@/modules/Workspace/components/parts/NodeNameCard.tsx'
+import { NodeTypes } from '@/modules/Workspace/types.ts'
 
 const TopicFilterManager: FC = () => {
   const { t } = useTranslation()
@@ -115,6 +117,7 @@ const TopicFilterManager: FC = () => {
   return (
     <ExpandableDrawer
       header={t('topicFilter.manager.header')}
+      subHeader={<NodeNameCard type={NodeTypes.EDGE_NODE} name={t('branding.appName')} />}
       isOpen={isOpen}
       onClose={handleClose}
       closeOnOverlayClick={false}

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/drawers/DevicePropertyDrawer.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/drawers/DevicePropertyDrawer.spec.cy.tsx
@@ -75,7 +75,6 @@ describe('DevicePropertyDrawer', () => {
     cy.get('@onClose').should('have.been.calledOnce')
 
     cy.get('header').should('contain.text', 'Device Overview')
-    cy.get('h2').eq(0).should('contain.text', 'simulation')
-    cy.get('h2').eq(1).should('contain.text', 'List of Device Tags')
+    cy.get('h2').eq(0).should('contain.text', 'List of Device Tags')
   })
 })

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/drawers/DevicePropertyDrawer.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/drawers/DevicePropertyDrawer.tsx
@@ -15,10 +15,10 @@ import { Adapter } from '@/api/__generated__'
 import { useGetAdapterTypes } from '@/api/hooks/useProtocolAdapters/useGetAdapterTypes.ts'
 import LoaderSpinner from '@/components/Chakra/LoaderSpinner.tsx'
 import ErrorMessage from '@/components/ErrorMessage.tsx'
-import DeviceMetadataViewer from '@/modules/Device/components/DeviceMetadataViewer.tsx'
 import DeviceTagList from '@/modules/Device/components/DeviceTagList.tsx'
 import useWorkspaceStore from '@/modules/Workspace/hooks/useWorkspaceStore.ts'
-import { DeviceMetadata } from '@/modules/Workspace/types.ts'
+import { DeviceMetadata, NodeTypes } from '@/modules/Workspace/types.ts'
+import NodeNameCard from '@/modules/Workspace/components/parts/NodeNameCard.tsx'
 
 interface DevicePropertyDrawerProps {
   nodeId: string
@@ -48,12 +48,14 @@ const DevicePropertyDrawer: FC<DevicePropertyDrawerProps> = ({ isOpen, selectedN
         <DrawerCloseButton />
         <DrawerHeader>
           <Text> {t('workspace.property.header', { context: selectedNode.type })}</Text>
+          <NodeNameCard
+            name={selectedNode.data.name}
+            type={selectedNode.type as NodeTypes}
+            description={selectedNode.data.id}
+          />
         </DrawerHeader>
         <DrawerBody display="flex" flexDirection="column" gap={6}>
-          <DrawerBody display="flex" flexDirection="column" gap={6}>
-            <DeviceMetadataViewer protocolAdapter={protocol} />
-            <DeviceTagList adapter={adapter} />
-          </DrawerBody>
+          <DeviceTagList adapter={adapter} />
         </DrawerBody>
       </DrawerContent>
     </Drawer>

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/drawers/EdgePropertyDrawer.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/drawers/EdgePropertyDrawer.tsx
@@ -14,6 +14,8 @@ import {
 
 import TopicExplorer from '@/modules/Workspace/components/topics/TopicExplorer.tsx'
 import MetadataExplorer from '@/modules/Workspace/components/topics/MetadataExplorer.tsx'
+import NodeNameCard from '@/modules/Workspace/components/parts/NodeNameCard.tsx'
+import { NodeTypes } from '@/modules/Workspace/types.ts'
 
 interface NodePropertyDrawerProps {
   nodeId: string
@@ -35,6 +37,7 @@ const EdgePropertyDrawer: FC<NodePropertyDrawerProps> = ({ isOpen, selectedNode,
         <DrawerCloseButton />
         <DrawerHeader>
           <Text> {t('workspace.property.header', { context: selectedNode.type })}</Text>
+          <NodeNameCard type={NodeTypes.EDGE_NODE} name={t('branding.appName')} />{' '}
         </DrawerHeader>
         <DrawerBody display="flex" flexDirection="column" gap={6}>
           <TopicExplorer onSelect={(topic) => setSelectedTopic(topic)} />

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/drawers/GroupPropertyDrawer.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/drawers/GroupPropertyDrawer.spec.cy.tsx
@@ -43,8 +43,6 @@ describe('GroupPropertyDrawer', () => {
     cy.wait('@getMetricForX')
 
     cy.getByTestId('group-panel-title').should('contain.text', 'Group Observability')
-    cy.getByTestId('group-panel-keys').find('p').eq(0).should('contain.text', 'adapter: bridge-id-01')
-    cy.getByTestId('group-panel-keys').find('p').eq(1).should('contain.text', 'adapter: my-adapter')
 
     cy.get('dt').eq(0).should('contain.text', 'bridge-id-01')
     cy.get('dt').eq(1).should('contain.text', 'my-adapter')

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/drawers/GroupPropertyDrawer.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/drawers/GroupPropertyDrawer.tsx
@@ -2,7 +2,6 @@ import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Node } from 'reactflow'
 import {
-  Box,
   Drawer,
   DrawerBody,
   DrawerCloseButton,
@@ -19,6 +18,7 @@ import useWorkspaceStore from '../../hooks/useWorkspaceStore.ts'
 import { getDefaultMetricsFor } from '../../utils/nodes-utils.ts'
 import GroupMetadataEditor from '../parts/GroupMetadataEditor.tsx'
 import { ChartType } from '@/modules/Metrics/types.ts'
+import NodeNameCard from '@/modules/Workspace/components/parts/NodeNameCard.tsx'
 
 interface GroupPropertyDrawerProps {
   nodeId: string
@@ -56,14 +56,11 @@ const GroupPropertyDrawer: FC<GroupPropertyDrawerProps> = ({
 
         <DrawerHeader>
           <Text data-testid="group-panel-title">{panelTitle}</Text>
-          <Box data-testid="group-panel-keys">
-            {selectedNode.data.childrenNodeIds.map((e) => (
-              <Text key={e}>
-                {t('workspace.device.type', { context: NodeTypes.ADAPTER_NODE })}:{' '}
-                {nodes.find((x) => x.id === e)?.data.id}
-              </Text>
-            ))}
-          </Box>
+          <NodeNameCard
+            description={t('workspace.device.type', { context: selectedNode.type })}
+            type={selectedNode.type as NodeTypes}
+            name={selectedNode.data.title}
+          />
         </DrawerHeader>
         <DrawerBody display="flex" flexDirection="column" gap={6}>
           {showConfig && (

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/drawers/LinkPropertyDrawer.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/drawers/LinkPropertyDrawer.tsx
@@ -1,13 +1,14 @@
 import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Node } from 'reactflow'
-import { Box, Drawer, DrawerBody, DrawerCloseButton, DrawerContent, DrawerHeader, Text } from '@chakra-ui/react'
+import { Drawer, DrawerBody, DrawerCloseButton, DrawerContent, DrawerHeader, Text } from '@chakra-ui/react'
 
 import { Adapter, Bridge } from '@/api/__generated__'
+import { useGetAdapterTypes } from '@/api/hooks/useProtocolAdapters/useGetAdapterTypes.ts'
 import MetricsContainer from '@/modules/Metrics/MetricsContainer.tsx'
-
-import { getDefaultMetricsFor } from '../../utils/nodes-utils.ts'
-import { NodeTypes } from '../../types.ts'
+import NodeNameCard from '@/modules/Workspace/components/parts/NodeNameCard.tsx'
+import { NodeTypes } from '@/modules/Workspace/types.ts'
+import { getDefaultMetricsFor } from '@/modules/Workspace/utils/nodes-utils.ts'
 
 interface LinkPropertyDrawerProps {
   nodeId: string
@@ -19,20 +20,25 @@ interface LinkPropertyDrawerProps {
 
 const LinkPropertyDrawer: FC<LinkPropertyDrawerProps> = ({ nodeId, isOpen, selectedNode, onClose }) => {
   const { t } = useTranslation()
+  const { data: protocols } = useGetAdapterTypes()
+  const adapterProtocol =
+    selectedNode.type === NodeTypes.ADAPTER_NODE
+      ? protocols?.items?.find((e) => e.id === (selectedNode as Node<Adapter>).data.type)
+      : undefined
 
   return (
     <Drawer isOpen={isOpen} placement="right" size="md" onClose={onClose} variant="hivemq">
-      {/*<DrawerOverlay />*/}
       <DrawerContent>
         <DrawerCloseButton />
 
         <DrawerHeader>
-          <Box>
-            <Text>{t('workspace.observability.header', { context: selectedNode.type })}</Text>
-            <Text>
-              {t('workspace.device.type', { context: selectedNode.type })}: {selectedNode.data.id}
-            </Text>
-          </Box>
+          <Text>{t('workspace.observability.header', { context: selectedNode.type })}</Text>
+          <NodeNameCard
+            name={selectedNode.data.id}
+            type={selectedNode.type as NodeTypes}
+            icon={adapterProtocol?.logoUrl}
+            description={adapterProtocol?.name}
+          />
         </DrawerHeader>
         <DrawerBody display="flex" flexDirection="column" gap={6}>
           <MetricsContainer

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/drawers/NodePropertyDrawer.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/drawers/NodePropertyDrawer.tsx
@@ -30,7 +30,8 @@ import { ChartType } from '@/modules/Metrics/types.ts'
 
 import { NodeTypes } from '../../types.ts'
 import { getDefaultMetricsFor } from '../../utils/nodes-utils.ts'
-import NodeNameCard from '../parts/NodeNameCard.tsx'
+import NodeNameCard from '@/modules/Workspace/components/parts/NodeNameCard.tsx'
+import { useGetAdapterTypes } from '@/api/hooks/useProtocolAdapters/useGetAdapterTypes.ts'
 
 interface NodePropertyDrawerProps {
   nodeId: string
@@ -42,6 +43,11 @@ interface NodePropertyDrawerProps {
 
 const NodePropertyDrawer: FC<NodePropertyDrawerProps> = ({ nodeId, isOpen, selectedNode, onClose, onEditEntity }) => {
   const { t } = useTranslation()
+  const { data: protocols } = useGetAdapterTypes()
+  const adapterProtocol =
+    selectedNode.type === NodeTypes.ADAPTER_NODE
+      ? protocols?.items?.find((e) => e.id === (selectedNode as Node<Adapter>).data.type)
+      : undefined
 
   return (
     <Drawer isOpen={isOpen} placement="right" size="md" onClose={onClose} variant="hivemq">
@@ -49,10 +55,15 @@ const NodePropertyDrawer: FC<NodePropertyDrawerProps> = ({ nodeId, isOpen, selec
       <DrawerContent aria-label={t('workspace.property.header', { context: selectedNode.type })}>
         <DrawerCloseButton />
         <DrawerHeader>
-          <Text> {t('workspace.property.header', { context: selectedNode.type })}</Text>
+          <Text>{t('workspace.property.header', { context: selectedNode.type })}</Text>
+          <NodeNameCard
+            name={selectedNode.data.id}
+            type={selectedNode.type as NodeTypes}
+            icon={adapterProtocol?.logoUrl}
+            description={adapterProtocol?.name}
+          />
         </DrawerHeader>
         <DrawerBody display="flex" flexDirection="column" gap={6}>
-          <NodeNameCard selectedNode={selectedNode} />
           <MetricsContainer
             nodeId={nodeId}
             type={selectedNode.type as NodeTypes}

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/parts/NodeNameCard.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/parts/NodeNameCard.spec.cy.tsx
@@ -1,49 +1,54 @@
-/// <reference types="cypress" />
-
-import { Node } from 'reactflow'
-
-import { MOCK_NODE_ADAPTER, MOCK_NODE_BRIDGE } from '@/__test-utils__/react-flow/nodes.ts'
-import { Adapter, Bridge } from '@/api/__generated__'
 import { NodeTypes } from '@/modules/Workspace/types.ts'
+import anyLogo from '@/assets/edge/05-icon-industrial-hivemq-edge.svg'
 
 import NodeNameCard from './NodeNameCard.tsx'
 import { mockProtocolAdapter } from '@/api/hooks/useProtocolAdapters/__handlers__'
 
-const mockNodeAdapter: Node<Bridge | Adapter> = {
-  position: { x: 0, y: 0 },
-  id: 'adapter@fgffgf',
-  type: NodeTypes.ADAPTER_NODE,
-  data: MOCK_NODE_ADAPTER.data,
-}
-
-const mockNodeBridg: Node<Bridge | Adapter> = {
-  position: { x: 0, y: 0 },
-  id: 'adapter@fgffgf',
-  type: NodeTypes.BRIDGE_NODE,
-  data: MOCK_NODE_BRIDGE.data,
-}
-
 describe('NodeNameCard', () => {
   beforeEach(() => {
     cy.viewport(400, 400)
-    cy.intercept('/api/v1/management/protocol-adapters/types', { items: [mockProtocolAdapter] }).as('getConfig1')
+    cy.intercept('/api/v1/management/protocol-adapters/types', { items: [mockProtocolAdapter] }).as('getConfig')
   })
 
   it('should render adapter properly', () => {
-    cy.mountWithProviders(<NodeNameCard selectedNode={mockNodeAdapter} />)
+    cy.mountWithProviders(
+      <NodeNameCard type={NodeTypes.ADAPTER_NODE} name="The adapter" description="The adapter type" icon={anyLogo} />
+    )
 
     cy.getByTestId('node-type-icon').should('exist').should('have.attr', 'data-nodeicon', NodeTypes.ADAPTER_NODE)
-    cy.getByTestId('node-type-text').should('contain.text', 'adapter')
-    cy.getByTestId('node-adapter-type').should('contain.text', 'Simulated Edge Device')
-    cy.getByTestId('node-name').should('contain.text', 'my-adapter')
+    cy.getByTestId('node-name').should('contain.text', 'The adapter')
+    cy.getByTestId('node-description').should('contain.text', 'The adapter type')
   })
 
   it('should render bridge properly', () => {
-    cy.mountWithProviders(<NodeNameCard selectedNode={mockNodeBridg} />)
+    cy.mountWithProviders(<NodeNameCard type={NodeTypes.BRIDGE_NODE} name="The Bridge" description="Bridge" />)
 
     cy.getByTestId('node-type-icon').should('exist').should('have.attr', 'data-nodeicon', NodeTypes.BRIDGE_NODE)
-    cy.getByTestId('node-type-text').should('contain.text', 'bridge')
-    cy.getByTestId('node-adapter-type').should('not.exist')
-    cy.getByTestId('node-name').should('contain.text', 'bridge-id-01')
+    cy.getByTestId('node-name').should('contain.text', 'The Bridge')
+    cy.getByTestId('node-description').should('contain.text', 'Bridge')
+  })
+
+  it('should render groups properly', () => {
+    cy.mountWithProviders(<NodeNameCard type={NodeTypes.CLUSTER_NODE} name="The Group" description="Group" />)
+
+    cy.getByTestId('node-type-icon').should('exist').should('have.attr', 'data-nodeicon', NodeTypes.CLUSTER_NODE)
+    cy.getByTestId('node-name').should('contain.text', 'The Group')
+    cy.getByTestId('node-description').should('contain.text', 'Group')
+  })
+
+  it('should render the edge properly', () => {
+    cy.mountWithProviders(<NodeNameCard type={NodeTypes.EDGE_NODE} name="The Edge" />)
+
+    cy.getByTestId('node-type-icon').should('exist').should('have.attr', 'data-nodeicon', NodeTypes.EDGE_NODE)
+    cy.getByTestId('node-name').should('contain.text', 'The Edge')
+    cy.getByTestId('node-description').should('not.exist')
+  })
+
+  it('should render the devices properly', () => {
+    cy.mountWithProviders(<NodeNameCard type={NodeTypes.DEVICE_NODE} />)
+
+    cy.getByTestId('node-type-icon').should('exist').should('have.attr', 'data-nodeicon', NodeTypes.DEVICE_NODE)
+    cy.getByTestId('node-name').should('not.exist')
+    cy.getByTestId('node-description').should('not.exist')
   })
 })

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/parts/NodeNameCard.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/parts/NodeNameCard.tsx
@@ -20,15 +20,25 @@ const NodeNameCard: FC<NodeNameCardProps> = ({ name, type, description, icon }) 
   const EntityIcon = useMemo(() => {
     switch (type) {
       case NodeTypes.ADAPTER_NODE:
-        // return <Icon data-testid="node-type-icon" data-nodeicon={type} as={PiPlugsConnectedFill} fontSize="24px" />
-        return <Image aria-label={type} boxSize="20px" objectFit="scale-down" src={icon} />
+        return (
+          <Image
+            aria-label={type}
+            boxSize="20px"
+            objectFit="scale-down"
+            src={icon}
+            data-testid="node-type-icon"
+            data-nodeicon={type}
+          />
+        )
 
       case NodeTypes.BRIDGE_NODE:
         return <Icon data-testid="node-type-icon" data-nodeicon={type} as={PiBridgeThin} fontSize="24px" />
       case NodeTypes.CLUSTER_NODE:
         return <Icon data-testid="node-type-icon" data-nodeicon={type} as={ImMakeGroup} fontSize="24px" />
       case NodeTypes.EDGE_NODE:
-        return <Image objectFit="cover" w="24px" src={edgeLogo} alt="SS" />
+        return (
+          <Image data-testid="node-type-icon" data-nodeicon={type} objectFit="cover" w="24px" src={edgeLogo} alt="SS" />
+        )
 
       case NodeTypes.DEVICE_NODE:
         return (
@@ -50,12 +60,16 @@ const NodeNameCard: FC<NodeNameCardProps> = ({ name, type, description, icon }) 
         <HStack divider={<StackDivider />}>
           {EntityIcon}
           <VStack alignItems="flex-start" gap={0}>
-            <Text data-testid="node-name" noOfLines={1}>
-              {name}
-            </Text>
-            <Text data-testid="node-description" noOfLines={1} fontWeight="normal">
-              {description}
-            </Text>
+            {name && (
+              <Text data-testid="node-name" noOfLines={1}>
+                {name}
+              </Text>
+            )}
+            {description && (
+              <Text data-testid="node-description" noOfLines={1} fontWeight="normal">
+                {description}
+              </Text>
+            )}
           </VStack>
         </HStack>
       </CardBody>

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/parts/NodeNameCard.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/parts/NodeNameCard.tsx
@@ -1,54 +1,60 @@
 import { FC, useMemo } from 'react'
-import { Node } from 'reactflow'
-import { Card, CardBody, HStack, Icon, StackDivider, Tag, Text, VStack } from '@chakra-ui/react'
-import { PiBridgeThin, PiPlugsConnectedFill } from 'react-icons/pi'
-import { useTranslation } from 'react-i18next'
+import { Card, CardBody, HStack, Icon, Image, StackDivider, Text, VStack } from '@chakra-ui/react'
+import { PiBridgeThin } from 'react-icons/pi'
+import { GrStatusUnknown } from 'react-icons/gr'
+import { ImMakeGroup } from 'react-icons/im'
 
-import { Adapter, Bridge } from '@/api/__generated__'
-import { useGetAdapterTypes } from '@/api/hooks/useProtocolAdapters/useGetAdapterTypes.ts'
+import edgeLogo from '@/assets/edge/05-icon-industrial-hivemq-edge.svg'
 
-import { NodeTypes } from '../../types.ts'
+import { deviceCategoryIcon, ProtocolAdapterCategoryName } from '@/modules/Workspace/utils/adapter.utils.ts'
+import { NodeTypes } from '@/modules/Workspace/types.ts'
 
 interface NodeNameCardProps {
-  selectedNode: Node<Bridge | Adapter>
+  type: NodeTypes
+  name?: string
+  description?: string
+  icon?: string
 }
 
-const NodeNameCard: FC<NodeNameCardProps> = ({ selectedNode }) => {
-  const { t } = useTranslation()
-  const { data } = useGetAdapterTypes()
-  const { type } = selectedNode
-
-  const adapterType = useMemo(() => {
-    if (!data) return undefined
-    if (type === NodeTypes.BRIDGE_NODE) return undefined
-
-    const adapterType = (selectedNode as Node<Adapter>).data.type
-    return data?.items?.find((e) => e.id === adapterType)
-  }, [data, selectedNode, type])
-
+const NodeNameCard: FC<NodeNameCardProps> = ({ name, type, description, icon }) => {
   const EntityIcon = useMemo(() => {
-    if (type === NodeTypes.BRIDGE_NODE)
-      return (
-        <Icon data-testid="node-type-icon" data-nodeicon={NodeTypes.BRIDGE_NODE} as={PiBridgeThin} fontSize="40px" />
-      )
-    return <Icon data-testid="node-type-icon" data-nodeicon={NodeTypes.ADAPTER_NODE} as={PiPlugsConnectedFill} />
-  }, [type])
+    switch (type) {
+      case NodeTypes.ADAPTER_NODE:
+        // return <Icon data-testid="node-type-icon" data-nodeicon={type} as={PiPlugsConnectedFill} fontSize="24px" />
+        return <Image aria-label={type} boxSize="20px" objectFit="scale-down" src={icon} />
+
+      case NodeTypes.BRIDGE_NODE:
+        return <Icon data-testid="node-type-icon" data-nodeicon={type} as={PiBridgeThin} fontSize="24px" />
+      case NodeTypes.CLUSTER_NODE:
+        return <Icon data-testid="node-type-icon" data-nodeicon={type} as={ImMakeGroup} fontSize="24px" />
+      case NodeTypes.EDGE_NODE:
+        return <Image objectFit="cover" w="24px" src={edgeLogo} alt="SS" />
+
+      case NodeTypes.DEVICE_NODE:
+        return (
+          <Icon
+            data-testid="node-type-icon"
+            data-nodeicon={type}
+            as={deviceCategoryIcon[ProtocolAdapterCategoryName.SIMULATION]}
+            fontSize="24px"
+          />
+        )
+      default:
+        return <Icon data-testid="node-type-icon" data-nodeicon={type} as={GrStatusUnknown} />
+    }
+  }, [icon, type])
 
   return (
-    <Card size="sm" direction="row">
+    <Card size="sm" direction="row" fontSize="sm">
       <CardBody>
         <HStack divider={<StackDivider />}>
-          <VStack>
-            {EntityIcon}
-            <Tag data-testid="node-type-text" textTransform="uppercase">
-              {t('workspace.device.type', { context: type })}{' '}
-            </Tag>
-          </VStack>
-
-          <VStack alignItems="flex-start">
-            {adapterType && <Text data-testid="node-adapter-type">{adapterType.name}</Text>}
+          {EntityIcon}
+          <VStack alignItems="flex-start" gap={0}>
             <Text data-testid="node-name" noOfLines={1}>
-              {selectedNode.data.id}
+              {name}
+            </Text>
+            <Text data-testid="node-description" noOfLines={1} fontWeight="normal">
+              {description}
             </Text>
           </VStack>
         </HStack>


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/28703/details/

The PR fixes a significant usability issue, whereas most of the side panels opening in the workspace would not mention which node or link would have triggered the opening.

The side panels now contain a cartouche in the header which will indicate which content is associated with the specific instance of the panel. 

The content of that cartouche has been normalised to render the icon of the entity, its name and its description. 

Note that, in most cases, the trigger of the side panel will be one of the nodes on the workspace (or a link connecting them). The cartouche therefore refers to these nodes, which might reinforce a somehow loose coupling (e.g. `topic filters` being located within the `Edge` node)

### Before
![screenshot-localhost_3000-2024_12_16-10_35_04](https://github.com/user-attachments/assets/f350ad3a-b1cf-47e4-b06a-874df733c0b7)

### After 
![screenshot-localhost_3000-2024_12_16-10_33_28](https://github.com/user-attachments/assets/2482fb5c-a59e-46b0-b68b-0e3893360d29)

![screenshot-localhost_3000-2024_12_16-10_33_39](https://github.com/user-attachments/assets/579010e8-67e2-45ed-a579-d536fdf6bf09)

![screenshot-localhost_3000-2024_12_16-10_33_56](https://github.com/user-attachments/assets/7e003c97-6932-448f-9d12-1b1885f2374c)

