### PR TITLE
Add version to config

### DIFF
--- a/hivemq-edge/src/main/java/com/hivemq/api/resources/impl/ProtocolAdaptersResourceImpl.java
+++ b/hivemq-edge/src/main/java/com/hivemq/api/resources/impl/ProtocolAdaptersResourceImpl.java
@@ -696,6 +696,7 @@ public class ProtocolAdaptersResourceImpl extends AbstractApi implements Protoco
 
             protocolAdapterManager.addAdapter(new ProtocolAdapterConfig(adapterId,
                     adapterType,
+                    protocolAdapterInformation.get().getCurrentConfigVersion(),
                     protocolSpecificAdapterConfig,
                     southboundMappings,
                     northboundMappings,

--- a/hivemq-edge/src/main/java/com/hivemq/configuration/entity/HiveMQConfigEntity.java
+++ b/hivemq-edge/src/main/java/com/hivemq/configuration/entity/HiveMQConfigEntity.java
@@ -34,6 +34,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * @author Dominik Obermaier
@@ -43,6 +44,11 @@ import java.util.Map;
 @XmlAccessorType(XmlAccessType.NONE)
 @SuppressWarnings({"FieldMayBeFinal", "FieldCanBeLocal"})
 public class HiveMQConfigEntity {
+
+    public static final int CURRENT_CONFIG_VERSION = 1;
+
+    @XmlElement(name = "config-version", defaultValue = "" + CURRENT_CONFIG_VERSION)
+    private int version = CURRENT_CONFIG_VERSION;
 
     @XmlElementWrapper(name = "mqtt-listeners", required = true)
     @XmlElementRef(required = false)
@@ -95,11 +101,12 @@ public class HiveMQConfigEntity {
     private final @NotNull InternalConfigEntity internal = new InternalConfigEntity();
 
     // no-arg constructor as JaxB does need one
-    public HiveMQConfigEntity(){
+    public HiveMQConfigEntity() {
 
     }
 
     public HiveMQConfigEntity(
+            final @NotNull Integer version,
             final @NotNull AdminApiEntity api,
             final @NotNull DynamicConfigEntity gateway,
             final @NotNull Map<String, Object> moduleConfigs,
@@ -114,6 +121,7 @@ public class HiveMQConfigEntity {
             final @NotNull SecurityConfigEntity security,
             final @NotNull UnsConfigEntity uns,
             final @NotNull UsageTrackingConfigEntity usageTracking) {
+        this.version = Objects.requireNonNullElse(version, CURRENT_CONFIG_VERSION);
         this.api = api;
         this.gateway = gateway;
         this.moduleConfigs = moduleConfigs;
@@ -174,9 +182,13 @@ public class HiveMQConfigEntity {
         return moduleConfigs;
     }
 
-    public @NotNull UnsConfigEntity getUns() { return uns; }
+    public @NotNull UnsConfigEntity getUns() {
+        return uns;
+    }
 
-    public @NotNull DynamicConfigEntity getGatewayConfig() { return gateway;}
+    public @NotNull DynamicConfigEntity getGatewayConfig() {
+        return gateway;
+    }
 
     public @NotNull UsageTrackingConfigEntity getUsageTracking() {
         return usageTracking;
@@ -184,5 +196,9 @@ public class HiveMQConfigEntity {
 
     public @NotNull InternalConfigEntity getInternal() {
         return internal;
+    }
+
+    public int getVersion() {
+        return version;
     }
 }

--- a/hivemq-edge/src/main/java/com/hivemq/configuration/entity/adapter/ProtocolAdapterEntity.java
+++ b/hivemq-edge/src/main/java/com/hivemq/configuration/entity/adapter/ProtocolAdapterEntity.java
@@ -43,7 +43,7 @@ public class ProtocolAdapterEntity {
     @XmlElement(name = "protocolId", required = true)
     private @NotNull String protocolId;
 
-    @XmlElement(name = "protocolId")
+    @XmlElement(name = "configVersion")
     private @Nullable Integer configVersion;
 
     @XmlElement(name = "config")

--- a/hivemq-edge/src/main/java/com/hivemq/configuration/entity/adapter/ProtocolAdapterEntity.java
+++ b/hivemq-edge/src/main/java/com/hivemq/configuration/entity/adapter/ProtocolAdapterEntity.java
@@ -43,7 +43,7 @@ public class ProtocolAdapterEntity {
     private @NotNull String protocolId;
 
     @XmlElement(name = "protocolId")
-    private @NotNull Integer configVersion;
+    private @Nullable Integer configVersion;
 
     @XmlElement(name = "config")
     @XmlJavaTypeAdapter(ArbitraryValuesMapAdapter.class)
@@ -77,7 +77,7 @@ public class ProtocolAdapterEntity {
         this.adapterId = adapterId;
         this.config = config;
         // if no config version is present, we assume it is the oldest possible version
-        this.configVersion = configVersion != null ? configVersion : 1;
+        this.configVersion = configVersion;
         this.northboundMappingEntities = northboundMappingEntities;
         this.protocolId = protocolId;
         this.tags = tags;
@@ -109,7 +109,11 @@ public class ProtocolAdapterEntity {
     }
 
     public @NotNull Integer getConfigVersion() {
-        return configVersion;
+        if (configVersion == null) {
+            return 1;
+        } else {
+            return configVersion;
+        }
     }
 
     public void validate(final @NotNull List<ValidationEvent> validationEvents) {

--- a/hivemq-edge/src/main/java/com/hivemq/configuration/entity/adapter/ProtocolAdapterEntity.java
+++ b/hivemq-edge/src/main/java/com/hivemq/configuration/entity/adapter/ProtocolAdapterEntity.java
@@ -18,8 +18,9 @@ package com.hivemq.configuration.entity.adapter;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hivemq.configuration.reader.ArbitraryValuesMapAdapter;
-import org.jetbrains.annotations.NotNull;
 import com.hivemq.protocols.ProtocolAdapterConfig;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import javax.xml.bind.ValidationEvent;
 import javax.xml.bind.annotation.XmlElement;
@@ -40,6 +41,9 @@ public class ProtocolAdapterEntity {
 
     @XmlElement(name = "protocolId", required = true)
     private @NotNull String protocolId;
+
+    @XmlElement(name = "protocolId")
+    private @NotNull Integer configVersion;
 
     @XmlElement(name = "config")
     @XmlJavaTypeAdapter(ArbitraryValuesMapAdapter.class)
@@ -65,12 +69,15 @@ public class ProtocolAdapterEntity {
     public ProtocolAdapterEntity(
             final @NotNull String adapterId,
             final @NotNull String protocolId,
+            final @Nullable Integer configVersion,
             final @NotNull Map<String, Object> config,
             final @NotNull List<NorthboundMappingEntity> northboundMappingEntities,
             final @NotNull List<SouthboundMappingEntity> southboundMappingEntities,
             final @NotNull List<TagEntity> tags) {
         this.adapterId = adapterId;
         this.config = config;
+        // if no config version is present, we assume it is the oldest possible version
+        this.configVersion = configVersion != null ? configVersion : 1;
         this.northboundMappingEntities = northboundMappingEntities;
         this.protocolId = protocolId;
         this.tags = tags;
@@ -99,6 +106,10 @@ public class ProtocolAdapterEntity {
 
     public @NotNull String getAdapterId() {
         return adapterId;
+    }
+
+    public @NotNull Integer getConfigVersion() {
+        return configVersion;
     }
 
     public void validate(final @NotNull List<ValidationEvent> validationEvents) {
@@ -130,16 +141,17 @@ public class ProtocolAdapterEntity {
                 .collect(Collectors.toList());
 
         final List<TagEntity> tagEntities = protocolAdapterConfig.getTags()
-                .stream().map(tag -> TagEntity.fromAdapterTag(tag, objectMapper))
+                .stream()
+                .map(tag -> TagEntity.fromAdapterTag(tag, objectMapper))
                 .collect(Collectors.toList());
 
         final Map<String, Object> configAsMaps =
                 objectMapper.convertValue(protocolAdapterConfig.getAdapterConfig(), new TypeReference<>() {
                 });
 
-        return new ProtocolAdapterEntity(
-                protocolAdapterConfig.getAdapterId(),
+        return new ProtocolAdapterEntity(protocolAdapterConfig.getAdapterId(),
                 protocolAdapterConfig.getProtocolId(),
+                protocolAdapterConfig.getConfigVersion(),
                 configAsMaps,
                 northboundMappings,
                 southboundMappings,

--- a/hivemq-edge/src/main/java/com/hivemq/configuration/entity/adapter/ProtocolAdapterEntity.java
+++ b/hivemq-edge/src/main/java/com/hivemq/configuration/entity/adapter/ProtocolAdapterEntity.java
@@ -31,6 +31,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 @SuppressWarnings({"FieldMayBeFinal", "unused"})
@@ -109,11 +110,7 @@ public class ProtocolAdapterEntity {
     }
 
     public @NotNull Integer getConfigVersion() {
-        if (configVersion == null) {
-            return 1;
-        } else {
-            return configVersion;
-        }
+        return Objects.requireNonNullElse(configVersion, 1);
     }
 
     public void validate(final @NotNull List<ValidationEvent> validationEvents) {

--- a/hivemq-edge/src/main/java/com/hivemq/configuration/migration/ConfigurationMigrator.java
+++ b/hivemq-edge/src/main/java/com/hivemq/configuration/migration/ConfigurationMigrator.java
@@ -89,7 +89,8 @@ public class ConfigurationMigrator {
 
     @VisibleForTesting
     public ConfigurationMigrator(
-            final @NotNull ConfigurationFile configurationFile, final @NotNull ModuleLoader moduleLoader) {
+            final @NotNull ConfigurationFile configurationFile,
+            final @NotNull ModuleLoader moduleLoader) {
         this.moduleLoader = moduleLoader;
         moduleLoader.loadModules();
         this.configurationFile = configurationFile;
@@ -188,6 +189,7 @@ public class ConfigurationMigrator {
 
             return List.of(new ProtocolAdapterEntity(configTagsTuple.getAdapterId(),
                     protocolId,
+                    protocolAdapterFactory.getInformation().getCurrentConfigVersion(),
                     objectMapper.convertValue(configTagsTuple.getConfig(), new TypeReference<>() {
                     }),
                     northboundMappingEntities,

--- a/hivemq-edge/src/main/java/com/hivemq/configuration/migration/LegacyHiveMQConfigEntity.java
+++ b/hivemq-edge/src/main/java/com/hivemq/configuration/migration/LegacyHiveMQConfigEntity.java
@@ -44,6 +44,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static com.hivemq.configuration.entity.HiveMQConfigEntity.CURRENT_CONFIG_VERSION;
+
 /**
  * @author Dominik Obermaier
  * @author Lukas brandl
@@ -165,7 +167,8 @@ public class LegacyHiveMQConfigEntity {
 
     final @NotNull HiveMQConfigEntity to(
             final @NotNull List<ProtocolAdapterEntity> adapterEntities) {
-        return new HiveMQConfigEntity(this.getApiConfig(),
+        return new HiveMQConfigEntity(CURRENT_CONFIG_VERSION,
+                this.getApiConfig(),
                 this.getGatewayConfig(),
                 this.getModuleConfigs(),
                 this.getMqttConfig(),

--- a/hivemq-edge/src/main/java/com/hivemq/edge/modules/adapters/simulation/SimulationProtocolAdapterInformation.java
+++ b/hivemq-edge/src/main/java/com/hivemq/edge/modules/adapters/simulation/SimulationProtocolAdapterInformation.java
@@ -36,9 +36,11 @@ import java.util.List;
 
 public class SimulationProtocolAdapterInformation implements ProtocolAdapterInformation {
 
+    public static final ProtocolAdapterInformation INSTANCE = new SimulationProtocolAdapterInformation();
+
     private static final Logger log = LoggerFactory.getLogger(SimulationProtocolAdapterInformation.class);
 
-    public static final ProtocolAdapterInformation INSTANCE = new SimulationProtocolAdapterInformation();
+    public static final int CURRENT_CONFIG_VERSION = 1;
 
     private SimulationProtocolAdapterInformation() {
     }
@@ -112,6 +114,11 @@ public class SimulationProtocolAdapterInformation implements ProtocolAdapterInfo
             log.warn("The UISchema for the Simulation Adapter could not be loaded from resources:", e);
             return null;
         }
+    }
+
+    @Override
+    public int getCurrentConfigVersion() {
+        return CURRENT_CONFIG_VERSION;
     }
 
 

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/ProtocolAdapterConfig.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/ProtocolAdapterConfig.java
@@ -32,18 +32,21 @@ public class ProtocolAdapterConfig {
     private final @NotNull List<? extends Tag> tags;
     private final @NotNull String adapterId;
     private final @NotNull String protocolId;
+    private final int configVersion;
     private final @NotNull List<SouthboundMapping> southboundMappings;
     private final @NotNull List<NorthboundMapping> northboundMappings;
 
     public ProtocolAdapterConfig(
             final @NotNull String adapterId,
             final @NotNull String protocolId,
+            final int configVersion,
             final @NotNull ProtocolSpecificAdapterConfig protocolSpecificConfig,
             final @NotNull List<SouthboundMapping> southboundMappings,
             final @NotNull List<NorthboundMapping> northboundMappings,
             final @NotNull List<? extends Tag> tags) {
         this.adapterId = adapterId;
         this.protocolId = protocolId;
+        this.configVersion = configVersion;
         this.southboundMappings = southboundMappings;
         this.northboundMappings = northboundMappings;
         this.adapterConfig = protocolSpecificConfig;
@@ -89,5 +92,9 @@ public class ProtocolAdapterConfig {
 
     public @NotNull List<SouthboundMapping> getToEdgeMappings() {
         return southboundMappings;
+    }
+
+    public int getConfigVersion() {
+        return configVersion;
     }
 }

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/ProtocolAdapterConfigConverter.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/ProtocolAdapterConfigConverter.java
@@ -77,7 +77,9 @@ public class ProtocolAdapterConfigConverter {
 
         return new ProtocolAdapterConfig(protocolAdapterEntity.getAdapterId(),
                 protocolAdapterEntity.getProtocolId(),
-                protocolSpecificAdapterConfig, southboundMappingList,
+                protocolAdapterEntity.getConfigVersion(),
+                protocolSpecificAdapterConfig,
+                southboundMappingList,
                 northboundMappingList,
                 tags);
     }

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/ProtocolAdapterManager.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/ProtocolAdapterManager.java
@@ -421,7 +421,8 @@ public class ProtocolAdapterManager {
         Preconditions.checkNotNull(adapterId);
         Preconditions.checkNotNull(config);
 
-        if (getAdapterTypeById(adapterType).isEmpty()) {
+        final Optional<ProtocolAdapterInformation> adapterInformationOptional = getAdapterTypeById(adapterType);
+        if (adapterInformationOptional.isEmpty()) {
             throw new IllegalArgumentException("invalid adapter type '" + adapterType + "'");
         }
         if (getAdapterById(adapterId).isPresent()) {
@@ -436,6 +437,7 @@ public class ProtocolAdapterManager {
         final ProtocolAdapterConfig protocolAdapterConfig = new ProtocolAdapterConfig(
                 adapterId,
                 adapterType,
+                adapterInformationOptional.get().getCurrentConfigVersion(),
                 protocolSpecificAdapterConfig,
                 List.of(),
                 List.of(),
@@ -498,6 +500,7 @@ public class ProtocolAdapterManager {
 
             final ProtocolAdapterConfig protocolAdapterConfig = new ProtocolAdapterConfig(adapterId,
                     adapterType,
+                    oldInstance.getAdapterInformation().getCurrentConfigVersion(),
                     protocolSpecificAdapterConfig,
                     oldInstance.getToEdgeMappings(),
                     oldInstance.getFromEdgeMappings(),
@@ -516,6 +519,7 @@ public class ProtocolAdapterManager {
             final String protocolId = oldInstance.getAdapterInformation().getProtocolId();
             final ProtocolAdapterConfig protocolAdapterConfig = new ProtocolAdapterConfig(oldInstance.getId(),
                     protocolId,
+                    oldInstance.getAdapterInformation().getCurrentConfigVersion(),
                     oldInstance.getConfigObject(),
                     oldInstance.getToEdgeMappings(),
                     oldInstance.getFromEdgeMappings(),
@@ -533,6 +537,7 @@ public class ProtocolAdapterManager {
             final String protocolId = oldInstance.getAdapterInformation().getProtocolId();
             final ProtocolAdapterConfig protocolAdapterConfig = new ProtocolAdapterConfig(oldInstance.getId(),
                     protocolId,
+                    oldInstance.getAdapterInformation().getCurrentConfigVersion(),
                     oldInstance.getConfigObject(),
                     oldInstance.getToEdgeMappings(), northboundMappings,
                     oldInstance.getTags());
@@ -556,6 +561,7 @@ public class ProtocolAdapterManager {
             final String protocolId = oldInstance.getAdapterInformation().getProtocolId();
             final ProtocolAdapterConfig protocolAdapterConfig = new ProtocolAdapterConfig(oldInstance.getId(),
                     protocolId,
+                    oldInstance.getAdapterInformation().getCurrentConfigVersion(),
                     oldInstance.getConfigObject(), southboundMappings,
                     oldInstance.getFromEdgeMappings(),
                     oldInstance.getTags());

--- a/hivemq-edge/src/main/resources/config.xsd
+++ b/hivemq-edge/src/main/resources/config.xsd
@@ -23,6 +23,7 @@
 
     <xs:complexType name="hiveMQConfigEntity">
         <xs:all>
+            <xs:element name="config-version" type="xs:integer" minOccurs="0"/>
             <xs:element name="mqtt-listeners" type="mqttListenersEntity" minOccurs="0"/>
             <xs:element name="mqtt-sn-listeners" type="mqttsnListenersEntity" minOccurs="0"/>
             <xs:element name="mqtt" type="mqttConfigEntity" minOccurs="0"/>
@@ -861,7 +862,7 @@
                                                         <xs:complexType>
                                                             <xs:choice>
                                                                 <xs:element name="mqtt-topic-filter"
-                                                                            type="nonEmptyString" minOccurs="1"
+                                                                            type="nonEmptyString"
                                                                             maxOccurs="unbounded"/>
                                                             </xs:choice>
                                                         </xs:complexType>

--- a/hivemq-edge/src/test/java/com/hivemq/protocols/ProtocolAdapterManagerTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/protocols/ProtocolAdapterManagerTest.java
@@ -338,6 +338,11 @@ class ProtocolAdapterManagerTest {
         public @org.jetbrains.annotations.NotNull Class<? extends ProtocolSpecificAdapterConfig> configurationClassNorthAndSouthbound() {
             return null;
         }
+
+        @Override
+        public int getCurrentConfigVersion() {
+            return 1;
+        }
     }
 
     static class TestWritingAdapter implements WritingProtocolAdapter {

--- a/hivemq-edge/src/test/resources/test-config.xml
+++ b/hivemq-edge/src/test/resources/test-config.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <hivemq xsi:schemaLocation="config.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <config-version>1</config-version>
     <mqtt-listeners>
         <tcp-listener>
             <port>1883</port>

--- a/modules/hivemq-edge-module-etherip/src/main/java/com/hivemq/edge/adapters/etherip/EipProtocolAdapterInformation.java
+++ b/modules/hivemq-edge-module-etherip/src/main/java/com/hivemq/edge/adapters/etherip/EipProtocolAdapterInformation.java
@@ -40,6 +40,7 @@ public class EipProtocolAdapterInformation implements ProtocolAdapterInformation
     public static final @NotNull ProtocolAdapterInformation INSTANCE = new EipProtocolAdapterInformation();
     private static final @NotNull Logger log = LoggerFactory.getLogger(EipProtocolAdapterInformation.class);
     public static final String PROTOCOL_ID = "eip";
+    private static final int CURRENT_CONFIG_VERSION = 1;
 
     private EipProtocolAdapterInformation() {
     }
@@ -136,5 +137,10 @@ public class EipProtocolAdapterInformation implements ProtocolAdapterInformation
     @Override
     public @NotNull Class<? extends ProtocolSpecificAdapterConfig> configurationClassNorthAndSouthbound() {
         return EipSpecificAdapterConfig.class;
+    }
+
+    @Override
+    public int getCurrentConfigVersion() {
+        return CURRENT_CONFIG_VERSION;
     }
 }

--- a/modules/hivemq-edge-module-file/src/main/java/com/hivemq/edge/adapters/file/FileProtocolAdapterInformation.java
+++ b/modules/hivemq-edge-module-file/src/main/java/com/hivemq/edge/adapters/file/FileProtocolAdapterInformation.java
@@ -38,8 +38,11 @@ import java.util.List;
 public class FileProtocolAdapterInformation implements ProtocolAdapterInformation {
 
     public static final @NotNull ProtocolAdapterInformation INSTANCE = new FileProtocolAdapterInformation();
-    private static final @NotNull Logger LOG = LoggerFactory.getLogger(FileProtocolAdapterInformation.class);
     public static final String PROTOCOL_ID = "file";
+
+    private static final @NotNull Logger LOG = LoggerFactory.getLogger(FileProtocolAdapterInformation.class);
+    private static final int CURRENT_CONFIG_VERSION = 1;
+
 
     protected FileProtocolAdapterInformation() {
     }
@@ -134,5 +137,10 @@ public class FileProtocolAdapterInformation implements ProtocolAdapterInformatio
     @Override
     public @NotNull Class<? extends ProtocolSpecificAdapterConfig> configurationClassNorthAndSouthbound() {
         return FileSpecificAdapterConfig.class;
+    }
+
+    @Override
+    public int getCurrentConfigVersion() {
+        return CURRENT_CONFIG_VERSION;
     }
 }

--- a/modules/hivemq-edge-module-http/src/main/java/com/hivemq/edge/adapters/http/HttpProtocolAdapterInformation.java
+++ b/modules/hivemq-edge-module-http/src/main/java/com/hivemq/edge/adapters/http/HttpProtocolAdapterInformation.java
@@ -39,10 +39,11 @@ import java.util.List;
  */
 public class HttpProtocolAdapterInformation implements ProtocolAdapterInformation {
 
-    private static final @NotNull Logger log = LoggerFactory.getLogger(HttpProtocolAdapterInformation.class);
     public static final ProtocolAdapterInformation INSTANCE = new HttpProtocolAdapterInformation();
     public static final String PROTOCOL_ID = "http";
 
+    private static final @NotNull Logger log = LoggerFactory.getLogger(HttpProtocolAdapterInformation.class);
+    private static final int CURRENT_CONFIG_VERSION = 1;
 
     protected HttpProtocolAdapterInformation() {
     }
@@ -131,5 +132,10 @@ public class HttpProtocolAdapterInformation implements ProtocolAdapterInformatio
     @Override
     public @NotNull Class<? extends ProtocolSpecificAdapterConfig> configurationClassNorthAndSouthbound() {
         return HttpSpecificAdapterConfig.class;
+    }
+
+    @Override
+    public int getCurrentConfigVersion() {
+        return CURRENT_CONFIG_VERSION;
     }
 }

--- a/modules/hivemq-edge-module-modbus/src/main/java/com/hivemq/edge/adapters/modbus/ModbusProtocolAdapterInformation.java
+++ b/modules/hivemq-edge-module-modbus/src/main/java/com/hivemq/edge/adapters/modbus/ModbusProtocolAdapterInformation.java
@@ -37,6 +37,7 @@ public class ModbusProtocolAdapterInformation implements ProtocolAdapterInformat
     public static final ProtocolAdapterInformation INSTANCE = new ModbusProtocolAdapterInformation();
     private static final @NotNull Logger log = LoggerFactory.getLogger(ModbusProtocolAdapterInformation.class);
     public static final @NotNull String PROTOCOL_ID = "modbus";
+    private static final int CURRENT_CONFIG_VERSION = 1;
 
     protected ModbusProtocolAdapterInformation() {
     }
@@ -105,6 +106,11 @@ public class ModbusProtocolAdapterInformation implements ProtocolAdapterInformat
             log.warn("The UISchema for the Simulation Adapter could not be loaded from resources:", e);
             return null;
         }
+    }
+
+    @Override
+    public int getCurrentConfigVersion() {
+        return CURRENT_CONFIG_VERSION;
     }
 
     @Override

--- a/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/OpcUaProtocolAdapterInformation.java
+++ b/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/OpcUaProtocolAdapterInformation.java
@@ -38,8 +38,10 @@ import java.util.List;
 public class OpcUaProtocolAdapterInformation implements ProtocolAdapterInformation{
 
     public static final ProtocolAdapterInformation INSTANCE = new OpcUaProtocolAdapterInformation();
-    private static final @NotNull Logger log = LoggerFactory.getLogger(OpcUaProtocolAdapterInformation.class);
     public static final String PROTOCOL_ID = "opcua";
+
+    private static final @NotNull Logger log = LoggerFactory.getLogger(OpcUaProtocolAdapterInformation.class);
+    private static final int CURRENT_CONFIG_VERSION = 1;
 
 
     private OpcUaProtocolAdapterInformation() {
@@ -135,5 +137,10 @@ public class OpcUaProtocolAdapterInformation implements ProtocolAdapterInformati
     @Override
     public @NotNull Class<? extends ProtocolSpecificAdapterConfig> configurationClassNorthAndSouthbound() {
         return BidirectionalOpcUaSpecificAdapterConfig.class;
+    }
+
+    @Override
+    public int getCurrentConfigVersion() {
+        return CURRENT_CONFIG_VERSION;
     }
 }

--- a/modules/hivemq-edge-module-plc4x/src/main/java/com/hivemq/edge/adapters/plc4x/types/ads/ADSProtocolAdapterInformation.java
+++ b/modules/hivemq-edge-module-plc4x/src/main/java/com/hivemq/edge/adapters/plc4x/types/ads/ADSProtocolAdapterInformation.java
@@ -37,11 +37,13 @@ import java.util.List;
 /**
  * @author HiveMQ Adapter Generator
  */
-public class ADSProtocolAdapterInformation
-    implements ProtocolAdapterInformation {
+public class ADSProtocolAdapterInformation implements ProtocolAdapterInformation {
 
     public static final ProtocolAdapterInformation INSTANCE = new ADSProtocolAdapterInformation();
+
     private static final @NotNull Logger log = LoggerFactory.getLogger(ADSProtocolAdapterInformation.class);
+    private static final int CURRENT_CONFIG_VERSION = 1;
+
 
     protected ADSProtocolAdapterInformation() {
     }
@@ -133,5 +135,10 @@ public class ADSProtocolAdapterInformation
     @Override
     public @NotNull Class<? extends ProtocolSpecificAdapterConfig> configurationClassNorthAndSouthbound() {
         return ADSSpecificAdapterConfig.class;
+    }
+
+    @Override
+    public int getCurrentConfigVersion() {
+        return CURRENT_CONFIG_VERSION;
     }
 }

--- a/modules/hivemq-edge-module-plc4x/src/main/java/com/hivemq/edge/adapters/plc4x/types/siemens/S7ProtocolAdapterInformation.java
+++ b/modules/hivemq-edge-module-plc4x/src/main/java/com/hivemq/edge/adapters/plc4x/types/siemens/S7ProtocolAdapterInformation.java
@@ -40,9 +40,10 @@ import java.util.List;
 public class S7ProtocolAdapterInformation implements ProtocolAdapterInformation {
 
     public static final ProtocolAdapterInformation INSTANCE = new S7ProtocolAdapterInformation();
-    private static final @NotNull Logger log = LoggerFactory.getLogger(S7ProtocolAdapterInformation.class);
     public static final String PROTOCOL_ID = "s7";
 
+    private static final @NotNull Logger log = LoggerFactory.getLogger(S7ProtocolAdapterInformation.class);
+    private static final int CURRENT_CONFIG_VERSION = 1;
 
     protected S7ProtocolAdapterInformation() {
     }
@@ -134,5 +135,10 @@ public class S7ProtocolAdapterInformation implements ProtocolAdapterInformation 
     @Override
     public @NotNull Class<? extends ProtocolSpecificAdapterConfig> configurationClassNorthAndSouthbound() {
         return S7SpecificAdapterConfig.class;
+    }
+
+    @Override
+    public int getCurrentConfigVersion() {
+        return CURRENT_CONFIG_VERSION;
     }
 }


### PR DESCRIPTION
https://hivemq.kanbanize.com/ctrl_board/57/cards/27422/details/

Currently we have no way to find out for what edge version a given config.xml was written. This makes it hard to find out which migrations might be needed. A simple version field that indicates that will resolve this issue.
