### PR TITLE
fix(28895): Fix rendering of metrics for groups

### DIFF
--- a/hivemq-edge/src/frontend/src/__test-utils__/mocks.ts
+++ b/hivemq-edge/src/frontend/src/__test-utils__/mocks.ts
@@ -18,3 +18,4 @@ export const MOCK_NAMESPACE: ISA95ApiBean = {
 
 export const MOCK_BRIDGE_ID = 'first-bridge'
 export const MOCK_ADAPTER_ID = 'my-adapter'
+export const MOCK_ADAPTER_ID2 = 'my-adapter2'

--- a/hivemq-edge/src/frontend/src/api/hooks/useGetMetrics/__handlers__/index.ts
+++ b/hivemq-edge/src/frontend/src/api/hooks/useGetMetrics/__handlers__/index.ts
@@ -1,6 +1,6 @@
 import { DataPoint, Metric, MetricList } from '@/api/__generated__'
 import { mockBridgeId } from '@/api/hooks/useGetBridges/__handlers__'
-import { MOCK_ADAPTER_ID } from '@/__test-utils__/mocks.ts'
+import { MOCK_ADAPTER_ID, MOCK_ADAPTER_ID2 } from '@/__test-utils__/mocks.ts'
 import { DateTime } from 'luxon'
 import { http, HttpResponse } from 'msw'
 
@@ -42,6 +42,10 @@ export const MOCK_METRICS: Array<Metric> = [
   { name: `com.hivemq.edge.protocol-adapters.simulation.${MOCK_ADAPTER_ID}.connection.success.count` },
   { name: `com.hivemq.edge.protocol-adapters.simulation.${MOCK_ADAPTER_ID}.read.publish.failed.count` },
   { name: `com.hivemq.edge.protocol-adapters.simulation.${MOCK_ADAPTER_ID}.read.publish.success.count` },
+  { name: `com.hivemq.edge.protocol-adapters.simulation.${MOCK_ADAPTER_ID2}.connection.failed.count` },
+  { name: `com.hivemq.edge.protocol-adapters.simulation.${MOCK_ADAPTER_ID2}.connection.success.count` },
+  { name: `com.hivemq.edge.protocol-adapters.simulation.${MOCK_ADAPTER_ID2}.read.publish.failed.count` },
+  { name: `com.hivemq.edge.protocol-adapters.simulation.${MOCK_ADAPTER_ID2}.read.publish.success.count` },
   { name: `com.hivemq.edge.sessions.overall.current` },
   { name: `com.hivemq.edge.subscriptions.overall.current` },
   { name: `com.hivemq.messages.governance.count` },

--- a/hivemq-edge/src/frontend/src/modules/Metrics/MetricsContainer.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Metrics/MetricsContainer.spec.cy.tsx
@@ -18,7 +18,12 @@ describe('MetricsContainer', () => {
       <MetricsContainer
         nodeId="bridge@bridge-id-01"
         initMetrics={[]}
-        adapterIDs={[mockBridgeId]}
+        filters={[
+          {
+            id: mockBridgeId,
+            type: 'com.hivemq.edge.bridge',
+          },
+        ]}
         type={NodeTypes.BRIDGE_NODE}
       />
     )

--- a/hivemq-edge/src/frontend/src/modules/Metrics/MetricsContainer.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Metrics/MetricsContainer.tsx
@@ -15,7 +15,7 @@ import { useTranslation } from 'react-i18next'
 
 import { NodeTypes } from '@/modules/Workspace/types.ts'
 
-import { ChartType, MetricDefinition } from './types.ts'
+import { ChartType, MetricDefinition, MetricsFilter } from './types.ts'
 import useMetricsStore from './hooks/useMetricsStore.ts'
 import { extractMetricInfo } from './utils/metrics-name.utils.ts'
 import MetricEditor from './components/editor/MetricEditor.tsx'
@@ -25,7 +25,7 @@ import Sample from './components/container/Sample.tsx'
 interface MetricsProps {
   nodeId: string
   type: NodeTypes
-  adapterIDs: string[]
+  filters: MetricsFilter[]
   initMetrics?: string[]
   defaultChartType?: ChartType
 }
@@ -38,7 +38,7 @@ export interface MetricSpecStorage {
 // TODO[NVL] Should go to some kind of reusable routine, with verification
 const defaultColorSchemes = ['blue', 'green', 'orange', 'pink', 'purple', 'red', 'teal', 'yellow', 'cyan']
 
-const MetricsContainer: FC<MetricsProps> = ({ nodeId, adapterIDs, initMetrics, defaultChartType }) => {
+const MetricsContainer: FC<MetricsProps> = ({ nodeId, filters, initMetrics, defaultChartType }) => {
   const { t } = useTranslation()
   const { isOpen, onOpen, onClose } = useDisclosure()
   const { addMetrics, getMetricsFor, removeMetrics } = useMetricsStore()
@@ -89,7 +89,7 @@ const MetricsContainer: FC<MetricsProps> = ({ nodeId, adapterIDs, initMetrics, d
 
             <AccordionPanel pb={4}>
               <MetricEditor
-                filter={adapterIDs}
+                filters={filters}
                 selectedMetrics={metrics.map((e) => e.metrics)}
                 selectedChart={defaultChartType}
                 onSubmit={handleCreateMetrics}
@@ -107,7 +107,7 @@ const MetricsContainer: FC<MetricsProps> = ({ nodeId, adapterIDs, initMetrics, d
       >
         {metrics.map((e) => {
           const { id } = extractMetricInfo(e.metrics)
-          const colorSchemeIndex = adapterIDs.indexOf(id as string)
+          const colorSchemeIndex = filters.findIndex((e) => e.id === id)
 
           if (!e.chart || e.chart === ChartType.SAMPLE)
             return (

--- a/hivemq-edge/src/frontend/src/modules/Metrics/components/editor/MetricEditor.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Metrics/components/editor/MetricEditor.spec.cy.tsx
@@ -19,7 +19,12 @@ describe('MetricEditor', () => {
       const onSubmit = cy.stub().as('onSubmit')
       cy.mountWithProviders(
         <MetricSelector
-          filter={[mockBridgeId]}
+          filters={[
+            {
+              id: mockBridgeId,
+              type: 'com.hivemq.edge.bridge',
+            },
+          ]}
           onSubmit={onSubmit}
           selectedChart={ChartType.SAMPLE}
           selectedMetrics={[MOCK_METRICS[0].name as string, MOCK_METRICS[0].name as string]}
@@ -55,7 +60,12 @@ describe('MetricEditor', () => {
       cy.injectAxe()
       cy.mountWithProviders(
         <MetricSelector
-          filter={[mockBridgeId]}
+          filters={[
+            {
+              id: mockBridgeId,
+              type: 'com.hivemq.edge.bridge',
+            },
+          ]}
           onSubmit={cy.stub()}
           selectedChart={ChartType.SAMPLE}
           selectedMetrics={[MOCK_METRICS[0].name as string, MOCK_METRICS[0].name as string]}
@@ -71,7 +81,16 @@ describe('MetricEditor', () => {
       const onSubmit = cy.stub().as('onSubmit')
       cy.mountWithProviders(
         <MetricSelector
-          filter={[mockBridgeId, MOCK_ADAPTER_ID]}
+          filters={[
+            {
+              id: mockBridgeId,
+              type: 'com.hivemq.edge.bridge',
+            },
+            {
+              id: MOCK_ADAPTER_ID,
+              type: 'com.hivemq.edge.protocol-adapters',
+            },
+          ]}
           onSubmit={onSubmit}
           selectedChart={ChartType.SAMPLE}
           selectedMetrics={[MOCK_METRICS[0].name as string, MOCK_METRICS[1].name as string]}

--- a/hivemq-edge/src/frontend/src/modules/Metrics/components/editor/MetricEditor.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Metrics/components/editor/MetricEditor.tsx
@@ -42,7 +42,10 @@ const MetricEditor: FC<MetricEditorProps> = ({ onSubmit, filters, selectedMetric
     const groupedMetrics = filters
       .map((filter) => {
         const metrics: MetricNameOption[] = items
-          .filter((metric) => metric.name && metric.name.includes(adapter))
+          .filter((metric) => {
+            const structure = extractMetricInfo(metric.name as string)
+            return filter.id === structure.id
+          })
           .map((metric) => {
             const { device, suffix } = extractMetricInfo(metric.name as string)
             return {

--- a/hivemq-edge/src/frontend/src/modules/Metrics/components/editor/MetricEditor.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Metrics/components/editor/MetricEditor.tsx
@@ -64,7 +64,7 @@ const MetricEditor: FC<MetricEditorProps> = ({ onSubmit, filters, selectedMetric
       .sort((a, b) => a.label.localeCompare(b.label))
 
     return groupedMetrics.length === 1 ? groupedMetrics[0].options : groupedMetrics
-  }, [data, filters, selectedMetrics])
+  }, [data, filters, selectedMetrics, t])
 
   useEffect(() => {
     if (isSubmitted) {

--- a/hivemq-edge/src/frontend/src/modules/Metrics/components/editor/MetricEditor.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Metrics/components/editor/MetricEditor.tsx
@@ -8,13 +8,13 @@ import { BiAddToQueue } from 'react-icons/bi'
 import { useGetMetrics } from '@/api/hooks/useGetMetrics/useGetMetrics.ts'
 
 import { extractMetricInfo } from '../../utils/metrics-name.utils.ts'
-import { ChartType, ChartTypeOption, MetricDefinition, MetricNameOption } from '../../types.ts'
+import { ChartType, ChartTypeOption, MetricDefinition, MetricNameOption, MetricsFilter } from '../../types.ts'
 
 interface MetricEditorProps {
   onSubmit: SubmitHandler<MetricDefinition>
   selectedMetrics: string[]
   selectedChart?: ChartType
-  filter: string[]
+  filters: MetricsFilter[]
 }
 
 const chartTypeOptions: ChartTypeOption[] = [
@@ -23,7 +23,7 @@ const chartTypeOptions: ChartTypeOption[] = [
   { value: ChartType.SAMPLE, label: 'Stat' },
 ]
 
-const MetricEditor: FC<MetricEditorProps> = ({ onSubmit, filter, selectedMetrics, selectedChart }) => {
+const MetricEditor: FC<MetricEditorProps> = ({ onSubmit, filters, selectedMetrics, selectedChart }) => {
   const { t } = useTranslation()
   const { data } = useGetMetrics()
   const {
@@ -39,8 +39,8 @@ const MetricEditor: FC<MetricEditorProps> = ({ onSubmit, filter, selectedMetrics
     if (!data || !data.items) return []
     const { items } = data
 
-    const groupedMetrics = filter
-      .map((adapter) => {
+    const groupedMetrics = filters
+      .map((filter) => {
         const metrics: MetricNameOption[] = items
           .filter((metric) => metric.name && metric.name.includes(adapter))
           .map((metric) => {
@@ -54,14 +54,14 @@ const MetricEditor: FC<MetricEditorProps> = ({ onSubmit, filter, selectedMetrics
           .sort((a, b) => a.label.localeCompare(b.label))
 
         return {
-          label: adapter,
+          label: filter.id,
           options: metrics,
         }
       })
       .sort((a, b) => a.label.localeCompare(b.label))
 
     return groupedMetrics.length === 1 ? groupedMetrics[0].options : groupedMetrics
-  }, [data, filter, selectedMetrics, t])
+  }, [data, filters, selectedMetrics])
 
   useEffect(() => {
     if (isSubmitted) {

--- a/hivemq-edge/src/frontend/src/modules/Metrics/types.ts
+++ b/hivemq-edge/src/frontend/src/modules/Metrics/types.ts
@@ -7,6 +7,11 @@ export enum ChartType {
   BAR_CHART = 'BAR_CHART',
 }
 
+export interface MetricsFilter {
+  type: string
+  id: string
+}
+
 export interface MetricNameOption {
   label: string
   value: string

--- a/hivemq-edge/src/frontend/src/modules/Metrics/utils/metrics-name.utils.spec.ts
+++ b/hivemq-edge/src/frontend/src/modules/Metrics/utils/metrics-name.utils.spec.ts
@@ -48,7 +48,7 @@ describe('extractMetricInfo', () => {
       },
     },
     {
-      metricName: MOCK_METRICS[38].name as string,
+      metricName: MOCK_METRICS[42].name as string,
       expected: {
         device: 'subscriptions',
         id: 'current',

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/drawers/GroupPropertyDrawer.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/drawers/GroupPropertyDrawer.spec.cy.tsx
@@ -55,7 +55,7 @@ describe('GroupPropertyDrawer', () => {
 
     cy.getByTestId('group-panel-title').should('contain.text', 'Group Observability')
 
-    cy.get('dt').eq(0).should('contain.text', 'bridge-id-01')
+    cy.get('dt').eq(0).should('contain.text', 'my-adapter')
     cy.get('dt').eq(1).should('contain.text', 'my-adapter')
 
     // check the panel control

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/drawers/GroupPropertyDrawer.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/drawers/GroupPropertyDrawer.spec.cy.tsx
@@ -5,18 +5,29 @@ import { Group, NodeTypes } from '../../types.ts'
 import GroupPropertyDrawer from './GroupPropertyDrawer.tsx'
 import { MOCK_METRICS } from '@/api/hooks/useGetMetrics/__handlers__'
 import { MetricList } from '@/api/__generated__'
-import { MOCK_NODE_ADAPTER, MOCK_NODE_BRIDGE } from '@/__test-utils__/react-flow/nodes.ts'
+import { MOCK_NODE_ADAPTER } from '@/__test-utils__/react-flow/nodes.ts'
+import { MOCK_ADAPTER_ID, MOCK_ADAPTER_ID2 } from '@/__test-utils__/mocks.ts'
 
 const mockNode: Node<Group> = {
   position: { x: 0, y: 0 },
-  id: 'adapter@fgffgf',
+  id: 'adapter@group',
   type: NodeTypes.CLUSTER_NODE,
-  data: { childrenNodeIds: ['bridge-id-01', 'my-adapter'], title: 'dfdf', isOpen: true },
+  data: { childrenNodeIds: [MOCK_ADAPTER_ID, MOCK_ADAPTER_ID2], title: 'the group', isOpen: true },
 }
 
-const mockNodes: Node<NodeTypes.BRIDGE_NODE | NodeTypes.ADAPTER_NODE>[] = [
-  { ...MOCK_NODE_BRIDGE, id: 'bridge-id-01', position: { x: 0, y: 0 } },
-  { ...MOCK_NODE_ADAPTER, id: 'my-adapter', position: { x: 0, y: 0 } },
+const mockNodes: Node<NodeTypes.ADAPTER_NODE>[] = [
+  {
+    ...MOCK_NODE_ADAPTER,
+    id: MOCK_ADAPTER_ID,
+    data: { ...MOCK_NODE_ADAPTER.data, id: MOCK_ADAPTER_ID },
+    position: { x: 0, y: 0 },
+  },
+  {
+    ...MOCK_NODE_ADAPTER,
+    id: MOCK_ADAPTER_ID2,
+    data: { ...MOCK_NODE_ADAPTER.data, id: MOCK_ADAPTER_ID2 },
+    position: { x: 0, y: 0 },
+  },
 ]
 
 describe('GroupPropertyDrawer', () => {

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/drawers/GroupPropertyDrawer.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/drawers/GroupPropertyDrawer.spec.cy.tsx
@@ -22,7 +22,7 @@ const mockNodes: Node<NodeTypes.BRIDGE_NODE | NodeTypes.ADAPTER_NODE>[] = [
 describe('GroupPropertyDrawer', () => {
   beforeEach(() => {
     cy.viewport(800, 800)
-    cy.intercept('/api/v1/metrics', [{ items: MOCK_METRICS } as MetricList])
+    cy.intercept('/api/v1/metrics', { items: MOCK_METRICS } as MetricList)
     cy.intercept('/api/v1/metrics/**', []).as('getMetricForX')
   })
 

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/drawers/GroupPropertyDrawer.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/drawers/GroupPropertyDrawer.tsx
@@ -17,7 +17,7 @@ import { Group, NodeTypes } from '../../types.ts'
 import useWorkspaceStore from '../../hooks/useWorkspaceStore.ts'
 import { getDefaultMetricsFor } from '../../utils/nodes-utils.ts'
 import GroupMetadataEditor from '../parts/GroupMetadataEditor.tsx'
-import { ChartType } from '@/modules/Metrics/types.ts'
+import { ChartType, MetricsFilter } from '@/modules/Metrics/types.ts'
 import NodeNameCard from '@/modules/Workspace/components/parts/NodeNameCard.tsx'
 
 interface GroupPropertyDrawerProps {
@@ -74,9 +74,9 @@ const GroupPropertyDrawer: FC<GroupPropertyDrawerProps> = ({
           <MetricsContainer
             nodeId={nodeId}
             type={selectedNode.type as NodeTypes}
-            adapterIDs={adapterIDs.reduce<string[]>((acc, cur) => {
+            filters={adapterIDs.reduce<MetricsFilter[]>((acc, cur) => {
               if (cur && cur.type === NodeTypes.ADAPTER_NODE) {
-                acc.push(cur.data.id)
+                acc.push({ id: cur.data.id, type: `com.hivemq.edge.protocol-adapters.${cur.data.type}` })
               }
               return acc
             }, [])}

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/drawers/GroupPropertyDrawer.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/drawers/GroupPropertyDrawer.tsx
@@ -74,7 +74,12 @@ const GroupPropertyDrawer: FC<GroupPropertyDrawerProps> = ({
           <MetricsContainer
             nodeId={nodeId}
             type={selectedNode.type as NodeTypes}
-            adapterIDs={adapterIDs.map((e) => e?.data.id)}
+            adapterIDs={adapterIDs.reduce<string[]>((acc, cur) => {
+              if (cur && cur.type === NodeTypes.ADAPTER_NODE) {
+                acc.push(cur.data.id)
+              }
+              return acc
+            }, [])}
             initMetrics={metrics}
             defaultChartType={showConfig ? ChartType.SAMPLE : undefined}
           />

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/drawers/LinkPropertyDrawer.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/drawers/LinkPropertyDrawer.tsx
@@ -44,7 +44,15 @@ const LinkPropertyDrawer: FC<LinkPropertyDrawerProps> = ({ nodeId, isOpen, selec
           <MetricsContainer
             nodeId={nodeId}
             type={selectedNode.type as NodeTypes}
-            adapterIDs={[selectedNode.data.id]}
+            filters={[
+              {
+                id: selectedNode.data.id,
+                type:
+                  selectedNode.type === NodeTypes.ADAPTER_NODE
+                    ? `com.hivemq.edge.protocol-adapters.${(selectedNode as Node<Adapter>).data.type}`
+                    : 'com.hivemq.edge.bridge',
+              },
+            ]}
             initMetrics={getDefaultMetricsFor(selectedNode)}
           />
         </DrawerBody>

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/drawers/NodePropertyDrawer.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/drawers/NodePropertyDrawer.tsx
@@ -67,7 +67,15 @@ const NodePropertyDrawer: FC<NodePropertyDrawerProps> = ({ nodeId, isOpen, selec
           <MetricsContainer
             nodeId={nodeId}
             type={selectedNode.type as NodeTypes}
-            adapterIDs={[selectedNode.data.id]}
+            filters={[
+              {
+                id: selectedNode.data.id,
+                type:
+                  selectedNode.type === NodeTypes.ADAPTER_NODE
+                    ? `com.hivemq.edge.protocol-adapters.${(selectedNode as Node<Adapter>).data.type}`
+                    : 'com.hivemq.edge.bridge',
+              },
+            ]}
             initMetrics={getDefaultMetricsFor(selectedNode)}
             defaultChartType={ChartType.SAMPLE}
           />


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/28895/details/


The PR fixes a bug in the rendering of the list of metrics available for groups. The process was considering device nodes in the list of available targets for metrics, resulting in a wrong list 

Device nodes are now properly excluded from the processing of metrics

### Before 
![screenshot-localhost_3000-2025_01_06-18_43_53](https://github.com/user-attachments/assets/7ec913c2-6c48-43de-91c9-2e8d3ab63bd1)


### After
![screenshot-localhost_3000-2025_01_06-18_44_43](https://github.com/user-attachments/assets/86202e3e-eba0-4c57-aeef-e729e9fd8ed4)
