### PR TITLE
feat(29159): Improve the integration of the adapter page with the workspace

### DIFF
--- a/hivemq-edge/src/frontend/src/components/Icons/TopicIcon.tsx
+++ b/hivemq-edge/src/frontend/src/components/Icons/TopicIcon.tsx
@@ -28,5 +28,5 @@ export const ClientIcon: FC<IconProps> = (props) => {
 
 export const WorkspaceIcon: FC<IconProps> = (props) => {
   const { t } = useTranslation('components')
-  return <Icon as={PiGraphFill} boxSize={6} aria-label={t('iconLabel.workspace')} {...props} />
+  return <Icon as={PiGraphFill} boxSize={4} aria-label={t('iconLabel.workspace')} {...props} />
 }

--- a/hivemq-edge/src/frontend/src/locales/en/translation.json
+++ b/hivemq-edge/src/frontend/src/locales/en/translation.json
@@ -486,9 +486,12 @@
         "delete": "Delete",
         "workspace": {
           "group": "Manage from Workspace",
-          "view": "View on workspace",
+          "view": "Adapter and Device",
           "tags": "Device tags",
-          "mappings": "Mappings",
+          "mappings": {
+            "north": "Northbound mappings",
+            "south": "Southbound mappings"
+          },
           "topicFilters": "Topic filters"
         },
         "export": "Export"

--- a/hivemq-edge/src/frontend/src/locales/en/translation.json
+++ b/hivemq-edge/src/frontend/src/locales/en/translation.json
@@ -484,7 +484,13 @@
         "create": "Create similar",
         "edit": "Edit",
         "delete": "Delete",
-        "workspace": "View on workspace",
+        "workspace": {
+          "group": "Manage from Workspace",
+          "view": "View on workspace",
+          "tags": "Device tags",
+          "mappings": "Mappings",
+          "topicFilters": "Topic filters"
+        },
         "export": "Export"
       }
     },

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/adapters/AdapterActionMenu.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/adapters/AdapterActionMenu.spec.cy.tsx
@@ -1,12 +1,13 @@
 /// <reference types="cypress" />
 
-import { mockAdapter } from '@/api/hooks/useProtocolAdapters/__handlers__'
+import { mockAdapter, mockProtocolAdapter } from '@/api/hooks/useProtocolAdapters/__handlers__'
 import { Adapter, Status } from '@/api/__generated__'
 import AdapterActionMenu from '@/modules/ProtocolAdapters/components/adapters/AdapterActionMenu.tsx'
+import { WorkspaceAdapterCommand } from '@/modules/ProtocolAdapters/types.ts'
 
 describe('AdapterActionMenu', () => {
   beforeEach(() => {
-    cy.viewport(350, 400)
+    cy.viewport(350, 600)
   })
 
   it('should render properly', () => {
@@ -48,7 +49,6 @@ describe('AdapterActionMenu', () => {
     const onEdit = cy.stub().as('onEdit')
     const onCreate = cy.stub().as('onCreate')
     const onDelete = cy.stub().as('onDelete')
-    const onViewWorkspace = cy.stub().as('onViewWorkspace')
     const onExport = cy.stub().as('onExport')
 
     cy.mountWithProviders(
@@ -57,7 +57,6 @@ describe('AdapterActionMenu', () => {
         onEdit={onEdit}
         onCreate={onCreate}
         onDelete={onDelete}
-        onViewWorkspace={onViewWorkspace}
         onExport={onExport}
       />
     )
@@ -80,12 +79,6 @@ describe('AdapterActionMenu', () => {
     cy.get('@onDelete').should('have.been.calledWith', 'my-adapter')
     cy.getByTestId('adapter-action-delete').should('not.be.visible')
 
-    cy.get('@onViewWorkspace').should('not.have.been.called')
-    cy.getByAriaLabel('Actions').click()
-    cy.getByTestId('adapter-action-workspace').click()
-    cy.get('@onViewWorkspace').should('have.been.calledWith', 'my-adapter', 'simulation')
-    cy.getByTestId('adapter-action-workspace').should('not.be.visible')
-
     cy.get('@onExport').should('not.have.been.called')
     cy.getByAriaLabel('Actions').click()
     cy.getByTestId('adapter-action-export').click()
@@ -103,5 +96,117 @@ describe('AdapterActionMenu', () => {
       },
     })
     cy.percySnapshot('Component: AdapterActionMenu')
+  })
+
+  describe('Workspace group', () => {
+    it('should render workspace commands', () => {
+      cy.mountWithProviders(<AdapterActionMenu adapter={mockAdapter} protocol={mockProtocolAdapter} />)
+      cy.getByAriaLabel('Actions').click()
+
+      cy.get('[role="group"] p').should('have.text', 'Manage from Workspace')
+      cy.getByTestId('adapter-action-tags').should('be.visible').should('have.text', 'Device tags')
+      cy.getByTestId('adapter-action-filters').should('be.visible').should('have.text', 'Topic filters')
+      cy.getByTestId('adapter-action-mappings-northbound')
+        .should('be.visible')
+        .should('have.text', 'Northbound mappings')
+      cy.getByTestId('adapter-action-mappings-southbound').should('not.exist')
+      cy.getByTestId('adapter-action-filters').should('be.visible').should('have.text', 'Topic filters')
+    })
+
+    it('should render southbound command', () => {
+      cy.mountWithProviders(
+        <AdapterActionMenu
+          adapter={mockAdapter}
+          protocol={{ ...mockProtocolAdapter, capabilities: ['READ', 'WRITE'] }}
+        />
+      )
+      cy.getByAriaLabel('Actions').click()
+
+      cy.get('[role="group"] p').should('have.text', 'Manage from Workspace')
+      cy.getByTestId('adapter-action-tags').should('be.visible').should('have.text', 'Device tags')
+      cy.getByTestId('adapter-action-filters').should('be.visible').should('have.text', 'Topic filters')
+      cy.getByTestId('adapter-action-mappings-northbound')
+        .should('be.visible')
+        .should('have.text', 'Northbound mappings')
+      cy.getByTestId('adapter-action-mappings-southbound')
+        .should('be.visible')
+        .should('have.text', 'Southbound mappings')
+    })
+
+    it('should trigger actions', () => {
+      const onViewWorkspace = cy.stub().as('onViewWorkspace')
+
+      cy.mountWithProviders(
+        <AdapterActionMenu
+          adapter={mockAdapter}
+          onViewWorkspace={onViewWorkspace}
+          protocol={{ ...mockProtocolAdapter, capabilities: ['READ', 'WRITE'] }}
+        />
+      )
+
+      cy.get('@onViewWorkspace').should(
+        'not.have.been.calledWith',
+        'my-adapter',
+        'simulation',
+        WorkspaceAdapterCommand.VIEW
+      )
+      cy.getByAriaLabel('Actions').click()
+      cy.getByTestId('adapter-action-workspace').click()
+      cy.get('@onViewWorkspace').should(
+        'have.been.calledWith',
+        'my-adapter',
+        'simulation',
+        WorkspaceAdapterCommand.VIEW
+      )
+      cy.getByTestId('adapter-action-workspace').should('not.be.visible')
+
+      cy.get('@onViewWorkspace').should(
+        'not.have.been.calledWith',
+        'my-adapter',
+        'simulation',
+        WorkspaceAdapterCommand.TAGS
+      )
+      cy.getByAriaLabel('Actions').click()
+      cy.getByTestId('adapter-action-tags').click()
+      cy.get('@onViewWorkspace').should(
+        'have.been.calledWith',
+        'my-adapter',
+        'simulation',
+        WorkspaceAdapterCommand.TAGS
+      )
+      cy.getByTestId('adapter-action-workspace').should('not.be.visible')
+
+      cy.get('@onViewWorkspace').should(
+        'not.have.been.calledWith',
+        'my-adapter',
+        'simulation',
+        WorkspaceAdapterCommand.TOPIC_FILTERS
+      )
+      cy.getByAriaLabel('Actions').click()
+      cy.getByTestId('adapter-action-filters').click()
+      cy.get('@onViewWorkspace').should(
+        'have.been.calledWith',
+        'my-adapter',
+        'simulation',
+        WorkspaceAdapterCommand.TOPIC_FILTERS
+      )
+      cy.getByTestId('adapter-action-workspace').should('not.be.visible')
+
+      cy.get('@onViewWorkspace').should(
+        'not.have.been.calledWith',
+        'my-adapter',
+        'simulation',
+        WorkspaceAdapterCommand.MAPPINGS
+      )
+      cy.getByAriaLabel('Actions').click()
+      cy.getByTestId('adapter-action-mappings-northbound').click()
+      cy.get('@onViewWorkspace').should(
+        'have.been.calledWith',
+        'my-adapter',
+        'simulation',
+        WorkspaceAdapterCommand.MAPPINGS
+      )
+      cy.getByTestId('adapter-action-workspace').should('not.be.visible')
+    })
   })
 })

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/adapters/AdapterActionMenu.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/adapters/AdapterActionMenu.tsx
@@ -7,7 +7,7 @@ import { Adapter, ProtocolAdapter } from '@/api/__generated__'
 import { DeviceTypes } from '@/api/types/api-devices.ts'
 
 import ConnectionController from '@/components/ConnectionController/ConnectionController.tsx'
-import { PLCTagIcon, TopicIcon } from '@/components/Icons/TopicIcon.tsx'
+import { PLCTagIcon, TopicIcon, WorkspaceIcon } from '@/components/Icons/TopicIcon.tsx'
 import { deviceCapabilityIcon } from '@/modules/Workspace/utils/adapter.utils.ts'
 import { WorkspaceAdapterCommand } from '@/modules/ProtocolAdapters/types.ts'
 
@@ -69,23 +69,23 @@ const AdapterActionMenu: FC<AdapterActionMenuProps> = ({
               onClick={() => onViewWorkspace?.(id, type as string, WorkspaceAdapterCommand.MAPPINGS)}
               icon={<Icon as={deviceCapabilityIcon['READ']} />}
             >
-              Northbound {t('protocolAdapter.table.actions.workspace.mappings')}
+              {t('protocolAdapter.table.actions.workspace.mappings.north')}
             </MenuItem>
           )}
           {capabilities?.includes('WRITE') && (
             <MenuItem
               data-testid="adapter-action-mappings"
               onClick={() => onViewWorkspace?.(id, type as string, WorkspaceAdapterCommand.MAPPINGS)}
-              icon={<Icon as={deviceCapabilityIcon['READ']} />}
+              icon={<Icon as={deviceCapabilityIcon['WRITE']} />}
             >
-              Southbound {t('protocolAdapter.table.actions.workspace.mappings')}
+              {t('protocolAdapter.table.actions.workspace.mappings.south')}
             </MenuItem>
           )}
         </MenuGroup>
         <MenuItem
           data-testid="adapter-action-workspace"
           onClick={() => onViewWorkspace?.(id, type as string, WorkspaceAdapterCommand.VIEW)}
-          // icon={<WorkspaceIcon />}
+          icon={<WorkspaceIcon />}
         >
           {t('protocolAdapter.table.actions.workspace.view')}
         </MenuItem>

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/adapters/AdapterActionMenu.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/adapters/AdapterActionMenu.tsx
@@ -1,24 +1,29 @@
 import { FC } from 'react'
-import { IconButton, Menu, MenuButton, MenuDivider, MenuItem, MenuList, Text } from '@chakra-ui/react'
+import { Icon, IconButton, Menu, MenuButton, MenuDivider, MenuGroup, MenuItem, MenuList, Text } from '@chakra-ui/react'
 import { ChevronDownIcon } from '@chakra-ui/icons'
 import { useTranslation } from 'react-i18next'
 
-import { Adapter } from '@/api/__generated__'
+import { Adapter, ProtocolAdapter } from '@/api/__generated__'
 import { DeviceTypes } from '@/api/types/api-devices.ts'
 
 import ConnectionController from '@/components/ConnectionController/ConnectionController.tsx'
+import { PLCTagIcon, TopicIcon } from '@/components/Icons/TopicIcon.tsx'
+import { deviceCapabilityIcon } from '@/modules/Workspace/utils/adapter.utils.ts'
+import { WorkspaceAdapterCommand } from '@/modules/ProtocolAdapters/types.ts'
 
 interface AdapterActionMenuProps {
   adapter: Adapter
+  protocol?: ProtocolAdapter
   onCreate?: (type: string | undefined) => void
   onEdit?: (id: string, type: string) => void
   onDelete?: (id: string) => void
-  onViewWorkspace?: (id: string, type: string) => void
+  onViewWorkspace?: (id: string, type: string, command: WorkspaceAdapterCommand) => void
   onExport?: (id: string, type: string) => void
 }
 
 const AdapterActionMenu: FC<AdapterActionMenuProps> = ({
   adapter,
+  protocol,
   onCreate,
   onEdit,
   onDelete,
@@ -28,6 +33,8 @@ const AdapterActionMenu: FC<AdapterActionMenuProps> = ({
   const { t } = useTranslation()
 
   const { type, id, status } = adapter
+  const { capabilities } = protocol || {}
+
   return (
     <Menu>
       <MenuButton
@@ -40,9 +47,47 @@ const AdapterActionMenu: FC<AdapterActionMenuProps> = ({
       />
       <MenuList>
         <ConnectionController type={DeviceTypes.ADAPTER} id={id} status={status} variant="menuItem" />
-
-        <MenuItem data-testid="adapter-action-workspace" onClick={() => onViewWorkspace?.(id, type as string)}>
-          {t('protocolAdapter.table.actions.workspace')}
+        <MenuDivider />
+        <MenuGroup title={t('protocolAdapter.table.actions.workspace.group')}>
+          <MenuItem
+            data-testid="adapter-action-tags"
+            onClick={() => onViewWorkspace?.(id, type as string, WorkspaceAdapterCommand.TAGS)}
+            icon={<PLCTagIcon />}
+          >
+            {t('protocolAdapter.table.actions.workspace.tags')}
+          </MenuItem>
+          <MenuItem
+            data-testid="adapter-action-filters"
+            onClick={() => onViewWorkspace?.(id, type as string, WorkspaceAdapterCommand.TOPIC_FILTERS)}
+            icon={<Icon as={TopicIcon} />}
+          >
+            {t('protocolAdapter.table.actions.workspace.topicFilters')}
+          </MenuItem>
+          {capabilities?.includes('READ') && (
+            <MenuItem
+              data-testid="adapter-action-mappings"
+              onClick={() => onViewWorkspace?.(id, type as string, WorkspaceAdapterCommand.MAPPINGS)}
+              icon={<Icon as={deviceCapabilityIcon['READ']} />}
+            >
+              Northbound {t('protocolAdapter.table.actions.workspace.mappings')}
+            </MenuItem>
+          )}
+          {capabilities?.includes('WRITE') && (
+            <MenuItem
+              data-testid="adapter-action-mappings"
+              onClick={() => onViewWorkspace?.(id, type as string, WorkspaceAdapterCommand.MAPPINGS)}
+              icon={<Icon as={deviceCapabilityIcon['READ']} />}
+            >
+              Southbound {t('protocolAdapter.table.actions.workspace.mappings')}
+            </MenuItem>
+          )}
+        </MenuGroup>
+        <MenuItem
+          data-testid="adapter-action-workspace"
+          onClick={() => onViewWorkspace?.(id, type as string, WorkspaceAdapterCommand.VIEW)}
+          // icon={<WorkspaceIcon />}
+        >
+          {t('protocolAdapter.table.actions.workspace.view')}
         </MenuItem>
         <MenuDivider />
         <MenuItem data-testid="adapter-action-export" onClick={() => onExport?.(id, type as string)}>

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/adapters/AdapterActionMenu.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/adapters/AdapterActionMenu.tsx
@@ -65,7 +65,7 @@ const AdapterActionMenu: FC<AdapterActionMenuProps> = ({
           </MenuItem>
           {capabilities?.includes('READ') && (
             <MenuItem
-              data-testid="adapter-action-mappings"
+              data-testid="adapter-action-mappings-northbound"
               onClick={() => onViewWorkspace?.(id, type as string, WorkspaceAdapterCommand.MAPPINGS)}
               icon={<Icon as={deviceCapabilityIcon['READ']} />}
             >
@@ -74,21 +74,21 @@ const AdapterActionMenu: FC<AdapterActionMenuProps> = ({
           )}
           {capabilities?.includes('WRITE') && (
             <MenuItem
-              data-testid="adapter-action-mappings"
+              data-testid="adapter-action-mappings-southbound"
               onClick={() => onViewWorkspace?.(id, type as string, WorkspaceAdapterCommand.MAPPINGS)}
               icon={<Icon as={deviceCapabilityIcon['WRITE']} />}
             >
               {t('protocolAdapter.table.actions.workspace.mappings.south')}
             </MenuItem>
           )}
+          <MenuItem
+            data-testid="adapter-action-workspace"
+            onClick={() => onViewWorkspace?.(id, type as string, WorkspaceAdapterCommand.VIEW)}
+            icon={<WorkspaceIcon />}
+          >
+            {t('protocolAdapter.table.actions.workspace.view')}
+          </MenuItem>
         </MenuGroup>
-        <MenuItem
-          data-testid="adapter-action-workspace"
-          onClick={() => onViewWorkspace?.(id, type as string, WorkspaceAdapterCommand.VIEW)}
-          icon={<WorkspaceIcon />}
-        >
-          {t('protocolAdapter.table.actions.workspace.view')}
-        </MenuItem>
         <MenuDivider />
         <MenuItem data-testid="adapter-action-export" onClick={() => onExport?.(id, type as string)}>
           {t('protocolAdapter.table.actions.export')}

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/panels/ProtocolAdapters.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/panels/ProtocolAdapters.tsx
@@ -23,7 +23,11 @@ import PaginatedTable from '@/components/PaginatedTable/PaginatedTable.tsx'
 import { WorkspaceIcon } from '@/components/Icons/TopicIcon.tsx'
 import DateTimeRenderer from '@/components/DateTime/DateTimeRenderer.tsx'
 
-import { AdapterNavigateState, ProtocolAdapterTabIndex } from '@/modules/ProtocolAdapters/types.ts'
+import {
+  AdapterNavigateState,
+  ProtocolAdapterTabIndex,
+  WorkspaceAdapterCommand,
+} from '@/modules/ProtocolAdapters/types.ts'
 import useWorkspaceStore from '@/modules/Workspace/hooks/useWorkspaceStore.ts'
 import { NodeTypes } from '@/modules/Workspace/types.ts'
 
@@ -92,8 +96,8 @@ const ProtocolAdapters: FC = () => {
       onConfirmDeleteOpen()
     }
 
-    const handleViewWorkspace = (adapterId: string, type: string) => {
-      if (adapterId) navigate(`/workspace`, { state: { selectedAdapter: { adapterId, type } } })
+    const handleViewWorkspace = (adapterId: string, type: string, command: WorkspaceAdapterCommand) => {
+      if (adapterId) navigate(`/workspace`, { state: { selectedAdapter: { adapterId, type, command } } })
     }
 
     const handleExport = (adapterId: string, type: string) => {
@@ -147,9 +151,11 @@ const ProtocolAdapters: FC = () => {
         cell: (info) => {
           const { id, type } = info.row.original
           const { selectedActiveAdapter } = (state || {}) as AdapterNavigateState
+          const protocol = allAdapters?.items?.find((e) => e.id === info.row.original.type)
           return (
             <Skeleton isLoaded={!isLoading}>
               <AdapterActionMenu
+                protocol={protocol}
                 adapter={info.row.original}
                 onCreate={handleCreateInstance}
                 onEdit={handleEditInstance}
@@ -161,8 +167,8 @@ const ProtocolAdapters: FC = () => {
                 <IconButton
                   size="sm"
                   ml={2}
-                  onClick={() => handleViewWorkspace(id, type as string)}
-                  aria-label={t('protocolAdapter.table.actions.workspace')}
+                  onClick={() => handleViewWorkspace(id, type as string, WorkspaceAdapterCommand.VIEW)}
+                  aria-label={t('protocolAdapter.table.actions.workspace.view')}
                   icon={<WorkspaceIcon />}
                 />
               )}

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/types.ts
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/types.ts
@@ -4,6 +4,13 @@ import { Adapter, ProtocolAdapter } from '@/api/__generated__'
 import { FlatJSONSchema7 } from '@/components/rjsf/MqttTransformation/utils/json-schema.utils.ts'
 import { Dispatch, SetStateAction } from 'react'
 
+export enum WorkspaceAdapterCommand {
+  VIEW = 'VIEW',
+  TAGS = 'TAGS',
+  TOPIC_FILTERS = 'TOPIC_FILTERS',
+  MAPPINGS = 'MAPPINGS',
+}
+
 export type SubscriptionType = 'remoteSubscriptions' | 'localSubscriptions'
 
 export interface GenericPanelType<T extends FieldValues> {

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/controls/SelectionListener.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/controls/SelectionListener.tsx
@@ -1,20 +1,78 @@
 import { useEffect } from 'react'
-import { useLocation } from 'react-router-dom'
-import { ReactFlowState, useStore } from 'reactflow'
+import { useLocation, useNavigate } from 'react-router-dom'
+import { ReactFlowState, useStore, Node, useReactFlow } from 'reactflow'
+
+import useWorkspaceStore from '@/modules/Workspace/hooks/useWorkspaceStore.ts'
+import { DeviceMetadata, NodeTypes } from '@/modules/Workspace/types.ts'
+import { WorkspaceAdapterCommand } from '@/modules/ProtocolAdapters/types.ts'
 
 const addSelectedNodesState = (state: ReactFlowState) => (nodeIds: string[]) => state.addSelectedNodes(nodeIds)
 
 const SelectionListener = () => {
-  const { state } = useLocation()
+  const { state, pathname } = useLocation()
+  const navigate = useNavigate()
   const addSelectedNodes = useStore(addSelectedNodesState)
+  const { nodes } = useWorkspaceStore()
+  const { fitView } = useReactFlow()
 
   useEffect(() => {
-    const { selectedAdapter } = state || {}
-    const { adapterId, type } = selectedAdapter || {}
+    const { adapterId, type, command } = state?.selectedAdapter || {}
     if (!adapterId || !type) return
 
-    addSelectedNodes([`adapter@${adapterId}`])
-  }, [addSelectedNodes, state])
+    const focusOnNodes = (nodesIds: string[]) => {
+      addSelectedNodes(nodesIds)
+      fitView({ nodes: nodesIds.map((e) => ({ id: e })), duration: 750 })
+      navigate(pathname, { state: null, replace: true })
+    }
+
+    switch (command) {
+      case WorkspaceAdapterCommand.TOPIC_FILTERS: {
+        // Topic filters are on the Edge node
+        const edgeFound = nodes.find((e) => e.type === NodeTypes.EDGE_NODE)
+        if (edgeFound) focusOnNodes([edgeFound.id])
+
+        return
+      }
+      case WorkspaceAdapterCommand.TAGS: {
+        // Tags are on the Device node connected to the adapter
+        const found = nodes.find((e) => adapterId === e.data.id)
+        if (found?.type === NodeTypes.ADAPTER_NODE) {
+          const device = nodes.find(
+            (e) => e.type === NodeTypes.DEVICE_NODE && adapterId === (e as Node<DeviceMetadata>).data.sourceAdapterId
+          )
+          if (device) focusOnNodes([device.id])
+        }
+        return
+      }
+      case WorkspaceAdapterCommand.MAPPINGS: {
+        // N and S mappings are on the adapter node
+        const found = nodes.find((e) => adapterId === e.data.id)
+        if (found) {
+          focusOnNodes([found.id])
+        }
+        return
+      }
+      default: {
+        // For all other navigation commands, just select adapter + device nodes
+        const found = nodes.find((e) => adapterId === e.data.id)
+        if (found) {
+          const nodesToAdd: string[] = []
+
+          nodesToAdd.push(found.id)
+
+          if (found.type === NodeTypes.ADAPTER_NODE) {
+            const device = nodes.find(
+              (e) => e.type === NodeTypes.DEVICE_NODE && adapterId === (e as Node<DeviceMetadata>).data.sourceAdapterId
+            )
+            if (device) nodesToAdd.push(device.id)
+          }
+
+          focusOnNodes(nodesToAdd)
+        }
+        return
+      }
+    }
+  }, [addSelectedNodes, fitView, navigate, nodes, pathname, state?.selectedAdapter])
 
   return null
 }


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/29159/details/

The PR is the first step in resolving the lack of context for managing tsgs, topic filters and mappings in the workspace after creating a new adapter in a different context of the application 

In the adapter list, the PR adds several items in the contextual menu ("actions£) of an adapter, under the common group "Manage from Workspace": 
- Device Tags
- Topic Filters
- Northbound mappings
- Southbound mapping (if enabled for the adapter)
- Adapter and Device

Each of the commands links to the relevant node on the workspace. The transition is animated, with a managed zoom ("fit view") on the relevant node(s). 

The animation and zoom should help to contextualise the different elements of an adapter that requires further management from the workspace 

### Out-of-scope
- Allowing the creation of an adapter directly from the workspace, which will also improve the intergration will be implemented in subsequent tickets
- 
### Before 
![screenshot-localhost_3000-2025_01_06-19_47_28](https://github.com/user-attachments/assets/a9b6d247-6f99-43d1-b0bf-17c3f4b77553)

![screenshot-localhost_3000-2025_01_06-19_47_53](https://github.com/user-attachments/assets/5126cf2e-d4ee-47ef-8258-8490ac6b330e)

### After
![screenshot-localhost_3000-2025_01_06-19_50_58](https://github.com/user-attachments/assets/749bd3f1-acf1-47ca-9f26-32db9d3255d8)

![screenshot-localhost_3000-2025_01_06-19_51_09](https://github.com/user-attachments/assets/b7b99ea8-67ce-4f3e-b7ec-74062580830a)

![screenshot-localhost_3000-2025_01_06-19_51_26](https://github.com/user-attachments/assets/716db2db-adb4-46d0-8237-d8d8c58d49ec)
