### PR TITLE
feat(28974): Refactor the group side panel in the workspace

### DIFF
--- a/hivemq-edge/src/frontend/src/components/PaginatedTable/PaginatedTable.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/components/PaginatedTable/PaginatedTable.spec.cy.tsx
@@ -41,7 +41,7 @@ describe('PaginatedTable', () => {
     cy.get('th').should('have.length', 2)
     cy.get('th').eq(0).should('contain.text', 'item')
     cy.get('th').eq(1).should('contain.text', 'value')
-    cy.get('tr').should('have.length', 10 + 1)
+    cy.get('tr').should('have.length', 5 + 1)
 
     cy.get('[aria-label="Go to the first page"]').should('be.visible')
   })

--- a/hivemq-edge/src/frontend/src/components/PaginatedTable/PaginatedTable.tsx
+++ b/hivemq-edge/src/frontend/src/components/PaginatedTable/PaginatedTable.tsx
@@ -75,6 +75,7 @@ const PaginatedTable = <T,>({
   const table = useReactTable({
     data: data,
     columns,
+    initialState: { pagination: { pageSize: 5 } },
     state: {
       columnFilters,
       globalFilter,

--- a/hivemq-edge/src/frontend/src/locales/en/translation.json
+++ b/hivemq-edge/src/frontend/src/locales/en/translation.json
@@ -822,6 +822,20 @@
           "events": "Events",
           "metrics": "Metrics"
         },
+        "content": {
+          "header": {
+            "type": "Type",
+            "status": "Status",
+            "id": "Id",
+            "actions": "Actions"
+          },
+          "actions": {
+            "ungroup": "Remove from group",
+            "startAll": "Start all",
+            "stopAll": "Stop all",
+            "restartAll": "Restart all"
+          }
+        },
         "eventLog": {
           "header": "The 5 most recent events for devices in the group",
           "showMore": "Show more in the Event Log"

--- a/hivemq-edge/src/frontend/src/locales/en/translation.json
+++ b/hivemq-edge/src/frontend/src/locales/en/translation.json
@@ -817,6 +817,15 @@
         "ungroup": "Ungroup"
       },
       "editor": {
+        "tabs": {
+          "config": "Configuration",
+          "events": "Events",
+          "metrics": "Metrics"
+        },
+        "eventLog": {
+          "header": "The 5 most recent events for devices in the group",
+          "showMore": "Show more in the Event Log"
+        },
         "title": "Configure the group",
         "input-title": "Title",
         "input-color": "Group colour",

--- a/hivemq-edge/src/frontend/src/modules/EventLog/components/table/EventLogTable.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/EventLog/components/table/EventLogTable.spec.cy.tsx
@@ -28,10 +28,10 @@ describe('EventLogTable', () => {
       identifier: { identifier: 'EVENT-0', type: TypeIdentifier.type.EVENT },
     } as Partial<Event>)
 
-    cy.getByAriaLabel('View details of event').eq(7).click()
+    cy.getByAriaLabel('View details of event').eq(4).click()
 
     cy.get('@onOpen').should('have.been.calledWithMatch', {
-      identifier: { identifier: 'EVENT-7', type: TypeIdentifier.type.EVENT },
+      identifier: { identifier: 'EVENT-4', type: TypeIdentifier.type.EVENT },
     } as Partial<Event>)
   })
 

--- a/hivemq-edge/src/frontend/src/modules/EventLog/components/table/EventLogTable.tsx
+++ b/hivemq-edge/src/frontend/src/modules/EventLog/components/table/EventLogTable.tsx
@@ -49,7 +49,7 @@ const EventLogTable: FC<EventLogTableProps> = ({
     return data.items
   }, [data, globalSourceFilter, maxEvents])
 
-  const columns = useMemo<ColumnDef<Event>[]>(() => {
+  const allColumns = useMemo<ColumnDef<Event>[]>(() => {
     return [
       {
         accessorKey: 'identifier.identifier',
@@ -119,6 +119,13 @@ const EventLogTable: FC<EventLogTableProps> = ({
     ]
   }, [isLoading, onOpen, t])
 
+  const displayColumns = useMemo(() => {
+    const [, createdColumn, severityColumn, idColumn, messageColumn] = allColumns
+    if (variant === 'full') return allColumns
+    if (isSingleSource) return [createdColumn, severityColumn, messageColumn]
+    else return [createdColumn, idColumn, severityColumn, messageColumn]
+  }, [allColumns, isSingleSource, variant])
+
   if (error) {
     return (
       <Box mt="20%" mx="20%" alignItems="center">
@@ -129,9 +136,6 @@ const EventLogTable: FC<EventLogTableProps> = ({
       </Box>
     )
   }
-
-  // TODO[NVL] Not the best approach; destructure within memo
-  const [, a, b, d, c] = columns
 
   return (
     <>
@@ -152,7 +156,7 @@ const EventLogTable: FC<EventLogTableProps> = ({
       <PaginatedTable<Event>
         aria-label={t('eventLog.title')}
         data={safeData}
-        columns={variant === 'full' ? columns : isSingleSource ? [a, b, c] : [a, d, b, c]}
+        columns={displayColumns}
         enablePaginationGoTo={variant === 'full'}
         enablePaginationSizes={variant === 'full'}
         enableColumnFilters={variant === 'full'}

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/adapters/AdapterStatusContainer.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/adapters/AdapterStatusContainer.spec.cy.tsx
@@ -1,0 +1,20 @@
+import { AdapterStatusContainer } from '@/modules/ProtocolAdapters/components/adapters/AdapterStatusContainer.tsx'
+import { mockAdapterConnectionStatus } from '@/api/hooks/useConnection/__handlers__'
+import { MOCK_ADAPTER_ID } from '@/__test-utils__/mocks.ts'
+
+describe('AdapterStatusContainer', () => {
+  beforeEach(() => {
+    cy.viewport(800, 900)
+    cy.intercept('api/v1/management/protocol-adapters/status', { items: [mockAdapterConnectionStatus] }).as('getStatus')
+  })
+
+  it('should render properly an existing adapter', () => {
+    cy.mountWithProviders(<AdapterStatusContainer id={MOCK_ADAPTER_ID} />)
+    cy.getByTestId('connection-status').should('have.text', 'Connected')
+  })
+
+  it('should render unknown if not an adapter', () => {
+    cy.mountWithProviders(<AdapterStatusContainer id="not-an-adapter" />)
+    cy.getByTestId('connection-status').should('have.text', 'Unknown')
+  })
+})

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/adapters/AdapterStatusContainer.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/adapters/AdapterStatusContainer.tsx
@@ -4,7 +4,6 @@ import { ConnectionStatusBadge } from '@/components/ConnectionStatusBadge'
 
 export const AdapterStatusContainer: FC<{ id: string }> = ({ id }) => {
   const { data: connections } = useGetAdaptersStatus()
-  console.log('XXXXXX sss', id, connections)
 
   const connection = connections?.items?.find((e) => e.id === id)
 

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/adapters/AdapterStatusContainer.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/adapters/AdapterStatusContainer.tsx
@@ -1,0 +1,12 @@
+import { FC } from 'react'
+import { useGetAdaptersStatus } from '@/api/hooks/useConnection/useGetAdaptersStatus.ts'
+import { ConnectionStatusBadge } from '@/components/ConnectionStatusBadge'
+
+export const AdapterStatusContainer: FC<{ id: string }> = ({ id }) => {
+  const { data: connections } = useGetAdaptersStatus()
+  console.log('XXXXXX sss', id, connections)
+
+  const connection = connections?.items?.find((e) => e.id === id)
+
+  return <ConnectionStatusBadge status={connection} />
+}

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/panels/ProtocolAdapters.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/panels/ProtocolAdapters.tsx
@@ -8,7 +8,6 @@ import { useLocation, useNavigate } from 'react-router-dom'
 import { Adapter, ApiError, ProtocolAdapter } from '@/api/__generated__'
 import { useListProtocolAdapters } from '@/api/hooks/useProtocolAdapters/useListProtocolAdapters.ts'
 import { useDeleteProtocolAdapter } from '@/api/hooks/useProtocolAdapters/useDeleteProtocolAdapter.ts'
-import { useGetAdaptersStatus } from '@/api/hooks/useConnection/useGetAdaptersStatus.ts'
 import { ProblemDetails } from '@/api/types/http-problem-details.ts'
 import { useGetAdapterTypes } from '@/api/hooks/useProtocolAdapters/useGetAdapterTypes.ts'
 import { mockAdapter } from '@/api/hooks/useProtocolAdapters/__handlers__'
@@ -17,7 +16,6 @@ import AdapterEmptyLogo from '@/assets/app/adaptor-empty.svg'
 
 import ErrorMessage from '@/components/ErrorMessage.tsx'
 import WarningMessage from '@/components/WarningMessage.tsx'
-import { ConnectionStatusBadge } from '@/components/ConnectionStatusBadge'
 import ConfirmationDialog from '@/components/Modal/ConfirmationDialog.tsx'
 import PaginatedTable from '@/components/PaginatedTable/PaginatedTable.tsx'
 import { WorkspaceIcon } from '@/components/Icons/TopicIcon.tsx'
@@ -36,16 +34,9 @@ import { useEdgeToast } from '@/hooks/useEdgeToast/useEdgeToast.tsx'
 import AdapterActionMenu from '../adapters/AdapterActionMenu.tsx'
 import { compareStatus } from '../../utils/pagination-utils.ts'
 import IconButton from '@/components/Chakra/IconButton.tsx'
+import { AdapterStatusContainer } from '@/modules/ProtocolAdapters/components/adapters/AdapterStatusContainer.tsx'
 
 const DEFAULT_PER_PAGE = 10
-
-const AdapterStatusContainer: FC<{ id: string }> = ({ id }) => {
-  const { data: connections } = useGetAdaptersStatus()
-
-  const connection = connections?.items?.find((e) => e.id === id)
-
-  return <ConnectionStatusBadge status={connection} />
-}
 
 const AdapterTypeContainer: FC<ProtocolAdapter> = (adapter) => {
   return (

--- a/hivemq-edge/src/frontend/src/modules/Theme/foundations/colors.ts
+++ b/hivemq-edge/src/frontend/src/modules/Theme/foundations/colors.ts
@@ -2,6 +2,7 @@ import { theme as baseTheme } from '@chakra-ui/react'
 
 const colors = {
   status: {
+    unknown: baseTheme.colors.gray,
     error: baseTheme.colors.red,
     connected: baseTheme.colors.green,
     disconnected: baseTheme.colors.orange,

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/drawers/GroupPropertyDrawer.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/drawers/GroupPropertyDrawer.spec.cy.tsx
@@ -7,6 +7,7 @@ import { MOCK_METRICS } from '@/api/hooks/useGetMetrics/__handlers__'
 import { MetricList } from '@/api/__generated__'
 import { MOCK_NODE_ADAPTER } from '@/__test-utils__/react-flow/nodes.ts'
 import { MOCK_ADAPTER_ID, MOCK_ADAPTER_ID2 } from '@/__test-utils__/mocks.ts'
+import { mockEdgeEvent } from '@/api/hooks/useEvents/__handlers__'
 
 const mockNode: Node<Group> = {
   position: { x: 0, y: 0 },
@@ -37,7 +38,7 @@ describe('GroupPropertyDrawer', () => {
     cy.intercept('/api/v1/metrics/**', []).as('getMetricForX')
   })
 
-  it('should render properly', () => {
+  it('should render the minimal metrics properly', () => {
     const onClose = cy.stub().as('onClose')
     const onEditEntity = cy.stub()
     cy.mountWithProviders(
@@ -65,6 +66,47 @@ describe('GroupPropertyDrawer', () => {
 
     // check that the metrics is there
     cy.getByTestId('metrics-toggle').should('be.visible')
+  })
+
+  it.only('should render the full config tabs properly', () => {
+    cy.intercept('/api/v1/management/events?*', { items: [...mockEdgeEvent(150)] })
+    const onClose = cy.stub().as('onClose')
+    const onEditEntity = cy.stub()
+    cy.mountWithProviders(
+      <GroupPropertyDrawer
+        showConfig
+        nodeId="adapter@fgffgf"
+        nodes={mockNodes}
+        selectedNode={mockNode}
+        isOpen={true}
+        onClose={onClose}
+        onEditEntity={onEditEntity}
+      />
+    )
+
+    cy.wait('@getMetricForX')
+
+    // check the panel header
+    cy.getByTestId('group-panel-title').should('contain.text', 'Group Overview')
+
+    // check the panel control
+    cy.get('@onClose').should('not.have.been.called')
+    cy.getByAriaLabel('Close').click()
+    cy.get('@onClose').should('have.been.calledOnce')
+
+    // check the panel tabs
+    cy.get('[role="tablist"] [role="tab"]').should('have.length', 3)
+    cy.get('[role="tablist"] [role="tab"]').eq(0).should('have.text', 'Configuration')
+    cy.get('[role="tablist"] [role="tab"]').eq(1).should('have.text', 'Events')
+    cy.get('[role="tablist"] [role="tab"]').eq(2).should('have.text', 'Metrics')
+
+    cy.get('[role="tablist"] + div > [role="tabpanel"]').should('have.length', 3)
+    cy.get('[role="tablist"] + div > [role="tabpanel"]').eq(0).should('not.have.attr', 'hidden')
+    cy.get('[role="tablist"] + div > [role="tabpanel"]').eq(1).should('have.attr', 'hidden')
+    cy.get('[role="tablist"] + div > [role="tabpanel"]').eq(2).should('have.attr', 'hidden')
+
+    cy.getByTestId('group-metadata-header').should('be.visible')
+    cy.getByTestId('group-content-header').should('be.visible')
   })
 
   it('should be accessible', () => {

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/drawers/GroupPropertyDrawer.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/drawers/GroupPropertyDrawer.tsx
@@ -1,15 +1,28 @@
-import { FC } from 'react'
+import { FC, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Node } from 'reactflow'
+import { Link as RouterLink } from 'react-router-dom'
 import {
+  Button,
+  Card,
+  CardBody,
+  CardFooter,
+  CardHeader,
   Drawer,
   DrawerBody,
   DrawerCloseButton,
   DrawerContent,
   DrawerHeader,
   DrawerOverlay,
+  Tab,
+  TabList,
+  TabPanel,
+  TabPanels,
+  Tabs,
   Text,
+  VStack,
 } from '@chakra-ui/react'
+import { MdOutlineEventNote } from 'react-icons/md'
 
 import MetricsContainer from '@/modules/Metrics/MetricsContainer.tsx'
 
@@ -19,6 +32,8 @@ import { getDefaultMetricsFor } from '../../utils/nodes-utils.ts'
 import GroupMetadataEditor from '../parts/GroupMetadataEditor.tsx'
 import { ChartType, MetricsFilter } from '@/modules/Metrics/types.ts'
 import NodeNameCard from '@/modules/Workspace/components/parts/NodeNameCard.tsx'
+import GroupContentEditor from '@/modules/Workspace/components/parts/GroupContentEditor.tsx'
+import EventLogTable from '@/modules/EventLog/components/table/EventLogTable.tsx'
 
 interface GroupPropertyDrawerProps {
   nodeId: string
@@ -44,6 +59,12 @@ const GroupPropertyDrawer: FC<GroupPropertyDrawerProps> = ({
   const adapterIDs = selectedNode.data.childrenNodeIds.map<Node | undefined>((e) => nodes.find((x) => x.id === e))
   const metrics = adapterIDs.map((x) => (x ? getDefaultMetricsFor(x) : [])).flat()
 
+  const linkEventLog = useMemo(() => {
+    const searchParams = new URLSearchParams()
+    for (const node of adapterIDs) if (node) searchParams.append('source', node.data.id)
+    return `/event-logs?${searchParams.toString()}`
+  }, [adapterIDs])
+
   const panelTitle = showConfig
     ? t('workspace.property.header', { context: selectedNode.type })
     : t('workspace.observability.header', { context: selectedNode.type })
@@ -64,25 +85,78 @@ const GroupPropertyDrawer: FC<GroupPropertyDrawerProps> = ({
         </DrawerHeader>
         <DrawerBody display="flex" flexDirection="column" gap={6}>
           {showConfig && (
-            <GroupMetadataEditor
-              group={selectedNode}
-              onSubmit={(group) => {
-                onGroupSetData(nodeId, group)
-              }}
-            />
+            <Tabs>
+              <TabList>
+                <Tab>{t('workspace.grouping.editor.tabs.config')}</Tab>
+                <Tab>{t('workspace.grouping.editor.tabs.events')}</Tab>
+                <Tab>{t('workspace.grouping.editor.tabs.metrics')}</Tab>
+              </TabList>
+
+              <TabPanels>
+                <TabPanel px={0} as={VStack} alignItems="stretch">
+                  <GroupMetadataEditor
+                    group={selectedNode}
+                    onSubmit={(group) => {
+                      onGroupSetData(nodeId, group)
+                    }}
+                  />
+                  <GroupContentEditor group={selectedNode} />
+                </TabPanel>
+                <TabPanel px={0} as={VStack} alignItems="stretch">
+                  <Card size="sm">
+                    <CardHeader>
+                      <Text>{t('workspace.grouping.editor.eventLog.header')}</Text>
+                    </CardHeader>
+                    <CardBody>
+                      <EventLogTable
+                        globalSourceFilter={adapterIDs.map((e) => e?.data.id)}
+                        variant="summary"
+                        maxEvents={10}
+                        isSingleSource={false}
+                      />
+                    </CardBody>
+                    <CardFooter justifyContent="flex-end" pt={0}>
+                      <Button
+                        data-testid="navigate-eventLog-filtered"
+                        variant="link"
+                        as={RouterLink}
+                        // URL options not yet supported
+                        to={linkEventLog}
+                        rightIcon={<MdOutlineEventNote />}
+                        size="sm"
+                      >
+                        {t('workspace.grouping.editor.eventLog.showMore')}
+                      </Button>
+                    </CardFooter>
+                  </Card>
+                </TabPanel>
+                <TabPanel px={0} as={VStack} alignItems="stretch">
+                  <MetricsContainer
+                    nodeId={nodeId}
+                    type={selectedNode.type as NodeTypes}
+                    adapterIDs={adapterIDs.map((e) => e?.data.id)}
+                    initMetrics={metrics}
+                    defaultChartType={showConfig ? ChartType.SAMPLE : undefined}
+                  />
+                </TabPanel>
+              </TabPanels>
+            </Tabs>
           )}
-          <MetricsContainer
-            nodeId={nodeId}
-            type={selectedNode.type as NodeTypes}
-            filters={adapterIDs.reduce<MetricsFilter[]>((acc, cur) => {
+
+          {!showConfig && (
+            <MetricsContainer
+              nodeId={nodeId}
+              type={selectedNode.type as NodeTypes}
+              filters={adapterIDs.reduce<MetricsFilter[]>((acc, cur) => {
               if (cur && cur.type === NodeTypes.ADAPTER_NODE) {
                 acc.push({ id: cur.data.id, type: `com.hivemq.edge.protocol-adapters.${cur.data.type}` })
               }
               return acc
             }, [])}
-            initMetrics={metrics}
-            defaultChartType={showConfig ? ChartType.SAMPLE : undefined}
-          />
+              initMetrics={metrics}
+              defaultChartType={showConfig ? ChartType.SAMPLE : undefined}
+            />
+          )}
         </DrawerBody>
       </DrawerContent>
     </Drawer>

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/drawers/GroupPropertyDrawer.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/drawers/GroupPropertyDrawer.tsx
@@ -61,7 +61,9 @@ const GroupPropertyDrawer: FC<GroupPropertyDrawerProps> = ({
 
   const linkEventLog = useMemo(() => {
     const searchParams = new URLSearchParams()
-    for (const node of adapterIDs) if (node) searchParams.append('source', node.data.id)
+    for (const node of adapterIDs) {
+      if (node) searchParams.append('source', node.data.id)
+    }
     return `/event-logs?${searchParams.toString()}`
   }, [adapterIDs])
 

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/drawers/GroupPropertyDrawer.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/drawers/GroupPropertyDrawer.tsx
@@ -71,6 +71,74 @@ const GroupPropertyDrawer: FC<GroupPropertyDrawerProps> = ({
     ? t('workspace.property.header', { context: selectedNode.type })
     : t('workspace.observability.header', { context: selectedNode.type })
 
+  const renderMetricsContainer = () => (
+    <MetricsContainer
+      nodeId={nodeId}
+      type={selectedNode.type as NodeTypes}
+      filters={adapterIDs.reduce<MetricsFilter[]>((acc, cur) => {
+        if (cur && cur.type === NodeTypes.ADAPTER_NODE) {
+          acc.push({ id: cur.data.id, type: `com.hivemq.edge.protocol-adapters.${cur.data.type}` })
+        }
+        return acc
+      }, [])}
+      initMetrics={metrics}
+      defaultChartType={showConfig ? ChartType.SAMPLE : undefined}
+    />
+  )
+
+  const renderGroupTabs = () => (
+    <Tabs>
+      <TabList>
+        <Tab>{t('workspace.grouping.editor.tabs.config')}</Tab>
+        <Tab>{t('workspace.grouping.editor.tabs.events')}</Tab>
+        <Tab>{t('workspace.grouping.editor.tabs.metrics')}</Tab>
+      </TabList>
+
+      <TabPanels>
+        <TabPanel px={0} as={VStack} alignItems="stretch">
+          <GroupMetadataEditor
+            group={selectedNode}
+            onSubmit={(group) => {
+              onGroupSetData(nodeId, group)
+            }}
+          />
+          <GroupContentEditor group={selectedNode} />
+        </TabPanel>
+        <TabPanel px={0} as={VStack} alignItems="stretch">
+          <Card size="sm">
+            <CardHeader>
+              <Text>{t('workspace.grouping.editor.eventLog.header')}</Text>
+            </CardHeader>
+            <CardBody>
+              <EventLogTable
+                globalSourceFilter={adapterIDs.map((e) => e?.data.id)}
+                variant="summary"
+                maxEvents={10}
+                isSingleSource={false}
+              />
+            </CardBody>
+            <CardFooter justifyContent="flex-end" pt={0}>
+              <Button
+                data-testid="navigate-eventLog-filtered"
+                variant="link"
+                as={RouterLink}
+                // URL options not yet supported
+                to={linkEventLog}
+                rightIcon={<MdOutlineEventNote />}
+                size="sm"
+              >
+                {t('workspace.grouping.editor.eventLog.showMore')}
+              </Button>
+            </CardFooter>
+          </Card>
+        </TabPanel>
+        <TabPanel px={0} as={VStack} alignItems="stretch">
+          {renderMetricsContainer()}
+        </TabPanel>
+      </TabPanels>
+    </Tabs>
+  )
+
   return (
     <Drawer isOpen={isOpen} placement="right" size="lg" onClose={onClose} variant="hivemq">
       <DrawerOverlay />
@@ -86,79 +154,8 @@ const GroupPropertyDrawer: FC<GroupPropertyDrawerProps> = ({
           />
         </DrawerHeader>
         <DrawerBody display="flex" flexDirection="column" gap={6}>
-          {showConfig && (
-            <Tabs>
-              <TabList>
-                <Tab>{t('workspace.grouping.editor.tabs.config')}</Tab>
-                <Tab>{t('workspace.grouping.editor.tabs.events')}</Tab>
-                <Tab>{t('workspace.grouping.editor.tabs.metrics')}</Tab>
-              </TabList>
-
-              <TabPanels>
-                <TabPanel px={0} as={VStack} alignItems="stretch">
-                  <GroupMetadataEditor
-                    group={selectedNode}
-                    onSubmit={(group) => {
-                      onGroupSetData(nodeId, group)
-                    }}
-                  />
-                  <GroupContentEditor group={selectedNode} />
-                </TabPanel>
-                <TabPanel px={0} as={VStack} alignItems="stretch">
-                  <Card size="sm">
-                    <CardHeader>
-                      <Text>{t('workspace.grouping.editor.eventLog.header')}</Text>
-                    </CardHeader>
-                    <CardBody>
-                      <EventLogTable
-                        globalSourceFilter={adapterIDs.map((e) => e?.data.id)}
-                        variant="summary"
-                        maxEvents={10}
-                        isSingleSource={false}
-                      />
-                    </CardBody>
-                    <CardFooter justifyContent="flex-end" pt={0}>
-                      <Button
-                        data-testid="navigate-eventLog-filtered"
-                        variant="link"
-                        as={RouterLink}
-                        // URL options not yet supported
-                        to={linkEventLog}
-                        rightIcon={<MdOutlineEventNote />}
-                        size="sm"
-                      >
-                        {t('workspace.grouping.editor.eventLog.showMore')}
-                      </Button>
-                    </CardFooter>
-                  </Card>
-                </TabPanel>
-                <TabPanel px={0} as={VStack} alignItems="stretch">
-                  <MetricsContainer
-                    nodeId={nodeId}
-                    type={selectedNode.type as NodeTypes}
-                    adapterIDs={adapterIDs.map((e) => e?.data.id)}
-                    initMetrics={metrics}
-                    defaultChartType={showConfig ? ChartType.SAMPLE : undefined}
-                  />
-                </TabPanel>
-              </TabPanels>
-            </Tabs>
-          )}
-
-          {!showConfig && (
-            <MetricsContainer
-              nodeId={nodeId}
-              type={selectedNode.type as NodeTypes}
-              filters={adapterIDs.reduce<MetricsFilter[]>((acc, cur) => {
-              if (cur && cur.type === NodeTypes.ADAPTER_NODE) {
-                acc.push({ id: cur.data.id, type: `com.hivemq.edge.protocol-adapters.${cur.data.type}` })
-              }
-              return acc
-            }, [])}
-              initMetrics={metrics}
-              defaultChartType={showConfig ? ChartType.SAMPLE : undefined}
-            />
-          )}
+          {showConfig && renderGroupTabs()}
+          {!showConfig && renderMetricsContainer()}
         </DrawerBody>
       </DrawerContent>
     </Drawer>

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/drawers/NodePropertyDrawer.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/drawers/NodePropertyDrawer.tsx
@@ -86,7 +86,11 @@ const NodePropertyDrawer: FC<NodePropertyDrawerProps> = ({ nodeId, isOpen, selec
               </Text>
             </CardHeader>
             <CardBody>
-              <EventLogTable globalSourceFilter={(selectedNode?.data as Adapter).id} variant="summary" />
+              <EventLogTable
+                globalSourceFilter={[(selectedNode?.data as Adapter).id]}
+                variant="summary"
+                isSingleSource
+              />
             </CardBody>
             <CardFooter justifyContent="flex-end" pt={0}>
               <Button

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/parts/GroupContentEditor.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/parts/GroupContentEditor.spec.cy.tsx
@@ -1,0 +1,75 @@
+import { Node } from 'reactflow'
+import { MOCK_NODE_ADAPTER, MOCK_NODE_DEVICE, MOCK_NODE_GROUP } from '@/__test-utils__/react-flow/nodes.ts'
+import { ReactFlowTesting } from '@/__test-utils__/react-flow/ReactFlowTesting.tsx'
+import GroupContentEditor from '@/modules/Workspace/components/parts/GroupContentEditor.tsx'
+import { mockAdapterConnectionStatus } from '@/api/hooks/useConnection/__handlers__'
+
+const getWrapperWith = (initialNodes?: Node[]) => {
+  const Wrapper: React.JSXElementConstructor<{ children: React.ReactNode }> = ({ children }) => {
+    return (
+      <ReactFlowTesting
+        config={{
+          initialState: {
+            nodes: initialNodes,
+          },
+        }}
+      >
+        {children}
+      </ReactFlowTesting>
+    )
+  }
+
+  return Wrapper
+}
+
+describe('GroupContentEditor', () => {
+  beforeEach(() => {
+    cy.viewport(800, 600)
+    cy.intercept('api/v1/management/protocol-adapters/status', { items: [mockAdapterConnectionStatus] }).as('getStatus')
+  })
+
+  it('should render properly', () => {
+    cy.mountWithProviders(<GroupContentEditor group={{ ...MOCK_NODE_GROUP, position: { x: 50, y: 100 } }} />, {
+      wrapper: getWrapperWith([
+        { ...MOCK_NODE_ADAPTER, position: { x: 50, y: 100 } },
+        { ...MOCK_NODE_DEVICE, id: 'idBridge', position: { x: 50, y: 100 } },
+      ]),
+    })
+
+    cy.getByTestId('group-content-header').should('have.text', 'Content Management')
+    cy.get('table').should('be.visible')
+    cy.get('table thead tr th').should('have.length', 4)
+    cy.get('table thead tr th').eq(0).should('have.text', 'Type')
+    cy.get('table thead tr th').eq(1).should('have.text', 'Status')
+    cy.get('table thead tr th').eq(2).should('have.text', 'Id')
+    cy.get('table thead tr th').eq(3).should('have.text', 'Actions')
+    cy.get('table tbody tr').should('have.length', 2)
+    cy.get('table tbody tr').eq(0).find('td').as('adapter-row')
+    cy.get('table tbody tr').eq(1).find('td').as('device-row')
+
+    cy.get('@adapter-row').should('have.length', 4)
+    cy.get('@adapter-row').eq(0).should('have.text', 'adapter')
+    cy.get('@adapter-row').eq(1).should('have.text', 'Connected')
+    cy.get('@adapter-row').eq(2).should('have.text', 'my-adapter')
+
+    cy.get('@device-row').should('have.length', 4)
+    cy.get('@device-row').eq(0).should('have.text', 'device')
+    cy.get('@device-row').eq(1).should('have.text', 'Unknown')
+    cy.get('@device-row').eq(2).should('have.text', 'simulation')
+
+    cy.get('nav').should('be.visible').should('have.attr', 'aria-label', 'Pagination')
+    cy.get('nav').find('[role="group"]').should('have.length', 2)
+  })
+
+  it('should be accessible', () => {
+    cy.injectAxe()
+    cy.mountWithProviders(<GroupContentEditor group={{ ...MOCK_NODE_GROUP, position: { x: 50, y: 100 } }} />, {
+      wrapper: getWrapperWith([
+        { ...MOCK_NODE_ADAPTER, position: { x: 50, y: 100 } },
+        { ...MOCK_NODE_DEVICE, id: 'idBridge', position: { x: 50, y: 100 } },
+      ]),
+    })
+    cy.checkAccessibility()
+    cy.percySnapshot('Component: GroupContentEditor')
+  })
+})

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/parts/GroupContentEditor.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/parts/GroupContentEditor.tsx
@@ -50,7 +50,7 @@ const GroupContentEditor: FC<GroupContentEditorProps> = ({ group }) => {
   }, [t])
 
   const data = useMemo<Node[]>(() => {
-    return group.data.childrenNodeIds.map((e) => nodes.find((x) => x.id === e)) as Node[]
+    return group.data.childrenNodeIds.map((e) => nodes.find((x) => x.id === e)).filter((e) => Boolean(e)) as Node[]
   }, [group.data.childrenNodeIds, nodes])
 
   return (

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/parts/GroupContentEditor.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/parts/GroupContentEditor.tsx
@@ -1,0 +1,67 @@
+import { FC, useMemo } from 'react'
+import { Node } from 'reactflow'
+import { Group } from '@/modules/Workspace/types.ts'
+import { ButtonGroup, Card, CardBody, CardFooter, CardHeader } from '@chakra-ui/react'
+import { useTranslation } from 'react-i18next'
+import PaginatedTable from '@/components/PaginatedTable/PaginatedTable.tsx'
+import { ColumnDef } from '@tanstack/react-table'
+import useWorkspaceStore from '@/modules/Workspace/hooks/useWorkspaceStore.ts'
+import IconButton from '@/components/Chakra/IconButton.tsx'
+import { MdPlayArrow, MdRestartAlt, MdStop } from 'react-icons/md'
+import { AdapterStatusContainer } from '@/modules/ProtocolAdapters/components/adapters/AdapterStatusContainer.tsx'
+
+interface GroupContentEditorProps {
+  group: Node<Group>
+}
+
+const GroupContentEditor: FC<GroupContentEditorProps> = ({ group }) => {
+  const { t } = useTranslation()
+  const { nodes } = useWorkspaceStore()
+
+  const columns = useMemo<ColumnDef<Node>[]>(() => {
+    return [
+      {
+        accessorKey: 'type',
+      },
+      {
+        accessorKey: 'data.status',
+        cell: (info) => {
+          return <AdapterStatusContainer id={info.row.original.data.id} />
+        },
+      },
+      {
+        accessorKey: 'data.id',
+      },
+      {
+        id: 'actions',
+        header: t('topicFilter.listing.column.action'),
+        sortingFn: undefined,
+        footer: () => {
+          return (
+            <ButtonGroup isAttached size="sm" colorScheme="red">
+              <IconButton aria-label={t('Stop all')} icon={<MdPlayArrow />} onClick={() => undefined} />
+              <IconButton aria-label={t('Stop all')} icon={<MdStop />} onClick={() => undefined} />
+              <IconButton aria-label={t('Restart all')} icon={<MdRestartAlt />} onClick={() => undefined} />
+            </ButtonGroup>
+          )
+        },
+      },
+    ]
+  }, [t])
+
+  const data = useMemo<Node[]>(() => {
+    return group.data.childrenNodeIds.map((e) => nodes.find((x) => x.id === e)) as Node[]
+  }, [group.data.childrenNodeIds, nodes])
+
+  return (
+    <Card size="sm">
+      <CardHeader> {t('Content Management')}</CardHeader>
+      <CardBody>
+        <PaginatedTable<Node> aria-label={t('eventLog.title')} data={data} columns={columns} />
+      </CardBody>
+      <CardFooter justifyContent="flex-end"></CardFooter>
+    </Card>
+  )
+}
+
+export default GroupContentEditor

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/parts/GroupContentEditor.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/parts/GroupContentEditor.tsx
@@ -36,12 +36,35 @@ const GroupContentEditor: FC<GroupContentEditorProps> = ({ group }) => {
         id: 'actions',
         header: t('topicFilter.listing.column.action'),
         sortingFn: undefined,
+        cell: () => {
+          return (
+            <ButtonGroup isAttached size="xs" isDisabled>
+              <IconButton
+                aria-label={t('workspace.grouping.editor.content.actions.ungroup')}
+                icon={<Icon as={ImUngroup} />}
+                onClick={() => undefined}
+              />
+            </ButtonGroup>
+          )
+        },
         footer: () => {
           return (
-            <ButtonGroup isAttached size="sm" colorScheme="red">
-              <IconButton aria-label={t('Stop all')} icon={<MdPlayArrow />} onClick={() => undefined} />
-              <IconButton aria-label={t('Stop all')} icon={<MdStop />} onClick={() => undefined} />
-              <IconButton aria-label={t('Restart all')} icon={<MdRestartAlt />} onClick={() => undefined} />
+            <ButtonGroup isAttached size="xs" isDisabled>
+              <IconButton
+                aria-label={t('workspace.grouping.editor.content.actions.startAll')}
+                icon={<MdPlayArrow />}
+                onClick={() => undefined}
+              />
+              <IconButton
+                aria-label={t('workspace.grouping.editor.content.actions.stopAll')}
+                icon={<MdStop />}
+                onClick={() => undefined}
+              />
+              <IconButton
+                aria-label={t('workspace.grouping.editor.content.actions.restartAll')}
+                icon={<MdRestartAlt />}
+                onClick={() => undefined}
+              />
             </ButtonGroup>
           )
         },

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/parts/GroupContentEditor.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/parts/GroupContentEditor.tsx
@@ -1,14 +1,16 @@
 import { FC, useMemo } from 'react'
 import { Node } from 'reactflow'
-import { Group } from '@/modules/Workspace/types.ts'
-import { ButtonGroup, Card, CardBody, CardFooter, CardHeader } from '@chakra-ui/react'
 import { useTranslation } from 'react-i18next'
-import PaginatedTable from '@/components/PaginatedTable/PaginatedTable.tsx'
 import { ColumnDef } from '@tanstack/react-table'
-import useWorkspaceStore from '@/modules/Workspace/hooks/useWorkspaceStore.ts'
-import IconButton from '@/components/Chakra/IconButton.tsx'
+import { ButtonGroup, Card, CardBody, CardFooter, CardHeader, Icon } from '@chakra-ui/react'
 import { MdPlayArrow, MdRestartAlt, MdStop } from 'react-icons/md'
+
+import IconButton from '@/components/Chakra/IconButton.tsx'
+import PaginatedTable from '@/components/PaginatedTable/PaginatedTable.tsx'
+import useWorkspaceStore from '@/modules/Workspace/hooks/useWorkspaceStore.ts'
+import { Group } from '@/modules/Workspace/types.ts'
 import { AdapterStatusContainer } from '@/modules/ProtocolAdapters/components/adapters/AdapterStatusContainer.tsx'
+import { ImUngroup } from 'react-icons/im'
 
 interface GroupContentEditorProps {
   group: Node<Group>
@@ -22,19 +24,22 @@ const GroupContentEditor: FC<GroupContentEditorProps> = ({ group }) => {
     return [
       {
         accessorKey: 'type',
+        header: t('workspace.grouping.editor.content.header.type'),
       },
       {
         accessorKey: 'data.status',
+        header: t('workspace.grouping.editor.content.header.status'),
         cell: (info) => {
           return <AdapterStatusContainer id={info.row.original.data.id} />
         },
       },
       {
         accessorKey: 'data.id',
+        header: t('workspace.grouping.editor.content.header.id'),
       },
       {
         id: 'actions',
-        header: t('topicFilter.listing.column.action'),
+        header: t('workspace.grouping.editor.content.header.actions'),
         sortingFn: undefined,
         cell: () => {
           return (

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/parts/GroupContentEditor.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/parts/GroupContentEditor.tsx
@@ -25,6 +25,9 @@ const GroupContentEditor: FC<GroupContentEditorProps> = ({ group }) => {
       {
         accessorKey: 'type',
         header: t('workspace.grouping.editor.content.header.type'),
+        cell: (info) => {
+          return t('workspace.device.type', { context: info.getValue<string>() })
+        },
       },
       {
         accessorKey: 'data.status',
@@ -83,7 +86,7 @@ const GroupContentEditor: FC<GroupContentEditorProps> = ({ group }) => {
 
   return (
     <Card size="sm">
-      <CardHeader> {t('Content Management')}</CardHeader>
+      <CardHeader data-testid="group-content-header">{t('Content Management')}</CardHeader>
       <CardBody>
         <PaginatedTable<Node>
           aria-label={t('eventLog.title')}

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/parts/GroupContentEditor.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/parts/GroupContentEditor.tsx
@@ -57,7 +57,13 @@ const GroupContentEditor: FC<GroupContentEditorProps> = ({ group }) => {
     <Card size="sm">
       <CardHeader> {t('Content Management')}</CardHeader>
       <CardBody>
-        <PaginatedTable<Node> aria-label={t('eventLog.title')} data={data} columns={columns} />
+        <PaginatedTable<Node>
+          aria-label={t('eventLog.title')}
+          data={data}
+          columns={columns}
+          enablePaginationSizes={false}
+          enablePaginationGoTo={false}
+        />
       </CardBody>
       <CardFooter justifyContent="flex-end"></CardFooter>
     </Card>

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/parts/GroupMetadataEditor.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/parts/GroupMetadataEditor.spec.cy.tsx
@@ -1,0 +1,46 @@
+import { MOCK_NODE_GROUP } from '@/__test-utils__/react-flow/nodes.ts'
+import GroupMetadataEditor from '@/modules/Workspace/components/parts/GroupMetadataEditor.tsx'
+
+describe('GroupMetadataEditor', () => {
+  beforeEach(() => {
+    cy.viewport(400, 400)
+  })
+
+  it('should render properly', () => {
+    const onSubmit = cy.stub().as('onSubmit')
+    cy.mountWithProviders(
+      <GroupMetadataEditor group={{ ...MOCK_NODE_GROUP, position: { x: 50, y: 100 } }} onSubmit={onSubmit} />
+    )
+
+    cy.getByTestId('group-metadata-header').should('contain.text', 'Configure the group')
+    cy.get('form [role="group"]').as('editor')
+    cy.get('@editor').eq(0).find('label').should('contain.text', 'Title')
+    cy.get('@editor').eq(0).find('input').should('have.value', 'The group title')
+
+    cy.get('@editor').eq(1).find('legend').should('contain.text', 'Group colour')
+    cy.get('@editor').eq(1).find('button').should('have.attr', 'data-color-scheme', 'gray')
+
+    cy.getByTestId('form-submit').should('have.text', 'Save changes').should('be.disabled')
+    cy.get('@onSubmit').should('not.have.been.called')
+
+    cy.get('@editor').eq(0).find('input').type(' 123')
+    cy.getByTestId('form-submit').should('not.be.disabled')
+    cy.getByTestId('form-submit').click()
+
+    cy.get('@onSubmit').should('have.been.calledWithMatch', {
+      childrenNodeIds: ['idAdapter', 'idBridge'],
+      title: 'The group title 123',
+      colorScheme: undefined,
+    })
+  })
+
+  it('should be accessible', () => {
+    const onSubmit = cy.stub().as('onSubmit')
+    cy.injectAxe()
+    cy.mountWithProviders(
+      <GroupMetadataEditor group={{ ...MOCK_NODE_GROUP, position: { x: 50, y: 100 } }} onSubmit={onSubmit} />
+    )
+    cy.checkAccessibility()
+    cy.percySnapshot('Component: GroupMetadataEditor')
+  })
+})

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/parts/GroupMetadataEditor.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/parts/GroupMetadataEditor.tsx
@@ -27,7 +27,7 @@ const GroupMetadataEditor: FC<GroupMetadataEditorProps> = ({ group, onSubmit }) 
 
   return (
     <Card size="sm">
-      <CardHeader data-testid="group-metadata-header"> {t('workspace.grouping.editor.title')}</CardHeader>
+      <CardHeader data-testid="group-metadata-header">{t('workspace.grouping.editor.title')}</CardHeader>
       <CardBody>
         <form
           id="group-form"

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/parts/GroupMetadataEditor.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/parts/GroupMetadataEditor.tsx
@@ -1,26 +1,13 @@
 import { FC } from 'react'
 import { Node } from 'reactflow'
-import {
-  Accordion,
-  AccordionButton,
-  AccordionIcon,
-  AccordionItem,
-  AccordionPanel,
-  Box,
-  Button,
-  Card,
-  FormControl,
-  FormLabel,
-  Input,
-  VStack,
-} from '@chakra-ui/react'
 import { useTranslation } from 'react-i18next'
 import { Controller, useForm } from 'react-hook-form'
+import { Button, Card, CardBody, CardFooter, CardHeader, FormControl, FormLabel, Input } from '@chakra-ui/react'
+
 import { Group } from '@/modules/Workspace/types.ts'
 import { ColorPicker } from '@/components/Chakra/ColorPicker.tsx'
 
 interface GroupMetadataEditorProps {
-  id?: string
   group: Node<Group>
   onSubmit: (data: Group) => void
 }
@@ -40,54 +27,36 @@ const GroupMetadataEditor: FC<GroupMetadataEditorProps> = ({ group, onSubmit }) 
 
   return (
     <Card size="sm">
-      <Accordion allowToggle>
-        <AccordionItem>
-          <AccordionButton data-testid="metrics-toggle">
-            <Box as="span" flex="1" textAlign="left">
-              {t('workspace.grouping.editor.title')}
-            </Box>
-            <AccordionIcon />
-          </AccordionButton>
+      <CardHeader> {t('workspace.grouping.editor.title')}</CardHeader>
+      <CardBody>
+        <form
+          id="group-form"
+          onSubmit={handleSubmit(handleFormSubmit)}
+          style={{ display: 'flex', flexDirection: 'row', gap: '18px' }}
+        >
+          <FormControl>
+            <FormLabel htmlFor="group-title">{t('workspace.grouping.editor.input-title')}</FormLabel>
+            <Input id="group-title" {...register('title')} />
+          </FormControl>
 
-          <AccordionPanel pb={4}>
-            <VStack gap={2} alignItems="stretch">
-              <form
-                id="group-form"
-                onSubmit={handleSubmit(handleFormSubmit)}
-                style={{ display: 'flex', flexDirection: 'row', gap: '18px' }}
-              >
-                <FormControl>
-                  <FormLabel htmlFor="group-title">{t('workspace.grouping.editor.input-title')}</FormLabel>
-                  <Input id="group-title" {...register('title')} />
-                </FormControl>
-
-                <FormControl as="fieldset">
-                  <FormLabel as="legend">{t('workspace.grouping.editor.input-color')}</FormLabel>
-                  <Controller
-                    name="colorScheme"
-                    render={({ field }) => {
-                      const { value, onChange, ...rest } = field
-                      return <ColorPicker colorScheme={value} onChange={(value) => onChange(value)} {...rest} />
-                    }}
-                    control={control}
-                  />
-                </FormControl>
-              </form>
-              <VStack alignItems="end">
-                <Button
-                  isDisabled={!formState.isDirty}
-                  type="submit"
-                  form="group-form"
-                  data-testid="form-submit"
-                  mt={8}
-                >
-                  {t('workspace.grouping.editor.save')}
-                </Button>
-              </VStack>
-            </VStack>
-          </AccordionPanel>
-        </AccordionItem>
-      </Accordion>
+          <FormControl as="fieldset">
+            <FormLabel as="legend">{t('workspace.grouping.editor.input-color')}</FormLabel>
+            <Controller
+              name="colorScheme"
+              render={({ field }) => {
+                const { value, onChange, ...rest } = field
+                return <ColorPicker colorScheme={value} onChange={(value) => onChange(value)} {...rest} />
+              }}
+              control={control}
+            />
+          </FormControl>
+        </form>
+      </CardBody>
+      <CardFooter justifyContent="flex-end">
+        <Button isDisabled={!formState.isDirty} type="submit" form="group-form" data-testid="form-submit">
+          {t('workspace.grouping.editor.save')}
+        </Button>
+      </CardFooter>
     </Card>
   )
 }

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/parts/GroupMetadataEditor.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/parts/GroupMetadataEditor.tsx
@@ -27,7 +27,7 @@ const GroupMetadataEditor: FC<GroupMetadataEditorProps> = ({ group, onSubmit }) 
 
   return (
     <Card size="sm">
-      <CardHeader> {t('workspace.grouping.editor.title')}</CardHeader>
+      <CardHeader data-testid="group-metadata-header"> {t('workspace.grouping.editor.title')}</CardHeader>
       <CardBody>
         <form
           id="group-form"

--- a/hivemq-edge/src/frontend/src/modules/Workspace/utils/adapter.utils.ts
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/utils/adapter.utils.ts
@@ -47,7 +47,7 @@ export const deviceCapabilityIcon: Record<CapabilityType, IconType> = {
 export const statusMapping = {
   [Status.runtime.STOPPED]: { text: 'STOPPED', color: 'status.error' },
   [Status.connection.ERROR]: { text: 'ERROR', color: 'status.error' },
-  [Status.connection.UNKNOWN]: { text: 'UNKNOWN', color: 'status.error' },
+  [Status.connection.UNKNOWN]: { text: 'UNKNOWN', color: 'status.unknown' },
   [Status.connection.CONNECTED]: { text: 'CONNECTED', color: 'status.connected' },
   [Status.connection.DISCONNECTED]: { text: 'DISCONNECTED', color: 'status.disconnected' },
   [Status.connection.STATELESS]: { text: 'STATELESS', color: 'status.stateless' },


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/28974/details/

The PR refactors the content of the side panel associated with custom groups on the workspace, making it consistent with the other nodes. 

- the layout of the panel is now split into three tabs: configuration, events and metrics
- the header of the group panel is now consistent with all the other side panels
- the configuration of the group (title and colour) is complemented by the list of all nodes in the group
- the event tab shows the most recent events for all nodes in the group. A link allows access to the complete event log
- the metrics tab contains the observability dashboard for all nodes in the group

### Out-of-scope
- the actions in the list of nodes are disabled since we lack an easy way of controlling several adapters at a time. This will be investigated in a further ticket

### Before
![screenshot-localhost_3000-2025_01_07-08_56_51](https://github.com/user-attachments/assets/e4126d94-9843-4569-ba79-9760389f658c)


### After
![screenshot-localhost_3000-2025_01_07-08_56_03](https://github.com/user-attachments/assets/0090eeed-e5ca-4404-bd0a-f53fa63eb384)

![screenshot-localhost_3000-2025_01_07-08_56_16](https://github.com/user-attachments/assets/0df8ca91-9c26-40eb-a325-2788de1fcb7b)

![screenshot-localhost_3000-2025_01_07-08_56_26](https://github.com/user-attachments/assets/18356cb9-d157-4745-9cb7-2078565ee112)
