### PR TITLE
refactor(29205): Improve the UX flow on the adapter pages

### DIFF
--- a/hivemq-edge/src/frontend/src/components/PageContainer.tsx
+++ b/hivemq-edge/src/frontend/src/components/PageContainer.tsx
@@ -14,7 +14,7 @@ const PageContainer: FC<PageContainerProps> = ({ title, subtitle, children, cta 
 
   return (
     <Flex flexDirection="column" p={4} pt={6} flexGrow={1}>
-      <Flex gap="50px">
+      <Flex gap="50px" data-testid="page-container-header">
         <Box maxW="50vw" pb={6}>
           <Heading as="h1">
             {title ? (
@@ -27,7 +27,7 @@ const PageContainer: FC<PageContainerProps> = ({ title, subtitle, children, cta 
           </Heading>
           {subtitle && <Text fontSize="md">{subtitle}</Text>}
         </Box>
-        <Box flexGrow={1} alignItems="flex-end">
+        <Box flexGrow={1} alignItems="flex-end" data-testid="page-container-cta">
           {cta}
         </Box>
       </Flex>

--- a/hivemq-edge/src/frontend/src/locales/en/translation.json
+++ b/hivemq-edge/src/frontend/src/locales/en/translation.json
@@ -398,6 +398,8 @@
     "description": "Protocol adapters provide the ability to connect your HiveMQ Edge installation to local and remote devices. Once a connection has been established, you can consolidate data from this connection into your HiveMQ MQTT Broker.",
     "list": "List of protocol adapters",
     "action": {
+      "goCatalog": "Add a new adapter",
+      "goAdapter": "Back to active adapters",
       "add": "Add",
       "delete": "Delete",
       "create": "Create",

--- a/hivemq-edge/src/frontend/src/modules/App/routes.tsx
+++ b/hivemq-edge/src/frontend/src/modules/App/routes.tsx
@@ -19,6 +19,10 @@ const NodePanelController = lazy(() => import('@/modules/Workspace/components/co
 const EvenLogPage = lazy(() => import('@/modules/EventLog/EvenLogPage.tsx'))
 const AdapterSubscriptionManager = lazy(() => import('@/modules/Mappings/AdapterMappingManager.tsx'))
 const TopicFilterManager = lazy(() => import('@/modules/TopicFilters/TopicFilterManager.tsx'))
+const ProtocolIntegrationStore = lazy(
+  () => import('@/modules/ProtocolAdapters/components/panels/ProtocolIntegrationStore.tsx')
+)
+const ProtocolAdapters = lazy(() => import('@/modules/ProtocolAdapters/components/panels/ProtocolAdapters.tsx'))
 
 import { dataHubRoutes } from '@/extensions/datahub/routes.tsx'
 import { MappingType } from '@/modules/Mappings/types.ts'
@@ -55,16 +59,28 @@ export const routes = createBrowserRouter(
           element: <ProtocolAdapterPage />,
           children: [
             {
-              path: 'new/:type',
-              element: <AdapterController isNew />,
+              path: '',
+              element: <ProtocolAdapters />,
+              children: [
+                {
+                  path: 'edit/:type/:adapterId',
+                  element: <AdapterController />,
+                },
+                {
+                  path: 'edit/:type/:adapterId/export',
+                  element: <ExportDrawer />,
+                },
+              ],
             },
             {
-              path: 'edit/:type/:adapterId',
-              element: <AdapterController />,
-            },
-            {
-              path: 'edit/:type/:adapterId/export',
-              element: <ExportDrawer />,
+              path: 'catalog',
+              element: <ProtocolIntegrationStore />,
+              children: [
+                {
+                  path: 'new/:type',
+                  element: <AdapterController isNew />,
+                },
+              ],
             },
           ],
         },

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/ProtocolAdapterPage.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/ProtocolAdapterPage.tsx
@@ -1,60 +1,42 @@
-import { FC, useEffect, useMemo, useState } from 'react'
+import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Tab, TabList, TabPanel, TabPanels, Tabs } from '@chakra-ui/react'
+import { useLocation, useNavigate } from 'react-router-dom'
+import { Button, Flex } from '@chakra-ui/react'
+import { BiAddToQueue, BiArrowBack } from 'react-icons/bi'
 
-import { useLocation } from 'react-router-dom'
-
-import { useGetConfiguration } from '@/api/hooks/useFrontendServices/useGetConfiguration.ts'
 import SuspenseOutlet from '@/components/SuspenseOutlet.tsx'
 import PageContainer from '@/components/PageContainer.tsx'
-import ProtocolAdapters from '@/modules/ProtocolAdapters/components/panels/ProtocolAdapters.tsx'
-import ProtocolIntegrationStore from '@/modules/ProtocolAdapters/components/panels/ProtocolIntegrationStore.tsx'
-import { AdapterNavigateState, ProtocolAdapterTabIndex } from '@/modules/ProtocolAdapters/types.ts'
 
 const ProtocolAdapterPage: FC = () => {
   const { t } = useTranslation()
-  const { state } = useLocation()
-  const { data: configuration } = useGetConfiguration()
-  const isReturningUser = useMemo(() => {
-    return configuration?.firstUseInformation?.firstUse !== true
-  }, [configuration?.firstUseInformation?.firstUse])
-  const [tabIndex, setTabIndex] = useState(0)
+  const { pathname } = useLocation()
+  const navigate = useNavigate()
 
-  useEffect(() => {
-    setTabIndex(isReturningUser ? ProtocolAdapterTabIndex.ADAPTERS : ProtocolAdapterTabIndex.PROTOCOLS)
-  }, [isReturningUser])
-
-  useEffect(() => {
-    if ((state as AdapterNavigateState)?.protocolAdapterTabIndex) {
-      setTabIndex(state.protocolAdapterTabIndex)
-    }
-  }, [state])
-
-  const handleTabsChange = (index: number) => {
-    setTabIndex(index)
-  }
+  const isMainPage = pathname === '/protocol-adapters'
 
   return (
-    <PageContainer title={t('protocolAdapter.title')} subtitle={t('protocolAdapter.description')}>
-      <Tabs onChange={handleTabsChange} index={tabIndex} isLazy colorScheme="brand">
-        <TabList>
-          <Tab fontSize="lg" fontWeight="bold">
-            {t('protocolAdapter.tabs.protocols')}
-          </Tab>
-          <Tab fontSize="lg" fontWeight="bold">
-            {t('protocolAdapter.tabs.adapters')}
-          </Tab>
-        </TabList>
-
-        <TabPanels>
-          <TabPanel>
-            <ProtocolIntegrationStore />
-          </TabPanel>
-          <TabPanel>
-            <ProtocolAdapters />
-          </TabPanel>
-        </TabPanels>
-      </Tabs>
+    <PageContainer
+      title={t('protocolAdapter.title')}
+      subtitle={t('protocolAdapter.description')}
+      cta={
+        <Flex height="100%" justifyContent="flex-end" alignItems="flex-end" pb={6}>
+          {isMainPage && (
+            <Button
+              leftIcon={<BiAddToQueue />}
+              onClick={() => navigate('/protocol-adapters/catalog')}
+              variant="primary"
+            >
+              {t('protocolAdapter.action.goCatalog')}
+            </Button>
+          )}
+          {!isMainPage && (
+            <Button leftIcon={<BiArrowBack />} onClick={() => navigate('/protocol-adapters', { replace: true })}>
+              {t('protocolAdapter.action.goAdapter')}
+            </Button>
+          )}
+        </Flex>
+      }
+    >
       <SuspenseOutlet />
     </PageContainer>
   )

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/panels/ProtocolAdapters.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/panels/ProtocolAdapters.spec.cy.tsx
@@ -17,6 +17,9 @@ describe('ProtocolAdapters', () => {
     cy.injectAxe()
     cy.mountWithProviders(<ProtocolAdapters />)
 
+    cy.getByTestId('heading-adapters-list').find('h2').should('have.text', 'Active Adapters')
+    cy.getByTestId('heading-adapters-list').find('h2 + p').should('have.text', 'Seeing 1 of 1 adapters')
+
     cy.wait('@getAdapters')
     cy.get('tbody').find('tr').should('have.length', 1)
     cy.get('tbody').find('tr').find('td').eq(0).should('contain.text', MOCK_ADAPTER_ID)

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/panels/ProtocolAdapters.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/panels/ProtocolAdapters.tsx
@@ -1,5 +1,16 @@
 import { FC, useMemo, useState } from 'react'
-import { Box, HStack, Image, Skeleton, Text, useColorModeValue, useDisclosure, useToken } from '@chakra-ui/react'
+import {
+  Box,
+  Flex,
+  Heading,
+  HStack,
+  Image,
+  Skeleton,
+  Text,
+  useColorModeValue,
+  useDisclosure,
+  useToken,
+} from '@chakra-ui/react'
 import { ColumnDef, Row } from '@tanstack/react-table'
 import { useTranslation } from 'react-i18next'
 import { DateTime } from 'luxon'
@@ -221,15 +232,18 @@ const ProtocolAdapters: FC = () => {
     )
 
   return (
-    <>
-      <Text>
-        {!isLoading
-          ? t('protocolAdapter.table.pagination.summary', {
-              count: Math.min(DEFAULT_PER_PAGE, safeData.length),
-              total: safeData.length,
-            })
-          : t('protocolAdapter.loading.activeAdapters')}
-      </Text>
+    <Flex flexDirection="column" gap={4}>
+      <Box>
+        <Heading size="md">{t('protocolAdapter.tabs.adapters')}</Heading>
+        <Text>
+          {!isLoading
+            ? t('protocolAdapter.table.pagination.summary', {
+                count: Math.min(DEFAULT_PER_PAGE, safeData.length),
+                total: safeData.length,
+              })
+            : t('protocolAdapter.loading.activeAdapters')}
+        </Text>
+      </Box>
       <PaginatedTable<Adapter>
         aria-label={t('protocolAdapter.tabs.adapters')}
         data={safeData}

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/panels/ProtocolAdapters.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/panels/ProtocolAdapters.tsx
@@ -45,6 +45,7 @@ import { useEdgeToast } from '@/hooks/useEdgeToast/useEdgeToast.tsx'
 import AdapterActionMenu from '../adapters/AdapterActionMenu.tsx'
 import { compareStatus } from '../../utils/pagination-utils.ts'
 import IconButton from '@/components/Chakra/IconButton.tsx'
+import SuspenseOutlet from '@/components/SuspenseOutlet.tsx'
 import { AdapterStatusContainer } from '@/modules/ProtocolAdapters/components/adapters/AdapterStatusContainer.tsx'
 
 const DEFAULT_PER_PAGE = 10
@@ -82,7 +83,7 @@ const ProtocolAdapters: FC = () => {
         protocolAdapterTabIndex: ProtocolAdapterTabIndex.ADAPTERS,
         protocolAdapterType: type,
       }
-      navigate(`/protocol-adapters/new/${type}`, { state: adapterNavigateState })
+      navigate(`/protocol-adapters/catalog/new/${type}`, { state: adapterNavigateState })
     }
 
     const handleEditInstance = (adapterId: string, type: string) => {
@@ -263,7 +264,8 @@ const ProtocolAdapters: FC = () => {
         message={t('modals.generics.confirmation')}
         header={t('modals.deleteProtocolAdapterDialog.header')}
       />
-    </>
+      <SuspenseOutlet />
+    </Flex>
   )
 }
 

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/panels/ProtocolAdapters.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/panels/ProtocolAdapters.tsx
@@ -234,7 +234,7 @@ const ProtocolAdapters: FC = () => {
 
   return (
     <Flex flexDirection="column" gap={4}>
-      <Box>
+      <Box data-testid="heading-adapters-list">
         <Heading size="md">{t('protocolAdapter.tabs.adapters')}</Heading>
         <Text>
           {!isLoading

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/panels/ProtocolIntegrationStore.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/panels/ProtocolIntegrationStore.spec.cy.tsx
@@ -1,0 +1,45 @@
+import ProtocolIntegrationStore from '@/modules/ProtocolAdapters/components/panels/ProtocolIntegrationStore.tsx'
+import { mockProtocolAdapter } from '@/api/hooks/useProtocolAdapters/__handlers__'
+
+describe('ProtocolIntegrationStore', () => {
+  beforeEach(() => {
+    cy.viewport(800, 900)
+    cy.intercept('/api/v1/management/protocol-adapters/types', { items: [mockProtocolAdapter] }).as('getProtocols')
+    //   cy.intercept('api/v1/management/protocol-adapters/adapters', { items: [mockAdapter] }).as('getAdapters')
+    //   cy.intercept('api/v1/management/protocol-adapters/status', { items: [mockAdapterConnectionStatus] }).as('getStatus')
+  })
+
+  it('should handle loading errors', () => {
+    cy.intercept('/api/v1/management/protocol-adapters/types', { statusCode: 404 }).as('getProtocols')
+    cy.mountWithProviders(<ProtocolIntegrationStore />)
+
+    cy.wait('@getProtocols')
+    cy.get('[role="alert"]').should('have.attr', 'data-status', 'error')
+    cy.get('[role="alert"] div div').eq(0).should('have.text', 'Not Found')
+    cy.get('[role="alert"] div div')
+      .eq(1)
+      .should('have.text', 'We cannot load your adapters for the time being. Please try again later')
+  })
+
+  it.only('should render properly', () => {
+    cy.mountWithProviders(<ProtocolIntegrationStore />)
+
+    cy.wait('@getProtocols')
+
+    cy.getByTestId('heading-protocols-list').find('h2').should('have.text', 'Protocol Adapter Catalog')
+    cy.getByTestId('heading-protocols-list')
+      .find('h2 + p')
+      .should('have.text', 'Select the protocol to start creating your connection')
+
+    cy.get('[role="region"]').should('have.attr', 'aria-label', 'Search and filter protocol adapters')
+    cy.get('[role="region"] + [role="list"]').should('have.attr', 'aria-label', 'List of protocol adapters')
+  })
+
+  it('should be accessible', () => {
+    cy.injectAxe()
+    cy.mountWithProviders(<ProtocolIntegrationStore />)
+
+    cy.checkAccessibility()
+    cy.percySnapshot('Component: ProtocolIntegrationStore')
+  })
+})

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/panels/ProtocolIntegrationStore.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/panels/ProtocolIntegrationStore.spec.cy.tsx
@@ -5,8 +5,6 @@ describe('ProtocolIntegrationStore', () => {
   beforeEach(() => {
     cy.viewport(800, 900)
     cy.intercept('/api/v1/management/protocol-adapters/types', { items: [mockProtocolAdapter] }).as('getProtocols')
-    //   cy.intercept('api/v1/management/protocol-adapters/adapters', { items: [mockAdapter] }).as('getAdapters')
-    //   cy.intercept('api/v1/management/protocol-adapters/status', { items: [mockAdapterConnectionStatus] }).as('getStatus')
   })
 
   it('should handle loading errors', () => {
@@ -21,7 +19,7 @@ describe('ProtocolIntegrationStore', () => {
       .should('have.text', 'We cannot load your adapters for the time being. Please try again later')
   })
 
-  it.only('should render properly', () => {
+  it('should render properly', () => {
     cy.mountWithProviders(<ProtocolIntegrationStore />)
 
     cy.wait('@getProtocols')

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/panels/ProtocolIntegrationStore.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/panels/ProtocolIntegrationStore.tsx
@@ -71,12 +71,12 @@ const ProtocolIntegrationStore: FC = () => {
 
   return (
     <Flex flexDirection="column" gap={4}>
-      <Box>
+      <Box data-testid="heading-protocols-list">
         <Heading size="md">{t('protocolAdapter.tabs.protocols')}</Heading>
         <Text>
           {isLoading
             ? t('protocolAdapter.loading.protocolAdapters')
-            : t('protocolAdapter.protocols.description', { count: safeData.length })}{' '}
+            : t('protocolAdapter.protocols.description', { count: safeData.length })}
         </Text>
       </Box>
       <Flex flexDirection="row" alignItems="flex-start" gap={6}>

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/panels/ProtocolIntegrationStore.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/panels/ProtocolIntegrationStore.tsx
@@ -1,6 +1,6 @@
 import { FC, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { Box, Flex, Text } from '@chakra-ui/react'
+import { Box, Flex, Heading, Text } from '@chakra-ui/react'
 import { useTranslation } from 'react-i18next'
 
 import AdapterEmptyLogo from '@/assets/app/adaptor-empty.svg'
@@ -70,11 +70,14 @@ const ProtocolIntegrationStore: FC = () => {
 
   return (
     <Flex flexDirection="column" gap={4}>
-      <Text>
-        {isLoading
-          ? t('protocolAdapter.loading.protocolAdapters')
-          : t('protocolAdapter.protocols.description', { count: safeData.length })}{' '}
-      </Text>
+      <Box>
+        <Heading size="md">{t('protocolAdapter.tabs.protocols')}</Heading>
+        <Text>
+          {isLoading
+            ? t('protocolAdapter.loading.protocolAdapters')
+            : t('protocolAdapter.protocols.description', { count: safeData.length })}{' '}
+        </Text>
+      </Box>
       <Flex flexDirection="row" alignItems="flex-start" gap={6}>
         <FacetSearch items={safeData} facet={facet} onChange={handleOnSearch} isLoading={isLoading} />
         <ProtocolsBrowser items={safeData} facet={facet} onCreate={handleCreateInstance} isLoading={isLoading} />

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/panels/ProtocolIntegrationStore.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/panels/ProtocolIntegrationStore.tsx
@@ -16,6 +16,7 @@ import { AdapterNavigateState, ProtocolAdapterTabIndex, ProtocolFacetType } from
 import ProtocolsBrowser from '../IntegrationStore/ProtocolsBrowser.tsx'
 import FacetSearch from '../IntegrationStore/FacetSearch.tsx'
 import { mockProtocolAdapter } from '@/api/hooks/useProtocolAdapters/__handlers__'
+import SuspenseOutlet from '@/components/SuspenseOutlet.tsx'
 
 const ProtocolIntegrationStore: FC = () => {
   const { t } = useTranslation()
@@ -31,7 +32,7 @@ const ProtocolIntegrationStore: FC = () => {
       protocolAdapterType: adapterId,
       // selectedActiveAdapter: { isNew: false, isOpen: false, adapterId: (selected?.data as Adapter).id },
     }
-    navigate(`/protocol-adapters/new/${adapterId}`, {
+    navigate(`/protocol-adapters/catalog/new/${adapterId}`, {
       state: adapterNavigateState,
     })
   }
@@ -82,6 +83,7 @@ const ProtocolIntegrationStore: FC = () => {
         <FacetSearch items={safeData} facet={facet} onChange={handleOnSearch} isLoading={isLoading} />
         <ProtocolsBrowser items={safeData} facet={facet} onCreate={handleCreateInstance} isLoading={isLoading} />
       </Flex>
+      <SuspenseOutlet />
     </Flex>
   )
 }


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/29205/details/

The PR refactors the adapter landing page in order to simplify the navigation to, from and between active adapters and the protocol catalogue

### Design
- The `Active Adapters` and `Protocol Adapter Catalog` tabs have been removed from the old landing page
- The new landing page is consistently showing the list of `Active Adapters`
  - whether you are a new user or not
  - whether the list is empty or not
- The landing page has a primary CTA in its banner (consistent with the Bridge landing page) labelled `Add a new Adapter`  
- The CTA leads to the `Protocol Adapter Catalog` page (replacing the `Active Adapters` list); a new secondary CTA, labelled `Back to active adapters` allows users to navigate back to the landing page
- Creating a new adapter will also navigate back to the landing page

### Out-of-scope
- The empty state (no adapter) and the error messages (cannot load) are not properly integrated into the layout. A ticket for uniforming such states will address this issue

### Before 
![screenshot-localhost_3000-2025_01_08-10_25_45](https://github.com/user-attachments/assets/23404582-f725-4f59-b751-d6717971a904)


### After
![screenshot-localhost_3000-2025_01_08-10_22_28](https://github.com/user-attachments/assets/bde3635d-e102-4038-98c1-c8c0a934e018)

![screenshot-localhost_3000-2025_01_08-10_22_38](https://github.com/user-attachments/assets/14054ea5-3418-4df8-a655-be83b9fbd575)

![screenshot-localhost_3000-2025_01_08-10_23_03](https://github.com/user-attachments/assets/a569fbac-a21b-48c4-95a7-b05ddcb97a17)

![screenshot-localhost_3000-2025_01_08-10_23_29](https://github.com/user-attachments/assets/9e0b0520-64e5-4955-87b0-49a19d755bca)
