### PR TITLE
fix(29347): fix bug with empty targets of deletion

### DIFF
--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/DeleteListener.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/DeleteListener.spec.cy.tsx
@@ -57,6 +57,16 @@ describe('DeleteListener', () => {
     cy.viewport(800, 400)
   })
 
+  it('should not render a confirmation if nothing selected', () => {
+    cy.mountWithProviders(<DeleteListener />, {
+      wrapper: getWrapperWith([], []),
+    })
+
+    cy.get("[role='alertdialog']").should('not.exist')
+    cy.get('body').type('{backspace}')
+    cy.get("[role='alertdialog']").should('not.exist')
+  })
+
   it('should render a confirmation modal when deleting', () => {
     cy.mountWithProviders(<DeleteListener />, {
       wrapper: getWrapperWith(

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/DeleteListener.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/DeleteListener.tsx
@@ -45,6 +45,8 @@ const DeleteListener: FC = () => {
     const canDeleteEdges = selectedEdges.map((edge) => canDeleteEdge(edge, nodes))
 
     const allElements = [...canDeleteNodes, ...canDeleteEdges]
+    if (allElements.length === 0) return
+
     const canDeleteElements = allElements.every((element) => Boolean(element.delete))
     if (canDeleteElements) {
       return onOpen()


### PR DESCRIPTION
See 

A quick fix for preventing an unnecessary confirmation message when there are no element to delete 

### Before 
![screenshot-localhost_3000-2025_01_10-16_52_40](https://github.com/user-attachments/assets/a577509b-7783-4248-8afd-80c1bea0149f)
