### PR TITLE
refactor(27113): Ensure a single policy used in the Designer

### DIFF
--- a/hivemq-edge/src/frontend/src/components/PageContainer.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/components/PageContainer.spec.cy.tsx
@@ -1,23 +1,37 @@
 /// <reference types="cypress" />
 import PageContainer from './PageContainer.tsx'
+import { Button } from '@chakra-ui/react'
 
-const MOCK_STATUS_TEXT = 'This is a test'
+const MOCK_HEADER = 'This is a test'
+const MOCK_SUBHEADER = 'This is below the test'
 const MOCK_CONTENT = <div data-testid="the-test-id">This is a dummy component</div>
+const MOCK_CTA = <Button>Button</Button>
 
 describe('PageContainer', () => {
   beforeEach(() => {
-    // run these tests as if in a desktop
-    // browser with a 720p monitor
     cy.viewport(800, 250)
   })
-  it('should renders', () => {
-    cy.mountWithProviders(<PageContainer title={MOCK_STATUS_TEXT}>{MOCK_CONTENT}</PageContainer>)
-    // cy.get('.chakra-alert__title').should('contain.text', 'This is a test')
-    // cy.get('.chakra-alert__desc').should('contain.text', 'This is a title')
-    // cy.get("[role='alert']").should('have.attr', 'data-status', 'error')
+
+  it('should render properly', () => {
+    cy.mountWithProviders(
+      <PageContainer title={MOCK_HEADER} subtitle={MOCK_SUBHEADER} cta={MOCK_CTA}>
+        {MOCK_CONTENT}
+      </PageContainer>
+    )
+    cy.get('header h1').should('have.text', 'This is a test')
+    cy.get('header h1 + p').should('have.text', 'This is below the test')
+    cy.getByTestId('page-container-cta').find('button').should('have.text', 'Button')
+    cy.getByTestId('the-test-id').should('have.text', 'This is a dummy component')
   })
 
-  it('should also render', () => {
-    cy.mountWithProviders(<PageContainer>{MOCK_CONTENT}</PageContainer>)
+  it('should be accessible', () => {
+    cy.injectAxe()
+    cy.mountWithProviders(
+      <PageContainer title={MOCK_HEADER} subtitle={MOCK_SUBHEADER} cta={<Button>Button</Button>}>
+        {MOCK_CONTENT}
+      </PageContainer>
+    )
+
+    cy.checkAccessibility()
   })
 })

--- a/hivemq-edge/src/frontend/src/components/PageContainer.tsx
+++ b/hivemq-edge/src/frontend/src/components/PageContainer.tsx
@@ -1,33 +1,22 @@
 import { FC, ReactNode } from 'react'
-import { useTranslation } from 'react-i18next'
-import { Box, Text, Flex, Heading, VisuallyHidden, chakra as Chakra } from '@chakra-ui/react'
+import { Box, Text, Flex, Heading, chakra as Chakra } from '@chakra-ui/react'
 
 interface PageContainerProps {
-  title?: string
+  title: string
   subtitle?: string
   children?: ReactNode
   cta?: ReactNode
 }
 
 const PageContainer: FC<PageContainerProps> = ({ title, subtitle, children, cta }) => {
-  const { t } = useTranslation()
-
   return (
     <Flex flexDirection="column" p={4} pt={6} flexGrow={1}>
       <Flex gap="50px">
-        <Chakra.header maxW="50vw" pb={6}>
-          <Heading as="h1">
-            {title ? (
-              title
-            ) : (
-              <VisuallyHidden>
-                <h1>{t('translation:navigation.mainPage')}</h1>
-              </VisuallyHidden>
-            )}
-          </Heading>
+        <Chakra.header maxW="50vw" pb={6} data-testid="page-container-header">
+          <Heading as="h1">{title}</Heading>
           {subtitle && <Text fontSize="md">{subtitle}</Text>}
         </Chakra.header>
-        <Box flexGrow={1} alignItems="flex-end">
+        <Box flexGrow={1} alignItems="flex-end" data-testid="page-container-cta">
           {cta}
         </Box>
       </Flex>

--- a/hivemq-edge/src/frontend/src/components/PageContainer.tsx
+++ b/hivemq-edge/src/frontend/src/components/PageContainer.tsx
@@ -1,6 +1,6 @@
 import { FC, ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Box, Text, Flex, Heading, VisuallyHidden } from '@chakra-ui/react'
+import { Box, Text, Flex, Heading, VisuallyHidden, chakra as Chakra } from '@chakra-ui/react'
 
 interface PageContainerProps {
   title?: string
@@ -14,8 +14,8 @@ const PageContainer: FC<PageContainerProps> = ({ title, subtitle, children, cta 
 
   return (
     <Flex flexDirection="column" p={4} pt={6} flexGrow={1}>
-      <Flex gap="50px" data-testid="page-container-header">
-        <Box maxW="50vw" pb={6}>
+      <Flex gap="50px">
+        <Chakra.header maxW="50vw" pb={6}>
           <Heading as="h1">
             {title ? (
               title
@@ -26,8 +26,8 @@ const PageContainer: FC<PageContainerProps> = ({ title, subtitle, children, cta 
             )}
           </Heading>
           {subtitle && <Text fontSize="md">{subtitle}</Text>}
-        </Box>
-        <Box flexGrow={1} alignItems="flex-end" data-testid="page-container-cta">
+        </Chakra.header>
+        <Box flexGrow={1} alignItems="flex-end">
           {cta}
         </Box>
       </Flex>

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/CopyPasteStatus.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/CopyPasteStatus.spec.cy.tsx
@@ -1,5 +1,3 @@
-/// <reference types="cypress" />
-
 import { ReactFlowProvider } from 'reactflow'
 
 import { MockStoreWrapper } from '@datahub/__test-utils__/MockStoreWrapper.tsx'
@@ -38,15 +36,10 @@ describe('CopyPasteStatus', () => {
     cy.getByTestId('copy-paste-status').should('contain.text', '2')
   })
 
-  it('should render properly the readonly status', () => {
-    cy.mountWithProviders(<CopyPasteStatus nbCopied={2} />, { wrapper: getWrapperWith(DesignerStatus.LOADED) })
-    cy.getByTestId('edit-status').should('be.visible')
-    cy.getByTestId('edit-status').find('svg').should('have.attr', 'data-readonly', 'true')
-  })
-
-  it('should render properly the editable status', () => {
+  it('should be accessible', () => {
+    cy.injectAxe()
     cy.mountWithProviders(<CopyPasteStatus nbCopied={2} />, { wrapper: getWrapperWith(DesignerStatus.DRAFT) })
-    cy.getByTestId('edit-status').should('be.visible')
-    cy.getByTestId('edit-status').find('svg').should('have.attr', 'data-readonly', 'false')
+
+    cy.checkAccessibility()
   })
 })

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/CopyPasteStatus.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/CopyPasteStatus.tsx
@@ -1,33 +1,31 @@
-import { FC, useMemo } from 'react'
-import { Tag, TagLabel, TagLeftIcon } from '@chakra-ui/react'
+import { FC } from 'react'
+import { ButtonGroup, Tag, TagLabel, TagLeftIcon } from '@chakra-ui/react'
 import { LuCopy, LuCopyCheck } from 'react-icons/lu'
-import { PiPencilSimpleLineFill, PiPencilSimpleSlashFill } from 'react-icons/pi'
 
 import Panel from '@/components/react-flow/Panel.tsx'
-import useDataHubDraftStore from '@datahub/hooks/useDataHubDraftStore.ts'
-import { DesignerStatus } from '@datahub/types.ts'
+import { useTranslation } from 'react-i18next'
 
 interface CopyPasteStatusProps {
   nbCopied: number | undefined
 }
 
 const CopyPasteStatus: FC<CopyPasteStatusProps> = ({ nbCopied }) => {
-  const { status } = useDataHubDraftStore()
-  const isEditable = useMemo(() => status !== DesignerStatus.LOADED, [status])
-
+  const { t } = useTranslation('datahub')
   return (
     <Panel position="bottom-center">
-      <Tag size="lg" variant="subtle" userSelect="none" data-testid="edit-status">
-        <TagLeftIcon
-          boxSize="18px"
-          as={isEditable ? PiPencilSimpleLineFill : PiPencilSimpleSlashFill}
-          data-readonly={!isEditable}
-        />
-      </Tag>
-      <Tag size="lg" variant="subtle" userSelect="none" data-testid="copy-paste-status">
-        <TagLeftIcon boxSize="12px" as={nbCopied ? LuCopyCheck : LuCopy} />
-        <TagLabel>{nbCopied}</TagLabel>
-      </Tag>
+      <ButtonGroup variant="outline" isAttached size="sm" aria-label={t('workspace.toolbars.clipboard.aria-label')}>
+        <Tag
+          size="lg"
+          variant="subtle"
+          userSelect="none"
+          data-testid="copy-paste-status"
+          tabIndex={0}
+          aria-label={t(`workspace.toolbars.clipboard.content`, { count: nbCopied })}
+        >
+          <TagLeftIcon boxSize="12px" as={nbCopied ? LuCopyCheck : LuCopy} />
+          <TagLabel>{nbCopied}</TagLabel>
+        </Tag>
+      </ButtonGroup>
     </Panel>
   )
 }

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/DesignerToolbox.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/DesignerToolbox.spec.cy.tsx
@@ -9,7 +9,7 @@ describe('DesignerToolbox', () => {
     cy.viewport(850, 600)
   })
 
-  it('should renders properly', () => {
+  it('should render properly', () => {
     cy.mountWithProviders(<DesignerToolbox />, { wrapper })
     cy.getByTestId('toolbox-trigger').should('have.attr', 'aria-expanded', 'false')
     cy.getByTestId('toolbox-container').should('not.be.visible')
@@ -17,12 +17,17 @@ describe('DesignerToolbox', () => {
     cy.getByTestId('toolbox-trigger').click()
     cy.getByTestId('toolbox-trigger').should('have.attr', 'aria-expanded', 'true')
     cy.getByTestId('toolbox-container').should('be.visible')
+
+    cy.getByTestId('toolbox-container').find('header').should('have.text', 'Policy Toolbox')
   })
 
   it('should be accessible', () => {
     cy.injectAxe()
     cy.mountWithProviders(<DesignerToolbox />, { wrapper })
     cy.getByTestId('toolbox-trigger').click()
+
+    cy.wait(100) // Wait for dropdown (ugly)
+
     cy.checkAccessibility()
     cy.percySnapshot('Component: DesignerToolbox')
   })

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/DesignerToolbox.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/DesignerToolbox.spec.cy.tsx
@@ -26,6 +26,7 @@ describe('DesignerToolbox', () => {
     cy.mountWithProviders(<DesignerToolbox />, { wrapper })
     cy.getByTestId('toolbox-trigger').click()
 
+    // eslint-disable-next-line cypress/no-unnecessary-waiting
     cy.wait(100) // Wait for dropdown (ugly)
 
     cy.checkAccessibility()

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/DesignerToolbox.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/DesignerToolbox.spec.cy.tsx
@@ -6,7 +6,7 @@ const wrapper: FC<PropsWithChildren> = ({ children }) => <ReactFlowProvider>{chi
 
 describe('DesignerToolbox', () => {
   beforeEach(() => {
-    cy.viewport(850, 250)
+    cy.viewport(850, 600)
   })
 
   it('should renders properly', () => {

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/DesignerToolbox.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/DesignerToolbox.tsx
@@ -47,7 +47,7 @@ const DesignerToolbox: FC = () => {
               <PopoverContent width="unset" id="toolbox-content" data-testid="toolbox-container">
                 <PopoverArrow />
                 <PopoverCloseButton />
-                <PopoverHeader>Policy Toolbox</PopoverHeader>
+                <PopoverHeader>{t('workspace.toolbox.panel.aria-label')}</PopoverHeader>
                 <PopoverBody as={VStack} alignItems="flex-start" maxWidth="12rem">
                   <Text fontSize="sm">{t('workspace.toolbox.panel.helper')}</Text>
                   <ToolboxNodes direction="vertical" />

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/DesignerToolbox.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/DesignerToolbox.tsx
@@ -44,7 +44,7 @@ const DesignerToolbox: FC = () => {
                   px={2}
                 />
               </PopoverTrigger>
-              <PopoverContent width="unset" id="toolbox-content">
+              <PopoverContent width="unset" id="toolbox-content" data-testid="toolbox-container">
                 <PopoverArrow />
                 <PopoverCloseButton />
                 <PopoverHeader>Policy Toolbox</PopoverHeader>

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/DesignerToolbox.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/DesignerToolbox.tsx
@@ -1,9 +1,21 @@
-import { FC, useState } from 'react'
+import type { FC } from 'react'
 import { useTranslation } from 'react-i18next'
-import { motion } from 'framer-motion'
-import { Box, HStack, Icon, IconButton, useDisclosure } from '@chakra-ui/react'
+import {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+  PopoverHeader,
+  PopoverBody,
+  PopoverArrow,
+  PopoverCloseButton,
+  Text,
+  VStack,
+  IconButton,
+  Icon,
+  HStack,
+} from '@chakra-ui/react'
+import { ChevronDownIcon, ChevronRightIcon } from '@chakra-ui/icons'
 import { FaTools } from 'react-icons/fa'
-import { LuPanelLeftOpen, LuPanelRightOpen } from 'react-icons/lu'
 
 import Panel from '@/components/react-flow/Panel.tsx'
 import { ToolboxNodes } from '@datahub/components/controls/ToolboxNodes.tsx'
@@ -11,41 +23,38 @@ import DraftStatus from '@datahub/components/helpers/DraftStatus.tsx'
 
 const DesignerToolbox: FC = () => {
   const { t } = useTranslation('datahub')
-  const { getButtonProps, getDisclosureProps, isOpen } = useDisclosure()
-  const [hidden, setHidden] = useState(!isOpen)
 
   return (
     <Panel position="top-left">
-      <HStack alignItems="center" userSelect="none">
-        <Box>
-          <IconButton
-            data-testid="toolbox-trigger"
-            aria-label={t('workspace.toolbox.trigger', { context: !isOpen ? 'open' : 'close' })}
-            icon={
-              <>
-                <Icon as={FaTools} />
-                <Icon as={isOpen ? LuPanelRightOpen : LuPanelLeftOpen} ml={2} boxSize="24px" />
-              </>
-            }
-            {...getButtonProps()}
-            px={2}
-          />
-        </Box>
-        <motion.div
-          {...getDisclosureProps()}
-          data-testid="toolbox-container"
-          hidden={hidden}
-          initial={false}
-          onAnimationStart={() => setHidden(false)}
-          onAnimationComplete={() => setHidden(!isOpen)}
-          animate={{ width: isOpen ? '100%' : 0 }}
-          style={{
-            overflow: 'hidden',
-            whiteSpace: 'nowrap',
-          }}
-        >
-          <ToolboxNodes />
-        </motion.div>
+      <HStack>
+        <Popover>
+          {({ isOpen }) => (
+            <>
+              <PopoverTrigger>
+                <IconButton
+                  data-testid="toolbox-trigger"
+                  aria-label={t('workspace.toolbox.trigger', { context: !isOpen ? 'open' : 'close' })}
+                  icon={
+                    <>
+                      <Icon as={FaTools} />
+                      <Icon as={isOpen ? ChevronDownIcon : ChevronRightIcon} ml={2} boxSize="24px" />
+                    </>
+                  }
+                  px={2}
+                />
+              </PopoverTrigger>
+              <PopoverContent width="unset">
+                <PopoverArrow />
+                <PopoverCloseButton />
+                <PopoverHeader>Policy Toolbox</PopoverHeader>
+                <PopoverBody as={VStack} alignItems="flex-start" maxWidth="12rem">
+                  <Text fontSize="sm">Drag elements on the canvas then connect them</Text>
+                  <ToolboxNodes direction="vertical" />
+                </PopoverBody>
+              </PopoverContent>
+            </>
+          )}
+        </Popover>
         <DraftStatus />
       </HStack>
     </Panel>

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/DesignerToolbox.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/DesignerToolbox.tsx
@@ -26,7 +26,7 @@ const DesignerToolbox: FC = () => {
 
   return (
     <Panel position="top-left">
-      <HStack>
+      <HStack role="group" aria-label={t('workspace.toolbars.draft.aria-label')}>
         <Popover>
           {({ isOpen }) => (
             <>
@@ -34,6 +34,7 @@ const DesignerToolbox: FC = () => {
                 <IconButton
                   data-testid="toolbox-trigger"
                   aria-label={t('workspace.toolbox.trigger', { context: !isOpen ? 'open' : 'close' })}
+                  aria-controls="toolbox-content"
                   icon={
                     <>
                       <Icon as={FaTools} />
@@ -43,12 +44,12 @@ const DesignerToolbox: FC = () => {
                   px={2}
                 />
               </PopoverTrigger>
-              <PopoverContent width="unset">
+              <PopoverContent width="unset" id="toolbox-content">
                 <PopoverArrow />
                 <PopoverCloseButton />
                 <PopoverHeader>Policy Toolbox</PopoverHeader>
                 <PopoverBody as={VStack} alignItems="flex-start" maxWidth="12rem">
-                  <Text fontSize="sm">Drag elements on the canvas then connect them</Text>
+                  <Text fontSize="sm">{t('workspace.toolbox.panel.helper')}</Text>
                   <ToolboxNodes direction="vertical" />
                 </PopoverBody>
               </PopoverContent>

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/ToolGroup.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/ToolGroup.spec.cy.tsx
@@ -1,0 +1,32 @@
+import ToolGroup from '@datahub/components/controls/ToolGroup.tsx'
+import { Button } from '@chakra-ui/react'
+
+describe('ToolGroup', () => {
+  beforeEach(() => {
+    cy.viewport(800, 600)
+  })
+
+  it('should render the toolbox', () => {
+    cy.mountWithProviders(
+      <ToolGroup title="The title" id="my-id">
+        <Button>Button 1</Button>
+        <Button>Button 2</Button>
+      </ToolGroup>
+    )
+
+    cy.getByTestId('toolbox-group-title').should('have.text', 'The title')
+    cy.getByTestId('toolbox-group-container').find('button').should('have.length', 2)
+  })
+
+  it('should be accessible', () => {
+    cy.injectAxe()
+    cy.mountWithProviders(
+      <ToolGroup title="The title" id="my-id">
+        <Button>Button 1</Button>
+        <Button>Button 2</Button>
+      </ToolGroup>
+    )
+
+    cy.checkAccessibility()
+  })
+})

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/ToolGroup.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/ToolGroup.tsx
@@ -11,10 +11,10 @@ const ToolGroup: FC<ToolProps> = ({ title, id, children, ...props }) => {
   return (
     <ButtonGroup variant="outline" size="sm" aria-labelledby={id} {...props}>
       <VStack alignItems="flex-start">
-        <Heading as="h2" size="sm" id={id}>
+        <Heading as="h2" size="sm" id={id} data-testid="toolbox-group-title">
           {title}
         </Heading>
-        <HStack>{children}</HStack>
+        <HStack data-testid="toolbox-group-container">{children}</HStack>
       </VStack>
     </ButtonGroup>
   )

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/ToolGroup.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/ToolGroup.tsx
@@ -1,0 +1,23 @@
+import type { FC, ReactNode } from 'react'
+import { ButtonGroup, type ButtonGroupProps, Heading, HStack, VStack } from '@chakra-ui/react'
+
+interface ToolProps extends ButtonGroupProps {
+  title: string
+  id: string
+  children: ReactNode
+}
+
+const ToolGroup: FC<ToolProps> = ({ title, id, children, ...props }) => {
+  return (
+    <ButtonGroup variant="outline" size="sm" aria-labelledby={id} {...props}>
+      <VStack alignItems="flex-start">
+        <Heading as="h2" size="sm" id={id}>
+          {title}
+        </Heading>
+        <HStack>{children}</HStack>
+      </VStack>
+    </ButtonGroup>
+  )
+}
+
+export default ToolGroup

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/ToolItem.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/ToolItem.spec.cy.tsx
@@ -1,7 +1,7 @@
 /// <reference types="cypress" />
 
 import { DataHubNodeType } from '@datahub/types.ts'
-import Tool from './Tool.tsx'
+import ToolItem from './ToolItem.tsx'
 
 describe('Tool', () => {
   beforeEach(() => {
@@ -9,14 +9,14 @@ describe('Tool', () => {
   })
 
   it('should render function', () => {
-    cy.mountWithProviders(<Tool nodeType={DataHubNodeType.FUNCTION} />)
+    cy.mountWithProviders(<ToolItem nodeType={DataHubNodeType.FUNCTION} />)
 
     cy.get('button').should('have.attr', 'aria-label', 'JS Function')
     cy.get('button').should('have.attr', 'draggable', 'true')
   })
 
   it('should render data policy', () => {
-    cy.mountWithProviders(<Tool nodeType={DataHubNodeType.DATA_POLICY} />)
+    cy.mountWithProviders(<ToolItem nodeType={DataHubNodeType.DATA_POLICY} />)
 
     cy.get('button').should('have.attr', 'aria-label', 'Data Policy')
     cy.get('button').should('have.attr', 'draggable', 'true')

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/ToolItem.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/ToolItem.tsx
@@ -11,7 +11,7 @@ interface ToolProps extends ButtonProps {
   nodeType: DataHubNodeType
 }
 
-const Tool: FC<ToolProps> = ({ nodeType, isDisabled }) => {
+const ToolItem: FC<ToolProps> = ({ nodeType, isDisabled }) => {
   const { t } = useTranslation('datahub')
 
   const onButtonDragStart = useCallback(
@@ -38,4 +38,4 @@ const Tool: FC<ToolProps> = ({ nodeType, isDisabled }) => {
   )
 }
 
-export default Tool
+export default ToolItem

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/ToolboxNodes.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/ToolboxNodes.tsx
@@ -1,65 +1,53 @@
 import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
-import { HStack, Text, VStack, ButtonGroup } from '@chakra-ui/react'
+import { HStack, VStack } from '@chakra-ui/react'
 
 import config from '@/config'
 
 import { DataHubNodeType, DesignerStatus } from '@datahub/types.ts'
-import Tool from '@datahub/components/controls/Tool.tsx'
+import ToolItem from '@datahub/components/controls/ToolItem.tsx'
 import useDataHubDraftStore from '@datahub/hooks/useDataHubDraftStore.ts'
+import ToolGroup from '@datahub/components/controls/ToolGroup.tsx'
 
-export const ToolboxNodes: FC = () => {
+interface ToolboxNodesProps {
+  direction?: 'horizontal' | 'vertical'
+}
+
+export const ToolboxNodes: FC<ToolboxNodesProps> = ({ direction = 'horizontal' }) => {
   const { t } = useTranslation('datahub')
-  const { nodes, status } = useDataHubDraftStore()
+  const { nodes, status, isPolicyInDraft } = useDataHubDraftStore()
 
   const isEditEnabled = config.features.DATAHUB_EDIT_POLICY_ENABLED || status === DesignerStatus.DRAFT
   const isDraftEmpty = nodes.length === 0
 
+  const Wrapper = direction === 'horizontal' ? HStack : VStack
+
   return (
-    <HStack
+    <Wrapper
       pb={2}
       gap={5}
       role="group"
       aria-label={t('workspace.toolbox.aria-label')}
       backgroundColor="var(--chakra-colors-chakra-body-bg)"
+      alignItems={direction === 'horizontal' ? 'center' : 'flex-start'}
     >
-      <ButtonGroup variant="outline" size="sm" aria-labelledby="group-integrations">
-        <VStack alignItems="flex-start">
-          <Text id="group-integrations">{t('workspace.toolbox.group.integration.edge')}</Text>
-          <HStack>
-            <Tool nodeType={DataHubNodeType.TOPIC_FILTER} isDisabled={isDraftEmpty || !isEditEnabled} />
-            <Tool nodeType={DataHubNodeType.CLIENT_FILTER} isDisabled={isDraftEmpty || !isEditEnabled} />
-          </HStack>
-        </VStack>
-      </ButtonGroup>
-      <ButtonGroup variant="outline" size="sm" aria-labelledby="group-dataPolicy">
-        <VStack alignItems="flex-start">
-          <Text id="group-dataPolicy">{t('workspace.toolbox.group.dataPolicy')}</Text>
-          <HStack>
-            <Tool nodeType={DataHubNodeType.DATA_POLICY} isDisabled={!isEditEnabled} />
-            <Tool nodeType={DataHubNodeType.VALIDATOR} isDisabled={isDraftEmpty || !isEditEnabled} />
-            <Tool nodeType={DataHubNodeType.SCHEMA} isDisabled={isDraftEmpty || !isEditEnabled} />
-          </HStack>
-        </VStack>
-      </ButtonGroup>
-      <ButtonGroup variant="outline" size="sm" aria-labelledby="group-behaviorPolicy">
-        <VStack alignItems="flex-start">
-          <Text id="group-behaviorPolicy">{t('workspace.toolbox.group.behaviorPolicy')}</Text>
-          <HStack>
-            <Tool nodeType={DataHubNodeType.BEHAVIOR_POLICY} isDisabled={!isEditEnabled} />
-            <Tool nodeType={DataHubNodeType.TRANSITION} isDisabled={isDraftEmpty || !isEditEnabled} />
-          </HStack>
-        </VStack>
-      </ButtonGroup>
-      <ButtonGroup variant="outline" size="sm" aria-labelledby="group-operation">
-        <VStack alignItems="flex-start" pr={2}>
-          <Text id="group-operation">{t('workspace.toolbox.group.operation')}</Text>
-          <HStack>
-            <Tool nodeType={DataHubNodeType.OPERATION} isDisabled={isDraftEmpty || !isEditEnabled} />
-            <Tool nodeType={DataHubNodeType.FUNCTION} isDisabled={isDraftEmpty || !isEditEnabled} />
-          </HStack>
-        </VStack>
-      </ButtonGroup>
-    </HStack>
+      <ToolGroup title={t('workspace.toolbox.group.integration.edge')} id="group-integrations">
+        <ToolItem nodeType={DataHubNodeType.TOPIC_FILTER} isDisabled={isDraftEmpty || !isEditEnabled} />
+        <ToolItem nodeType={DataHubNodeType.CLIENT_FILTER} isDisabled={isDraftEmpty || !isEditEnabled} />
+      </ToolGroup>
+      <ToolGroup title={t('workspace.toolbox.group.dataPolicy')} id="group-dataPolicy">
+        <ToolItem nodeType={DataHubNodeType.DATA_POLICY} isDisabled={!isEditEnabled || isPolicyInDraft()} />
+        <ToolItem nodeType={DataHubNodeType.VALIDATOR} isDisabled={isDraftEmpty || !isEditEnabled} />
+        <ToolItem nodeType={DataHubNodeType.SCHEMA} isDisabled={isDraftEmpty || !isEditEnabled} />
+      </ToolGroup>
+      <ToolGroup title={t('workspace.toolbox.group.behaviorPolicy')} id="group-behaviorPolicy">
+        <ToolItem nodeType={DataHubNodeType.BEHAVIOR_POLICY} isDisabled={!isEditEnabled || isPolicyInDraft()} />
+        <ToolItem nodeType={DataHubNodeType.TRANSITION} isDisabled={isDraftEmpty || !isEditEnabled} />
+      </ToolGroup>
+      <ToolGroup title={t('workspace.toolbox.group.operation')} id="group-operation">
+        <ToolItem nodeType={DataHubNodeType.OPERATION} isDisabled={isDraftEmpty || !isEditEnabled} />
+        <ToolItem nodeType={DataHubNodeType.FUNCTION} isDisabled={isDraftEmpty || !isEditEnabled} />
+      </ToolGroup>
+    </Wrapper>
   )
 }

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/helpers/DraftStatus.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/helpers/DraftStatus.tsx
@@ -28,11 +28,11 @@ const DraftStatus: FC = () => {
 
   return (
     <HStack alignItems="center" sx={{ textWrap: 'nowrap' }} gap={4}>
-      <HStack>
+      <HStack role="group" aria-label={t('workspace.toolbars.status.aria-label')}>
         <NodeIcon type={DataHubNodeType.DATA_POLICY} />
         <Text>{t('workspace.toolbox.draft.status', { context: status, name: name, type })}</Text>
       </HStack>
-      <ButtonGroup>
+      <ButtonGroup role="group" aria-label={t('workspace.toolbars.edit.aria-label')}>
         <IconButton
           isDisabled={isEditable}
           data-testid="designer-edit-"

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/ConnectionLine.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/nodes/ConnectionLine.tsx
@@ -4,6 +4,8 @@ import { Tag } from '@chakra-ui/react'
 
 import { getConnectedNodeFrom } from '@datahub/utils/node.utils.ts'
 import { NodeIcon } from '@datahub/components/helpers'
+import useDataHubDraftStore from '@datahub/hooks/useDataHubDraftStore.ts'
+import { DataHubNodeType } from '@datahub/types.ts'
 
 const ICON_SIZE = 50
 const ICON_OFFSET = 20
@@ -17,9 +19,16 @@ const ConnectionLine: FC<ConnectionLineComponentProps> = ({
   toX,
   ...props
 }) => {
+  const { isPolicyInDraft } = useDataHubDraftStore()
   const droppedNode = useMemo(() => {
-    return getConnectedNodeFrom(fromNode?.type, fromHandle?.id)
-  }, [fromHandle?.id, fromNode?.type])
+    const droppedNode = getConnectedNodeFrom(fromNode?.type, fromHandle?.id)
+    if (
+      droppedNode?.type === DataHubNodeType.DATA_POLICY ||
+      (droppedNode?.type === DataHubNodeType.BEHAVIOR_POLICY && isPolicyInDraft())
+    )
+      return undefined
+    return droppedNode
+  }, [fromHandle?.id, fromNode?.type, isPolicyInDraft])
 
   const pathParams = {
     sourceX: fromX,

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/PolicyEditor.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/PolicyEditor.spec.cy.tsx
@@ -29,7 +29,7 @@ describe('PolicyEditor', () => {
       { routerProps: { initialEntries: ['/BEHAVIOR/1'] } }
     )
 
-    cy.get('[role="toolbar"]').should('have.attr', 'aria-label', 'Workspace toolbar')
+    cy.get('[role="toolbar"]').should('have.attr', 'aria-label', 'Policy Designer toolbars')
     cy.getByAriaLabel('Open the toolbox').should('be.visible')
     cy.getByTestId('rf__minimap').should('be.visible')
     cy.getByAriaLabel('Canvas controls').find('button').should('have.length', 5)

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/PolicyEditor.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/PolicyEditor.tsx
@@ -149,7 +149,7 @@ const PolicyEditor: FC = () => {
         }
       }
     },
-    [onAddNodes, onConnect, reactFlowInstance]
+    [isPolicyInDraft, onAddNodes, onConnect, reactFlowInstance]
   )
 
   const onConnectNodes = useCallback(

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/PolicyEditor.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/PolicyEditor.tsx
@@ -165,7 +165,7 @@ const PolicyEditor: FC = () => {
       <ReactFlowProvider>
         <ReactFlow
           ref={reactFlowWrapper}
-          id="edge-workspace-canvas"
+          id="edge-datahub-canvas"
           nodes={nodes}
           edges={edges}
           nodeTypes={nodeTypes}
@@ -188,17 +188,18 @@ const PolicyEditor: FC = () => {
           deleteKeyCode={[]}
           nodesConnectable={isEditable}
           proOptions={proOptions}
-
+          role="region"
+          aria-label={t('workspace.canvas.aria-label')}
           // nodesDraggable={isEditable}
           // elementsSelectable={isEditable}
           // onError={(id: string, message: string) => console.log('XXXXXX e', id, message)}
         >
-          <Box role="toolbar" aria-label={t('workspace.aria-label')} aria-controls="edge-workspace-canvas">
-            <ToolboxSelectionListener />
+          <Box role="toolbar" aria-label={t('workspace.toolbars.aria-label')} aria-controls="edge-datahub-canvas">
             <DeleteListener />
-            <CopyPasteListener render={(copiedNodes) => <CopyPasteStatus nbCopied={copiedNodes.length} />} />
+            <ToolboxSelectionListener />
             <DesignerToolbox />
             <CanvasControls />
+            <CopyPasteListener render={(copiedNodes) => <CopyPasteStatus nbCopied={copiedNodes.length} />} />
             <MiniMap />
           </Box>
         </ReactFlow>

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/PolicyEditor.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/PolicyEditor.tsx
@@ -42,7 +42,8 @@ const PolicyEditor: FC = () => {
   const { t } = useTranslation('datahub')
   const reactFlowWrapper = useRef(null)
   const [reactFlowInstance, setReactFlowInstance] = useState<ReactFlowInstance | null>(null)
-  const { status, nodes, edges, onNodesChange, onEdgesChange, onConnect, onAddNodes } = useDataHubDraftStore()
+  const { status, nodes, edges, onNodesChange, onEdgesChange, onConnect, onAddNodes, isPolicyInDraft } =
+    useDataHubDraftStore()
   const edgeConnectStart = useRef<OnConnectStartParamsNode | undefined>(undefined)
   const nodeTypes = useMemo(() => CustomNodeTypes, [])
 

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/PolicyEditor.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/PolicyEditor.tsx
@@ -26,7 +26,7 @@ import ConnectionLine from '@datahub/components/nodes/ConnectionLine.tsx'
 import { CustomNodeTypes } from '@datahub/config/nodes.config.tsx'
 import useDataHubDraftStore from '@datahub/hooks/useDataHubDraftStore.ts'
 import { getConnectedNodeFrom, getNodeId, getNodePayload, isValidPolicyConnection } from '@datahub/utils/node.utils.ts'
-import { DesignerStatus } from '@datahub/types.ts'
+import { DataHubNodeType, DesignerStatus } from '@datahub/types.ts'
 
 export type OnConnectStartParams = {
   nodeId: string | null
@@ -110,6 +110,14 @@ const PolicyEditor: FC = () => {
         const { type, handleId, nodeId } = edgeConnectStart.current
 
         const droppedNode = getConnectedNodeFrom(type, handleId)
+        if (!droppedNode) return
+
+        if (
+          droppedNode.type === DataHubNodeType.DATA_POLICY ||
+          (droppedNode.type === DataHubNodeType.BEHAVIOR_POLICY && isPolicyInDraft())
+        )
+          return
+
         if (droppedNode) {
           const id = getNodeId()
           const newNode: Node = {

--- a/hivemq-edge/src/frontend/src/extensions/datahub/hooks/useDataHubDraftStore.spec.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/hooks/useDataHubDraftStore.spec.ts
@@ -59,6 +59,64 @@ describe('useDataHubDraftStore', () => {
     expect(result.current.edges).toHaveLength(1)
   })
 
+  it('should check if a policy is already in the store', async () => {
+    const { result } = renderHook<WorkspaceState & WorkspaceAction, unknown>(useDataHubDraftStore)
+    const { nodes, edges } = result.current
+
+    expect(nodes).toHaveLength(0)
+    expect(edges).toHaveLength(0)
+
+    act(() => {
+      const { onNodesChange } = result.current
+      const item1: Node = { ...MOCK_NODE, id: '1', position: { x: 0, y: 0 } }
+      onNodesChange([{ item: item1, type: 'add' }])
+    })
+
+    expect(result.current.nodes).toHaveLength(1)
+    expect(result.current.edges).toHaveLength(0)
+
+    act(() => {
+      const { isPolicyInDraft } = result.current
+      expect(isPolicyInDraft()).toBeFalsy()
+    })
+
+    act(() => {
+      const { onNodesChange } = result.current
+      const item2: Node = { ...MOCK_NODE, type: DataHubNodeType.BEHAVIOR_POLICY, id: '2', position: { x: 0, y: 0 } }
+      onNodesChange([{ item: item2, type: 'add' }])
+    })
+
+    expect(result.current.nodes).toHaveLength(2)
+    expect(result.current.edges).toHaveLength(0)
+
+    act(() => {
+      const { isPolicyInDraft } = result.current
+      expect(isPolicyInDraft()).toBeTruthy()
+    })
+
+    act(() => {
+      const { reset } = result.current
+      reset()
+    })
+
+    expect(result.current.nodes).toHaveLength(0)
+    expect(result.current.edges).toHaveLength(0)
+
+    act(() => {
+      const { onNodesChange } = result.current
+      const item3: Node = { ...MOCK_NODE, type: DataHubNodeType.DATA_POLICY, id: '3', position: { x: 0, y: 0 } }
+      onNodesChange([{ item: item3, type: 'add' }])
+    })
+
+    expect(result.current.nodes).toHaveLength(1)
+    expect(result.current.edges).toHaveLength(0)
+
+    act(() => {
+      const { isPolicyInDraft } = result.current
+      expect(isPolicyInDraft()).toBeTruthy()
+    })
+  })
+
   it('should update the connection between two nodes', async () => {
     const { result } = renderHook<WorkspaceState & WorkspaceAction, unknown>(useDataHubDraftStore)
     expect(result.current.nodes).toHaveLength(0)

--- a/hivemq-edge/src/frontend/src/extensions/datahub/hooks/useDataHubDraftStore.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/hooks/useDataHubDraftStore.ts
@@ -35,6 +35,13 @@ const useDataHubDraftStore = create<WorkspaceState & WorkspaceStatus & Workspace
       isDirty: () => {
         return get().nodes.length !== 0 && get().edges.length !== 0
       },
+      isPolicyInDraft: () => {
+        return (
+          get().nodes.filter(
+            (node) => node.type === DataHubNodeType.DATA_POLICY || node.type === DataHubNodeType.BEHAVIOR_POLICY
+          ).length !== 0
+        )
+      },
       onNodesChange: (changes: NodeChange[]) => {
         set({
           nodes: applyNodeChanges(changes, get().nodes),

--- a/hivemq-edge/src/frontend/src/extensions/datahub/locales/en/datahub.json
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/locales/en/datahub.json
@@ -94,7 +94,27 @@
     }
   },
   "workspace": {
-    "aria-label": "Workspace toolbar",
+    "canvas": {
+      "aria-label": "Policy Designer"
+    },
+    "toolbars": {
+      "aria-label": "Policy Designer toolbars",
+      "clipboard": {
+        "aria-label": "Clipboard controls",
+        "content_zero": "No items copied in the clipboard",
+        "content_one": "1 items in the clipboard",
+        "content_many": "{{ count }} items in the clipboard"
+      },
+      "draft": {
+        "aria-label": "Draft controls"
+      },
+      "status": {
+        "aria-label": "Status"
+      },
+      "edit": {
+        "aria-label": "Edit Operations"
+      }
+    },
     "controls": {
       "aria-label": "Canvas controls",
       "zoomIn": "Zoom in",
@@ -105,11 +125,13 @@
       "edit": "Edit the policy",
       "shortcuts": "Help using the Designer"
     },
+
     "toolbox": {
       "aria-label": "Policy controls",
       "trigger_open": "Open the toolbox",
       "trigger_close": "Close the toolbox",
       "panel": {
+        "helper": "Drag elements on the canvas then connect them",
         "build": {
           "title": "Build",
           "description": "Build your policy on the canvas"

--- a/hivemq-edge/src/frontend/src/extensions/datahub/locales/en/datahub.json
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/locales/en/datahub.json
@@ -131,6 +131,7 @@
       "trigger_open": "Open the toolbox",
       "trigger_close": "Close the toolbox",
       "panel": {
+        "aria-label": "Policy Toolbox",
         "helper": "Drag elements on the canvas then connect them",
         "build": {
           "title": "Build",

--- a/hivemq-edge/src/frontend/src/extensions/datahub/types.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/types.ts
@@ -60,6 +60,7 @@ export interface WorkspaceAction {
   onSerializePolicy: (node: Node<DataPolicyData | BehaviorPolicyData>) => string | undefined
 
   isDirty: () => boolean
+  isPolicyInDraft: () => boolean
 
   setStatus: (
     status: DesignerStatus,

--- a/hivemq-edge/src/frontend/src/locales/en/translation.json
+++ b/hivemq-edge/src/frontend/src/locales/en/translation.json
@@ -735,6 +735,9 @@
     }
   },
   "workspace": {
+    "canvas": {
+      "aria-label": "Edge Workspace"
+    },
     "controls": {
       "aria-label": "Workspace toolbar",
       "zoomIn": "Zoom in",

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/ReactFlowWrapper.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/ReactFlowWrapper.tsx
@@ -101,6 +101,8 @@ const ReactFlowWrapper = () => {
       nodesConnectable={false}
       deleteKeyCode={null}
       proOptions={proOptions}
+      role="region"
+      aria-label={t('workspace.canvas.aria-label')}
     >
       <Box role="toolbar" aria-label={t('workspace.controls.aria-label')} aria-controls="edge-workspace-canvas">
         <SelectionListener />


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/27113/details/

The PR refactors the designer's UX so that a single police node (either `Data Policy` or `Behavior Policy`) can be present in the canvas at a given time. 

The restriction applies to the loading of policies and to the creation of a new `draft`: the toolbox is disabled when one of the two nodes is added, and the contextual connection (when a node is created by dragging a handle) cannot create a new node on drop.

The PR also redesigns the toolbox to improve usability and accessibility, and also to make it more future-friendly (e.g. adding new construction inodes)

### Out-of-scope
- Several aspects of the Designer will be refactored in a subsequent ticket, to reflect comments and suggestions made on this epic

### Before
![screenshot-localhost_3000-2025_01_13-12_12_31](https://github.com/user-attachments/assets/4bb5fed0-9150-483a-a3c1-333bb1a17091)

### After
![screenshot-localhost_3000-2025_01_13-12_10_55](https://github.com/user-attachments/assets/3aa40fed-2bd3-4270-abc0-fdfa0420758a)

![screenshot-localhost_3000-2025_01_13-12_11_27](https://github.com/user-attachments/assets/9d146d14-3349-4a15-ba7a-7af466b749cc)

![screenshot-localhost_3000-2025_01_13-12_12_01](https://github.com/user-attachments/assets/d0eafef0-71d2-4e66-8bc9-3c595aa7001e)
