### PR TITLE
fix(27115): Fix bugs with the Designer shortcuts

### DIFF
--- a/hivemq-edge/src/frontend/src/components/Chakra/ShortcutRenderer.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/components/Chakra/ShortcutRenderer.spec.cy.tsx
@@ -17,9 +17,9 @@ describe('ShortcutRenderer', () => {
     cy.get('[role="definition"]').should('contain.text', 'This is a description')
   })
 
-  it('should render multiple shortcuts', () => {
+  it.only('should render multiple shortcuts', () => {
     cy.mountWithProviders(<ShortcutRenderer hotkeys="CTRL+C,Meta+V,ESC" description="This is a description" />)
-    const cmd = Cypress.platform === 'darwin' ? 'Command' : 'Ctrl'
+    const cmd = Cypress.platform === 'darwin' ? 'Cmd (⌘)' : 'Ctrl'
 
     cy.get('[role="term"]').should('contain.text', `CTRL + C , ${cmd} + V , ESC`)
     cy.get('kbd').should('have.length', 5)

--- a/hivemq-edge/src/frontend/src/components/Chakra/ShortcutRenderer.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/components/Chakra/ShortcutRenderer.spec.cy.tsx
@@ -19,7 +19,7 @@ describe('ShortcutRenderer', () => {
 
   it('should render multiple shortcuts', () => {
     cy.mountWithProviders(<ShortcutRenderer hotkeys="CTRL+C,Meta+V,ESC" description="This is a description" />)
-    const cmd = Cypress.platform === 'darwin' ? '⌘' : 'Ctrl'
+    const cmd = Cypress.platform === 'darwin' ? '⌘' : '^'
 
     cy.get('[role="term"]').should('contain.text', `CTRL + C , ${cmd} + V , ESC`)
     cy.get('kbd').should('have.length', 5)

--- a/hivemq-edge/src/frontend/src/components/Chakra/ShortcutRenderer.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/components/Chakra/ShortcutRenderer.spec.cy.tsx
@@ -17,9 +17,9 @@ describe('ShortcutRenderer', () => {
     cy.get('[role="definition"]').should('contain.text', 'This is a description')
   })
 
-  it.only('should render multiple shortcuts', () => {
+  it('should render multiple shortcuts', () => {
     cy.mountWithProviders(<ShortcutRenderer hotkeys="CTRL+C,Meta+V,ESC" description="This is a description" />)
-    const cmd = Cypress.platform === 'darwin' ? 'Cmd (⌘)' : 'Ctrl'
+    const cmd = Cypress.platform === 'darwin' ? '⌘' : 'Ctrl'
 
     cy.get('[role="term"]').should('contain.text', `CTRL + C , ${cmd} + V , ESC`)
     cy.get('kbd').should('have.length', 5)

--- a/hivemq-edge/src/frontend/src/components/Chakra/ShortcutRenderer.tsx
+++ b/hivemq-edge/src/frontend/src/components/Chakra/ShortcutRenderer.tsx
@@ -2,22 +2,11 @@ import { FC, Fragment } from 'react'
 import { chakra, Kbd, Text } from '@chakra-ui/react'
 
 import i18n from '@/config/i18n.config.ts'
-
-const PLATFORM_MACOS = 'MacOS'
-const PLATFORM_OTHERS = 'Others'
+import { getUserAgentPlatform } from '@/utils/user-agent.utils.ts'
 
 interface ShortcutRendererProps {
   hotkeys: string
   description?: string
-}
-
-/**
- * TODO: navigator.platform is deprecated/obsolete
- *   We need tp build a common routine with `navigator.userAgentData.platform` (experimental) and `navigator.userAgent` (requires careful parsing)
- */
-const getUserAgentPlatform = () => {
-  const os = window.navigator.platform
-  return os.startsWith('Mac') ? PLATFORM_MACOS : PLATFORM_OTHERS
 }
 
 const ShortcutRenderer: FC<ShortcutRendererProps> = ({ hotkeys, description }) => {

--- a/hivemq-edge/src/frontend/src/components/Chakra/ShortcutRenderer.tsx
+++ b/hivemq-edge/src/frontend/src/components/Chakra/ShortcutRenderer.tsx
@@ -45,7 +45,7 @@ const ShortcutRenderer: FC<ShortcutRendererProps> = ({ hotkeys, description }) =
               {localisedShortcut.map((element, indexElement) => (
                 <chakra.span key={`$${shortcut}-${indexShortcut}-${indexElement}`} aria-hidden="true">
                   {indexElement !== 0 && ' + '}
-                  <Kbd>{element}</Kbd>
+                  <Kbd fontSize="md">{element}</Kbd>
                 </chakra.span>
               ))}
             </Fragment>

--- a/hivemq-edge/src/frontend/src/components/Chakra/ShortcutRenderer.tsx
+++ b/hivemq-edge/src/frontend/src/components/Chakra/ShortcutRenderer.tsx
@@ -1,9 +1,23 @@
 import { FC, Fragment } from 'react'
 import { chakra, Kbd, Text } from '@chakra-ui/react'
 
+import i18n from '@/config/i18n.config.ts'
+
+const PLATFORM_MACOS = 'MacOS'
+const PLATFORM_OTHERS = 'Others'
+
 interface ShortcutRendererProps {
   hotkeys: string
   description?: string
+}
+
+/**
+ * TODO: navigator.platform is deprecated/obsolete
+ *   We need tp build a common routine with `navigator.userAgentData.platform` (experimental) and `navigator.userAgent` (requires careful parsing)
+ */
+const getUserAgentPlatform = () => {
+  const os = window.navigator.platform
+  return os.startsWith('Mac') ? PLATFORM_MACOS : PLATFORM_OTHERS
 }
 
 const ShortcutRenderer: FC<ShortcutRendererProps> = ({ hotkeys, description }) => {
@@ -14,12 +28,8 @@ const ShortcutRenderer: FC<ShortcutRendererProps> = ({ hotkeys, description }) =
     const [modifier, ...rest] = shortcut
 
     if (modifier === 'Meta') {
-      const os = window.navigator.platform
-      if (os.startsWith('Mac')) {
-        return ['Command', ...rest]
-      } else {
-        return ['Ctrl', ...rest]
-      }
+      const modifier = i18n.t('shortcuts.modifier.META', { ns: 'components', context: getUserAgentPlatform() })
+      return [modifier, ...rest]
     }
     return shortcut
   }

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/DesignerCheatSheet.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/DesignerCheatSheet.spec.cy.tsx
@@ -1,5 +1,3 @@
-/// <reference types="cypress" />
-
 import DesignerCheatSheet from '@datahub/components/controls/DesignerCheatSheet.tsx'
 
 describe('DesignerCheatSheet', () => {
@@ -7,12 +5,21 @@ describe('DesignerCheatSheet', () => {
     cy.viewport(800, 800)
   })
 
-  it('should renders properly ', () => {
+  it('should render properly ', () => {
     cy.mountWithProviders(<DesignerCheatSheet />)
 
     cy.get("[role='dialog']").should('not.exist')
     cy.getByTestId('canvas-control-help').click()
     cy.get("[role='dialog']").should('be.visible')
     cy.get("[role='dialog'] header").should('contain.text', 'Keyboard shortcuts')
+  })
+
+  it('should be accessible', () => {
+    cy.injectAxe()
+    cy.mountWithProviders(<DesignerCheatSheet />)
+    cy.getByTestId('canvas-control-help').click()
+
+    cy.checkAccessibility()
+    cy.percySnapshot('Component: DesignerCheatSheet')
   })
 })

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/DesignerCheatSheet.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/DesignerCheatSheet.tsx
@@ -54,7 +54,7 @@ const DesignerCheatSheet: FC = () => {
             <Text fontSize="md">{t(`shortcuts.header`)}</Text>
           </ModalHeader>
           <ModalCloseButton />
-          <ModalBody>
+          <ModalBody overflowY="scroll" tabIndex={0}>
             <HStack gap={4} alignItems="flex-start">
               {Object.entries(groupedKeys).map(([group, keys]) => (
                 <Card key={group} role="group" aria-labelledby={`group-${group}`} flex={1}>

--- a/hivemq-edge/src/frontend/src/extensions/datahub/locales/en/datahub.json
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/locales/en/datahub.json
@@ -354,7 +354,7 @@
       "Selected": "Selected Nodes"
     },
     "keys": {
-      "ESC": "Cancel the node selection and the copy",
+      "ESC": "Cancel the node selection and clear the content of the clipboard",
       "TAB": "Nodes, connections and toolbars are all focusable by using the TAB key",
       "ENTER": "Select the focused node",
       "Meta+ENTER": "Add the focused node to the selection (or remove it if selected)",

--- a/hivemq-edge/src/frontend/src/extensions/datahub/locales/en/datahub.json
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/locales/en/datahub.json
@@ -355,7 +355,7 @@
     },
     "keys": {
       "ESC": "Cancel the node selection and the copy",
-      "TAB": "Set the focus on the next node",
+      "TAB": "Nodes, connections and toolbars are all focusable by using the TAB key",
       "ENTER": "Select the focused node",
       "Meta+ENTER": "Add the focused node to the selection (or remove it if selected)",
       "Meta+C_Selected": "Copy the selected nodes (and their connections)",

--- a/hivemq-edge/src/frontend/src/locales/en/components.json
+++ b/hivemq-edge/src/frontend/src/locales/en/components.json
@@ -1,4 +1,10 @@
 {
+  "shortcuts": {
+    "modifier": {
+      "META_MacOS": "Cmd (⌘)",
+      "META_Others": "CTRL"
+    }
+  },
   "iconLabel": {
     "topic": "Topic",
     "topic-filter": "Topic Filter",

--- a/hivemq-edge/src/frontend/src/locales/en/components.json
+++ b/hivemq-edge/src/frontend/src/locales/en/components.json
@@ -1,8 +1,8 @@
 {
   "shortcuts": {
     "modifier": {
-      "META_MacOS": "Cmd (⌘)",
-      "META_Others": "CTRL"
+      "META_MacOS": "⌘",
+      "META_Others": "^"
     }
   },
   "iconLabel": {

--- a/hivemq-edge/src/frontend/src/utils/user-agent.utils.ts
+++ b/hivemq-edge/src/frontend/src/utils/user-agent.utils.ts
@@ -1,0 +1,16 @@
+/* istanbul ignore file -- @preserve */
+export const PLATFORM_MACOS = 'MacOS'
+export const PLATFORM_OTHERS = 'Others'
+
+/**
+ * TODO[NVL] This is unsafe, navigator.platform is deprecated
+ */
+export const getUserAgentPlatform = () => {
+  const { platform, userAgent } = navigator
+  let os = platform
+  if (!os) {
+    os = userAgent
+  }
+  os = os.toLowerCase()
+  return os.includes('mac') ? PLATFORM_MACOS : PLATFORM_OTHERS
+}


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/27115/details/

The PR fixes a few issues with the shortcut cheatsheet in the Designer:
- detection of the user agent (platform) made more resilient 
- shortcuts are displayed using the reduced version of the modifier (`⌘` instead of `Command`)

### Design
- The `Designer` is a "normal" widget displayed in the DOM, like any other interactive element: it reacts to `tab` navigation and other keyboard rules of HTML 
- The `Designer` is not a modal, therefore it doesn't "trap" the `tabs` within its confine: tab iteration will go through the internal elements of the `Designer` (links, nodes, UI elements) before continuing back to the rest of the page (e.g. side navigation) 

### Before 
![screenshot-localhost_3000-2025_01_13-15_28_58](https://github.com/user-attachments/assets/5812c2f1-8996-46d7-8832-931b4a20a5b7)

### After 
![screenshot-localhost_3000-2025_01_13-15_28_30](https://github.com/user-attachments/assets/f9393e27-1fa1-42f2-a494-35c82c8a416d)
