### PR TITLE
refactor(29589): Refactor the nodes' initial position in the Designer

### DIFF
--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/PolicyEditor.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/pages/PolicyEditor.tsx
@@ -22,6 +22,7 @@ import { getConnectedNodeFrom, getNodeId, getNodePayload, isValidPolicyConnectio
 import { CANVAS_GRID } from '@datahub/utils/theme.utils.ts'
 import { DataHubNodeType } from '@datahub/types.ts'
 import { usePolicyGuards } from '@datahub/hooks/usePolicyGuards.ts'
+import { CANVAS_DROP_DELTA } from '@datahub/designer/checks.utils.ts'
 
 export type OnConnectStartParams = {
   nodeId: string | null
@@ -104,7 +105,7 @@ const PolicyEditor: FC = () => {
       const isTargetCanvas = targetElement.classList.contains('react-flow__pane')
 
       if (isTargetCanvas && edgeConnectStart.current && reactFlowInstance) {
-        const { type, handleId, nodeId } = edgeConnectStart.current
+        const { type, handleId, handleType, nodeId } = edgeConnectStart.current
 
         const droppedNode = getConnectedNodeFrom(type, handleId)
         if (!droppedNode) return
@@ -126,6 +127,9 @@ const PolicyEditor: FC = () => {
             type: droppedNode.type,
             data: getNodePayload(droppedNode.type),
           }
+
+          newNode.position.y += CANVAS_DROP_DELTA.y
+          if (handleType === 'target') newNode.position.x += CANVAS_DROP_DELTA.x
 
           const edgeConnection: Connection = droppedNode.isSource
             ? {

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/checks.utils.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/checks.utils.ts
@@ -10,9 +10,9 @@ export const CANVAS_DROP_DELTA: XYPosition = {
 export const CANVAS_POSITION = {
   Client: { x: -10 * CANVAS_GRID, y: 0 } as XYPosition,
   Topic: { x: -10 * CANVAS_GRID, y: 0 } as XYPosition,
-  Function: { x: -10 * CANVAS_GRID, y: CANVAS_GRID * 10 } as XYPosition,
+  Function: { x: -10 * CANVAS_GRID, y: CANVAS_GRID * 5 } as XYPosition,
   Transition: { x: 10 * CANVAS_GRID, y: 4 * CANVAS_GRID } as XYPosition,
-  PolicySchema: { x: -10 * CANVAS_GRID, y: 0 } as XYPosition,
+  PolicySchema: { x: -10 * CANVAS_GRID, y: CANVAS_GRID * 10 } as XYPosition,
   SchemaOperation: { x: -10 * CANVAS_GRID, y: CANVAS_GRID * 5 } as XYPosition,
   Validator: { x: -10 * CANVAS_GRID, y: CANVAS_GRID * 5 } as XYPosition,
   OperationSuccess: { x: 10 * CANVAS_GRID, y: 0 } as XYPosition,

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/checks.utils.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/checks.utils.ts
@@ -9,11 +9,12 @@ export const CANVAS_DROP_DELTA: XYPosition = {
 // The delta positions used to locate nodes on the canvas at loading time, as position is not serialised
 export const CANVAS_POSITION = {
   Client: { x: -300, y: 0 } as XYPosition,
-  Topic: { x: -300, y: 0 } as XYPosition,
-  Function: { x: 350, y: -400 } as XYPosition,
-  Transition: { x: 400, y: 100 } as XYPosition,
-  PolicySchema: { x: 0, y: -150 } as XYPosition,
-  Validator: { x: 0, y: -150 } as XYPosition,
-  OperationSuccess: { x: 200, y: 0 } as XYPosition,
-  OperationError: { x: 200, y: 100 } as XYPosition,
+  Topic: { x: -10 * CANVAS_GRID, y: 0 } as XYPosition,
+  Function: { x: -10 * CANVAS_GRID, y: CANVAS_GRID * 10 } as XYPosition,
+  Transition: { x: 10 * CANVAS_GRID, y: 4 * CANVAS_GRID } as XYPosition,
+  PolicySchema: { x: -10 * CANVAS_GRID, y: 0 } as XYPosition,
+  SchemaOperation: { x: -10 * CANVAS_GRID, y: CANVAS_GRID * 5 } as XYPosition,
+  Validator: { x: -10 * CANVAS_GRID, y: CANVAS_GRID * 5 } as XYPosition,
+  OperationSuccess: { x: 10 * CANVAS_GRID, y: 0 } as XYPosition,
+  OperationError: { x: 10 * CANVAS_GRID, y: CANVAS_GRID * 4 } as XYPosition,
 }

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/checks.utils.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/checks.utils.ts
@@ -1,4 +1,10 @@
 import type { XYPosition } from 'reactflow'
+import { CANVAS_GRID } from '@datahub/utils/theme.utils.ts'
+
+export const CANVAS_DROP_DELTA: XYPosition = {
+  x: -CANVAS_GRID * 8,
+  y: -CANVAS_GRID * 2,
+}
 
 // The delta positions used to locate nodes on the canvas at loading time, as position is not serialised
 export const CANVAS_POSITION = {

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/checks.utils.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/checks.utils.ts
@@ -8,7 +8,7 @@ export const CANVAS_DROP_DELTA: XYPosition = {
 
 // The delta positions used to locate nodes on the canvas at loading time, as position is not serialised
 export const CANVAS_POSITION = {
-  Client: { x: -300, y: 0 } as XYPosition,
+  Client: { x: -10 * CANVAS_GRID, y: 0 } as XYPosition,
   Topic: { x: -10 * CANVAS_GRID, y: 0 } as XYPosition,
   Function: { x: -10 * CANVAS_GRID, y: CANVAS_GRID * 10 } as XYPosition,
   Transition: { x: 10 * CANVAS_GRID, y: 4 * CANVAS_GRID } as XYPosition,

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/client_filter/ClientFilterNode.utils.spec.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/client_filter/ClientFilterNode.utils.spec.ts
@@ -150,7 +150,7 @@ describe('loadClientFilter', () => {
           },
           id: expect.stringContaining('node_'),
           position: {
-            x: -300,
+            x: -320,
             y: 0,
           },
           type: DataHubNodeType.CLIENT_FILTER,

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/operation/OperationNode.utils.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/operation/OperationNode.utils.ts
@@ -289,7 +289,7 @@ export const loadPipeline = (
   const delta =
     handle === DataPolicyData.Handle.ON_ERROR ? CANVAS_POSITION.OperationError : CANVAS_POSITION.OperationSuccess
   const position: XYPosition = {
-    x: parentNode.position.x + delta.x,
+    x: parentNode.position.x,
     y: parentNode.position.y + delta.y,
   }
 
@@ -338,22 +338,24 @@ export const loadPipeline = (
             },
           }
 
+          const items = functions.length + 2
+
           const deserialisers = loadSchema(
             operationNode,
             OperationData.Handle.DESERIALISER,
-            -200,
+            CANVAS_POSITION.SchemaOperation.y,
             deserializer.arguments as SchemaReference,
             schemas
           )
           const serialisers = loadSchema(
             operationNode,
             OperationData.Handle.SERIALISER,
-            200,
+            CANVAS_POSITION.SchemaOperation.y * items,
             policyOperation.arguments as SchemaReference,
             schemas
           )
 
-          const allScripts = loadScripts(operationNode, functions, scripts)
+          const allScripts = loadScripts(operationNode, CANVAS_POSITION.SchemaOperation.y, functions, scripts)
           newNodes.push(...deserialisers)
           newNodes.push(...serialisers)
           newNodes.push(...allScripts)

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/operation/OperationNode.utils.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/operation/OperationNode.utils.ts
@@ -338,24 +338,24 @@ export const loadPipeline = (
             },
           }
 
-          const items = functions.length + 2
+          const nbItems = functions.length + 2
 
           const deserialisers = loadSchema(
             operationNode,
             OperationData.Handle.DESERIALISER,
-            CANVAS_POSITION.SchemaOperation.y,
+            1,
             deserializer.arguments as SchemaReference,
             schemas
           )
           const serialisers = loadSchema(
             operationNode,
             OperationData.Handle.SERIALISER,
-            CANVAS_POSITION.SchemaOperation.y * items,
+            nbItems,
             policyOperation.arguments as SchemaReference,
             schemas
           )
 
-          const allScripts = loadScripts(operationNode, CANVAS_POSITION.SchemaOperation.y, functions, scripts)
+          const allScripts = loadScripts(operationNode, 2, functions, scripts)
           newNodes.push(...deserialisers)
           newNodes.push(...serialisers)
           newNodes.push(...allScripts)

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/schema/SchemaNode.utils.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/schema/SchemaNode.utils.ts
@@ -114,7 +114,7 @@ export function checkValiditySchema(schemaNode: Node<SchemaData>): DryRunResults
 export function loadSchema(
   parentNode: Node<DataHubNodeData>,
   targetHandle: string | null,
-  positionDeltaX: number,
+  positionInGroup: number,
   schemaRef: SchemaReference,
   schemas: PolicySchema[]
 ): (NodeAddChange | Connection)[] {
@@ -128,7 +128,7 @@ export function loadSchema(
       type: DataHubNodeType.SCHEMA,
       position: {
         x: parentNode.position.x + CANVAS_POSITION.PolicySchema.x,
-        y: parentNode.position.y + positionDeltaX,
+        y: parentNode.position.y + positionInGroup * CANVAS_POSITION.SchemaOperation.y,
       },
       data: {
         name: schema.id,
@@ -162,7 +162,7 @@ export function loadSchema(
       id: schemaRef.schemaId,
       type: DataHubNodeType.SCHEMA,
       position: {
-        x: parentNode.position.x + positionDeltaX,
+        x: parentNode.position.x + positionInGroup,
         y: parentNode.position.y + CANVAS_POSITION.PolicySchema.y,
       },
       data: {

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/schema/SchemaNode.utils.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/schema/SchemaNode.utils.ts
@@ -127,8 +127,8 @@ export function loadSchema(
       id: schemaRef.schemaId,
       type: DataHubNodeType.SCHEMA,
       position: {
-        x: parentNode.position.x + positionDeltaX,
-        y: parentNode.position.y + CANVAS_POSITION.PolicySchema.y,
+        x: parentNode.position.x + CANVAS_POSITION.PolicySchema.x,
+        y: parentNode.position.y + positionDeltaX,
       },
       data: {
         name: schema.id,

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/script/FunctionNode.utils.spec.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/script/FunctionNode.utils.spec.ts
@@ -123,7 +123,7 @@ describe('loadScripts', () => {
       },
     ]
 
-    expect(loadScripts(node, policyOperations, scripts)).toStrictEqual<(NodeAddChange | Connection)[]>([
+    expect(loadScripts(node, 0, policyOperations, scripts)).toStrictEqual<(NodeAddChange | Connection)[]>([
       expect.objectContaining<NodeAddChange>({
         item: {
           data: {
@@ -134,8 +134,8 @@ describe('loadScripts', () => {
           },
           id: 'script1',
           position: {
-            x: 0,
-            y: -400,
+            x: -320,
+            y: 0,
           },
           type: DataHubNodeType.FUNCTION,
         },
@@ -156,6 +156,6 @@ describe('loadScripts', () => {
         arguments: {},
       },
     ]
-    expect(() => loadScripts(node, policyOperations, scripts)).toThrow('Cannot find the JS Function node')
+    expect(() => loadScripts(node, 0, policyOperations, scripts)).toThrow('Cannot find the JS Function node')
   })
 })

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/script/FunctionNode.utils.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/script/FunctionNode.utils.ts
@@ -42,15 +42,19 @@ export function checkValidityJSScript(scriptNode: Node<FunctionData>): DryRunRes
   return { data: script, node: scriptNode }
 }
 
-export const loadScripts = (parentNode: Node<DataHubNodeData>, functions: PolicyOperation[], scripts: Script[]) => {
-  const delta = ((Math.max(functions.length || 0, 1) - 1) * CANVAS_POSITION.Function.x) / 2
+export const loadScripts = (
+  parentNode: Node<DataHubNodeData>,
+  positionInGroup: number,
+  functions: PolicyOperation[],
+  scripts: Script[]
+) => {
   const position: XYPosition = {
-    x: parentNode.position.x - CANVAS_POSITION.Function.x - delta,
-    y: parentNode.position.y + CANVAS_POSITION.Function.y,
+    x: parentNode.position.x + CANVAS_POSITION.Function.x,
+    y: parentNode.position.y,
   }
 
   const shiftLeft = () => {
-    position.x += CANVAS_POSITION.Function.x
+    position.y += positionInGroup * CANVAS_POSITION.Function.y
     return position
   }
 

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/topic_filter/TopicFilterNode.utils.spec.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/topic_filter/TopicFilterNode.utils.spec.ts
@@ -30,7 +30,7 @@ describe('loadTopicFilter', () => {
           },
           id: expect.stringContaining('node_'),
           position: {
-            x: -300,
+            x: -320,
             y: 0,
           },
           type: DataHubNodeType.TOPIC_FILTER,

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/validator/ValidatorNode.utils.spec.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/validator/ValidatorNode.utils.spec.ts
@@ -204,8 +204,8 @@ describe('loadValidators', () => {
           },
           id: expect.stringContaining('node_'), //'node_0bf21139-7f2c-41d0-98b5-6024af1b31e4',
           position: {
-            x: 0,
-            y: -150,
+            x: -320,
+            y: 160,
           },
           type: 'VALIDATOR',
         },
@@ -227,8 +227,8 @@ describe('loadValidators', () => {
           },
           id: 'test',
           position: {
-            x: 0,
-            y: -300,
+            x: -640,
+            y: 160,
           },
           type: 'SCHEMA',
         },
@@ -249,8 +249,8 @@ describe('loadValidators', () => {
           },
           id: 'test',
           position: {
-            x: 0,
-            y: -300,
+            x: -640,
+            y: 320,
           },
           type: 'SCHEMA',
         },

--- a/hivemq-edge/src/frontend/src/extensions/datahub/designer/validator/ValidatorNode.utils.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/designer/validator/ValidatorNode.utils.ts
@@ -94,8 +94,9 @@ export const loadValidators = (policy: DataPolicy, schemas: PolicySchema[], data
       targetHandle: DataPolicyData.Handle.VALIDATION,
     })
 
+    let nb = 0
     for (const schemaRef of validatorArguments.schemas) {
-      const schemaNodes = loadSchema(validatorNode, null, 0, schemaRef, schemas)
+      const schemaNodes = loadSchema(validatorNode, null, nb++, schemaRef, schemas)
       newNodes.push(...schemaNodes)
     }
   }


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/29589/details/
See https://hivemq.kanbanize.com/ctrl_board/57/cards/29579/details/

The PR fixes the computation of the initial position of the nodes on the canvas when a policy is loaded. It changes the basis of the layout to match the new design constraints (left-to-right orientation of policy graphs)

The positions are not persisted with the policy so the loaded policy needs to be re-layouted at load time. The process in place is a simple predecessor- and grid-based position shifting, not a full graph layout: overlaps are still expected. 

The PR also fixes an irritating anti-pattern: when constructing a node by dragging from the handle, the new node is created based on the expected position of the new handle, guaranteeing alignment.

### Before
![screenshot-localhost_3000-2025_01_23-15_39_36](https://github.com/user-attachments/assets/83eb7fc9-79a3-4a0a-bc4b-a53ac596ab40)

![screenshot-localhost_3000-2025_01_23-15_41_11](https://github.com/user-attachments/assets/df587252-5b66-4102-83d8-6bc54d1f265c)

### After

![screenshot-localhost_3000-2025_01_23-15_40_08](https://github.com/user-attachments/assets/de7104f6-e056-4a48-9664-7c9ee5f9e4ca)

![screenshot-localhost_3000-2025_01_23-15_40_47](https://github.com/user-attachments/assets/d878593a-f7ef-4689-a95c-62119decad88)
