### PR TITLE
feat(29524): Enable modification of published policy

### DIFF
--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/helpers/DraftStatus.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/helpers/DraftStatus.spec.cy.tsx
@@ -1,6 +1,6 @@
 import DraftStatus from '@datahub/components/helpers/DraftStatus.tsx'
 
-describe('DataHubListAction', () => {
+describe('DraftStatus', () => {
   beforeEach(() => {
     cy.viewport(800, 800)
   })

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/helpers/DraftStatus.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/helpers/DraftStatus.spec.cy.tsx
@@ -8,7 +8,7 @@ describe('DraftStatus', () => {
   it.only('should render ', () => {
     cy.mountWithProviders(<DraftStatus />)
 
-    cy.getByTestId('status-container-type').should('contain.text', 'No type selected')
+    cy.getByTestId('status-container-type').should('contain.text', 'No type')
     cy.getByTestId('status-container-name').should('contain.text', 'Unnamed policy')
     cy.getByTestId('status-container-status').should('contain.text', 'Draft')
 

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/toolbar/NodeDatahubToolbar.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/toolbar/NodeDatahubToolbar.tsx
@@ -28,7 +28,7 @@ const NodeDatahubToolbar: FC<NodeToolbarProps> = ({ onCopy, onEdit, onDelete, ch
           <Divider orientation="vertical" />
         </>
       )}
-      <ToolbarButtonGroup orientation="horizontal" isAttached {...props}>
+      <ToolbarButtonGroup orientation="horizontal" isAttached variant="outline" {...props}>
         <IconButton
           icon={<Icon as={LuFileCog} boxSize="20px" />}
           data-testid="node-toolbar-config"
@@ -48,7 +48,6 @@ const NodeDatahubToolbar: FC<NodeToolbarProps> = ({ onCopy, onEdit, onDelete, ch
           icon={<Icon as={LuDelete} boxSize="20px" />}
           data-testid="node-toolbar-delete"
           aria-label={t('Listings.action.delete')}
-          colorScheme="red"
           onClick={onDelete}
           isDisabled={!isNodeEditable}
         />

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/toolbar/NodeDatahubToolbar.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/toolbar/NodeDatahubToolbar.tsx
@@ -16,9 +16,9 @@ interface NodeToolbarProps extends ButtonGroupProps {
   selectedNode: string
 }
 
-const NodeDatahubToolbar: FC<NodeToolbarProps> = ({ onCopy, onEdit, onDelete, children, ...props }) => {
+const NodeDatahubToolbar: FC<NodeToolbarProps> = ({ onCopy, onEdit, onDelete, children, selectedNode, ...props }) => {
   const { t } = useTranslation('datahub')
-  const { isNodeEditable } = usePolicyGuards(props.selectedNode)
+  const { isNodeEditable } = usePolicyGuards(selectedNode)
 
   return (
     <>

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/toolbar/ToolbarPublish.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/toolbar/ToolbarPublish.spec.cy.tsx
@@ -19,8 +19,8 @@ describe('ToolbarPublish', () => {
     cy.get('button').click()
     cy.wait('@getPolicies')
     cy.get('[role="status"] div').should('have.attr', 'data-status', 'error')
-    cy.get('[role="status"] div#toast-1-title').should('have.text', 'Error publishing Data Policy')
-    cy.get('[role="status"] div#toast-1-description').should('have.text', 'Not Found')
+    cy.get('[role="status"] div#toast-publish-error-title').should('have.text', 'Error publishing Data Policy')
+    cy.get('[role="status"] div#toast-publish-error-description').should('have.text', 'Not Found')
   })
 
   it('should handle success', () => {
@@ -31,8 +31,11 @@ describe('ToolbarPublish', () => {
     cy.get('button').click()
     cy.wait('@getPolicies')
     cy.get('[role="status"] div').should('have.attr', 'data-status', 'success')
-    cy.get('[role="status"] div#toast-2-title').should('have.text', 'Data Policy published')
-    cy.get('[role="status"] div#toast-2-description').should('have.text', "We've created a new Data Policy for you.")
+    cy.get('[role="status"] div#toast-publish-success-title').should('have.text', 'Data Policy published')
+    cy.get('[role="status"] div#toast-publish-success-description').should(
+      'have.text',
+      "We've created a new Data Policy for you."
+    )
   })
 
   it('should be accessible', () => {

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/toolbar/ToolbarPublish.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/toolbar/ToolbarPublish.tsx
@@ -70,6 +70,7 @@ export const ToolbarPublish: FC = () => {
       title: t('publish.internal.title', { source: selectedNode?.type }),
       description: message,
       status: 'error',
+      id: 'publish-internal',
     })
   }
 
@@ -81,6 +82,7 @@ export const ToolbarPublish: FC = () => {
           title: t('publish.success.title', { source: type || selectedNode?.type }),
           description: t('publish.success.description', { source: type || selectedNode?.type, context: status }),
           status: 'success',
+          id: 'publish-success',
         })
       })
       .catch((error) => {
@@ -92,6 +94,7 @@ export const ToolbarPublish: FC = () => {
           title: t('publish.error.title', { source: type || selectedNode?.type }),
           description: message,
           status: 'error',
+          id: 'publish-error',
         })
       })
     return promise
@@ -196,6 +199,7 @@ export const ToolbarPublish: FC = () => {
           title: t('publish.error.title', { source: DataHubNodeType.DATA_POLICY }),
           description: message.toString(),
           status: 'error',
+          id: 'publish-runtime-error',
         })
       })
   }

--- a/hivemq-edge/src/frontend/src/extensions/datahub/locales/en/datahub.json
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/locales/en/datahub.json
@@ -15,7 +15,7 @@
     "description": "The Data Hub on Edge provides mechanisms to define how MQTT data and MQTT client behavior are handled from the adaptors to the HiveMQ broker"
   },
   "policy": {
-    "type_CREATE_POLICY": "Draft",
+    "type_CREATE_POLICY": "No type",
     "type_DATA_POLICY": "Data Policy",
     "type_BEHAVIOR_POLICY": "Behavior Policy",
     "unnamed": "Unnamed policy"

--- a/hivemq-edge/src/frontend/src/extensions/datahub/locales/en/datahub.json
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/locales/en/datahub.json
@@ -321,6 +321,22 @@
       }
     }
   },
+  "publish": {
+    "internal": {
+      "title": "Internal error publishing $t(datahub:workspace.nodes.type, { 'context': '{{source}}' })"
+    },
+    "success": {
+      "title": "$t(datahub:workspace.nodes.type, { 'context': '{{source}}' }) published",
+      "description_DRAFT": "We've created a new $t(datahub:workspace.nodes.type, { 'context': '{{source}}' }) for you.",
+      "description_MODIFIED": "We've updated the $t(datahub:workspace.nodes.type, { 'context': '{{source}}' }) for you."
+    },
+    "error": {
+      "title": "Error publishing $t(datahub:workspace.nodes.type, { 'context': '{{source}}' })"
+    },
+    "title111": "$t(datahub:workspace.nodes.type, { 'context': '{{source}}' }) published",
+    "description1111": "We've created a new $t(datahub:workspace.nodes.type, { 'context': '{{source}}' }) for you.",
+    "error1111": "Error publishing $t(datahub:workspace.nodes.type, { 'context': '{{source}}' })"
+  },
   "error": {
     "validation": {
       "noNode": "Node is unknown",
@@ -368,11 +384,6 @@
       "notValidated": "The $t(datahub:workspace.nodes.type, { 'context': '{{source}}' }) is not properly configured: {{ error }}",
       "internal": "Encountered an error while processing $t(datahub:workspace.nodes.type, { 'context': '{{source}}' }): {{ error }}"
     },
-    "publish": {
-      "title": "$t(datahub:workspace.nodes.type, { 'context': '{{source}}' }) published",
-      "description": "We've created a new $t(datahub:workspace.nodes.type, { 'context': '{{source}}' }) for you.",
-      "error": "Error publishing $t(datahub:workspace.nodes.type, { 'context': '{{source}}' })"
-    },
     "load": {
       "title": "$t(datahub:workspace.nodes.type, { 'context': '{{source}}' }) published",
       "description": "We've created a new $t(datahub:workspace.nodes.type, { 'context': '{{source}}' }) for you.",
@@ -395,6 +406,11 @@
     "elementNotDefined": {
       "title": "Error loading the node",
       "description": "The $t(datahub:workspace.nodes.type, { 'context': '{{nodeType}}' }) is not a valid element"
+    },
+    "validityReport": {
+      "motFound": "Cannot access the validity report",
+      "notValid": "The validity report cannot be parsed successfully",
+      "noContext": "The nature of the modifications cannot be safely determined"
     }
   },
   "shortcuts": {

--- a/hivemq-edge/src/frontend/src/extensions/datahub/locales/en/datahub.json
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/locales/en/datahub.json
@@ -15,7 +15,7 @@
     "description": "The Data Hub on Edge provides mechanisms to define how MQTT data and MQTT client behavior are handled from the adaptors to the HiveMQ broker"
   },
   "policy": {
-    "type_CREATE_POLICY": "No type selected",
+    "type_CREATE_POLICY": "Draft",
     "type_DATA_POLICY": "Data Policy",
     "type_BEHAVIOR_POLICY": "Behavior Policy",
     "unnamed": "Unnamed policy"

--- a/hivemq-edge/src/frontend/src/modules/Theme/globals/react-flow.ts
+++ b/hivemq-edge/src/frontend/src/modules/Theme/globals/react-flow.ts
@@ -9,7 +9,7 @@ export const reactFlow: SystemStyleObject = {
 
   '.react-flow__handle-connecting': {
     '&.react-flow__handle-valid': {
-      'box-shadow': '0 0 10px 2px rgb(88 144 255 / 75%), 0 1px 1px rgb(0 0 0 / 15%);',
+      boxShadow: '0 0 10px 2px rgb(88 144 255 / 75%), 0 1px 1px rgb(0 0 0 / 15%);',
     },
     '&:not(.react-flow__handle-valid)': {
       cursor: 'no-drop',


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/29524/details/

This PR fixes the publishing process of a policy by allowing users to modify a published policy.

In the previous releases, policies could only be created once, as the "modify" part of the process had never been implemented. 

The constraints on policies, both `Data` and `Behaviour` remain the same
- the policy node itself cannot be modified (in practice, its 'id`)
- the triggers (topic filter and client filter) cannot be modified
- Modifying an existing resource creates a new one (new version)

### Out-of-scope
- Multiple resources are not properly published, see https://hivemq.kanbanize.com/ctrl_board/57/cards/29734/details/
- Persistence of the policy layout is not yet supported, see https://hivemq.kanbanize.com/ctrl_board/57/cards/29735/details/

### Before 
![screenshot-localhost_3000-2025_01_27-11_00_20](https://github.com/user-attachments/assets/ea1dfedb-14b0-413d-bc6b-edb3337c56e4)

### After
![screenshot-localhost_3000-2025_01_27-11_00_54](https://github.com/user-attachments/assets/8b120d49-a710-4afa-bc6b-e35e41f31e32)
