### PR TITLE
fix(29608): Fix the display of resource version

### DIFF
--- a/hivemq-edge/src/frontend/src/extensions/datahub/utils/node.utils.spec.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/utils/node.utils.spec.ts
@@ -25,7 +25,6 @@ import {
   DesignerStatus,
   OperationData,
   ResourceWorkingVersion,
-  ResourceStatus,
   SchemaType,
   StrategyType,
   TransitionData,
@@ -666,7 +665,7 @@ describe('getConnectedNodeFrom', () => {
 
 interface ResourceNameTest {
   name?: string
-  version?: ResourceStatus.DRAFT | number | ResourceStatus.MODIFIED
+  version?: number
   result: string
 }
 
@@ -686,8 +685,13 @@ const resourceNameTestSuite: ResourceNameTest[] = [
   },
   {
     name: 'test',
-    version: ResourceStatus.DRAFT,
+    version: ResourceWorkingVersion.DRAFT,
     result: 'test:DRAFT',
+  },
+  {
+    name: 'test',
+    version: ResourceWorkingVersion.MODIFIED,
+    result: 'test:MODIFIED',
   },
 ]
 

--- a/hivemq-edge/src/frontend/src/extensions/datahub/utils/node.utils.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/utils/node.utils.ts
@@ -32,7 +32,6 @@ import {
   TransitionData,
 } from '../types.ts'
 import { DataPolicyValidator } from '@/api/__generated__'
-import { enumFromStringValue } from '@/utils/types.utils.ts'
 import { CustomNodeJSONSchema } from '@datahub/config/schemas.config.ts'
 import { PolicyCheckErrors } from '@datahub/designer/validation.errors.ts'
 
@@ -374,15 +373,18 @@ export const isNodeHandleConnectable = (handle: ConnectableHandleProps, node: No
   return handle.isConnectable
 }
 
-export const renderResourceName = (
-  name: string | undefined,
-  version: ResourceStatus.DRAFT | number | ResourceStatus.MODIFIED | undefined,
-  t: TFunction
-) => {
+export const renderResourceName = (name: string | undefined, version: number | undefined, t: TFunction) => {
   if (!name || !version) return t('error.noSet.select', { ns: 'datahub' })
 
-  const isDraft = enumFromStringValue(ResourceStatus, version.toString())
-  const formatedVersion = !isDraft ? version : t('workspace.nodes.status', { context: version, ns: 'datahub' })
+  const getResourceNormalisedVersion = (version: number, t: TFunction) => {
+    if (version === ResourceWorkingVersion.DRAFT)
+      return t('workspace.nodes.status', { context: ResourceStatus.DRAFT, ns: 'datahub' })
+    if (version === ResourceWorkingVersion.MODIFIED)
+      return t('workspace.nodes.status', { context: ResourceStatus.MODIFIED, ns: 'datahub' })
+    return version
+  }
+
+  const formatedVersion = getResourceNormalisedVersion(version, t)
 
   return `${name}:${formatedVersion}`
 }


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/29608/details/

The PR fixes the display of the resource's version in the Designer. The version number will be shown, `DRAFT` for a new resource and `MODIFIED` for a new version of an existing resource. The fix applies to both `Schema` and `Function`.

For compatibility purposes, the non-published version of a resource is internally identified by a number (9 ** 9 for DRAFT, incremented for MODIFIED). These fake numbers are unlikely to be reached by the `Data Hub`c version increment. But they should not be displayed as such 

### Out-of-scope
- There is a bug loading a new version, where `latest` is not found (nor the list of the different versions). It will be fixed in another ticket.

### Before 
![screenshot-localhost_3000-2025_01_27-11_37_00](https://github.com/user-attachments/assets/a424d1f6-f2fe-4602-9649-12705cb288ac)

### After
![screenshot-localhost_3000-2025_01_27-11_11_14](https://github.com/user-attachments/assets/ca7dc45c-2454-475a-ad7a-397e80512b52)
![screenshot-localhost_3000-2025_01_27-11_11_36](https://github.com/user-attachments/assets/1f07b50b-278b-40b3-84b4-7e3dabd67971)
![screenshot-localhost_3000-2025_01_27-11_12_29](https://github.com/user-attachments/assets/13d0d39c-9cc2-4fe7-ae87-0abba91a27be)
![screenshot-localhost_3000-2025_01_27-11_19_42](https://github.com/user-attachments/assets/296527ce-b4ed-4750-97b2-2fc778fbffb4)
