### PR TITLE
fix(29845): A handful of UI improvements

### DIFF
--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/DesignerToolbox.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/DesignerToolbox.tsx
@@ -28,7 +28,7 @@ const DesignerToolbox: FC = () => {
 
   return (
     <Panel position="top-left">
-      <HStack role="group" aria-label={t('workspace.toolbars.draft.aria-label')}>
+      <HStack role="group" aria-label={t('workspace.toolbars.draft.aria-label')} p={1}>
         <Popover>
           {({ isOpen }) => (
             <>

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/helpers/DraftStatus.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/helpers/DraftStatus.spec.cy.tsx
@@ -8,7 +8,7 @@ describe('DraftStatus', () => {
   it('should render', () => {
     cy.mountWithProviders(<DraftStatus />)
 
-    cy.getByTestId('status-container-type').should('contain.text', 'No type')
+    cy.getByTestId('status-container-type').should('contain.text', 'Active draft')
     cy.getByTestId('status-container-name').should('contain.text', 'Unnamed policy')
     cy.getByTestId('status-container-status').should('contain.text', 'Draft')
 

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/toolbar/ToolbarShowReport.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/toolbar/ToolbarShowReport.spec.cy.tsx
@@ -8,14 +8,14 @@ describe('ToolbarShowReport', () => {
 
   it('should render without report', () => {
     cy.mountWithProviders(<ToolbarShowReport />, { wrapper: getPolicyPublishWrapper() })
-    cy.get('button').should('have.attr', 'aria-label', 'Show Validity Report').should('be.disabled')
+    cy.get('button').should('have.text', 'Show Report').should('be.disabled')
   })
 
   it('should render with report', () => {
     cy.mountWithProviders(<ToolbarShowReport />, {
       wrapper: getPolicyPublishWrapper([{ node: MOCK_NODE_DATA_POLICY }]),
     })
-    cy.get('button').should('have.attr', 'aria-label', 'Show Validity Report').should('not.be.disabled')
+    cy.get('button').should('have.text', 'Show Report').should('not.be.disabled')
     cy.getByTestId('test-dashboard').should('have.text', '/')
     cy.get('button').click()
     cy.getByTestId('test-dashboard').should('have.text', '/validation/')

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/toolbar/ToolbarShowReport.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/toolbar/ToolbarShowReport.tsx
@@ -1,10 +1,8 @@
 import type { FC } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useLocation, useNavigate } from 'react-router-dom'
-import { Icon } from '@chakra-ui/react'
+import { Button, Icon } from '@chakra-ui/react'
 import { RiPassportLine } from 'react-icons/ri'
-
-import IconButton from '@/components/Chakra/IconButton.tsx'
 
 import { usePolicyChecksStore } from '@datahub/hooks/usePolicyChecksStore.ts'
 
@@ -15,12 +13,13 @@ export const ToolbarShowReport: FC = () => {
   const { pathname } = useLocation()
 
   return (
-    <IconButton
-      icon={<Icon as={RiPassportLine} boxSize="24px" />}
+    <Button
+      leftIcon={<Icon as={RiPassportLine} boxSize="24px" />}
       data-testid="toolbox-policy-report"
-      aria-label={t('workspace.toolbar.policy.showReport')}
       isDisabled={!report}
       onClick={() => navigate('validation/', { state: { origin: pathname } })}
-    />
+    >
+      {t('workspace.toolbar.policy.showReport')}
+    </Button>
   )
 }

--- a/hivemq-edge/src/frontend/src/extensions/datahub/locales/en/datahub.json
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/locales/en/datahub.json
@@ -15,7 +15,7 @@
     "description": "HiveMQ Data Hub on Edge provides mechanisms to define how the HiveMQ Edge MQTT broker handles MQTT data, MQTT client behavior, and data from the protocol adaptors."
   },
   "policy": {
-    "type_CREATE_POLICY": "No type",
+    "type_CREATE_POLICY": "Active draft",
     "type_DATA_POLICY": "Data Policy",
     "type_BEHAVIOR_POLICY": "Behavior Policy",
     "unnamed": "Unnamed policy"
@@ -259,7 +259,7 @@
       "policy": {
         "check": "Check",
         "publish": "Publish",
-        "showReport": "Show Validity Report",
+        "showReport": "Show Report",
         "clearReport": "Clear Validity Report",
         "delete": "Delete Policy"
       }


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/29845/details/

The PR fixes several small UI glitches on the `Data Hub Designer`

- The label for the "canvas draft" has been changed, to highlight the difference with the bona fide policies in the table
- The publish toolbar has full-text button for all operations: `check`, `show report` and `publish`
- A margin has been added to the top-left toolbar


### Before

### After
![screenshot-localhost_3000-2025_01_28-14_10_09](https://github.com/user-attachments/assets/4233d84e-9379-4742-9fab-a602190b0c05)

![screenshot-localhost_3000-2025_01_28-14_10_36](https://github.com/user-attachments/assets/136c99c5-4549-49f8-83e6-e9a5f7b3803c)

