### PR TITLE
Add a capability to indicate whether config can be written back. Adjust endpoints accordingly

### DIFF
--- a/hivemq-edge/src/main/java/com/hivemq/HiveMQEdgeBootstrap.java
+++ b/hivemq-edge/src/main/java/com/hivemq/HiveMQEdgeBootstrap.java
@@ -17,6 +17,7 @@ package com.hivemq;
 
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.base.Preconditions;
+import com.hivemq.api.model.capabilities.Capability;
 import com.hivemq.api.resources.GenericAPIHolder;
 import com.hivemq.bootstrap.HiveMQExceptionHandlerBootstrap;
 import com.hivemq.bootstrap.LoggingBootstrap;
@@ -95,6 +96,11 @@ public class HiveMQEdgeBootstrap {
     public @NotNull Injector bootstrap() throws HiveMQEdgeStartupException {
         metricRegistry.addListener(new MetricRegistryLogger());
 
+        if(systemInformation.isConfigWriteable()) {
+            capabilityService.addCapability(new Capability("config-writeable",
+                    "Config can be manipulated via the REST API",
+                    "Changes to the configuration made via the REST API are persisted back into the config.xml."));
+        }
         LoggingBootstrap.prepareLogging();
 
         // Embedded has already called init as it is required to read the config file.

--- a/hivemq-edge/src/main/java/com/hivemq/api/errors/ConfigWritingDisabled.java
+++ b/hivemq-edge/src/main/java/com/hivemq/api/errors/ConfigWritingDisabled.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.api.errors;
+
+import com.hivemq.http.HttpStatus;
+import com.hivemq.http.error.Error;
+import com.hivemq.http.error.ProblemDetails;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+
+public class ConfigWritingDisabled extends ProblemDetails {
+    public ConfigWritingDisabled() {
+        super(
+                "ConfigWritingDisabledError",
+                "Config writing is disabled",
+                "Modifying the config via the API has been disabled.",
+                HttpStatus.FORBIDDEN_403,
+                List.of());
+    }
+}

--- a/hivemq-edge/src/main/java/com/hivemq/api/resources/impl/UnsResourceImpl.java
+++ b/hivemq-edge/src/main/java/com/hivemq/api/resources/impl/UnsResourceImpl.java
@@ -16,10 +16,12 @@
 package com.hivemq.api.resources.impl;
 
 import com.hivemq.api.AbstractApi;
+import com.hivemq.api.errors.ConfigWritingDisabled;
 import com.hivemq.api.errors.ValidationError;
 import com.hivemq.api.model.ApiErrorMessages;
 import com.hivemq.api.utils.ApiErrorUtils;
 import com.hivemq.api.utils.ApiValidation;
+import com.hivemq.configuration.info.SystemInformation;
 import com.hivemq.edge.api.UnsApi;
 import com.hivemq.edge.api.model.ISA95ApiBean;
 import com.hivemq.uns.UnifiedNamespaceService;
@@ -36,11 +38,14 @@ import javax.ws.rs.core.Response;
 public class UnsResourceImpl extends AbstractApi implements UnsApi {
 
     private final @NotNull UnifiedNamespaceService unifiedNamespaceService;
+    private final @NotNull SystemInformation systemInformation;
 
     @Inject
     public UnsResourceImpl(
-            final @NotNull UnifiedNamespaceService unifiedNamespaceService) {
+            final @NotNull UnifiedNamespaceService unifiedNamespaceService,
+            final @NotNull SystemInformation systemInformation) {
         this.unifiedNamespaceService = unifiedNamespaceService;
+        this.systemInformation = systemInformation;
     }
 
     @Override
@@ -52,6 +57,9 @@ public class UnsResourceImpl extends AbstractApi implements UnsApi {
 
     @Override
     public @NotNull Response setIsa95(final @NotNull ISA95ApiBean isa95) {
+        if (!systemInformation.isConfigWriteable()) {
+            return ErrorResponseUtil.errorResponse(new ConfigWritingDisabled());
+        }
 
         final ApiErrorMessages errorMessages = ApiErrorUtils.createErrorContainer();
 

--- a/hivemq-edge/src/main/java/com/hivemq/configuration/EnvironmentVariables.java
+++ b/hivemq-edge/src/main/java/com/hivemq/configuration/EnvironmentVariables.java
@@ -49,6 +49,11 @@ public class EnvironmentVariables {
     public static final String CONFIG_REFRESH_INTERVAL = "HIVEMQ_CONFIG_REFRESHINTERVAL";
 
     /**
+     * Name of the environment variable for indicating a writeable config
+     */
+    public static final String CONFIG_WRITEABLE = "HIVEMQ_CONFIG_WRITEABLE";
+
+    /**
      * Name of the environment variable for configuring the data folder.
      */
     public static final String DATA_FOLDER = "HIVEMQ_DATA_FOLDER";

--- a/hivemq-edge/src/main/java/com/hivemq/configuration/SystemProperties.java
+++ b/hivemq-edge/src/main/java/com/hivemq/configuration/SystemProperties.java
@@ -26,6 +26,7 @@ public class SystemProperties {
 
     public static final String CONFIG_FOLDER = "hivemq.config.folder";
     public static final String CONFIG_REFRESH_INTERVAL = "hivemq.config.refreshinterval";
+    public static final String CONFIG_WRITEABLE = "hivemq.config.writeable";
     public static final String LICENSE_FOLDER = "hivemq.license.folder";
 
     public static final String DATA_FOLDER = "hivemq.data.folder";

--- a/hivemq-edge/src/main/java/com/hivemq/configuration/info/SystemInformation.java
+++ b/hivemq-edge/src/main/java/com/hivemq/configuration/info/SystemInformation.java
@@ -103,4 +103,10 @@ public interface SystemInformation {
      */
     long configRefreshIntervalInMs();
 
+    /**
+     * Indicates whether the config can be written
+     *
+     * @return false if the config can't be written.
+     */
+    boolean isConfigWriteable();
 }

--- a/hivemq-edge/src/main/java/com/hivemq/configuration/info/SystemInformationImpl.java
+++ b/hivemq-edge/src/main/java/com/hivemq/configuration/info/SystemInformationImpl.java
@@ -56,6 +56,8 @@ public class SystemInformationImpl implements SystemInformation {
 
     private final boolean usePathOfRunningJar;
 
+    private final boolean configWriteable;
+
     public SystemInformationImpl() {
         this(false);
     }
@@ -73,6 +75,7 @@ public class SystemInformationImpl implements SystemInformation {
             final @Nullable File modulesFolder,
             final @Nullable File licenseFolder) {
         final String refreshInterval = getSystemPropertyOrEnvironmentVariable(SystemProperties.CONFIG_REFRESH_INTERVAL, EnvironmentVariables.CONFIG_REFRESH_INTERVAL);
+        final String configWriteable = getSystemPropertyOrEnvironmentVariable(SystemProperties.CONFIG_WRITEABLE, EnvironmentVariables.CONFIG_WRITEABLE);
         this.usePathOfRunningJar = usePathOfRunningJar;
         this.embedded = embedded;
         this.configFolder = configFolder;
@@ -82,6 +85,7 @@ public class SystemInformationImpl implements SystemInformation {
         this.licenseFolder = licenseFolder;
         this.runningSince = System.currentTimeMillis();
         this.configRefreshIntervalInMs = Long.parseLong(Objects.requireNonNullElse(refreshInterval, "-1"));
+        this.configWriteable = Boolean.parseBoolean((configWriteable == null || configWriteable.isEmpty()) ? "true" : configWriteable );
         processorCount = getPhysicalProcessorCount();
     }
 
@@ -331,5 +335,8 @@ public class SystemInformationImpl implements SystemInformation {
         return embedded;
     }
 
-
+    @Override
+    public boolean isConfigWriteable() {
+        return configWriteable;
+    }
 }

--- a/hivemq-edge/src/test/java/com/hivemq/api/resources/impl/ProtocolAdaptersResourceImplTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/api/resources/impl/ProtocolAdaptersResourceImplTest.java
@@ -30,6 +30,7 @@ import com.hivemq.protocols.InternalProtocolAdapterWritingService;
 import com.hivemq.protocols.ProtocolAdapterConfigConverter;
 import com.hivemq.protocols.ProtocolAdapterManager;
 import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import javax.ws.rs.core.Response;
@@ -70,6 +71,11 @@ class ProtocolAdaptersResourceImplTest {
                     configConverter,
                     topicFilterPersistence,
                     systemInformation);
+
+    @BeforeEach
+    public void setUp() {
+        when(systemInformation.isConfigWriteable()).thenReturn(true);
+    }
 
     @Test
     void getDomainTagsForAdapter() {

--- a/hivemq-edge/src/test/java/com/hivemq/api/resources/impl/ProtocolAdaptersResourceImplTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/api/resources/impl/ProtocolAdaptersResourceImplTest.java
@@ -16,6 +16,7 @@
 package com.hivemq.api.resources.impl;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hivemq.configuration.info.SystemInformation;
 import com.hivemq.configuration.service.ConfigurationService;
 import com.hivemq.edge.HiveMQEdgeRemoteService;
 import com.hivemq.edge.VersionProvider;
@@ -56,6 +57,7 @@ class ProtocolAdaptersResourceImplTest {
     private final @NotNull VersionProvider versionProvider = mock();
     private final @NotNull ProtocolAdapterConfigConverter configConverter = mock();
     private final @NotNull TopicFilterPersistence topicFilterPersistence = mock();
+    private final @NotNull SystemInformation systemInformation = mock();
 
 
     private final ProtocolAdaptersResourceImpl protocolAdaptersResource =
@@ -66,7 +68,8 @@ class ProtocolAdaptersResourceImplTest {
                     objectMapper,
                     versionProvider,
                     configConverter,
-                    topicFilterPersistence);
+                    topicFilterPersistence,
+                    systemInformation);
 
     @Test
     void getDomainTagsForAdapter() {


### PR DESCRIPTION
**Motivation**

Resolves #29317

**Changes**
- Add config-writeable
- Enable capability via property hivemq.config.writeable or env HIVEMQ_CONFIG_WRITEABLE (enabled if both are absent
- Have all writing endpoints return a 403 with ConfigWritingDisabled as the body when writing id disabled