### PR TITLE
fix(29918): clear toast before publishing again

### DIFF
--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/toolbar/ToolbarPublish.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/toolbar/ToolbarPublish.tsx
@@ -175,6 +175,7 @@ export const ToolbarPublish: FC = () => {
 
   const handlePublish = () => {
     if (!report) return toastInternalError(t('error.validityReport.motFound'))
+    toast.closeAll()
 
     const payload = [...report].pop()
     if (!payload) return toastInternalError(t('error.validityReport.notValid'))


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/29918/details/

The PR introduces a hack aiming at avoiding duplication ot toast with the same `id` (with the effect that they cannot be dismissed)

### Out-of-scope
- A better approach will be to disable the "publish" button until the toasts are cleared by a timeout or when the problems flagged up by the error toasts are resolved. The latter solution is implied with the delivery of a "validity report" but requires tighter integration with the REST API request. It might be done in a further ticket
- The `id` created for the toasts assumes a single instance (otherwise they face a duplicated key error). A bug is currently preventing resources from generating their own toast so that assumption is still holding. This bug will be fixed in a subsequent ticket.

### Before
![screenshot-localhost_3000-2025_01_29-14_39_55](https://github.com/user-attachments/assets/f07557bd-820f-49c5-86ac-c02367de2231)

### After
![screenshot-localhost_3000-2025_01_29-13_52_20](https://github.com/user-attachments/assets/9dd71037-f4fc-4fc0-9d33-e8efc2c31f0c)
