### PR TITLE
Changed access rights for dirs and scripts so they can be used with changing user ids

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -171,9 +171,9 @@ oci {
             layer("hivemq") {
                 contents {
                     into("opt") {
-                        filePermissions = 0b110_110_000
-                        directoryPermissions = 0b111_111_000
-                        permissions("**/*.sh", 0b111_111_000)
+                        filePermissions = 0b110_110_110
+                        directoryPermissions = 0b111_111_111
+                        permissions("**/*.sh", 0b111_111_111)
                         from("docker/docker-entrypoint.sh")
                         into("hivemq") {
                             from("./hivemq-edge/src/distribution") { filter { exclude("**/.gitkeep") } }
@@ -195,8 +195,8 @@ oci {
             layer("open-source-modules") {
                 contents {
                     into("opt") {
-                        filePermissions = 0b110_110_000
-                        directoryPermissions = 0b111_111_000
+                        filePermissions = 0b110_110_110
+                        directoryPermissions = 0b111_111_111
                         into("hivemq/modules") {
                             // copy OSS modules
                             from(openSourceEdgeModuleBinaries.elements)

--- a/docker/config-k8s.xml
+++ b/docker/config-k8s.xml
@@ -71,6 +71,15 @@
             </https-listener>
             ${IF:HIVEMQ_HTTPS_ENABLED}
         </listeners>
+        <users>
+            <user>
+                <username>${ENV:HIVEMQ_ADMIN_USER}</username>
+                <password>${ENV:HIVEMQ_ADMIN_PASSWORD}</password>
+                <roles>
+                    <role>admin</role>
+                </roles>
+            </user>
+        </users>
     </admin-api>
     <persistence>
         <mode>${ENV:HIVEMQ_PERSISTENCE_MODE}</mode>


### PR DESCRIPTION
**Motivation**

Resolves #30295

For pod securityContexts we must allow the container to work with differing users being used than the one defined in the container.

**Changes**
- Allow others (as in ugo) to run the shell scripts, access all required directories and write to hivemq home

