### PR TITLE
feat(30678): Add support for schema fetching on the sources

### DIFF
--- a/hivemq-edge/src/frontend/src/api/hooks/useDomainModel/useGetCombinedDataSchemas.spec.ts
+++ b/hivemq-edge/src/frontend/src/api/hooks/useDomainModel/useGetCombinedDataSchemas.spec.ts
@@ -1,0 +1,47 @@
+import { beforeEach, expect } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+
+import { server } from '@/__test-utils__/msw/mockServer.ts'
+import { SimpleWrapper as wrapper } from '@/__test-utils__/hooks/SimpleWrapper.tsx'
+
+import type { JsonNode } from '@/api/__generated__'
+
+import { DataReferenceType, useGetCombinedDataSchemas } from './useGetCombinedDataSchemas'
+import { mappingHandlers } from '../useProtocolAdapters/__handlers__/mapping.mocks'
+import { handlers } from '../useTopicFilters/__handlers__'
+
+const mockFFF = [
+  {
+    id: 'my-tag',
+    adapterId: 'string',
+    type: DataReferenceType.TAG,
+  },
+  {
+    id: 'a/topic/+/filter',
+    type: DataReferenceType.TOPIC_FILTER,
+  },
+]
+
+describe('useGetCombinedDataSchemas', () => {
+  beforeEach(() => {
+    // server.use(...handlers)
+    server.use(...mappingHandlers, ...handlers)
+  })
+
+  afterEach(() => {
+    server.resetHandlers()
+  })
+
+  it('should load the data', async () => {
+    const { result } = renderHook(() => useGetCombinedDataSchemas(mockFFF), { wrapper })
+    await waitFor(() => {
+      expect(result.current).not.toBeUndefined()
+      expect(result.current.every((e) => e.isLoading)).toBeFalsy()
+    })
+    expect(result.current[0].data).toStrictEqual<JsonNode>(
+      expect.objectContaining({ description: 'A simple form example.', title: 'my-tag', type: 'object' })
+    )
+
+    expect(result.current[1].data).not.toBeUndefined()
+  })
+})

--- a/hivemq-edge/src/frontend/src/api/hooks/useDomainModel/useGetCombinedDataSchemas.ts
+++ b/hivemq-edge/src/frontend/src/api/hooks/useDomainModel/useGetCombinedDataSchemas.ts
@@ -1,0 +1,44 @@
+import { useQueries } from '@tanstack/react-query'
+
+import { QUERY_KEYS } from '@/api/utils.ts'
+import { useHttpClient } from '@/api/hooks/useHttpClient/useHttpClient.ts'
+import type { SchemaHandler } from '@/modules/TopicFilters/utils/topic-filter.schema'
+
+export enum DataReferenceType {
+  TAG = 'TAG',
+  TOPIC_FILTER = 'TOPIC_FILTER',
+}
+
+export type DataReference = {
+  id: string
+  type: DataReferenceType
+  adapterId?: string
+  schema?: SchemaHandler
+}
+
+export const useGetCombinedDataSchemas = (dataIdentifiers: DataReference[]) => {
+  const appClient = useHttpClient()
+
+  return useQueries({
+    queries: dataIdentifiers.map((dataPoint) => {
+      return dataPoint.type === DataReferenceType.TAG
+        ? {
+            queryKey: [QUERY_KEYS.ADAPTERS, dataPoint.adapterId, QUERY_KEYS.DISCOVERY_TAGS, dataPoint.id],
+            queryFn: () =>
+              appClient.protocolAdapters.getWritingSchema(
+                dataPoint.adapterId as string,
+                encodeURIComponent(dataPoint.id)
+              ),
+          }
+        : {
+            // TODO[NVL] Certainly a hack: returns topic filters. Bridges are not supported yet
+            queryKey: [QUERY_KEYS.DISCOVERY_TOPIC_FILTERS, dataPoint.id, QUERY_KEYS.DISCOVERY_SCHEMAS],
+            queryFn: async () => {
+              const { items } = await appClient.topicFilters.getTopicFilters()
+              // TODO[NVL] Definitely a hack
+              return items.find((e) => e.topicFilter === dataPoint.id)?.schema
+            },
+          }
+    }),
+  })
+}

--- a/hivemq-edge/src/frontend/src/api/hooks/useDomainModel/useGetCombinedDataSchemas.ts
+++ b/hivemq-edge/src/frontend/src/api/hooks/useDomainModel/useGetCombinedDataSchemas.ts
@@ -35,7 +35,7 @@ export const useGetCombinedDataSchemas = (dataIdentifiers: DataReference[]) => {
             queryKey: [QUERY_KEYS.DISCOVERY_TOPIC_FILTERS, dataPoint.id, QUERY_KEYS.DISCOVERY_SCHEMAS],
             queryFn: async () => {
               const { items } = await appClient.topicFilters.getTopicFilters()
-              // TODO[NVL] Definitely a hack
+              // TODO[NVL] Definitely a hack; cannot return undefined
               return items.find((e) => e.topicFilter === dataPoint.id)?.schema
             },
           }

--- a/hivemq-edge/src/frontend/src/api/hooks/useDomainModel/useGetCombinedEntities.spec.ts
+++ b/hivemq-edge/src/frontend/src/api/hooks/useDomainModel/useGetCombinedEntities.spec.ts
@@ -1,0 +1,69 @@
+import { beforeEach, expect } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+
+import { server } from '@/__test-utils__/msw/mockServer.ts'
+import { SimpleWrapper as wrapper } from '@/__test-utils__/hooks/SimpleWrapper.tsx'
+
+import { type DomainTagList, EntityType, type TopicFilterList } from '@/api/__generated__'
+import type { EntityReference } from '@/api/__generated__'
+import { deviceHandlers } from '@/api/hooks/useProtocolAdapters/__handlers__'
+import { handlers, MOCK_TOPIC_FILTER_SCHEMA_VALID } from '@/api/hooks/useTopicFilters/__handlers__'
+import { useGetCombinedEntities } from './useGetCombinedEntities'
+
+const mockEntityReferences: EntityReference[] = [
+  {
+    id: 'opcua',
+    type: EntityType.ADAPTER,
+  },
+  {
+    id: 'a/topic/+/filter',
+    type: EntityType.BRIDGE,
+  },
+]
+
+describe('useGetCombinedEntities', () => {
+  beforeEach(() => {
+    // server.use(...handlers)
+    server.use(...deviceHandlers, ...handlers)
+  })
+
+  afterEach(() => {
+    server.resetHandlers()
+  })
+
+  it('should load the data', async () => {
+    const { result } = renderHook(() => useGetCombinedEntities(mockEntityReferences), { wrapper })
+    await waitFor(() => {
+      expect(result.current).not.toBeUndefined()
+      expect(result.current.every((e) => e.isLoading)).toBeFalsy()
+    })
+    expect(result.current.length).toEqual(2)
+
+    expect(result.current[0].data).toStrictEqual<DomainTagList>({
+      items: [
+        {
+          definition: {
+            node: 'ns=3;i=1002',
+          },
+          name: 'opcua/power/off',
+        },
+        {
+          definition: {
+            node: 'ns=3;i=1008',
+          },
+          name: 'opcua/log/event',
+        },
+      ],
+    })
+
+    expect(result.current[1].data).toStrictEqual<TopicFilterList>({
+      items: [
+        {
+          description: 'This is a topic filter',
+          schema: MOCK_TOPIC_FILTER_SCHEMA_VALID,
+          topicFilter: 'a/topic/+/filter',
+        },
+      ],
+    })
+  })
+})

--- a/hivemq-edge/src/frontend/src/modules/Mappings/CombinerMappingManager.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/CombinerMappingManager.tsx
@@ -23,18 +23,19 @@ import {
 
 import config from '@/config'
 
+import type { CombinerContext } from './types'
 import { MappingType } from './types'
 import type { Combiner } from '@/api/__generated__'
 import { combinerMappingJsonSchema } from '@/api/schemas/combiner-mapping.json-schema'
 import { combinerMappingUiSchema } from '@/api/schemas/combiner-mapping.ui-schema'
 import { useUpdateCombiner } from '@/api/hooks/useCombiners/useUpdateCombiner'
+import { useGetCombinedEntities } from '@/api/hooks/useDomainModel/useGetCombinedEntities'
 import DrawerExpandButton from '@/components/Chakra/DrawerExpandButton.tsx'
 import ChakraRJSForm from '@/components/rjsf/Form/ChakraRJSForm'
 import ErrorMessage from '@/components/ErrorMessage'
 import type { NodeTypes } from '@/modules/Workspace/types.ts'
 import useWorkspaceStore from '@/modules/Workspace/hooks/useWorkspaceStore.ts'
 import NodeNameCard from '@/modules/Workspace/components/parts/NodeNameCard.tsx'
-import { useGetCombinedEntities } from '../../api/hooks/useDomainModel/useGetCombinedEntities'
 
 const CombinerMappingManager: FC = () => {
   const { t } = useTranslation()
@@ -111,7 +112,7 @@ const CombinerMappingManager: FC = () => {
               uiSchema={combinerMappingUiSchema}
               formData={selectedNode.data}
               onSubmit={handleOnSubmit}
-              formContext={{ sources: sources }}
+              formContext={{ queries: sources, entities } as CombinerContext}
             />
           )}
         </DrawerBody>

--- a/hivemq-edge/src/frontend/src/modules/Mappings/CombinerMappingManager.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/CombinerMappingManager.tsx
@@ -91,7 +91,7 @@ const CombinerMappingManager: FC = () => {
   return (
     <Drawer isOpen={isOpen} placement="right" size={isExpanded ? 'full' : 'lg'} onClose={handleClose} variant="hivemq">
       <DrawerOverlay />
-      <DrawerContent>
+      <DrawerContent aria-label={t('protocolAdapter.mapping.manager.header', { context: MappingType.COMBINING })}>
         <DrawerCloseButton />
         <DrawerExpandButton isExpanded={isExpanded} toggle={setExpanded.toggle} />
         <DrawerHeader>

--- a/hivemq-edge/src/frontend/src/modules/Mappings/components/combiner/CombinedEntitySelect.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/components/combiner/CombinedEntitySelect.spec.cy.tsx
@@ -36,7 +36,7 @@ const CombinedEntitySelectWrapper: FC<PropsWithChildren<EntityReferenceSelectPro
           tags={tags}
           topicFilters={topicFilters}
           onChange={onChange}
-          optionQueries={sources}
+          formContext={{ queries: sources, entities: mockCombiner.sources.items }}
         />
       </FormControl>
       {children}

--- a/hivemq-edge/src/frontend/src/modules/Mappings/components/combiner/CombinedSchemaLoader.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/components/combiner/CombinedSchemaLoader.spec.cy.tsx
@@ -1,0 +1,50 @@
+import { DataCombining } from '@/api/__generated__'
+import { mockCombinerMapping } from '@/api/hooks/useCombiners/__handlers__'
+import type { CombinerContext } from '@/modules/Mappings/types'
+
+import { CombinedSchemaLoader } from './CombinedSchemaLoader'
+
+const mockFormData: DataCombining = {
+  ...mockCombinerMapping,
+  sources: {
+    primary: '',
+    primaryType: DataCombining.primaryType.TAG,
+    tags: ['test'],
+    topicFilters: ['truc'],
+  },
+}
+
+const mockFormContext: CombinerContext = {
+  queries: [],
+  entities: [],
+}
+
+describe('CombinedSchemaLoader', () => {
+  beforeEach(() => {
+    cy.viewport(800, 800)
+  })
+
+  it('should render warning', () => {
+    cy.mountWithProviders(<CombinedSchemaLoader />)
+
+    cy.get('[role="alert"]')
+      .should('have.attr', 'data-status', 'info')
+      .should('have.text', 'There are no schemas available yet')
+  })
+
+  it('should render properly', () => {
+    cy.mountWithProviders(<CombinedSchemaLoader formData={mockFormData} formContext={mockFormContext} />)
+
+    // TODO[NVL] Need to build a wrapper and generate the mocks
+    cy.get('[role="alert"]')
+      .should('have.attr', 'data-status', 'info')
+      .should('have.text', 'There are no schemas available yet')
+  })
+
+  it('should be accessible', () => {
+    cy.injectAxe()
+    cy.mountWithProviders(<CombinedSchemaLoader />)
+
+    cy.checkAccessibility()
+  })
+})

--- a/hivemq-edge/src/frontend/src/modules/Mappings/components/combiner/CombinedSchemaLoader.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/components/combiner/CombinedSchemaLoader.tsx
@@ -1,5 +1,6 @@
 import { type FC, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
+import { Box, Heading } from '@chakra-ui/react'
 
 import type { DataCombining, DomainTag, TopicFilter } from '@/api/__generated__'
 import type { DataReference } from '@/api/hooks/useDomainModel/useGetCombinedDataSchemas'
@@ -46,7 +47,7 @@ export const CombinedSchemaLoader: FC<CombinedSchemaLoaderProps> = ({ formData, 
     const tags = formData?.sources?.tags || []
     const topicFilters = formData?.sources?.topicFilters || []
     const indexes = [...tags, ...topicFilters]
-    return allDataReferences?.filter((e) => indexes.includes(e.id)) || []
+    return allDataReferences?.filter((dataReference) => indexes.includes(dataReference.id)) || []
   }, [allDataReferences, formData?.sources?.tags, formData?.sources?.topicFilters])
 
   const queries = useGetCombinedDataSchemas(allSchemas)
@@ -54,8 +55,16 @@ export const CombinedSchemaLoader: FC<CombinedSchemaLoaderProps> = ({ formData, 
   const test = useMemo(() => {
     return allSchemas.map((dataReference, index) => {
       const { data } = queries[index]
+
+      // TODO[30744] Type of schema inconsistent between tag and topic filter
       if (typeof data === 'string') {
         dataReference.schema = validateSchemaFromDataURI(data)
+      } else if (typeof data === 'object') {
+        dataReference.schema = {
+          schema: data,
+          status: 'success',
+          message: t('topicFilter.schema.status.success'),
+        }
       } else {
         dataReference.schema = {
           status: 'warning',
@@ -64,16 +73,34 @@ export const CombinedSchemaLoader: FC<CombinedSchemaLoaderProps> = ({ formData, 
       }
       return dataReference
     })
-  }, [allSchemas, queries])
+  }, [allSchemas, queries, t])
 
   if (!test.length) return <ErrorMessage message={t('combiner.error.noSchemaLoadedYet')} status={'info'} />
 
   return (
     <>
-      {test.map((e) => {
-        const schema =
-          e.schema?.status === 'success' && e.schema.schema ? { ...e.schema.schema, title: e.id } : { title: e.id }
-        return <JsonSchemaBrowser key={e.id} schema={schema} isDraggable hasExamples />
+      {test.map((dataReference) => {
+        const hasSchema = dataReference.schema?.status === 'success' && dataReference.schema.schema
+
+        if (!hasSchema) {
+          // TODO[NVL] Duplication; integrate error message into the schema browser
+          return (
+            <Box key={dataReference.id}>
+              <Heading as="h4" size="sm">
+                {dataReference.id}
+              </Heading>
+              <ErrorMessage message={dataReference.schema?.message} status={dataReference.schema?.status} />
+            </Box>
+          )
+        }
+        return (
+          <JsonSchemaBrowser
+            key={dataReference.id}
+            schema={{ ...dataReference.schema?.schema, title: dataReference.id }}
+            isDraggable
+            hasExamples
+          />
+        )
       })}
     </>
   )

--- a/hivemq-edge/src/frontend/src/modules/Mappings/components/combiner/CombinedSchemaLoader.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/components/combiner/CombinedSchemaLoader.tsx
@@ -1,0 +1,80 @@
+import { type FC, useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import type { DataCombining, DomainTag, TopicFilter } from '@/api/__generated__'
+import type { DataReference } from '@/api/hooks/useDomainModel/useGetCombinedDataSchemas'
+import { useGetCombinedDataSchemas } from '@/api/hooks/useDomainModel/useGetCombinedDataSchemas'
+import { DataReferenceType } from '@/api/hooks/useDomainModel/useGetCombinedDataSchemas'
+import ErrorMessage from '@/components/ErrorMessage'
+import JsonSchemaBrowser from '@/components/rjsf/MqttTransformation/JsonSchemaBrowser'
+import type { CombinerContext } from '@/modules/Mappings/types'
+import { validateSchemaFromDataURI } from '@/modules/TopicFilters/utils/topic-filter.schema'
+
+interface CombinedSchemaLoaderProps {
+  formData?: DataCombining
+  formContext?: CombinerContext
+}
+
+export const CombinedSchemaLoader: FC<CombinedSchemaLoaderProps> = ({ formData, formContext }) => {
+  const { t } = useTranslation()
+
+  // TODO[NVL] This is almost a duplicate of the CombinedEntitySelect; reuse
+  const allDataReferences = useMemo(() => {
+    return formContext?.queries?.reduce<DataReference[]>((acc, cur) => {
+      const firstItem = cur.data?.items?.[0]
+      if ((firstItem as DomainTag).name) {
+        const tagDataReferences = (cur.data?.items as DomainTag[]).map<DataReference>((tag, index) => ({
+          id: tag.name,
+          type: DataReferenceType.TAG,
+          adapterId: formContext.entities?.[index]?.id,
+        }))
+        acc.push(...tagDataReferences)
+      } else if ((firstItem as TopicFilter).topicFilter) {
+        const topicFilterDataReferences = (cur.data?.items as TopicFilter[]).map<DataReference>((topicFilter) => ({
+          id: topicFilter.topicFilter,
+          type: DataReferenceType.TOPIC_FILTER,
+          adapterId: undefined,
+        }))
+        acc.push(...topicFilterDataReferences)
+      }
+
+      return acc
+    }, [])
+  }, [formContext?.entities, formContext?.queries])
+
+  const allSchemas = useMemo(() => {
+    const tags = formData?.sources?.tags || []
+    const topicFilters = formData?.sources?.topicFilters || []
+    const indexes = [...tags, ...topicFilters]
+    return allDataReferences?.filter((e) => indexes.includes(e.id)) || []
+  }, [allDataReferences, formData?.sources?.tags, formData?.sources?.topicFilters])
+
+  const queries = useGetCombinedDataSchemas(allSchemas)
+
+  const test = useMemo(() => {
+    return allSchemas.map((dataReference, index) => {
+      const { data } = queries[index]
+      if (typeof data === 'string') {
+        dataReference.schema = validateSchemaFromDataURI(data)
+      } else {
+        dataReference.schema = {
+          status: 'warning',
+          message: t('topicFilter.schema.status.missing'),
+        }
+      }
+      return dataReference
+    })
+  }, [allSchemas, queries])
+
+  if (!test.length) return <ErrorMessage message={t('combiner.error.noSchemaLoadedYet')} status={'info'} />
+
+  return (
+    <>
+      {test.map((e) => {
+        const schema =
+          e.schema?.status === 'success' && e.schema.schema ? { ...e.schema.schema, title: e.id } : { title: e.id }
+        return <JsonSchemaBrowser key={e.id} schema={schema} isDraggable hasExamples />
+      })}
+    </>
+  )
+}

--- a/hivemq-edge/src/frontend/src/modules/Mappings/components/combiner/DataCombiningEditorField.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/components/combiner/DataCombiningEditorField.tsx
@@ -29,6 +29,7 @@ import ErrorMessage from '@/components/ErrorMessage'
 import SchemaUploader from '@/modules/TopicFilters/components/SchemaUploader'
 import type { CombinerContext } from '@/modules/Mappings/types'
 import CombinedEntitySelect from './CombinedEntitySelect'
+import { CombinedSchemaLoader } from './CombinedSchemaLoader'
 
 export const DataCombiningEditorField: FC<FieldProps<DataCombining, RJSFSchema, CombinerContext>> = (props) => {
   const { t } = useTranslation()
@@ -36,8 +37,8 @@ export const DataCombiningEditorField: FC<FieldProps<DataCombining, RJSFSchema, 
   const { formData, formContext } = props
 
   const primary = useMemo(() => {
-    const tags = formData?.sources.tags || []
-    const topicFilters = formData?.sources.topicFilters || []
+    const tags = formData?.sources?.tags || []
+    const topicFilters = formData?.sources?.topicFilters || []
 
     return [...tags, ...topicFilters].map((entity) => ({ label: entity }))
   }, [formData])
@@ -50,7 +51,7 @@ export const DataCombiningEditorField: FC<FieldProps<DataCombining, RJSFSchema, 
             <CombinedEntitySelect
               tags={formData?.sources?.tags}
               topicFilters={formData?.sources?.topicFilters}
-              optionQueries={formContext?.sources}
+              formContext={formContext}
               onChange={(values) => {
                 if (!formData) return
                 const tag: string[] = []
@@ -62,16 +63,14 @@ export const DataCombiningEditorField: FC<FieldProps<DataCombining, RJSFSchema, 
 
                 props.onChange({
                   ...formData,
+                  // @ts-ignore TODO check for type clash on primary
                   sources: { ...formData.sources, tags: tag, topicFilters: filter },
                 })
               }}
             />
           </Box>
           <VStack height={500} overflow={'auto'} alignItems={'flex-start'} justifyContent={'center'} tabIndex={0}>
-            <ErrorMessage message={t('combiner.error.noSchemaLoadedYet')} status={'info'} />
-            {/*<JsonSchemaBrowser schema={{ ...MOCK_MQTT_SCHEMA_PLAIN, title: 'my/tag/t1' }} hasExamples />*/}
-            {/*<JsonSchemaBrowser schema={{ ...MOCK_MQTT_SCHEMA_REFS, title: 'my/tag/t3' }} hasExamples />*/}
-            {/*<JsonSchemaBrowser schema={{ ...GENERATE_DATA_MODELS(true), title: 'my/tag/t3' }} hasExamples />*/}
+            <CombinedSchemaLoader formData={props.formData} formContext={formContext} />
           </VStack>
           <Box>
             <Select<{ label: string }>

--- a/hivemq-edge/src/frontend/src/modules/Mappings/types.ts
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/types.ts
@@ -1,7 +1,7 @@
 import type { GenericObjectType } from '@rjsf/utils'
 import { type RJSFSchema, type UiSchema } from '@rjsf/utils'
 import type { AlertProps } from '@chakra-ui/react'
-import type { ApiError, DomainTagList, TopicFilterList } from '@/api/__generated__'
+import type { ApiError, DomainTagList, EntityReference, TopicFilterList } from '@/api/__generated__'
 import type { UseQueryResult } from '@tanstack/react-query'
 
 export interface ManagerContextType<T> {
@@ -43,5 +43,6 @@ export interface MappingValidation extends Pick<AlertProps, 'status'> {
 }
 
 export interface CombinerContext {
-  sources?: UseQueryResult<DomainTagList | TopicFilterList, Error>[]
+  queries?: UseQueryResult<DomainTagList | TopicFilterList, Error>[]
+  entities?: EntityReference[]
 }


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/30678/details/

The PR is the next step in building the UX for the data-combining feature of Edge, see https://hivemq.kanbanize.com/ctrl_board/57/cards/29097/details/. It implements the fetching and handling of the schema associated with the aggregated `tags` and `topic filters`. 

### Design 
- Upon selection of a tag or a topic filter in the combined widget, schemas are fetched and processed for rendering
- Schemas (or their error messages) are displayed in the form in the order the tags or topic filters have been selected. They will both show the name of the data identifier/.
- If a schema is valid (i.e. a JSONSchema delivered either as a JSON object or as a `data-uri` encoded string), it is rendered as a list of draggable properties 
- If the schema is invalid (e.g. not assigned to a topic filter), an error message will be displayed 

### Out-of-scope
- there is an inconsistency in the format of the schemas delivered for `tags` and `topic filters`. It will be fixed in a subsequent ticket, see https://hivemq.kanbanize.com/ctrl_board/57/cards/30744/details/
- `Tags` from uneligible adapters are still being processed. This will be fixed in a subsequent ticket, see https://hivemq.kanbanize.com/ctrl_board/57/cards/30741/details/
- Error messages, especially when fetching `tag` schemas, are incorrect. See https://hivemq.kanbanize.com/ctrl_board/57/cards/30750/details/

### Before
![HiveMQ-Edge-02-25-2025_02_03_PM](https://github.com/user-attachments/assets/8d5f3c66-ed53-4903-8d60-88e931c20759)

### After
![HiveMQ-Edge-02-25-2025_02_04_PM](https://github.com/user-attachments/assets/c38ef5cd-0eea-4c37-9964-9ce3f223c529)
