### PR TITLE
feat(30680): Add support for destination schema

### DIFF
--- a/hivemq-edge/src/frontend/src/api/__generated__/models/DataCombining.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/models/DataCombining.ts
@@ -25,7 +25,13 @@ export type DataCombining = {
          */
         topicFilters?: Array<string>;
     };
-    destination?: string;
+    destination: {
+        topic?: string;
+        /**
+         * The optional json schema for this topic filter in the data uri format.
+         */
+        schema?: string;
+    };
     /**
      * List of instructions to be applied to incoming data
      */

--- a/hivemq-edge/src/frontend/src/api/__generated__/schemas/$DataCombining.ts
+++ b/hivemq-edge/src/frontend/src/api/__generated__/schemas/$DataCombining.ts
@@ -36,8 +36,18 @@ export const $DataCombining = {
             },
         },
         destination: {
-            type: 'string',
-            format: 'mqtt-topic',
+            properties: {
+                topic: {
+                    type: 'string',
+                    format: 'mqtt-topic',
+                },
+                schema: {
+                    type: 'string',
+                    description: `The optional json schema for this topic filter in the data uri format.`,
+                    format: 'data-url',
+                },
+            },
+            isRequired: true,
         },
         instructions: {
             type: 'array',

--- a/hivemq-edge/src/frontend/src/api/hooks/useCombiners/__handlers__/index.ts
+++ b/hivemq-edge/src/frontend/src/api/hooks/useCombiners/__handlers__/index.ts
@@ -43,13 +43,13 @@ export const mockCombiner: Combiner = {
           tags: ['my/tag/t1', 'my/tag/t3'],
           topicFilters: ['my/topic/+/temp'],
         },
-        destination: 'my/first/topic',
+        destination: { topic: 'my/first/topic' },
         instructions: [],
       },
       {
         id: 'c02a9d0f-02cb-4ff0-a7b4-6e1a16b08722',
         sources: { primary: '', primaryType: DataCombining.primaryType.TAG, tags: [], topicFilters: [] },
-        destination: 'my/other/topic',
+        destination: { topic: 'my/other/topic' },
         instructions: [],
       },
     ],
@@ -64,7 +64,7 @@ export const mockCombinerMapping: DataCombining = {
     tags: [],
     topicFilters: [],
   },
-  destination: 'my/topic',
+  destination: { topic: 'my/topic' },
   instructions: [],
 }
 

--- a/hivemq-edge/src/frontend/src/api/hooks/useCombiners/useListCombinerMappings.spec.ts
+++ b/hivemq-edge/src/frontend/src/api/hooks/useCombiners/useListCombinerMappings.spec.ts
@@ -35,7 +35,7 @@ describe('useListCombinerMappings', () => {
             tags: [],
             topicFilters: [],
           },
-          destination: 'my/topic',
+          destination: { topic: 'my/topic' },
           instructions: [],
         },
       ],

--- a/hivemq-edge/src/frontend/src/api/hooks/useCombiners/useListCombiners.spec.ts
+++ b/hivemq-edge/src/frontend/src/api/hooks/useCombiners/useListCombiners.spec.ts
@@ -46,7 +46,7 @@ describe('useListCombiners', () => {
           mappings: {
             items: [
               {
-                destination: 'my/first/topic',
+                destination: { topic: 'my/first/topic' },
                 id: '3b028f58-f949-4de1-9b8b-c1a35b1643a4',
                 instructions: [],
                 sources: {
@@ -57,7 +57,7 @@ describe('useListCombiners', () => {
                 },
               },
               {
-                destination: 'my/other/topic',
+                destination: { topic: 'my/other/topic' },
                 id: 'c02a9d0f-02cb-4ff0-a7b4-6e1a16b08722',
                 instructions: [],
                 sources: {

--- a/hivemq-edge/src/frontend/src/api/schemas/combiner-mapping.json-schema.ts
+++ b/hivemq-edge/src/frontend/src/api/schemas/combiner-mapping.json-schema.ts
@@ -63,8 +63,16 @@ export const combinerMappingJsonSchema: JSONSchema7 = {
           },
         },
         destination: {
-          type: 'string',
-          format: 'mqtt-topic',
+          type: 'object',
+          properties: {
+            topic: {
+              type: 'string',
+              format: 'mqtt-topic',
+            },
+            schema: {
+              type: 'string',
+            },
+          },
         },
         instructions: {
           type: 'array',

--- a/hivemq-edge/src/frontend/src/locales/en/translation.json
+++ b/hivemq-edge/src/frontend/src/locales/en/translation.json
@@ -1259,6 +1259,11 @@
       },
       "schemaManager": {
         "header": "Create a schema",
+        "action": {
+          "infer": "Infer a schema",
+          "upload": "Upload a new schema",
+          "download": "Download the schema"
+        },
         "infer": {
           "message": "We will create a new schema based on the combination of the sources",
           "action": "Generate"

--- a/hivemq-edge/src/frontend/src/modules/Mappings/components/combiner/DataCombiningEditorField.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/components/combiner/DataCombiningEditorField.tsx
@@ -93,12 +93,13 @@ export const DataCombiningEditorField: FC<FieldProps<DataCombining, RJSFSchema, 
               isMulti={false}
               isCreatable={true}
               id={'destination'}
-              value={formData?.destination || null}
-              onChange={(e) => {
+              value={formData?.destination?.topic || null}
+              onChange={(topic) => {
                 if (!props.formData) return
 
-                if (e && typeof e === 'string') props.onChange({ ...props.formData, destination: e })
-                else if (!e) props.onChange({ ...props.formData, destination: '' })
+                if (topic && typeof topic === 'string')
+                  props.onChange({ ...props.formData, destination: { topic: topic } })
+                else if (!topic) props.onChange({ ...props.formData, destination: { topic: '' } })
               }}
             />
           </Box>

--- a/hivemq-edge/src/frontend/src/modules/Mappings/components/combiner/DataCombiningEditorField.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/components/combiner/DataCombiningEditorField.tsx
@@ -79,8 +79,7 @@ export const DataCombiningEditorField: FC<FieldProps<DataCombining, RJSFSchema, 
               onChange={(topic) => {
                 if (!props.formData) return
 
-                if (topic && typeof topic === 'string')
-                  props.onChange({ ...props.formData, destination: { topic: topic } })
+                if (topic && typeof topic === 'string') props.onChange({ ...props.formData, destination: { topic } })
                 else if (!topic) props.onChange({ ...props.formData, destination: { topic: '' } })
               }}
             />
@@ -92,7 +91,7 @@ export const DataCombiningEditorField: FC<FieldProps<DataCombining, RJSFSchema, 
 
               props.onChange({
                 ...props.formData,
-                destination: { topic: props.formData.destination.topic, schema: schema },
+                destination: { topic: props.formData.destination.topic, schema },
               })
             }}
           />

--- a/hivemq-edge/src/frontend/src/modules/Mappings/components/combiner/DataCombiningEditorField.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/components/combiner/DataCombiningEditorField.tsx
@@ -3,33 +3,15 @@ import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Select } from 'chakra-react-select'
 import type { FieldProps, RJSFSchema } from '@rjsf/utils'
-import {
-  Box,
-  Button,
-  ButtonGroup,
-  HStack,
-  Icon,
-  Popover,
-  PopoverTrigger,
-  PopoverContent,
-  PopoverHeader,
-  PopoverBody,
-  PopoverArrow,
-  PopoverCloseButton,
-  Stack,
-  Text,
-  VStack,
-  PopoverFooter,
-} from '@chakra-ui/react'
+import { Box, HStack, Icon, Stack, VStack } from '@chakra-ui/react'
 import { FaRightFromBracket } from 'react-icons/fa6'
 
 import { DataCombining } from '@/api/__generated__'
 import { SelectTopic } from '@/components/MQTT/EntityCreatableSelect'
-import ErrorMessage from '@/components/ErrorMessage'
-import SchemaUploader from '@/modules/TopicFilters/components/SchemaUploader'
 import type { CombinerContext } from '@/modules/Mappings/types'
 import CombinedEntitySelect from './CombinedEntitySelect'
 import { CombinedSchemaLoader } from './CombinedSchemaLoader'
+import { DestinationSchemaLoader } from './DestinationSchemaLoader'
 
 export const DataCombiningEditorField: FC<FieldProps<DataCombining, RJSFSchema, CombinerContext>> = (props) => {
   const { t } = useTranslation()
@@ -103,40 +85,17 @@ export const DataCombiningEditorField: FC<FieldProps<DataCombining, RJSFSchema, 
               }}
             />
           </Box>
-          <ButtonGroup size="sm" variant="outline" justifyContent={'flex-end'}>
-            <Popover>
-              <PopoverTrigger>
-                <Button>{t('topicFilter.schema.tabs.infer')}</Button>
-              </PopoverTrigger>
-              <PopoverContent>
-                <PopoverArrow />
-                <PopoverCloseButton />
-                <PopoverHeader>{t('combiner.schema.schemaManager.header')}</PopoverHeader>
-                <PopoverBody>
-                  <Text>{t('combiner.schema.schemaManager.infer.message')}</Text>
-                </PopoverBody>
-                <PopoverFooter gap={2} display={'flex'}>
-                  <Button isDisabled>{t('combiner.schema.schemaManager.infer.action')}</Button>
-                </PopoverFooter>
-              </PopoverContent>
-            </Popover>
-            <Popover>
-              <PopoverTrigger>
-                <Button>{t('topicFilter.schema.tabs.upload')}</Button>
-              </PopoverTrigger>
-              <PopoverContent>
-                <PopoverArrow />
-                <PopoverCloseButton />
-                <PopoverHeader>{t('combiner.schema.schemaManager.header')}</PopoverHeader>
-                <PopoverBody>
-                  <SchemaUploader onUpload={() => console.log('uploaded')} />
-                </PopoverBody>
-              </PopoverContent>
-            </Popover>
-          </ButtonGroup>
-          <VStack height={420} justifyContent={'center'} alignItems={'center'}>
-            <ErrorMessage message={t('combiner.error.noSchemaLoadedYet')} status={'info'} />
-          </VStack>
+          <DestinationSchemaLoader
+            formData={props.formData}
+            onChange={(schema) => {
+              if (!props.formData) return
+
+              props.onChange({
+                ...props.formData,
+                destination: { topic: props.formData.destination.topic, schema: schema },
+              })
+            }}
+          />
         </VStack>
       </Stack>
     </VStack>

--- a/hivemq-edge/src/frontend/src/modules/Mappings/components/combiner/DataCombiningTableField.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/components/combiner/DataCombiningTableField.tsx
@@ -42,7 +42,7 @@ export const DataCombiningTableField: FC<FieldProps<DataCombining[], RJSFSchema,
           tags: [],
           topicFilters: [],
         },
-        destination: '',
+        destination: { topic: '' },
         instructions: [],
       }
       props.onChange([...(props.formData || []), newMapping])
@@ -61,7 +61,7 @@ export const DataCombiningTableField: FC<FieldProps<DataCombining[], RJSFSchema,
       {
         accessorKey: 'destination',
         cell: (info) => {
-          if (info.row.original.destination) return <Topic tagTitle={info.row.original.destination} />
+          if (info.row.original.destination) return <Topic tagTitle={info.row.original.destination.topic} />
           return <Text>{t('combiner.unset')}</Text>
         },
       },

--- a/hivemq-edge/src/frontend/src/modules/Mappings/components/combiner/DestinationSchemaLoader.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/components/combiner/DestinationSchemaLoader.spec.cy.tsx
@@ -1,0 +1,41 @@
+import { DataCombining } from '@/api/__generated__'
+import { DestinationSchemaLoader } from './DestinationSchemaLoader'
+
+const mockDataCombining: DataCombining = {
+  id: '1f64f351-dcef-4ca1-ad09-26cd07f45be4',
+  sources: {
+    primary: '',
+    primaryType: DataCombining.primaryType.TAG,
+    tags: [],
+    topicFilters: [],
+  },
+  destination: { topic: 'my/topic', schema: undefined },
+  instructions: [],
+}
+
+describe('DestinationSchemaLoader', () => {
+  beforeEach(() => {
+    cy.viewport(800, 800)
+  })
+
+  it.only('should render properly', () => {
+    const onChange = cy.stub().as('onChange')
+    cy.mountWithProviders(<DestinationSchemaLoader formData={mockDataCombining} onChange={onChange} />)
+
+    cy.get('@onChange').should('have.not.been.called')
+
+    cy.getByTestId('combiner-destination-infer').should('have.text', 'Infer a schema').should('be.disabled', true)
+    cy.getByTestId('combiner-destination-upload').should('have.text', 'Upload a new schema')
+    cy.getByTestId('combiner-destination-download').should('have.text', 'Download the schema')
+
+    cy.get('[role="dialog"][data-testid="combiner-destination-upload-content"]').should('not.be.visible')
+    cy.getByTestId('combiner-destination-upload').click()
+    cy.get('[role="dialog"][data-testid="combiner-destination-upload-content"]').should('be.visible')
+  })
+
+  it('should be accessible', () => {
+    cy.injectAxe()
+    cy.mountWithProviders(<DestinationSchemaLoader formData={mockDataCombining} onChange={cy.stub} />)
+    cy.checkAccessibility()
+  })
+})

--- a/hivemq-edge/src/frontend/src/modules/Mappings/components/combiner/DestinationSchemaLoader.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/components/combiner/DestinationSchemaLoader.tsx
@@ -105,15 +105,6 @@ export const DestinationSchemaLoader: FC<DestinationSchemaLoaderProps> = ({ form
         <VStack w="100%" height={420} justifyContent={'center'} alignItems={'flex-start'}>
           <JsonSchemaBrowser schema={schema.schema} isDraggable hasExamples />
         </VStack>
-        // <VStack w="100%" height={420} justifyContent={'center'} alignItems={'stretch'} gap={3}>
-        //   <MappingInstructionList
-        //     schema={schema.schema}
-        //     instructions={[]}
-        //     display={'flex'}
-        //     flexDirection={'column'}
-        //     gap={4}
-        //   />
-        // </VStack>
       )}
     </>
   )

--- a/hivemq-edge/src/frontend/src/modules/Mappings/components/combiner/DestinationSchemaLoader.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/components/combiner/DestinationSchemaLoader.tsx
@@ -55,7 +55,9 @@ export const DestinationSchemaLoader: FC<DestinationSchemaLoaderProps> = ({ form
       <ButtonGroup size="sm" variant="outline" justifyContent={'flex-end'}>
         <Popover>
           <PopoverTrigger>
-            <Button isDisabled>{t('combiner.schema.schemaManager.action.infer')}</Button>
+            <Button data-testid={'combiner-destination-infer'} isDisabled>
+              {t('combiner.schema.schemaManager.action.infer')}
+            </Button>
           </PopoverTrigger>
           <PopoverContent>
             <PopoverArrow />
@@ -71,9 +73,11 @@ export const DestinationSchemaLoader: FC<DestinationSchemaLoaderProps> = ({ form
         </Popover>
         <Popover>
           <PopoverTrigger>
-            <Button isDisabled={!isTopicDefined}>{t('combiner.schema.schemaManager.action.upload')}</Button>
+            <Button data-testid={'combiner-destination-upload'} isDisabled={!isTopicDefined}>
+              {t('combiner.schema.schemaManager.action.upload')}
+            </Button>
           </PopoverTrigger>
-          <PopoverContent>
+          <PopoverContent data-testid={'combiner-destination-upload-content'}>
             <PopoverArrow />
             <PopoverCloseButton />
             <PopoverHeader>{t('combiner.schema.schemaManager.header')}</PopoverHeader>
@@ -82,7 +86,11 @@ export const DestinationSchemaLoader: FC<DestinationSchemaLoaderProps> = ({ form
             </PopoverBody>
           </PopoverContent>
         </Popover>
-        <Button onClick={handleSchemaDownload} isDisabled={!isSchemaDefined}>
+        <Button
+          data-testid={'combiner-destination-download'}
+          onClick={handleSchemaDownload}
+          isDisabled={!isSchemaDefined}
+        >
           {t('combiner.schema.schemaManager.action.download')}
         </Button>
       </ButtonGroup>

--- a/hivemq-edge/src/frontend/src/modules/Mappings/components/combiner/DestinationSchemaLoader.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/components/combiner/DestinationSchemaLoader.tsx
@@ -1,0 +1,112 @@
+import { type FC, useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+import type { JSONSchema7 } from 'json-schema'
+
+import {
+  Button,
+  ButtonGroup,
+  Popover,
+  PopoverArrow,
+  PopoverBody,
+  PopoverCloseButton,
+  PopoverContent,
+  PopoverFooter,
+  PopoverHeader,
+  PopoverTrigger,
+  Text,
+  VStack,
+} from '@chakra-ui/react'
+
+import type { DataCombining } from '@/api/__generated__'
+import ErrorMessage from '@/components/ErrorMessage'
+import SchemaUploader from '@/modules/TopicFilters/components/SchemaUploader'
+import { validateSchemaFromDataURI } from '@/modules/TopicFilters/utils/topic-filter.schema'
+import JsonSchemaBrowser from '@/components/rjsf/MqttTransformation/JsonSchemaBrowser'
+import { downloadJSON } from '@/extensions/datahub/utils/download.utils'
+
+interface DestinationSchemaLoaderProps {
+  formData?: DataCombining
+  onChange: (schema: string) => void
+}
+
+export const DestinationSchemaLoader: FC<DestinationSchemaLoaderProps> = ({ formData, onChange }) => {
+  const { t } = useTranslation()
+  const isTopicDefined = Boolean(formData?.destination?.topic && formData?.destination?.topic !== '')
+  const isSchemaDefined = Boolean(formData?.destination?.schema && formData?.destination?.schema !== '')
+
+  const handleSchemaUpload = (schema: string) => {
+    onChange(schema)
+  }
+
+  const handleSchemaDownload = () => {
+    if (!formData?.destination?.schema) return
+
+    const handler = validateSchemaFromDataURI(formData?.destination?.schema)
+    if (handler.schema) downloadJSON<JSONSchema7>(handler.schema.title || 'topic-untitled', handler.schema)
+  }
+
+  const schema = useMemo(() => {
+    if (!formData?.destination?.schema) return undefined
+    return validateSchemaFromDataURI(formData?.destination?.schema)
+  }, [formData?.destination?.schema])
+
+  return (
+    <>
+      <ButtonGroup size="sm" variant="outline" justifyContent={'flex-end'}>
+        <Popover>
+          <PopoverTrigger>
+            <Button isDisabled>{t('combiner.schema.schemaManager.action.infer')}</Button>
+          </PopoverTrigger>
+          <PopoverContent>
+            <PopoverArrow />
+            <PopoverCloseButton />
+            <PopoverHeader>{t('combiner.schema.schemaManager.header')}</PopoverHeader>
+            <PopoverBody>
+              <Text>{t('combiner.schema.schemaManager.infer.message')}</Text>
+            </PopoverBody>
+            <PopoverFooter gap={2} display={'flex'}>
+              <Button isDisabled>{t('combiner.schema.schemaManager.infer.action')}</Button>
+            </PopoverFooter>
+          </PopoverContent>
+        </Popover>
+        <Popover>
+          <PopoverTrigger>
+            <Button isDisabled={!isTopicDefined}>{t('combiner.schema.schemaManager.action.upload')}</Button>
+          </PopoverTrigger>
+          <PopoverContent>
+            <PopoverArrow />
+            <PopoverCloseButton />
+            <PopoverHeader>{t('combiner.schema.schemaManager.header')}</PopoverHeader>
+            <PopoverBody>
+              <SchemaUploader onUpload={handleSchemaUpload} />
+            </PopoverBody>
+          </PopoverContent>
+        </Popover>
+        <Button onClick={handleSchemaDownload} isDisabled={!isSchemaDefined}>
+          {t('combiner.schema.schemaManager.action.download')}
+        </Button>
+      </ButtonGroup>
+
+      {!formData?.destination?.schema && (
+        <VStack w="100%" height={420} justifyContent={'center'} alignItems={'center'}>
+          <ErrorMessage message={t('combiner.error.noSchemaLoadedYet')} status={'info'} />
+        </VStack>
+      )}
+
+      {schema?.schema && (
+        <VStack w="100%" height={420} justifyContent={'center'} alignItems={'flex-start'}>
+          <JsonSchemaBrowser schema={schema.schema} isDraggable hasExamples />
+        </VStack>
+        // <VStack w="100%" height={420} justifyContent={'center'} alignItems={'stretch'} gap={3}>
+        //   <MappingInstructionList
+        //     schema={schema.schema}
+        //     instructions={[]}
+        //     display={'flex'}
+        //     flexDirection={'column'}
+        //     gap={4}
+        //   />
+        // </VStack>
+      )}
+    </>
+  )
+}


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/30678/details/

The PR is the next step in building the UX for the data-combining feature of Edge, see https://hivemq.kanbanize.com/ctrl_board/57/cards/29097/details/. It implements the handling of the destination schema

### Design
-  Adding a schema is contingent on a destination topic being selected 
- The "upload schema" CTA opens a dropdown with the now-ubiquitous user interface for uploading files (drag-and-drop or select)
- Note that the file upload is based on the file extension (`.json`) but not on the content of the file
- Upload uploading the schema will be rendered using the same property-based display used in the source schemas.
- The "download schema" is available to save a copy of the schema into a timestamped `.json` document 

### Out-of-scope
- The possibility of interring a destination schema out of the specified source schemas will be investigated in another ticket, see https://hivemq.kanbanize.com/ctrl_board/57/cards/30574/details/
- Warning or error message should be added when the file is successfully loaded but doesn't contain any meaningful schema (i.e. selectable properties)


### Before
![HiveMQ-Edge-02-26-2025_10_53_AM](https://github.com/user-attachments/assets/2569bc37-43e3-47f6-9fe5-8b838729ab6a)

### After
![HiveMQ-Edge-02-26-2025_10_52_AM](https://github.com/user-attachments/assets/1805eebc-f437-4644-aa05-f4a5df729c96)

