### PR TITLE
feat(30602): Support deleting combiners

### DIFF
--- a/hivemq-edge/src/frontend/src/api/hooks/useCombiners/index.ts
+++ b/hivemq-edge/src/frontend/src/api/hooks/useCombiners/index.ts
@@ -1,0 +1,17 @@
+import { useCreateCombiner } from './useCreateCombiner'
+import { useDeleteCombiner } from './useDeleteCombiner'
+import { useGetCombiner } from './useGetCombiner'
+import { useListCombinerMappingInstructions } from './useListCombinerMappingInstructions'
+import { useListCombinerMappings } from './useListCombinerMappings'
+import { useListCombiners } from './useListCombiners'
+import { useUpdateCombiner } from './useUpdateCombiner'
+
+export {
+  useCreateCombiner,
+  useDeleteCombiner,
+  useGetCombiner,
+  useListCombinerMappingInstructions,
+  useListCombinerMappings,
+  useListCombiners,
+  useUpdateCombiner,
+}

--- a/hivemq-edge/src/frontend/src/locales/en/translation.json
+++ b/hivemq-edge/src/frontend/src/locales/en/translation.json
@@ -1188,7 +1188,14 @@
   },
   "combiner": {
     "actions": {
-      "submit": "Submit"
+      "submit": "Submit",
+      "delete": "Delete"
+    },
+    "modal": {
+      "delete": {
+        "header": "Delete the Combiner?",
+        "message": "Do you want to delete the combiner and its content? The action cannot be reversed."
+      }
     },
     "type": "Data Combiner",
     "unnamed": "< unnamed combiner >",
@@ -1204,6 +1211,11 @@
         "title": "Update the combiner",
         "success": "We've successfully updated the combiner for you.",
         "error": "There was a problem trying to update the combiner"
+      },
+      "delete": {
+        "title": "Delete the combiner",
+        "success": "We've successfully deleted the combiner for you.",
+        "error": "There was a problem trying to delete the combiner"
       }
     },
     "error": {

--- a/hivemq-edge/src/frontend/src/modules/Mappings/CombinerMappingManager.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/CombinerMappingManager.tsx
@@ -1,5 +1,5 @@
 import { type FC, useEffect, useMemo } from 'react'
-import type { Node } from 'reactflow'
+import type { Node, NodeRemoveChange } from 'reactflow'
 import { useNavigate, useParams } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import type { IChangeEvent } from '@rjsf/core'
@@ -29,7 +29,7 @@ import { MappingType } from './types'
 import type { Combiner } from '@/api/__generated__'
 import { combinerMappingJsonSchema } from '@/api/schemas/combiner-mapping.json-schema'
 import { combinerMappingUiSchema } from '@/api/schemas/combiner-mapping.ui-schema'
-import { useUpdateCombiner } from '@/api/hooks/useCombiners/useUpdateCombiner'
+import { useUpdateCombiner, useDeleteCombiner } from '@/api/hooks/useCombiners/'
 import { useGetCombinedEntities } from '@/api/hooks/useDomainModel/useGetCombinedEntities'
 import ChakraRJSForm from '@/components/rjsf/Form/ChakraRJSForm'
 import ErrorMessage from '@/components/ErrorMessage'
@@ -43,9 +43,10 @@ const CombinerMappingManager: FC = () => {
   const { isOpen, onOpen, onClose } = useDisclosure()
   const navigate = useNavigate()
   const { combinerId } = useParams()
-  const { nodes, onUpdateNode } = useWorkspaceStore()
+  const { nodes, onUpdateNode, onNodesChange } = useWorkspaceStore()
   const toast = useToast()
   const updateCombiner = useUpdateCombiner()
+  const deleteCombiner = useDeleteCombiner()
 
   const selectedNode = useMemo(() => {
     return nodes.find((node) => node.id === combinerId) as Node<Combiner> | undefined
@@ -78,6 +79,22 @@ const CombinerMappingManager: FC = () => {
         success: { title: t('combiner.toast.update.title'), description: t('combiner.toast.update.success') },
         error: { title: t('combiner.toast.update.title'), description: t('combiner.toast.update.error') },
         loading: { title: t('combiner.toast.update.title'), description: t('combiner.toast.loading') },
+      }
+    )
+  }
+
+  const handleOnDelete = () => {
+    if (!combinerId) return
+    const promise = deleteCombiner.mutateAsync({ combinerId })
+    toast.promise(
+      promise.then(() => {
+        if (selectedNode) onNodesChange([{ id: selectedNode.id, type: 'remove' } as NodeRemoveChange])
+        handleClose()
+      }),
+      {
+        success: { title: t('combiner.toast.delete.title'), description: t('combiner.toast.delete.success') },
+        error: { title: t('combiner.toast.delete.title'), description: t('combiner.toast.delete.error') },
+        loading: { title: t('combiner.toast.delete.title'), description: t('combiner.toast.loading') },
       }
     )
   }

--- a/hivemq-edge/src/frontend/src/modules/Mappings/CombinerMappingManager.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/CombinerMappingManager.tsx
@@ -63,18 +63,16 @@ const CombinerMappingManager: FC = () => {
     navigate('/workspace')
   }
 
-  const handleUpdateCombiner = (data: Combiner) => {
-    if (selectedNode) onUpdateNode<Combiner>(selectedNode.id, data)
-    handleClose()
-  }
-
   const handleOnSubmit = (data: IChangeEvent) => {
     if (!data.formData || !combinerId) return
 
-    const promise = updateCombiner.mutateAsync({ combinerId: combinerId, requestBody: data.formData })
+    const promise = updateCombiner.mutateAsync({ combinerId, requestBody: data.formData })
 
     toast.promise(
-      promise.then(() => handleUpdateCombiner(data.formData)),
+      promise.then(() => {
+        if (selectedNode) onUpdateNode<Combiner>(selectedNode.id, data.formData)
+        handleClose()
+      }),
       {
         success: { title: t('combiner.toast.update.title'), description: t('combiner.toast.update.success') },
         error: { title: t('combiner.toast.update.title'), description: t('combiner.toast.update.error') },

--- a/hivemq-edge/src/frontend/src/modules/Mappings/CombinerMappingManager.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/CombinerMappingManager.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next'
 import type { IChangeEvent } from '@rjsf/core'
 import {
   Button,
+  ButtonGroup,
   Drawer,
   DrawerBody,
   DrawerCloseButton,
@@ -35,6 +36,7 @@ import ErrorMessage from '@/components/ErrorMessage'
 import type { NodeTypes } from '@/modules/Workspace/types.ts'
 import useWorkspaceStore from '@/modules/Workspace/hooks/useWorkspaceStore.ts'
 import NodeNameCard from '@/modules/Workspace/components/parts/NodeNameCard.tsx'
+import DangerZone from './components/DangerZone'
 
 const CombinerMappingManager: FC = () => {
   const { t } = useTranslation()
@@ -113,15 +115,18 @@ const CombinerMappingManager: FC = () => {
             />
           )}
         </DrawerBody>
-        <DrawerFooter>
-          {config.isDevMode && (
-            <FormControl display="flex" alignItems="center">
-              <FormLabel htmlFor="email-alerts" mb="0">
-                {t('modals.native')}
-              </FormLabel>
-              <Switch id="email-alerts" isChecked={showNativeWidgets} onChange={setShowNativeWidgets.toggle} />
-            </FormControl>
-          )}
+        <DrawerFooter justifyContent={'space-between'}>
+          <ButtonGroup>
+            {config.isDevMode && (
+              <FormControl display="flex" alignItems="center">
+                <FormLabel htmlFor="email-alerts" mb="0">
+                  {t('modals.native')}
+                </FormLabel>
+                <Switch id="email-alerts" isChecked={showNativeWidgets} onChange={setShowNativeWidgets.toggle} />
+              </FormControl>
+            )}
+            {selectedNode && <DangerZone onSubmit={handleOnDelete} />}
+          </ButtonGroup>
           {selectedNode && (
             <Button variant="primary" type="submit" form="combiner-main-form" isLoading={updateCombiner.isPending}>
               {t('combiner.actions.submit')}

--- a/hivemq-edge/src/frontend/src/modules/Mappings/components/DangerZone.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/components/DangerZone.spec.cy.tsx
@@ -1,0 +1,54 @@
+import DangerZone from './DangerZone'
+
+describe('DangerZone', () => {
+  beforeEach(() => {
+    cy.viewport(800, 800)
+  })
+
+  it('should render properly', () => {
+    const onSubmit = cy.stub().as('onSubmit')
+    cy.mountWithProviders(<DangerZone onSubmit={onSubmit} />)
+
+    cy.get('button').should('have.text', 'Delete')
+
+    cy.get('@onSubmit').should('not.have.been.called')
+    cy.get('[role="alertdialog"]').should('not.exist')
+    cy.get('button').click()
+    cy.get('[role="alertdialog"]').should('be.visible')
+    cy.get('[role="alertdialog"]').within(() => {
+      cy.get('header').should('have.text', 'Delete the Combiner?')
+      cy.get('header + div').should(
+        'have.text',
+        'Do you want to delete the combiner and its content? The action cannot be reversed.'
+      )
+
+      cy.get('footer').within(() => {
+        cy.get('button').eq(0).should('have.text', 'Cancel')
+
+        cy.get('button').eq(0).click()
+        cy.get('@onSubmit').should('not.have.been.called')
+      })
+    })
+
+    cy.get('[role="alertdialog"]').should('not.exist')
+    cy.get('button').click()
+
+    cy.get('[role="alertdialog"]').should('be.visible')
+    cy.get('[role="alertdialog"]').within(() => {
+      cy.get('footer').within(() => {
+        cy.get('button').eq(1).should('have.text', 'Delete')
+
+        cy.get('button').eq(1).click()
+        cy.get('@onSubmit').should('have.been.called')
+      })
+    })
+  })
+
+  it('should be accessible', () => {
+    cy.injectAxe()
+    cy.mountWithProviders(<DangerZone onSubmit={cy.stub} />)
+    cy.get('button').click()
+
+    cy.checkAccessibility()
+  })
+})

--- a/hivemq-edge/src/frontend/src/modules/Mappings/components/DangerZone.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/components/DangerZone.tsx
@@ -1,0 +1,40 @@
+import type { FC } from 'react'
+import { Button, useDisclosure } from '@chakra-ui/react'
+import ConfirmationDialog from '../../../components/Modal/ConfirmationDialog'
+import { useTranslation } from 'react-i18next'
+
+interface DangerZoneProps {
+  onSubmit: () => void
+}
+
+const DangerZone: FC<DangerZoneProps> = ({ onSubmit }) => {
+  const { t } = useTranslation()
+  const { isOpen: isConfirmDeleteOpen, onOpen: onConfirmDeleteOpen, onClose: onConfirmDeleteClose } = useDisclosure()
+
+  function onHandleClear() {
+    onConfirmDeleteClose()
+  }
+
+  function onHandleSubmit() {
+    onConfirmDeleteClose()
+    onSubmit()
+  }
+
+  return (
+    <>
+      <Button variant="danger" onClick={onConfirmDeleteOpen}>
+        {t('combiner.actions.delete')}
+      </Button>
+      <ConfirmationDialog
+        isOpen={isConfirmDeleteOpen}
+        onClose={onHandleClear}
+        onSubmit={onHandleSubmit}
+        message={t('combiner.modal.delete.message')}
+        header={t('combiner.modal.delete.header')}
+        action={t('combiner.actions.delete')}
+      />
+    </>
+  )
+}
+
+export default DangerZone


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/30602/details/

The PR adds a small but important aspect of the combiner user flow: the ability to delete a combiner after its creation. 

### Design
- A "delete" button, clearly labelled as "danger", has been added to the foot of the main panel associated with a combiner
- The operation needs validation in the modal
- The operation cannot be reversed
- The `DELETE /combiner` request might fail for internal reasons. In such case, the deletion will not have been applied

### Out-of-scope
- The "delete" CTA could also be made available in the toolbar, pending usability testing. This will be part of the refactoring of the `Workspace`, https://hivemq.kanbanize.com/ctrl_board/57/cards/30497/details/

### Before 

### After
![HiveMQ-Edge-02-28-2025_10_07_AM](https://github.com/user-attachments/assets/395abe4a-6c9c-4899-964e-6f9d8fcd8932)

![HiveMQ-Edge-02-28-2025_10_08_AM](https://github.com/user-attachments/assets/e94e8df8-f5a4-4d31-83ce-6756d968be2a)
