### PR TITLE
fix(30890): Ensure that topic filters are in the mapping selector

### DIFF
--- a/hivemq-edge/src/frontend/src/locales/en/translation.json
+++ b/hivemq-edge/src/frontend/src/locales/en/translation.json
@@ -1111,7 +1111,9 @@
         "noBase64Data": "The data is not properly encoded as a `base64` string",
         "noJSON": "The data is not properly encoded as a `JSON` object",
         "ajvValidationFails": "Internal validation error",
-        "ajvNoProperties": "Not a valid JSONSchema: `properties` is missing"
+        "ajvNoProperties": "Not a valid JSONSchema: `properties` is missing",
+        "noAssignedSchema_TAG": "Your tag is currently not assigned a schema",
+        "noAssignedSchema_TOPIC_FILTER": "Your topic filter is currently not assigned a schema"
       }
     },
     "toast": {
@@ -1240,6 +1242,9 @@
           "action": "Actions",
           "delete": "Delete the source",
           "source": "Source"
+        },
+        "edge": {
+          "description": "Always added as the owner of the topic filters"
         }
       },
       "mappings": {

--- a/hivemq-edge/src/frontend/src/modules/Mappings/CombinerMappingManager.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/CombinerMappingManager.tsx
@@ -27,6 +27,7 @@ import config from '@/config'
 import type { CombinerContext } from './types'
 import { MappingType } from './types'
 import type { Combiner } from '@/api/__generated__'
+import { EntityType } from '@/api/__generated__'
 import { combinerMappingJsonSchema } from '@/api/schemas/combiner-mapping.json-schema'
 import { combinerMappingUiSchema } from '@/api/schemas/combiner-mapping.ui-schema'
 import { useUpdateCombiner, useDeleteCombiner } from '@/api/hooks/useCombiners/'
@@ -34,6 +35,7 @@ import { useGetCombinedEntities } from '@/api/hooks/useDomainModel/useGetCombine
 import ChakraRJSForm from '@/components/rjsf/Form/ChakraRJSForm'
 import ErrorMessage from '@/components/ErrorMessage'
 import type { NodeTypes } from '@/modules/Workspace/types.ts'
+import { IdStubs } from '@/modules/Workspace/types.ts'
 import useWorkspaceStore from '@/modules/Workspace/hooks/useWorkspaceStore.ts'
 import NodeNameCard from '@/modules/Workspace/components/parts/NodeNameCard.tsx'
 import DangerZone from './components/DangerZone'
@@ -53,7 +55,12 @@ const CombinerMappingManager: FC = () => {
   }, [combinerId, nodes])
 
   const entities = useMemo(() => {
-    return selectedNode?.data?.sources?.items || []
+    const entities = selectedNode?.data?.sources?.items || []
+    const isBridgeIn = Boolean(
+      entities.find((entity) => entity.id === IdStubs.EDGE_NODE && entity.type === EntityType.EDGE_BROKER)
+    )
+    if (!isBridgeIn) entities.push({ id: IdStubs.EDGE_NODE, type: EntityType.EDGE_BROKER })
+    return entities
   }, [selectedNode?.data?.sources?.items])
 
   const sources = useGetCombinedEntities(entities)

--- a/hivemq-edge/src/frontend/src/modules/Mappings/components/combiner/CombinedEntitySelect.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/components/combiner/CombinedEntitySelect.tsx
@@ -5,8 +5,8 @@ import type { GroupBase, MultiValue, OptionBase } from 'chakra-react-select'
 import { Select } from 'chakra-react-select'
 import { Box } from '@chakra-ui/react'
 
-import { DataIdentifierReference } from '@/api/__generated__'
 import type { DomainTag, TopicFilter } from '@/api/__generated__'
+import { DataIdentifierReference } from '@/api/__generated__'
 import type { CombinerContext } from '@/modules/Mappings/types'
 
 interface EntityReferenceSelectProps {
@@ -34,7 +34,7 @@ const CombinedEntitySelect: FC<EntityReferenceSelectProps> = ({ id, tags, topicF
   const allOptions = useMemo(() => {
     if (isLoading) return []
 
-    return (
+    const combinedOptions =
       formContext?.queries?.reduce<EntityOption[]>((acc, queryResult) => {
         if (!queryResult.data) return acc
         if (!queryResult.data.items.length) return acc
@@ -60,7 +60,14 @@ const CombinedEntitySelect: FC<EntityReferenceSelectProps> = ({ id, tags, topicF
 
         return acc
       }, []) || []
-    )
+
+    return combinedOptions.reduce<EntityOption[]>((acc, current) => {
+      const isAlreadyIn = acc.find((item) => item.value === current.value && item.type === current.type)
+      if (!isAlreadyIn) {
+        return acc.concat([current])
+      }
+      return acc
+    }, [])
   }, [formContext?.entities, formContext?.queries, isLoading])
 
   const values = useMemo(() => {

--- a/hivemq-edge/src/frontend/src/modules/Mappings/components/combiner/CombinedSchemaLoader.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/components/combiner/CombinedSchemaLoader.tsx
@@ -77,7 +77,7 @@ export const CombinedSchemaLoader: FC<CombinedSchemaLoaderProps> = ({ formData, 
       } else {
         dataReference.schema = {
           status: 'warning',
-          message: t('topicFilter.schema.status.missing'),
+          message: t('topicFilter.error.schema.noAssignedSchema', { context: dataReference.type }),
         }
       }
       return dataReference

--- a/hivemq-edge/src/frontend/src/modules/Mappings/components/combiner/CombinedSchemaLoader.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/components/combiner/CombinedSchemaLoader.tsx
@@ -48,12 +48,20 @@ export const CombinedSchemaLoader: FC<CombinedSchemaLoaderProps> = ({ formData, 
     const tags = formData?.sources?.tags || []
     const topicFilters = formData?.sources?.topicFilters || []
     const indexes = [...tags, ...topicFilters]
-    return allDataReferences?.filter((dataReference) => indexes.includes(dataReference.id)) || []
+
+    const selectedReferences = allDataReferences?.filter((dataReference) => indexes.includes(dataReference.id)) || []
+    return selectedReferences.reduce<DataReference[]>((acc, current) => {
+      const isAlreadyIn = acc.find((item) => item.id === current.id && item.type === current.type)
+      if (!isAlreadyIn) {
+        return acc.concat([current])
+      }
+      return acc
+    }, [])
   }, [allDataReferences, formData?.sources?.tags, formData?.sources?.topicFilters])
 
   const queries = useGetCombinedDataSchemas(allSchemas)
 
-  const test = useMemo(() => {
+  const displayedSchemas = useMemo(() => {
     return allSchemas.map((dataReference, index) => {
       const { data } = queries[index]
 
@@ -76,11 +84,11 @@ export const CombinedSchemaLoader: FC<CombinedSchemaLoaderProps> = ({ formData, 
     })
   }, [allSchemas, queries, t])
 
-  if (!test.length) return <ErrorMessage message={t('combiner.error.noSchemaLoadedYet')} status={'info'} />
+  if (!displayedSchemas.length) return <ErrorMessage message={t('combiner.error.noSchemaLoadedYet')} status={'info'} />
 
   return (
     <>
-      {test.map((dataReference) => {
+      {displayedSchemas.map((dataReference) => {
         const hasSchema = dataReference.schema?.status === 'success' && dataReference.schema.schema
 
         if (!hasSchema) {

--- a/hivemq-edge/src/frontend/src/modules/Mappings/components/combiner/EntityRenderer.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/components/combiner/EntityRenderer.tsx
@@ -39,9 +39,21 @@ const BridgeEntityRenderer: FC<EntityRendererProps> = ({ reference }) => {
   return <NodeNameCard type={NodeTypes.BRIDGE_NODE} name={data?.id} />
 }
 
+const BrokerEntityRenderer: FC<EntityRendererProps> = () => {
+  const { t } = useTranslation()
+  return (
+    <NodeNameCard
+      type={NodeTypes.EDGE_NODE}
+      name={t('branding.appName')}
+      description={t('combiner.schema.sources.edge.description')}
+    />
+  )
+}
+
 export const EntityRenderer: FC<EntityRendererProps> = ({ reference }) => {
   const { t } = useTranslation()
   if (reference.type === EntityType.BRIDGE) return <BridgeEntityRenderer reference={reference} />
   if (reference.type === EntityType.ADAPTER) return <AdapterEntityRenderer reference={reference} />
+  if (reference.type === EntityType.EDGE_BROKER) return <BrokerEntityRenderer reference={reference} />
   return <ErrorMessage message={t('combiner.error.noValidReference')} />
 }


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/30890/details/

The PR fixes a bug which prevented the `topic filter` from being available to the mappings.

If no `bridge` was added to the selected entities in the workspace, then `topic filters` would not be processed. This situation is not corrected by ensuring that the `Edge` entity, as the owner of the `topic filters` is automatically added to the list of sources

The PR also improves error message on the schema selector and remove duplicates from the list of tag/topic filters.

### Out-of-scope
- Sources, including the `edge` cannot be removed from the `combiner`. When that is the case, a decision on keeping the `edge` node as a default source must be taken
- Error message has been improved (mentioning the right type of source) but is still lacking enough context. This will be improved, see https://hivemq.kanbanize.com/ctrl_board/57/cards/30750/details/

### Before
![HiveMQ-Edge-02-28-2025_03_45_PM](https://github.com/user-attachments/assets/fb5c5cd1-9841-433f-a96d-a0b7afc68ccb)


### After
![HiveMQ-Edge-02-28-2025_03_43_PM](https://github.com/user-attachments/assets/05ae46e1-e93f-4c2a-8fd3-1bf459b4dcf5)

