### PR TITLE
fix(30892): remove the filter on "supported" properties

### DIFF
--- a/hivemq-edge/src/frontend/src/components/rjsf/MqttTransformation/components/MappingEditor.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/components/rjsf/MqttTransformation/components/MappingEditor.spec.cy.tsx
@@ -32,7 +32,7 @@ describe('MappingEditor', () => {
     cy.getByTestId('loading-spinner').should('be.visible')
     cy.getByTestId('loading-spinner').should('not.exist')
 
-    cy.get('[role=list]').find('li').should('have.length', 6)
+    cy.get('[role=list]').find('li').should('have.length', 8)
     cy.getByTestId('mapping-instruction-dropzone').eq(0).should('have.text', 'Drag a source property here')
     cy.getByTestId('mapping-instruction-dropzone').eq(1).should('have.text', 'dropped-property')
   })

--- a/hivemq-edge/src/frontend/src/components/rjsf/MqttTransformation/components/MappingInstructionList.tsx
+++ b/hivemq-edge/src/frontend/src/components/rjsf/MqttTransformation/components/MappingInstructionList.tsx
@@ -6,7 +6,6 @@ import type { ListProps } from '@chakra-ui/react'
 import { List, ListItem } from '@chakra-ui/react'
 
 import type { Instruction } from '@/api/__generated__'
-import { filterSupportedProperties } from '@/components/rjsf/MqttTransformation/utils/data-type.utils.ts'
 import MappingInstruction from '@/components/rjsf/MqttTransformation/components/mapping/MappingInstruction.tsx'
 import { getPropertyListFrom } from '@/components/rjsf/MqttTransformation/utils/json-schema.utils.ts'
 
@@ -25,8 +24,7 @@ export const MappingInstructionList: FC<MappingEditorProps> = ({
   ...props
 }) => {
   const properties = useMemo(() => {
-    const allProperties = getPropertyListFrom(schema)
-    return allProperties.filter(filterSupportedProperties)
+    return getPropertyListFrom(schema)
   }, [schema])
 
   return (


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/30892/details/

Fix a bug with the "flattening" of properties that prevented nested properties from being displayed in the drag-and-drop editor

Notes
- The reason for the original filter has been lost ! 
- The fix will also impact the southbound mapping editor

### Before
![HiveMQ-Edge-02-28-2025_05_10_PM](https://github.com/user-attachments/assets/ce76b8a9-861b-4ce2-8f7f-3a4db7c8d79c)


### After
![HiveMQ-Edge-02-28-2025_05_10_PM (1)](https://github.com/user-attachments/assets/9c3226b5-6213-420c-bc3d-12afa71dd17e)
