### PR TITLE
feat(30712): add custom renderer for the options of the entity selector

### DIFF
--- a/hivemq-edge/src/frontend/src/locales/en/translation.json
+++ b/hivemq-edge/src/frontend/src/locales/en/translation.json
@@ -1268,7 +1268,9 @@
           "cancel": "Cancel"
         },
         "combinedSelector": {
-          "placeholder": "Select tags and topic filters to combine ..."
+          "placeholder": "Select tags and topic filters to combine ...",
+          "type_TAG": "Tag",
+          "type_TOPIC_FILTER": "Topic Filter"
         },
         "primary": {
           "placeholder": "Select a primary data key ..."

--- a/hivemq-edge/src/frontend/src/modules/Mappings/components/combiner/CombinedEntitySelect.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/components/combiner/CombinedEntitySelect.tsx
@@ -2,8 +2,9 @@ import type { FC } from 'react'
 import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { GroupBase, MultiValue, OptionBase } from 'chakra-react-select'
+import { chakraComponents } from 'chakra-react-select'
 import { Select } from 'chakra-react-select'
-import { Box } from '@chakra-ui/react'
+import { Box, HStack, Text, VStack } from '@chakra-ui/react'
 
 import type { DomainTag, TopicFilter } from '@/api/__generated__'
 import { DataIdentifierReference } from '@/api/__generated__'
@@ -52,7 +53,7 @@ const CombinedEntitySelect: FC<EntityReferenceSelectProps> = ({ id, tags, topicF
             label: topicFilter.topicFilter,
             value: topicFilter.topicFilter,
             description: topicFilter.description,
-            type: DataIdentifierReference.type.TAG,
+            type: DataIdentifierReference.type.TOPIC_FILTER,
           }))
 
           acc.push(...options)
@@ -98,9 +99,29 @@ const CombinedEntitySelect: FC<EntityReferenceSelectProps> = ({ id, tags, topicF
         }}
         isClearable
         placeholder={t('combiner.schema.mapping.combinedSelector.placeholder')}
-        // noOptionsMessage={() => t('EntityCreatableSelect.options.noOptionsMessage', { context: type })}
-        // components={customComponents(isMulti, type)}
-        // filterOption={createFilter(filterConfig)}
+        components={{
+          Option: ({ children, ...props }) => {
+            return (
+              <chakraComponents.Option {...props}>
+                <VStack gap={0} alignItems="stretch" w="100%">
+                  <HStack>
+                    <Box flex={1}>
+                      <Text flex={1}>{props.data.label}</Text>
+                    </Box>
+                    <Box>
+                      <Text fontSize="sm" fontWeight="bold">
+                        {t('combiner.schema.mapping.combinedSelector.type', { context: props.data.type })}
+                      </Text>
+                    </Box>
+                  </HStack>
+                  <Text fontSize="sm" noOfLines={3} ml={2} lineHeight={'normal'} textAlign={'justify'}>
+                    {props.data.description}
+                  </Text>
+                </VStack>
+              </chakraComponents.Option>
+            )
+          },
+        }}
       />
     </Box>
   )


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/30712/details/

The PR adds a custom renderer to improve the identification of the tags and topic filters in the options of the selector. 

### Before 
![HiveMQ-Edge-02-28-2025_06_58_PM (1)](https://github.com/user-attachments/assets/8c0291ce-8dfb-421c-a872-17166dc9b34f)


### After
![HiveMQ-Edge-02-28-2025_06_58_PM](https://github.com/user-attachments/assets/8bb7d54d-aff6-42d8-8a5d-2eb5ecfdcfc7)
