### PR TITLE
feat(30829): Add custom validation to the combiner form

### DIFF
--- a/hivemq-edge/src/frontend/src/components/rjsf/Form/ChakraRJSForm.tsx
+++ b/hivemq-edge/src/frontend/src/components/rjsf/Form/ChakraRJSForm.tsx
@@ -35,7 +35,8 @@ interface CustomFormProps<T>
 
 const FLAG_POST_VALIDATE = false
 
-const ChakraRJSForm: FC<CustomFormProps<unknown>> = ({
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const ChakraRJSForm: FC<CustomFormProps<any>> = ({
   id,
   schema,
   uiSchema,

--- a/hivemq-edge/src/frontend/src/locales/en/translation.json
+++ b/hivemq-edge/src/frontend/src/locales/en/translation.json
@@ -1234,7 +1234,9 @@
         "notDestinationProperties": "The destination schema doesn't have any property to be mapped into",
         "notMinimumRequiredSchema": "At least one schema should be available",
         "notDataSourceProperties_TAG": "The destination schema doesn't have any property to be mapped into",
-        "notDataSourceProperties_TOPIC_FILTER": "The destination schema doesn't have any property to be mapped into"
+        "notDataSourceProperties_TOPIC_FILTER": "The destination schema doesn't have any property to be mapped into",
+        "notInstructionSourcePath": "The instruction is not a recognised destination property",
+        "notInstructionDestinationPath": "The instruction is not a recognised source property"
       }
     },
     "schema": {

--- a/hivemq-edge/src/frontend/src/locales/en/translation.json
+++ b/hivemq-edge/src/frontend/src/locales/en/translation.json
@@ -1224,7 +1224,16 @@
       "noDataUri": "There was a problem loading the data",
       "noValidReference": "This is not a valid reference to a Workspace entity",
       "invalidData": "Invalid data",
-      "noSchemaLoadedYet": "There are no schemas available yet"
+      "noSchemaLoadedYet": "There are no schemas available yet",
+      "validation": {
+        "notValidReference": "This is not a valid reference to a Workspace entity",
+        "notCombineCapability": "The adapter does not support data combining and cannot be used as a source",
+        "notEdgeSource": "The Edge broker must be connected to the combiner's sources",
+        "notDataSourceOwner_TAG": "The tag {{ tag }} is not defined in any of the combiner's sources",
+        "notDataSourceOwner_TOPIC_FILTER": "The topic filter {{ topicFilter }} is not defined in any of the combiner's sources",
+        "notDestinationProperties": "The destination schema doesn't have any property to be mapped into",
+        "notMinimumRequiredSchema": "At least one schema should be available"
+      }
     },
     "schema": {
       "tabs": {

--- a/hivemq-edge/src/frontend/src/locales/en/translation.json
+++ b/hivemq-edge/src/frontend/src/locales/en/translation.json
@@ -1232,7 +1232,9 @@
         "notDataSourceOwner_TAG": "The tag {{ tag }} is not defined in any of the combiner's sources",
         "notDataSourceOwner_TOPIC_FILTER": "The topic filter {{ topicFilter }} is not defined in any of the combiner's sources",
         "notDestinationProperties": "The destination schema doesn't have any property to be mapped into",
-        "notMinimumRequiredSchema": "At least one schema should be available"
+        "notMinimumRequiredSchema": "At least one schema should be available",
+        "notDataSourceProperties_TAG": "The destination schema doesn't have any property to be mapped into",
+        "notDataSourceProperties_TOPIC_FILTER": "The destination schema doesn't have any property to be mapped into"
       }
     },
     "schema": {

--- a/hivemq-edge/src/frontend/src/modules/Mappings/CombinerMappingManager.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/CombinerMappingManager.tsx
@@ -63,7 +63,7 @@ const CombinerMappingManager: FC = () => {
   }, [selectedNode?.data?.sources?.items])
 
   const sources = useGetCombinedEntities(entities)
-  const validateCombiner = useValidateCombiner(sources)
+  const validateCombiner = useValidateCombiner(sources, entities)
   const updateCombiner = useUpdateCombiner()
   const deleteCombiner = useDeleteCombiner()
 

--- a/hivemq-edge/src/frontend/src/modules/Mappings/CombinerMappingManager.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/CombinerMappingManager.tsx
@@ -39,6 +39,7 @@ import { IdStubs } from '@/modules/Workspace/types.ts'
 import useWorkspaceStore from '@/modules/Workspace/hooks/useWorkspaceStore.ts'
 import NodeNameCard from '@/modules/Workspace/components/parts/NodeNameCard.tsx'
 import DangerZone from './components/DangerZone'
+import { useValidateCombiner } from './hooks/useValidateCombiner'
 
 const CombinerMappingManager: FC = () => {
   const { t } = useTranslation()
@@ -47,8 +48,6 @@ const CombinerMappingManager: FC = () => {
   const { combinerId } = useParams()
   const { nodes, onUpdateNode, onNodesChange } = useWorkspaceStore()
   const toast = useToast()
-  const updateCombiner = useUpdateCombiner()
-  const deleteCombiner = useDeleteCombiner()
 
   const selectedNode = useMemo(() => {
     return nodes.find((node) => node.id === combinerId) as Node<Combiner> | undefined
@@ -64,6 +63,9 @@ const CombinerMappingManager: FC = () => {
   }, [selectedNode?.data?.sources?.items])
 
   const sources = useGetCombinedEntities(entities)
+  const validateCombiner = useValidateCombiner(sources)
+  const updateCombiner = useUpdateCombiner()
+  const deleteCombiner = useDeleteCombiner()
 
   const handleClose = () => {
     onClose()
@@ -134,6 +136,7 @@ const CombinerMappingManager: FC = () => {
               formData={selectedNode.data}
               onSubmit={handleOnSubmit}
               formContext={{ queries: sources, entities } as CombinerContext}
+              customValidate={validateCombiner}
             />
           )}
         </DrawerBody>

--- a/hivemq-edge/src/frontend/src/modules/Mappings/hooks/useValidateCombiner.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/hooks/useValidateCombiner.tsx
@@ -3,21 +3,69 @@ import type { CustomValidator, RJSFSchema } from '@rjsf/utils'
 import type { UseQueryResult } from '@tanstack/react-query'
 
 import type { Combiner, DomainTagList, TopicFilterList } from '@/api/__generated__'
+import { EntityType } from '@/api/__generated__'
+import { useGetAdapterTypes } from '@/api/hooks/useProtocolAdapters/useGetAdapterTypes'
+import { useListProtocolAdapters } from '@/api/hooks/useProtocolAdapters/useListProtocolAdapters'
 
 import type { CombinerContext } from '@/modules/Mappings/types'
 
 // TODO[NVL] Context is not part of the customValidator props; need to get a better construction of props
 export const useValidateCombiner = (queries: UseQueryResult<DomainTagList | TopicFilterList, Error>[]) => {
-  const validateCombiner = useCallback<CustomValidator<Combiner, RJSFSchema, CombinerContext>>((formData, errors) => {
-    formData?.mappings?.items?.forEach((entity, index) => {
-      if (!errors.mappings?.items?.[index]) return
+  const { data: adapterInfo } = useGetAdapterTypes()
+  const { data: adapters } = useListProtocolAdapters()
 
-      console.log('XXX', queries, entity)
-      // TODO
-    })
+  /**
+   * Verify that a connected entity is eligible for data combining:
+   * - ADAPTER: must have the `COMBINE` capability
+   * - BRIDGE: no condition
+   *     TODO[NVL] Should we ban bridges that have no proper topic filters
+   * - EDGE: mandatory inclusion to the sources
+   */
+  const validateSourceCapability = useCallback<CustomValidator<Combiner, RJSFSchema, CombinerContext>>(
+    (formData, errors) => {
+      formData?.sources.items.forEach((entity, index) => {
+        if (entity.type === EntityType.ADAPTER) {
+          const adapter = adapters?.find((e) => e.id === entity.id)
+          const protocolAdapter = adapter
+            ? adapterInfo?.items.find((protocol) => protocol.id === adapter.type)
+            : undefined
+          if (!adapter || !protocolAdapter)
+            errors.sources?.items?.[index]?.addError('This is not a valid reference to a Workspace entity')
+          else {
+            if (protocolAdapter.capabilities && !protocolAdapter.capabilities.includes('COMBINE')) {
+              errors.sources?.items?.[index]?.addError(
+                'The adapter does not support data combining and cannot be used as a source'
+              )
+            }
+          }
+        }
+      })
 
-    return errors
-  }, [])
+      const hasEdge = formData?.sources.items?.filter((e) => e.type === EntityType.EDGE_BROKER)
+      if (!hasEdge || hasEdge.length !== 1) {
+        errors.sources?.items?.addError("The Edge broker must be connected to the combiner's sources")
+      }
+
+      return errors
+    },
+    [adapterInfo?.items, adapters]
+  )
+
+  const validateCombiner = useCallback<CustomValidator<Combiner, RJSFSchema, CombinerContext>>(
+    (formData, errors) => {
+      validateSourceCapability(formData, errors)
+
+      formData?.mappings?.items?.forEach((entity, index) => {
+        if (!errors.mappings?.items?.[index]) return
+
+        console.log('XXX', queries, entity)
+        // TODO
+      })
+
+      return errors
+    },
+    [queries, validateSourceCapability]
+  )
 
   return validateCombiner
 }

--- a/hivemq-edge/src/frontend/src/modules/Mappings/hooks/useValidateCombiner.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/hooks/useValidateCombiner.tsx
@@ -233,8 +233,6 @@ export const useValidateCombiner = (
         if (!knownPaths.includes(instruction.destination))
           errors.instructions?.[index]?.addError(t('combiner.error.validation.notInstructionDestinationPath'))
 
-        // TODO[NVL] check validity of source path
-
         if (!allPathsFromSources.includes(instruction.source))
           errors.instructions?.[index]?.addError(t('combiner.error.validation.notInstructionSourcePath'))
       })
@@ -244,27 +242,20 @@ export const useValidateCombiner = (
     [allPathsFromSources, t]
   )
 
-  return useCallback<CustomValidator<Combiner, RJSFSchema, CombinerContext>>(
-    (formData, errors) => {
-      validateSourceCapability(formData, errors)
+  const validateCombiner: CustomValidator<Combiner, RJSFSchema, CombinerContext> = (formData, errors) => {
+    validateSourceCapability(formData, errors)
 
-      formData?.mappings?.items?.forEach((entity, index) => {
-        if (!errors.mappings?.items?.[index]) return
+    formData?.mappings?.items?.forEach((entity, index) => {
+      if (!errors.mappings?.items?.[index]) return
 
-        validateDataSources(entity, errors.mappings.items[index])
-        validateDataSourceSchemas(entity, errors.mappings.items[index])
-        validateDestinationSchema(entity, errors.mappings.items[index])
-        validateInstructions(entity, errors.mappings.items[index])
-      })
+      validateDataSources(entity, errors.mappings.items[index])
+      validateDataSourceSchemas(entity, errors.mappings.items[index])
+      validateDestinationSchema(entity, errors.mappings.items[index])
+      validateInstructions(entity, errors.mappings.items[index])
+    })
 
-      return errors
-    },
-    [
-      validateDataSourceSchemas,
-      validateDataSources,
-      validateDestinationSchema,
-      validateInstructions,
-      validateSourceCapability,
-    ]
-  )
+    return errors
+  }
+
+  return validateCombiner
 }

--- a/hivemq-edge/src/frontend/src/modules/Mappings/hooks/useValidateCombiner.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/hooks/useValidateCombiner.tsx
@@ -81,15 +81,15 @@ export const useValidateCombiner = (
 
   const allPathsFromSources = useMemo<string[]>(() => {
     return allSchemaReferences.reduce<string[]>((acc, cur) => {
-      let flat: FlatJSONSchema7[] = []
+      let flatList: FlatJSONSchema7[]
       if (typeof cur.data === 'string') {
         const handleSchema = validateSchemaFromDataURI(cur.data)
-        flat = handleSchema.schema ? getPropertyListFrom(handleSchema.schema) : []
+        flatList = handleSchema.schema ? getPropertyListFrom(handleSchema.schema) : []
       } else {
-        flat = cur.data ? getPropertyListFrom(cur.data) : []
+        flatList = cur.data ? getPropertyListFrom(cur.data) : []
       }
-      const hhh = flat.map((e) => [...e.path, e.key].join('.'))
-      acc.push(...hhh)
+      const fullPaths = flatList.map((e) => [...e.path, e.key].join('.'))
+      acc.push(...fullPaths)
 
       return Array.from(new Set(acc))
     }, [])
@@ -241,10 +241,10 @@ export const useValidateCombiner = (
 
       return errors
     },
-    []
+    [allPathsFromSources, t]
   )
 
-  const validateCombiner = useCallback<CustomValidator<Combiner, RJSFSchema, CombinerContext>>(
+  return useCallback<CustomValidator<Combiner, RJSFSchema, CombinerContext>>(
     (formData, errors) => {
       validateSourceCapability(formData, errors)
 
@@ -267,6 +267,4 @@ export const useValidateCombiner = (
       validateSourceCapability,
     ]
   )
-
-  return validateCombiner
 }

--- a/hivemq-edge/src/frontend/src/modules/Mappings/hooks/useValidateCombiner.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/hooks/useValidateCombiner.tsx
@@ -1,0 +1,23 @@
+import { useCallback } from 'react'
+import type { CustomValidator, RJSFSchema } from '@rjsf/utils'
+import type { UseQueryResult } from '@tanstack/react-query'
+
+import type { Combiner, DomainTagList, TopicFilterList } from '@/api/__generated__'
+
+import type { CombinerContext } from '@/modules/Mappings/types'
+
+// TODO[NVL] Context is not part of the customValidator props; need to get a better construction of props
+export const useValidateCombiner = (queries: UseQueryResult<DomainTagList | TopicFilterList, Error>[]) => {
+  const validateCombiner = useCallback<CustomValidator<Combiner, RJSFSchema, CombinerContext>>((formData, errors) => {
+    formData?.mappings?.items?.forEach((entity, index) => {
+      if (!errors.mappings?.items?.[index]) return
+
+      console.log('XXX', queries, entity)
+      // TODO
+    })
+
+    return errors
+  }, [])
+
+  return validateCombiner
+}


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/30829/details/

The PR adds custom validation to the `combiner` payload, augmenting the basic elements of the OpenAPI specs. 

The custom validations are rules expressed with the `RJSF` framework, which means they integrate (almost) completely with the UX in the form:  
- errors are associated with specific properties of the schema
- when triggered, the message is displayed by the relevant widget in the form UI (or will be)
- errors are also listed in the summary at the bottom of the form

### Design
- The following validation rules are in operation: 
  
```json
{
  "notValidReference": "This is not a valid reference to a Workspace entity",
  "notCombineCapability": "The adapter does not support data combining and cannot be used as a source",
  "notEdgeSource": "The Edge broker must be connected to the combiner's sources",
  "notDataSourceOwner_TAG": "The tag {{ tag }} is not defined in any of the combiner's sources",
  "notDataSourceOwner_TOPIC_FILTER": "The topic filter {{ topicFilter }} is not defined in any of the combiner's sources",
  "notDestinationProperties": "The destination schema doesn't have any property to be mapped into",
  "notMinimumRequiredSchema": "At least one schema should be available",
  "notDataSourceProperties_TAG": "The destination schema doesn't have any property to be mapped into",
  "notDataSourceProperties_TOPIC_FILTER": "The destination schema doesn't have any property to be mapped into",
  "notInstructionSourcePath": "The instruction is not a recognised destination property",
  "notInstructionDestinationPath": "The instruction is not a recognised source property"

}
```

- The `RJSF` framework only supports errors, not warnings. Any validation failure will render an error and prevent the form from being published. 

### Out-of-scope
- Some widgets in the custom forms are not properly rendering errors (e.g. red borders). This will be done in a subsequent ticket
- The list of errors doesn't support focus on individual property in the new table-based component. This will be fixed in a subsequent ticket, see https://hivemq.kanbanize.com/ctrl_board/57/cards/30666/details/
- The second form (`DataCombining`) also needs the custom validation rules. It will be made available in a subsequent ticket.

### Before
![HiveMQ-Edge-03-03-2025_02_21_PM (1)](https://github.com/user-attachments/assets/79b3f062-0359-4dc7-8f53-da56b48ba684)

![HiveMQ-Edge-03-03-2025_02_21_PM](https://github.com/user-attachments/assets/4db93068-041a-4da3-ae90-9386dabe435d)


### After
![HiveMQ-Edge-03-03-2025_02_20_PM](https://github.com/user-attachments/assets/5f86dc75-27f7-4a3f-946d-37a22405c0cd)
