### PR TITLE
fix(30977) Fix the primary key selection in the combiner's mappings

### DIFF
--- a/hivemq-edge/src/frontend/src/api/schemas/combiner-mapping.json-schema.ts
+++ b/hivemq-edge/src/frontend/src/api/schemas/combiner-mapping.json-schema.ts
@@ -11,6 +11,8 @@ export const combinerMappingJsonSchema: JSONSchema7 = {
     Instruction: Instruction,
     DataIdentifierReference: {
       description: `A reference to one of the data identifiers (topic filter or tag) in Edge`,
+      required: ['id', 'type'],
+
       properties: {
         id: {
           type: 'string',
@@ -45,6 +47,7 @@ export const combinerMappingJsonSchema: JSONSchema7 = {
     },
     DataCombining: {
       description: 'Define individual rules for data combining, based on the entities selected in the Orchestrator',
+      required: ['id', 'sources'],
       properties: {
         id: {
           type: 'string',
@@ -52,6 +55,7 @@ export const combinerMappingJsonSchema: JSONSchema7 = {
           format: 'uuid',
         },
         sources: {
+          required: ['primary'],
           properties: {
             primary: {
               $ref: '#/definitions/DataIdentifierReference',

--- a/hivemq-edge/src/frontend/src/modules/Mappings/components/combiner/DataCombiningEditorField.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/components/combiner/DataCombiningEditorField.tsx
@@ -28,15 +28,24 @@ export const DataCombiningEditorField: FC<FieldProps<DataCombining, RJSFSchema, 
                 if (!formData) return
                 const tag: string[] = []
                 const filter: string[] = []
+
+                let isPrimary = false
                 values.forEach((entity) => {
                   if (entity.type === DataIdentifierReference.type.TAG) tag.push(entity.value)
                   if (entity.type === DataIdentifierReference.type.TOPIC_FILTER) filter.push(entity.value)
+                  if (formData.sources.primary?.type === entity.type && formData.sources.primary?.id === entity.value)
+                    isPrimary = true
                 })
 
                 props.onChange({
                   ...formData,
-                  // @ts-ignore TODO check for type clash on primary
-                  sources: { ...formData.sources, tags: tag, topicFilters: filter },
+                  sources: {
+                    ...formData.sources,
+                    tags: tag,
+                    topicFilters: filter,
+                    // @ts-ignore TODO[30935] check for type clash on primary
+                    primary: isPrimary ? formData.sources.primary : undefined,
+                  },
                 })
               }}
             />

--- a/hivemq-edge/src/frontend/src/modules/Mappings/components/combiner/DataCombiningEditorField.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/components/combiner/DataCombiningEditorField.tsx
@@ -1,7 +1,4 @@
 import type { FC } from 'react'
-import { useMemo } from 'react'
-import { useTranslation } from 'react-i18next'
-import { Select } from 'chakra-react-select'
 import type { FieldProps, RJSFSchema } from '@rjsf/utils'
 import { Box, HStack, Icon, Stack, VStack } from '@chakra-ui/react'
 import { FaRightFromBracket } from 'react-icons/fa6'
@@ -13,18 +10,10 @@ import type { CombinerContext } from '@/modules/Mappings/types'
 import CombinedEntitySelect from './CombinedEntitySelect'
 import { CombinedSchemaLoader } from './CombinedSchemaLoader'
 import { DestinationSchemaLoader } from './DestinationSchemaLoader'
+import { PrimarySelect } from './PrimarySelect'
 
 export const DataCombiningEditorField: FC<FieldProps<DataCombining, RJSFSchema, CombinerContext>> = (props) => {
-  const { t } = useTranslation()
-
   const { formData, formContext } = props
-
-  const primary = useMemo(() => {
-    const tags = formData?.sources?.tags || []
-    const topicFilters = formData?.sources?.topicFilters || []
-
-    return [...tags, ...topicFilters].map((entity) => ({ label: entity }))
-  }, [formData])
 
   return (
     <VStack alignItems="stretch" gap={4}>
@@ -56,12 +45,25 @@ export const DataCombiningEditorField: FC<FieldProps<DataCombining, RJSFSchema, 
             <CombinedSchemaLoader formData={props.formData} formContext={formContext} />
           </VStack>
           <Box>
-            <Select<{ label: string }>
-              options={primary}
-              data-testid={'combiner-mapping-primary'}
-              value={undefined}
-              isClearable
-              placeholder={t('combiner.schema.mapping.primary.placeholder')}
+            <PrimarySelect
+              formData={formData}
+              onChange={(values) => {
+                if (!props.formData) return
+
+                props.onChange({
+                  ...props.formData,
+                  sources: {
+                    ...props.formData.sources,
+                    // @ts-ignore TODO[30935] check for type clash on primary
+                    primary: values
+                      ? {
+                          id: values.value,
+                          type: values.type,
+                        }
+                      : undefined,
+                  },
+                })
+              }}
             />
           </Box>
         </VStack>

--- a/hivemq-edge/src/frontend/src/modules/Mappings/components/combiner/PrimarySelect.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/components/combiner/PrimarySelect.tsx
@@ -1,0 +1,58 @@
+import { useMemo, type FC } from 'react'
+import { useTranslation } from 'react-i18next'
+import { type SingleValue, Select } from 'chakra-react-select'
+
+import type { DataCombining } from '@/api/__generated__'
+import { DataIdentifierReference } from '@/api/__generated__'
+
+interface PrimaryOption {
+  label: string
+  value: string
+  type: DataIdentifierReference.type
+}
+interface PrimarySelectProps {
+  formData?: DataCombining
+  onChange: (newValue: SingleValue<PrimaryOption>) => void
+}
+
+export const PrimarySelect: FC<PrimarySelectProps> = ({ formData, onChange }) => {
+  const { t } = useTranslation()
+
+  const primaryOptions = useMemo(() => {
+    const tags = formData?.sources?.tags || []
+    const topicFilters = formData?.sources?.topicFilters || []
+
+    return [
+      ...tags.map<PrimaryOption>((entity) => ({
+        label: entity,
+        value: entity,
+        type: DataIdentifierReference.type.TAG,
+      })),
+      ...topicFilters.map<PrimaryOption>((entity) => ({
+        label: entity,
+        value: entity,
+        type: DataIdentifierReference.type.TOPIC_FILTER,
+      })),
+    ]
+  }, [formData])
+
+  const primaryValue = useMemo<PrimaryOption | null>(() => {
+    if (!formData?.sources.primary) return null
+    return {
+      label: formData.sources.primary.id,
+      value: formData.sources.primary.id,
+      type: formData.sources.primary.type,
+    }
+  }, [formData?.sources.primary])
+
+  return (
+    <Select<PrimaryOption>
+      options={primaryOptions}
+      data-testid={'combiner-mapping-primaryOptions'}
+      value={primaryValue}
+      onChange={onChange}
+      isClearable
+      placeholder={t('combiner.schema.mapping.primary.placeholder')}
+    />
+  )
+}


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/30977/details/

The PR refactors the UX that allows the primary key of a combiner's mapping to be defined. 

### Design
- The key is selectable from the list of data sources (both tags and topic filters) presented in the mapping editor
- When a selected key is removed from the source list, the primary key is set to `undefined`
- The `required` attributes of the the `RJSF` fomr have been changed to ensure the key is required

### Out-of-scope
- The design of the key selector is flawed in several aspects and will be resolved in subsequent tickets. See https://hivemq.kanbanize.com/ctrl_board/57/cards/30982/details/ and https://hivemq.kanbanize.com/ctrl_board/57/cards/30983/details/ 

### Before

### After
