### PR TITLE
fix(30988): Fix the pagination bar when no page exists

### DIFF
--- a/hivemq-edge/src/frontend/src/components/PaginatedTable/components/PaginationBar.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/components/PaginatedTable/components/PaginationBar.spec.cy.tsx
@@ -63,10 +63,93 @@ describe('PaginationBar', () => {
     cy.get('@nextPage').should('have.been.calledOnce')
   })
 
+  it('should render properly', () => {
+    cy.mountWithProviders(
+      <PaginationBar
+        // @ts-ignore force mocked partial object
+        table={MOCK_TABLE}
+        pageSizes={MOCK_PAGE_SIZES}
+        options={{ enablePaginationSizes: true, enablePaginationGoTo: true }}
+      />
+    )
+
+    cy.getByTestId('table-pagination-navigation').within(() => {
+      cy.get('button').should('have.length', 4)
+      cy.get('button').eq(0).should('have.attr', 'aria-label', 'Go to the first page').should('not.be.disabled')
+      cy.get('button').eq(1).should('have.attr', 'aria-label', 'Go to the previous page').should('not.be.disabled')
+      cy.get('button').eq(2).should('have.attr', 'aria-label', 'Go to the next page').should('not.be.disabled')
+      cy.get('button').eq(3).should('have.attr', 'aria-label', 'Go to the last page').should('not.be.disabled')
+    })
+
+    cy.getByTestId('table-pagination-currentPage').should('have.text', 'Page 3 of 10')
+    cy.getByTestId('table-pagination-goto').within(() => {
+      cy.get('label').should('have.text', 'Go to page')
+      cy.get('input')
+        .should('have.value', 3)
+        .should('have.attr', 'role', 'spinbutton')
+        .should('have.attr', 'inputmode', 'decimal')
+        .should('have.attr', 'aria-valuemin', '1')
+        .should('have.attr', 'aria-valuemax', '10')
+    })
+
+    cy.getByTestId('table-pagination-perPages').within(() => {
+      cy.get('label').should('have.text', 'Items per page')
+      cy.get('select').should('have.value', 5)
+    })
+  })
+
+  it('should hide page controls if no data', () => {
+    const mockEmptyTable = { ...MOCK_TABLE, getPageCount: () => 0 }
+    cy.mountWithProviders(
+      <PaginationBar
+        // @ts-ignore force mocked partial object
+        table={mockEmptyTable}
+        pageSizes={MOCK_PAGE_SIZES}
+        options={{ enablePaginationSizes: true, enablePaginationGoTo: true }}
+      />
+    )
+
+    cy.getByTestId('table-pagination-navigation').should('be.visible')
+    cy.getByTestId('table-pagination-currentPage').should('not.exist')
+    cy.getByTestId('table-pagination-goto').should('not.exist')
+  })
+
+  it('should hide pagination size', () => {
+    cy.mountWithProviders(
+      <PaginationBar
+        // @ts-ignore force mocked partial object
+        table={MOCK_TABLE}
+        pageSizes={MOCK_PAGE_SIZES}
+        options={{ enablePaginationSizes: false, enablePaginationGoTo: true }}
+      />
+    )
+
+    cy.getByTestId('table-pagination-perPage').should('not.exist')
+  })
+
+  it('should hide page go to', () => {
+    cy.mountWithProviders(
+      <PaginationBar
+        // @ts-ignore force mocked partial object
+        table={MOCK_TABLE}
+        pageSizes={MOCK_PAGE_SIZES}
+        options={{ enablePaginationSizes: true, enablePaginationGoTo: false }}
+      />
+    )
+
+    cy.getByTestId('table-pagination-goto').should('not.exist')
+  })
+
   it('should be accessible', () => {
     cy.injectAxe()
-    // @ts-ignore force mocked partial object
-    cy.mountWithProviders(<PaginationBar table={MOCK_TABLE} pageSizes={MOCK_PAGE_SIZES} />)
+    cy.mountWithProviders(
+      <PaginationBar
+        // @ts-ignore force mocked partial object
+        table={MOCK_TABLE}
+        pageSizes={MOCK_PAGE_SIZES}
+        options={{ enablePaginationSizes: true, enablePaginationGoTo: true }}
+      />
+    )
     cy.checkAccessibility()
     cy.percySnapshot('Component: PaginationBar')
   })

--- a/hivemq-edge/src/frontend/src/components/PaginatedTable/components/PaginationBar.tsx
+++ b/hivemq-edge/src/frontend/src/components/PaginatedTable/components/PaginationBar.tsx
@@ -40,7 +40,7 @@ const PaginationBar = <T,>({ table, pageSizes, options }: PaginationProps<T>) =>
 
   return (
     <HStack as="nav" aria-label={t('components:pagination.ariaLabel')} gap={8} mt={4}>
-      <ButtonGroup isAttached variant="ghost">
+      <ButtonGroup isAttached variant="ghost" data-testid={'table-pagination-navigation'}>
         <PaginationButton
           icon={<LuSkipBack />}
           onClick={() => table.setPageIndex(0)}
@@ -100,8 +100,13 @@ const PaginationBar = <T,>({ table, pageSizes, options }: PaginationProps<T>) =>
 
       {options?.enablePaginationSizes && (
         <Flex flex={1}>
-          <FormControl display="flex" alignItems="baseline" justifyContent="flex-end">
-            <FormLabel> {t('components:pagination.perPage')}</FormLabel>
+          <FormControl
+            display="flex"
+            alignItems="baseline"
+            justifyContent="flex-end"
+            data-testid={'table-pagination-perPages'}
+          >
+            <FormLabel>{t('components:pagination.perPage')}</FormLabel>
             <Select
               maxWidth="80px"
               size="sm"

--- a/hivemq-edge/src/frontend/src/components/PaginatedTable/components/PaginationBar.tsx
+++ b/hivemq-edge/src/frontend/src/components/PaginatedTable/components/PaginationBar.tsx
@@ -36,6 +36,8 @@ const PaginationButton: FC<IconButtonProps> = (props) => (
 
 const PaginationBar = <T,>({ table, pageSizes, options }: PaginationProps<T>) => {
   const { t } = useTranslation()
+  const showPageControls = table.getPageCount() !== 0
+
   return (
     <HStack as="nav" aria-label={t('components:pagination.ariaLabel')} gap={8} mt={4}>
       <ButtonGroup isAttached variant="ghost">
@@ -65,17 +67,19 @@ const PaginationBar = <T,>({ table, pageSizes, options }: PaginationProps<T>) =>
         />
       </ButtonGroup>
 
-      <Box role="group">
-        <Text fontSize="md" whiteSpace="nowrap">
-          {t('components:pagination.pageOf', {
-            page: table.getState().pagination.pageIndex + 1,
-            max: table.getPageCount(),
-          })}
-        </Text>
-      </Box>
+      {showPageControls && (
+        <Box role="group" data-testid={'table-pagination-currentPage'}>
+          <Text fontSize="md" whiteSpace="nowrap">
+            {t('components:pagination.pageOf', {
+              page: table.getState().pagination.pageIndex + 1,
+              max: table.getPageCount(),
+            })}
+          </Text>
+        </Box>
+      )}
 
-      {options?.enablePaginationGoTo && (
-        <FormControl display="flex" alignItems="center" w="inherit">
+      {showPageControls && options?.enablePaginationGoTo && (
+        <FormControl display="flex" alignItems="center" w="inherit" data-testid={'table-pagination-goto'}>
           <FormLabel mb={0}>{t('components:pagination.goPage')}</FormLabel>
           <NumberInput
             size="sm"


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/30988/details/

The PR is a quick fix to hide the page indicators when there is no page available (i.e. no data to render). This only concerns the data-related controls; the "items per page" is still active.

The PR also adds missing tests

Note that the fix will apply to EVERY table used in Edge

### Before
![HiveMQ-Edge-03-19-2025_02_51_PM](https://github.com/user-attachments/assets/2d4e37fd-9046-463d-af1a-ecd860359f57)

### After
![HiveMQ-Edge-03-19-2025_02_50_PM](https://github.com/user-attachments/assets/ea11a7bc-d032-46e4-802c-2c323963c9f6)

