### PR TITLE
fix(30954): Ensure combiner toasts can be manually closed

### DIFF
--- a/hivemq-edge/src/frontend/src/hooks/useEdgeToast/toast-utils.ts
+++ b/hivemq-edge/src/frontend/src/hooks/useEdgeToast/toast-utils.ts
@@ -1,8 +1,12 @@
 import type { UseToastOptions } from '@chakra-ui/react'
 
-export const DEFAULT_TOAST_OPTION: UseToastOptions = {
-  status: 'success',
+export const BASE_TOAST_OPTION: UseToastOptions = {
   duration: 3000,
   isClosable: true,
+}
+
+export const DEFAULT_TOAST_OPTION: UseToastOptions = {
+  ...BASE_TOAST_OPTION,
+  status: 'success',
   position: 'top-right',
 }

--- a/hivemq-edge/src/frontend/src/modules/Mappings/CombinerMappingManager.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/CombinerMappingManager.tsx
@@ -34,6 +34,7 @@ import { useUpdateCombiner, useDeleteCombiner } from '@/api/hooks/useCombiners/'
 import { useGetCombinedEntities } from '@/api/hooks/useDomainModel/useGetCombinedEntities'
 import ChakraRJSForm from '@/components/rjsf/Form/ChakraRJSForm'
 import ErrorMessage from '@/components/ErrorMessage'
+import { BASE_TOAST_OPTION } from '@/hooks/useEdgeToast/toast-utils'
 import type { NodeTypes } from '@/modules/Workspace/types.ts'
 import { IdStubs } from '@/modules/Workspace/types.ts'
 import useWorkspaceStore from '@/modules/Workspace/hooks/useWorkspaceStore.ts'
@@ -47,7 +48,7 @@ const CombinerMappingManager: FC = () => {
   const navigate = useNavigate()
   const { combinerId } = useParams()
   const { nodes, onUpdateNode, onNodesChange } = useWorkspaceStore()
-  const toast = useToast()
+  const toast = useToast(BASE_TOAST_OPTION)
 
   const selectedNode = useMemo(() => {
     return nodes.find((node) => node.id === combinerId) as Node<Combiner> | undefined

--- a/hivemq-edge/src/frontend/src/modules/Mappings/hooks/useNorthboundMappingManager.ts
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/hooks/useNorthboundMappingManager.ts
@@ -7,15 +7,12 @@ import { useUpdateNorthboundMappings } from '@/api/hooks/useProtocolAdapters/use
 
 import { northboundMappingListSchema } from '@/api/schemas/northbound.json-schema.ts'
 import { northboundMappingListUISchema } from '@/api/schemas/northbound.ui-schema.ts'
-import { DEFAULT_TOAST_OPTION } from '@/hooks/useEdgeToast/toast-utils.ts'
+import { BASE_TOAST_OPTION } from '@/hooks/useEdgeToast/toast-utils.ts'
 import type { ManagerContextType, MappingManagerType } from '@/modules/Mappings/types.ts'
 
 export const useNorthboundMappingManager = (adapterId: string): MappingManagerType<NorthboundMappingList> => {
   const { t } = useTranslation()
-  const toast = useToast({
-    duration: DEFAULT_TOAST_OPTION.duration,
-    isClosable: DEFAULT_TOAST_OPTION.isClosable,
-  })
+  const toast = useToast(BASE_TOAST_OPTION)
   const { data, isError, isLoading, error } = useListNorthboundMappings(adapterId)
 
   const updateCollectionMutator = useUpdateNorthboundMappings()

--- a/hivemq-edge/src/frontend/src/modules/Mappings/hooks/useSouthboundMappingManager.ts
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/hooks/useSouthboundMappingManager.ts
@@ -8,14 +8,11 @@ import { useUpdateSouthboundMappings } from '@/api/hooks/useProtocolAdapters/use
 import type { ManagerContextType, MappingManagerType } from '@/modules/Mappings/types.ts'
 import { southboundMappingListSchema } from '@/api/schemas/southbound.json-schema.ts'
 import { southboundMappingListUISchema } from '@/api/schemas/southbound.ui-schema.ts'
-import { DEFAULT_TOAST_OPTION } from '@/hooks/useEdgeToast/toast-utils.ts'
+import { BASE_TOAST_OPTION } from '@/hooks/useEdgeToast/toast-utils.ts'
 
 export const useSouthboundMappingManager = (adapterId: string): MappingManagerType<SouthboundMappingList> => {
   const { t } = useTranslation()
-  const toast = useToast({
-    duration: DEFAULT_TOAST_OPTION.duration,
-    isClosable: DEFAULT_TOAST_OPTION.isClosable,
-  })
+  const toast = useToast(BASE_TOAST_OPTION)
 
   const { data, isError, isLoading, error } = useListSouthboundMappings(adapterId)
 


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/30954/details/

The PR fixes a configuration bug resulting in `Combiner` toasts not being closable by end users.

### Before 
![HiveMQ-Edge-03-19-2025_03_15_PM](https://github.com/user-attachments/assets/e3f12e6f-9019-49cf-a3c5-aabd0b01f99b)


### After
![HiveMQ-Edge-03-19-2025_03_14_PM](https://github.com/user-attachments/assets/d6faf57c-1e01-4ccd-a5f6-3470653f351f)