### PR TITLE
fix(30987): Add styling for the primary key in the tabular summary

### DIFF
--- a/hivemq-edge/src/frontend/src/components/MQTT/EntityTag.tsx
+++ b/hivemq-edge/src/frontend/src/components/MQTT/EntityTag.tsx
@@ -18,15 +18,15 @@ interface EntityTagProps extends CustomTagProps {
 export const EntityTag: FC<EntityTagProps> = ({ tagTitle, tagIcon: TagIcon, colorScheme, ...rest }) => {
   const expandedTagTitle = typeof tagTitle === 'string' ? formatTopicString(tagTitle) : tagTitle
   return (
-    <Tag data-testid="topic-wrapper" {...rest} letterSpacing="-0.05rem" colorScheme={colorScheme}>
+    <Tag data-testid="topic-wrapper" {...rest} letterSpacing="-0.05rem" colorScheme={colorScheme} role={'group'}>
       <TagIcon boxSize="12px" mr={2} />
       {typeof tagTitle === 'string' ? <TagLabel>{expandedTagTitle}</TagLabel> : tagTitle}
     </Tag>
   )
 }
 
-export const PLCTag: FC<CustomTagProps> = ({ tagTitle }) => (
-  <EntityTag tagIcon={PLCTagIcon} tagTitle={tagTitle} colorScheme="blue" />
+export const PLCTag: FC<CustomTagProps> = ({ tagTitle, ...rest }) => (
+  <EntityTag tagIcon={PLCTagIcon} tagTitle={tagTitle} {...rest} colorScheme="blue" />
 )
 
 export const ClientTag: FC<CustomTagProps> = ({ tagTitle, ...rest }) => (

--- a/hivemq-edge/src/frontend/src/locales/en/translation.json
+++ b/hivemq-edge/src/frontend/src/locales/en/translation.json
@@ -1263,6 +1263,7 @@
         }
       },
       "mappings": {
+        "description": "The list of mappings created for this combiner",
         "table": {
           "action": "Actions",
           "delete": "Delete the mapping",
@@ -1288,6 +1289,7 @@
           "type_TOPIC_FILTER": "Topic Filter"
         },
         "primary": {
+          "aria-label": "Primary key",
           "label": "The primary data key of the mapping",
           "placeholder": "Select a primary data key ..."
         }

--- a/hivemq-edge/src/frontend/src/modules/Mappings/components/combiner/DataCombiningTableField.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/components/combiner/DataCombiningTableField.tsx
@@ -4,7 +4,7 @@ import { useMemo } from 'react'
 import { v4 as uuidv4 } from 'uuid'
 import { useTranslation } from 'react-i18next'
 import type { ColumnDef } from '@tanstack/react-table'
-import { ButtonGroup, HStack, Text } from '@chakra-ui/react'
+import { ButtonGroup, HStack, type TagProps, Text } from '@chakra-ui/react'
 import type { FieldProps, RJSFSchema } from '@rjsf/utils'
 import { LuPencil, LuPlus, LuTrash } from 'react-icons/lu'
 
@@ -55,9 +55,6 @@ export const DataCombiningTableField: FC<FieldProps<DataCombining[], RJSFSchema,
     }
 
     return [
-      // {
-      //   accessorKey: 'id',
-      // },
       {
         accessorKey: 'destination',
         cell: (info) => {
@@ -72,10 +69,31 @@ export const DataCombiningTableField: FC<FieldProps<DataCombining[], RJSFSchema,
           const nbItems = (sources?.tags?.length || 0) + (sources?.topicFilters?.length || 0)
           if (nbItems === 0) return <Text>{t('combiner.unset')}</Text>
 
+          const primary = info.row.original.sources.primary
+
+          const getPrimaryStyle = (type: DataIdentifierReference.type, id: string): TagProps | undefined => {
+            if (primary.type === type && primary.id === id)
+              return {
+                borderColor: 'currentcolor',
+                borderLeftWidth: '.75em',
+                borderRightWidth: '.75em',
+                'aria-label': t('combiner.schema.mapping.primary.aria-label'),
+              }
+            return undefined
+          }
+
           return (
             <HStack flexWrap={'wrap'}>
-              {info.row.original.sources?.tags?.map((tag) => <PLCTag tagTitle={tag} key={tag} />)}
-              {info.row.original.sources?.topicFilters?.map((tag) => <TopicFilter tagTitle={tag} key={tag} />)}
+              {info.row.original.sources?.tags?.map((tag) => (
+                <PLCTag tagTitle={tag} key={tag} {...getPrimaryStyle(DataIdentifierReference.type.TAG, tag)} />
+              ))}
+              {info.row.original.sources?.topicFilters?.map((tag) => (
+                <TopicFilter
+                  tagTitle={tag}
+                  key={tag}
+                  {...getPrimaryStyle(DataIdentifierReference.type.TOPIC_FILTER, tag)}
+                />
+              ))}
             </HStack>
           )
         },

--- a/hivemq-edge/src/frontend/src/modules/Mappings/components/combiner/DataCombiningTableField.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/components/combiner/DataCombiningTableField.tsx
@@ -140,7 +140,7 @@ export const DataCombiningTableField: FC<FieldProps<DataCombining[], RJSFSchema,
   return (
     <>
       <PaginatedTable<DataCombining>
-        aria-label={t('combiner.schema.sources.description')}
+        aria-label={t('combiner.schema.mappings.description')}
         data={props.formData || []}
         columns={displayColumns}
         enablePaginationGoTo={false}

--- a/hivemq-edge/src/frontend/src/modules/Mappings/components/combiner/DataCombiningTableField.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/components/combiner/DataCombiningTableField.tsx
@@ -1,20 +1,41 @@
-import type { FC } from 'react'
+import type { FC, ReactElement } from 'react'
 import { useState } from 'react'
 import { useMemo } from 'react'
 import { v4 as uuidv4 } from 'uuid'
 import { useTranslation } from 'react-i18next'
 import type { ColumnDef } from '@tanstack/react-table'
-import { ButtonGroup, HStack, type TagProps, Text } from '@chakra-ui/react'
+import { ButtonGroup, HStack, Tag, TagLeftIcon, Text } from '@chakra-ui/react'
 import type { FieldProps, RJSFSchema } from '@rjsf/utils'
 import { LuPencil, LuPlus, LuTrash } from 'react-icons/lu'
+import { FaKey } from 'react-icons/fa'
 
 import type { DataCombining } from '@/api/__generated__'
 import { DataIdentifierReference } from '@/api/__generated__'
 import PaginatedTable from '@/components/PaginatedTable/PaginatedTable'
 import IconButton from '@/components/Chakra/IconButton'
+import { ConditionalWrapper } from '@/components/ConditonalWrapper'
 import { PLCTag, Topic, TopicFilter } from '@/components/MQTT/EntityTag'
 import DataCombiningEditorDrawer from './DataCombiningEditorDrawer'
 import type { CombinerContext } from '../../types'
+
+interface PrimaryWrapperProps {
+  isPrimary: boolean
+  children: ReactElement
+}
+
+export const PrimaryWrapper: FC<PrimaryWrapperProps> = ({ children, isPrimary }) => (
+  <ConditionalWrapper
+    condition={isPrimary}
+    wrapper={(children) => (
+      <Tag data-testid="wrapper" p={1} variant="outline">
+        <TagLeftIcon boxSize="12px" as={FaKey} ml={1} />
+        {children}
+      </Tag>
+    )}
+  >
+    {children}
+  </ConditionalWrapper>
+)
 
 export const DataCombiningTableField: FC<FieldProps<DataCombining[], RJSFSchema, CombinerContext>> = (props) => {
   const { t } = useTranslation()
@@ -71,28 +92,24 @@ export const DataCombiningTableField: FC<FieldProps<DataCombining[], RJSFSchema,
 
           const primary = info.row.original.sources.primary
 
-          const getPrimaryStyle = (type: DataIdentifierReference.type, id: string): TagProps | undefined => {
-            if (primary.type === type && primary.id === id)
-              return {
-                borderColor: 'currentcolor',
-                borderLeftWidth: '.75em',
-                borderRightWidth: '.75em',
-                'aria-label': t('combiner.schema.mapping.primary.aria-label'),
-              }
-            return undefined
+          const isPrimary = (type: DataIdentifierReference.type, id: string): boolean => {
+            return primary.type === type && primary.id === id
           }
 
           return (
             <HStack flexWrap={'wrap'}>
               {info.row.original.sources?.tags?.map((tag) => (
-                <PLCTag tagTitle={tag} key={tag} {...getPrimaryStyle(DataIdentifierReference.type.TAG, tag)} />
+                <PrimaryWrapper key={tag} isPrimary={Boolean(isPrimary(DataIdentifierReference.type.TAG, tag))}>
+                  <PLCTag tagTitle={tag} />
+                </PrimaryWrapper>
               ))}
               {info.row.original.sources?.topicFilters?.map((tag) => (
-                <TopicFilter
-                  tagTitle={tag}
+                <PrimaryWrapper
                   key={tag}
-                  {...getPrimaryStyle(DataIdentifierReference.type.TOPIC_FILTER, tag)}
-                />
+                  isPrimary={Boolean(isPrimary(DataIdentifierReference.type.TOPIC_FILTER, tag))}
+                >
+                  <TopicFilter tagTitle={tag} />
+                </PrimaryWrapper>
               ))}
             </HStack>
           )

--- a/hivemq-edge/src/frontend/src/modules/Mappings/components/combiner/PrimarySelect.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/components/combiner/PrimarySelect.tsx
@@ -1,6 +1,8 @@
 import { useMemo, type FC } from 'react'
 import { useTranslation } from 'react-i18next'
-import { type SingleValue, Select } from 'chakra-react-select'
+import { type SingleValue, Select, chakraComponents } from 'chakra-react-select'
+import { Icon } from '@chakra-ui/react'
+import { FaKey } from 'react-icons/fa'
 
 import type { DataCombining } from '@/api/__generated__'
 import { DataIdentifierReference } from '@/api/__generated__'
@@ -54,6 +56,14 @@ export const PrimarySelect: FC<PrimarySelectProps> = ({ id, formData, onChange }
       value={primaryValue}
       onChange={onChange}
       isClearable
+      components={{
+        Control: ({ children, ...props }) => (
+          <chakraComponents.Control {...props}>
+            <Icon as={FaKey} ml={3} />
+            {children}
+          </chakraComponents.Control>
+        ),
+      }}
       placeholder={t('combiner.schema.mapping.primary.placeholder')}
       aria-label={t('combiner.schema.mapping.primary.label')}
     />


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/30987/details/

The PR adds visual cues to the data point, `tag` or `topic filter`, that is used as a `primary key` for the listed mapping. Only one of the presented data points must have the primary cues.

In this first iteration, cues are a `key` icon in a tag wrapping the data tag. The `key` icon has also been added to the selector in the main editor, for contextualization 

The PR also fixes an accessibility issue (label of the table)

### Before
![HiveMQ-Edge-03-19-2025_05_23_PM](https://github.com/user-attachments/assets/0b4a80eb-29cc-465e-b94e-7e21bbc6ee40)

### After 
![HiveMQ-Edge-03-20-2025_03_00_PM](https://github.com/user-attachments/assets/42dcc4e0-ee48-43a7-ae6c-f032c9b2b894)

![HiveMQ-Edge-03-20-2025_03_01_PM](https://github.com/user-attachments/assets/f53c253a-d1b1-4b61-997f-ee0bc9a9550e)
