### PR TITLE
fix(30982): Add Form Control to all widgets in the mapping editor

### DIFF
--- a/hivemq-edge/src/frontend/src/api/schemas/combiner-mapping.ui-schema.ts
+++ b/hivemq-edge/src/frontend/src/api/schemas/combiner-mapping.ui-schema.ts
@@ -47,11 +47,30 @@ export const combinerMappingUiSchema: UiSchema = {
   mappings: {
     items: {
       'ui:field': DataCombiningTableField,
-      // TODO[NVL] Add `ui:options to pass table configuration and the whole RJSF construct is fully generic!
       items: {
         'ui:field': DataCombiningEditorField,
         'ui:submitButtonOptions': {
           norender: true,
+        },
+        sources: {
+          'ui:title': i18nConfig.t('combiner.schema.mappings.sources.title'),
+          'ui:description': i18nConfig.t('combiner.schema.mappings.sources.description'),
+          primary: {
+            'ui:title': i18nConfig.t('combiner.schema.mappings.sources.primary.title'),
+            'ui:description': i18nConfig.t('combiner.schema.mappings.sources.primary.description'),
+          },
+        },
+        destination: {
+          'ui:title': i18nConfig.t('combiner.schema.mappings.destination.title'),
+          'ui:description': i18nConfig.t('combiner.schema.mappings.destination.description'),
+          topic: {
+            'ui:title': i18nConfig.t('combiner.schema.mappings.destination.topic.title'),
+            'ui:description': i18nConfig.t('combiner.schema.mappings.destination.topic.description'),
+          },
+          schema: {
+            'ui:title': i18nConfig.t('combiner.schema.mappings.destination.schema.title'),
+            'ui:description': i18nConfig.t('combiner.schema.mappings.destination.schema.description'),
+          },
         },
       },
     },

--- a/hivemq-edge/src/frontend/src/components/rjsf/MqttTransformation/JsonSchemaBrowser.tsx
+++ b/hivemq-edge/src/frontend/src/components/rjsf/MqttTransformation/JsonSchemaBrowser.tsx
@@ -28,7 +28,7 @@ const JsonSchemaBrowser: FC<JsonSchemaBrowserProps> = ({
   return (
     <>
       {schema.title && (
-        <Heading as="h4" size="sm">
+        <Heading as="h3" size="sm">
           {schema.title}
         </Heading>
       )}

--- a/hivemq-edge/src/frontend/src/locales/en/translation.json
+++ b/hivemq-edge/src/frontend/src/locales/en/translation.json
@@ -1272,7 +1272,32 @@
           "source": "Source"
         },
         "sources": {
-          "description": "Select the tags and topic filters to combine"
+          "title": "Sources",
+          "description": "Define the elements to combine",
+          "primary": {
+            "title": "Primary key",
+            "description": "Select the tag or topic filters that will act as the trigger for the combining"
+          },
+          "combinedData": {
+            "title": "Source tags and topic filters",
+            "description": "Select the tags and topic filters you want to us as a source for the combining"
+          },
+          "combinedSchema": {
+            "title": "Source schemas",
+            "description": "Drag the required properties into the destination schema"
+          }
+        },
+        "destination": {
+          "title": "Destination",
+          "description": "Define the topic to subscribe the combination to",
+          "topic": {
+            "title": "Destination topic",
+            "description": "Select or create a new topic"
+          },
+          "schema": {
+            "title": "Destination schema",
+            "description": "Upload or create a schema then drop source properties on every required destination properties"
+          }
         }
       },
       "mapping": {

--- a/hivemq-edge/src/frontend/src/modules/DomainOntology/components/MetadataExplorer.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/DomainOntology/components/MetadataExplorer.spec.cy.tsx
@@ -17,8 +17,8 @@ describe('MetadataExplorer', () => {
 
     // cy.get('button').should('have.attr', 'aria-label', 'Load samples').should('have.attr', 'disabled', 'disabled')
 
-    cy.get('h4').should('have.length', 1)
-    cy.get('h4').eq(0).should('contain.text', 'test')
+    cy.get('h3').should('have.length', 1)
+    cy.get('h3').eq(0).should('contain.text', 'test')
   })
 
   it('should render error properly', () => {

--- a/hivemq-edge/src/frontend/src/modules/Mappings/components/combiner/CombinedEntitySelect.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/components/combiner/CombinedEntitySelect.tsx
@@ -92,7 +92,7 @@ const CombinedEntitySelect: FC<EntityReferenceSelectProps> = ({
   }, [tags, topicFilters])
 
   return (
-    <Box maxW={'25vw'} {...boxProps}>
+    <Box {...boxProps}>
       <Select<EntityOption, true, GroupBase<EntityOption>>
         inputId={id}
         id={'combiner-entity-select'}

--- a/hivemq-edge/src/frontend/src/modules/Mappings/components/combiner/CombinedSchemaLoader.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/components/combiner/CombinedSchemaLoader.tsx
@@ -96,7 +96,7 @@ export const CombinedSchemaLoader: FC<CombinedSchemaLoaderProps> = ({ formData, 
           // TODO[NVL] Duplication; integrate error message into the schema browser
           return (
             <Box key={dataReference.id}>
-              <Heading as="h4" size="sm">
+              <Heading as="h3" size="sm">
                 {dataReference.id}
               </Heading>
               <ErrorMessage message={dataReference.schema?.message} status={dataReference.schema?.status} />

--- a/hivemq-edge/src/frontend/src/modules/Mappings/components/combiner/CombinedSchemaLoader.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/components/combiner/CombinedSchemaLoader.tsx
@@ -86,10 +86,9 @@ export const CombinedSchemaLoader: FC<CombinedSchemaLoaderProps> = ({ formData, 
     })
   }, [allSchemas, queries, t])
 
-  if (!displayedSchemas.length) return <ErrorMessage message={t('combiner.error.noSchemaLoadedYet')} status={'info'} />
-
   return (
-    <>
+    <Box borderWidth={1} p={3}>
+      {!displayedSchemas.length && <ErrorMessage message={t('combiner.error.noSchemaLoadedYet')} status={'info'} />}
       {displayedSchemas.map((dataReference) => {
         const hasSchema = dataReference.schema?.status === 'success' && dataReference.schema.schema
 
@@ -114,6 +113,6 @@ export const CombinedSchemaLoader: FC<CombinedSchemaLoaderProps> = ({ formData, 
           />
         )
       })}
-    </>
+    </Box>
   )
 }

--- a/hivemq-edge/src/frontend/src/modules/Mappings/components/combiner/DataCombiningEditorField.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/components/combiner/DataCombiningEditorField.tsx
@@ -7,10 +7,10 @@ import {
   FormErrorMessage,
   FormHelperText,
   FormLabel,
+  Grid,
+  GridItem,
   HStack,
   Icon,
-  Stack,
-  VStack,
 } from '@chakra-ui/react'
 import { FaRightFromBracket } from 'react-icons/fa6'
 
@@ -50,162 +50,162 @@ export const DataCombiningEditorField: FC<FieldProps<DataCombining, RJSFSchema, 
   // TODO[RJSF] Create a custom error message, ensuring tag + topic filters >= 1
 
   return (
-    <VStack alignItems="stretch" gap={4}>
-      <Stack gap={2} flexDirection="row">
-        <VStack flex={1} alignItems="stretch" maxW="40vw" gap={5}>
-          <Box>
-            {sourceOptions.title && (
-              <TitleFieldTemplate id={'FIXME'} title={sourceOptions.title} schema={props.schema} registry={registry} />
-            )}
-            {sourceOptions.description && (
-              <DescriptionFieldTemplate
-                id={'FIXME'}
-                description={sourceOptions.description}
-                schema={props.schema}
-                registry={registry}
-              />
-            )}
-          </Box>
-          <Box>
-            <FormControl isInvalid={Boolean(sourceError)}>
-              <FormLabel>{t('combiner.schema.mappings.sources.combinedData.title')}</FormLabel>
-              <CombinedEntitySelect
-                tags={formData?.sources?.tags}
-                topicFilters={formData?.sources?.topicFilters}
-                formContext={formContext}
-                onChange={(values) => {
-                  if (!formData) return
-                  const tag: string[] = []
-                  const filter: string[] = []
-
-                  let isPrimary = false
-                  values.forEach((entity) => {
-                    if (entity.type === DataIdentifierReference.type.TAG) tag.push(entity.value)
-                    if (entity.type === DataIdentifierReference.type.TOPIC_FILTER) filter.push(entity.value)
-                    if (formData.sources.primary?.type === entity.type && formData.sources.primary?.id === entity.value)
-                      isPrimary = true
-                  })
-
-                  props.onChange({
-                    ...formData,
-                    sources: {
-                      ...formData.sources,
-                      tags: tag,
-                      topicFilters: filter,
-                      // @ts-ignore TODO[30935] check for type clash on primary
-                      primary: isPrimary ? formData.sources.primary : undefined,
-                    },
-                  })
-                }}
-              />
-              {!sourceError && (
-                <FormHelperText>{t('combiner.schema.mappings.sources.combinedData.description')}</FormHelperText>
-              )}
-              <FormErrorMessage>{sourceError?.join(' ')}</FormErrorMessage>
-            </FormControl>
-          </Box>
-          <VStack overflow={'auto'} alignItems={'flex-start'} justifyContent={'center'} tabIndex={0} gap={5}>
-            <FormControl>
-              <FormLabel>{t('combiner.schema.mappings.sources.combinedSchema.title')}</FormLabel>
-              <CombinedSchemaLoader formData={props.formData} formContext={formContext} />
-              {!sourceError && (
-                <FormHelperText>{t('combiner.schema.mappings.sources.combinedSchema.description')}</FormHelperText>
-              )}
-            </FormControl>
-          </VStack>
-          <Box maxW={'25vw'}>
-            <FormControl isInvalid={Boolean(primaryError)}>
-              <FormLabel>{primaryOptions.title}</FormLabel>
-              <PrimarySelect
-                formData={formData}
-                onChange={(values) => {
-                  if (!props.formData) return
-
-                  props.onChange({
-                    ...props.formData,
-                    sources: {
-                      ...props.formData.sources,
-                      // @ts-ignore TODO[30935] check for type clash on primary
-                      primary: values
-                        ? {
-                            id: values.value,
-                            type: values.type,
-                          }
-                        : undefined,
-                    },
-                  })
-                }}
-              />
-              {!primaryError && <FormHelperText>{primaryOptions.description}</FormHelperText>}
-              <FormErrorMessage>{props.errorSchema?.sources?.primary?.__errors}</FormErrorMessage>
-            </FormControl>
-          </Box>
-        </VStack>
-        <VStack justifyContent="center">
-          <HStack height={38}>
-            <Icon as={FaRightFromBracket} />
-          </HStack>
-        </VStack>
-        <VStack flex={1} alignItems="stretch" maxW="50vw">
-          <Box>
-            {destOptions.title && (
-              <TitleFieldTemplate id={'FIXME'} title={destOptions.title} schema={props.schema} registry={registry} />
-            )}
-            {destOptions.description && (
-              <DescriptionFieldTemplate
-                id={'FIXME'}
-                description={destOptions.description}
-                schema={props.schema}
-                registry={registry}
-              />
-            )}
-          </Box>
-          <Box maxW={'25vw'}>
-            <FormControl isInvalid={Boolean(destinationError)}>
-              <FormLabel>{destTopicOptions.title}</FormLabel>
-              <SelectTopic
-                isMulti={false}
-                isCreatable={true}
-                id={'destination'}
-                value={formData?.destination?.topic || null}
-                onChange={(topic) => {
-                  if (!props.formData) return
-
-                  if (topic && typeof topic === 'string') props.onChange({ ...props.formData, destination: { topic } })
-                  else if (!topic) props.onChange({ ...props.formData, destination: { topic: '' } })
-                }}
-              />
-              {!destinationError && <FormHelperText>{destTopicOptions.description}</FormHelperText>}
-
-              <FormErrorMessage>{destinationError}</FormErrorMessage>
-            </FormControl>
-          </Box>
-          <FormControl isInvalid={Boolean(destinationError)}>
-            <FormLabel>{destSchemaOptions.title}</FormLabel>
-            <DestinationSchemaLoader
-              formData={props.formData}
-              onChange={(schema) => {
-                if (!props.formData) return
-
-                props.onChange({
-                  ...props.formData,
-                  destination: { topic: props.formData.destination.topic, schema },
-                })
-              }}
-              onChangeInstructions={(v: Instruction[]) => {
-                if (!props.formData) return
-                if (!v.length) return
-
-                props.onChange({
-                  ...props.formData,
-                  instructions: v,
-                })
-              }}
+    <Grid templateColumns="1fr repeat(2, 1px) 1fr" gap={6}>
+      <GridItem colSpan={2}>
+        <Box>
+          {sourceOptions.title && (
+            <TitleFieldTemplate id={'FIXME'} title={sourceOptions.title} schema={props.schema} registry={registry} />
+          )}
+          {sourceOptions.description && (
+            <DescriptionFieldTemplate
+              id={'FIXME'}
+              description={sourceOptions.description}
+              schema={props.schema}
+              registry={registry}
             />
-            <FormHelperText>{destSchemaOptions.description}</FormHelperText>
-          </FormControl>
-        </VStack>
-      </Stack>
-    </VStack>
+          )}
+        </Box>
+      </GridItem>
+      <GridItem colSpan={2}>
+        <Box>
+          {destOptions.title && (
+            <TitleFieldTemplate id={'FIXME'} title={destOptions.title} schema={props.schema} registry={registry} />
+          )}
+          {destOptions.description && (
+            <DescriptionFieldTemplate
+              id={'FIXME'}
+              description={destOptions.description}
+              schema={props.schema}
+              registry={registry}
+            />
+          )}
+        </Box>
+      </GridItem>
+      <GridItem colSpan={2}>
+        <FormControl isInvalid={Boolean(sourceError)}>
+          <FormLabel>{t('combiner.schema.mappings.sources.combinedData.title')}</FormLabel>
+          <CombinedEntitySelect
+            tags={formData?.sources?.tags}
+            topicFilters={formData?.sources?.topicFilters}
+            formContext={formContext}
+            onChange={(values) => {
+              if (!formData) return
+              const tag: string[] = []
+              const filter: string[] = []
+
+              let isPrimary = false
+              values.forEach((entity) => {
+                if (entity.type === DataIdentifierReference.type.TAG) tag.push(entity.value)
+                if (entity.type === DataIdentifierReference.type.TOPIC_FILTER) filter.push(entity.value)
+                if (formData.sources.primary?.type === entity.type && formData.sources.primary?.id === entity.value)
+                  isPrimary = true
+              })
+
+              props.onChange({
+                ...formData,
+                sources: {
+                  ...formData.sources,
+                  tags: tag,
+                  topicFilters: filter,
+                  // @ts-ignore TODO[30935] check for type clash on primary
+                  primary: isPrimary ? formData.sources.primary : undefined,
+                },
+              })
+            }}
+          />
+          {!sourceError && (
+            <FormHelperText>{t('combiner.schema.mappings.sources.combinedData.description')}</FormHelperText>
+          )}
+          <FormErrorMessage>{sourceError?.join(' ')}</FormErrorMessage>
+        </FormControl>
+      </GridItem>
+      <GridItem colSpan={2}>
+        <FormControl isInvalid={Boolean(destinationError)}>
+          <FormLabel>{destTopicOptions.title}</FormLabel>
+          <SelectTopic
+            isMulti={false}
+            isCreatable={true}
+            id={'destination'}
+            value={formData?.destination?.topic || null}
+            onChange={(topic) => {
+              if (!props.formData) return
+
+              if (topic && typeof topic === 'string') props.onChange({ ...props.formData, destination: { topic } })
+              else if (!topic) props.onChange({ ...props.formData, destination: { topic: '' } })
+            }}
+          />
+          {!destinationError && <FormHelperText>{destTopicOptions.description}</FormHelperText>}
+
+          <FormErrorMessage>{destinationError}</FormErrorMessage>
+        </FormControl>
+      </GridItem>
+      <GridItem>
+        <FormControl>
+          <FormLabel>{t('combiner.schema.mappings.sources.combinedSchema.title')}</FormLabel>
+          <CombinedSchemaLoader formData={props.formData} formContext={formContext} />
+          {!sourceError && (
+            <FormHelperText>{t('combiner.schema.mappings.sources.combinedSchema.description')}</FormHelperText>
+          )}
+        </FormControl>
+      </GridItem>
+      <GridItem>
+        <HStack height={'100%'} justifyContent={'center'}>
+          <Icon as={FaRightFromBracket} />
+        </HStack>
+      </GridItem>
+      <GridItem colSpan={2}>
+        <FormControl isInvalid={Boolean(destinationError)}>
+          <FormLabel>{destSchemaOptions.title}</FormLabel>
+          <DestinationSchemaLoader
+            formData={props.formData}
+            onChange={(schema) => {
+              if (!props.formData) return
+
+              props.onChange({
+                ...props.formData,
+                destination: { topic: props.formData.destination.topic, schema },
+              })
+            }}
+            onChangeInstructions={(v: Instruction[]) => {
+              if (!props.formData) return
+              if (!v.length) return
+
+              props.onChange({
+                ...props.formData,
+                instructions: v,
+              })
+            }}
+          />
+          <FormHelperText>{destSchemaOptions.description}</FormHelperText>
+        </FormControl>
+      </GridItem>
+      <GridItem colSpan={2}>
+        <FormControl isInvalid={Boolean(primaryError)}>
+          <FormLabel>{primaryOptions.title}</FormLabel>
+          <PrimarySelect
+            formData={formData}
+            onChange={(values) => {
+              if (!props.formData) return
+
+              props.onChange({
+                ...props.formData,
+                sources: {
+                  ...props.formData.sources,
+                  // @ts-ignore TODO[30935] check for type clash on primary
+                  primary: values
+                    ? {
+                        id: values.value,
+                        type: values.type,
+                      }
+                    : undefined,
+                },
+              })
+            }}
+          />
+          {!primaryError && <FormHelperText>{primaryOptions.description}</FormHelperText>}
+          <FormErrorMessage>{props.errorSchema?.sources?.primary?.__errors}</FormErrorMessage>
+        </FormControl>
+      </GridItem>
+    </Grid>
   )
 }

--- a/hivemq-edge/src/frontend/src/modules/Mappings/components/combiner/DataCombiningEditorField.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/components/combiner/DataCombiningEditorField.tsx
@@ -1,6 +1,17 @@
 import type { FC } from 'react'
 import type { FieldProps, RJSFSchema } from '@rjsf/utils'
-import { Box, HStack, Icon, Stack, VStack } from '@chakra-ui/react'
+import { getTemplate, getUiOptions } from '@rjsf/utils'
+import {
+  Box,
+  FormControl,
+  FormErrorMessage,
+  FormHelperText,
+  FormLabel,
+  HStack,
+  Icon,
+  Stack,
+  VStack,
+} from '@chakra-ui/react'
 import { FaRightFromBracket } from 'react-icons/fa6'
 
 import type { DataCombining, Instruction } from '@/api/__generated__'
@@ -11,69 +22,123 @@ import CombinedEntitySelect from './CombinedEntitySelect'
 import { CombinedSchemaLoader } from './CombinedSchemaLoader'
 import { DestinationSchemaLoader } from './DestinationSchemaLoader'
 import { PrimarySelect } from './PrimarySelect'
+import { useTranslation } from 'react-i18next'
 
 export const DataCombiningEditorField: FC<FieldProps<DataCombining, RJSFSchema, CombinerContext>> = (props) => {
-  const { formData, formContext } = props
+  const { t } = useTranslation()
+  const { formData, formContext, uiSchema, registry } = props
+
+  const fieldOptions = getUiOptions(uiSchema)
+
+  const TitleFieldTemplate = getTemplate<'TitleFieldTemplate'>('TitleFieldTemplate', registry, fieldOptions)
+  const DescriptionFieldTemplate = getTemplate<'DescriptionFieldTemplate'>(
+    'DescriptionFieldTemplate',
+    registry,
+    fieldOptions
+  )
+
+  // TODO[RJSF] Would prefer to reuse the templates; need investigation
+  const sourceOptions = getUiOptions(uiSchema?.sources)
+  const destOptions = getUiOptions(uiSchema?.destination)
+  const primaryOptions = getUiOptions(uiSchema?.sources.primary)
+  const destTopicOptions = getUiOptions(uiSchema?.destination.topic)
+  const destSchemaOptions = getUiOptions(uiSchema?.destination.schema)
+
+  const sourceError = props.errorSchema?.sources?.__errors
+  const primaryError = props.errorSchema?.sources?.primary?.__errors
+  const destinationError = props.errorSchema?.destination?.topic?.__errors
+  // TODO[RJSF] Create a custom error message, ensuring tag + topic filters >= 1
 
   return (
     <VStack alignItems="stretch" gap={4}>
       <Stack gap={2} flexDirection="row">
-        <VStack flex={1} alignItems="stretch" maxW="40vw">
+        <VStack flex={1} alignItems="stretch" maxW="40vw" gap={5}>
           <Box>
-            <CombinedEntitySelect
-              tags={formData?.sources?.tags}
-              topicFilters={formData?.sources?.topicFilters}
-              formContext={formContext}
-              onChange={(values) => {
-                if (!formData) return
-                const tag: string[] = []
-                const filter: string[] = []
-
-                let isPrimary = false
-                values.forEach((entity) => {
-                  if (entity.type === DataIdentifierReference.type.TAG) tag.push(entity.value)
-                  if (entity.type === DataIdentifierReference.type.TOPIC_FILTER) filter.push(entity.value)
-                  if (formData.sources.primary?.type === entity.type && formData.sources.primary?.id === entity.value)
-                    isPrimary = true
-                })
-
-                props.onChange({
-                  ...formData,
-                  sources: {
-                    ...formData.sources,
-                    tags: tag,
-                    topicFilters: filter,
-                    // @ts-ignore TODO[30935] check for type clash on primary
-                    primary: isPrimary ? formData.sources.primary : undefined,
-                  },
-                })
-              }}
-            />
+            {sourceOptions.title && (
+              <TitleFieldTemplate id={'FIXME'} title={sourceOptions.title} schema={props.schema} registry={registry} />
+            )}
+            {sourceOptions.description && (
+              <DescriptionFieldTemplate
+                id={'FIXME'}
+                description={sourceOptions.description}
+                schema={props.schema}
+                registry={registry}
+              />
+            )}
           </Box>
-          <VStack height={'60vh'} overflow={'auto'} alignItems={'flex-start'} justifyContent={'center'} tabIndex={0}>
-            <CombinedSchemaLoader formData={props.formData} formContext={formContext} />
-          </VStack>
           <Box>
-            <PrimarySelect
-              formData={formData}
-              onChange={(values) => {
-                if (!props.formData) return
+            <FormControl isInvalid={Boolean(sourceError)}>
+              <FormLabel>{t('combiner.schema.mappings.sources.combinedData.title')}</FormLabel>
+              <CombinedEntitySelect
+                tags={formData?.sources?.tags}
+                topicFilters={formData?.sources?.topicFilters}
+                formContext={formContext}
+                onChange={(values) => {
+                  if (!formData) return
+                  const tag: string[] = []
+                  const filter: string[] = []
 
-                props.onChange({
-                  ...props.formData,
-                  sources: {
-                    ...props.formData.sources,
-                    // @ts-ignore TODO[30935] check for type clash on primary
-                    primary: values
-                      ? {
-                          id: values.value,
-                          type: values.type,
-                        }
-                      : undefined,
-                  },
-                })
-              }}
-            />
+                  let isPrimary = false
+                  values.forEach((entity) => {
+                    if (entity.type === DataIdentifierReference.type.TAG) tag.push(entity.value)
+                    if (entity.type === DataIdentifierReference.type.TOPIC_FILTER) filter.push(entity.value)
+                    if (formData.sources.primary?.type === entity.type && formData.sources.primary?.id === entity.value)
+                      isPrimary = true
+                  })
+
+                  props.onChange({
+                    ...formData,
+                    sources: {
+                      ...formData.sources,
+                      tags: tag,
+                      topicFilters: filter,
+                      // @ts-ignore TODO[30935] check for type clash on primary
+                      primary: isPrimary ? formData.sources.primary : undefined,
+                    },
+                  })
+                }}
+              />
+              {!sourceError && (
+                <FormHelperText>{t('combiner.schema.mappings.sources.combinedData.description')}</FormHelperText>
+              )}
+              <FormErrorMessage>{sourceError?.join(' ')}</FormErrorMessage>
+            </FormControl>
+          </Box>
+          <VStack overflow={'auto'} alignItems={'flex-start'} justifyContent={'center'} tabIndex={0} gap={5}>
+            <FormControl>
+              <FormLabel>{t('combiner.schema.mappings.sources.combinedSchema.title')}</FormLabel>
+              <CombinedSchemaLoader formData={props.formData} formContext={formContext} />
+              {!sourceError && (
+                <FormHelperText>{t('combiner.schema.mappings.sources.combinedSchema.description')}</FormHelperText>
+              )}
+            </FormControl>
+          </VStack>
+          <Box maxW={'25vw'}>
+            <FormControl isInvalid={Boolean(primaryError)}>
+              <FormLabel>{primaryOptions.title}</FormLabel>
+              <PrimarySelect
+                formData={formData}
+                onChange={(values) => {
+                  if (!props.formData) return
+
+                  props.onChange({
+                    ...props.formData,
+                    sources: {
+                      ...props.formData.sources,
+                      // @ts-ignore TODO[30935] check for type clash on primary
+                      primary: values
+                        ? {
+                            id: values.value,
+                            type: values.type,
+                          }
+                        : undefined,
+                    },
+                  })
+                }}
+              />
+              {!primaryError && <FormHelperText>{primaryOptions.description}</FormHelperText>}
+              <FormErrorMessage>{props.errorSchema?.sources?.primary?.__errors}</FormErrorMessage>
+            </FormControl>
           </Box>
         </VStack>
         <VStack justifyContent="center">
@@ -82,40 +147,63 @@ export const DataCombiningEditorField: FC<FieldProps<DataCombining, RJSFSchema, 
           </HStack>
         </VStack>
         <VStack flex={1} alignItems="stretch" maxW="50vw">
+          <Box>
+            {destOptions.title && (
+              <TitleFieldTemplate id={'FIXME'} title={destOptions.title} schema={props.schema} registry={registry} />
+            )}
+            {destOptions.description && (
+              <DescriptionFieldTemplate
+                id={'FIXME'}
+                description={destOptions.description}
+                schema={props.schema}
+                registry={registry}
+              />
+            )}
+          </Box>
           <Box maxW={'25vw'}>
-            <SelectTopic
-              isMulti={false}
-              isCreatable={true}
-              id={'destination'}
-              value={formData?.destination?.topic || null}
-              onChange={(topic) => {
+            <FormControl isInvalid={Boolean(destinationError)}>
+              <FormLabel>{destTopicOptions.title}</FormLabel>
+              <SelectTopic
+                isMulti={false}
+                isCreatable={true}
+                id={'destination'}
+                value={formData?.destination?.topic || null}
+                onChange={(topic) => {
+                  if (!props.formData) return
+
+                  if (topic && typeof topic === 'string') props.onChange({ ...props.formData, destination: { topic } })
+                  else if (!topic) props.onChange({ ...props.formData, destination: { topic: '' } })
+                }}
+              />
+              {!destinationError && <FormHelperText>{destTopicOptions.description}</FormHelperText>}
+
+              <FormErrorMessage>{destinationError}</FormErrorMessage>
+            </FormControl>
+          </Box>
+          <FormControl isInvalid={Boolean(destinationError)}>
+            <FormLabel>{destSchemaOptions.title}</FormLabel>
+            <DestinationSchemaLoader
+              formData={props.formData}
+              onChange={(schema) => {
                 if (!props.formData) return
 
-                if (topic && typeof topic === 'string') props.onChange({ ...props.formData, destination: { topic } })
-                else if (!topic) props.onChange({ ...props.formData, destination: { topic: '' } })
+                props.onChange({
+                  ...props.formData,
+                  destination: { topic: props.formData.destination.topic, schema },
+                })
+              }}
+              onChangeInstructions={(v: Instruction[]) => {
+                if (!props.formData) return
+                if (!v.length) return
+
+                props.onChange({
+                  ...props.formData,
+                  instructions: v,
+                })
               }}
             />
-          </Box>
-          <DestinationSchemaLoader
-            formData={props.formData}
-            onChange={(schema) => {
-              if (!props.formData) return
-
-              props.onChange({
-                ...props.formData,
-                destination: { topic: props.formData.destination.topic, schema },
-              })
-            }}
-            onChangeInstructions={(v: Instruction[]) => {
-              if (!props.formData) return
-              if (!v.length) return
-
-              props.onChange({
-                ...props.formData,
-                instructions: v,
-              })
-            }}
-          />
+            <FormHelperText>{destSchemaOptions.description}</FormHelperText>
+          </FormControl>
         </VStack>
       </Stack>
     </VStack>

--- a/hivemq-edge/src/frontend/src/modules/Mappings/components/combiner/DestinationSchemaLoader.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/components/combiner/DestinationSchemaLoader.tsx
@@ -61,7 +61,7 @@ export const DestinationSchemaLoader: FC<DestinationSchemaLoaderProps> = ({
 
   return (
     <>
-      <ButtonGroup size="sm" variant="outline" flexWrap={'wrap'} rowGap={2}>
+      <ButtonGroup size="sm" variant="outline" flexWrap={'wrap'} rowGap={2} mb={2}>
         <Popover>
           <PopoverTrigger>
             <Button data-testid={'combiner-destination-infer'} isDisabled>

--- a/hivemq-edge/src/frontend/src/modules/Mappings/components/combiner/DestinationSchemaLoader.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/components/combiner/DestinationSchemaLoader.tsx
@@ -105,7 +105,7 @@ export const DestinationSchemaLoader: FC<DestinationSchemaLoaderProps> = ({
       </ButtonGroup>
 
       {!formData?.destination?.schema && (
-        <VStack flex={1} justifyContent={'center'} alignItems={'center'}>
+        <VStack flex={1}>
           <ErrorMessage message={t('combiner.error.noSchemaLoadedYet')} status={'info'} />
         </VStack>
       )}

--- a/hivemq-edge/src/frontend/src/modules/TopicFilters/components/SchemaSampler.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/TopicFilters/components/SchemaSampler.spec.cy.tsx
@@ -1,7 +1,6 @@
 import { MOCK_TOPIC_FILTER } from '@/api/hooks/useTopicFilters/__handlers__'
 import { GENERATE_DATA_MODELS } from '@/api/hooks/useDomainModel/__handlers__'
 import SchemaSampler from '@/modules/TopicFilters/components/SchemaSampler.tsx'
-import Login from '../../Login/components/Login'
 
 describe('SchemaSampler', () => {
   beforeEach(() => {

--- a/hivemq-edge/src/frontend/src/modules/TopicFilters/components/SchemaSampler.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/TopicFilters/components/SchemaSampler.spec.cy.tsx
@@ -1,6 +1,7 @@
 import { MOCK_TOPIC_FILTER } from '@/api/hooks/useTopicFilters/__handlers__'
 import { GENERATE_DATA_MODELS } from '@/api/hooks/useDomainModel/__handlers__'
 import SchemaSampler from '@/modules/TopicFilters/components/SchemaSampler.tsx'
+import Login from '../../Login/components/Login'
 
 describe('SchemaSampler', () => {
   beforeEach(() => {
@@ -37,12 +38,21 @@ describe('SchemaSampler', () => {
     const onUpload = cy.stub().as('onUpload')
     cy.mountWithProviders(<SchemaSampler topicFilter={MOCK_TOPIC_FILTER} onUpload={onUpload} />)
 
-    cy.getByTestId('loading-spinner')
-    cy.get('h4').should('contain.text', 'a/topic/+/filter')
+    cy.get('h3').should('contain.text', 'a/topic/+/filter')
     cy.get('[role="list"]').should('be.visible')
 
     cy.get('@onUpload').should('not.have.been.called')
     cy.getByTestId('schema-sampler-upload').should('have.text', 'Assign schema').click()
     cy.get('@onUpload').should('have.been.calledWithMatch', 'data:application/json;base64,')
+  })
+
+  it('should be accessible', () => {
+    cy.intercept('/api/v1/management/sampling/topic/**', { items: [] })
+    cy.intercept('/api/v1/management/sampling/schema/**', GENERATE_DATA_MODELS(true, MOCK_TOPIC_FILTER.topicFilter)).as(
+      'getSchema'
+    )
+    cy.injectAxe()
+    cy.mountWithProviders(<SchemaSampler topicFilter={MOCK_TOPIC_FILTER} onUpload={cy.stub} />)
+    cy.checkAccessibility()
   })
 })


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/30982/details/

The PR adds a form control to every widget in the combiner mapping editor, in effect adding proper title, helper and error messages to them.

The PR also improves on the main layout of the editor

### Out-of-scope
- Validation and error messages for schema is missing. Will be added at a later stage, see https://hivemq.kanbanize.com/ctrl_board/57/cards/31362/details/ and https://hivemq.kanbanize.com/ctrl_board/57/cards/31360/details/
- The southbound editor, using the same mapping UX, needs updating. See https://hivemq.kanbanize.com/ctrl_board/57/cards/31363/details/

### Before
![HiveMQ-Edge-03-21-2025_12_04_PM](https://github.com/user-attachments/assets/c47af544-a0aa-4f89-a7fa-5f3d092e3cd6)

### After
![HiveMQ-Edge-03-21-2025_12_03_PM](https://github.com/user-attachments/assets/54bce7a5-cc4a-49de-8da2-a25d1180c184)
