### PR TITLE
fix(30993): Improving toast management

### DIFF
--- a/hivemq-edge/src/frontend/src/components/rjsf/BatchModeMappings/components/DataSourceStep.tsx
+++ b/hivemq-edge/src/frontend/src/components/rjsf/BatchModeMappings/components/DataSourceStep.tsx
@@ -9,12 +9,12 @@ import { Button, Text, useToast, VStack } from '@chakra-ui/react'
 import { acceptMimeTypes } from '@/components/rjsf/BatchModeMappings/utils/config.utils.ts'
 import { readFileAsync } from '@/components/rjsf/BatchModeMappings/utils/dropzone.utils.ts'
 import type { StepRendererProps, WorksheetData } from '@/components/rjsf/BatchModeMappings/types.ts'
-import { DEFAULT_TOAST_OPTION } from '@/hooks/useEdgeToast/toast-utils.ts'
+import { BASE_TOAST_OPTION, DEFAULT_TOAST_OPTION } from '@/hooks/useEdgeToast/toast-utils.ts'
 import { getDropZoneBorder } from '@/modules/Theme/utils.ts'
 
 const DataSourceStep: FC<StepRendererProps> = ({ onContinue, store }) => {
   const { t } = useTranslation('components')
-  const toast = useToast()
+  const toast = useToast(BASE_TOAST_OPTION)
   const [loading, setLoading] = useState(false)
   const { fileName } = store
   const { getRootProps, getInputProps, isDragActive, open } = useDropzone({

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/toolbar/ToolbarPublish.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/toolbar/ToolbarPublish.tsx
@@ -181,6 +181,7 @@ export const ToolbarPublish: FC = () => {
 
     const { resources } = payload
 
+    toast.closeAll()
     const promises = publishResources(resources)
 
     Promise.all(promises)

--- a/hivemq-edge/src/frontend/src/hooks/useEdgeToast/toast-utils.ts
+++ b/hivemq-edge/src/frontend/src/hooks/useEdgeToast/toast-utils.ts
@@ -3,6 +3,7 @@ import type { UseToastOptions } from '@chakra-ui/react'
 export const BASE_TOAST_OPTION: UseToastOptions = {
   duration: 3000,
   isClosable: true,
+  position: 'top-right',
 }
 
 export const DEFAULT_TOAST_OPTION: UseToastOptions = {

--- a/hivemq-edge/src/frontend/src/hooks/useEdgeToast/useEdgeToast.tsx
+++ b/hivemq-edge/src/frontend/src/hooks/useEdgeToast/useEdgeToast.tsx
@@ -3,10 +3,10 @@ import { Text, useToast } from '@chakra-ui/react'
 
 import type { ApiError } from '@/api/__generated__'
 import type { ProblemDetailsExtended } from '@/api/types/http-problem-details.ts'
-import { DEFAULT_TOAST_OPTION } from '@/hooks/useEdgeToast/toast-utils.ts'
+import { BASE_TOAST_OPTION, DEFAULT_TOAST_OPTION } from '@/hooks/useEdgeToast/toast-utils.ts'
 
 export const useEdgeToast = () => {
-  const createToast = useToast()
+  const createToast = useToast(BASE_TOAST_OPTION)
 
   const successToast = (options: UseToastOptions) =>
     createToast({

--- a/hivemq-edge/src/frontend/src/modules/Device/hooks/useTagManager.ts
+++ b/hivemq-edge/src/frontend/src/modules/Device/hooks/useTagManager.ts
@@ -12,10 +12,11 @@ import { useUpdateDomainTags } from '@/api/hooks/useProtocolAdapters/useUpdateDo
 import { useGetDomainTagSchema } from '@/api/hooks/useDomainModel/useGetDomainTagSchema.ts'
 import useGetAdapterInfo from '@/modules/ProtocolAdapters/hooks/useGetAdapterInfo.ts'
 import type { ManagerContextType } from '@/modules/Mappings/types.ts'
+import { BASE_TOAST_OPTION } from '@/hooks/useEdgeToast/toast-utils'
 
 export const useTagManager = (adapterId: string) => {
   const { t } = useTranslation()
-  const toast = useToast()
+  const toast = useToast(BASE_TOAST_OPTION)
 
   const { protocol, isLoading: protocolLoad } = useGetAdapterInfo(adapterId)
   const { data: tagSchema, isError: isSchemaError, error: errorSchema } = useGetDomainTagSchema(protocol?.id)

--- a/hivemq-edge/src/frontend/src/modules/Notifications/NotificationBadge.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Notifications/NotificationBadge.tsx
@@ -8,10 +8,11 @@ import ButtonBadge from '@/components/Chakra/ButtonBadge.tsx'
 
 import { useGetManagedNotifications } from './hooks/useGetManagedNotifications.tsx'
 import { SkipNotification } from './components/SkipNotification.tsx'
+import { BASE_TOAST_OPTION } from '@/hooks/useEdgeToast/toast-utils'
 
 const NotificationBadge: FC = () => {
   const { t } = useTranslation()
-  const toast = useToast()
+  const toast = useToast(BASE_TOAST_OPTION)
   const { notifications } = useGetManagedNotifications()
   const containerStyle = useColorModeValue(undefined, {
     bg: 'chakra-body-bg',

--- a/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/drawers/ExportDrawer.tsx
+++ b/hivemq-edge/src/frontend/src/modules/ProtocolAdapters/components/drawers/ExportDrawer.tsx
@@ -34,7 +34,7 @@ import type { ExportFormatDisplay } from '@/modules/ProtocolAdapters/types.ts'
 import { AdapterExportError, ExportFormat, ProtocolAdapterTabIndex } from '@/modules/ProtocolAdapters/types.ts'
 import useGetAdapterInfo from '@/modules/ProtocolAdapters/hooks/useGetAdapterInfo.ts'
 import { adapterExportFormats } from '@/modules/ProtocolAdapters/utils/export.utils.ts'
-import { DEFAULT_TOAST_OPTION } from '@/hooks/useEdgeToast/toast-utils.ts'
+import { BASE_TOAST_OPTION, DEFAULT_TOAST_OPTION } from '@/hooks/useEdgeToast/toast-utils.ts'
 
 interface SelectedExportFormat {
   content: ExportFormat.Type
@@ -50,7 +50,7 @@ interface MIMETypeOptions {
 const ExportDrawer: FC = () => {
   const { t } = useTranslation()
   const { isOpen, onOpen, onClose } = useDisclosure()
-  const toast = useToast()
+  const toast = useToast(BASE_TOAST_OPTION)
   const { adapterId } = useParams()
   const navigate = useNavigate()
   const { protocol, adapter } = useGetAdapterInfo(adapterId)

--- a/hivemq-edge/src/frontend/src/modules/TopicFilters/components/SchemaUploader.tsx
+++ b/hivemq-edge/src/frontend/src/modules/TopicFilters/components/SchemaUploader.tsx
@@ -5,7 +5,7 @@ import { useDropzone } from 'react-dropzone'
 import type { AlertStatus } from '@chakra-ui/react'
 import { Button, Card, CardBody, Text, useToast } from '@chakra-ui/react'
 
-import { DEFAULT_TOAST_OPTION } from '@/hooks/useEdgeToast/toast-utils.ts'
+import { BASE_TOAST_OPTION, DEFAULT_TOAST_OPTION } from '@/hooks/useEdgeToast/toast-utils.ts'
 import { getDropZoneBorder } from '@/modules/Theme/utils.ts'
 import { ACCEPT_JSON_SCHEMA } from '@/modules/TopicFilters/utils/topic-filter.schema.ts'
 
@@ -16,7 +16,7 @@ interface SchemaUploaderProps {
 const SchemaUploader: FC<SchemaUploaderProps> = ({ onUpload }) => {
   const [loading, setLoading] = useState(false)
   const { t } = useTranslation()
-  const toast = useToast()
+  const toast = useToast(BASE_TOAST_OPTION)
 
   const { getRootProps, getInputProps, isDragActive, open } = useDropzone({
     noClick: true,

--- a/hivemq-edge/src/frontend/src/modules/TopicFilters/hooks/useTopicFilterManager.ts
+++ b/hivemq-edge/src/frontend/src/modules/TopicFilters/hooks/useTopicFilterManager.ts
@@ -11,6 +11,7 @@ import { useDeleteTopicFilter } from '@/api/hooks/useTopicFilters/useDeleteTopic
 import { useUpdateTopicFilter } from '@/api/hooks/useTopicFilters/useUpdateTopicFilter.ts'
 import { useUpdateAllTopicFilter } from '@/api/hooks/useTopicFilters/useUpdateAllTopicFilters.ts'
 import type { ManagerContextType } from '@/modules/Mappings/types.ts'
+import { BASE_TOAST_OPTION } from '@/hooks/useEdgeToast/toast-utils'
 
 interface TopicFilterSchemas {
   schema: RJSFSchema
@@ -18,7 +19,7 @@ interface TopicFilterSchemas {
 
 export const useTopicFilterManager = () => {
   const { t } = useTranslation()
-  const toast = useToast()
+  const toast = useToast(BASE_TOAST_OPTION)
 
   const { data: topicFilterList, isLoading, isError, error } = useListTopicFilters()
 

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/ContextualToolbar.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/ContextualToolbar.tsx
@@ -22,6 +22,7 @@ import useWorkspaceStore from '@/modules/Workspace/hooks/useWorkspaceStore.ts'
 import { getGroupLayout } from '@/modules/Workspace/utils/group.utils.ts'
 import { getThemeForStatus } from '@/modules/Workspace/utils/status-utils.ts'
 import { gluedNodeDefinition } from '@/modules/Workspace/utils/nodes-utils.ts'
+import { BASE_TOAST_OPTION } from '@/hooks/useEdgeToast/toast-utils'
 
 // TODO[NVL] Should the grouping only be available if ALL nodes match the filter ?
 type CombinerEligibleNode = Node<Adapter, NodeTypes.ADAPTER_NODE> | Node<Bridge, NodeTypes.BRIDGE_NODE>
@@ -47,7 +48,7 @@ const ContextualToolbar: FC<ContextualToolbarProps> = ({
   const theme = useTheme()
   const createCombiner = useCreateCombiner()
   // TODO[30429] Need a workspace-wide feedback mechanism
-  const toast = useToast()
+  const toast = useToast(BASE_TOAST_OPTION)
 
   const selectedNodes = nodes.filter((node) => node.selected)
   const selectedGroupCandidates = useMemo(() => {


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/30993/details/

The PR fixes the `Designer` publish toasts, preventing duplicates to be shown when repeatedly pressing "publish".

The PR also ensures that every toasts in Edge are using the same base config.

### Before
![screenshot-localhost_3000-2025_01_29-14_39_55](https://github.com/user-attachments/assets/476ae03c-5279-4953-900a-617beb3912e4)


### After 
![HiveMQ-Edge-03-21-2025_04_30_PM](https://github.com/user-attachments/assets/9a572988-4f16-44a1-b9d1-260ddbd4ea58)
