### PR TITLE
fix(30741): Add checks for valid combiner creation

### DIFF
--- a/hivemq-edge/src/frontend/src/components/Icons/index.ts
+++ b/hivemq-edge/src/frontend/src/components/Icons/index.ts
@@ -1,0 +1,3 @@
+import { TbArrowsJoin } from 'react-icons/tb'
+
+export { TbArrowsJoin as HqCombiner }

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/DryRunPanelController.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/DryRunPanelController.tsx
@@ -22,9 +22,7 @@ import PolicyErrorReport from '@datahub/components/helpers/PolicyErrorReport.tsx
 import { usePolicyChecksStore } from '@datahub/hooks/usePolicyChecksStore.ts'
 import { PolicyDryRunStatus } from '@datahub/types.ts'
 
-import { ANIMATION } from '@datahub/utils/datahub.utils.ts'
-import { ToolbarPublish } from '@datahub/components/toolbar/ToolbarPublish.tsx'
-import { useTranslation } from 'react-i18next'
+import { ANIMATION } from '@/modules/Theme/utils.ts'
 
 const DryRunPanelController = () => {
   const { t } = useTranslation('datahub')

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/DryRunPanelController.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/DryRunPanelController.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect } from 'react'
 import { useLocation, useNavigate, useParams } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
 import type { Node } from 'reactflow'
 import { useReactFlow } from 'reactflow'
 import {
@@ -19,6 +20,7 @@ import {
 import useDataHubDraftStore from '@datahub/hooks/useDataHubDraftStore.ts'
 import PolicySummaryReport from '@datahub/components/helpers/PolicySummaryReport.tsx'
 import PolicyErrorReport from '@datahub/components/helpers/PolicyErrorReport.tsx'
+import { ToolbarPublish } from '@datahub/components/toolbar/ToolbarPublish'
 import { usePolicyChecksStore } from '@datahub/hooks/usePolicyChecksStore.ts'
 import { PolicyDryRunStatus } from '@datahub/types.ts'
 

--- a/hivemq-edge/src/frontend/src/extensions/datahub/utils/datahub.utils.ts
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/utils/datahub.utils.ts
@@ -4,11 +4,6 @@ export const SCRIPT_FUNCTION_SEPARATOR = ':'
 export const SCRIPT_FUNCTION_PREFIX = 'fn'
 export const SCRIPT_FUNCTION_LATEST = 'latest'
 
-// TODO[THEME] Import from the ChakraUI Theme
-export const ANIMATION = {
-  FIT_VIEW_DURATION_MS: 500,
-}
-
 export const DRYRUN_VALIDATION_DELAY = 250
 
 export const DATAHUB_HOTKEY = {

--- a/hivemq-edge/src/frontend/src/locales/en/translation.json
+++ b/hivemq-edge/src/frontend/src/locales/en/translation.json
@@ -1277,11 +1277,11 @@
           "description": "Define the elements to combine",
           "primary": {
             "title": "Primary key",
-            "description": "Select the tag or topic filters that will act as the trigger for the combining"
+            "description": "Select the tag or topic filter that will act as the trigger for combining"
           },
           "combinedData": {
             "title": "Source tags and topic filters",
-            "description": "Select the tags and topic filters you want to us as a source for the combining"
+            "description": "Select the tags and topic filters you want to use for combining"
           },
           "combinedSchema": {
             "title": "Source schemas",

--- a/hivemq-edge/src/frontend/src/locales/en/translation.json
+++ b/hivemq-edge/src/frontend/src/locales/en/translation.json
@@ -1207,6 +1207,7 @@
       "create": {
         "title": "Create the combiner",
         "success": "We've successfully created the combiner for you.",
+        "partialSuccess": "We've successfully created the combiner for you. Please note that some of the selected entities are not valid for data combining and have not been connected.",
         "error": "There was a problem trying to create the combiner"
       },
       "update": {

--- a/hivemq-edge/src/frontend/src/modules/Theme/utils.ts
+++ b/hivemq-edge/src/frontend/src/modules/Theme/utils.ts
@@ -8,3 +8,7 @@ export const getDropZoneBorder = (color: string) => {
     borderRadius: '4px',
   }
 }
+
+export const ANIMATION = {
+  FIT_VIEW_DURATION_MS: 500,
+}

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/ContextualToolbar.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/ContextualToolbar.tsx
@@ -71,12 +71,16 @@ const ContextualToolbar: FC<ContextualToolbarProps> = ({
   }, [edges, nodes, selectedNodes])
 
   const selectedCombinerCandidates = useMemo(() => {
-    // TODO[29097] Decide which entities are eligible for combining. Hidden is EDGE, default are ADAPTER and BRIDGE;
-    const result = selectedNodes.filter(
-      (node) => node.type === NodeTypes.ADAPTER_NODE || node.type === NodeTypes.BRIDGE_NODE
-    ) as CombinerEligibleNode[]
+    const result = selectedNodes.filter((node) => {
+      if (node.type === NodeTypes.ADAPTER_NODE) {
+        const protocol = data?.items.find((e) => e.id === node.data.type)
+        return protocol?.capabilities?.includes('COMBINE')
+      }
+
+      return node.type === NodeTypes.BRIDGE_NODE
+    }) as CombinerEligibleNode[]
     return result.length ? result : undefined
-  }, [selectedNodes])
+  }, [data?.items, selectedNodes])
 
   const onCreateGroup = () => {
     if (!selectedGroupCandidates) return

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/ContextualToolbar.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/ContextualToolbar.tsx
@@ -195,7 +195,12 @@ const ContextualToolbar: FC<ContextualToolbarProps> = ({
     }
 
     toast.promise(createCombiner.mutateAsync({ requestBody: newCombiner }), {
-      success: { title: t('combiner.toast.create.title'), description: t('combiner.toast.create.success') },
+      success: {
+        title: t('combiner.toast.create.title'),
+        description: isCombinerSourcesAllValid
+          ? t('combiner.toast.create.success')
+          : t('combiner.toast.create.partialSuccess'),
+      },
       error: { title: t('combiner.toast.create.title'), description: t('combiner.toast.create.error') },
       loading: { title: t('combiner.toast.create.title'), description: t('combiner.toast.loading') },
     })

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/ContextualToolbar.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/ContextualToolbar.tsx
@@ -13,6 +13,7 @@ import type { Adapter, Bridge, Combiner, EntityReference } from '@/api/__generat
 import { EntityType, Status } from '@/api/__generated__'
 import { useCreateCombiner } from '@/api/hooks/useCombiners/useCreateCombiner'
 
+import { HqCombiner } from '@/components/Icons'
 import IconButton from '@/components/Chakra/IconButton.tsx'
 import NodeToolbar from '@/components/react-flow/NodeToolbar.tsx'
 import ToolbarButtonGroup from '@/components/react-flow/ToolbarButtonGroup.tsx'
@@ -202,7 +203,7 @@ const ContextualToolbar: FC<ContextualToolbarProps> = ({
         <IconButton
           isDisabled={!selectedCombinerCandidates}
           data-testid="node-group-toolbar-combiner"
-          icon={<MdScheduleSend />}
+          icon={<HqCombiner />}
           aria-label={t('workspace.toolbar.command.combiner.create')}
           onClick={onManageCombiners}
         />

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/ContextualToolbar.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/ContextualToolbar.tsx
@@ -28,7 +28,6 @@ import { getGroupLayout } from '@/modules/Workspace/utils/group.utils.ts'
 import { getThemeForStatus } from '@/modules/Workspace/utils/status-utils.ts'
 import { gluedNodeDefinition } from '@/modules/Workspace/utils/nodes-utils.ts'
 import { arrayWithSameObjects } from '@/modules/Workspace/utils/combiner.utils'
-import { BASE_TOAST_OPTION } from '@/hooks/useEdgeToast/toast-utils'
 
 // TODO[NVL] Should the grouping only be available if ALL nodes match the filter ?
 type CombinerEligibleNode = Node<Adapter, NodeTypes.ADAPTER_NODE> | Node<Bridge, NodeTypes.BRIDGE_NODE>

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/ContextualToolbar.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/ContextualToolbar.tsx
@@ -141,7 +141,7 @@ const ContextualToolbar: FC<ContextualToolbarProps> = ({
     onInsertGroupNode(newGroupNode, newAEdge, rect)
   }
 
-  const onManageOrchestrators = () => {
+  const onManageCombiners = () => {
     if (!selectedCombinerCandidates) return
     const edgeNode = nodes.find((node) => node.type === NodeTypes.EDGE_NODE)
     if (!edgeNode) return
@@ -204,7 +204,7 @@ const ContextualToolbar: FC<ContextualToolbarProps> = ({
           data-testid="node-group-toolbar-combiner"
           icon={<MdScheduleSend />}
           aria-label={t('workspace.toolbar.command.combiner.create')}
-          onClick={onManageOrchestrators}
+          onClick={onManageCombiners}
         />
       </ToolbarButtonGroup>
 

--- a/hivemq-edge/src/frontend/src/modules/Workspace/utils/combiner.utils.spec.ts
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/utils/combiner.utils.spec.ts
@@ -1,0 +1,82 @@
+import { expect } from 'vitest'
+import { arrayContains, arrayWithSameObjects, objectsEqual } from './combiner.utils'
+
+interface Test {
+  name?: string
+  age?: number
+  fake?: boolean
+}
+
+const test1: Test = { name: 'John', age: 33 }
+const test2: Test = { age: 33, name: 'John' }
+const test3: Test = { name: 'John', age: 45 }
+const test4: Test = { name: 'John', age: 33, fake: true }
+
+interface ObjectsEqualSuite<T> {
+  rule: string
+  obj1: T
+  obj2: T
+  expected: boolean
+}
+
+const objectsEqualSuiteTests: ObjectsEqualSuite<Test>[] = [
+  { rule: 'same object', obj1: test1, obj2: test1, expected: true },
+  { rule: 'different order', obj1: test1, obj2: test2, expected: true },
+  { rule: 'different objects', obj1: test1, obj2: test3, expected: false },
+  { rule: 'empty objects', obj1: {}, obj2: {}, expected: true },
+  { rule: 'different keys', obj1: test1, obj2: test4, expected: false },
+]
+
+describe('objectsEqual', () => {
+  test.each<ObjectsEqualSuite<Test>>(objectsEqualSuiteTests)(
+    '$rule should return $expected',
+    ({ obj1, obj2, expected }) => {
+      expect(objectsEqual(obj1, obj2)).toStrictEqual(expected)
+    }
+  )
+})
+
+interface ArrayContainsSuite<T> {
+  rule: string
+  array: T[]
+  obj: T
+  expected: boolean
+}
+
+const arrayContainsSuiteTests: ArrayContainsSuite<Test>[] = [
+  { rule: 'same object1', array: [test1], obj: test1, expected: true },
+  { rule: 'same object22', array: [test2], obj: test1, expected: true },
+  { rule: 'same object3', array: [], obj: test1, expected: false },
+  { rule: 'same object33', array: [test3, test4], obj: test1, expected: false },
+]
+
+describe('arrayContains', () => {
+  test.each<ArrayContainsSuite<Test>>(arrayContainsSuiteTests)(
+    '$rule should return $expected',
+    ({ array, obj, expected }) => {
+      expect(arrayContains(array, obj)).toStrictEqual(expected)
+    }
+  )
+})
+
+interface ArraysSuite<T> {
+  rule: string
+  array1: T[]
+  array2: T[]
+  expected: T[] | undefined
+}
+
+const arraysSuiteTests: ArraysSuite<Test>[] = [
+  { rule: 'empty array', array1: [], array2: [], expected: [] },
+  { rule: 'same objects', array1: [test1], array2: [test1], expected: [test1] },
+  { rule: 'similar objects', array1: [test1], array2: [test2], expected: [test1] },
+  { rule: 'different objects', array1: [test1], array2: [test3], expected: undefined },
+  { rule: 'more objects', array1: [test1, test3], array2: [test1], expected: undefined },
+  { rule: 'less objects', array1: [test1], array2: [test1, test3], expected: undefined },
+]
+
+describe('arrayWithSameObjects', () => {
+  test.each<ArraysSuite<Test>>(arraysSuiteTests)('$rule should return $expected', ({ array1, array2, expected }) => {
+    expect(arrayWithSameObjects(array1)(array2)).toStrictEqual(expected)
+  })
+})

--- a/hivemq-edge/src/frontend/src/modules/Workspace/utils/combiner.utils.ts
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/utils/combiner.utils.ts
@@ -6,12 +6,6 @@ export const arrayContains = <T extends object>(container: T[], o: T) => {
   return container.some((c) => objectsEqual<T>(c, o))
 }
 
-// export const combinerWithSameEntities = (entities: EntityReference[]) => (combiner: Combiner) => {
-//   return entities.every((entity) => arrayContains<EntityReference>(combiner.sources.items, entity))
-//     ? combiner
-//     : undefined
-// }
-
 export const arrayWithSameObjects =
   <T extends object>(entities: T[]) =>
   (container: T[]) => {

--- a/hivemq-edge/src/frontend/src/modules/Workspace/utils/combiner.utils.ts
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/utils/combiner.utils.ts
@@ -1,0 +1,23 @@
+export const objectsEqual = <T extends object>(o1: T, o2: T) =>
+  Object.keys(o1).length === Object.keys(o2).length &&
+  Object.keys(o1).every((p) => o1[p as keyof T] === o2[p as keyof T])
+
+export const arrayContains = <T extends object>(container: T[], o: T) => {
+  return container.some((c) => objectsEqual<T>(c, o))
+}
+
+// export const combinerWithSameEntities = (entities: EntityReference[]) => (combiner: Combiner) => {
+//   return entities.every((entity) => arrayContains<EntityReference>(combiner.sources.items, entity))
+//     ? combiner
+//     : undefined
+// }
+
+export const arrayWithSameObjects =
+  <T extends object>(entities: T[]) =>
+  (container: T[]) => {
+    return entities.every((entity) => arrayContains<T>(container, entity)) &&
+      // container.every((entity) => arrayContains<T>(entities, entity))
+      container.length === entities.length
+      ? container
+      : undefined
+  }


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/30741/details/

The PR adds checks to the creation of a new combiner:
- Every selected adapter source must have the `COMBINE` capability. If not, the combiner will be created by excluding those without. 
- If a combiner using the same set of sources already exists, creating a new one will be prevented. The user will be redirected to the combiner's configuration panel, and adding mappings to this one will be suggested. 

### Before 
![HiveMQ-Edge-03-24-2025_03_45](https://github.com/user-attachments/assets/3330bd09-8bc1-4a7b-a968-e590ab550be0)


### After 
![HiveMQ-Edge-03-24-2025_03_35_AM](https://github.com/user-attachments/assets/40c160c4-acc0-4377-b4d5-0a2ce3f7aae2)

![HiveMQ-Edge-03-24-2025_03_39_AM (1)](https://github.com/user-attachments/assets/00c32319-607b-4671-8e62-fdfae33aa864)
