### PR TITLE
fix(30538): Improve the combiner visual identity in the workspace

### DIFF
--- a/hivemq-edge/src/frontend/src/api/schemas/combiner-mapping.json-schema.ts
+++ b/hivemq-edge/src/frontend/src/api/schemas/combiner-mapping.json-schema.ts
@@ -46,7 +46,7 @@ export const combinerMappingJsonSchema: JSONSchema7 = {
       },
     },
     DataCombining: {
-      description: 'Define individual rules for data combining, based on the entities selected in the Orchestrator',
+      description: 'Define individual rules for data combining, based on the entities selected in the Combiner',
       required: ['id', 'sources'],
       properties: {
         id: {

--- a/hivemq-edge/src/frontend/src/components/MQTT/EntityTag.tsx
+++ b/hivemq-edge/src/frontend/src/components/MQTT/EntityTag.tsx
@@ -38,5 +38,5 @@ export const Topic: FC<CustomTagProps> = ({ tagTitle, ...rest }) => (
 )
 
 export const TopicFilter: FC<CustomTagProps> = ({ tagTitle, ...rest }) => (
-  <EntityTag tagIcon={TopicFilterIcon} tagTitle={tagTitle} {...rest} colorScheme="cyan" />
+  <EntityTag tagIcon={TopicFilterIcon} tagTitle={tagTitle} {...rest} colorScheme="orange" />
 )

--- a/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/DryRunPanelController.tsx
+++ b/hivemq-edge/src/frontend/src/extensions/datahub/components/controls/DryRunPanelController.tsx
@@ -17,7 +17,6 @@ import {
   useDisclosure,
 } from '@chakra-ui/react'
 
-import useDataHubDraftStore from '@datahub/hooks/useDataHubDraftStore.ts'
 import PolicySummaryReport from '@datahub/components/helpers/PolicySummaryReport.tsx'
 import PolicyErrorReport from '@datahub/components/helpers/PolicyErrorReport.tsx'
 import { ToolbarPublish } from '@datahub/components/toolbar/ToolbarPublish'

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeAdapter.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeAdapter.tsx
@@ -11,6 +11,7 @@ import { useGetAdapterTypes } from '@/api/hooks/useProtocolAdapters/useGetAdapte
 import { useListNorthboundMappings } from '@/api/hooks/useProtocolAdapters/useListNorthboundMappings.ts'
 import { useListSouthboundMappings } from '@/api/hooks/useProtocolAdapters/useListSouthboundMappings.ts'
 
+import { SelectEntityType } from '@/components/MQTT/types'
 import IconButton from '@/components/Chakra/IconButton.tsx'
 import { ConnectionStatusBadge } from '@/components/ConnectionStatusBadge'
 import ToolbarButtonGroup from '@/components/react-flow/ToolbarButtonGroup.tsx'
@@ -76,7 +77,7 @@ const NodeAdapter: FC<NodeProps<Adapter>> = ({ id, data: adapter, selected, drag
       >
         {!showSkeleton && (
           <VStack>
-            {bidirectional && <MappingBadge destinations={southFlags} />}
+            {bidirectional && <MappingBadge destinations={southFlags} type={SelectEntityType.TOPIC} />}
 
             <HStack>
               <Image aria-label={adapter.type} boxSize="20px" objectFit="scale-down" src={adapterProtocol?.logoUrl} />
@@ -89,7 +90,7 @@ const NodeAdapter: FC<NodeProps<Adapter>> = ({ id, data: adapter, selected, drag
                 <ConnectionStatusBadge status={adapter.status} />
               </Box>
             )}
-            {options.showTopics && <MappingBadge destinations={northFlags} />}
+            {options.showTopics && <MappingBadge destinations={northFlags} type={SelectEntityType.TOPIC} />}
           </VStack>
         )}
         {showSkeleton && (

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeBridge.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeBridge.tsx
@@ -5,17 +5,19 @@ import { Box, HStack, Image, SkeletonText, Text, VStack } from '@chakra-ui/react
 import { useTranslation } from 'react-i18next'
 
 import type { Bridge } from '@/api/__generated__'
-import { ConnectionStatusBadge } from '@/components/ConnectionStatusBadge'
 import logo from '@/assets/hivemq/05-icon-hivemq-bridge-extension.svg'
 
-import NodeWrapper from '../parts/NodeWrapper.tsx'
-import MappingBadge from '../parts/MappingBadge.tsx'
-import { getBridgeTopics } from '../../utils/topics-utils.ts'
-import { useEdgeFlowContext } from '../../hooks/useEdgeFlowContext.ts'
-import { useContextMenu } from '../../hooks/useContextMenu.ts'
+import { SelectEntityType } from '@/components/MQTT/types'
+import { ConnectionStatusBadge } from '@/components/ConnectionStatusBadge'
 import ContextualToolbar from '@/modules/Workspace/components/nodes/ContextualToolbar.tsx'
 import { CONFIG_ADAPTER_WIDTH } from '@/modules/Workspace/utils/nodes-utils.ts'
 import { selectorIsSkeletonZoom } from '@/modules/Workspace/utils/react-flow.utils.ts'
+import { getBridgeTopics } from '@/modules/Workspace/utils/topics-utils.ts'
+import { useEdgeFlowContext } from '@/modules/Workspace/hooks/useEdgeFlowContext.ts'
+import { useContextMenu } from '@/modules/Workspace/hooks/useContextMenu.ts'
+
+import NodeWrapper from '../parts/NodeWrapper.tsx'
+import MappingBadge from '../parts/MappingBadge.tsx'
 
 const NodeBridge: FC<NodeProps<Bridge>> = ({ id, selected, data: bridge, dragging }) => {
   const { t } = useTranslation()
@@ -36,7 +38,9 @@ const NodeBridge: FC<NodeProps<Bridge>> = ({ id, selected, data: bridge, draggin
       >
         {!showSkeleton && (
           <VStack>
-            {options.showTopics && <MappingBadge destinations={topics.remote.map((filter) => filter.topic)} />}
+            {options.showTopics && (
+              <MappingBadge destinations={topics.remote.map((filter) => filter.topic)} type={SelectEntityType.TOPIC} />
+            )}
             <HStack>
               <Image boxSize="20px" objectFit="scale-down" src={logo} alt={t('workspace.node.bridge')} />
               <Text flex={1} data-testid="bridge-node-name">
@@ -48,7 +52,9 @@ const NodeBridge: FC<NodeProps<Bridge>> = ({ id, selected, data: bridge, draggin
                 <ConnectionStatusBadge status={bridge.status} />
               </Box>
             )}
-            {options.showTopics && <MappingBadge destinations={topics.local.map((filter) => filter.topic)} />}
+            {options.showTopics && (
+              <MappingBadge destinations={topics.local.map((filter) => filter.topic)} type={SelectEntityType.TOPIC} />
+            )}
           </VStack>
         )}
         {showSkeleton && (

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeCombiner.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeCombiner.spec.cy.tsx
@@ -29,6 +29,15 @@ describe('NodeCombiner', () => {
     cy.getByTestId('test-navigate-pathname').should('have.text', `/workspace/combiner/${MOCK_NODE_COMBINER.id}`)
   })
 
+  it('should render the mapping flags', () => {
+    cy.mountWithProviders(
+      <CustomNodeTesting
+        nodes={[{ ...MOCK_NODE_COMBINER, position: { x: 90, y: 100 }, selected: true }]}
+        nodeTypes={{ [NodeTypes.COMBINER_NODE]: NodeCombiner }}
+      />
+    )
+  })
+
   it('should be accessible', () => {
     cy.injectAxe()
     cy.mountWithProviders(mockReactFlow(<NodeCombiner {...MOCK_NODE_COMBINER} />))

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeCombiner.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeCombiner.tsx
@@ -1,18 +1,26 @@
 import type { FC } from 'react'
+import { useMemo } from 'react'
 import type { NodeProps } from 'reactflow'
 import { Handle, Position } from 'reactflow'
-import { Box, Icon, Text } from '@chakra-ui/react'
-import { MdScheduleSend } from 'react-icons/md'
+import { Icon, Text, useColorModeValue, VStack } from '@chakra-ui/react'
 
 import type { Combiner } from '@/api/__generated__'
 
+import { HqCombiner } from '@/components/Icons'
+import { SelectEntityType } from '@/components/MQTT/types'
 import NodeWrapper from '@/modules/Workspace/components/parts/NodeWrapper.tsx'
-
 import { useContextMenu } from '@/modules/Workspace/hooks/useContextMenu.ts'
 import ContextualToolbar from '@/modules/Workspace/components/nodes/ContextualToolbar.tsx'
+import { CONFIG_ADAPTER_WIDTH } from '@/modules/Workspace/utils/nodes-utils'
+import MappingBadge from '../parts/MappingBadge'
 
 const NodeCombiner: FC<NodeProps<Combiner>> = ({ id, selected, data, dragging }) => {
   const { onContextMenu } = useContextMenu(id, selected, '/workspace/combiner')
+  const bgColour = useColorModeValue('gray.300', 'gray.900')
+
+  const topics = useMemo(() => {
+    return data.mappings.items.map((e) => e.destination.topic as string)
+  }, [data.mappings.items])
 
   return (
     <>
@@ -27,15 +35,26 @@ const NodeCombiner: FC<NodeProps<Combiner>> = ({ id, selected, data, dragging })
         borderBottomRadius={30}
         flexDirection="row"
         p={0}
-        w={150}
+        w={CONFIG_ADAPTER_WIDTH}
         alignItems="center"
+        h={120}
       >
-        <Box p={4} backgroundColor="gray.300" borderTopLeftRadius={30} borderBottomLeftRadius={30}>
-          <Icon as={MdScheduleSend} boxSize={6} />
-        </Box>
-        <Box flex={1} p={1} data-testid="combiner-description">
-          <Text noOfLines={2}>{data.name}</Text>
-        </Box>
+        <VStack
+          h={'100%'}
+          p={4}
+          backgroundColor={bgColour}
+          borderTopLeftRadius={30}
+          borderBottomLeftRadius={30}
+          justifyContent={'center'}
+        >
+          <Icon as={HqCombiner} boxSize={10} />
+        </VStack>
+        <VStack p={2} h={'100%'} justifyContent={'space-evenly'}>
+          <Text data-testid="combiner-description" noOfLines={1}>
+            {data.name}
+          </Text>
+          <MappingBadge destinations={topics} type={SelectEntityType.TOPIC} />
+        </VStack>
       </NodeWrapper>
       <Handle type="source" position={Position.Bottom} />
       <Handle type="target" position={Position.Top} />

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeDevice.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeDevice.tsx
@@ -21,6 +21,7 @@ import ContextualToolbar from '@/modules/Workspace/components/nodes/ContextualTo
 import { CONFIG_ADAPTER_WIDTH } from '@/modules/Workspace/utils/nodes-utils.ts'
 import { selectorIsSkeletonZoom } from '@/modules/Workspace/utils/react-flow.utils.ts'
 import MappingBadge from '@/modules/Workspace/components/parts/MappingBadge.tsx'
+import { SelectEntityType } from '@/components/MQTT/types'
 
 const NodeDevice: FC<NodeProps<DeviceMetadata>> = ({ id, selected, data, dragging }) => {
   const { t } = useTranslation()
@@ -68,7 +69,7 @@ const NodeDevice: FC<NodeProps<DeviceMetadata>> = ({ id, selected, data, draggin
                 />
                 <Text>{data.protocol}</Text>
               </HStack>
-              <MappingBadge destinations={tagNames} isTag />
+              <MappingBadge destinations={tagNames} type={SelectEntityType.TAG} />
             </>
           )}
           {showSkeleton && (

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeEdge.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeEdge.spec.cy.tsx
@@ -4,6 +4,9 @@ import { MOCK_NODE_EDGE } from '@/__test-utils__/react-flow/nodes.ts'
 import { mockReactFlow } from '@/__test-utils__/react-flow/providers.tsx'
 
 import NodeEdge from './NodeEdge.tsx'
+import { mockProtocolAdapter } from '@/api/hooks/useProtocolAdapters/__handlers__'
+import { MOCK_TOPIC_FILTER } from '@/api/hooks/useTopicFilters/__handlers__'
+import { formatTopicString } from '../../../../components/MQTT/topic-utils'
 
 describe('NodeEdge', () => {
   beforeEach(() => {
@@ -11,13 +14,39 @@ describe('NodeEdge', () => {
   })
 
   it('should render properly', () => {
+    cy.intercept('/api/v1/management/protocol-adapters/types', { items: [mockProtocolAdapter] }).as('getTypes')
+    cy.intercept('/api/v1/management/topic-filters', {
+      items: [
+        MOCK_TOPIC_FILTER,
+        {
+          topicFilter: 'another/filter',
+          description: 'This is a topic filter',
+        },
+        {
+          topicFilter: 'another/filter/too',
+          description: 'This is another topic filter',
+        },
+      ],
+    }).as('getTopicFilters')
+
     cy.mountWithProviders(mockReactFlow(<NodeEdge {...MOCK_NODE_EDGE} />))
 
-    cy.getByTestId('edge-node').should('have.attr', 'alt', 'Node: HiveMQ Edge')
+    cy.getByTestId('edge-node-icon').should('have.attr', 'alt', 'Node: HiveMQ Edge')
     cy.get('[data-handleid]').should('have.length', 4)
+
+    cy.getByTestId('edge-node-title').should('have.text', 'HiveMQ Edge')
+    cy.getByTestId('topics-container').within(() => {
+      cy.getByTestId('topic-wrapper').eq(0).should('have.text', formatTopicString('a/topic/+/filter'))
+      cy.getByTestId('topic-wrapper').eq(1).should('have.text', formatTopicString('another/filter'))
+      cy.getByTestId('topics-show-more').should('have.text', '+1')
+    })
   })
 
   it('should be accessible', () => {
+    cy.intercept('/api/v1/management/protocol-adapters/types', { items: [mockProtocolAdapter] }).as('getTypes')
+    cy.intercept('/api/v1/management/topic-filters', {
+      items: [MOCK_TOPIC_FILTER],
+    }).as('getTopicFilters')
     cy.injectAxe()
     cy.mountWithProviders(mockReactFlow(<NodeEdge {...MOCK_NODE_EDGE} />))
     cy.checkAccessibility()

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeEdge.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeEdge.tsx
@@ -1,22 +1,33 @@
 import type { FC } from 'react'
+import { useMemo } from 'react'
 import { useNavigate } from 'react-router-dom'
 import type { NodeProps } from 'reactflow'
 import { Handle, Position } from 'reactflow'
 import { useTranslation } from 'react-i18next'
-import { Icon, Image } from '@chakra-ui/react'
+import { Icon, Image, Text, VStack } from '@chakra-ui/react'
 
 import logo from '@/assets/edge/05-icon-industrial-hivemq-edge.svg'
+
+import { useListTopicFilters } from '@/api/hooks/useTopicFilters/useListTopicFilters'
+import { SelectEntityType } from '@/components/MQTT/types'
 import ToolbarButtonGroup from '@/components/react-flow/ToolbarButtonGroup.tsx'
 import IconButton from '@/components/Chakra/IconButton.tsx'
 import { TopicIcon } from '@/components/Icons/TopicIcon.tsx'
 import NodeWrapper from '@/modules/Workspace/components/parts/NodeWrapper.tsx'
 import { useContextMenu } from '@/modules/Workspace/hooks/useContextMenu.ts'
 import ContextualToolbar from '@/modules/Workspace/components/nodes/ContextualToolbar.tsx'
+import { CONFIG_ADAPTER_WIDTH } from '../../utils/nodes-utils'
+import MappingBadge from '../parts/MappingBadge'
 
 const NodeEdge: FC<NodeProps> = (props) => {
   const { t } = useTranslation()
   const { onContextMenu } = useContextMenu(props.id, props.selected, '/workspace/edge')
   const navigate = useNavigate()
+  const { data } = useListTopicFilters()
+
+  const topicFilters = useMemo(() => {
+    return data?.items.map((e) => e.topicFilter) || []
+  }, [data?.items])
 
   return (
     <>
@@ -38,12 +49,19 @@ const NodeEdge: FC<NodeProps> = (props) => {
         isSelected={props.selected}
         onDoubleClick={onContextMenu}
         onContextMenu={onContextMenu}
-        variant="unstyled"
-        borderWidth={0}
-        px={2}
-        py={0}
+        flexDirection="row"
+        w={CONFIG_ADAPTER_WIDTH}
+        p={2}
+        h={120}
       >
-        <Image data-testid="edge-node" src={logo} alt={t('workspace.node.edge')} boxSize="96px" />
+        <VStack h={'100%'} justifyContent={'center'}>
+          <Image data-testid="edge-node-icon" src={logo} alt={t('workspace.node.edge')} boxSize="96px" />
+        </VStack>
+        <VStack h={'100%'} flex={1} justifyContent={'space-between'}>
+          <Text data-testid="edge-node-title">{t('branding.appName')}</Text>
+          <MappingBadge destinations={topicFilters} type={SelectEntityType.TOPIC_FILTER} />
+        </VStack>
+        .
         <Handle
           type="target"
           position={Position.Bottom}

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/parts/MappingBadge.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/parts/MappingBadge.spec.cy.tsx
@@ -3,6 +3,7 @@
 import { formatTopicString } from '@/components/MQTT/topic-utils.ts'
 
 import MappingBadge from './MappingBadge.tsx'
+import { SelectEntityType } from '../../../../components/MQTT/types'
 
 describe('TopicsContainer', () => {
   beforeEach(() => {
@@ -10,7 +11,9 @@ describe('TopicsContainer', () => {
   })
 
   it('should render properly all topics', () => {
-    cy.mountWithProviders(<MappingBadge destinations={['my/first/topic', 'my/second/topic']} />)
+    cy.mountWithProviders(
+      <MappingBadge destinations={['my/first/topic', 'my/second/topic']} type={SelectEntityType.TOPIC} />
+    )
 
     cy.getByTestId('topic-wrapper').should('have.length', 2)
     cy.getByTestId('topic-wrapper').eq(0).should('contain.text', formatTopicString('my/first/topic'))
@@ -21,7 +24,7 @@ describe('TopicsContainer', () => {
   })
 
   it('should render properly all tags', () => {
-    cy.mountWithProviders(<MappingBadge destinations={['my/first/tag']} isTag />)
+    cy.mountWithProviders(<MappingBadge destinations={['my/first/tag']} type={SelectEntityType.TAG} />)
 
     cy.getByTestId('topic-wrapper').should('have.length', 1)
     cy.getByTestId('topic-wrapper').eq(0).should('contain.text', formatTopicString('my/first/tag'))
@@ -31,7 +34,12 @@ describe('TopicsContainer', () => {
   })
 
   it('should render properly a show more if too many topics', () => {
-    cy.mountWithProviders(<MappingBadge destinations={['my/first/topic', 'my/second/topic', 'my/second/topic']} />)
+    cy.mountWithProviders(
+      <MappingBadge
+        destinations={['my/first/topic', 'my/second/topic', 'my/second/topic']}
+        type={SelectEntityType.TOPIC}
+      />
+    )
 
     cy.getByTestId('topic-wrapper').should('have.length', 2)
     cy.getByTestId('topic-wrapper').eq(0).should('contain.text', formatTopicString('my/first/topic'))

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/parts/MappingBadge.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/parts/MappingBadge.tsx
@@ -1,16 +1,29 @@
 import type { FC } from 'react'
+import { useMemo } from 'react'
 import { HStack, Tag, TagLabel, VStack } from '@chakra-ui/react'
-import { PLCTag, Topic } from '@/components/MQTT/EntityTag.tsx'
+import { PLCTag, Topic, TopicFilter } from '@/components/MQTT/EntityTag.tsx'
+import { SelectEntityType } from '@/components/MQTT/types'
 
 const MAX_MAPPINGS = 2
 
 interface MappingBadgeProps {
   destinations: string[]
-  isTag?: boolean
+  type: SelectEntityType
 }
 
-const MappingBadge: FC<MappingBadgeProps> = ({ destinations, isTag = false }) => {
-  const Component = isTag ? PLCTag : Topic
+const MappingBadge: FC<MappingBadgeProps> = ({ destinations, type }) => {
+  const Component = useMemo(() => {
+    switch (type) {
+      case SelectEntityType.TOPIC:
+        return Topic
+      case SelectEntityType.TAG:
+        return PLCTag
+      case SelectEntityType.TOPIC_FILTER:
+      default:
+        return TopicFilter
+    }
+  }, [type])
+
   return (
     <HStack spacing="4" data-testid="topics-container">
       <VStack alignItems="flex-start">

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/parts/NodeNameCard.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/parts/NodeNameCard.tsx
@@ -4,7 +4,7 @@ import { Card, CardBody, HStack, Icon, Image, StackDivider, Text, VStack } from 
 import { PiBridgeThin } from 'react-icons/pi'
 import { GrStatusUnknown } from 'react-icons/gr'
 import { ImMakeGroup } from 'react-icons/im'
-import { MdScheduleSend } from 'react-icons/md'
+import { HqCombiner } from '@/components/Icons'
 
 import edgeLogo from '@/assets/edge/05-icon-industrial-hivemq-edge.svg'
 
@@ -42,7 +42,7 @@ const NodeNameCard: FC<NodeNameCardProps> = ({ name, type, description, icon }) 
           <Image data-testid="node-type-icon" data-nodeicon={type} objectFit="cover" w="24px" src={edgeLogo} alt="SS" />
         )
       case NodeTypes.COMBINER_NODE:
-        return <Icon data-testid="node-type-icon" data-nodeicon={type} as={MdScheduleSend} fontSize="24px" />
+        return <Icon data-testid="node-type-icon" data-nodeicon={type} as={HqCombiner} fontSize="24px" />
 
       case NodeTypes.DEVICE_NODE:
         return (

--- a/hivemq-edge/src/frontend/src/modules/Workspace/utils/adapter.utils.ts
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/utils/adapter.utils.ts
@@ -4,6 +4,7 @@ import { FaIndustry } from 'react-icons/fa6'
 import { GrConnectivity } from 'react-icons/gr'
 import { AiFillExperiment } from 'react-icons/ai'
 import { RiCompassDiscoverLine } from 'react-icons/ri'
+import { HqCombiner } from '@/components/Icons'
 
 import { type ProtocolAdapter, Status } from '@/api/__generated__'
 import { HmInput, HmOutput } from '@/components/react-icons/hm'
@@ -42,6 +43,7 @@ export const deviceCapabilityIcon: Record<CapabilityType, IconType> = {
   ['READ']: HmOutput,
   ['DISCOVER']: RiCompassDiscoverLine,
   ['WRITE']: HmInput,
+  ['COMBINE']: HqCombiner,
 }
 
 export const statusMapping = {


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/30538/details/

The PR improves the visual identity of the `combiner` node in the `workspace`, in particular by adding the `topic` flags of the mappings to the node, similar to every other entity. 

The `edge` node is also refactored to display the `topic filters` flags on the node, as well as the instance name (not yet implemented, replaced by the generic product name)

### Before 
![HiveMQ-Edge-03-24-2025_03_49](https://github.com/user-attachments/assets/0398a257-ca4d-4d36-81fc-16321f9c5cd6)


### After'
![HiveMQ-Edge-03-24-2025_03_51](https://github.com/user-attachments/assets/b701edda-1e0e-4257-8c61-59dd6af09773)
