### PR TITLE
Fix/31448 opcua timestamp tagname

### DIFF
--- a/hivemq-edge/src/main/java/com/hivemq/protocols/northbound/NorthboundConsumerFactory.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/northbound/NorthboundConsumerFactory.java
@@ -18,6 +18,7 @@ package com.hivemq.protocols.northbound;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hivemq.adapter.sdk.api.config.PollingContext;
 import com.hivemq.adapter.sdk.api.events.EventService;
+import com.hivemq.adapter.sdk.api.factories.DataPointFactory;
 import com.hivemq.adapter.sdk.api.services.ProtocolAdapterMetricsService;
 import com.hivemq.edge.modules.adapters.impl.ProtocolAdapterPublishServiceImpl;
 import com.hivemq.protocols.ProtocolAdapterWrapper;
@@ -50,7 +51,8 @@ public class NorthboundConsumerFactory {
             final @NotNull ProtocolAdapterWrapper protocolAdapterWrapper,
             final @NotNull PollingContext pollingContext,
             final @NotNull ProtocolAdapterMetricsService protocolAdapterMetricsService) {
-        return new NorthboundTagConsumer(pollingContext,
+        return new NorthboundTagConsumer(
+                pollingContext,
                 protocolAdapterWrapper,
                 objectMapper,
                 jsonPayloadCreator,


### PR DESCRIPTION
**Motivation**

Resolves #31448

**Changes**

Resolves an issue where northbound messages for OPC UA tags would not honor the includTimestamp/includeTagName settings.