### PR TITLE
fix(31710): Prevent crash with edge status

### DIFF
--- a/hivemq-edge/src/frontend/src/modules/Workspace/types.ts
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/types.ts
@@ -32,6 +32,11 @@ export enum EdgeTypes {
   REPORT_EDGE = 'REPORT_EDGE',
 }
 
+export interface EdgeStatus {
+  isConnected: boolean
+  hasTopics: boolean
+}
+
 export enum IdStubs {
   EDGE_NODE = 'edge',
   BRIDGE_NODE = 'bridge',

--- a/hivemq-edge/src/frontend/src/modules/Workspace/utils/status-utils.spec.ts
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/utils/status-utils.spec.ts
@@ -14,7 +14,7 @@ import { mockBridgeId } from '@/api/hooks/useGetBridges/__handlers__'
 
 import type { EdgeStyle } from './status-utils.ts'
 import { getEdgeStatus, getThemeForStatus, updateEdgesStatus, updateNodeStatus } from './status-utils.ts'
-import { NodeTypes } from '../types.ts'
+import { type EdgeStatus, NodeTypes } from '../types.ts'
 
 const disconnectedBridge: NodeProps<Bridge> = {
   ...MOCK_NODE_BRIDGE,
@@ -164,12 +164,12 @@ describe('updateEdgesStatus', () => {
 interface StatusStyleSuite {
   isConnected: boolean
   hasTopics: boolean
-  expected: EdgeStyle
+  expected: EdgeStyle<EdgeStatus>
 }
 
 describe('getEdgeStatus', () => {
   const color = MOCK_THEME.colors.status.connected[500]
-  const edge: EdgeStyle = {}
+  const edge: EdgeStyle<EdgeStatus> = {}
 
   edge.data = {
     hasTopics: true,

--- a/hivemq-edge/src/frontend/src/modules/Workspace/utils/status-utils.ts
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/utils/status-utils.ts
@@ -109,9 +109,11 @@ export const updateEdgesStatus = (
       const group = getNode(edge.source)
       if (!group || group.type !== NodeTypes.CLUSTER_NODE) return edge
 
-      const groupEdges = newEdges.filter((e) => (group as Node<Group>).data.childrenNodeIds.includes(e.source))
-      const isConnected = groupEdges.every((e) => e.data.isConnected)
-      const hasTopics = groupEdges.every((e) => e.data.hasTopics)
+      const groupEdges = newEdges.filter((e) =>
+        (group as Node<Group>).data.childrenNodeIds.includes(e.source)
+      ) as Edge<EdgeStatus>[]
+      const isConnected = groupEdges.every((e) => e.data?.isConnected)
+      const hasTopics = groupEdges.every((e) => e.data?.hasTopics)
       // status is mocked from the metadata
       const status: Status = {
         runtime: isConnected ? Status.runtime.STARTED : Status.runtime.STOPPED,

--- a/hivemq-edge/src/frontend/src/modules/Workspace/utils/status-utils.ts
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/utils/status-utils.ts
@@ -5,11 +5,11 @@ import type { Dict } from '@chakra-ui/utils'
 
 import type { Adapter, Bridge, ProtocolAdapter } from '@/api/__generated__'
 import { Status } from '@/api/__generated__'
-
-import type { Group } from '../types.ts'
-import { NodeTypes } from '../types.ts'
-import { getBridgeTopics } from './topics-utils.ts'
+import type { EdgeStatus, Group } from '@/modules/Workspace/types.ts'
+import { NodeTypes } from '@/modules/Workspace/types.ts'
 import { isBidirectional } from '@/modules/Workspace/utils/adapter.utils.ts'
+
+import { getBridgeTopics } from './topics-utils.ts'
 
 /**
  * @param theme
@@ -62,15 +62,15 @@ export const updateNodeStatus = (currentNodes: Node[], updates: Status[]) => {
   })
 }
 
-export type EdgeStyle = Pick<Edge, 'style' | 'animated' | 'markerEnd' | 'data'>
+export type EdgeStyle<T> = Pick<Edge<T>, 'style' | 'animated' | 'markerEnd' | 'data'>
 
 export const getEdgeStatus = (
   isConnected: boolean,
   hasTopics: boolean,
   hasMarker: boolean,
   themeForStatus: string
-): EdgeStyle => {
-  const edge: EdgeStyle = {}
+): EdgeStyle<EdgeStatus> => {
+  const edge: EdgeStyle<EdgeStatus> = {}
   edge.style = {
     strokeWidth: 1.5,
     stroke: themeForStatus,


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/31710/details/

The PR adds missing optional chaining  on accessing a data payload that was also not properly typed. Enough said