### PR TITLE
Added modules as compileOnly dependency to reliably reload changes when testing

### DIFF
--- a/hivemq-edge/build.gradle.kts
+++ b/hivemq-edge/build.gradle.kts
@@ -196,6 +196,15 @@ dependencies {
     implementation(libs.victools.jsonschema.generator)
     implementation(libs.victools.jsonschema.jackson)
     implementation(libs.jsonSchemaInferrer)
+
+    // Edge modules
+    compileOnly("com.hivemq:hivemq-edge-module-etherip")
+    compileOnly("com.hivemq:hivemq-edge-module-plc4x")
+    compileOnly("com.hivemq:hivemq-edge-module-http")
+    compileOnly("com.hivemq:hivemq-edge-module-modbus")
+    compileOnly("com.hivemq:hivemq-edge-module-mtconnect")
+    compileOnly("com.hivemq:hivemq-edge-module-opcua")
+    compileOnly("com.hivemq:hivemq-edge-module-file")
 }
 
 /* ******************** test ******************** */

--- a/modules/hivemq-edge-module-modbus/src/main/java/com/hivemq/edge/adapters/modbus/ModbusProtocolAdapter.java
+++ b/modules/hivemq-edge-module-modbus/src/main/java/com/hivemq/edge/adapters/modbus/ModbusProtocolAdapter.java
@@ -69,7 +69,6 @@ public class ModbusProtocolAdapter implements BatchPollingProtocolAdapter {
         this.tags = input.getTags().stream().map(t -> (ModbusTag)t).toList();
         this.modbusClient =
                 new ModbusClient(input.getAdapterId(), adapterConfig);
-
     }
 
     @Override


### PR DESCRIPTION
When hivemq-edge is included in hivemq-edge-test changes to the protocol adapter modules wouldn't trigger the module to be rebuilt.

Only using includeBuild results in modules not being rebuilt when hivemq-edge is included in other builds.
This is due to a not-declared dependency between the modules and edge.

I made the protocol adapter modules compileOnly depdencies instead of only doing includeBuild which gives gradle the required information to react to changes in the modules.
