### PR TITLE
fix(31771): Improve the toolbar when multiple nodes are selected

### DIFF
--- a/hivemq-edge/src/frontend/src/components/react-flow/NodeToolbar.tsx
+++ b/hivemq-edge/src/frontend/src/components/react-flow/NodeToolbar.tsx
@@ -2,8 +2,7 @@ import type { FC } from 'react'
 import type { NodeToolbarProps } from '@xyflow/react'
 import { NodeToolbar as ReactFlowNodeToolbar } from '@xyflow/react'
 import type { As } from '@chakra-ui/react'
-import { chakra, Icon } from '@chakra-ui/react'
-import { BsGripVertical } from 'react-icons/bs'
+import { chakra } from '@chakra-ui/react'
 
 const NodeToolbarChakra = chakra<As, NodeToolbarProps>(ReactFlowNodeToolbar)
 
@@ -24,13 +23,12 @@ const NodeToolbar: FC<NodeToolbarProps> = ({ children, ...props }) => {
         _dark: {
           backgroundColor: 'var(--chakra-colors-gray-700)',
         },
-        paddingRight: 2,
+        padding: 2,
         borderRadius: 'var(--chakra-radii-md)',
         backgroundColor: 'var(--chakra-colors-chakra-body-bg)',
         boxShadow: 'var(--chakra-shadows-dark-lg)',
       }}
     >
-      <Icon as={BsGripVertical} boxSize={7} aria-hidden={true} />
       {children}
     </NodeToolbarChakra>
   )

--- a/hivemq-edge/src/frontend/src/locales/en/translation.json
+++ b/hivemq-edge/src/frontend/src/locales/en/translation.json
@@ -837,6 +837,10 @@
       "container": {
         "label": "Node toolbar"
       },
+      "selection": {
+        "title_one": "1 entity selected",
+        "title_other": "{{ count}} entities selected"
+      },
       "command": {
         "overview": "Open the overview panel",
         "group": "Group the selected adapters",

--- a/hivemq-edge/src/frontend/src/modules/Theme/globals/react-flow.ts
+++ b/hivemq-edge/src/frontend/src/modules/Theme/globals/react-flow.ts
@@ -7,11 +7,11 @@ export const reactFlow: SystemStyleObject = {
     },
   },
 
-  '.react-flow__handle-connecting': {
-    '&.react-flow__handle-valid': {
+  '.connectingto': {
+    '&.valid': {
       boxShadow: '0 0 10px 2px rgb(88 144 255 / 75%), 0 1px 1px rgb(0 0 0 / 15%);',
     },
-    '&:not(.react-flow__handle-valid)': {
+    '&:not(.valid)': {
       cursor: 'no-drop',
       boxShadow: '0 0 10px 2px rgba(226, 85, 85, 0.75), 0 1px 1px rgb(0 0 0 / 15%);',
     },

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/ContextualToolbar.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/ContextualToolbar.tsx
@@ -58,7 +58,20 @@ const ContextualToolbar: FC<ContextualToolbarProps> = ({
   const navigate = useNavigate()
   const { fitView } = useReactFlow()
 
-  const selectedNodes = nodes.filter((node) => node.selected)
+  const selectedNodes = useMemo(() => {
+    return nodes.filter((node) => node.selected)
+  }, [nodes])
+
+  const topSelectedNode = useMemo(() => {
+    const [firstNode] = nodes
+      .filter((node) => node.selected)
+      .sort((a, b) => {
+        return a.position.y - b.position.y < 0 ? -1 : 1
+      })
+
+    return firstNode
+  }, [nodes])
+
   const selectedGroupCandidates = useMemo(() => {
     // TODO[NVL] Should the grouping only be available if ALL nodes match the filter ?
     const adapters = selectedNodes.filter(
@@ -212,7 +225,7 @@ const ContextualToolbar: FC<ContextualToolbarProps> = ({
 
   return (
     <NodeToolbar
-      isVisible={Boolean(mainNodes?.id === id && !dragging)}
+      isVisible={Boolean(topSelectedNode?.id === id && !dragging)}
       position={Position.Top}
       aria-label={t('workspace.toolbar.container.label')}
     >

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/ContextualToolbar.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/ContextualToolbar.tsx
@@ -63,14 +63,12 @@ const ContextualToolbar: FC<ContextualToolbarProps> = ({
   }, [nodes])
 
   const topSelectedNode = useMemo(() => {
-    const [firstNode] = nodes
-      .filter((node) => node.selected)
-      .sort((a, b) => {
-        return a.position.y - b.position.y < 0 ? -1 : 1
-      })
+    const [firstNode] = selectedNodes.sort((a, b) => {
+      return a.position.y - b.position.y < 0 ? -1 : 1
+    })
 
     return firstNode
-  }, [nodes])
+  }, [selectedNodes])
 
   const selectedGroupCandidates = useMemo(() => {
     // TODO[NVL] Should the grouping only be available if ALL nodes match the filter ?

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/ContextualToolbar.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/ContextualToolbar.tsx
@@ -220,8 +220,7 @@ const ContextualToolbar: FC<ContextualToolbarProps> = ({
     })
   }
 
-  // TODO[NVL] Weird side effect if first node has no toolbar; get the first suitable node instead?
-  const [mainNodes] = selectedNodes
+  const isMultiple = selectedNodes.length >= 2
 
   return (
     <NodeToolbar
@@ -229,8 +228,10 @@ const ContextualToolbar: FC<ContextualToolbarProps> = ({
       position={Position.Top}
       aria-label={t('workspace.toolbar.container.label')}
     >
-      <Text data-testid="toolbar-title">{title || id}</Text>
-      {children && (
+      <Text data-testid="toolbar-title">
+        {isMultiple ? t('workspace.toolbar.selection.title', { count: selectedNodes.length }) : title || id}
+      </Text>
+      {children && !isMultiple && (
         <>
           <Divider orientation="vertical" />
           {children}
@@ -257,7 +258,7 @@ const ContextualToolbar: FC<ContextualToolbarProps> = ({
         />
       </ToolbarButtonGroup>
 
-      {!hasNoOverview && (
+      {!hasNoOverview && !isMultiple && (
         <>
           <Divider orientation="vertical" />
           <ToolbarButtonGroup>

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeAdapter.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeAdapter.spec.cy.tsx
@@ -90,14 +90,14 @@ describe('NodeAdapter', () => {
           {
             ...MOCK_NODE_ADAPTER,
             id: 'idAdapter2',
-            position: { x: 0, y: 0 },
+            position: { x: 50, y: 100 },
             selected: true,
             hidden: true,
           },
           {
             ...MOCK_NODE_ADAPTER,
             id: 'idAdapter3',
-            position: { x: 0, y: 0 },
+            position: { x: 50, y: 100 },
             selected: true,
             hidden: true,
           },
@@ -106,9 +106,15 @@ describe('NodeAdapter', () => {
       />
     )
     cy.getByTestId('adapter-node-name').should('contain', MOCK_ADAPTER_ID)
-    cy.getByTestId('node-adapter-toolbar-northbound').should('have.attr', 'aria-label', 'Edit Northbound mappings')
+    cy.get('[role="toolbar"][aria-label="Node toolbar"]').should('be.visible')
+    cy.getByTestId('toolbar-title').should('have.text', '3 entities selected')
+    // cy.getByTestId('node-adapter-toolbar-northbound').should('have.attr', 'aria-label', 'Edit Northbound mappings')
     cy.getByTestId('node-group-toolbar-group').should('have.attr', 'aria-label', 'Group the selected adapters')
-    cy.getByTestId('node-group-toolbar-panel').should('have.attr', 'aria-label', 'Open the overview panel')
+    cy.getByTestId('node-group-toolbar-combiner').should(
+      'have.attr',
+      'aria-label',
+      'Create a data combiner from selection'
+    )
   })
 
   it('should render the toolbar properly', () => {


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/31771/details/

The PR improves. the toolbar in the workspace, to deal with situations when multiple nodes are selected.

### Design
- As before, only one toolbar is displayed on the workspace
- When multiple nodes are selected, the toolbar will be displayed on the topmost node, ensuring a better experience 
- The `title` of the toolbar will show either the name of the component (single selection) or a text such as "3 elements selected" (multiple selection)
- Only the CTAs for selection-based commands are shown on the toolbar: `group` and `combine`

### Before
![HiveMQ-Edge-04-07-2025_11_43](https://github.com/user-attachments/assets/cfbfeeda-684f-463a-81fe-a6c2b364481f)

### After
![HiveMQ-Edge-04-07-2025_11_42](https://github.com/user-attachments/assets/99740a5e-6579-4e29-8b0d-678184c2efd1)