### PR TITLE
fix(31834): Fix routing of adapter pages

### DIFF
--- a/hivemq-edge/src/frontend/src/components/rjsf/utils/getChakra.ts
+++ b/hivemq-edge/src/frontend/src/components/rjsf/utils/getChakra.ts
@@ -1,5 +1,5 @@
 /* extracted from RJSF -- do no edit */
-/* istanbul ignore file */
+/* istanbul ignore file -- @preserve */
 
 import type { ChakraProps } from '@chakra-ui/react'
 import { shouldForwardProp } from '@chakra-ui/react'

--- a/hivemq-edge/src/frontend/src/locales/en/translation.json
+++ b/hivemq-edge/src/frontend/src/locales/en/translation.json
@@ -536,7 +536,8 @@
       "view": {
         "title": "Viewing Protocol Adapter",
         "error": "There was a problem trying to view the protocol adapter",
-        "noLongerExist": "The Protocol Adapter {{id}} doesn't exist"
+        "noLongerExist": "The adapter {{id}} doesn't exist",
+        "noValidProtocol": "The Protocol Adapter {{id}} doesn't exist"
       }
     },
     "type": {


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/31834/details/

The PR fixes a problem, whereas navigation to `Adapter`-related pages from the rest of the web app would no work.

The PR also adds toast when the URL used for navigation leads to non-existent adapter or protocol adapters. 

### Out-of-scope
- The main app's routing leads to an error page if the destination doesnt exist. The use of toasts for this case might be revisited in a future ticket.

### Before

### After
![HiveMQ-Edge-04-07-2025_12_26](https://github.com/user-attachments/assets/7755d21d-2fb7-46cd-abd7-4cb972cb4418)
