### PR TITLE
feat(30497): Improve the layout and UX of the workspace

### DIFF
--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/ReactFlowWrapper.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/ReactFlowWrapper.tsx
@@ -122,8 +122,7 @@ const ReactFlowWrapper = () => {
           nodeComponent={(miniMapNode) => {
             if (miniMapNode.className === NodeTypes.EDGE_NODE)
               return <circle cx={miniMapNode.x} cy={miniMapNode.y} r="50" fill="#ffc000" />
-            if (miniMapNode.className === NodeTypes.DEVICE_NODE || miniMapNode.className === NodeTypes.HOST_NODE)
-              return null
+            if (miniMapNode.className === NodeTypes.HOST_NODE) return null
             return (
               <rect
                 x={miniMapNode.x}

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/ReactFlowWrapper.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/ReactFlowWrapper.tsx
@@ -29,6 +29,7 @@ import {
 } from '@/modules/Workspace/components/nodes'
 import { gluedNodeDefinition } from '@/modules/Workspace/utils/nodes-utils.ts'
 import { proOptions } from '@/components/react-flow/react-flow.utils.ts'
+import { DynamicEdge } from './edges/DynamicEdge'
 
 const ReactFlowWrapper = () => {
   const { t } = useTranslation()
@@ -56,6 +57,7 @@ const ReactFlowWrapper = () => {
   const edgeTypes = useMemo(
     () => ({
       [EdgeTypes.REPORT_EDGE]: MonitoringEdge,
+      [EdgeTypes.DYNAMIC_EDGE]: DynamicEdge,
     }),
     []
   )

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/ReactFlowWrapper.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/ReactFlowWrapper.tsx
@@ -27,7 +27,7 @@ import {
   NodeDevice,
   NodeCombiner,
 } from '@/modules/Workspace/components/nodes'
-import { gluedNodeDefinition } from '@/modules/Workspace/utils/nodes-utils.ts'
+import { getGluedPosition, gluedNodeDefinition } from '@/modules/Workspace/utils/nodes-utils.ts'
 import { proOptions } from '@/components/react-flow/react-flow.utils.ts'
 import { DynamicEdge } from './edges/DynamicEdge'
 
@@ -71,8 +71,10 @@ const ReactFlowWrapper = () => {
       const gluedDraggedNodes = draggedNodes.filter((node) =>
         Object.keys(gluedNodeDefinition).includes(node.type as NodeTypes)
       )
+
+      const edge = nodes.find((e) => e.type === NodeTypes.EDGE_NODE)
       for (const movedNode of gluedDraggedNodes) {
-        const [type, spacing, handle] = gluedNodeDefinition[movedNode.type as NodeTypes]
+        const [type, , handle] = gluedNodeDefinition[movedNode.type as NodeTypes]
         if (!type) continue
 
         const outgoers =
@@ -83,7 +85,7 @@ const ReactFlowWrapper = () => {
         const positionChange: NodePositionChange = {
           id: gluedNode.id,
           type: 'position',
-          position: { x: movedNode.position.x, y: movedNode.position.y + spacing },
+          position: getGluedPosition(movedNode, edge),
         }
 
         onNodesChange([positionChange])

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/edges/DynamicEdge.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/edges/DynamicEdge.tsx
@@ -1,0 +1,26 @@
+import type { FC } from 'react'
+import { type EdgeProps, getBezierPath, useInternalNode } from '@xyflow/react'
+
+import { getEdgeParams } from '@/modules/Workspace/utils/edge.utils'
+
+export const DynamicEdge: FC<EdgeProps> = ({ id, source, target, markerEnd, style }) => {
+  const sourceNode = useInternalNode(source)
+  const targetNode = useInternalNode(target)
+
+  if (!sourceNode || !targetNode) {
+    return null
+  }
+
+  const { sx, sy, tx, ty, sourcePos, targetPos } = getEdgeParams(sourceNode, targetNode)
+
+  const [edgePath] = getBezierPath({
+    sourceX: sx,
+    sourceY: sy,
+    sourcePosition: sourcePos,
+    targetPosition: targetPos,
+    targetX: tx,
+    targetY: ty,
+  })
+
+  return <path id={id} className="react-flow__edge-path" d={edgePath} markerEnd={markerEnd} style={style} />
+}

--- a/hivemq-edge/src/frontend/src/modules/Workspace/types.ts
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/types.ts
@@ -39,6 +39,7 @@ export enum NodeTypes {
 
 export enum EdgeTypes {
   REPORT_EDGE = 'REPORT_EDGE',
+  DYNAMIC_EDGE = 'DYNAMIC_EDGE',
 }
 
 export type EdgeStatus = {

--- a/hivemq-edge/src/frontend/src/modules/Workspace/utils/edge.utils.ts
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/utils/edge.utils.ts
@@ -1,5 +1,6 @@
 import type { InternalNode, Node, XYPosition } from '@xyflow/react'
 import { Position, MarkerType } from '@xyflow/react'
+import { CONFIG_ADAPTER_WIDTH } from './nodes-utils'
 
 // this helper function returns the intersection point
 // of the line between the center of the intersectionNode and the target node
@@ -83,11 +84,13 @@ export function initialElements() {
 
   nodes.push({ id: 'target', data: { label: 'Target' }, position: center })
 
-  for (let i = 0; i < 8; i++) {
-    const degrees = i * (360 / 8)
+  const OCTAGON_DISTRIBUTION = 8
+
+  for (let i = 0; i < OCTAGON_DISTRIBUTION; i++) {
+    const degrees = i * (360 / OCTAGON_DISTRIBUTION)
     const radians = degrees * (Math.PI / 180)
-    const x = 250 * Math.cos(radians) + center.x
-    const y = 250 * Math.sin(radians) + center.y
+    const x = CONFIG_ADAPTER_WIDTH * Math.cos(radians) + center.x
+    const y = CONFIG_ADAPTER_WIDTH * Math.sin(radians) + center.y
 
     nodes.push({ id: `${i}`, data: { label: 'Source' }, position: { x, y } })
 

--- a/hivemq-edge/src/frontend/src/modules/Workspace/utils/edge.utils.ts
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/utils/edge.utils.ts
@@ -1,0 +1,106 @@
+import type { InternalNode, Node, XYPosition } from '@xyflow/react'
+import { Position, MarkerType } from '@xyflow/react'
+
+// this helper function returns the intersection point
+// of the line between the center of the intersectionNode and the target node
+// https://math.stackexchange.com/questions/1724792/an-algorithm-for-finding-the-intersection-point-between-a-center-of-vision-and-a
+/**
+ * this helper function returns the intersection point of the line between the center of the intersectionNode and the target node
+ * @see https://math.stackexchange.com/questions/1724792/an-algorithm-for-finding-the-intersection-point-between-a-center-of-vision-and-a
+ * @param intersectionNode
+ * @param targetNode
+ */
+function getNodeIntersection(intersectionNode: InternalNode<Node>, targetNode: InternalNode<Node>) {
+  const { width: intersectionNodeWidth, height: intersectionNodeHeight } = intersectionNode.measured
+  const intersectionNodePosition = intersectionNode.internals.positionAbsolute
+  const targetPosition = targetNode.internals.positionAbsolute
+
+  const w = (intersectionNodeWidth || 0) / 2
+  const h = (intersectionNodeHeight || 0) / 2
+
+  const x2 = intersectionNodePosition.x + w
+  const y2 = intersectionNodePosition.y + h
+  const x1 = targetPosition.x + (targetNode.measured.width || 0) / 2
+  const y1 = targetPosition.y + (targetNode.measured.height || 0) / 2
+
+  const xx1 = (x1 - x2) / (2 * w) - (y1 - y2) / (2 * h)
+  const yy1 = (x1 - x2) / (2 * w) + (y1 - y2) / (2 * h)
+  const a = 1 / (Math.abs(xx1) + Math.abs(yy1))
+  const xx3 = a * xx1
+  const yy3 = a * yy1
+  const x = w * (xx3 + yy3) + x2
+  const y = h * (-xx3 + yy3) + y2
+
+  return { x, y } as XYPosition
+}
+
+// returns the position (top,right,bottom or right) passed node compared to the intersection point
+function getEdgePosition(node: InternalNode<Node>, intersectionPoint: XYPosition) {
+  const n = { ...node.internals.positionAbsolute, ...node }
+  const nx = Math.round(n.x)
+  const ny = Math.round(n.y)
+  const px = Math.round(intersectionPoint.x)
+  const py = Math.round(intersectionPoint.y)
+
+  if (px <= nx + 1) {
+    return Position.Left
+  }
+  if (px >= nx + (n.measured.width || 0) - 1) {
+    return Position.Right
+  }
+  if (py <= ny + 1) {
+    return Position.Top
+  }
+  if (py >= n.y + (n.measured.height || 0) - 1) {
+    return Position.Bottom
+  }
+
+  return Position.Top
+}
+
+// returns the parameters (sx, sy, tx, ty, sourcePos, targetPos) you need to create an edge
+export function getEdgeParams(source: InternalNode<Node>, target: InternalNode<Node>) {
+  const sourceIntersectionPoint = getNodeIntersection(source, target)
+  const targetIntersectionPoint = getNodeIntersection(target, source)
+
+  const sourcePos = getEdgePosition(source, sourceIntersectionPoint)
+  const targetPos = getEdgePosition(target, targetIntersectionPoint)
+
+  return {
+    sx: sourceIntersectionPoint.x,
+    sy: sourceIntersectionPoint.y,
+    tx: targetIntersectionPoint.x,
+    ty: targetIntersectionPoint.y,
+    sourcePos,
+    targetPos,
+  }
+}
+
+export function initialElements() {
+  const nodes = []
+  const edges = []
+  const center = { x: window.innerWidth / 2, y: window.innerHeight / 2 }
+
+  nodes.push({ id: 'target', data: { label: 'Target' }, position: center })
+
+  for (let i = 0; i < 8; i++) {
+    const degrees = i * (360 / 8)
+    const radians = degrees * (Math.PI / 180)
+    const x = 250 * Math.cos(radians) + center.x
+    const y = 250 * Math.sin(radians) + center.y
+
+    nodes.push({ id: `${i}`, data: { label: 'Source' }, position: { x, y } })
+
+    edges.push({
+      id: `edge-${i}`,
+      target: 'target',
+      source: `${i}`,
+      type: 'floating',
+      markerEnd: {
+        type: MarkerType.Arrow,
+      },
+    })
+  }
+
+  return { nodes, edges }
+}

--- a/hivemq-edge/src/frontend/src/modules/Workspace/utils/nodes-utils.spec.ts
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/utils/nodes-utils.spec.ts
@@ -283,7 +283,3 @@ describe('createCombinerNode', () => {
     })
   })
 })
-
-export const getGluedPosition = (s: Node, t: Node, c: Node): XYPosition => {
-  return { x: 0, y: 0 }
-}

--- a/hivemq-edge/src/frontend/src/modules/Workspace/utils/nodes-utils.spec.ts
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/utils/nodes-utils.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from 'vitest'
-import type { Edge, Node } from '@xyflow/react'
+import type { Edge, Node, XYPosition } from '@xyflow/react'
 import { Position } from '@xyflow/react'
 
 import { MOCK_LOCAL_STORAGE, MOCK_THEME } from '@/__test-utils__/react-flow/utils.ts'
@@ -255,7 +255,6 @@ describe('createCombinerNode', () => {
         id: `connect-edge-${mockId}`,
         source: mockId,
         target: 'edge',
-        type: 'default',
       }),
       sourceConnectors: [],
     })
@@ -279,9 +278,12 @@ describe('createCombinerNode', () => {
           id: `connect-idEdge-${mockId}`,
           source: 'idEdge',
           target: '6991ff43-9105-445f-bce3-976720df40a3',
-          type: 'default',
         }),
       ],
     })
   })
 })
+
+export const getGluedPosition = (s: Node, t: Node, c: Node): XYPosition => {
+  return { x: 0, y: 0 }
+}

--- a/hivemq-edge/src/frontend/src/modules/Workspace/utils/nodes-utils.spec.ts
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/utils/nodes-utils.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from 'vitest'
-import type { Edge, Node, XYPosition } from '@xyflow/react'
+import type { Edge, Node } from '@xyflow/react'
 import { Position } from '@xyflow/react'
 
 import { MOCK_LOCAL_STORAGE, MOCK_THEME } from '@/__test-utils__/react-flow/utils.ts'

--- a/hivemq-edge/src/frontend/src/modules/Workspace/utils/nodes-utils.ts
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/utils/nodes-utils.ts
@@ -15,15 +15,16 @@ import { getThemeForStatus } from '@/modules/Workspace/utils/status-utils.ts'
 export const CONFIG_ADAPTER_WIDTH = 245
 
 const POS_SEPARATOR = 80
+const GLUE_SEPARATOR = 200
 const POS_EDGE: XYPosition = { x: 300, y: 200 }
 const POS_NODE_INC: XYPosition = { x: CONFIG_ADAPTER_WIDTH + POS_SEPARATOR, y: 400 }
 const MAX_ADAPTERS = 10
 
 export const gluedNodeDefinition: Record<string, [NodeTypes, number, 'target' | 'source']> = {
-  [NodeTypes.BRIDGE_NODE]: [NodeTypes.HOST_NODE, -200, 'target'],
-  [NodeTypes.ADAPTER_NODE]: [NodeTypes.DEVICE_NODE, -175, 'target'],
-  [NodeTypes.HOST_NODE]: [NodeTypes.BRIDGE_NODE, 200, 'source'],
-  [NodeTypes.DEVICE_NODE]: [NodeTypes.ADAPTER_NODE, 175, 'source'],
+  [NodeTypes.BRIDGE_NODE]: [NodeTypes.HOST_NODE, -GLUE_SEPARATOR, 'target'],
+  [NodeTypes.ADAPTER_NODE]: [NodeTypes.DEVICE_NODE, -GLUE_SEPARATOR, 'target'],
+  [NodeTypes.HOST_NODE]: [NodeTypes.BRIDGE_NODE, GLUE_SEPARATOR, 'source'],
+  [NodeTypes.DEVICE_NODE]: [NodeTypes.ADAPTER_NODE, GLUE_SEPARATOR, 'source'],
 }
 
 export const createEdgeNode = (label: string, positionStorage?: Record<string, XYPosition>) => {

--- a/hivemq-edge/src/frontend/src/modules/Workspace/utils/nodes-utils.ts
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/utils/nodes-utils.ts
@@ -67,7 +67,7 @@ export const createBridgeNode = (
     targetHandle: 'Bottom',
     focusable: false,
     source: idBridge,
-    type: EdgeTypes.REPORT_EDGE,
+    type: EdgeTypes.DYNAMIC_EDGE,
     markerEnd: {
       type: MarkerType.ArrowClosed,
       width: 20,
@@ -98,7 +98,7 @@ export const createBridgeNode = (
     target: idBridgeHost,
     sourceHandle: 'Bottom',
     source: idBridge,
-    // type: EdgeTypes.REPORT_EDGE,
+    type: EdgeTypes.DYNAMIC_EDGE,
     focusable: false,
     markerEnd: {
       type: MarkerType.ArrowClosed,
@@ -140,7 +140,7 @@ export const createListenerNode = (
     targetHandle: 'Listeners',
     target: idListener,
     focusable: false,
-    // type: EdgeTypes.REPORT_EDGE,
+    type: EdgeTypes.DYNAMIC_EDGE,
     markerEnd: {
       type: MarkerType.ArrowClosed,
       width: 20,
@@ -186,7 +186,7 @@ export const createAdapterNode = (
     targetHandle: 'Top',
     source: idAdapter,
     focusable: false,
-    type: EdgeTypes.REPORT_EDGE,
+    type: EdgeTypes.DYNAMIC_EDGE,
     markerEnd: {
       type: MarkerType.ArrowClosed,
       width: 20,
@@ -221,6 +221,7 @@ export const createAdapterNode = (
     sourceHandle: 'Top',
     source: idAdapter,
     focusable: false,
+    type: EdgeTypes.DYNAMIC_EDGE,
     markerEnd: {
       type: MarkerType.ArrowClosed,
       width: 20,
@@ -261,7 +262,7 @@ export const createCombinerNode = (
       targetHandle: 'Top',
       source: source.id,
       focusable: false,
-      type: 'default',
+      type: EdgeTypes.DYNAMIC_EDGE,
       markerEnd: {
         type: MarkerType.ArrowClosed,
         width: 20,
@@ -283,7 +284,7 @@ export const createCombinerNode = (
     targetHandle: 'Top',
     source: combiner.id,
     focusable: false,
-    type: 'default',
+    type: EdgeTypes.DYNAMIC_EDGE,
     markerEnd: {
       type: MarkerType.ArrowClosed,
       width: 20,

--- a/hivemq-edge/src/frontend/src/modules/Workspace/utils/nodes-utils.ts
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/utils/nodes-utils.ts
@@ -20,9 +20,9 @@ const POS_NODE_INC: XYPosition = { x: CONFIG_ADAPTER_WIDTH + POS_SEPARATOR, y: 4
 const MAX_ADAPTERS = 10
 
 export const gluedNodeDefinition: Record<string, [NodeTypes, number, 'target' | 'source']> = {
-  [NodeTypes.BRIDGE_NODE]: [NodeTypes.HOST_NODE, 200, 'target'],
+  [NodeTypes.BRIDGE_NODE]: [NodeTypes.HOST_NODE, -200, 'target'],
   [NodeTypes.ADAPTER_NODE]: [NodeTypes.DEVICE_NODE, -175, 'target'],
-  [NodeTypes.HOST_NODE]: [NodeTypes.BRIDGE_NODE, -200, 'source'],
+  [NodeTypes.HOST_NODE]: [NodeTypes.BRIDGE_NODE, 200, 'source'],
   [NodeTypes.DEVICE_NODE]: [NodeTypes.ADAPTER_NODE, 175, 'source'],
 }
 


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/30497/details/

The PR is the first of a series of improvements on the `Workspace`. 

Its main objective is to improve the readability of the whole graph by removing the fixed top/below layout for (respectively) adapters and bridges and adding dynamic link positioning to support more complex connected configurations. 

### Design
- The edge between nodes has been redesigned to support dynamic positioning. 
- An edge will connect to the nearest point  on the boundary of the nodes, rather than using the handles
- The direction of all edges is now clearly visible at the contact points with the nodes they connect with
- "Glued" nodes (for example a device and its adapter) are rendered using a simple half-space approach (above or below the edge node), maintaining their relative position


### Before
![HiveMQ-Edge-04-09-2025_10_59](https://github.com/user-attachments/assets/a1975923-c205-424f-9d89-726fc210f410)


### After
![HiveMQ-Edge-04-09-2025_10_58](https://github.com/user-attachments/assets/736b621d-7e13-4cd0-b9c3-9ef1c7eb9306)
