### PR TITLE
Fixed cases where processing stopped because of a broken consumer

### DIFF
--- a/hivemq-edge/src/main/java/com/hivemq/combining/runtime/DataCombiningRuntime.java
+++ b/hivemq-edge/src/main/java/com/hivemq/combining/runtime/DataCombiningRuntime.java
@@ -210,7 +210,11 @@ public class DataCombiningRuntime {
         public void accept(final @NotNull List<DataPoint> dataPoints) {
             tagResults.put(tagName, dataPoints);
             if (isPrimary) {
-                triggerPublish(dataCombining);
+                try {
+                    triggerPublish(dataCombining);
+                } catch (final Exception e) {
+                    log.warn("Unable to process data points '{}'", dataPoints, e);
+                }
             }
         }
     }

--- a/hivemq-edge/src/main/java/com/hivemq/edge/modules/adapters/data/TagManager.java
+++ b/hivemq-edge/src/main/java/com/hivemq/edge/modules/adapters/data/TagManager.java
@@ -64,7 +64,7 @@ public class TagManager implements ProtocolAdapterTagStreamingService {
                     try {
                         consumer.accept(dataPoints);
                     } catch (final Exception e) {
-                        log.warn("An error was thrown while processing tag {} with consumer {}", tagName, consumer, e);
+                        log.error("An error was thrown while processing tag {} with consumer {}", tagName, consumer, e);
                     }
                 });
             }

--- a/hivemq-edge/src/test/java/com/hivemq/edge/modules/adapters/data/TagManagerTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/edge/modules/adapters/data/TagManagerTest.java
@@ -1,0 +1,102 @@
+package com.hivemq.edge.modules.adapters.data;
+
+
+import com.codahale.metrics.NoopMetricRegistry;
+import com.hivemq.adapter.sdk.api.data.DataPoint;
+import com.hivemq.metrics.MetricsHolder;
+import com.hivemq.protocols.northbound.TagConsumer;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TagManagerTest {
+
+    @Test
+    public void test_allSucceeds() throws Exception{
+        var tagManager = new TagManager(new MetricsHolder(new NoopMetricRegistry()));
+        var countDownLatch = new CountDownLatch(3);
+        tagManager.addConsumer(new SucceedingConsumer("tag1", countDownLatch));
+        tagManager.feed("tag1", List.of(new DataPointImpl("tag1", 1), new DataPointImpl("tag1", 2)));
+        tagManager.feed("tag1", List.of(new DataPointImpl("tag1", 1), new DataPointImpl("tag1", 2)));
+        tagManager.feed("tag1", List.of(new DataPointImpl("tag1", 1), new DataPointImpl("tag1", 2)));
+
+        assertThat(countDownLatch.await(5, TimeUnit.SECONDS)).isTrue();
+    }
+
+    @Test
+    public void test_succeedForMultipleConsumers() throws Exception{
+        var tagManager = new TagManager(new MetricsHolder(new NoopMetricRegistry()));
+        var countDownLatch = new CountDownLatch(3);
+        var countDownLatch1 = new CountDownLatch(3);
+        var countDownLatch2 = new CountDownLatch(3);
+        tagManager.addConsumer(new SucceedingConsumer("tag1", countDownLatch));
+        tagManager.addConsumer(new SucceedingConsumer("tag1", countDownLatch1));
+        tagManager.addConsumer(new SucceedingConsumer("tag1", countDownLatch2));
+        tagManager.feed("tag1", List.of(new DataPointImpl("tag1", 1), new DataPointImpl("tag1", 2)));
+        tagManager.feed("tag1", List.of(new DataPointImpl("tag1", 1), new DataPointImpl("tag1", 2)));
+        tagManager.feed("tag1", List.of(new DataPointImpl("tag1", 1), new DataPointImpl("tag1", 2)));
+
+        assertThat(countDownLatch.await(5, TimeUnit.SECONDS)).isTrue();
+        assertThat(countDownLatch1.await(5, TimeUnit.SECONDS)).isTrue();
+        assertThat(countDownLatch2.await(5, TimeUnit.SECONDS)).isTrue();
+    }
+
+    @Test
+    public void test_succeedForMultipleConsumers_withOneBroken() throws Exception{
+        var tagManager = new TagManager(new MetricsHolder(new NoopMetricRegistry()));
+        var countDownLatch = new CountDownLatch(3);
+        var countDownLatch1 = new CountDownLatch(3);
+        tagManager.addConsumer(new SucceedingConsumer("tag1", countDownLatch));
+        tagManager.addConsumer(new FailingTagConsumer("tag1"));
+        tagManager.addConsumer(new SucceedingConsumer("tag1", countDownLatch1));
+        tagManager.feed("tag1", List.of(new DataPointImpl("tag1", 1), new DataPointImpl("tag1", 2)));
+        tagManager.feed("tag1", List.of(new DataPointImpl("tag1", 1), new DataPointImpl("tag1", 2)));
+        tagManager.feed("tag1", List.of(new DataPointImpl("tag1", 1), new DataPointImpl("tag1", 2)));
+
+        assertThat(countDownLatch.await(5, TimeUnit.SECONDS)).isTrue();
+        assertThat(countDownLatch1.await(5, TimeUnit.SECONDS)).isTrue();
+    }
+
+    public static class FailingTagConsumer implements TagConsumer {
+        private final @NotNull String tagName;
+
+        public FailingTagConsumer(@NotNull final String tagName) {
+            this.tagName = tagName;
+        }
+
+        @Override
+        public @NotNull String getTagName() {
+            return tagName;
+        }
+
+        @Override
+        public void accept(final List<DataPoint> dataPoints) {
+            throw new RuntimeException();
+        }
+    }
+
+    public static class SucceedingConsumer implements TagConsumer {
+        private final @NotNull String tagName;
+        private final @NotNull CountDownLatch countDownLatch;
+
+        public SucceedingConsumer(@NotNull final String tagName, @NotNull final CountDownLatch countDownLatch) {
+            this.tagName = tagName;
+            this.countDownLatch = countDownLatch;
+        }
+
+        @Override
+        public @NotNull String getTagName() {
+            return tagName;
+        }
+
+        @Override
+        public void accept(final List<DataPoint> dataPoints) {
+            countDownLatch.countDown();
+        }
+    }
+}

--- a/hivemq-edge/src/test/java/com/hivemq/edge/modules/adapters/data/TagManagerTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/edge/modules/adapters/data/TagManagerTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hivemq.edge.modules.adapters.data;
 
 


### PR DESCRIPTION
**Motivation**

Resolves #31949

**Changes**
When a new tag value came in we iterated over all consumers to inform them about the new value.
A broken consumer could throw an exception which would stop the iteration.

The fix is to catch and report the errors and then continue processing.