### PR TITLE
CI(31985): add path exclusion for the ci-check on frontend

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,6 +1,9 @@
 name: CI Check
 
-on: [ push ]
+on:
+  push:
+    paths-ignore:
+      - hivemq-edge/src/frontend/**
 
 concurrency:
   group: ${{ github.ref }}-check


### PR DESCRIPTION
See  https://hivemq.kanbanize.com/ctrl_board/57/cards/29697/details/

As part of the build process clean-up, the PR changes the conditions for executing the `CI Check` workflow, only running on push events that include at least one file outside the directory containing the frontend "monorepo".

The change will only affect pure-frontend PRs and will streamline the build process:
- the `check` workflow will not run on the PR without some change on the composite repo
- the `code coverage` report, which only includes backend code and infrastructure, will not be included in frontend tickets, leaving the space for frontend-dedicated code coverage, see https://hivemq.kanbanize.com/ctrl_board/57/cards/31835/details/

The change is matching similar restrictions on frontend-only pipeline that are not triggered if the "monorepo" is not targetted
