### PR TITLE
Bugfix/packet id is returned twice

### DIFF
--- a/hivemq-edge/src/main/java/com/hivemq/mqtt/callback/PublishStatusFutureCallback.java
+++ b/hivemq-edge/src/main/java/com/hivemq/mqtt/callback/PublishStatusFutureCallback.java
@@ -102,13 +102,13 @@ public class PublishStatusFutureCallback implements FutureCallback<PublishStatus
             log.error("Exceptions in publish status callback handling, queue ID = " + queueId, e);
         }
 
-        if (status != PublishStatus.NOT_CONNECTED) {
-            checkForNewMessages();
-        }
         if (packetIdentifier != 0) {
             messageIDPool.returnId(packetIdentifier);
         }
 
+        if (status != PublishStatus.NOT_CONNECTED) {
+            checkForNewMessages();
+        }
     }
 
     private void checkForNewMessages() {

--- a/hivemq-edge/src/main/java/com/hivemq/mqtt/services/PublishDistributorImpl.java
+++ b/hivemq-edge/src/main/java/com/hivemq/mqtt/services/PublishDistributorImpl.java
@@ -20,6 +20,7 @@ import com.google.common.primitives.ImmutableIntArray;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.SettableFuture;
 import com.hivemq.bridge.MessageForwarderImpl;
 import com.hivemq.bridge.config.LocalSubscription;
@@ -272,7 +273,7 @@ public class PublishDistributorImpl implements PublishDistributor {
 
         final SettableFuture<PublishStatus> statusFuture = SettableFuture.create();
 
-        Futures.addCallback(future, new FutureCallback<Void>() {
+        Futures.addCallback(future, new FutureCallback<>() {
             @Override
             public void onSuccess(final @Nullable Void result) {
                 statusFuture.set(DELIVERED);
@@ -282,7 +283,7 @@ public class PublishDistributorImpl implements PublishDistributor {
             public void onFailure(final @NotNull Throwable t) {
                 statusFuture.set(FAILED);
             }
-        }, singleWriterService.callbackExecutor(client));
+        }, MoreExecutors.directExecutor());
         return statusFuture;
     }
 

--- a/hivemq-edge/src/main/java/com/hivemq/mqtt/services/PublishPollServiceImpl.java
+++ b/hivemq-edge/src/main/java/com/hivemq/mqtt/services/PublishPollServiceImpl.java
@@ -227,7 +227,7 @@ public class PublishPollServiceImpl implements PublishPollService {
                 Exceptions.rethrowError("Exception in new messages handling", t);
                 channel.disconnect();
             }
-        }, singleWriterService.callbackExecutor(client));
+        }, MoreExecutors.directExecutor());
     }
 
     @Override
@@ -305,7 +305,7 @@ public class PublishPollServiceImpl implements PublishPollService {
             public void onFailure(final Throwable t) {
                 Exceptions.rethrowError("Exception in inflight messages handling", t);
             }
-        }, singleWriterService.callbackExecutor(client));
+        }, MoreExecutors.directExecutor());
     }
 
     @Override
@@ -435,7 +435,7 @@ public class PublishPollServiceImpl implements PublishPollService {
                         "for shared subscription " +
                         sharedSubscription, t);
             }
-        }, singleWriterService.callbackExecutor(client));
+        }, MoreExecutors.directExecutor());
     }
 
     @NotNull

--- a/hivemq-edge/src/main/java/com/hivemq/persistence/InMemoryProducerQueues.java
+++ b/hivemq-edge/src/main/java/com/hivemq/persistence/InMemoryProducerQueues.java
@@ -47,8 +47,6 @@ import static com.hivemq.persistence.SingleWriterService.Task;
  */
 public class InMemoryProducerQueues implements ProducerQueues {
 
-    private final int amountOfQueues;
-
     private final int bucketsPerQueue;
 
     private final @NotNull AtomicBoolean shutdown = new AtomicBoolean(false);
@@ -66,7 +64,6 @@ public class InMemoryProducerQueues implements ProducerQueues {
     public InMemoryProducerQueues(final int persistenceBucketCount, final int amountOfQueues) {
 
         this.persistenceBucketCount = persistenceBucketCount;
-        this.amountOfQueues = amountOfQueues;
         bucketsPerQueue = persistenceBucketCount / amountOfQueues;
         shutdownGracePeriod = InternalConfigurations.PERSISTENCE_SHUTDOWN_GRACE_PERIOD_MSEC.get();
 
@@ -85,7 +82,8 @@ public class InMemoryProducerQueues implements ProducerQueues {
     }
 
     @VisibleForTesting
-    @NotNull ImmutableList<Integer> createBucketIndexes(final int queueIndex, final int bucketsPerQueue) {
+    @NotNull
+    ImmutableList<Integer> createBucketIndexes(final int queueIndex, final int bucketsPerQueue) {
         final ImmutableList.Builder<Integer> builder = ImmutableList.builder();
         for (int i = bucketsPerQueue * queueIndex; i < bucketsPerQueue * (queueIndex + 1); i++) {
             builder.add(i);
@@ -95,59 +93,32 @@ public class InMemoryProducerQueues implements ProducerQueues {
 
     public <R> @NotNull ListenableFuture<R> submit(final @NotNull String key, final @NotNull Task<R> task) {
         //noinspection ConstantConditions (future is never null if the callbacks are null)
-        return submitInternal(getBucket(key), task, null, null, false);
+        return submitInternal(getBucket(key), task, false);
     }
 
-    public <R> @NotNull ListenableFuture<R> submit(final int bucketIndex,
-                                          final @NotNull Task<R> task) {
+    public <R> @NotNull ListenableFuture<R> submit(final int bucketIndex, final @NotNull Task<R> task) {
         //noinspection ConstantConditions (futuer is never null if the callbacks are null)
-        return submitInternal(bucketIndex, task, null, null, false);
+        return submitInternal(bucketIndex, task, false);
     }
 
-
-    public <R> @Nullable ListenableFuture<R> submit(final int bucketIndex,
-                                                    final @NotNull Task<R> task,
-                                                    final @Nullable SingleWriterService.SuccessCallback<R> successCallback,
-                                                    final @Nullable SingleWriterService.FailedCallback failedCallback) {
-
-        return submitInternal(bucketIndex, task, successCallback, failedCallback, false);
-    }
-
-
-    private <R> @Nullable ListenableFuture<R> submitInternal(final int bucketIndex,
-                                                     final @NotNull Task<R> task,
-                                                     final @Nullable SingleWriterService.SuccessCallback<R> successCallback,
-                                                     final @Nullable SingleWriterService.FailedCallback failedCallback,
-                                                     final boolean ignoreShutdown) {
+    private <R> @Nullable ListenableFuture<R> submitInternal(
+            final int bucketIndex,
+            final @NotNull Task<R> task,
+            final boolean ignoreShutdown) {
         if (!ignoreShutdown && shutdown.get() && System.currentTimeMillis() - shutdownStartTime > shutdownGracePeriod) {
             return SettableFuture.create(); // Future will never return since we are shutting down.
         }
         final int queueIndex = bucketIndex / bucketsPerQueue;
-        final SettableFuture<R> resultFuture;
-        if (successCallback == null) {
-            resultFuture = SettableFuture.create();
-        } else {
-            resultFuture = null;
-        }
+        final SettableFuture<R> resultFuture = SettableFuture.create();
 
         final MpscUnboundedArrayQueue<Runnable> queue = queues[queueIndex];
         final AtomicInteger wip = wips[queueIndex];
         queue.offer(() -> {
             try {
                 final R result = task.doTask(bucketIndex);
-                if (resultFuture != null) {
-                    resultFuture.set(result);
-                } else {
-                    successCallback.afterTask(result);
-                }
+                resultFuture.set(result);
             } catch (final Throwable e) {
-                if (resultFuture != null) {
-                    resultFuture.setException(e);
-                } else {
-                    if (failedCallback != null) {
-                        failedCallback.afterTask(e);
-                    }
-                }
+                resultFuture.setException(e);
             }
         });
 
@@ -206,7 +177,7 @@ public class InMemoryProducerQueues implements ProducerQueues {
         final ImmutableList.Builder<ListenableFuture<R>> builder = ImmutableList.builder();
         for (int bucket = 0; bucket < persistenceBucketCount; bucket++) {
             //noinspection ConstantConditions (futuer is never null if the callbacks are null)
-            builder.add(submitInternal(bucket, task, null, null, ignoreShutdown));
+            builder.add(submitInternal(bucket, task, ignoreShutdown));
         }
         return builder.build();
     }
@@ -227,11 +198,9 @@ public class InMemoryProducerQueues implements ProducerQueues {
         return builder.build();
     }
 
-
     public int getBucket(final @NotNull String key) {
         return BucketUtils.getBucket(key, persistenceBucketCount);
     }
-
 
     @NotNull
     public ListenableFuture<Void> shutdown(final @Nullable Task<Void> finalTask) {
@@ -273,5 +242,4 @@ public class InMemoryProducerQueues implements ProducerQueues {
         }, executorService);
         return closeFuture;
     }
-
 }

--- a/hivemq-edge/src/main/java/com/hivemq/persistence/ProducerQueues.java
+++ b/hivemq-edge/src/main/java/com/hivemq/persistence/ProducerQueues.java
@@ -26,23 +26,15 @@ import java.util.List;
  */
 public interface ProducerQueues {
 
+    <R> @NotNull ListenableFuture<R> submit(@NotNull String key, @NotNull SingleWriterService.Task<R> task);
 
-    <R> @NotNull ListenableFuture<R> submit(final @NotNull String key, final @NotNull SingleWriterService.Task<R> task);
+    <R> @NotNull ListenableFuture<R> submit(int bucketIndex, @NotNull SingleWriterService.Task<R> task);
 
-    <R> @NotNull ListenableFuture<R> submit(final int bucketIndex, final @NotNull SingleWriterService.Task<R> task);
+    @NotNull <R> List<ListenableFuture<R>> submitToAllBucketsParallel(@NotNull SingleWriterService.Task<R> task);
 
+    @NotNull <R> List<ListenableFuture<R>> submitToAllBucketsSequential(@NotNull SingleWriterService.Task<R> task);
 
-    <R> @Nullable ListenableFuture<R> submit(final int bucketIndex,
-                                             final @NotNull SingleWriterService.Task<R> task,
-                                             final @Nullable SingleWriterService.SuccessCallback<R> successCallback,
-                                             final @Nullable SingleWriterService.FailedCallback failedCallback);
-
-    @NotNull <R> List<ListenableFuture<R>> submitToAllBucketsParallel(final @NotNull SingleWriterService.Task<R> task);
-
-    @NotNull <R> List<ListenableFuture<R>> submitToAllBucketsSequential(final @NotNull SingleWriterService.Task<R> task);
-
-    int getBucket(final @NotNull String key);
+    int getBucket(@NotNull String key);
 
     @NotNull ListenableFuture<Void> shutdown(final @Nullable SingleWriterService.Task<Void> finalTask);
-
 }

--- a/hivemq-edge/src/main/java/com/hivemq/persistence/SingleWriterService.java
+++ b/hivemq-edge/src/main/java/com/hivemq/persistence/SingleWriterService.java
@@ -31,21 +31,11 @@ public interface SingleWriterService {
 
     @NotNull ProducerQueues getAttributeStoreQueue();
 
-    @NotNull Executor callbackExecutor(final @NotNull String key);
-
     int getPersistenceBucketCount();
 
     void stop();
 
     interface Task<R> {
         @NotNull R doTask(int bucketIndex);
-    }
-
-    interface SuccessCallback<R> {
-        void afterTask(@NotNull R result);
-    }
-
-    interface FailedCallback {
-        void afterTask(@NotNull Throwable exception);
     }
 }

--- a/hivemq-edge/src/test/java/com/hivemq/persistence/InFileSingleWriterTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/persistence/InFileSingleWriterTest.java
@@ -104,10 +104,6 @@ public class InFileSingleWriterTest {
         singleWriterServiceImpl.stop();
         assertTrue(singleWriterServiceImpl.checkScheduler.isShutdown());
         assertTrue(singleWriterServiceImpl.singleWriterExecutor.isShutdown());
-
-        for (final ExecutorService callbackExecutor : singleWriterServiceImpl.callbackExecutors) {
-            assertTrue(callbackExecutor.isShutdown());
-        }
     }
 
     private static class NoOpExecutor implements ExecutorService {

--- a/hivemq-edge/src/test/java/com/hivemq/persistence/InMemorySingleWriterServiceTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/persistence/InMemorySingleWriterServiceTest.java
@@ -24,8 +24,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.util.ArrayList;
-import java.util.LinkedList;
-import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
@@ -58,41 +56,6 @@ public class InMemorySingleWriterServiceTest {
         assertEquals(8, singleWriterServiceImpl.validAmountOfQueues(5, 64));
         assertEquals(8, singleWriterServiceImpl.validAmountOfQueues(8, 64));
         assertEquals(64, singleWriterServiceImpl.validAmountOfQueues(64, 64));
-    }
-
-
-    @Test
-    public void test_callbackExecutor_whenManyThreadsSubmitConcurrently_thenOnlyOneThreadWorksConcurrently() throws InterruptedException {
-        final LinkedList<Integer> list = new LinkedList<>();
-        list.add(0);
-
-        final List<Thread> threads = new ArrayList<>();
-        final int numberOfConcurrentThreads = 4;
-
-        // this is highly un-thread-safe, when this is concurrently executed
-        // there are many sources for exceptions
-        final Runnable runnable = () -> {
-            final Integer poll = list.pollFirst();
-            list.add(poll + 1);
-        };
-
-        for (int j = 0; j < 4; j++) {
-            final Thread thread = new Thread(() -> {
-                for (int i = 0; i < 10_000; i++) {
-                    singleWriterServiceImpl.callbackExecutor("sameKey").execute(runnable);
-                }
-            });
-            threads.add(thread);
-            thread.start();
-        }
-
-        //wait for all threads to finish their submissions
-        for (final Thread thread : threads) {
-            thread.join();
-        }
-
-        // 4 threads with 10_000 adds = 40_000
-        assertEquals(40_000, (int) list.pollFirst());
     }
 
     @Test

--- a/hivemq-edge/src/test/java/com/hivemq/persistence/ProducerQueuesImplTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/persistence/ProducerQueuesImplTest.java
@@ -44,7 +44,6 @@ public class ProducerQueuesImplTest {
         MockitoAnnotations.initMocks(this);
 
         when(singleWriterServiceImpl.getPersistenceBucketCount()).thenReturn(64);
-        when(singleWriterServiceImpl.getThreadPoolSize()).thenReturn(4);
         when(singleWriterServiceImpl.getGlobalTaskCount()).thenReturn(new AtomicLong());
 
         producerQueues = new ProducerQueuesImpl(singleWriterServiceImpl, 4);


### PR DESCRIPTION
**Motivation**

Resolves 31972

**Changes**
Fixing: The broker returns every packet ID twice when the publish flow is complete. Therefore, the same packet ID can be assigned to two publishes. The OrderedTopicService maps the packet ID to a future, which is complete when the publish flow is complete. When two publishes have the same packet ID, the map entry will be replaced, and one of the futures will never be complete.