### PR TITLE
fix(32008): Fix access to Observability from links

### DIFF
--- a/hivemq-edge/src/frontend/cypress/e2e/adapters/s7.spec.cy.ts
+++ b/hivemq-edge/src/frontend/cypress/e2e/adapters/s7.spec.cy.ts
@@ -236,7 +236,7 @@ describe('S7 adapter', () => {
 
       workspacePage.navLink.click()
       workspacePage.canvas.should('be.visible')
-      workspacePage.toolbox.fit.click().type('tab')
+      workspacePage.toolbox.fit.click()
 
       workspacePage.edgeNode.click()
       workspacePage.nodeToolbar.should('be.visible').should('have.attr', 'data-id', 'edge')

--- a/hivemq-edge/src/frontend/cypress/e2e/combiners/create.spec.cy.ts
+++ b/hivemq-edge/src/frontend/cypress/e2e/combiners/create.spec.cy.ts
@@ -112,6 +112,23 @@ describe('Combiner', () => {
     rjsf.field('mappings').table.noDataMessage.should('have.text', 'No data received yet.')
     rjsf.field('mappings').table.addItem.click()
     rjsf.field('mappings').table.rows.should('have.length', 1)
-    rjsf.field('mappings').table.rowAction(0).edit.click()
+    rjsf.field('mappings').table.row(0).edit.click()
+
+    combinerForm.mappingEditor.form.should('be.visible')
+    combinerForm.mappingEditor.sources.selector.should('contain.text', 'Select tags and topic filters to combine ...')
+    combinerForm.mappingEditor.sources.selector.click()
+    combinerForm.mappingEditor.sources.options.should('have.length', 3)
+
+    combinerForm.mappingEditor.sources.selector.type('a/topic/')
+    combinerForm.mappingEditor.sources.options.click()
+    combinerForm.mappingEditor.sources.selector.should('contain.text', 'a/topic/+/filter')
+    combinerForm.mappingEditor.sources.schema.should('have.length', 2)
+    combinerForm.mappingEditor.primary.selector.type('a/topic{enter}')
+
+    combinerForm.mappingEditor.destination.selector.type('my/topic{enter}')
+    combinerForm.mappingEditor.destination.inferSchema.click()
+
+    combinerForm.inferSchema.modal.should('be.visible')
+    combinerForm.inferSchema.submit.click()
   })
 })

--- a/hivemq-edge/src/frontend/cypress/e2e/combiners/create.spec.cy.ts
+++ b/hivemq-edge/src/frontend/cypress/e2e/combiners/create.spec.cy.ts
@@ -1,0 +1,117 @@
+import type { Combiner } from '@/api/__generated__'
+import { factory, primaryKey, drop } from '@mswjs/data'
+
+import { MOCK_ADAPTER_OPC_UA, MOCK_PROTOCOL_OPC_UA } from '@/__test-utils__/adapters/opc-ua.ts'
+import { MOCK_TOPIC_FILTER } from '@/api/hooks/useTopicFilters/__handlers__'
+
+import { adapterPage, loginPage, rjsf, workspacePage } from 'cypress/pages'
+import { cy_interceptCoreE2E } from 'cypress/utils/intercept.utils.ts'
+import { combinerForm } from '../../pages/Workspace/CombinerFormPage.ts'
+
+const COMBINER_ID = '9e975b62-6f8d-410f-9007-3f83719aec6f'
+
+describe('Combiner', () => {
+  // Creating a mock storage for Combiner
+  const mswDB = factory({
+    combiner: {
+      id: primaryKey(String),
+      // TODO[E2E] Could we use the OpenAPI or the TS types?
+      // Stringified version of the payload
+      json: String,
+    },
+  })
+
+  beforeEach(() => {
+    cy_interceptCoreE2E()
+
+    cy.intercept('/api/v1/data-hub/data-validation/policies', { statusCode: 203, log: false })
+    cy.intercept('/api/v1/gateway/listeners', { statusCode: 203, log: false })
+    cy.intercept('/api/v1/management/bridges', { statusCode: 203, log: false })
+    cy.intercept('/api/v1/management/protocol-adapters/adapters/*/northboundMappings', { statusCode: 203, log: false })
+    cy.intercept('/api/v1/management/protocol-adapters/adapters/*/southboundMappings', { statusCode: 203, log: false })
+    cy.intercept('/api/v1/management/protocol-adapters/adapters/*/tags', { statusCode: 203, log: false })
+
+    cy.intercept('/api/v1/management/protocol-adapters/types', { items: [MOCK_PROTOCOL_OPC_UA] }).as('getProtocols')
+    cy.intercept('/api/v1/management/protocol-adapters/adapters', {
+      items: [MOCK_ADAPTER_OPC_UA, { ...MOCK_ADAPTER_OPC_UA, id: 'opcua-boiler' }],
+    }).as('getAdapters')
+    cy.intercept('/api/v1/management/topic-filters', {
+      items: [
+        MOCK_TOPIC_FILTER,
+        {
+          topicFilter: 'another/filter',
+          description: 'This is a topic filter',
+        },
+        {
+          topicFilter: 'another/filter/too',
+          description: 'This is another topic filter',
+        },
+      ],
+    }).as('getTopicFilters')
+
+    cy.intercept<Combiner>('POST', '/api/v1/management/combiners', (req) => {
+      const combiner = req.body
+      const newCombinerData = mswDB.combiner.create({
+        id: COMBINER_ID,
+        json: JSON.stringify({ ...combiner, id: COMBINER_ID }),
+      })
+      req.reply(200, newCombinerData)
+    }).as('postCombiner')
+
+    cy.intercept('GET', '/api/v1/management/combiners', (req) => {
+      // Create a new entity for the "post" model.
+      const allCombinerData = mswDB.combiner.getAll()
+      const allCombiners = allCombinerData.map<Combiner>((data) => ({ ...JSON.parse(data.json) }))
+      req.reply(200, { items: allCombiners })
+    }).as('getCombiners')
+
+    loginPage.visit('/app/workspace')
+    loginPage.loginButton.click()
+    workspacePage.navLink.click()
+  })
+
+  afterEach(() => {
+    drop(mswDB)
+  })
+
+  it('should render the workspace', () => {
+    // Check that the expected content is there
+
+    workspacePage.combinerNode(COMBINER_ID).should('not.exist')
+  })
+
+  it('should create the first combiner', () => {
+    workspacePage.canvas.should('be.visible')
+    workspacePage.toolbox.fit.click()
+
+    workspacePage.act.selectReactFlowNodes(['opcua-pump', 'opcua-boiler'])
+    workspacePage.toolbar.combine.click()
+
+    cy.wait('@postCombiner')
+    workspacePage.toast.success
+      .should('be.visible')
+      .should('contain.text', "We've successfully created the combiner for you.")
+
+    cy.wait('@getCombiners')
+
+    workspacePage.combinerNode(COMBINER_ID).should('be.visible').should('contain.text', 'unnamed combiner')
+
+    // double tap is needed
+    workspacePage.combinerNode(COMBINER_ID).click()
+    workspacePage.combinerNode(COMBINER_ID).dblclick()
+
+    combinerForm.form.should('be.visible')
+
+    rjsf.field('name').input.should('have.value', '< unnamed combiner >')
+    rjsf.field('name').input.clear()
+    rjsf.field('name').input.type('my adapter')
+
+    // technically should not be from adapterPage
+    adapterPage.config.formTab(2).click()
+
+    rjsf.field('mappings').table.noDataMessage.should('have.text', 'No data received yet.')
+    rjsf.field('mappings').table.addItem.click()
+    rjsf.field('mappings').table.rows.should('have.length', 1)
+    rjsf.field('mappings').table.rowAction(0).edit.click()
+  })
+})

--- a/hivemq-edge/src/frontend/cypress/pages/RJSF/RJSFomField.ts
+++ b/hivemq-edge/src/frontend/cypress/pages/RJSF/RJSFomField.ts
@@ -85,7 +85,7 @@ export class RJSFomField {
           return cy.get(`${rootSelector} tbody tr`)
         },
 
-        rowAction(index: number) {
+        row(index: number) {
           return {
             get edit() {
               cy.get(`${rootSelector} tbody tr`)

--- a/hivemq-edge/src/frontend/cypress/pages/RJSF/RJSFomField.ts
+++ b/hivemq-edge/src/frontend/cypress/pages/RJSF/RJSFomField.ts
@@ -1,5 +1,15 @@
 // MUST BE USED WITHIN a field element in a RJSF form
 export class RJSFomField {
+  get form() {
+    return cy.get('[role="dialog"]')
+  }
+
+  header = {
+    get title() {
+      return cy.get('')
+    },
+  }
+
   /**
    * Retrieve all fields in the form
    */
@@ -64,6 +74,34 @@ export class RJSFomField {
 
       get errors() {
         return cy.get(`${rootSelector} #${safeId}__error`)
+      },
+
+      table: {
+        get noDataMessage() {
+          return cy.get(`${rootSelector} tbody tr td [role="alert"][data-status="info"]`)
+        },
+
+        get rows() {
+          return cy.get(`${rootSelector} tbody tr`)
+        },
+
+        rowAction(index: number) {
+          return {
+            get edit() {
+              cy.get(`${rootSelector} tbody tr`)
+                .eq(index)
+                .within(() => {
+                  cy.getByTestId('combiner-mapping-list-edit').as('edit')
+                })
+              return cy.get('@edit')
+            },
+          }
+        },
+
+        get addItem() {
+          // Should be made more generic; remove reference to specific deployment (combiner)
+          return cy.get(`${rootSelector} tfoot button[data-testid="combiner-mapping-list-add"]`)
+        },
       },
     }
   }

--- a/hivemq-edge/src/frontend/cypress/pages/ShellPage.ts
+++ b/hivemq-edge/src/frontend/cypress/pages/ShellPage.ts
@@ -1,0 +1,17 @@
+import { Page } from './Page.ts'
+
+export class ShellPage extends Page {
+  get navLinks() {
+    return cy.get('nav [role="list"]')
+  }
+
+  get toasts() {
+    return cy.get('[role="region"][aria-label="Notifications-top-right"] [role="status"] [data-status]')
+  }
+
+  toast = {
+    get success() {
+      return cy.get('[role="region"][aria-label="Notifications-top-right"] [role="status"] [data-status="success"]')
+    },
+  }
+}

--- a/hivemq-edge/src/frontend/cypress/pages/ShellPage.ts
+++ b/hivemq-edge/src/frontend/cypress/pages/ShellPage.ts
@@ -9,9 +9,17 @@ export class ShellPage extends Page {
     return cy.get('[role="region"][aria-label="Notifications-top-right"] [role="status"] [data-status]')
   }
 
+  get closeToast() {
+    return cy.get('[role="region"][aria-label="Notifications-top-right"] [role="status"] [data-status] button')
+  }
+
   toast = {
     get success() {
       return cy.get('[role="region"][aria-label="Notifications-top-right"] [role="status"] [data-status="success"]')
+    },
+
+    get error() {
+      return cy.get('[role="region"][aria-label="Notifications-top-right"] [role="status"] [data-status="error"]')
     },
   }
 }

--- a/hivemq-edge/src/frontend/cypress/pages/Workspace/CombinerFormPage.ts
+++ b/hivemq-edge/src/frontend/cypress/pages/Workspace/CombinerFormPage.ts
@@ -1,8 +1,38 @@
-import { RJSFomField } from '../RJSF/RJSFomField.ts'
+import { rjsf, RJSFomField } from '../RJSF/RJSFomField.ts'
 
 export class CombinerFormPage extends RJSFomField {
   get form() {
     return cy.get('[role="dialog"][aria-label="Manage Data combining mappings"]')
+  }
+
+  get submit() {
+    return cy.get('[role="dialog"][aria-label="Manage Data combining mappings"] footer button[type="submit"]')
+  }
+
+  get delete() {
+    return cy.get('[role="dialog"][aria-label="Manage Data combining mappings"] footer button[type="button"]')
+  }
+
+  table = {
+    get destination() {
+      rjsf
+        .field('mappings')
+        .table.rows.eq(0)
+        .within(() => {
+          cy.get('td').eq(0).as('columnDestination')
+        })
+      return cy.get('@columnDestination')
+    },
+
+    get sources() {
+      rjsf
+        .field('mappings')
+        .table.rows.eq(0)
+        .within(() => {
+          cy.get('td').eq(1).as('columnSources')
+        })
+      return cy.get('@columnSources')
+    },
   }
 
   inferSchema = {
@@ -21,6 +51,10 @@ export class CombinerFormPage extends RJSFomField {
   mappingEditor = {
     get form() {
       return cy.get('[role="dialog"][aria-label="Data combining mapping"]')
+    },
+
+    get submit() {
+      return cy.get('[role="dialog"][aria-label="Data combining mapping"] footer button[type="submit"]')
     },
 
     sources: {
@@ -60,6 +94,40 @@ export class CombinerFormPage extends RJSFomField {
         })
         return cy.get('@destinationInfer')
       },
+
+      get schema() {
+        combinerForm.mappingEditor.form.within(() => {
+          cy.getByTestId('combining-editor-destination-schema').within(() => {
+            cy.get('ul#destination-mapping-editor li').as('destSchema')
+          })
+        })
+        return cy.get('@destSchema')
+      },
+
+      schemaProperty(index: number) {
+        return this.schema.eq(index)
+      },
+    },
+
+    instruction(index: number) {
+      return {
+        get mapping() {
+          cy.get('@destSchema')
+            .eq(index)
+            .within(() => {
+              cy.getByTestId('mapping-instruction-dropzone').as('dropzone')
+            })
+          return cy.get('@dropzone')
+        },
+        get status() {
+          cy.get('@destSchema')
+            .eq(index)
+            .within(() => {
+              cy.get('[role="alert"]').as('status')
+            })
+          return cy.get('@status')
+        },
+      }
     },
 
     primary: {
@@ -69,6 +137,16 @@ export class CombinerFormPage extends RJSFomField {
         })
         return cy.get('@selectPrimary')
       },
+    },
+  }
+
+  confirmDelete = {
+    get modal() {
+      return cy.get('[role="alertdialog"]')
+    },
+
+    get submit() {
+      return cy.get('[role="alertdialog"] footer button[data-testid="confirmation-submit"]')
     },
   }
 }

--- a/hivemq-edge/src/frontend/cypress/pages/Workspace/CombinerFormPage.ts
+++ b/hivemq-edge/src/frontend/cypress/pages/Workspace/CombinerFormPage.ts
@@ -1,0 +1,9 @@
+import { RJSFomField } from '../RJSF/RJSFomField.ts'
+
+export class CombinerFormPage extends RJSFomField {
+  get form() {
+    return cy.get('[role="dialog"][aria-label="Manage Data combining mappings"]')
+  }
+}
+
+export const combinerForm = new CombinerFormPage()

--- a/hivemq-edge/src/frontend/cypress/pages/Workspace/CombinerFormPage.ts
+++ b/hivemq-edge/src/frontend/cypress/pages/Workspace/CombinerFormPage.ts
@@ -4,6 +4,73 @@ export class CombinerFormPage extends RJSFomField {
   get form() {
     return cy.get('[role="dialog"][aria-label="Manage Data combining mappings"]')
   }
+
+  inferSchema = {
+    get modal() {
+      return cy.get('[role="dialog"]#chakra-modal-destination-schema')
+    },
+
+    get submit() {
+      cy.get('[role="dialog"]#chakra-modal-destination-schema footer').within(() => {
+        cy.getByTestId('schema-infer-generate').as('submit')
+      })
+      return cy.get('@submit')
+    },
+  }
+
+  mappingEditor = {
+    get form() {
+      return cy.get('[role="dialog"][aria-label="Data combining mapping"]')
+    },
+
+    sources: {
+      get selector() {
+        combinerForm.mappingEditor.form.within(() => {
+          cy.get('#combiner-entity-select').as('selectSources')
+        })
+        return cy.get('@selectSources')
+      },
+      get options() {
+        combinerForm.mappingEditor.form.within(() => {
+          cy.get('#react-select-entity-listbox > [role="listbox"] > [role="option"]').as('options')
+        })
+        return cy.get('@options')
+      },
+      get schema() {
+        combinerForm.mappingEditor.form.within(() => {
+          cy.getByTestId('combining-editor-sources-schemas').within(() => {
+            cy.get('label+div ul li').as('properties')
+          })
+        })
+        return cy.get('@properties')
+      },
+    },
+
+    destination: {
+      get selector() {
+        combinerForm.mappingEditor.form.within(() => {
+          cy.get('#destination').as('selectDestination')
+        })
+        return cy.get('@selectDestination')
+      },
+
+      get inferSchema() {
+        combinerForm.mappingEditor.form.within(() => {
+          cy.getByTestId('combiner-destination-infer').as('destinationInfer')
+        })
+        return cy.get('@destinationInfer')
+      },
+    },
+
+    primary: {
+      get selector() {
+        combinerForm.mappingEditor.form.within(() => {
+          cy.get('#mappings-primary').as('selectPrimary')
+        })
+        return cy.get('@selectPrimary')
+      },
+    },
+  }
 }
 
 export const combinerForm = new CombinerFormPage()

--- a/hivemq-edge/src/frontend/cypress/pages/Workspace/WorkspacePage.ts
+++ b/hivemq-edge/src/frontend/cypress/pages/Workspace/WorkspacePage.ts
@@ -1,6 +1,6 @@
-import { Page } from '../Page.ts'
+import { ShellPage } from '../ShellPage.ts'
 
-export class WorkspacePage extends Page {
+export class WorkspacePage extends ShellPage {
   get navLink() {
     cy.get('nav [role="list"]')
       .eq(0)
@@ -60,6 +60,27 @@ export class WorkspacePage extends Page {
    */
   deviceNode(id: string) {
     return cy.get(`[role="button"][data-id="device@adapter@${id}"]`)
+  }
+
+  combinerNode(id: string) {
+    return cy.get(`[role="button"][data-id="${id}"]`)
+  }
+
+  act = {
+    /**
+     * @todo This "double-back" sequence is necessary to effectively select multiple nodes. Need to check for better alternative
+     * @param nodes
+     */
+    selectReactFlowNodes(nodes: string[]) {
+      const [first, ...rest] = nodes
+      workspacePage.adapterNode(first).type('{meta}', { release: false })
+      workspacePage.adapterNode(first).click()
+      rest.forEach((node) => {
+        workspacePage.adapterNode(node).click()
+      })
+      workspacePage.adapterNode(first).type('{meta}')
+      // workspacePage.adapterNode('first').type('{leftArrow}{leftArrow}')
+    },
   }
 }
 

--- a/hivemq-edge/src/frontend/cypress/support/e2e.ts
+++ b/hivemq-edge/src/frontend/cypress/support/e2e.ts
@@ -3,6 +3,7 @@ import 'cypress-each'
 import '@percy/cypress'
 import 'cypress-real-events'
 import '@cypress/code-coverage/support'
+import '@4tw/cypress-drag-drop'
 
 import './commands'
 

--- a/hivemq-edge/src/frontend/cypress/utils/interactions.utils.ts
+++ b/hivemq-edge/src/frontend/cypress/utils/interactions.utils.ts
@@ -1,0 +1,15 @@
+/**
+ *
+ * @param dragLocator
+ * @param dropLocator
+ */
+export const cy_dragAndDrop = (
+  dragLocator: Cypress.Chainable<JQuery<HTMLElement>>,
+  dropLocator: Cypress.Chainable<JQuery<HTMLElement>>
+) => {
+  dragLocator
+    .realMouseDown({ button: 'left', position: 'center' })
+    .realMouseMove(0, 10, { position: 'center' })
+    .wait(200)
+  dropLocator.realMouseMove(0, 0, { position: 'center' }).realMouseUp()
+}

--- a/hivemq-edge/src/frontend/cypress/utils/intercept.utils.ts
+++ b/hivemq-edge/src/frontend/cypress/utils/intercept.utils.ts
@@ -4,9 +4,11 @@ import { mockAdapter_OPCUA } from '@/api/hooks/useProtocolAdapters/__handlers__'
 
 export const cy_interceptCoreE2E = () => {
   // requests sent but not necessary to logic
-  cy.intercept('/api/v1/frontend/notifications', { statusCode: 404, log: false })
-  cy.intercept('/api/v1/management/protocol-adapters/status', { statusCode: 404, log: false })
-  cy.intercept('/api/v1/frontend/capabilities', { statusCode: 404, log: false })
+  cy.intercept('https://api.github.com/repos/hivemq/hivemq-edge/releases', { statusCode: 202, log: false })
+  cy.intercept('/api/v1/frontend/notifications', { statusCode: 202, log: false })
+  cy.intercept('/api/v1/management/protocol-adapters/status', { statusCode: 202, log: false })
+  cy.intercept('/api/v1/management/bridges/status', { statusCode: 202, log: false })
+  cy.intercept('/api/v1/frontend/capabilities', { statusCode: 202, log: false })
 
   // code business requests
   cy.intercept('/api/v1/auth/authenticate', mockAuthApi(mockValidCredentials))

--- a/hivemq-edge/src/frontend/package.json
+++ b/hivemq-edge/src/frontend/package.json
@@ -112,6 +112,7 @@
     "zustand": "^4.4.7"
   },
   "devDependencies": {
+    "@4tw/cypress-drag-drop": "^2.3.0",
     "@chakra-ui/cli": "^2.4.1",
     "@cypress/code-coverage": "^3.13.11",
     "@eslint/js": "^9.17.0",

--- a/hivemq-edge/src/frontend/package.json
+++ b/hivemq-edge/src/frontend/package.json
@@ -115,6 +115,7 @@
     "@chakra-ui/cli": "^2.4.1",
     "@cypress/code-coverage": "^3.13.11",
     "@eslint/js": "^9.17.0",
+    "@mswjs/data": "^0.16.2",
     "@percy/cli": "^1.28.5",
     "@percy/cypress": "^3.1.3",
     "@tanstack/eslint-plugin-query": "^5.66.0",

--- a/hivemq-edge/src/frontend/pnpm-lock.yaml
+++ b/hivemq-edge/src/frontend/pnpm-lock.yaml
@@ -261,6 +261,9 @@ devDependencies:
   '@eslint/js':
     specifier: ^9.17.0
     version: 9.17.0
+  '@mswjs/data':
+    specifier: ^0.16.2
+    version: 0.16.2(typescript@5.7.3)
   '@percy/cli':
     specifier: ^1.28.5
     version: 1.28.9(typescript@5.7.3)
@@ -1537,7 +1540,6 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       regenerator-runtime: 0.14.1
-    dev: true
 
   /@babel/template@7.25.9:
     resolution: {integrity: sha512-9DGttpmPvIxBb/2uwpVo3dqJ+O6RooAFOS+lB+xDqoE2PVCE8nfoHMdZLpfCQRLwvohzXISPZcgxt80xLfsuwg==}
@@ -3843,6 +3845,30 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
+  /@mswjs/data@0.16.2(typescript@5.7.3):
+    resolution: {integrity: sha512-/C0d/PBcJyQJokUhcjO4HiZPc67hzllKlRtD1XELygl2t991/ATAAQJVcStn4YtVALsNodruzOHT0JIvgr0hnA==}
+    dependencies:
+      '@types/lodash': 4.17.5
+      '@types/md5': 2.3.5
+      '@types/pluralize': 0.0.29
+      '@types/uuid': 8.3.4
+      date-fns: 2.30.0
+      debug: 4.4.0(supports-color@8.1.1)
+      graphql: 16.9.0
+      lodash: 4.17.21
+      md5: 2.3.0
+      outvariant: 1.4.3
+      pluralize: 8.0.0
+      strict-event-emitter: 0.5.1
+      uuid: 8.3.2
+    optionalDependencies:
+      msw: 2.7.0(typescript@5.7.3)
+    transitivePeerDependencies:
+      - '@types/node'
+      - supports-color
+      - typescript
+    dev: true
+
   /@mswjs/interceptors@0.37.6:
     resolution: {integrity: sha512-wK+5pLK5XFmgtH3aQ2YVvA3HohS3xqV/OxuVOdNx9Wpnz7VE/fnC+e1A7ln6LFYeck7gOJ/dsZV6OLplOtAJ2w==}
     engines: {node: '>=18'}
@@ -5714,10 +5740,13 @@ packages:
 
   /@types/lodash@4.17.5:
     resolution: {integrity: sha512-MBIOHVZqVqgfro1euRDWX7OO0fBVUUMrN6Pwm8LQsz8cWhEpihlvR70ENj3f40j58TNxZaWv2ndSkInykNBBJw==}
-    dev: false
 
   /@types/luxon@3.3.0:
     resolution: {integrity: sha512-uKRI5QORDnrGFYgcdAVnHvEIvEZ8noTpP/Bg+HeUzZghwinDlIS87DEenV5r1YoOF9G4x600YsUXLWZ19rmTmg==}
+    dev: true
+
+  /@types/md5@2.3.5:
+    resolution: {integrity: sha512-/i42wjYNgE6wf0j2bcTX6kuowmdL/6PE4IVitMpm2eYKBUuYCprdcWVK+xEF0gcV6ufMCRhtxmReGfc6hIK7Jw==}
     dev: true
 
   /@types/ms@0.7.34:
@@ -5749,6 +5778,10 @@ packages:
   /@types/parse-json@4.0.2:
     resolution: {integrity: sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==}
     dev: false
+
+  /@types/pluralize@0.0.29:
+    resolution: {integrity: sha512-BYOID+l2Aco2nBik+iYS4SZX0Lf20KPILP5RGmM1IgzdwNdTs0eebiFriOPcej1sX9mLnSoiNte5zcFxssgpGA==}
+    dev: true
 
   /@types/prop-types@15.7.12:
     resolution: {integrity: sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q==}
@@ -5809,6 +5842,10 @@ packages:
   /@types/use-sync-external-store@0.0.6:
     resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
     dev: false
+
+  /@types/uuid@8.3.4:
+    resolution: {integrity: sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==}
+    dev: true
 
   /@types/uuid@9.0.8:
     resolution: {integrity: sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==}
@@ -6826,6 +6863,10 @@ packages:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
+  /charenc@0.0.2:
+    resolution: {integrity: sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==}
+    dev: true
+
   /check-error@2.1.1:
     resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
     engines: {node: '>= 16'}
@@ -7223,6 +7264,10 @@ packages:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  /crypt@0.0.2:
+    resolution: {integrity: sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==}
+    dev: true
 
   /css-box-model@1.2.1:
     resolution: {integrity: sha512-a7Vr4Q/kd/aw96bnJG332W9V9LkJO69JRcaCYDUqjp6/z0w6VcZjgAcTbgFxEPfBgdnAwlh3iwu+hLopa+flJw==}
@@ -7717,6 +7762,13 @@ packages:
       whatwg-mimetype: 4.0.0
       whatwg-url: 14.0.0
 
+  /date-fns@2.30.0:
+    resolution: {integrity: sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==}
+    engines: {node: '>=0.11'}
+    dependencies:
+      '@babel/runtime': 7.27.0
+    dev: true
+
   /dayjs@1.11.12:
     resolution: {integrity: sha512-Rt2g+nTbLlDWZTwwrIXjy9MeiZmSDI375FvZs72ngxx8PDC6YXOeR3q5LAuPzjZQxhiWdRKac7RKV+YyQYfYIg==}
     dev: false
@@ -7860,7 +7912,7 @@ packages:
   /dom-helpers@5.2.1:
     resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
     dependencies:
-      '@babel/runtime': 7.25.0
+      '@babel/runtime': 7.27.0
       csstype: 3.1.3
     dev: false
 
@@ -8311,7 +8363,7 @@ packages:
     resolution: {integrity: sha512-7OnTFAVPefgw2eBJ1xj2PGGR9FwYzSUso9decayHgCDX4sJkHLdcsYTytTg+tYv+wKF3U8gJuSBz2jJpQV4u/g==}
     engines: {node: '>=16.1.0'}
     dependencies:
-      '@babel/runtime': 7.25.0
+      '@babel/runtime': 7.27.0
       tslib: 2.6.3
     dev: false
 
@@ -8993,6 +9045,10 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       binary-extensions: 2.3.0
+
+  /is-buffer@1.1.6:
+    resolution: {integrity: sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==}
+    dev: true
 
   /is-core-module@2.15.1:
     resolution: {integrity: sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==}
@@ -9718,6 +9774,14 @@ packages:
     resolution: {integrity: sha512-APMBEanjybaPzUrfqU0IMU5I0AswKMH7k8OTLs0vvV4KZpExkTkY87nR/zpbuTPj+gARop7aGUbl11pnDfW6xg==}
     dev: true
 
+  /md5@2.3.0:
+    resolution: {integrity: sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==}
+    dependencies:
+      charenc: 0.0.2
+      crypt: 0.0.2
+      is-buffer: 1.1.6
+    dev: true
+
   /mdn-data@2.12.2:
     resolution: {integrity: sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==}
     dev: true
@@ -10438,7 +10502,6 @@ packages:
   /pluralize@8.0.0:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
     engines: {node: '>=4'}
-    dev: false
 
   /points-on-curve@0.2.0:
     resolution: {integrity: sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==}
@@ -10455,7 +10518,7 @@ packages:
     resolution: {integrity: sha512-OBatVyC/N7SCW/FaDHrSd+vn0o5cS855TOmYi4OkdWUMSJCET/xip//ch8xGUvtr3i44X9LVyWwQlRMTN3pwSA==}
     engines: {node: '>=10'}
     dependencies:
-      '@babel/runtime': 7.25.0
+      '@babel/runtime': 7.27.0
     dev: false
 
   /postcss-media-query-parser@0.2.3:
@@ -10842,7 +10905,7 @@ packages:
     peerDependencies:
       react: ^15.3.0 || ^16.0.0 || ^17.0.0 || ^18.0.0
     dependencies:
-      '@babel/runtime': 7.25.0
+      '@babel/runtime': 7.27.0
       react: 18.2.0
     dev: false
 
@@ -12800,7 +12863,7 @@ packages:
   /worker-timers-broker@6.1.8:
     resolution: {integrity: sha512-FUCJu9jlK3A8WqLTKXM9E6kAmI/dR1vAJ8dHYLMisLNB/n3GuaFIjJ7pn16ZcD1zCOf7P6H62lWIEBi+yz/zQQ==}
     dependencies:
-      '@babel/runtime': 7.25.0
+      '@babel/runtime': 7.27.0
       fast-unique-numbers: 8.0.13
       tslib: 2.6.3
       worker-timers-worker: 7.0.71
@@ -12809,7 +12872,7 @@ packages:
   /worker-timers-worker@7.0.71:
     resolution: {integrity: sha512-ks/5YKwZsto1c2vmljroppOKCivB/ma97g9y77MAAz2TBBjPPgpoOiS1qYQKIgvGTr2QYPT3XhJWIB6Rj2MVPQ==}
     dependencies:
-      '@babel/runtime': 7.25.0
+      '@babel/runtime': 7.27.0
       tslib: 2.6.3
     dev: false
 

--- a/hivemq-edge/src/frontend/pnpm-lock.yaml
+++ b/hivemq-edge/src/frontend/pnpm-lock.yaml
@@ -252,6 +252,9 @@ dependencies:
     version: 4.4.7(@types/react@18.0.28)(react@18.2.0)
 
 devDependencies:
+  '@4tw/cypress-drag-drop':
+    specifier: ^2.3.0
+    version: 2.3.0(cypress@14.0.2)
   '@chakra-ui/cli':
     specifier: ^2.4.1
     version: 2.4.1
@@ -392,6 +395,14 @@ devDependencies:
     version: 3.1.1(@types/debug@4.1.12)(@vitest/ui@3.1.1)(jsdom@24.0.0)(msw@2.7.0)(sass@1.70.0)
 
 packages:
+
+  /@4tw/cypress-drag-drop@2.3.0(cypress@14.0.2):
+    resolution: {integrity: sha512-r6/Um+GLidi9mFTx8qiFf1ECMNmwLTLp+CgKVLpYZvJ2aV6mYoe1Uv8Iq1AwqRhhIAdf04aFJ0xzGEO1gnOm1g==}
+    peerDependencies:
+      cypress: 2 - 14
+    dependencies:
+      cypress: 14.0.2
+    dev: true
 
   /@adobe/css-tools@4.4.0:
     resolution: {integrity: sha512-Ff9+ksdQQB3rMncgqDK78uLznstjyfIf2Arnh22pW8kBpLs6rpKDwgnZT46hin5Hl1WzazzK64DOrhSwYpS7bQ==}
@@ -1862,7 +1873,7 @@ packages:
     dependencies:
       '@chakra-ui/dom-utils': 2.1.0
       react: 18.2.0
-      react-focus-lock: 2.12.1(@types/react@18.0.28)(react@18.2.0)
+      react-focus-lock: 2.13.6(@types/react@18.0.28)(react@18.2.0)
     transitivePeerDependencies:
       - '@types/react'
     dev: false
@@ -2942,7 +2953,7 @@ packages:
     resolution: {integrity: sha512-m4HEDZleaaCH+XgDDsPF15Ht6wTLsgDTeR3WYj9Q/k76JtWhrJjcP4+/XlG8LGT/Rol9qUfOIztXeA84ATpqPQ==}
     dependencies:
       '@babel/helper-module-imports': 7.25.9
-      '@babel/runtime': 7.25.0
+      '@babel/runtime': 7.27.0
       '@emotion/hash': 0.9.1
       '@emotion/memoize': 0.8.1
       '@emotion/serialize': 1.1.4
@@ -6590,7 +6601,7 @@ packages:
     resolution: {integrity: sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==}
     engines: {node: '>=10', npm: '>=6'}
     dependencies:
-      '@babel/runtime': 7.25.0
+      '@babel/runtime': 7.27.0
       cosmiconfig: 7.1.0
       resolve: 1.22.8
     dev: false
@@ -8499,8 +8510,8 @@ packages:
   /flatted@3.3.3:
     resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
 
-  /focus-lock@1.3.5:
-    resolution: {integrity: sha512-QFaHbhv9WPUeLYBDe/PAuLKJ4Dd9OPvKs9xZBr3yLXnUrDNaVXKu2baDBXe3naPY30hgHYSsf2JW4jzas2mDEQ==}
+  /focus-lock@1.3.6:
+    resolution: {integrity: sha512-Ik/6OCk9RQQ0T5Xw+hKNLWrjSMtv51dD4GRmJjbD5a58TIEpI5a5iXagKVl3Z5UuyslMCA8Xwnu76jQob62Yhg==}
     engines: {node: '>=10'}
     dependencies:
       tslib: 2.6.3
@@ -8938,7 +8949,7 @@ packages:
   /i18next@19.9.2:
     resolution: {integrity: sha512-0i6cuo6ER6usEOtKajUUDj92zlG+KArFia0857xxiEHAQcUwh/RtOQocui1LPJwunSYT574Pk64aNva1kwtxZg==}
     dependencies:
-      '@babel/runtime': 7.25.0
+      '@babel/runtime': 7.27.0
     dev: true
 
   /i18next@23.11.5:
@@ -10900,10 +10911,10 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /react-clientside-effect@1.2.6(react@18.2.0):
-    resolution: {integrity: sha512-XGGGRQAKY+q25Lz9a/4EPqom7WRjz3z9R2k4jhVKA/puQFH/5Nt27vFZYql4m4NVNdUvX8PS3O7r/Zzm7cjUlg==}
+  /react-clientside-effect@1.2.7(react@18.2.0):
+    resolution: {integrity: sha512-gce9m0Pk/xYYMEojRI9bgvqQAkl6hm7ozQvqWPyQx+kULiatdHgkNM1QG4DQRx5N9BAzWSCJmt9mMV8/KsdgVg==}
     peerDependencies:
-      react: ^15.3.0 || ^16.0.0 || ^17.0.0 || ^18.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
     dependencies:
       '@babel/runtime': 7.27.0
       react: 18.2.0
@@ -10934,23 +10945,23 @@ packages:
     resolution: {integrity: sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==}
     dev: false
 
-  /react-focus-lock@2.12.1(@types/react@18.0.28)(react@18.2.0):
-    resolution: {integrity: sha512-lfp8Dve4yJagkHiFrC1bGtib3mF2ktqwPJw4/WGcgPW+pJ/AVQA5X2vI7xgp13FcxFEpYBBHpXai/N2DBNC0Jw==}
+  /react-focus-lock@2.13.6(@types/react@18.0.28)(react@18.2.0):
+    resolution: {integrity: sha512-ehylFFWyYtBKXjAO9+3v8d0i+cnc1trGS0vlTGhzFW1vbFXVUTmR8s2tt/ZQG8x5hElg6rhENlLG1H3EZK0Llg==}
     peerDependencies:
-      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.25.0
+      '@babel/runtime': 7.27.0
       '@types/react': 18.0.28
-      focus-lock: 1.3.5
+      focus-lock: 1.3.6
       prop-types: 15.8.1
       react: 18.2.0
-      react-clientside-effect: 1.2.6(react@18.2.0)
-      use-callback-ref: 1.3.2(@types/react@18.0.28)(react@18.2.0)
-      use-sidecar: 1.1.2(@types/react@18.0.28)(react@18.2.0)
+      react-clientside-effect: 1.2.7(react@18.2.0)
+      use-callback-ref: 1.3.3(@types/react@18.0.28)(react@18.2.0)
+      use-sidecar: 1.1.3(@types/react@18.0.28)(react@18.2.0)
     dev: false
 
   /react-hook-form@7.43.9(react@18.2.0):
@@ -11047,8 +11058,8 @@ packages:
       react-remove-scroll-bar: 2.3.6(@types/react@18.0.28)(react@18.2.0)
       react-style-singleton: 2.2.1(@types/react@18.0.28)(react@18.2.0)
       tslib: 2.6.3
-      use-callback-ref: 1.3.2(@types/react@18.0.28)(react@18.2.0)
-      use-sidecar: 1.1.2(@types/react@18.0.28)(react@18.2.0)
+      use-callback-ref: 1.3.3(@types/react@18.0.28)(react@18.2.0)
+      use-sidecar: 1.1.3(@types/react@18.0.28)(react@18.2.0)
     dev: false
 
   /react-router-dom@6.11.2(react-dom@18.2.0)(react@18.2.0):
@@ -11080,7 +11091,7 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
     dependencies:
-      '@babel/runtime': 7.25.0
+      '@babel/runtime': 7.27.0
       '@emotion/cache': 11.11.0
       '@emotion/react': 11.11.4(@types/react@18.0.28)(react@18.2.0)
       '@floating-ui/dom': 1.6.5
@@ -11102,7 +11113,7 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
     dependencies:
-      '@babel/runtime': 7.25.0
+      '@babel/runtime': 7.27.0
       '@emotion/cache': 11.11.0
       '@emotion/react': 11.11.4(@types/react@18.0.28)(react@18.2.0)
       '@floating-ui/dom': 1.6.5
@@ -11164,7 +11175,7 @@ packages:
       react: '>=16.6.0'
       react-dom: '>=16.6.0'
     dependencies:
-      '@babel/runtime': 7.25.0
+      '@babel/runtime': 7.27.0
       dom-helpers: 5.2.1
       loose-envify: 1.4.0
       prop-types: 15.8.1
@@ -12410,12 +12421,12 @@ packages:
     resolution: {integrity: sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==}
     dev: false
 
-  /use-callback-ref@1.3.2(@types/react@18.0.28)(react@18.2.0):
-    resolution: {integrity: sha512-elOQwe6Q8gqZgDA8mrh44qRTQqpIHDcZ3hXTLjBe1i4ph8XpNJnO+aQf3NaG+lriLopI4HMx9VjQLfPQ6vhnoA==}
+  /use-callback-ref@1.3.3(@types/react@18.0.28)(react@18.2.0):
+    resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
     engines: {node: '>=10'}
     peerDependencies:
-      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -12438,12 +12449,12 @@ packages:
       react: 18.2.0
     dev: false
 
-  /use-sidecar@1.1.2(@types/react@18.0.28)(react@18.2.0):
-    resolution: {integrity: sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==}
+  /use-sidecar@1.1.3(@types/react@18.0.28)(react@18.2.0):
+    resolution: {integrity: sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==}
     engines: {node: '>=10'}
     peerDependencies:
-      '@types/react': ^16.9.0 || ^17.0.0 || ^18.0.0
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -12879,7 +12890,7 @@ packages:
   /worker-timers@7.1.8:
     resolution: {integrity: sha512-R54psRKYVLuzff7c1OTFcq/4Hue5Vlz4bFtNEIarpSiCYhpifHU3aIQI29S84o1j87ePCYqbmEJPqwBTf+3sfw==}
     dependencies:
-      '@babel/runtime': 7.25.0
+      '@babel/runtime': 7.27.0
       tslib: 2.6.3
       worker-timers-broker: 6.1.8
       worker-timers-worker: 7.0.71

--- a/hivemq-edge/src/frontend/src/api/hooks/useDomainModel/useListDomainSouthboundMappings.spec.ts
+++ b/hivemq-edge/src/frontend/src/api/hooks/useDomainModel/useListDomainSouthboundMappings.spec.ts
@@ -29,8 +29,8 @@ describe('useListDomainNorthboundMappings', () => {
           fieldMapping: {
             instructions: [
               {
-                destination: 'lastName',
-                source: 'dropped-property',
+                destination: '$.lastName',
+                source: '$.dropped-property',
               },
             ],
           },

--- a/hivemq-edge/src/frontend/src/api/hooks/useProtocolAdapters/__handlers__/mapping.mocks.ts
+++ b/hivemq-edge/src/frontend/src/api/hooks/useProtocolAdapters/__handlers__/mapping.mocks.ts
@@ -9,7 +9,7 @@ export const MOCK_SOUTHBOUND_MAPPING: SouthboundMapping = {
   topicFilter: 'my/filter',
   tagName: 'my/tag',
   fieldMapping: {
-    instructions: [{ source: 'dropped-property', destination: 'lastName' }],
+    instructions: [{ source: '$.dropped-property', destination: '$.lastName' }],
   },
 }
 

--- a/hivemq-edge/src/frontend/src/components/ErrorMessage.tsx
+++ b/hivemq-edge/src/frontend/src/components/ErrorMessage.tsx
@@ -1,15 +1,16 @@
 import type { FC } from 'react'
+import type { AlertProps } from '@chakra-ui/react'
 import { Alert, AlertDescription, AlertIcon, type AlertStatus, AlertTitle } from '@chakra-ui/react'
 
-interface ErrorMessageProps {
+interface ErrorMessageProps extends AlertProps {
   type?: string | number
   message?: string
   status?: AlertStatus
 }
 
-const ErrorMessage: FC<ErrorMessageProps> = ({ type, message, status = 'error' }) => {
+const ErrorMessage: FC<ErrorMessageProps> = ({ type, message, status = 'error', ...rest }) => {
   return (
-    <Alert status={status}>
+    <Alert status={status} {...rest}>
       <AlertIcon />
       <div>
         <AlertTitle>{type || ''}</AlertTitle>

--- a/hivemq-edge/src/frontend/src/components/rjsf/MqttTransformation/components/MappingDrawer.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/components/rjsf/MqttTransformation/components/MappingDrawer.spec.cy.tsx
@@ -76,8 +76,8 @@ describe('MappingDrawer', () => {
         fieldMapping: {
           instructions: [
             {
-              source: 'dropped-property',
-              destination: 'lastName',
+              source: '$.dropped-property',
+              destination: '$.lastName',
             },
           ],
         },

--- a/hivemq-edge/src/frontend/src/components/rjsf/MqttTransformation/components/MappingInstructionList.tsx
+++ b/hivemq-edge/src/frontend/src/components/rjsf/MqttTransformation/components/MappingInstructionList.tsx
@@ -8,6 +8,7 @@ import { List, ListItem } from '@chakra-ui/react'
 import type { Instruction } from '@/api/__generated__'
 import MappingInstruction from '@/components/rjsf/MqttTransformation/components/mapping/MappingInstruction.tsx'
 import { getPropertyListFrom } from '@/components/rjsf/MqttTransformation/utils/json-schema.utils.ts'
+import { toJsonPath } from '@/components/rjsf/MqttTransformation/utils/data-type.utils'
 
 interface MappingEditorProps extends Omit<ListProps, 'onChange'> {
   instructions: Instruction[]
@@ -32,7 +33,7 @@ export const MappingInstructionList: FC<MappingEditorProps> = ({
       {properties.map((property) => {
         const instructionIndex = instructions
           ? instructions.findIndex((instruction) => {
-              const fullPath = [...property.path, property.key].join('.')
+              const fullPath = ['$', ...property.path, property.key].join('.')
               return instruction.destination === fullPath
             })
           : -1
@@ -47,8 +48,8 @@ export const MappingInstructionList: FC<MappingEditorProps> = ({
                 let newMappings = [...(instructions || [])]
                 if (source) {
                   const newItem: Instruction = {
-                    source: source,
-                    destination: destination,
+                    source: toJsonPath(source),
+                    destination: toJsonPath(destination),
                     sourceRef: sourceRef,
                   }
                   if (instructionIndex !== -1) {

--- a/hivemq-edge/src/frontend/src/components/rjsf/MqttTransformation/components/mapping/MappingInstruction.tsx
+++ b/hivemq-edge/src/frontend/src/components/rjsf/MqttTransformation/components/mapping/MappingInstruction.tsx
@@ -23,7 +23,11 @@ import type { DataIdentifierReference, Instruction } from '@/api/__generated__'
 import type { DataReference } from '@/api/hooks/useDomainModel/useGetCombinedDataSchemas'
 import IconButton from '@/components/Chakra/IconButton.tsx'
 import PropertyItem from '@/components/rjsf/MqttTransformation/components/schema/PropertyItem.tsx'
-import { formatPath, isMappingSupported } from '@/components/rjsf/MqttTransformation/utils/data-type.utils.ts'
+import {
+  formatPath,
+  fromJsonPath,
+  isMappingSupported,
+} from '@/components/rjsf/MqttTransformation/utils/data-type.utils.ts'
 import type { FlatJSONSchema7 } from '@/components/rjsf/MqttTransformation/utils/json-schema.utils.ts'
 import { getDropZoneBorder } from '@/modules/Theme/utils.ts'
 
@@ -129,7 +133,7 @@ const MappingInstruction: FC<MappingInstructionProps> = ({
             flex={3}
           >
             {instruction?.source ? (
-              <Code>{formatPath(instruction.source)}</Code>
+              <Code>{formatPath(fromJsonPath(instruction.source))}</Code>
             ) : (
               <Text as="span" color="var(--chakra-colors-chakra-placeholder-color)" userSelect="none">
                 {t('rjsf.MqttTransformationField.instructions.dropzone.arial-label')}

--- a/hivemq-edge/src/frontend/src/components/rjsf/MqttTransformation/components/mapping/MappingInstruction.tsx
+++ b/hivemq-edge/src/frontend/src/components/rjsf/MqttTransformation/components/mapping/MappingInstruction.tsx
@@ -27,6 +27,7 @@ import {
   formatPath,
   fromJsonPath,
   isMappingSupported,
+  toJsonPath,
 } from '@/components/rjsf/MqttTransformation/utils/data-type.utils.ts'
 import type { FlatJSONSchema7 } from '@/components/rjsf/MqttTransformation/utils/json-schema.utils.ts'
 import { getDropZoneBorder } from '@/modules/Theme/utils.ts'
@@ -96,8 +97,7 @@ const MappingInstruction: FC<MappingInstructionProps> = ({
   const onHandleClear = () => {
     setState(DropState.IDLE)
     const fullPath = [...property.path, property.key].join('.')
-
-    onChange?.(undefined, fullPath as string)
+    onChange?.(undefined, toJsonPath(fullPath))
   }
 
   if (!isSupported)

--- a/hivemq-edge/src/frontend/src/components/rjsf/MqttTransformation/utils/data-type.utils.spec.ts
+++ b/hivemq-edge/src/frontend/src/components/rjsf/MqttTransformation/utils/data-type.utils.spec.ts
@@ -3,7 +3,9 @@ import { type FlatJSONSchema7 } from '@/components/rjsf/MqttTransformation/utils
 import {
   filterSupportedProperties,
   formatPath,
+  fromJsonPath,
   isMappingSupported,
+  toJsonPath,
 } from '@/components/rjsf/MqttTransformation/utils/data-type.utils.ts'
 
 const MOCK_PROPERTY: FlatJSONSchema7 = {
@@ -40,5 +42,22 @@ describe('formatPath', () => {
     expect(formatPath('string')).toStrictEqual('string')
     expect(formatPath('path.to.string')).toStrictEqual('path.​to.​string')
     expect(formatPath('path.to.string')).not.toStrictEqual('path. to. string')
+  })
+})
+
+describe('toJsonPath', () => {
+  it('should tell when a property should be returned', async () => {
+    expect(toJsonPath('')).toStrictEqual('$')
+    expect(toJsonPath('$.123')).toStrictEqual('$.123')
+    expect(toJsonPath('123')).toStrictEqual('$.123')
+  })
+})
+
+describe('fromJsonPath', () => {
+  it('should tell when a property should be returned', async () => {
+    expect(fromJsonPath('')).toStrictEqual('')
+    expect(fromJsonPath('$')).toStrictEqual('')
+    expect(fromJsonPath('$.123')).toStrictEqual('123')
+    expect(fromJsonPath('123')).toStrictEqual('123')
   })
 })

--- a/hivemq-edge/src/frontend/src/components/rjsf/MqttTransformation/utils/data-type.utils.ts
+++ b/hivemq-edge/src/frontend/src/components/rjsf/MqttTransformation/utils/data-type.utils.ts
@@ -23,3 +23,17 @@ export const isMappingSupported = (property: FlatJSONSchema7) => {
 export const filterSupportedProperties = (property: FlatJSONSchema7) => Boolean(property.path.length === 0)
 
 export const formatPath = (path: string) => path.replaceAll('.', '.​')
+
+export const toJsonPath = (property: string) => {
+  // Not sure about the empty string case
+  if (property === '') return '$'
+  if (property.startsWith('$.')) return property
+  return `$.${property}`
+}
+
+export const fromJsonPath = (path: string) => {
+  if (path === '') return ''
+  if (path === '$') return ''
+  if (path.startsWith('$.')) return path.slice(2)
+  return path
+}

--- a/hivemq-edge/src/frontend/src/components/rjsf/MqttTransformation/utils/json-schema.utils.ts
+++ b/hivemq-edge/src/frontend/src/components/rjsf/MqttTransformation/utils/json-schema.utils.ts
@@ -7,6 +7,7 @@ import type { JsonNode } from '@/api/__generated__'
 import type { MQTTSample } from '@/hooks/usePrivateMqttClient/type.ts'
 
 import i18n from '@/config/i18n.config.ts'
+import type { DataReference } from '../../../../api/hooks/useDomainModel/useGetCombinedDataSchemas'
 
 export const ARRAY_ITEM_INDEX = '___index'
 
@@ -15,6 +16,7 @@ export interface FlatJSONSchema7 extends JSONSchema7 {
   key: string
   arrayType?: string
   origin?: string
+  metadata?: DataReference
 }
 
 export const getProperty = (

--- a/hivemq-edge/src/frontend/src/locales/en/translation.json
+++ b/hivemq-edge/src/frontend/src/locales/en/translation.json
@@ -927,7 +927,8 @@
       "aria-label": "Open the Observability panel",
       "header_ADAPTER_NODE": "Adapter Observability",
       "header_BRIDGE_NODE": "Bridge Observability",
-      "header_CLUSTER_NODE": "Group Observability"
+      "header_CLUSTER_NODE": "Group Observability",
+      "header_COMBINER_NODE": "Combiner Observability"
     },
     "datahub": {
       "aria-label": "Open the Data Hub policy",
@@ -1012,6 +1013,9 @@
         "expand": "Expand the chart",
         "collapse": "Collapse the chart"
       }
+    },
+    "error": {
+      "noMetrics": "There is no metrics available for this entity"
     },
     "charts": {
       "list": "List of metrics",

--- a/hivemq-edge/src/frontend/src/modules/DomainOntology/hooks/useGetDomainOntology.spec.ts
+++ b/hivemq-edge/src/frontend/src/modules/DomainOntology/hooks/useGetDomainOntology.spec.ts
@@ -103,8 +103,8 @@ describe('useGetDomainOntology', () => {
         fieldMapping: {
           instructions: [
             {
-              destination: 'lastName',
-              source: 'dropped-property',
+              destination: '$.lastName',
+              source: '$.dropped-property',
             },
           ],
         },

--- a/hivemq-edge/src/frontend/src/modules/Mappings/combiner/DataCombiningEditorField.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/combiner/DataCombiningEditorField.tsx
@@ -190,6 +190,7 @@ export const DataCombiningEditorField: FC<FieldProps<DataCombining, RJSFSchema, 
           <FormLabel>{primaryOptions.title}</FormLabel>
           <PrimarySelect
             formData={formData}
+            id={'mappings-primary'}
             onChange={(values) => {
               if (!props.formData) return
 

--- a/hivemq-edge/src/frontend/src/modules/Mappings/combiner/SchemaMerger.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/combiner/SchemaMerger.tsx
@@ -59,6 +59,7 @@ const SchemaMerger: FC<SchemaMergerProps> = ({ formData, formContext, onClose, o
 
       const conflictName: [number, string][] = []
       properties.forEach((property, pathIndex) => {
+        property.metadata = reference
         if (reference.type === DataIdentifierReference.type.TAG) {
           const index = tagIndexMap.get(reference.id)
           property.origin = `${STUB_TAG_PROPERTY}${index}`
@@ -90,7 +91,7 @@ const SchemaMerger: FC<SchemaMergerProps> = ({ formData, formContext, onClose, o
   return (
     <>
       <ModalBody>
-        <VStack spacing={2} alignItems={'flex-start'}>
+        <VStack spacing={4} alignItems={'flex-start'}>
           <Text data-testid={'schema-infer-prompt'}>{t('combiner.schema.schemaManager.infer.message')}</Text>
 
           <FormControl isInvalid={isError} data-testid={'schema-infer-merged'} id={'schema-infer-properties'}>

--- a/hivemq-edge/src/frontend/src/modules/Mappings/hooks/useSouthboundMappingManager.spec.ts
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/hooks/useSouthboundMappingManager.spec.ts
@@ -33,8 +33,8 @@ describe('useSouthboundMappingManager', () => {
           fieldMapping: expect.objectContaining<FieldMapping>({
             instructions: [
               {
-                destination: 'lastName',
-                source: 'dropped-property',
+                destination: '$.lastName',
+                source: '$.dropped-property',
               },
             ],
           }),

--- a/hivemq-edge/src/frontend/src/modules/Mappings/hooks/useValidateCombiner.ts
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/hooks/useValidateCombiner.ts
@@ -18,6 +18,7 @@ import { useListProtocolAdapters } from '@/api/hooks/useProtocolAdapters/useList
 import type { DataReference } from '@/api/hooks/useDomainModel/useGetCombinedDataSchemas'
 import { useGetCombinedDataSchemas } from '@/api/hooks/useDomainModel/useGetCombinedDataSchemas'
 
+import { fromJsonPath } from '@/components/rjsf/MqttTransformation/utils/data-type.utils'
 import { type FlatJSONSchema7, getPropertyListFrom } from '@/components/rjsf/MqttTransformation/utils/json-schema.utils'
 import type { CombinerContext } from '@/modules/Mappings/types'
 import { validateSchemaFromDataURI } from '@/modules/TopicFilters/utils/topic-filter.schema'
@@ -240,10 +241,10 @@ export const useValidateCombiner = (
       //   errors.addError(t('combiner.error.validation.notInstruction'))
 
       formData?.instructions?.forEach((instruction, index) => {
-        if (!knownPaths.includes(instruction.destination))
+        if (!knownPaths.includes(fromJsonPath(instruction.destination)))
           errors.instructions?.[index]?.addError(t('combiner.error.validation.notInstructionDestinationPath'))
 
-        if (!allPathsFromSources.includes(instruction.source))
+        if (!allPathsFromSources.includes(fromJsonPath(instruction.source)))
           errors.instructions?.[index]?.addError(t('combiner.error.validation.notInstructionSourcePath'))
       })
 

--- a/hivemq-edge/src/frontend/src/modules/Metrics/MetricsContainer.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Metrics/MetricsContainer.spec.cy.tsx
@@ -9,15 +9,16 @@ import { mockBridgeId } from '@/api/hooks/useGetBridges/__handlers__'
 
 describe('MetricsContainer', () => {
   beforeEach(() => {
-    cy.viewport(800, 800)
-    cy.intercept('/api/v1/metrics', { items: MOCK_METRICS } as MetricList)
+    cy.viewport(600, 800)
+    cy.intercept('/api/v1/metrics/**/*', { statusCode: 404, log: false })
+    cy.intercept('/api/v1/metrics', { items: MOCK_METRICS }).as('getMetrics')
   })
 
   it('should render the collapsible component', () => {
     cy.mountWithProviders(
       <MetricsContainer
         nodeId="bridge@bridge-id-01"
-        initMetrics={[]}
+        initMetrics={[MOCK_METRICS[0].name as string, MOCK_METRICS[1].name as string]}
         filters={[
           {
             id: mockBridgeId,
@@ -36,5 +37,47 @@ describe('MetricsContainer', () => {
 
     cy.getByTestId('metrics-toggle').click()
     cy.get('div#metrics-select-container').should('not.be.visible')
+  })
+
+  it('should render message when no metrics', () => {
+    cy.intercept('/api/v1/metrics**', { items: [] } as MetricList).as('getMetrics')
+
+    cy.mountWithProviders(
+      <MetricsContainer
+        nodeId="bridge@bridge-id-02"
+        initMetrics={[]}
+        filters={[
+          {
+            id: 'bridge@bridge-id-02',
+            type: 'com.hivemq.edge.bridge',
+          },
+        ]}
+        type={NodeTypes.BRIDGE_NODE}
+      />
+    )
+
+    cy.wait('@getMetrics')
+    cy.getByTestId('metrics-toggle').should('be.disabled')
+    cy.get('[role="alert"]')
+      .should('have.attr', 'data-status', 'info')
+      .should('have.text', 'There is no metrics available for this entity')
+  })
+
+  it('should be accessible', () => {
+    cy.injectAxe()
+    cy.mountWithProviders(
+      <MetricsContainer
+        nodeId="bridge@bridge-id-01"
+        initMetrics={[MOCK_METRICS[0].name as string, MOCK_METRICS[1].name as string]}
+        filters={[
+          {
+            id: mockBridgeId,
+            type: 'com.hivemq.edge.bridge',
+          },
+        ]}
+        type={NodeTypes.BRIDGE_NODE}
+      />
+    )
+    cy.checkAccessibility()
   })
 })

--- a/hivemq-edge/src/frontend/src/modules/Metrics/MetricsContainer.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Metrics/MetricsContainer.tsx
@@ -1,5 +1,6 @@
 import type { FC } from 'react'
 import { useEffect } from 'react'
+import { useTranslation } from 'react-i18next'
 import {
   Accordion,
   AccordionButton,
@@ -12,8 +13,8 @@ import {
   useDisclosure,
   useTheme,
 } from '@chakra-ui/react'
-import { useTranslation } from 'react-i18next'
 
+import ErrorMessage from '@/components/ErrorMessage.tsx'
 import type { NodeTypes } from '@/modules/Workspace/types.ts'
 
 import type { MetricDefinition, MetricsFilter } from './types.ts'
@@ -60,10 +61,11 @@ const MetricsContainer: FC<MetricsProps> = ({ nodeId, filters, initMetrics, defa
   }
 
   const metrics = getMetricsFor(nodeId)
+  console.log('XXXXXXX mer', metrics)
 
   useEffect(() => {
-    const gg = getMetricsFor(nodeId)
-    if (gg.length === 0 && initMetrics) {
+    const metrics = getMetricsFor(nodeId)
+    if (metrics.length === 0 && initMetrics) {
       initMetrics.map((e) => {
         addMetrics(nodeId, e, defaultChartType)
       })
@@ -81,7 +83,7 @@ const MetricsContainer: FC<MetricsProps> = ({ nodeId, filters, initMetrics, defa
             else onOpen()
           }}
         >
-          <AccordionItem>
+          <AccordionItem isDisabled={!metrics.length}>
             <AccordionButton data-testid="metrics-toggle">
               <Box as="span" flex="1" textAlign="left">
                 {t('metrics.editor.title')}
@@ -107,6 +109,9 @@ const MetricsContainer: FC<MetricsProps> = ({ nodeId, filters, initMetrics, defa
         role="list"
         aria-label={t('metrics.charts.list')}
       >
+        {!metrics.length && (
+          <ErrorMessage status={'info'} message={t('metrics.error.noMetrics')} gridColumn={'1 / span 2'} />
+        )}
         {metrics.map((e) => {
           const { id } = extractMetricInfo(e.metrics)
           const colorSchemeIndex = filters.findIndex((e) => e.id === id)

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/controls/NodePanelController.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/controls/NodePanelController.tsx
@@ -5,7 +5,7 @@ import type { Node } from '@xyflow/react'
 import { useEdges, useNodes } from '@xyflow/react'
 import { useDisclosure } from '@chakra-ui/react'
 
-import type { Adapter, Bridge } from '@/api/__generated__'
+import type { Adapter, Bridge, Combiner } from '@/api/__generated__'
 import { SuspenseFallback } from '@/components/SuspenseOutlet.tsx'
 import type { AdapterNavigateState } from '@/modules/ProtocolAdapters/types.ts'
 import { ProtocolAdapterTabIndex } from '@/modules/ProtocolAdapters/types.ts'
@@ -28,30 +28,26 @@ const NodePanelController: FC = () => {
   const { nodeId } = useParams()
 
   const selectedNode = nodes.find(
-    (e) => e.id === nodeId && (e.type === NodeTypes.BRIDGE_NODE || e.type === NodeTypes.ADAPTER_NODE)
+    (node) => node.id === nodeId && (node.type === NodeTypes.BRIDGE_NODE || node.type === NodeTypes.ADAPTER_NODE)
   ) as Node<Bridge | Adapter> | undefined
 
-  const selectedEdge = nodes.find((e) => e.id === nodeId && e.type === NodeTypes.EDGE_NODE)
-  const selectedDevice = nodes.find((e) => e.id === nodeId && e.type === NodeTypes.DEVICE_NODE) as
+  const selectedEdge = nodes.find((node) => node.id === nodeId && node.type === NodeTypes.EDGE_NODE)
+  const selectedDevice = nodes.find((node) => node.id === nodeId && node.type === NodeTypes.DEVICE_NODE) as
     | Node<DeviceMetadata>
     | undefined
 
-  const selectedLinkSource = nodes.find((e) => {
-    const link = edges.find((e) => e.id === nodeId && e.type === EdgeTypes.REPORT_EDGE)
+  const selectedLinkSource = nodes.find((node) => {
+    const link = edges.find((edge) => edge.id === nodeId && edge.type === EdgeTypes.DYNAMIC_EDGE)
     if (!link) return undefined
-    return e.id === link.source // && (e.type === NodeTypes.BRIDGE_NODE || e.type === NodeTypes.ADAPTER_NODE)
-  }) as Node<Bridge | Adapter | Group> | undefined
+    return node.id === link.source
+  }) as Node<Bridge | Adapter | Group | Combiner> | undefined
 
-  const selectedGroup = nodes.find((e) => e.id === nodeId && e.type === NodeTypes.CLUSTER_NODE) as
+  const selectedGroup = nodes.find((node) => node.id === nodeId && node.type === NodeTypes.CLUSTER_NODE) as
     | Node<Group>
     | undefined
 
   useEffect(() => {
     if (!nodes.length) return
-    // if (!selectedNode || !nodeId) {
-    //   navigate('/workspace', { replace: true })
-    //   return
-    // }
     onOpen()
   }, [navigate, nodeId, nodes.length, onOpen, selectedNode])
 
@@ -84,7 +80,7 @@ const NodePanelController: FC = () => {
       {selectedLinkSource && selectedLinkSource.type !== NodeTypes.CLUSTER_NODE && (
         <LinkPropertyDrawer
           nodeId={nodeId}
-          selectedNode={selectedLinkSource as Node<Bridge | Adapter>}
+          selectedNode={selectedLinkSource as Node<Adapter | Bridge | Combiner>}
           isOpen={isOpen}
           onClose={handleClose}
           onEditEntity={handleEditEntity}

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/drawers/GroupPropertyDrawer.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/drawers/GroupPropertyDrawer.tsx
@@ -27,7 +27,7 @@ import { MdOutlineEventNote } from 'react-icons/md'
 
 import MetricsContainer from '@/modules/Metrics/MetricsContainer.tsx'
 
-import type { Group } from '../../types.ts'
+import type { Group, NodeAdapterType } from '../../types.ts'
 import { NodeTypes } from '../../types.ts'
 import useWorkspaceStore from '../../hooks/useWorkspaceStore.ts'
 import { getDefaultMetricsFor } from '../../utils/nodes-utils.ts'
@@ -59,13 +59,13 @@ const GroupPropertyDrawer: FC<GroupPropertyDrawerProps> = ({
   const { t } = useTranslation()
   const { onGroupSetData } = useWorkspaceStore()
 
-  const adapterIDs = selectedNode.data.childrenNodeIds.map<Node | undefined>((e) => nodes.find((x) => x.id === e))
-  const metrics = adapterIDs.map((x) => (x ? getDefaultMetricsFor(x) : [])).flat()
+  const adapterIDs = nodes.filter((node) => selectedNode.data.childrenNodeIds.includes(node.id))
+  const metrics = adapterIDs.map((node) => (node ? getDefaultMetricsFor(node) : [])).flat()
 
   const linkEventLog = useMemo(() => {
     const searchParams = new URLSearchParams()
     for (const node of adapterIDs) {
-      if (node) searchParams.append('source', node.data.id)
+      if (node) searchParams.append('source', node.data.id as string)
     }
     return `/event-logs?${searchParams.toString()}`
   }, [adapterIDs])
@@ -80,7 +80,7 @@ const GroupPropertyDrawer: FC<GroupPropertyDrawerProps> = ({
       type={selectedNode.type as NodeTypes}
       filters={adapterIDs.reduce<MetricsFilter[]>((acc, cur) => {
         if (cur && cur.type === NodeTypes.ADAPTER_NODE) {
-          acc.push({ id: cur.data.id, type: `com.hivemq.edge.protocol-adapters.${cur.data.type}` })
+          acc.push({ id: (cur as NodeAdapterType).data.id, type: `com.hivemq.edge.protocol-adapters.${cur.data.type}` })
         }
         return acc
       }, [])}
@@ -114,7 +114,7 @@ const GroupPropertyDrawer: FC<GroupPropertyDrawerProps> = ({
             </CardHeader>
             <CardBody>
               <EventLogTable
-                globalSourceFilter={adapterIDs.map((e) => e?.data.id)}
+                globalSourceFilter={adapterIDs.map((e) => e.data.id as string)}
                 variant="summary"
                 maxEvents={10}
                 isSingleSource={false}

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/drawers/LinkPropertyDrawer.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/drawers/LinkPropertyDrawer.spec.cy.tsx
@@ -1,0 +1,67 @@
+import type { Node } from '@xyflow/react'
+
+import { MOCK_NODE_ADAPTER } from '@/__test-utils__/react-flow/nodes.ts'
+import type { Adapter, Bridge } from '@/api/__generated__'
+import { NodeTypes } from '@/modules/Workspace/types.ts'
+
+import LinkPropertyDrawer from './LinkPropertyDrawer'
+
+const mockNode: Node<Bridge | Adapter> = {
+  position: { x: 0, y: 0 },
+  id: 'adapter@fgffgf',
+  type: NodeTypes.ADAPTER_NODE,
+  data: MOCK_NODE_ADAPTER,
+}
+
+describe('NodePropertyDrawer', () => {
+  beforeEach(() => {
+    cy.viewport(800, 800)
+    cy.intercept('/api/v1/management/protocol-adapters/types', { statusCode: 404 })
+    cy.intercept('/api/v1/metrics', [])
+    cy.intercept('/api/v1/metrics/**', [])
+    cy.intercept('/api/v1/management/events?*', [])
+  })
+
+  it('should render properly', () => {
+    const onClose = cy.stub().as('onClose')
+    const onEditEntity = cy.stub().as('onEditEntity')
+    cy.mountWithProviders(
+      <LinkPropertyDrawer
+        nodeId="adapter@fgffgf"
+        selectedNode={mockNode}
+        isOpen={true}
+        onClose={onClose}
+        onEditEntity={onEditEntity}
+      />
+    )
+
+    // check the panel control
+    cy.get('@onClose').should('not.have.been.called')
+    cy.getByAriaLabel('Close').click()
+    cy.get('@onClose').should('have.been.calledOnce')
+
+    // check that the metrics is there
+    cy.getByTestId('metrics-toggle').should('be.visible')
+  })
+
+  it('should be accessible', () => {
+    cy.injectAxe()
+    cy.mountWithProviders(
+      <LinkPropertyDrawer
+        nodeId="adapter@fgffgf"
+        selectedNode={mockNode}
+        isOpen={true}
+        onClose={cy.stub()}
+        onEditEntity={cy.stub()}
+      />
+    )
+
+    cy.checkAccessibility(undefined, {
+      rules: {
+        // TODO[#17700] Color-contrast totally wrong; fix and test the component
+        'color-contrast': { enabled: false },
+      },
+    })
+    cy.percySnapshot('Component: LinkPropertyDrawer')
+  })
+})

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/drawers/LinkPropertyDrawer.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/drawers/LinkPropertyDrawer.tsx
@@ -1,9 +1,10 @@
 import type { FC } from 'react'
+import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { Node } from '@xyflow/react'
 import { Drawer, DrawerBody, DrawerCloseButton, DrawerContent, DrawerHeader, Text } from '@chakra-ui/react'
 
-import type { Adapter, Bridge } from '@/api/__generated__'
+import type { Adapter, Bridge, Combiner } from '@/api/__generated__'
 import { useGetAdapterTypes } from '@/api/hooks/useProtocolAdapters/useGetAdapterTypes.ts'
 import MetricsContainer from '@/modules/Metrics/MetricsContainer.tsx'
 import NodeNameCard from '@/modules/Workspace/components/parts/NodeNameCard.tsx'
@@ -12,7 +13,7 @@ import { getDefaultMetricsFor } from '@/modules/Workspace/utils/nodes-utils.ts'
 
 interface LinkPropertyDrawerProps {
   nodeId: string
-  selectedNode: Node<Bridge | Adapter>
+  selectedNode: Node<Bridge | Adapter | Combiner>
   isOpen: boolean
   onClose: () => void
   onEditEntity: () => void
@@ -26,6 +27,12 @@ const LinkPropertyDrawer: FC<LinkPropertyDrawerProps> = ({ nodeId, isOpen, selec
       ? protocols?.items?.find((e) => e.id === (selectedNode as Node<Adapter>).data.type)
       : undefined
 
+  const displayInfo = useMemo(() => {
+    if (selectedNode.type === NodeTypes.COMBINER_NODE)
+      return { name: (selectedNode.data as Combiner).name, description: t('combiner.type') }
+    return { name: selectedNode.data.id, description: adapterProtocol?.name }
+  }, [adapterProtocol?.name, selectedNode.data, selectedNode.type, t])
+
   return (
     <Drawer isOpen={isOpen} placement="right" size="md" onClose={onClose} variant="hivemq">
       <DrawerContent>
@@ -34,10 +41,10 @@ const LinkPropertyDrawer: FC<LinkPropertyDrawerProps> = ({ nodeId, isOpen, selec
         <DrawerHeader>
           <Text>{t('workspace.observability.header', { context: selectedNode.type })}</Text>
           <NodeNameCard
-            name={selectedNode.data.id}
+            name={displayInfo.name}
             type={selectedNode.type as NodeTypes}
             icon={adapterProtocol?.logoUrl}
-            description={adapterProtocol?.name}
+            description={displayInfo.description}
           />
         </DrawerHeader>
         <DrawerBody display="flex" flexDirection="column" gap={6}>

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/edges/DynamicEdge.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/edges/DynamicEdge.spec.cy.tsx
@@ -1,0 +1,75 @@
+import type { Edge, Node } from '@xyflow/react'
+
+import { CustomNodeTesting } from '@/__test-utils__/react-flow/CustomNodeTesting.tsx'
+import { mockProtocolAdapter } from '@/api/hooks/useProtocolAdapters/__handlers__'
+import { MOCK_CAPABILITIES } from '@/api/hooks/useFrontendServices/__handlers__'
+import { EdgeTypes, NodeTypes } from '@/modules/Workspace/types.ts'
+import { NodeAdapter } from '@/modules/Workspace/components/nodes'
+
+import DynamicEdge from './MonitoringEdge.tsx'
+
+const MOCK_NODES: Node[] = [
+  {
+    id: 'idAdapter',
+    data: { label: 'From here' },
+    position: { x: 0, y: 0 },
+    type: 'input',
+  },
+
+  {
+    id: 'idAdapter2',
+    data: { label: 'To there' },
+    position: { x: 100, y: 300 },
+    type: 'output',
+  },
+]
+
+const MOCK_EDGE_ID = 'edge-test'
+const MOCK_EDGE: Edge[] = [
+  {
+    id: MOCK_EDGE_ID,
+    source: 'idAdapter',
+    target: 'idAdapter2',
+    type: EdgeTypes.REPORT_EDGE,
+  },
+]
+
+describe('MonitoringEdge', () => {
+  beforeEach(() => {
+    cy.viewport(400, 450)
+    cy.intercept('/api/v1/frontend/capabilities', MOCK_CAPABILITIES)
+    cy.intercept('/api/v1/management/protocol-adapters/types', { items: [mockProtocolAdapter] })
+    cy.intercept('/api/v1/data-hub/data-validation/policies', [])
+  })
+
+  it('should render the observability CTA', () => {
+    cy.mountWithProviders(
+      <CustomNodeTesting
+        nodes={MOCK_NODES}
+        edges={MOCK_EDGE}
+        edgeTypes={{ [EdgeTypes.REPORT_EDGE]: DynamicEdge }}
+        nodeTypes={{
+          [NodeTypes.ADAPTER_NODE]: NodeAdapter,
+        }}
+      />
+    )
+    cy.getByTestId('observability-panel-trigger').should('have.attr', 'aria-label', 'Open the Observability panel')
+    cy.getByTestId('test-navigate-pathname').should('have.text', '/')
+    cy.getByTestId('observability-panel-trigger').click()
+    cy.getByTestId('test-navigate-pathname').should('have.text', `/workspace/link/${MOCK_EDGE_ID}`)
+  })
+
+  it('should be accessible', () => {
+    cy.injectAxe()
+    cy.mountWithProviders(
+      <CustomNodeTesting nodes={MOCK_NODES} edges={MOCK_EDGE} edgeTypes={{ [EdgeTypes.REPORT_EDGE]: DynamicEdge }} />
+    )
+    cy.checkAccessibility(undefined, {
+      rules: {
+        // ReactFlow watermark not accessible
+        'color-contrast': { enabled: false },
+      },
+    })
+    cy.percySnapshot('Component: DynamicEdge')
+  })
+})

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/edges/DynamicEdge.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/edges/DynamicEdge.tsx
@@ -1,11 +1,53 @@
+import { HStack } from '@chakra-ui/react'
 import type { FC } from 'react'
-import { type EdgeProps, getBezierPath, useInternalNode } from '@xyflow/react'
+import { useMemo } from 'react'
+import {
+  BaseEdge,
+  EdgeLabelRenderer,
+  type EdgeProps,
+  getBezierPath,
+  useInternalNode,
+  useNodesData,
+} from '@xyflow/react'
 
 import { getEdgeParams } from '@/modules/Workspace/utils/edge.utils'
+import { useNavigate } from 'react-router-dom'
+import { DataHubNodeType } from '../../../../extensions/datahub/types'
+import { useGetPoliciesMatching } from '../../hooks/useGetPoliciesMatching'
+import { NodeTypes } from '../../types'
+import DataPolicyEdgeCTA from './DataPolicyEdgeCTA'
+import ObservabilityEdgeCTA from './ObservabilityEdgeCTA'
 
 export const DynamicEdge: FC<EdgeProps> = ({ id, source, target, markerEnd, style }) => {
   const sourceNode = useInternalNode(source)
   const targetNode = useInternalNode(target)
+  const policies = useGetPoliciesMatching(source)
+  const navigate = useNavigate()
+  const nodeData = useNodesData(target)
+
+  const isObservable = useMemo(() => {
+    if (!nodeData) return false
+    const { type } = nodeData
+    return type === NodeTypes.EDGE_NODE
+  }, [nodeData])
+
+  const policyRoutes = useMemo(() => {
+    if (!policies) return undefined
+
+    return policies.map((policy) => `/datahub/${DataHubNodeType.DATA_POLICY}/${policy.id}`)
+  }, [policies])
+
+  const handleOpenObservability = () => {
+    navigate(`/workspace/link/${id}`)
+  }
+
+  const handleShowPolicy = (route: string) => {
+    navigate(route)
+  }
+
+  const handleShowAllPolicies = () => {
+    navigate('/datahub')
+  }
 
   if (!sourceNode || !targetNode) {
     return null
@@ -13,7 +55,7 @@ export const DynamicEdge: FC<EdgeProps> = ({ id, source, target, markerEnd, styl
 
   const { sx, sy, tx, ty, sourcePos, targetPos } = getEdgeParams(sourceNode, targetNode)
 
-  const [edgePath] = getBezierPath({
+  const [edgePath, labelX, labelY] = getBezierPath({
     sourceX: sx,
     sourceY: sy,
     sourcePosition: sourcePos,
@@ -22,5 +64,33 @@ export const DynamicEdge: FC<EdgeProps> = ({ id, source, target, markerEnd, styl
     targetY: ty,
   })
 
-  return <path id={id} className="react-flow__edge-path" d={edgePath} markerEnd={markerEnd} style={style} />
+  return (
+    <>
+      <BaseEdge id={id} path={edgePath} markerEnd={markerEnd} style={style} />
+      {isObservable && (
+        <EdgeLabelRenderer>
+          <HStack
+            sx={{
+              position: 'absolute',
+              transform: `translate(-50%, -50%) translate(${labelX}px,${labelY}px)`,
+              pointerEvents: 'all',
+            }}
+            className="nodrag nopan"
+          >
+            <ObservabilityEdgeCTA source={source} style={style} onClick={handleOpenObservability} />
+            {policyRoutes && (
+              <DataPolicyEdgeCTA
+                data-testid="policy-panel-trigger"
+                style={style}
+                policyRoutes={policyRoutes}
+                onClickPolicy={handleShowPolicy}
+                onClickAll={handleShowAllPolicies}
+              />
+            )}
+          </HStack>
+        </EdgeLabelRenderer>
+      )}
+    </>
+  )
+  // return <path id={id} className="react-flow__edge-path" d={edgePath} markerEnd={markerEnd} style={style} />
 }

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/ContextualToolbar.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/ContextualToolbar.tsx
@@ -105,9 +105,9 @@ const ContextualToolbar: FC<ContextualToolbarProps> = ({
     const rect = getNodesBounds(selectedGroupCandidates)
 
     const groupRect = getGroupBounds(rect)
-    const { newGroupNode, newAEdge } = createGroup(selectedGroupCandidates, groupRect, theme)
+    const { newGroupNode, newGroupEdge } = createGroup(selectedGroupCandidates, groupRect, theme)
 
-    onInsertGroupNode(newGroupNode, newAEdge, groupRect)
+    onInsertGroupNode(newGroupNode, newGroupEdge, groupRect)
   }
 
   const onManageCombiners = () => {

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeGroup.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeGroup.tsx
@@ -46,7 +46,7 @@ const NodeGroup: FC<NodeProps<NodeGroupType>> = ({ id, data, selected, ...props 
       item: { ...node, parentId: undefined },
       type: 'replace',
     }))
-    const changeContent2 = content.map<NodePositionChange>((node) => ({
+    const changePosition = content.map<NodePositionChange>((node) => ({
       id: node.id,
       position: { x: node.position.x + props.positionAbsoluteX, y: node.position.y + props.positionAbsoluteY },
       type: 'position',
@@ -54,7 +54,7 @@ const NodeGroup: FC<NodeProps<NodeGroupType>> = ({ id, data, selected, ...props 
 
     onToggleGroup({ id, data }, true)
     onNodesChange(changeContent)
-    onNodesChange(changeContent2)
+    onNodesChange(changePosition)
     onNodesChange([{ id, type: 'remove' } as NodeRemoveChange])
     onEdgesChange(
       edges.filter((edge) => edge.source === id).map((e) => ({ id: e.id, type: 'remove' }) as EdgeRemoveChange)

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeGroup.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/nodes/NodeGroup.tsx
@@ -1,6 +1,12 @@
 import type { FC } from 'react'
 import { useTranslation } from 'react-i18next'
-import type { NodeProps, NodeRemoveChange, NodeReplaceChange, EdgeRemoveChange } from '@xyflow/react'
+import type {
+  NodeProps,
+  NodePositionChange,
+  NodeRemoveChange,
+  NodeReplaceChange,
+  EdgeRemoveChange,
+} from '@xyflow/react'
 import { Handle, NodeResizer, Position } from '@xyflow/react'
 import { Box, Icon, Text, useColorMode, useDisclosure, useTheme } from '@chakra-ui/react'
 import { LuExpand, LuShrink } from 'react-icons/lu'
@@ -34,22 +40,21 @@ const NodeGroup: FC<NodeProps<NodeGroupType>> = ({ id, data, selected, ...props 
   }
 
   const handleUngroup = () => {
-    // TODO[NVL] Create a store action
+    const content = nodes.filter((node) => data.childrenNodeIds.includes(node.id))
+    const changeContent = content.map<NodeReplaceChange>((node) => ({
+      id: node.id,
+      item: { ...node, parentId: undefined },
+      type: 'replace',
+    }))
+    const changeContent2 = content.map<NodePositionChange>((node) => ({
+      id: node.id,
+      position: { x: node.position.x + props.positionAbsoluteX, y: node.position.y + props.positionAbsoluteY },
+      type: 'position',
+    }))
+
     onToggleGroup({ id, data }, true)
-    onNodesChange(
-      nodes.map((node) => {
-        if (data.childrenNodeIds.includes(node.id)) {
-          return {
-            item: {
-              ...node,
-              parentId: undefined,
-              position: { x: node.position.x + props.positionAbsoluteX, y: node.position.y + props.positionAbsoluteY },
-            },
-            type: 'replace',
-          } as NodeReplaceChange
-        } else return { item: node, type: 'replace' } as NodeReplaceChange
-      })
-    )
+    onNodesChange(changeContent)
+    onNodesChange(changeContent2)
     onNodesChange([{ id, type: 'remove' } as NodeRemoveChange])
     onEdgesChange(
       edges.filter((edge) => edge.source === id).map((e) => ({ id: e.id, type: 'remove' }) as EdgeRemoveChange)

--- a/hivemq-edge/src/frontend/src/modules/Workspace/utils/group.utils.spec.ts
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/utils/group.utils.spec.ts
@@ -1,13 +1,10 @@
 import { expect } from 'vitest'
-import { getGroupLayout } from './group.utils.ts'
 import type { Rect } from '@xyflow/react'
-import { MOCK_NODE_ADAPTER } from '@/__test-utils__/react-flow/nodes.ts'
+import { getGroupBounds } from './group.utils.ts'
 
-describe('getGroupLayout', () => {
+describe('getGroupBounds', () => {
   it('should return the layout characteristics of a group', async () => {
-    expect(
-      getGroupLayout([{ ...MOCK_NODE_ADAPTER, position: { x: 0, y: 0 }, width: 50, height: 100 }])
-    ).toStrictEqual<Rect>({
+    expect(getGroupBounds({ x: 0, y: 0, width: 50, height: 100 })).toStrictEqual<Rect>({
       height: 164,
       width: 90,
       x: -20,

--- a/hivemq-edge/src/frontend/src/modules/Workspace/utils/group.utils.spec.ts
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/utils/group.utils.spec.ts
@@ -1,6 +1,10 @@
 import { expect } from 'vitest'
-import type { Rect } from '@xyflow/react'
-import { getGroupBounds } from './group.utils.ts'
+import type { Edge, Rect } from '@xyflow/react'
+import { createGroup, getGroupBounds } from './group.utils.ts'
+import { MOCK_THEME } from '../../../__test-utils__/react-flow/utils'
+import { MOCK_NODE_ADAPTER } from '../../../__test-utils__/react-flow/nodes'
+import type { NodeGroupType } from '../types'
+import { EdgeTypes, NodeTypes } from '../types'
 
 describe('getGroupBounds', () => {
   it('should return the layout characteristics of a group', async () => {
@@ -10,5 +14,44 @@ describe('getGroupBounds', () => {
       x: -20,
       y: -44,
     })
+  })
+})
+
+describe('createGroup', () => {
+  it('should create a group out of adapters', async () => {
+    const test = createGroup(
+      [{ ...MOCK_NODE_ADAPTER, position: { x: 0, y: 0 } }],
+      { x: 0, y: 0, width: 50, height: 100 },
+      MOCK_THEME
+    )
+    expect(test.newGroupNode).toStrictEqual<NodeGroupType>(
+      expect.objectContaining({
+        type: NodeTypes.CLUSTER_NODE,
+        id: 'group@my-adapter',
+        data: {
+          childrenNodeIds: ['idAdapter'],
+          colorScheme: 'red',
+          isOpen: true,
+          title: 'Untitled group',
+        },
+        position: {
+          x: 0,
+          y: 0,
+        },
+        style: {
+          height: 100,
+          width: 50,
+        },
+      })
+    )
+    expect(test.newGroupEdge).toStrictEqual<Edge>(
+      expect.objectContaining({
+        id: 'connect-edge-group@my-adapter',
+        source: 'group@my-adapter',
+        target: 'edge',
+        targetHandle: 'Top',
+        type: EdgeTypes.DYNAMIC_EDGE,
+      })
+    )
   })
 })

--- a/hivemq-edge/src/frontend/src/modules/Workspace/utils/group.utils.ts
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/utils/group.utils.ts
@@ -25,7 +25,7 @@ export const getGroupBounds = (rect: Rect): Rect => {
 export const createGroup = (
   selectedGroupCandidates: (NodeAdapterType | NodeDeviceType)[],
   rect: Rect,
-  theme: WithCSSVar<Dict>
+  theme: Partial<WithCSSVar<Dict>>
 ) => {
   const groupId = `${IdStubs.GROUP_NODE}@${selectedGroupCandidates.map((node) => node.data.id).join('+')}`
   const groupTitle = i18n.t('workspace.grouping.untitled')
@@ -60,7 +60,7 @@ export const createGroup = (
       : Status.connection.DISCONNECTED,
   }
 
-  const newAEdge: Edge = {
+  const newGroupEdge: Edge = {
     id: `${IdStubs.CONNECTOR}-${IdStubs.EDGE_NODE}-${groupId}`,
     target: IdStubs.EDGE_NODE,
     targetHandle: 'Top',
@@ -81,5 +81,5 @@ export const createGroup = (
     },
   }
 
-  return { newGroupNode, newAEdge, rect }
+  return { newGroupNode, newGroupEdge, rect }
 }

--- a/hivemq-edge/src/frontend/src/modules/Workspace/utils/group.utils.ts
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/utils/group.utils.ts
@@ -1,16 +1,85 @@
-import type { Node, Rect } from '@xyflow/react'
-import { getNodesBounds } from '@xyflow/react'
+import type { Edge, Node, Rect } from '@xyflow/react'
+import { MarkerType } from '@xyflow/react'
+import type { Dict } from '@chakra-ui/utils'
+import type { WithCSSVar } from '@chakra-ui/react'
+
+import { Status } from '@/api/__generated__'
+import type { NodeAdapterType, NodeDeviceType } from '@/modules/Workspace/types'
+import { EdgeTypes, type Group, IdStubs, NodeTypes } from '@/modules/Workspace/types'
+import { getThemeForStatus } from './status-utils'
+
+import i18n from '@/config/i18n.config.ts'
 
 const GROUP_MARGIN = 20
 const GROUP_TITLE_MARGIN = 24
 
-export const getGroupLayout = (nodes: Node[]): Rect => {
-  const rect = getNodesBounds(nodes.filter((e) => e !== undefined))
-
+export const getGroupBounds = (rect: Rect): Rect => {
   return {
     x: rect.x - GROUP_MARGIN,
     y: rect.y - GROUP_MARGIN - GROUP_TITLE_MARGIN,
     width: rect.width + 2 * GROUP_MARGIN,
     height: rect.height + 2 * GROUP_MARGIN + GROUP_TITLE_MARGIN,
   }
+}
+
+export const createGroup = (
+  selectedGroupCandidates: (NodeAdapterType | NodeDeviceType)[],
+  rect: Rect,
+  theme: WithCSSVar<Dict>
+) => {
+  const groupId = `${IdStubs.GROUP_NODE}@${selectedGroupCandidates.map((node) => node.data.id).join('+')}`
+  const groupTitle = i18n.t('workspace.grouping.untitled')
+  const newGroupNode: Node<Group, NodeTypes.CLUSTER_NODE> = {
+    id: groupId,
+    type: NodeTypes.CLUSTER_NODE,
+    data: {
+      childrenNodeIds: selectedGroupCandidates.map((node) => node.id),
+      title: groupTitle,
+      isOpen: true,
+      colorScheme: 'red',
+    },
+    style: {
+      width: rect.width,
+      height: rect.height,
+    },
+    position: { x: rect.x, y: rect.y },
+  }
+
+  const groupStatus: Status = {
+    runtime: selectedGroupCandidates.every((node) => {
+      if ('status' in node.data) return node.data.status?.runtime === Status.runtime.STARTED
+      return false
+    })
+      ? Status.runtime.STARTED
+      : Status.runtime.STOPPED,
+    connection: selectedGroupCandidates.every((node) => {
+      if ('status' in node.data) return node.data.status?.connection === Status.connection.CONNECTED
+      return false
+    })
+      ? Status.connection.CONNECTED
+      : Status.connection.DISCONNECTED,
+  }
+
+  const newAEdge: Edge = {
+    id: `${IdStubs.CONNECTOR}-${IdStubs.EDGE_NODE}-${groupId}`,
+    target: IdStubs.EDGE_NODE,
+    targetHandle: 'Top',
+    source: groupId,
+    hidden: true,
+    focusable: false,
+    type: EdgeTypes.DYNAMIC_EDGE,
+    markerEnd: {
+      type: MarkerType.ArrowClosed,
+      width: 20,
+      height: 20,
+      color: getThemeForStatus(theme, groupStatus),
+    },
+    animated: groupStatus.connection === Status.connection.CONNECTED,
+    style: {
+      strokeWidth: 1.5,
+      stroke: getThemeForStatus(theme, groupStatus),
+    },
+  }
+
+  return { newGroupNode, newAEdge, rect }
 }

--- a/hivemq-edge/src/frontend/src/modules/Workspace/utils/nodes-utils.spec.ts
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/utils/nodes-utils.spec.ts
@@ -3,7 +3,12 @@ import type { Edge, Node } from '@xyflow/react'
 import { Position } from '@xyflow/react'
 
 import { MOCK_LOCAL_STORAGE, MOCK_THEME } from '@/__test-utils__/react-flow/utils.ts'
-import { MOCK_NODE_ADAPTER, MOCK_NODE_BRIDGE, MOCK_NODE_EDGE } from '@/__test-utils__/react-flow/nodes.ts'
+import {
+  MOCK_NODE_ADAPTER,
+  MOCK_NODE_BRIDGE,
+  MOCK_NODE_EDGE,
+  MOCK_NODE_LISTENER,
+} from '@/__test-utils__/react-flow/nodes.ts'
 import { MOCK_ADAPTER_ID } from '@/__test-utils__/mocks.ts'
 import type { Bridge } from '@/api/__generated__'
 import { mockBridge } from '@/api/hooks/useGetBridges/__handlers__'
@@ -20,6 +25,8 @@ import {
   createEdgeNode,
   createListenerNode,
   getDefaultMetricsFor,
+  getGluedPosition,
+  LAYOUT_GLUE_TYPE,
 } from './nodes-utils.ts'
 
 describe('createEdgeNode', () => {
@@ -280,6 +287,59 @@ describe('createCombinerNode', () => {
           target: '6991ff43-9105-445f-bce3-976720df40a3',
         }),
       ],
+    })
+  })
+})
+
+describe('getGluedPosition', () => {
+  it('should handle unsupported node', async () => {
+    const source: Node = { ...MOCK_NODE_LISTENER, position: { x: 0, y: 0 } }
+    expect(getGluedPosition(source)).toStrictEqual({
+      x: 0,
+      y: 0,
+    })
+  })
+
+  it('should handle nodes in a group', async () => {
+    const source: Node = { ...MOCK_NODE_ADAPTER, position: { x: 0, y: 0 }, parentId: 'my-group' }
+    expect(getGluedPosition(source)).toStrictEqual({
+      x: 0,
+      y: -200,
+    })
+  })
+
+  it('should handle top half-space', async () => {
+    const source: Node = { ...MOCK_NODE_ADAPTER, position: { x: 0, y: 0 } }
+    const centroid: Node = { ...MOCK_NODE_EDGE, position: { x: 50, y: 50 } }
+    expect(getGluedPosition(source, centroid)).toStrictEqual({
+      x: 0,
+      y: -200,
+    })
+  })
+
+  it('should handle bottom half-space', async () => {
+    const source: Node = { ...MOCK_NODE_ADAPTER, position: { x: 0, y: 0 } }
+    const centroid: Node = { ...MOCK_NODE_EDGE, position: { x: 50, y: -50 } }
+    expect(getGluedPosition(source, centroid)).toStrictEqual({
+      x: 0,
+      y: 200,
+    })
+  })
+
+  it('should handle radial position', async () => {
+    const source: Node = { ...MOCK_NODE_ADAPTER, position: { x: 0, y: 0 } }
+    const centroid: Node = { ...MOCK_NODE_EDGE, position: { x: 0, y: 50 } }
+    expect(getGluedPosition(source, centroid, LAYOUT_GLUE_TYPE.RADIAL)).toStrictEqual({
+      x: 0,
+      y: -400,
+    })
+  })
+
+  it('should handle default position', async () => {
+    const source: Node = { ...MOCK_NODE_ADAPTER, position: { x: 0, y: 0 } }
+    expect(getGluedPosition(source)).toStrictEqual({
+      x: 0,
+      y: -200,
     })
   })
 })

--- a/hivemq-edge/src/frontend/src/modules/Workspace/utils/nodes-utils.ts
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/utils/nodes-utils.ts
@@ -326,7 +326,19 @@ export const getGluedPosition = (
   centroid?: Node,
   type: LAYOUT_GLUE_TYPE = LAYOUT_GLUE_TYPE.HALF_SPACE
 ): XYPosition => {
-  const [, spacing] = gluedNodeDefinition[source.type as NodeTypes]
+  const [, spacing] = gluedNodeDefinition[source.type as NodeTypes] || []
+
+  if (!spacing) {
+    return source.position
+  }
+
+  // Do not shift position if nodes are in a group; their position is relative to the group
+  if (source.parentId) {
+    return {
+      x: source.position.x,
+      y: source.position.y + spacing,
+    }
+  }
 
   // Half-space position (the glued node is located up/down based on relative location to centroid)
   if (centroid && type === LAYOUT_GLUE_TYPE.HALF_SPACE) {


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/32008/details/

The PR adds support for "Observability" from the new dynamic links in the workspace


### Before 
![HiveMQ-Edge-04-14-2025_09_22](https://github.com/user-attachments/assets/e5bda788-bc46-434b-b994-15c6405f02b7)

### After
![HiveMQ-Edge-04-14-2025_09_23](https://github.com/user-attachments/assets/4b3c75b2-46c9-4f59-916e-a32cdb7790e7)

![HiveMQ-Edge-04-14-2025_09_23 (1)](https://github.com/user-attachments/assets/250584bc-e8e0-4ccc-a5f1-19ff27d07b1e)

