### PR TITLE
fix(32008): Fix access to Observability from links

### DIFF
--- a/.github/workflows/frontend-cli.yml
+++ b/.github/workflows/frontend-cli.yml
@@ -138,7 +138,6 @@ jobs:
           working-directory: ./hivemq-edge/src/frontend/
           quiet: false
       - name: 💾 Upload E2E videos
-        if: failure()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: cypress-e2e-videos

--- a/hivemq-edge/src/frontend/src/components/ErrorMessage.tsx
+++ b/hivemq-edge/src/frontend/src/components/ErrorMessage.tsx
@@ -1,15 +1,16 @@
 import type { FC } from 'react'
+import type { AlertProps } from '@chakra-ui/react'
 import { Alert, AlertDescription, AlertIcon, type AlertStatus, AlertTitle } from '@chakra-ui/react'
 
-interface ErrorMessageProps {
+interface ErrorMessageProps extends AlertProps {
   type?: string | number
   message?: string
   status?: AlertStatus
 }
 
-const ErrorMessage: FC<ErrorMessageProps> = ({ type, message, status = 'error' }) => {
+const ErrorMessage: FC<ErrorMessageProps> = ({ type, message, status = 'error', ...rest }) => {
   return (
-    <Alert status={status}>
+    <Alert status={status} {...rest}>
       <AlertIcon />
       <div>
         <AlertTitle>{type || ''}</AlertTitle>

--- a/hivemq-edge/src/frontend/src/locales/en/translation.json
+++ b/hivemq-edge/src/frontend/src/locales/en/translation.json
@@ -927,7 +927,8 @@
       "aria-label": "Open the Observability panel",
       "header_ADAPTER_NODE": "Adapter Observability",
       "header_BRIDGE_NODE": "Bridge Observability",
-      "header_CLUSTER_NODE": "Group Observability"
+      "header_CLUSTER_NODE": "Group Observability",
+      "header_COMBINER_NODE": "Combiner Observability"
     },
     "datahub": {
       "aria-label": "Open the Data Hub policy",
@@ -1012,6 +1013,9 @@
         "expand": "Expand the chart",
         "collapse": "Collapse the chart"
       }
+    },
+    "error": {
+      "noMetrics": "There is no metrics available for this entity"
     },
     "charts": {
       "list": "List of metrics",

--- a/hivemq-edge/src/frontend/src/modules/Mappings/hooks/useValidateCombiner.spec.ts
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/hooks/useValidateCombiner.spec.ts
@@ -388,7 +388,6 @@ describe('useValidateCombiner', () => {
     it.skip('should not validate when a topic filter schema is invalid', async () => {
       const result = await loadingEntities(sources, [
         http.get('**/management/topic-filters', () => {
-          console.log('XXXXXXX 11')
           return HttpResponse.json<TopicFilterList>(
             { items: [{ ...MOCK_TOPIC_FILTER, schema: MOCK_TOPIC_FILTER_SCHEMA_INVALID }] },
             { status: 200 }

--- a/hivemq-edge/src/frontend/src/modules/Metrics/MetricsContainer.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Metrics/MetricsContainer.spec.cy.tsx
@@ -9,15 +9,16 @@ import { mockBridgeId } from '@/api/hooks/useGetBridges/__handlers__'
 
 describe('MetricsContainer', () => {
   beforeEach(() => {
-    cy.viewport(800, 800)
-    cy.intercept('/api/v1/metrics', { items: MOCK_METRICS } as MetricList)
+    cy.viewport(600, 800)
+    cy.intercept('/api/v1/metrics/**/*', { statusCode: 404, log: false })
+    cy.intercept('/api/v1/metrics', { items: MOCK_METRICS }).as('getMetrics')
   })
 
   it('should render the collapsible component', () => {
     cy.mountWithProviders(
       <MetricsContainer
         nodeId="bridge@bridge-id-01"
-        initMetrics={[]}
+        initMetrics={[MOCK_METRICS[0].name as string, MOCK_METRICS[1].name as string]}
         filters={[
           {
             id: mockBridgeId,
@@ -36,5 +37,47 @@ describe('MetricsContainer', () => {
 
     cy.getByTestId('metrics-toggle').click()
     cy.get('div#metrics-select-container').should('not.be.visible')
+  })
+
+  it('should render message when no metrics', () => {
+    cy.intercept('/api/v1/metrics**', { items: [] } as MetricList).as('getMetrics')
+
+    cy.mountWithProviders(
+      <MetricsContainer
+        nodeId="bridge@bridge-id-02"
+        initMetrics={[]}
+        filters={[
+          {
+            id: 'bridge@bridge-id-02',
+            type: 'com.hivemq.edge.bridge',
+          },
+        ]}
+        type={NodeTypes.BRIDGE_NODE}
+      />
+    )
+
+    cy.wait('@getMetrics')
+    cy.getByTestId('metrics-toggle').should('be.disabled')
+    cy.get('[role="alert"]')
+      .should('have.attr', 'data-status', 'info')
+      .should('have.text', 'There is no metrics available for this entity')
+  })
+
+  it('should be accessible', () => {
+    cy.injectAxe()
+    cy.mountWithProviders(
+      <MetricsContainer
+        nodeId="bridge@bridge-id-01"
+        initMetrics={[MOCK_METRICS[0].name as string, MOCK_METRICS[1].name as string]}
+        filters={[
+          {
+            id: mockBridgeId,
+            type: 'com.hivemq.edge.bridge',
+          },
+        ]}
+        type={NodeTypes.BRIDGE_NODE}
+      />
+    )
+    cy.checkAccessibility()
   })
 })

--- a/hivemq-edge/src/frontend/src/modules/Metrics/MetricsContainer.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Metrics/MetricsContainer.tsx
@@ -1,5 +1,6 @@
 import type { FC } from 'react'
 import { useEffect } from 'react'
+import { useTranslation } from 'react-i18next'
 import {
   Accordion,
   AccordionButton,
@@ -12,8 +13,8 @@ import {
   useDisclosure,
   useTheme,
 } from '@chakra-ui/react'
-import { useTranslation } from 'react-i18next'
 
+import ErrorMessage from '@/components/ErrorMessage.tsx'
 import type { NodeTypes } from '@/modules/Workspace/types.ts'
 
 import type { MetricDefinition, MetricsFilter } from './types.ts'
@@ -60,10 +61,11 @@ const MetricsContainer: FC<MetricsProps> = ({ nodeId, filters, initMetrics, defa
   }
 
   const metrics = getMetricsFor(nodeId)
+  console.log('XXXXXXX mer', metrics)
 
   useEffect(() => {
-    const gg = getMetricsFor(nodeId)
-    if (gg.length === 0 && initMetrics) {
+    const metrics = getMetricsFor(nodeId)
+    if (metrics.length === 0 && initMetrics) {
       initMetrics.map((e) => {
         addMetrics(nodeId, e, defaultChartType)
       })
@@ -81,7 +83,7 @@ const MetricsContainer: FC<MetricsProps> = ({ nodeId, filters, initMetrics, defa
             else onOpen()
           }}
         >
-          <AccordionItem>
+          <AccordionItem isDisabled={!metrics.length}>
             <AccordionButton data-testid="metrics-toggle">
               <Box as="span" flex="1" textAlign="left">
                 {t('metrics.editor.title')}
@@ -107,6 +109,9 @@ const MetricsContainer: FC<MetricsProps> = ({ nodeId, filters, initMetrics, defa
         role="list"
         aria-label={t('metrics.charts.list')}
       >
+        {!metrics.length && (
+          <ErrorMessage status={'info'} message={t('metrics.error.noMetrics')} gridColumn={'1 / span 2'} />
+        )}
         {metrics.map((e) => {
           const { id } = extractMetricInfo(e.metrics)
           const colorSchemeIndex = filters.findIndex((e) => e.id === id)

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/controls/NodePanelController.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/controls/NodePanelController.tsx
@@ -5,7 +5,7 @@ import type { Node } from '@xyflow/react'
 import { useEdges, useNodes } from '@xyflow/react'
 import { useDisclosure } from '@chakra-ui/react'
 
-import type { Adapter, Bridge } from '@/api/__generated__'
+import type { Adapter, Bridge, Combiner } from '@/api/__generated__'
 import { SuspenseFallback } from '@/components/SuspenseOutlet.tsx'
 import type { AdapterNavigateState } from '@/modules/ProtocolAdapters/types.ts'
 import { ProtocolAdapterTabIndex } from '@/modules/ProtocolAdapters/types.ts'
@@ -28,30 +28,26 @@ const NodePanelController: FC = () => {
   const { nodeId } = useParams()
 
   const selectedNode = nodes.find(
-    (e) => e.id === nodeId && (e.type === NodeTypes.BRIDGE_NODE || e.type === NodeTypes.ADAPTER_NODE)
+    (node) => node.id === nodeId && (node.type === NodeTypes.BRIDGE_NODE || node.type === NodeTypes.ADAPTER_NODE)
   ) as Node<Bridge | Adapter> | undefined
 
-  const selectedEdge = nodes.find((e) => e.id === nodeId && e.type === NodeTypes.EDGE_NODE)
-  const selectedDevice = nodes.find((e) => e.id === nodeId && e.type === NodeTypes.DEVICE_NODE) as
+  const selectedEdge = nodes.find((node) => node.id === nodeId && node.type === NodeTypes.EDGE_NODE)
+  const selectedDevice = nodes.find((node) => node.id === nodeId && node.type === NodeTypes.DEVICE_NODE) as
     | Node<DeviceMetadata>
     | undefined
 
-  const selectedLinkSource = nodes.find((e) => {
-    const link = edges.find((e) => e.id === nodeId && e.type === EdgeTypes.REPORT_EDGE)
+  const selectedLinkSource = nodes.find((node) => {
+    const link = edges.find((edge) => edge.id === nodeId && edge.type === EdgeTypes.DYNAMIC_EDGE)
     if (!link) return undefined
-    return e.id === link.source // && (e.type === NodeTypes.BRIDGE_NODE || e.type === NodeTypes.ADAPTER_NODE)
-  }) as Node<Bridge | Adapter | Group> | undefined
+    return node.id === link.source
+  }) as Node<Bridge | Adapter | Group | Combiner> | undefined
 
-  const selectedGroup = nodes.find((e) => e.id === nodeId && e.type === NodeTypes.CLUSTER_NODE) as
+  const selectedGroup = nodes.find((node) => node.id === nodeId && node.type === NodeTypes.CLUSTER_NODE) as
     | Node<Group>
     | undefined
 
   useEffect(() => {
     if (!nodes.length) return
-    // if (!selectedNode || !nodeId) {
-    //   navigate('/workspace', { replace: true })
-    //   return
-    // }
     onOpen()
   }, [navigate, nodeId, nodes.length, onOpen, selectedNode])
 
@@ -84,7 +80,7 @@ const NodePanelController: FC = () => {
       {selectedLinkSource && selectedLinkSource.type !== NodeTypes.CLUSTER_NODE && (
         <LinkPropertyDrawer
           nodeId={nodeId}
-          selectedNode={selectedLinkSource as Node<Bridge | Adapter>}
+          selectedNode={selectedLinkSource as Node<Adapter | Bridge | Combiner>}
           isOpen={isOpen}
           onClose={handleClose}
           onEditEntity={handleEditEntity}

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/drawers/GroupPropertyDrawer.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/drawers/GroupPropertyDrawer.tsx
@@ -27,7 +27,7 @@ import { MdOutlineEventNote } from 'react-icons/md'
 
 import MetricsContainer from '@/modules/Metrics/MetricsContainer.tsx'
 
-import type { Group } from '../../types.ts'
+import type { Group, NodeAdapterType } from '../../types.ts'
 import { NodeTypes } from '../../types.ts'
 import useWorkspaceStore from '../../hooks/useWorkspaceStore.ts'
 import { getDefaultMetricsFor } from '../../utils/nodes-utils.ts'
@@ -59,13 +59,13 @@ const GroupPropertyDrawer: FC<GroupPropertyDrawerProps> = ({
   const { t } = useTranslation()
   const { onGroupSetData } = useWorkspaceStore()
 
-  const adapterIDs = selectedNode.data.childrenNodeIds.map<Node | undefined>((e) => nodes.find((x) => x.id === e))
-  const metrics = adapterIDs.map((x) => (x ? getDefaultMetricsFor(x) : [])).flat()
+  const adapterIDs = nodes.filter((node) => selectedNode.data.childrenNodeIds.includes(node.id))
+  const metrics = adapterIDs.map((node) => (node ? getDefaultMetricsFor(node) : [])).flat()
 
   const linkEventLog = useMemo(() => {
     const searchParams = new URLSearchParams()
     for (const node of adapterIDs) {
-      if (node) searchParams.append('source', node.data.id)
+      if (node) searchParams.append('source', node.data.id as string)
     }
     return `/event-logs?${searchParams.toString()}`
   }, [adapterIDs])
@@ -80,7 +80,7 @@ const GroupPropertyDrawer: FC<GroupPropertyDrawerProps> = ({
       type={selectedNode.type as NodeTypes}
       filters={adapterIDs.reduce<MetricsFilter[]>((acc, cur) => {
         if (cur && cur.type === NodeTypes.ADAPTER_NODE) {
-          acc.push({ id: cur.data.id, type: `com.hivemq.edge.protocol-adapters.${cur.data.type}` })
+          acc.push({ id: (cur as NodeAdapterType).data.id, type: `com.hivemq.edge.protocol-adapters.${cur.data.type}` })
         }
         return acc
       }, [])}
@@ -114,7 +114,7 @@ const GroupPropertyDrawer: FC<GroupPropertyDrawerProps> = ({
             </CardHeader>
             <CardBody>
               <EventLogTable
-                globalSourceFilter={adapterIDs.map((e) => e?.data.id)}
+                globalSourceFilter={adapterIDs.map((e) => e.data.id as string)}
                 variant="summary"
                 maxEvents={10}
                 isSingleSource={false}

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/drawers/LinkPropertyDrawer.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/drawers/LinkPropertyDrawer.spec.cy.tsx
@@ -1,0 +1,67 @@
+import type { Node } from '@xyflow/react'
+
+import { MOCK_NODE_ADAPTER } from '@/__test-utils__/react-flow/nodes.ts'
+import type { Adapter, Bridge } from '@/api/__generated__'
+import { NodeTypes } from '@/modules/Workspace/types.ts'
+
+import LinkPropertyDrawer from './LinkPropertyDrawer'
+
+const mockNode: Node<Bridge | Adapter> = {
+  position: { x: 0, y: 0 },
+  id: 'adapter@fgffgf',
+  type: NodeTypes.ADAPTER_NODE,
+  data: MOCK_NODE_ADAPTER,
+}
+
+describe('NodePropertyDrawer', () => {
+  beforeEach(() => {
+    cy.viewport(800, 800)
+    cy.intercept('/api/v1/management/protocol-adapters/types', { statusCode: 404 })
+    cy.intercept('/api/v1/metrics', [])
+    cy.intercept('/api/v1/metrics/**', [])
+    cy.intercept('/api/v1/management/events?*', [])
+  })
+
+  it('should render properly', () => {
+    const onClose = cy.stub().as('onClose')
+    const onEditEntity = cy.stub().as('onEditEntity')
+    cy.mountWithProviders(
+      <LinkPropertyDrawer
+        nodeId="adapter@fgffgf"
+        selectedNode={mockNode}
+        isOpen={true}
+        onClose={onClose}
+        onEditEntity={onEditEntity}
+      />
+    )
+
+    // check the panel control
+    cy.get('@onClose').should('not.have.been.called')
+    cy.getByAriaLabel('Close').click()
+    cy.get('@onClose').should('have.been.calledOnce')
+
+    // check that the metrics is there
+    cy.getByTestId('metrics-toggle').should('be.visible')
+  })
+
+  it('should be accessible', () => {
+    cy.injectAxe()
+    cy.mountWithProviders(
+      <LinkPropertyDrawer
+        nodeId="adapter@fgffgf"
+        selectedNode={mockNode}
+        isOpen={true}
+        onClose={cy.stub()}
+        onEditEntity={cy.stub()}
+      />
+    )
+
+    cy.checkAccessibility(undefined, {
+      rules: {
+        // TODO[#17700] Color-contrast totally wrong; fix and test the component
+        'color-contrast': { enabled: false },
+      },
+    })
+    cy.percySnapshot('Component: LinkPropertyDrawer')
+  })
+})

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/drawers/LinkPropertyDrawer.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/drawers/LinkPropertyDrawer.tsx
@@ -1,9 +1,10 @@
 import type { FC } from 'react'
+import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { Node } from '@xyflow/react'
 import { Drawer, DrawerBody, DrawerCloseButton, DrawerContent, DrawerHeader, Text } from '@chakra-ui/react'
 
-import type { Adapter, Bridge } from '@/api/__generated__'
+import type { Adapter, Bridge, Combiner } from '@/api/__generated__'
 import { useGetAdapterTypes } from '@/api/hooks/useProtocolAdapters/useGetAdapterTypes.ts'
 import MetricsContainer from '@/modules/Metrics/MetricsContainer.tsx'
 import NodeNameCard from '@/modules/Workspace/components/parts/NodeNameCard.tsx'
@@ -12,7 +13,7 @@ import { getDefaultMetricsFor } from '@/modules/Workspace/utils/nodes-utils.ts'
 
 interface LinkPropertyDrawerProps {
   nodeId: string
-  selectedNode: Node<Bridge | Adapter>
+  selectedNode: Node<Bridge | Adapter | Combiner>
   isOpen: boolean
   onClose: () => void
   onEditEntity: () => void
@@ -26,6 +27,12 @@ const LinkPropertyDrawer: FC<LinkPropertyDrawerProps> = ({ nodeId, isOpen, selec
       ? protocols?.items?.find((e) => e.id === (selectedNode as Node<Adapter>).data.type)
       : undefined
 
+  const displayInfo = useMemo(() => {
+    if (selectedNode.type === NodeTypes.COMBINER_NODE)
+      return { name: (selectedNode.data as Combiner).name, description: t('combiner.type') }
+    return { name: selectedNode.data.id, description: adapterProtocol?.name }
+  }, [adapterProtocol?.name, selectedNode.data, selectedNode.type, t])
+
   return (
     <Drawer isOpen={isOpen} placement="right" size="md" onClose={onClose} variant="hivemq">
       <DrawerContent>
@@ -34,10 +41,10 @@ const LinkPropertyDrawer: FC<LinkPropertyDrawerProps> = ({ nodeId, isOpen, selec
         <DrawerHeader>
           <Text>{t('workspace.observability.header', { context: selectedNode.type })}</Text>
           <NodeNameCard
-            name={selectedNode.data.id}
+            name={displayInfo.name}
             type={selectedNode.type as NodeTypes}
             icon={adapterProtocol?.logoUrl}
-            description={adapterProtocol?.name}
+            description={displayInfo.description}
           />
         </DrawerHeader>
         <DrawerBody display="flex" flexDirection="column" gap={6}>

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/edges/DynamicEdge.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/edges/DynamicEdge.spec.cy.tsx
@@ -1,0 +1,75 @@
+import type { Edge, Node } from '@xyflow/react'
+
+import { CustomNodeTesting } from '@/__test-utils__/react-flow/CustomNodeTesting.tsx'
+import { mockProtocolAdapter } from '@/api/hooks/useProtocolAdapters/__handlers__'
+import { MOCK_CAPABILITIES } from '@/api/hooks/useFrontendServices/__handlers__'
+import { EdgeTypes, NodeTypes } from '@/modules/Workspace/types.ts'
+import { NodeAdapter } from '@/modules/Workspace/components/nodes'
+
+import DynamicEdge from './MonitoringEdge.tsx'
+
+const MOCK_NODES: Node[] = [
+  {
+    id: 'idAdapter',
+    data: { label: 'From here' },
+    position: { x: 0, y: 0 },
+    type: 'input',
+  },
+
+  {
+    id: 'idAdapter2',
+    data: { label: 'To there' },
+    position: { x: 100, y: 300 },
+    type: 'output',
+  },
+]
+
+const MOCK_EDGE_ID = 'edge-test'
+const MOCK_EDGE: Edge[] = [
+  {
+    id: MOCK_EDGE_ID,
+    source: 'idAdapter',
+    target: 'idAdapter2',
+    type: EdgeTypes.REPORT_EDGE,
+  },
+]
+
+describe('MonitoringEdge', () => {
+  beforeEach(() => {
+    cy.viewport(400, 450)
+    cy.intercept('/api/v1/frontend/capabilities', MOCK_CAPABILITIES)
+    cy.intercept('/api/v1/management/protocol-adapters/types', { items: [mockProtocolAdapter] })
+    cy.intercept('/api/v1/data-hub/data-validation/policies', [])
+  })
+
+  it('should render the observability CTA', () => {
+    cy.mountWithProviders(
+      <CustomNodeTesting
+        nodes={MOCK_NODES}
+        edges={MOCK_EDGE}
+        edgeTypes={{ [EdgeTypes.REPORT_EDGE]: DynamicEdge }}
+        nodeTypes={{
+          [NodeTypes.ADAPTER_NODE]: NodeAdapter,
+        }}
+      />
+    )
+    cy.getByTestId('observability-panel-trigger').should('have.attr', 'aria-label', 'Open the Observability panel')
+    cy.getByTestId('test-navigate-pathname').should('have.text', '/')
+    cy.getByTestId('observability-panel-trigger').click()
+    cy.getByTestId('test-navigate-pathname').should('have.text', `/workspace/link/${MOCK_EDGE_ID}`)
+  })
+
+  it('should be accessible', () => {
+    cy.injectAxe()
+    cy.mountWithProviders(
+      <CustomNodeTesting nodes={MOCK_NODES} edges={MOCK_EDGE} edgeTypes={{ [EdgeTypes.REPORT_EDGE]: DynamicEdge }} />
+    )
+    cy.checkAccessibility(undefined, {
+      rules: {
+        // ReactFlow watermark not accessible
+        'color-contrast': { enabled: false },
+      },
+    })
+    cy.percySnapshot('Component: DynamicEdge')
+  })
+})

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/edges/DynamicEdge.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/edges/DynamicEdge.tsx
@@ -1,11 +1,53 @@
+import { HStack } from '@chakra-ui/react'
 import type { FC } from 'react'
-import { type EdgeProps, getBezierPath, useInternalNode } from '@xyflow/react'
+import { useMemo } from 'react'
+import {
+  BaseEdge,
+  EdgeLabelRenderer,
+  type EdgeProps,
+  getBezierPath,
+  useInternalNode,
+  useNodesData,
+} from '@xyflow/react'
 
 import { getEdgeParams } from '@/modules/Workspace/utils/edge.utils'
+import { useNavigate } from 'react-router-dom'
+import { DataHubNodeType } from '../../../../extensions/datahub/types'
+import { useGetPoliciesMatching } from '../../hooks/useGetPoliciesMatching'
+import { NodeTypes } from '../../types'
+import DataPolicyEdgeCTA from './DataPolicyEdgeCTA'
+import ObservabilityEdgeCTA from './ObservabilityEdgeCTA'
 
 export const DynamicEdge: FC<EdgeProps> = ({ id, source, target, markerEnd, style }) => {
   const sourceNode = useInternalNode(source)
   const targetNode = useInternalNode(target)
+  const policies = useGetPoliciesMatching(source)
+  const navigate = useNavigate()
+  const nodeData = useNodesData(target)
+
+  const isObservable = useMemo(() => {
+    if (!nodeData) return false
+    const { type } = nodeData
+    return type === NodeTypes.EDGE_NODE
+  }, [nodeData])
+
+  const policyRoutes = useMemo(() => {
+    if (!policies) return undefined
+
+    return policies.map((policy) => `/datahub/${DataHubNodeType.DATA_POLICY}/${policy.id}`)
+  }, [policies])
+
+  const handleOpenObservability = () => {
+    navigate(`/workspace/link/${id}`)
+  }
+
+  const handleShowPolicy = (route: string) => {
+    navigate(route)
+  }
+
+  const handleShowAllPolicies = () => {
+    navigate('/datahub')
+  }
 
   if (!sourceNode || !targetNode) {
     return null
@@ -13,7 +55,7 @@ export const DynamicEdge: FC<EdgeProps> = ({ id, source, target, markerEnd, styl
 
   const { sx, sy, tx, ty, sourcePos, targetPos } = getEdgeParams(sourceNode, targetNode)
 
-  const [edgePath] = getBezierPath({
+  const [edgePath, labelX, labelY] = getBezierPath({
     sourceX: sx,
     sourceY: sy,
     sourcePosition: sourcePos,
@@ -22,5 +64,33 @@ export const DynamicEdge: FC<EdgeProps> = ({ id, source, target, markerEnd, styl
     targetY: ty,
   })
 
-  return <path id={id} className="react-flow__edge-path" d={edgePath} markerEnd={markerEnd} style={style} />
+  return (
+    <>
+      <BaseEdge id={id} path={edgePath} markerEnd={markerEnd} style={style} />
+      {isObservable && (
+        <EdgeLabelRenderer>
+          <HStack
+            sx={{
+              position: 'absolute',
+              transform: `translate(-50%, -50%) translate(${labelX}px,${labelY}px)`,
+              pointerEvents: 'all',
+            }}
+            className="nodrag nopan"
+          >
+            <ObservabilityEdgeCTA source={source} style={style} onClick={handleOpenObservability} />
+            {policyRoutes && (
+              <DataPolicyEdgeCTA
+                data-testid="policy-panel-trigger"
+                style={style}
+                policyRoutes={policyRoutes}
+                onClickPolicy={handleShowPolicy}
+                onClickAll={handleShowAllPolicies}
+              />
+            )}
+          </HStack>
+        </EdgeLabelRenderer>
+      )}
+    </>
+  )
+  // return <path id={id} className="react-flow__edge-path" d={edgePath} markerEnd={markerEnd} style={style} />
 }

--- a/hivemq-edge/src/frontend/src/modules/Workspace/components/edges/DynamicEdge.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Workspace/components/edges/DynamicEdge.tsx
@@ -92,5 +92,4 @@ export const DynamicEdge: FC<EdgeProps> = ({ id, source, target, markerEnd, styl
       )}
     </>
   )
-  // return <path id={id} className="react-flow__edge-path" d={edgePath} markerEnd={markerEnd} style={style} />
 }


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/32008/details/

The PR adds support for "Observability" from the new dynamic links in the workspace


### Before 
![HiveMQ-Edge-04-14-2025_09_22](https://github.com/user-attachments/assets/e5bda788-bc46-434b-b994-15c6405f02b7)

### After
![HiveMQ-Edge-04-14-2025_09_23](https://github.com/user-attachments/assets/4b3c75b2-46c9-4f59-916e-a32cdb7790e7)

![HiveMQ-Edge-04-14-2025_09_23 (1)](https://github.com/user-attachments/assets/250584bc-e8e0-4ccc-a5f1-19ff27d07b1e)

