### PR TITLE
fix(31362): Add feedback to schema validation for destination

### DIFF
--- a/hivemq-edge/src/frontend/src/locales/en/translation.json
+++ b/hivemq-edge/src/frontend/src/locales/en/translation.json
@@ -1148,20 +1148,7 @@
     },
     "error": {
       "loading": "We cannot load the topic filters. Please try again later.",
-      "noSchemaSampled": "No schema could be inferred from the traffic on this topic filter. Please try again later.",
-      "schema": {
-        "noDataUri": "Not a valid data-url encoded JSONSchema",
-        "noScheme": "No scheme defined in the URI",
-        "noSchemeData": "The scheme of the uri is not defined as 'data'",
-        "noJsonSchemaMimeType": "The media types doesn't include the mandatory `application/schema+json`",
-        "noBase64MediaType": "The media types doesn't include the mandatory `base64`",
-        "noBase64Data": "The data is not properly encoded as a `base64` string",
-        "noJSON": "The data is not properly encoded as a `JSON` object",
-        "ajvValidationFails": "Internal validation error",
-        "ajvNoProperties": "Not a valid JSONSchema: `properties` is missing",
-        "noAssignedSchema_TAG": "Your tag is currently not assigned a schema",
-        "noAssignedSchema_TOPIC_FILTER": "Your topic filter is currently not assigned a schema"
-      }
+      "noSchemaSampled": "No schema could be inferred from the traffic on this topic filter. Please try again later."
     },
     "toast": {
       "description_loading": "Processing the request",
@@ -1180,6 +1167,35 @@
         "description_success": "The Topic Filters have been modified on the Edge",
         "description_error": "The list of Topic Filters could not be updated on the Edge"
       }
+    }
+  },
+  "schema": {
+    "status": {
+      "success_TOPIC_FILTER": "Your topic filter is currently assigned a valid schema",
+      "success_TOPIC": "Your topic is currently assigned a valid schema",
+      "success_TAG": "Your tag is currently assigned a valid schema",
+      "missing_TOPIC_FILTER": "Your topic filter is currently not assigned a schema",
+      "missing_TOPIC": "Your topic is currently not assigned a schema",
+      "missing_TAG": "Your tag is currently not assigned a schema",
+      "invalid_TOPIC_FILTER": "Your topic filter is currently assigned a schema that is not valid",
+      "invalid_TOPIC": "Your topic is currently assigned a schema that is not valid",
+      "invalid_TAG": "Your tag is currently assigned a schema that is not valid",
+      "internalError": "Internal error - cannot extract your schema"
+    },
+    "validation": {
+      "noDataUri": "Not a valid data-url encoded JSONSchema",
+      "noScheme": "No scheme defined in the URI",
+      "noSchemeData": "The scheme of the uri is not defined as 'data'",
+      "noJsonSchemaMimeType": "The media types doesn't include the mandatory `application/schema+json`",
+      "noBase64MediaType": "The media types doesn't include the mandatory `base64`",
+      "noBase64Data": "The data is not properly encoded as a `base64` string",
+      "noJSON": "The data is not properly encoded as a `JSON` object",
+      "ajvValidationFails": "Internal validation error",
+      "ajvNoProperties": "Not a valid JSONSchema: `properties` is missing",
+      "ajvEmptyProperties": "Not a valid JSONSchema: `properties` doesn't contain any properties",
+      "noAssignedSchema_TAG": "Your tag is currently not assigned a schema",
+      "noAssignedSchema_TOPIC": "Your topic is currently not assigned a schema",
+      "noAssignedSchema_TOPIC_FILTER": "Your topic filter is currently not assigned a schema"
     }
   },
   "ontology": {

--- a/hivemq-edge/src/frontend/src/modules/Mappings/combiner/DestinationSchemaLoader.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/combiner/DestinationSchemaLoader.tsx
@@ -15,8 +15,10 @@ import {
   useDisclosure,
 } from '@chakra-ui/react'
 
-import type { DataCombining, DataIdentifierReference, Instruction } from '@/api/__generated__'
+import type { DataCombining, Instruction } from '@/api/__generated__'
+import { DataIdentifierReference } from '@/api/__generated__'
 import ErrorMessage from '@/components/ErrorMessage'
+import { SelectEntityType } from '@/components/MQTT/types'
 import { MappingInstructionList } from '@/components/rjsf/MqttTransformation/components/MappingInstructionList'
 import { toJsonPath } from '@/components/rjsf/MqttTransformation/utils/data-type.utils'
 import {
@@ -85,7 +87,7 @@ export const DestinationSchemaLoader: FC<DestinationSchemaLoaderProps> = ({
   const handleSchemaDownload = () => {
     if (!formData?.destination?.schema) return
 
-    const handler = validateSchemaFromDataURI(formData?.destination?.schema)
+    const handler = validateSchemaFromDataURI(formData?.destination?.schema, SelectEntityType.TOPIC)
     if (handler.schema) downloadJSON<JSONSchema7>(handler.schema.title || 'topic-untitled', handler.schema)
   }
 
@@ -95,7 +97,7 @@ export const DestinationSchemaLoader: FC<DestinationSchemaLoaderProps> = ({
 
   const schema = useMemo(() => {
     if (!formData?.destination?.schema) return undefined
-    return validateSchemaFromDataURI(formData?.destination?.schema)
+    return validateSchemaFromDataURI(formData?.destination?.schema, DataIdentifierReference.type.TAG)
   }, [formData?.destination?.schema])
 
   return (
@@ -130,6 +132,8 @@ export const DestinationSchemaLoader: FC<DestinationSchemaLoaderProps> = ({
           <ErrorMessage message={t('combiner.error.noSchemaLoadedYet')} status={'info'} />
         </VStack>
       )}
+
+      {schema?.status === 'error' && <ErrorMessage type={schema?.message} message={schema?.error} />}
 
       {schema?.schema && (
         <VStack w="100%" justifyContent={'center'} alignItems={'stretch'} gap={3}>

--- a/hivemq-edge/src/frontend/src/modules/Mappings/hooks/useValidateCombiner.spec.ts
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/hooks/useValidateCombiner.spec.ts
@@ -502,7 +502,7 @@ describe('useValidateCombiner', () => {
       )
       expect(errors).toStrictEqual([
         expect.objectContaining({
-          message: 'Your topic filter is currently not assigned a schema',
+          message: 'Your topic is currently not assigned a schema',
         }),
       ])
     })
@@ -532,7 +532,7 @@ describe('useValidateCombiner', () => {
       )
       expect(errors).toStrictEqual([
         expect.objectContaining({
-          message: "The destination schema doesn't have any property to be mapped into",
+          message: 'Not a valid JSONSchema: `properties` is missing',
         }),
       ])
     })

--- a/hivemq-edge/src/frontend/src/modules/Mappings/hooks/useValidateCombiner.ts
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/hooks/useValidateCombiner.ts
@@ -20,6 +20,7 @@ import { useGetCombinedDataSchemas } from '@/api/hooks/useDomainModel/useGetComb
 
 import { fromJsonPath } from '@/components/rjsf/MqttTransformation/utils/data-type.utils'
 import { type FlatJSONSchema7, getPropertyListFrom } from '@/components/rjsf/MqttTransformation/utils/json-schema.utils'
+import { SelectEntityType } from '@/components/MQTT/types'
 import type { CombinerContext } from '@/modules/Mappings/types'
 import { validateSchemaFromDataURI } from '@/modules/TopicFilters/utils/topic-filter.schema'
 
@@ -95,6 +96,7 @@ export const useValidateCombiner = (
   const allPathsFromSources = useMemo<string[]>(() => {
     return allSchemaReferences.reduce<string[]>((acc, cur) => {
       let flatList: FlatJSONSchema7[]
+      // TODO[NVL] This is a hack to identify whether TOPIC FILTER (string) or TAG (object). When unified, it won't work
       if (typeof cur.data === 'string') {
         const handleSchema = validateSchemaFromDataURI(cur.data)
         flatList = handleSchema.schema ? getPropertyListFrom(handleSchema.schema) : []
@@ -173,7 +175,7 @@ export const useValidateCombiner = (
    */
   const validateDestinationSchema = useCallback<CustomValidator<DataCombining, RJSFSchema, CombinerContext>>(
     (formData, errors) => {
-      const handleSchema = validateSchemaFromDataURI(formData?.destination?.schema)
+      const handleSchema = validateSchemaFromDataURI(formData?.destination?.schema, SelectEntityType.TOPIC)
       if (handleSchema.status !== 'success' || !handleSchema.schema)
         errors.destination?.schema?.addError(handleSchema.error || handleSchema.message)
       else {
@@ -231,7 +233,7 @@ export const useValidateCombiner = (
 
   const validateInstructions = useCallback<CustomValidator<DataCombining, RJSFSchema, CombinerContext>>(
     (formData, errors) => {
-      const handleSchema = validateSchemaFromDataURI(formData?.destination?.schema)
+      const handleSchema = validateSchemaFromDataURI(formData?.destination?.schema, SelectEntityType.TOPIC)
       const properties = handleSchema.schema && getPropertyListFrom(handleSchema.schema)
 
       const knownPaths = properties?.map((e) => [...e.path, e.key].join('.')) || []

--- a/hivemq-edge/src/frontend/src/modules/Mappings/utils/combining.utils.spec.ts
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/utils/combining.utils.spec.ts
@@ -95,7 +95,7 @@ const schemaSuite: TestEachSchemaSuite[] = [
       expect.objectContaining({
         adapterId: 'string',
         schema: expect.objectContaining({
-          message: 'Your topic filter is currently assigned a valid schema',
+          message: 'Your tag is currently assigned a valid schema',
           schema: expect.objectContaining({
             description: 'A simple form example.',
           }),

--- a/hivemq-edge/src/frontend/src/modules/Mappings/utils/combining.utils.ts
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/utils/combining.utils.ts
@@ -86,17 +86,17 @@ export const getSchemasFromReferences = (
 
     // TODO[30744] Type of schema inconsistent between tag and topic filter
     if (typeof data === 'string') {
-      dataReference.schema = validateSchemaFromDataURI(data)
+      dataReference.schema = validateSchemaFromDataURI(data, dataReference.type)
     } else if (typeof data === 'object') {
       dataReference.schema = {
         schema: data || undefined,
         status: 'success',
-        message: i18n.t('topicFilter.schema.status.success'),
+        message: i18n.t('schema.status.success', { context: dataReference.type }),
       }
     } else {
       dataReference.schema = {
         status: 'warning',
-        message: i18n.t('topicFilter.error.schema.noAssignedSchema', { context: dataReference.type }),
+        message: i18n.t('schema.validation.noAssignedSchema', { context: dataReference.type }),
       }
     }
     return dataReference


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/31362/details/

The PR adds the missing error messages when the validation of the schema for the destination topic fails. 

The translations for the validation messages have been improved, in particular mentioning the correct Integration point (tag, topic or topic filter) for which the schema is being validated

### Out-of-scope
- The payloads that contains inbound schemas (tag and topic filter) are not consistent in shape and are not maintaining connection with the type of its integration point. The result is a series of hack in the frontend code. The issue should be fixed in subsequent ticket (see https://hivemq.kanbanize.com/ctrl_board/57/cards/30744/details/)
### Before 

### After