### PR TITLE
feat(31587): Add auto mapping assignment to the combiner

### DIFF
--- a/hivemq-edge/src/frontend/src/locales/en/translation.json
+++ b/hivemq-edge/src/frontend/src/locales/en/translation.json
@@ -1374,7 +1374,9 @@
         },
         "action": {
           "save": "Save",
-          "cancel": "Cancel"
+          "cancel": "Cancel",
+          "generateMappings": "Suggest appropriate mappings",
+          "clearMappings": "Clear mappings"
         },
         "combinedSelector": {
           "placeholder": "Select tags and topic filters to combine ...",

--- a/hivemq-edge/src/frontend/src/modules/Mappings/combiner/DataCombiningEditorField.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/combiner/DataCombiningEditorField.tsx
@@ -3,16 +3,15 @@ import { useTranslation } from 'react-i18next'
 import type { FieldProps, RJSFSchema } from '@rjsf/utils'
 import { getTemplate, getUiOptions } from '@rjsf/utils'
 import {
+  ButtonGroup,
   FormControl,
   FormErrorMessage,
   FormHelperText,
   FormLabel,
   Grid,
   GridItem,
-  HStack,
-  Icon,
+  VStack,
 } from '@chakra-ui/react'
-import { FaRightFromBracket } from 'react-icons/fa6'
 
 import type { DataCombining, Instruction } from '@/api/__generated__'
 import { DataIdentifierReference } from '@/api/__generated__'
@@ -20,6 +19,8 @@ import { SelectTopic } from '@/components/MQTT/EntityCreatableSelect'
 import type { CombinerContext } from '@/modules/Mappings/types'
 import CombinedEntitySelect from './CombinedEntitySelect'
 import { CombinedSchemaLoader } from './CombinedSchemaLoader'
+import { AutoMapping } from './components/AutoMapping'
+import { ClearMappings } from './components/ClearMappings'
 import { DestinationSchemaLoader } from './DestinationSchemaLoader'
 import { PrimarySelect } from './PrimarySelect'
 
@@ -154,9 +155,33 @@ export const DataCombiningEditorField: FC<FieldProps<DataCombining, RJSFSchema, 
         </FormControl>
       </GridItem>
       <GridItem>
-        <HStack height={'100%'} justifyContent={'center'}>
-          <Icon as={FaRightFromBracket} />
-        </HStack>
+        <VStack height={'100%'} justifyContent={'center'}>
+          <ButtonGroup size={'sm'} flexDirection={'column'} alignItems={'flex-end'} gap={2}>
+            <AutoMapping
+              formData={props.formData}
+              formContext={formContext}
+              onChange={(instructions: Instruction[]) => {
+                if (!props.formData) return
+
+                props.onChange({
+                  ...props.formData,
+                  instructions: instructions,
+                })
+              }}
+            />
+            <ClearMappings
+              formData={props.formData}
+              onChange={(instructions: Instruction[]) => {
+                if (!props.formData) return
+
+                props.onChange({
+                  ...props.formData,
+                  instructions: instructions,
+                })
+              }}
+            />
+          </ButtonGroup>
+        </VStack>
       </GridItem>
       <GridItem colSpan={2} data-testid={'combining-editor-destination-schema'}>
         <DestinationSchemaLoader

--- a/hivemq-edge/src/frontend/src/modules/Mappings/combiner/components/AutoMapping.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/combiner/components/AutoMapping.spec.cy.tsx
@@ -1,6 +1,6 @@
 import type { FC } from 'react'
 import { useMemo } from 'react'
-import { Box, Card, CardBody, CardHeader, Code, chakra as Chakra, List, ListItem } from '@chakra-ui/react'
+import { Box, Card, CardBody, CardHeader, Code, List, ListItem } from '@chakra-ui/react'
 
 import { MockAdapterType } from '@/__test-utils__/adapters/types'
 import type { DataCombining, Instruction } from '@/api/__generated__'

--- a/hivemq-edge/src/frontend/src/modules/Mappings/combiner/components/AutoMapping.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/combiner/components/AutoMapping.spec.cy.tsx
@@ -1,0 +1,128 @@
+import type { FC } from 'react'
+import { useMemo } from 'react'
+import { Box, Card, CardBody, CardHeader, Code, chakra as Chakra, List, ListItem } from '@chakra-ui/react'
+
+import { MockAdapterType } from '@/__test-utils__/adapters/types'
+import type { DataCombining, Instruction } from '@/api/__generated__'
+import { DataIdentifierReference } from '@/api/__generated__'
+import { mockCombiner } from '@/api/hooks/useCombiners/__handlers__'
+import { useGetCombinedEntities } from '@/api/hooks/useDomainModel/useGetCombinedEntities'
+import { GENERATE_DATA_MODELS } from '@/api/hooks/useDomainModel/__handlers__'
+import { MOCK_DEVICE_TAGS } from '@/api/hooks/useProtocolAdapters/__handlers__'
+import { MOCK_TOPIC_FILTER_SCHEMA_VALID } from '@/api/hooks/useTopicFilters/__handlers__'
+import { getPropertyListFrom } from '@/components/rjsf/MqttTransformation/utils/json-schema.utils'
+import { validateSchemaFromDataURI } from '@/modules/TopicFilters/utils/topic-filter.schema'
+
+import { AutoMapping } from './AutoMapping'
+
+const mockFormData: DataCombining = {
+  id: '58677276-fc48-4a9a-880c-41c755f5063b',
+  sources: {
+    primary: { id: '', type: DataIdentifierReference.type.TAG },
+    tags: ['my-adapter/power/off'],
+  },
+  destination: { topic: 'my/topic', schema: MOCK_TOPIC_FILTER_SCHEMA_VALID },
+  instructions: [
+    {
+      source: '$.dropped-property',
+      destination: '$.lastName',
+    },
+  ],
+}
+
+interface AutoMappingWrapperProps {
+  formData?: DataCombining
+  onChange?: (instructions: Instruction[]) => void
+}
+
+const AutoMappingWrapper: FC<AutoMappingWrapperProps> = ({ formData, onChange }) => {
+  const sources = useGetCombinedEntities(mockCombiner.sources.items)
+
+  const props = useMemo(() => {
+    if (!formData?.destination?.schema) return []
+
+    const handler = validateSchemaFromDataURI(formData?.destination?.schema)
+    return handler.schema ? getPropertyListFrom(handler.schema) : []
+  }, [formData?.destination?.schema])
+
+  return (
+    <Box>
+      <AutoMapping
+        formData={formData}
+        formContext={{ queries: sources, entities: mockCombiner.sources.items }}
+        onChange={onChange}
+      />
+      <Card mt={50} variant="filled" size="sm">
+        <CardHeader>Testing Dashboard</CardHeader>
+        <CardBody data-testid="test-context" as={Code}>
+          <List>
+            <ListItem>source: {sources.length}</ListItem>
+            <ListItem>destination:{props.length}</ListItem>
+          </List>
+        </CardBody>
+      </Card>
+    </Box>
+  )
+}
+
+describe('AutoMapping', () => {
+  beforeEach(() => {
+    cy.viewport(800, 800)
+
+    cy.intercept('/api/v1/management/protocol-adapters/adapters/my-adapter/tags', {
+      items: MOCK_DEVICE_TAGS('my-adapter', MockAdapterType.OPC_UA),
+    })
+    cy.intercept('/api/v1/management/protocol-adapters/adapters/my-other-adapter/tags', {
+      items: MOCK_DEVICE_TAGS('my-other-adapter', MockAdapterType.OPC_UA),
+    })
+
+    cy.intercept(
+      '/api/v1/management/protocol-adapters/writing-schema/**',
+      GENERATE_DATA_MODELS(true, 'my-adapter/power/off')
+    )
+  })
+
+  it('should render properly', () => {
+    const onClick = cy.stub().as('onClick')
+
+    cy.mountWithProviders(<AutoMappingWrapper onChange={onClick} formData={mockFormData} />)
+
+    cy.get('button').should('not.be.disabled').should('have.attr', 'aria-label', 'Suggest appropriate mappings')
+
+    cy.get('@onClick').should('not.have.been.called')
+    cy.get('button').click()
+    cy.get('@onClick').should('have.been.calledWith', [
+      {
+        sourceRef: {
+          id: 'my-adapter/power/off',
+          type: 'TAG',
+        },
+        destination: '$.description',
+        source: '$.firstName',
+      },
+      {
+        sourceRef: {
+          id: 'my-adapter/power/off',
+          type: 'TAG',
+        },
+        destination: '$.name',
+        source: '$.subItems.name',
+      },
+    ])
+  })
+
+  it('should render properly', () => {
+    const onClick = cy.stub().as('onClick')
+
+    cy.mountWithProviders(<AutoMappingWrapper onChange={onClick} />)
+
+    cy.get('button').should('be.disabled')
+  })
+
+  it('should be accessible', () => {
+    cy.injectAxe()
+    cy.mountWithProviders(<AutoMappingWrapper onChange={cy.stub} formData={mockFormData} />)
+
+    cy.checkAccessibility()
+  })
+})

--- a/hivemq-edge/src/frontend/src/modules/Mappings/combiner/components/AutoMapping.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/combiner/components/AutoMapping.tsx
@@ -41,16 +41,16 @@ export const AutoMapping: FC<AutoMappingProps> = ({ formData, formContext, onCha
     )
 
     return schemas
-      .map((e) => {
-        const gg = getPropertyListFrom(e.schema?.schema as JSONSchema7)
+      .map((dataRef) => {
+        const properties = getPropertyListFrom(dataRef.schema?.schema as JSONSchema7)
 
         const instruction: DataIdentifierReference = {
-          id: e.id as string,
-          type: e.type as DataIdentifierReference.type,
+          id: dataRef.id as string,
+          type: dataRef.type as DataIdentifierReference.type,
         }
 
-        gg.forEach((e) => (e.metadata = instruction))
-        return gg
+        properties.forEach((property) => (property.metadata = instruction))
+        return properties
       })
       .flat()
   }, [references, schemaQueries])
@@ -58,8 +58,8 @@ export const AutoMapping: FC<AutoMappingProps> = ({ formData, formContext, onCha
   const schema = useMemo(() => {
     if (!formData?.destination?.schema) return []
 
-    const hhh = validateSchemaFromDataURI(formData?.destination?.schema)
-    return hhh.schema ? getPropertyListFrom(hhh.schema) : []
+    const handler = validateSchemaFromDataURI(formData?.destination?.schema)
+    return handler.schema ? getPropertyListFrom(handler.schema) : []
   }, [formData?.destination?.schema])
 
   const handleMatching = () => {
@@ -67,7 +67,6 @@ export const AutoMapping: FC<AutoMappingProps> = ({ formData, formContext, onCha
 
     const inst = schema.reduce<Instruction[]>((acc, cur) => {
       const bestMatch = findBestMatch(cur, displayedSchemas, null)
-      console.log('XXXXXX mat', bestMatch)
       if (bestMatch?.value) {
         const { id, type } = bestMatch.value.metadata || {}
         const ref: DataIdentifierReference = { id: id as string, type: type as DataIdentifierReference.type }
@@ -81,7 +80,6 @@ export const AutoMapping: FC<AutoMappingProps> = ({ formData, formContext, onCha
       return acc
     }, [])
 
-    console.log('XXXXXX mat', inst)
     onChange?.(inst)
   }
 

--- a/hivemq-edge/src/frontend/src/modules/Mappings/combiner/components/AutoMapping.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/combiner/components/AutoMapping.tsx
@@ -2,7 +2,7 @@ import { type FC, useMemo } from 'react'
 import type { JSONSchema7 } from 'json-schema'
 import { useTranslation } from 'react-i18next'
 import { Icon } from '@chakra-ui/react'
-import { FaRightFromBracket } from 'react-icons/fa6'
+import { LuWand2 } from 'react-icons/lu'
 
 import type { DataCombining, DataIdentifierReference, Instruction } from '@/api/__generated__'
 import { useGetCombinedDataSchemas } from '@/api/hooks/useDomainModel/useGetCombinedDataSchemas'
@@ -86,7 +86,7 @@ export const AutoMapping: FC<AutoMappingProps> = ({ formData, formContext, onCha
   return (
     <IconButton
       isDisabled={!(schema.length && displayedSchemas.length)}
-      icon={<Icon as={FaRightFromBracket} />}
+      icon={<Icon as={LuWand2} />}
       aria-label={t('combiner.schema.mapping.action.generateMappings')}
       onClick={handleMatching}
     />

--- a/hivemq-edge/src/frontend/src/modules/Mappings/combiner/components/AutoMapping.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/combiner/components/AutoMapping.tsx
@@ -1,0 +1,96 @@
+import { type FC, useMemo } from 'react'
+import type { JSONSchema7 } from 'json-schema'
+import { useTranslation } from 'react-i18next'
+import { Icon } from '@chakra-ui/react'
+import { FaRightFromBracket } from 'react-icons/fa6'
+
+import type { DataCombining, DataIdentifierReference, Instruction } from '@/api/__generated__'
+import { useGetCombinedDataSchemas } from '@/api/hooks/useDomainModel/useGetCombinedDataSchemas'
+import IconButton from '@/components/Chakra/IconButton'
+import { getPropertyListFrom } from '@/components/rjsf/MqttTransformation/utils/json-schema.utils'
+import { toJsonPath } from '@/components/rjsf/MqttTransformation/utils/data-type.utils'
+import { validateSchemaFromDataURI } from '@/modules/TopicFilters/utils/topic-filter.schema'
+import {
+  findBestMatch,
+  getFilteredDataReferences,
+  getSchemasFromReferences,
+} from '@/modules/Mappings/utils/combining.utils'
+import type { CombinerContext } from '../../types'
+
+interface AutoMappingProps {
+  id?: string
+  formData?: DataCombining
+  formContext?: CombinerContext
+  onChange?: (instructions: Instruction[]) => void
+}
+
+export const AutoMapping: FC<AutoMappingProps> = ({ formData, formContext, onChange }) => {
+  const { t } = useTranslation()
+
+  // TODO[NVL] This is almost a duplicate of the CombinedEntitySelect; reuse
+  const references = useMemo(() => {
+    return getFilteredDataReferences(formData, formContext)
+  }, [formContext, formData])
+
+  const schemaQueries = useGetCombinedDataSchemas(references)
+
+  const displayedSchemas = useMemo(() => {
+    const dataRef = getSchemasFromReferences(references, schemaQueries)
+    const schemas = dataRef.filter(
+      (dataReference) => dataReference.schema?.status === 'success' && Boolean(dataReference.schema.schema)
+    )
+
+    return schemas
+      .map((e) => {
+        const gg = getPropertyListFrom(e.schema?.schema as JSONSchema7)
+
+        const instruction: DataIdentifierReference = {
+          id: e.id as string,
+          type: e.type as DataIdentifierReference.type,
+        }
+
+        gg.forEach((e) => (e.metadata = instruction))
+        return gg
+      })
+      .flat()
+  }, [references, schemaQueries])
+
+  const schema = useMemo(() => {
+    if (!formData?.destination?.schema) return []
+
+    const hhh = validateSchemaFromDataURI(formData?.destination?.schema)
+    return hhh.schema ? getPropertyListFrom(hhh.schema) : []
+  }, [formData?.destination?.schema])
+
+  const handleMatching = () => {
+    if (!schema.length) return
+
+    const inst = schema.reduce<Instruction[]>((acc, cur) => {
+      const bestMatch = findBestMatch(cur, displayedSchemas, null)
+      console.log('XXXXXX mat', bestMatch)
+      if (bestMatch?.value) {
+        const { id, type } = bestMatch.value.metadata || {}
+        const ref: DataIdentifierReference = { id: id as string, type: type as DataIdentifierReference.type }
+        const instruction = {
+          sourceRef: ref,
+          destination: toJsonPath([...cur.path, cur.key].join('.')),
+          source: toJsonPath([...bestMatch.value.path, bestMatch.value.key].join('.')),
+        }
+        acc.push(instruction)
+      }
+      return acc
+    }, [])
+
+    console.log('XXXXXX mat', inst)
+    onChange?.(inst)
+  }
+
+  return (
+    <IconButton
+      isDisabled={!(schema.length && displayedSchemas.length)}
+      icon={<Icon as={FaRightFromBracket} />}
+      aria-label={t('combiner.schema.mapping.action.generateMappings')}
+      onClick={handleMatching}
+    />
+  )
+}

--- a/hivemq-edge/src/frontend/src/modules/Mappings/combiner/components/ClearMappings.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/combiner/components/ClearMappings.spec.cy.tsx
@@ -1,0 +1,58 @@
+import type { DataCombining, Instruction } from '@/api/__generated__'
+import { DataIdentifierReference } from '@/api/__generated__'
+
+import { ClearMappings } from './ClearMappings'
+
+const mockFormData: DataCombining = {
+  id: '58677276-fc48-4a9a-880c-41c755f5063b',
+  sources: {
+    primary: { id: 'my/tag/t1', type: DataIdentifierReference.type.TAG },
+    tags: ['my/tag/t1', 'my/tag/t3'],
+    topicFilters: ['my/topic/+/temp'],
+  },
+  destination: { topic: 'my/topic' },
+  instructions: [],
+}
+
+const mockInstructions: Instruction[] = [
+  {
+    source: '$.dropped-property',
+    destination: '$.lastName',
+  },
+]
+
+describe('ClearMappings', () => {
+  beforeEach(() => {
+    cy.viewport(800, 800)
+  })
+
+  it('should render properly', () => {
+    const onClick = cy.stub().as('onClick')
+
+    cy.mountWithProviders(
+      <ClearMappings formData={{ ...mockFormData, instructions: mockInstructions }} onChange={onClick} />
+    )
+
+    cy.get('button').should('have.attr', 'aria-label', 'Clear mappings')
+    cy.get('button').should('not.be.disabled')
+
+    cy.get('@onClick').should('not.have.been.called')
+    cy.get('button').click()
+    cy.get('@onClick').should('have.been.called')
+  })
+
+  it('should render properly with no data', () => {
+    cy.mountWithProviders(<ClearMappings formData={mockFormData} onChange={cy.stub} />)
+    cy.get('button').should('have.attr', 'aria-label', 'Clear mappings')
+    cy.get('button').should('be.disabled')
+  })
+
+  it('should be accessible', () => {
+    cy.injectAxe()
+    cy.mountWithProviders(
+      <ClearMappings formData={{ ...mockFormData, instructions: mockInstructions }} onChange={cy.stub} />
+    )
+
+    cy.checkAccessibility()
+  })
+})

--- a/hivemq-edge/src/frontend/src/modules/Mappings/combiner/components/ClearMappings.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/combiner/components/ClearMappings.tsx
@@ -1,0 +1,25 @@
+import { Icon } from '@chakra-ui/react'
+import type { FC } from 'react'
+import { useTranslation } from 'react-i18next'
+import { RiDeleteBin2Fill } from 'react-icons/ri'
+
+import type { DataCombining, Instruction } from '@/api/__generated__'
+import IconButton from '@/components/Chakra/IconButton'
+
+interface ClearMappingsProps {
+  formData?: DataCombining
+  onChange?: (instructions: Instruction[]) => void
+}
+
+export const ClearMappings: FC<ClearMappingsProps> = ({ onChange, formData }) => {
+  const { t } = useTranslation()
+
+  return (
+    <IconButton
+      isDisabled={!formData?.instructions?.length}
+      icon={<Icon as={RiDeleteBin2Fill} />}
+      aria-label={t('combiner.schema.mapping.action.clearMappings')}
+      onClick={() => onChange?.([])}
+    />
+  )
+}

--- a/hivemq-edge/src/frontend/src/modules/Mappings/utils/combining.utils.spec.ts
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/utils/combining.utils.spec.ts
@@ -14,6 +14,7 @@ import { mappingHandlers } from '@/api/hooks/useProtocolAdapters/__handlers__/ma
 import { MOCK_DEVICE_TAGS } from '@/api/hooks/useProtocolAdapters/__handlers__'
 import { handlers, MOCK_TOPIC_FILTER } from '@/api/hooks/useTopicFilters/__handlers__'
 
+import type { AutoMatchAccumulator } from './combining.utils'
 import { findBestMatch, getCombinedDataEntityReference, getSchemasFromReferences } from './combining.utils'
 import type { FlatJSONSchema7 } from '../../../components/rjsf/MqttTransformation/utils/json-schema.utils'
 
@@ -162,11 +163,11 @@ describe('getSchemasFromReferences', () => {
   })
 })
 
-interface TestMAtchSuite {
+interface TestMatchSuite {
   test: string
   source: FlatJSONSchema7
   candidates: FlatJSONSchema7[]
-  result: FlatJSONSchema7 | undefined
+  result: AutoMatchAccumulator | undefined
   min?: number | null
 }
 
@@ -175,8 +176,8 @@ const mocProperty: FlatJSONSchema7 = {
   key: 'test_string1',
 }
 
-const tests: TestMAtchSuite[] = [
-  { test: 'same source', source: mocProperty, candidates: [mocProperty], result: mocProperty },
+const tests: TestMatchSuite[] = [
+  { test: 'same source', source: mocProperty, candidates: [mocProperty], result: { distance: 0, value: mocProperty } },
   {
     test: 'same source',
     source: mocProperty,
@@ -184,7 +185,7 @@ const tests: TestMAtchSuite[] = [
       { path: [], key: 'aaaa' },
       { path: [], key: 'test_string2' },
     ],
-    result: { path: [], key: 'test_string2' },
+    result: { distance: 1, value: { path: [], key: 'test_string2' } },
   },
   {
     test: 'same source',
@@ -198,7 +199,7 @@ const tests: TestMAtchSuite[] = [
 ]
 
 describe('findBestMatch', () => {
-  it.each<TestMAtchSuite>(tests)('should work for $test', ({ source, candidates, result }) => {
+  it.each<TestMatchSuite>(tests)('should work for $test', ({ source, candidates, result }) => {
     expect(findBestMatch(source, candidates)).toStrictEqual(result)
   })
 })

--- a/hivemq-edge/src/frontend/src/modules/Mappings/utils/combining.utils.spec.ts
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/utils/combining.utils.spec.ts
@@ -14,7 +14,8 @@ import { mappingHandlers } from '@/api/hooks/useProtocolAdapters/__handlers__/ma
 import { MOCK_DEVICE_TAGS } from '@/api/hooks/useProtocolAdapters/__handlers__'
 import { handlers, MOCK_TOPIC_FILTER } from '@/api/hooks/useTopicFilters/__handlers__'
 
-import { getCombinedDataEntityReference, getSchemasFromReferences } from './combining.utils'
+import { findBestMatch, getCombinedDataEntityReference, getSchemasFromReferences } from './combining.utils'
+import type { FlatJSONSchema7 } from '../../../components/rjsf/MqttTransformation/utils/json-schema.utils'
 
 interface TestEachSuite {
   test: string
@@ -158,5 +159,46 @@ describe('getSchemasFromReferences', () => {
         }),
       }),
     ])
+  })
+})
+
+interface TestMAtchSuite {
+  test: string
+  source: FlatJSONSchema7
+  candidates: FlatJSONSchema7[]
+  result: FlatJSONSchema7 | undefined
+  min?: number | null
+}
+
+const mocProperty: FlatJSONSchema7 = {
+  path: [],
+  key: 'test_string1',
+}
+
+const tests: TestMAtchSuite[] = [
+  { test: 'same source', source: mocProperty, candidates: [mocProperty], result: mocProperty },
+  {
+    test: 'same source',
+    source: mocProperty,
+    candidates: [
+      { path: [], key: 'aaaa' },
+      { path: [], key: 'test_string2' },
+    ],
+    result: { path: [], key: 'test_string2' },
+  },
+  {
+    test: 'same source',
+    source: mocProperty,
+    candidates: [
+      { path: [], key: 'aaaa' },
+      { path: [], key: 'bbbb' },
+    ],
+    result: undefined,
+  },
+]
+
+describe('findBestMatch', () => {
+  it.each<TestMAtchSuite>(tests)('should work for $test', ({ source, candidates, result }) => {
+    expect(findBestMatch(source, candidates)).toStrictEqual(result)
   })
 })

--- a/hivemq-edge/src/frontend/src/modules/Mappings/utils/combining.utils.ts
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/utils/combining.utils.ts
@@ -9,6 +9,9 @@ import {
   type TopicFilter,
 } from '@/api/__generated__'
 import type { DataReference } from '@/api/hooks/useDomainModel/useGetCombinedDataSchemas'
+import { AUTO_MATCH_DISTANCE } from '@/components/rjsf/BatchModeMappings/utils/config.utils'
+import levenshtein from '@/components/rjsf/BatchModeMappings/utils/levenshtein.utils'
+import type { FlatJSONSchema7 } from '@/components/rjsf/MqttTransformation/utils/json-schema.utils'
 import type { CombinerContext } from '@/modules/Mappings/types'
 import { validateSchemaFromDataURI } from '@/modules/TopicFilters/utils/topic-filter.schema'
 
@@ -101,4 +104,35 @@ export const getSchemasFromReferences = (
     }
     return dataReference
   })
+}
+
+type AutoMatchAccumulator = {
+  distance: number
+  value: FlatJSONSchema7
+}
+
+/**
+ *
+ * @param source
+ * @param candidates
+ * @param minDistance The minimum Levenshtein distance for a match, `null` for the best candidate
+ */
+export const findBestMatch = (
+  source: FlatJSONSchema7,
+  candidates: FlatJSONSchema7[],
+  minDistance: number | null = AUTO_MATCH_DISTANCE
+): AutoMatchAccumulator | undefined => {
+  const smallestValue = candidates.reduce<AutoMatchAccumulator>((acc, property) => {
+    const fullPath = (property: FlatJSONSchema7) => [...property.path, property.key].join('.')
+
+    if (source.type !== property.type) return acc
+
+    const distance = Math.min(
+      ...[levenshtein(property.key, source.key), levenshtein(fullPath(property), fullPath(source))]
+    )
+    return distance < acc.distance || acc.distance === undefined ? { value: property, distance } : acc
+  }, {} as AutoMatchAccumulator)
+
+  if (minDistance === null) return smallestValue
+  return smallestValue.distance <= minDistance ? smallestValue : undefined
 }

--- a/hivemq-edge/src/frontend/src/modules/Mappings/utils/combining.utils.ts
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/utils/combining.utils.ts
@@ -106,7 +106,7 @@ export const getSchemasFromReferences = (
   })
 }
 
-type AutoMatchAccumulator = {
+export type AutoMatchAccumulator = {
   distance: number
   value: FlatJSONSchema7
 }


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/31587/details/

The PR adds the option for the end-user to generate some suggested mappings for the instructions. Suggestion are made by finding the best match between properties on the sources and properties on the destination sides of the combiner.

### Design
- Matching is determined by the similarity between the names of the properties, ensuring equality of type.
- The similarity is computed by the Levenshten string metrics
- A threshold is defined internally for the  best find
- The process used ensures that the best match, regardless of the threshold will be proposed

### Out-of-scope
- The parameters of the matching routine are hard-coded. There is some value in allowing end-users to specify different values, it will be done in subsequent ticket 

### Before
![HiveMQ-Edge-04-15-2025_15_54 (1)](https://github.com/user-attachments/assets/a63dc659-5a91-48ed-a01c-4aceb9de6d86)

### After
![HiveMQ-Edge-04-15-2025_15_54](https://github.com/user-attachments/assets/baf38a10-e0ce-40f7-ae96-7b563937a121)

