### PR TITLE
fix(32398): Fix the rendering of combiner events in the Event Log

### DIFF
--- a/hivemq-edge/src/frontend/src/modules/EventLog/components/SourceLink.tsx
+++ b/hivemq-edge/src/frontend/src/modules/EventLog/components/SourceLink.tsx
@@ -7,6 +7,7 @@ import { MdOutlineEventNote } from 'react-icons/md'
 import { TypeIdentifier } from '@/api/__generated__'
 import type { AdapterNavigateState } from '@/modules/ProtocolAdapters/types.ts'
 import { ProtocolAdapterTabIndex } from '@/modules/ProtocolAdapters/types.ts'
+import { SourceCombiner } from './table/SourceCombiner'
 
 interface SourceLinkProps {
   source: TypeIdentifier | undefined
@@ -40,6 +41,10 @@ const SourceLink: FC<SourceLinkProps> = ({ source, type }) => {
     case TypeIdentifier.type.USER:
       icon = <Icon as={PiUserFill} mr={2} />
       break
+    // TODO[31411] The COMBINER type identifier is missing from the OpenAPI specs
+    // @ts-ignore
+    case 'DATA_COMBINING':
+      return <SourceCombiner source={source} />
     default:
       break
   }

--- a/hivemq-edge/src/frontend/src/modules/EventLog/components/SourceLink.tsx
+++ b/hivemq-edge/src/frontend/src/modules/EventLog/components/SourceLink.tsx
@@ -21,7 +21,7 @@ const SourceLink: FC<SourceLinkProps> = ({ source, type }) => {
 
   switch (source?.type) {
     case TypeIdentifier.type.ADAPTER:
-      icon = <Icon as={PiPlugsConnectedFill} mr={2} />
+      icon = <Icon as={PiPlugsConnectedFill} mr={2} data-type={TypeIdentifier.type.ADAPTER} />
       state = {
         protocolAdapterTabIndex: ProtocolAdapterTabIndex.ADAPTERS,
         protocolAdapterType: type?.identifier,
@@ -29,17 +29,17 @@ const SourceLink: FC<SourceLinkProps> = ({ source, type }) => {
       to = `/protocol-adapters/edit/${type?.identifier}/${source.identifier}`
       break
     case TypeIdentifier.type.ADAPTER_TYPE:
-      icon = <Icon as={PiPlugsConnectedFill} mr={2} />
+      icon = <Icon as={PiPlugsConnectedFill} mr={2} data-type={TypeIdentifier.type.ADAPTER_TYPE} />
       break
     case TypeIdentifier.type.BRIDGE:
-      icon = <Icon as={PiBridgeThin} fontSize="20px" mr={2} />
+      icon = <Icon as={PiBridgeThin} fontSize="20px" mr={2} data-type={TypeIdentifier.type.BRIDGE} />
       to = `/mqtt-bridges/${source.identifier}`
       break
     case TypeIdentifier.type.EVENT:
-      icon = <Icon as={MdOutlineEventNote} mr={2} />
+      icon = <Icon as={MdOutlineEventNote} mr={2} data-type={TypeIdentifier.type.EVENT} />
       break
     case TypeIdentifier.type.USER:
-      icon = <Icon as={PiUserFill} mr={2} />
+      icon = <Icon as={PiUserFill} mr={2} data-type={TypeIdentifier.type.USER} />
       break
     // TODO[31411] The COMBINER type identifier is missing from the OpenAPI specs
     // @ts-ignore
@@ -57,7 +57,14 @@ const SourceLink: FC<SourceLinkProps> = ({ source, type }) => {
     )
 
   return (
-    <ChakraLink as={ReactRouterLink} to={to} state={state} whiteSpace="nowrap" display="inline-flex">
+    <ChakraLink
+      as={ReactRouterLink}
+      to={to}
+      state={state}
+      whiteSpace="nowrap"
+      display="inline-flex"
+      alignItems="center"
+    >
       {Boolean(icon) && icon}
       {source?.identifier}
     </ChakraLink>

--- a/hivemq-edge/src/frontend/src/modules/EventLog/components/table/SourceCombiner.spec.cy.tsx
+++ b/hivemq-edge/src/frontend/src/modules/EventLog/components/table/SourceCombiner.spec.cy.tsx
@@ -1,0 +1,42 @@
+import type { TypeIdentifier } from '@/api/__generated__'
+import { mockCombiner, mockCombinerId } from '@/api/hooks/useCombiners/__handlers__'
+
+import { SourceCombiner } from './SourceCombiner'
+
+const mockCombinerIdentifier: TypeIdentifier = {
+  // TODO[31411] The COMBINER type identifier is missing from the OpenAPI specs
+  // @ts-ignore
+  type: 'DATA_COMBINING',
+  identifier: mockCombinerId,
+}
+
+describe('SourceCombiner', () => {
+  beforeEach(() => {
+    cy.viewport(800, 600)
+  })
+
+  it('should render properly', () => {
+    cy.intercept('GET', '/api/v1/management/combiners/**', mockCombiner)
+    cy.mountWithProviders(<SourceCombiner source={mockCombinerIdentifier} />)
+
+    cy.get('a').should('have.text', 'my-combiner')
+    cy.get('a').should('have.attr', 'href', `/workspace/combiner/${mockCombinerId}`)
+
+    cy.get('a > svg').should('have.attr', 'data-type', 'DATA_COMBINING')
+  })
+
+  it('should render non-existent combiner', () => {
+    cy.intercept('GET', '/api/v1/management/combiners/**', { statusCode: 404 })
+    cy.mountWithProviders(<SourceCombiner source={mockCombinerIdentifier} />)
+
+    cy.get('a').should('not.exist')
+    cy.get('p').should('have.text', mockCombinerId)
+  })
+
+  it('should be accessible', () => {
+    cy.intercept('GET', '/api/v1/management/combiners/**', mockCombiner)
+    cy.injectAxe()
+    cy.mountWithProviders(<SourceCombiner source={mockCombinerIdentifier} />)
+    cy.checkAccessibility()
+  })
+})

--- a/hivemq-edge/src/frontend/src/modules/EventLog/components/table/SourceCombiner.tsx
+++ b/hivemq-edge/src/frontend/src/modules/EventLog/components/table/SourceCombiner.tsx
@@ -23,9 +23,10 @@ export const SourceCombiner: FC<SourceLinkProps> = ({ source }) => {
       to={`/workspace/combiner/${source.identifier}`}
       whiteSpace="nowrap"
       display="inline-flex"
+      alignItems="center"
     >
-      <Icon as={HqCombiner} mr={2} fontSize="1rem" />
-      <Text>{visibleName}</Text>
+      <Icon as={HqCombiner} mr={2} data-type="DATA_COMBINING" />
+      {visibleName}
     </ChakraLink>
   )
 }

--- a/hivemq-edge/src/frontend/src/modules/EventLog/components/table/SourceCombiner.tsx
+++ b/hivemq-edge/src/frontend/src/modules/EventLog/components/table/SourceCombiner.tsx
@@ -1,0 +1,31 @@
+import type { FC } from 'react'
+import { Link as ReactRouterLink } from 'react-router-dom'
+import { Icon, Link as ChakraLink, Text } from '@chakra-ui/react'
+
+import type { TypeIdentifier } from '@/api/__generated__'
+import { useGetCombiner } from '@/api/hooks/useCombiners'
+import { HqCombiner } from '@/components/Icons'
+
+interface SourceLinkProps {
+  source: TypeIdentifier
+}
+
+export const SourceCombiner: FC<SourceLinkProps> = ({ source }) => {
+  const { data, isSuccess } = useGetCombiner(source.identifier as string)
+
+  const isExisting = isSuccess && Boolean(data)
+  if (!isExisting) return <Text>{source?.identifier}</Text>
+
+  const visibleName = isSuccess && data.name ? data?.name : source?.identifier
+  return (
+    <ChakraLink
+      as={ReactRouterLink}
+      to={`/workspace/combiner/${source.identifier}`}
+      whiteSpace="nowrap"
+      display="inline-flex"
+    >
+      <Icon as={HqCombiner} mr={2} fontSize="1rem" />
+      <Text>{visibleName}</Text>
+    </ChakraLink>
+  )
+}


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/32398/details/

The PR fixes the rendering of `Combiner` sources in the `Event Log`, making events consistent with other sources like `Adapter` or `Bridge`

### Design
- If the `Combiner` doesn't exist anymore, the `id` is simply rendered as it is
- If the `Combiner` still exists, the `name` (if defined) is displayed with the combiner icon and a link that redirects to the `Combiner` configuration panel on the `Workspace`

### Out-of-scope
- Filtering sources is still based on the internal values received by the API, i.e. the `id`. It creates a discrepancy between displayed and filtered values. This will be fixed in a future ticket.