### PR TITLE
fix(31360): Add custom validation to the Combiner's mapping editor

### DIFF
--- a/hivemq-edge/src/frontend/src/modules/Mappings/CombinerMappingManager.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/CombinerMappingManager.tsx
@@ -64,7 +64,7 @@ const CombinerMappingManager: FC = () => {
   }, [selectedNode?.data?.sources?.items])
 
   const sources = useGetCombinedEntities(entities)
-  const validateCombiner = useValidateCombiner(sources, entities)
+  const validator = useValidateCombiner(sources, entities)
   const updateCombiner = useUpdateCombiner()
   const deleteCombiner = useDeleteCombiner()
 
@@ -137,7 +137,7 @@ const CombinerMappingManager: FC = () => {
               formData={selectedNode.data}
               onSubmit={handleOnSubmit}
               formContext={{ queries: sources, entities } as CombinerContext}
-              customValidate={validateCombiner}
+              customValidate={validator?.validateCombiner}
             />
           )}
         </DrawerBody>

--- a/hivemq-edge/src/frontend/src/modules/Mappings/combiner/DataCombiningEditorDrawer.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/combiner/DataCombiningEditorDrawer.tsx
@@ -1,3 +1,4 @@
+import type { UseQueryResult } from '@tanstack/react-query'
 import type { FC } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { RJSFSchema, UiSchema } from '@rjsf/utils'
@@ -15,9 +16,10 @@ import {
   DrawerOverlay,
   useBoolean,
 } from '@chakra-ui/react'
-import type { DataCombining } from '@/api/__generated__'
+import type { DataCombining, DomainTagList, EntityReference, TopicFilterList } from '@/api/__generated__'
 import ChakraRJSForm from '@/components/rjsf/Form/ChakraRJSForm'
 import DrawerExpandButton from '@/components/Chakra/DrawerExpandButton.tsx'
+import { useValidateCombiner } from '../hooks/useValidateCombiner'
 import type { CombinerContext } from '../types'
 
 interface MappingDrawerProps<T> {
@@ -32,6 +34,10 @@ interface MappingDrawerProps<T> {
 const DataCombiningEditorDrawer: FC<MappingDrawerProps<DataCombining>> = ({ onClose, onSubmit, ...props }) => {
   const { t } = useTranslation()
   const [isExpanded, setExpanded] = useBoolean(true)
+  const validator = useValidateCombiner(
+    props.formContext?.queries as UseQueryResult<DomainTagList | TopicFilterList, Error>[],
+    props.formContext?.entities as EntityReference[]
+  )
 
   return (
     <Drawer isOpen={true} placement="right" size={isExpanded ? 'full' : 'lg'} onClose={onClose} variant="hivemq">
@@ -54,6 +60,7 @@ const DataCombiningEditorDrawer: FC<MappingDrawerProps<DataCombining>> = ({ onCl
                 onSubmit={(e) => {
                   onSubmit(e.formData)
                 }}
+                customValidate={validator?.validateCombining}
               />
             </CardBody>
           </Card>

--- a/hivemq-edge/src/frontend/src/modules/Mappings/combiner/DataCombiningEditorDrawer.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/combiner/DataCombiningEditorDrawer.tsx
@@ -1,4 +1,3 @@
-import type { UseQueryResult } from '@tanstack/react-query'
 import type { FC } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { RJSFSchema, UiSchema } from '@rjsf/utils'
@@ -16,7 +15,7 @@ import {
   DrawerOverlay,
   useBoolean,
 } from '@chakra-ui/react'
-import type { DataCombining, DomainTagList, EntityReference, TopicFilterList } from '@/api/__generated__'
+import type { DataCombining } from '@/api/__generated__'
 import ChakraRJSForm from '@/components/rjsf/Form/ChakraRJSForm'
 import DrawerExpandButton from '@/components/Chakra/DrawerExpandButton.tsx'
 import { useValidateCombiner } from '../hooks/useValidateCombiner'
@@ -34,10 +33,7 @@ interface MappingDrawerProps<T> {
 const DataCombiningEditorDrawer: FC<MappingDrawerProps<DataCombining>> = ({ onClose, onSubmit, ...props }) => {
   const { t } = useTranslation()
   const [isExpanded, setExpanded] = useBoolean(true)
-  const validator = useValidateCombiner(
-    props.formContext?.queries as UseQueryResult<DomainTagList | TopicFilterList, Error>[],
-    props.formContext?.entities as EntityReference[]
-  )
+  const validator = useValidateCombiner(props.formContext?.queries || [], props.formContext?.entities || [])
 
   return (
     <Drawer isOpen={true} placement="right" size={isExpanded ? 'full' : 'lg'} onClose={onClose} variant="hivemq">

--- a/hivemq-edge/src/frontend/src/modules/Mappings/combiner/DataCombiningEditorField.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/combiner/DataCombiningEditorField.tsx
@@ -44,10 +44,14 @@ export const DataCombiningEditorField: FC<FieldProps<DataCombining, RJSFSchema, 
   const destTopicOptions = getUiOptions(uiSchema?.destination?.topic)
   const destSchemaOptions = getUiOptions(uiSchema?.destination?.schema)
 
-  const sourceError = props.errorSchema?.sources?.__errors
-  const primaryError = props.errorSchema?.sources?.primary?.__errors
-  const destinationError = props.errorSchema?.destination?.topic?.__errors
-  // TODO[RJSF] Create a custom error message, ensuring tag + topic filters >= 1
+  const sourceErrors = props.errorSchema?.sources?.__errors
+  const primaryErrors = props.errorSchema?.sources?.primary?.__errors
+  const destinationErrors = props.errorSchema?.destination?.topic?.__errors
+  const destinationSchemaErrors = props.errorSchema?.destination?.schema?.__errors
+
+  const hasError = (field?: string[]) => {
+    return Boolean(field?.length)
+  }
 
   return (
     <Grid templateColumns="1fr repeat(2, 1px) 1fr" rowGap={4} columnGap={6}>
@@ -88,7 +92,7 @@ export const DataCombiningEditorField: FC<FieldProps<DataCombining, RJSFSchema, 
         )}
       </GridItem>
       <GridItem colSpan={2} data-testid={'combining-editor-sources-attributes'}>
-        <FormControl isInvalid={Boolean(sourceError)}>
+        <FormControl isInvalid={hasError(sourceErrors)}>
           <FormLabel>{t('combiner.schema.mappings.sources.combinedData.title')}</FormLabel>
           <CombinedEntitySelect
             tags={formData?.sources?.tags}
@@ -122,14 +126,14 @@ export const DataCombiningEditorField: FC<FieldProps<DataCombining, RJSFSchema, 
               })
             }}
           />
-          {!sourceError && (
+          {!hasError(sourceErrors) && (
             <FormHelperText>{t('combiner.schema.mappings.sources.combinedData.description')}</FormHelperText>
           )}
-          <FormErrorMessage>{sourceError?.join(' ')}</FormErrorMessage>
+          <FormErrorMessage>{sourceErrors?.join(' ')}</FormErrorMessage>
         </FormControl>
       </GridItem>
       <GridItem colSpan={2} data-testid={'combining-editor-destination-topic'}>
-        <FormControl isInvalid={Boolean(destinationError)}>
+        <FormControl isInvalid={hasError(destinationErrors)}>
           <FormLabel>{destTopicOptions.title}</FormLabel>
           <SelectTopic
             isMulti={false}
@@ -143,16 +147,16 @@ export const DataCombiningEditorField: FC<FieldProps<DataCombining, RJSFSchema, 
               else if (!topic) props.onChange({ ...props.formData, destination: { topic: '' } })
             }}
           />
-          {!destinationError && <FormHelperText>{destTopicOptions.description}</FormHelperText>}
+          {!hasError(destinationErrors) && <FormHelperText>{destTopicOptions.description}</FormHelperText>}
 
-          <FormErrorMessage>{destinationError}</FormErrorMessage>
+          <FormErrorMessage>{destinationErrors}</FormErrorMessage>
         </FormControl>
       </GridItem>
       <GridItem data-testid={'combining-editor-sources-schemas'}>
         <FormControl>
           <FormLabel mt={1}>{t('combiner.schema.mappings.sources.combinedSchema.title')}</FormLabel>
           <CombinedSchemaLoader formData={props.formData} formContext={formContext} />
-          {!sourceError && (
+          {!hasError(sourceErrors) && (
             <FormHelperText>{t('combiner.schema.mappings.sources.combinedSchema.description')}</FormHelperText>
           )}
         </FormControl>
@@ -188,7 +192,7 @@ export const DataCombiningEditorField: FC<FieldProps<DataCombining, RJSFSchema, 
       </GridItem>
       <GridItem colSpan={2} data-testid={'combining-editor-destination-schema'}>
         <DestinationSchemaLoader
-          isInvalid={Boolean(destinationError)}
+          isInvalid={hasError(destinationSchemaErrors)}
           title={destSchemaOptions.title}
           description={destSchemaOptions.description}
           formData={props.formData}
@@ -213,7 +217,7 @@ export const DataCombiningEditorField: FC<FieldProps<DataCombining, RJSFSchema, 
         />
       </GridItem>
       <GridItem colSpan={2} data-testid={'combining-editor-sources-primary'}>
-        <FormControl isInvalid={Boolean(primaryError)}>
+        <FormControl isInvalid={hasError(primaryErrors)}>
           <FormLabel>{primaryOptions.title}</FormLabel>
           <PrimarySelect
             formData={formData}
@@ -236,7 +240,7 @@ export const DataCombiningEditorField: FC<FieldProps<DataCombining, RJSFSchema, 
               })
             }}
           />
-          {!primaryError && <FormHelperText>{primaryOptions.description}</FormHelperText>}
+          {!hasError(primaryErrors) && <FormHelperText>{primaryOptions.description}</FormHelperText>}
           <FormErrorMessage>{props.errorSchema?.sources?.primary?.__errors}</FormErrorMessage>
         </FormControl>
       </GridItem>

--- a/hivemq-edge/src/frontend/src/modules/Mappings/hooks/useValidateCombiner.spec.ts
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/hooks/useValidateCombiner.spec.ts
@@ -84,7 +84,7 @@ describe('useValidateCombiner', () => {
       expect(result.current).not.toBeUndefined()
     })
 
-    const formValidation = result.current?.(formData, errors)
+    const formValidation = result.current?.validateCombiner(formData, errors)
     return toErrorList(formValidation)
   }
 

--- a/hivemq-edge/src/frontend/src/modules/Mappings/hooks/useValidateCombiner.ts
+++ b/hivemq-edge/src/frontend/src/modules/Mappings/hooks/useValidateCombiner.ts
@@ -275,5 +275,19 @@ export const useValidateCombiner = (
     return errors
   }
 
-  return isSuccess ? validateCombiner : undefined
+  const validateCombining: CustomValidator<DataCombining, RJSFSchema, CombinerContext> = (formData, errors) => {
+    if (!formData) {
+      errors.addError(t('combiner.error.validation.notValidPayload'))
+      return errors
+    }
+
+    validateDataSources(formData, errors)
+    validateDataSourceSchemas(formData, errors)
+    validateDestinationSchema(formData, errors)
+    validateInstructions(formData, errors)
+
+    return errors
+  }
+
+  return isSuccess ? { validateCombiner, validateCombining } : undefined
 }


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/31360/details/

The PR add custom validations to the `Combiner`'s mapping editor.

It ensures that individual mappings are validated in the editor the same way they are all validated in the complete `Combiner`.

### Before
![HiveMQ-Edge-04-24-2025_14_21](https://github.com/user-attachments/assets/227df357-05dc-4dbd-9967-94700060499d)

### After
![HiveMQ-Edge-04-24-2025_14_20](https://github.com/user-attachments/assets/27268e38-dca5-4b4c-b716-9190bcf3bb54)

