### PR TITLE
fix(31787): Prevent non-WRITE adapter to access tag schemas

### DIFF
--- a/hivemq-edge/src/frontend/src/__test-utils__/rjsf/CustomFormTesting.tsx
+++ b/hivemq-edge/src/frontend/src/__test-utils__/rjsf/CustomFormTesting.tsx
@@ -11,7 +11,10 @@ import { ObjectFieldTemplate } from '@/components/rjsf/ObjectFieldTemplate'
 import { DescriptionFieldTemplate, ErrorListTemplate, TitleFieldTemplate } from '@/components/rjsf/Templates'
 
 interface CustomFormTestingProps
-  extends Pick<FormProps<unknown>, 'schema' | 'uiSchema' | 'formData' | 'onChange' | 'onSubmit' | 'onError'> {
+  extends Pick<
+    FormProps<unknown>,
+    'schema' | 'uiSchema' | 'formData' | 'onChange' | 'onSubmit' | 'onError' | 'formContext'
+  > {
   id?: string
 }
 
@@ -19,6 +22,7 @@ export const CustomFormTesting: FC<CustomFormTestingProps> = ({
   schema,
   uiSchema,
   formData,
+  formContext,
   onChange,
   onError,
   onSubmit,
@@ -29,6 +33,7 @@ export const CustomFormTesting: FC<CustomFormTestingProps> = ({
       validator={validator}
       uiSchema={uiSchema}
       formData={formData}
+      formContext={formContext}
       onChange={onChange}
       onError={onError}
       onSubmit={onSubmit}

--- a/hivemq-edge/src/frontend/src/locales/en/translation.json
+++ b/hivemq-edge/src/frontend/src/locales/en/translation.json
@@ -634,7 +634,7 @@
           "edit": "Edit the tag",
           "delete": "Delete the tag",
           "add": "Add a new tag",
-          "schema": "View the schema",
+          "schema": "View the WRITE schema",
           "submit": "Submit"
         }
       },

--- a/hivemq-edge/src/frontend/src/modules/Device/components/DeviceTagList.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Device/components/DeviceTagList.tsx
@@ -26,7 +26,7 @@ const DeviceTagList: FC<DeviceTagListProps> = ({ adapter, onClose }) => {
 
   const formContext: DeviceTagListContext = {
     adapterId: adapter.id,
-    capabilities: capabilities,
+    capabilities,
   }
 
   return (

--- a/hivemq-edge/src/frontend/src/modules/Device/components/DeviceTagList.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Device/components/DeviceTagList.tsx
@@ -16,7 +16,7 @@ interface DeviceTagListProps {
 
 const DeviceTagList: FC<DeviceTagListProps> = ({ adapter, onClose }) => {
   const { t } = useTranslation()
-  const { isLoading, isError, context, onupdateCollection } = useTagManager(adapter.id)
+  const { isLoading, isError, context, onupdateCollection, capabilities } = useTagManager(adapter.id)
 
   const onHandleSubmit = (data: IChangeEvent) => {
     if (!data.formData) return
@@ -26,6 +26,7 @@ const DeviceTagList: FC<DeviceTagListProps> = ({ adapter, onClose }) => {
 
   const formContext: DeviceTagListContext = {
     adapterId: adapter.id,
+    capabilities: capabilities,
   }
 
   return (

--- a/hivemq-edge/src/frontend/src/modules/Device/components/TagTableField.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Device/components/TagTableField.tsx
@@ -125,7 +125,7 @@ export const TagTableField: FC<FieldProps<DomainTag[], RJSFSchema, DeviceTagList
         },
       },
     ]
-  }, [adapterId, props, t])
+  }, [adapterId, capabilities, props, t])
   if (schema.type !== 'array') throw new Error('[RJSF] Cannot apply the template to the schema')
 
   const handleTagSubmit = (data: DomainTag | undefined) => {

--- a/hivemq-edge/src/frontend/src/modules/Device/components/TagTableField.tsx
+++ b/hivemq-edge/src/frontend/src/modules/Device/components/TagTableField.tsx
@@ -19,7 +19,7 @@ export const TagTableField: FC<FieldProps<DomainTag[], RJSFSchema, DeviceTagList
   const itemErrorColor = useToken('colors', useColorModeValue('red.100', 'rgba(254, 178, 178, 0.16)'))
 
   const { schema, registry, uiSchema } = props
-  const { adapterId } = props.formContext || {}
+  const { adapterId, capabilities } = props.formContext || {}
 
   const fieldOptions = getUiOptions(uiSchema)
 
@@ -91,21 +91,23 @@ export const TagTableField: FC<FieldProps<DomainTag[], RJSFSchema, DeviceTagList
                   onClick={() => handleDelete(info.row.index)}
                 />
               </ButtonGroup>
-              <TagSchemaDrawer
-                tag={info.row.original}
-                adapterId={adapterId as string}
-                trigger={({ onOpen: onOpenArrayDrawer }) => (
-                  <ButtonGroup size="sm">
-                    <IconButton
-                      data-testid={'tag-list-schema'}
-                      aria-label={t('device.drawer.table.actions.schema')}
-                      icon={<LuView />}
-                      onClick={onOpenArrayDrawer}
-                      isDisabled={isSchemaError(info.row.index)}
-                    />
-                  </ButtonGroup>
-                )}
-              />
+              {capabilities?.includes('WRITE') && (
+                <TagSchemaDrawer
+                  tag={info.row.original}
+                  adapterId={adapterId as string}
+                  trigger={({ onOpen: onOpenArrayDrawer }) => (
+                    <ButtonGroup size="sm">
+                      <IconButton
+                        data-testid={'tag-list-schema'}
+                        aria-label={t('device.drawer.table.actions.schema')}
+                        icon={<LuView />}
+                        onClick={onOpenArrayDrawer}
+                        isDisabled={isSchemaError(info.row.index)}
+                      />
+                    </ButtonGroup>
+                  )}
+                />
+              )}
             </ButtonGroup>
           )
         },

--- a/hivemq-edge/src/frontend/src/modules/Device/hooks/useTagManager.spec.ts
+++ b/hivemq-edge/src/frontend/src/modules/Device/hooks/useTagManager.spec.ts
@@ -79,6 +79,7 @@ describe('useTagManager', () => {
         isError: true,
         isLoading: false,
         isPending: false,
+        capabilities: undefined,
       })
     )
   })
@@ -173,6 +174,7 @@ describe('useTagManager', () => {
     expect(result.current.onDelete).toBeTypeOf('function')
     expect(result.current.onUpdate).toBeTypeOf('function')
     expect(result.current.onupdateCollection).toBeTypeOf('function')
+    expect(result.current.capabilities).toStrictEqual(['READ', 'DISCOVER', 'WRITE', 'COMBINE'])
   })
 
   it('should do it properly', async () => {

--- a/hivemq-edge/src/frontend/src/modules/Device/hooks/useTagManager.ts
+++ b/hivemq-edge/src/frontend/src/modules/Device/hooks/useTagManager.ts
@@ -104,6 +104,7 @@ export const useTagManager = (adapterId: string) => {
   return {
     // The context of the operations
     context,
+    capabilities: protocol?.capabilities,
     // The CRUD operations
     data: tagList || { items: [] },
     onCreate,

--- a/hivemq-edge/src/frontend/src/modules/Device/types.ts
+++ b/hivemq-edge/src/frontend/src/modules/Device/types.ts
@@ -1,3 +1,6 @@
+import type { ProtocolAdapter } from '@/api/__generated__'
+
 export interface DeviceTagListContext {
   adapterId: string
+  capabilities?: ProtocolAdapter['capabilities']
 }


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/31787/details/

The PR fixes a bug, whereas a device with no `WRITE` capability would still show the writing schemas in the list of `tags`

### Before 
![HiveMQ-Edge-04-24-2025_18_23](https://github.com/user-attachments/assets/f3a4fd24-e405-4ab9-92f6-87040aa479bc)
![HiveMQ-Edge-04-24-2025_18_23 (1)](https://github.com/user-attachments/assets/42db2b14-319c-43b6-aa71-caf840346b49)

### After
![HiveMQ-Edge-04-24-2025_18_22 (1)](https://github.com/user-attachments/assets/155b708e-c301-4aa6-907d-78e3111e59a4)
![HiveMQ-Edge-04-24-2025_18_22](https://github.com/user-attachments/assets/d445e332-a9ac-4b2f-9e9d-5a287091aa76)
