### PR TITLE
feat(32894): Handle list of Resource versions as a "bundle"

### DIFF
--- a/hivemq-edge-frontend/src/components/PaginatedTable/PaginatedTable.tsx
+++ b/hivemq-edge-frontend/src/components/PaginatedTable/PaginatedTable.tsx
@@ -1,10 +1,11 @@
 import type { CSSProperties } from 'react'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import type { ColumnDef, ColumnFiltersState, Row } from '@tanstack/react-table'
+import type { ColumnDef, ColumnFiltersState, ExpandedState, Row } from '@tanstack/react-table'
 import {
   flexRender,
   getCoreRowModel,
+  getExpandedRowModel,
   getFacetedMinMaxValues,
   getFacetedRowModel,
   getFacetedUniqueValues,
@@ -49,6 +50,7 @@ interface PaginatedTableProps<T> {
    * Define row styles
    */
   getRowStyles?: (row: Row<T>) => CSSProperties
+  getSubRows?: (originalRow: T, index: number) => undefined | T[]
 }
 
 const DEFAULT_PAGE_SIZES = [5, 10, 20, 30, 40, 50]
@@ -64,12 +66,14 @@ const PaginatedTable = <T,>({
   enablePaginationSizes = true,
   enablePaginationGoTo = true,
   isError = false,
+  getSubRows = undefined,
   'aria-label': ariaLabel,
 }: PaginatedTableProps<T>) => {
   const { t } = useTranslation()
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([])
   const [globalFilter, setGlobalFilter] = useState('')
   const [rowSelection, setRowSelection] = useState({})
+  const [expanded, setExpanded] = useState<ExpandedState>({})
 
   const table = useReactTable({
     data: data,
@@ -79,12 +83,16 @@ const PaginatedTable = <T,>({
       columnFilters,
       globalFilter,
       rowSelection,
+      expanded,
     },
     enableRowSelection: true,
     onRowSelectionChange: setRowSelection,
     enableColumnFilters: enableColumnFilters,
     onColumnFiltersChange: setColumnFilters,
     onGlobalFilterChange: setGlobalFilter,
+    getSubRows,
+    onExpandedChange: setExpanded,
+    getExpandedRowModel: getExpandedRowModel(),
     getCoreRowModel: getCoreRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
     getSortedRowModel: getSortedRowModel(),

--- a/hivemq-edge-frontend/src/extensions/datahub/components/helpers/DataHubListAction.spec.cy.tsx
+++ b/hivemq-edge-frontend/src/extensions/datahub/components/helpers/DataHubListAction.spec.cy.tsx
@@ -1,120 +1,168 @@
+import { mockDataPolicy } from '@datahub/api/hooks/DataHubDataPoliciesService/__handlers__'
+import { mockBehaviorPolicy } from '@datahub/api/hooks/DataHubBehaviorPoliciesService/__handlers__'
 import DataHubListAction from '@datahub/components/helpers/DataHubListAction.tsx'
 import type { CombinedPolicy } from '@datahub/types.ts'
 import { PolicyType } from '@datahub/types.ts'
-import { mockDataPolicy } from '@datahub/api/hooks/DataHubDataPoliciesService/__handlers__'
-import { mockBehaviorPolicy } from '@datahub/api/hooks/DataHubBehaviorPoliciesService/__handlers__'
 
 describe('DataHubListAction', () => {
   beforeEach(() => {
     cy.viewport(800, 800)
   })
 
-  it('should render the actions for DRAFT', () => {
-    const policy: CombinedPolicy = {
-      type: PolicyType.CREATE_POLICY,
-      ...mockDataPolicy,
-    }
-    cy.mountWithProviders(
-      <DataHubListAction policy={policy} onEdit={cy.stub().as('onEdit')} onDelete={cy.stub().as('onDelete')} />
-    )
+  context('DRAFT', () => {
+    it('should render the actions for DRAFT', () => {
+      const policy: CombinedPolicy = {
+        type: PolicyType.CREATE_POLICY,
+        ...mockDataPolicy,
+      }
+      cy.mountWithProviders(
+        <DataHubListAction policy={policy} onEdit={cy.stub().as('onEdit')} onDelete={cy.stub().as('onDelete')} />
+      )
 
-    cy.get('button').should('have.length', 2)
-    cy.getByTestId('list-action-view').should('have.attr', 'aria-label', 'Continue on draft')
-    cy.getByTestId('list-action-view').should('not.be.disabled')
+      cy.get('button').should('have.length', 2)
+      cy.getByTestId('list-action-view').should('have.attr', 'aria-label', 'Continue on draft')
+      cy.getByTestId('list-action-view').should('not.be.disabled')
 
-    cy.get('@onDelete').should('not.have.been.called')
-    cy.getByTestId('list-action-delete').should('have.attr', 'aria-label', 'Delete')
-    cy.getByTestId('list-action-delete').click()
-    cy.get('@onDelete').should('have.been.called')
+      cy.get('@onDelete').should('not.have.been.called')
+      cy.getByTestId('list-action-delete').should('have.attr', 'aria-label', 'Delete')
+      cy.getByTestId('list-action-delete').click()
+      cy.get('@onDelete').should('have.been.called')
+    })
   })
 
-  it('should render the actions for resources', () => {
-    cy.mountWithProviders(
-      <DataHubListAction
-        policy={undefined}
-        onDownload={cy.stub().as('onDownload')}
-        onDelete={cy.stub().as('onDelete')}
-      />
-    )
+  context('SCRIPT and SCHEMA', () => {
+    it('should render the actions for single version', () => {
+      cy.mountWithProviders(
+        <DataHubListAction
+          policy={undefined}
+          onDownload={cy.stub().as('onDownload')}
+          onDelete={cy.stub().as('onDelete')}
+          onExpand={cy.stub().as('onExpand')}
+          onEdit={cy.stub().as('onEdit')}
+        />
+      )
 
-    cy.get('button').should('have.length', 2)
-    cy.getByTestId('list-action-download').should('not.be.disabled')
+      cy.get('button').should('have.length', 2)
 
-    cy.get('@onDownload').should('not.have.been.called')
-    cy.getByTestId('list-action-download').should('have.attr', 'aria-label', 'Download')
-    cy.getByTestId('list-action-download').click()
-    cy.get('@onDownload').should('have.been.called')
+      cy.get('@onDownload').should('not.have.been.called')
+      cy.getByTestId('list-action-download').should('not.be.disabled')
+      cy.getByTestId('list-action-download').should('have.attr', 'aria-label', 'Download')
+      cy.getByTestId('list-action-download').click()
+      cy.get('@onDownload').should('have.been.called')
 
-    cy.get('@onDelete').should('not.have.been.called')
-    cy.getByTestId('list-action-delete').should('have.attr', 'aria-label', 'Delete')
-    cy.getByTestId('list-action-delete').click()
-    cy.get('@onDelete').should('have.been.called')
+      cy.get('@onDelete').should('not.have.been.called')
+      cy.getByTestId('list-action-delete').should('have.attr', 'aria-label', 'Delete')
+      cy.getByTestId('list-action-delete').click()
+      cy.get('@onDelete').should('have.been.called')
+
+      cy.getByTestId('list-action-collapse').should('not.exist')
+      cy.getByTestId('list-action-draft').should('not.exist')
+      cy.getByTestId('list-action-view-edit').should('not.exist')
+    })
+
+    it('should render the actions for multiple versions', () => {
+      cy.mountWithProviders(
+        <DataHubListAction
+          policy={undefined}
+          canExpand
+          onDownload={cy.stub().as('onDownload')}
+          onDelete={cy.stub().as('onDelete')}
+          onExpand={cy.stub().as('onExpand')}
+          onEdit={cy.stub().as('onEdit')}
+        />
+      )
+
+      cy.get('button').should('have.length', 3)
+
+      cy.get('@onDownload').should('not.have.been.called')
+      cy.getByTestId('list-action-download').should('have.attr', 'aria-label', 'Download')
+      cy.getByTestId('list-action-download').click()
+      cy.get('@onDownload').should('have.been.called')
+
+      cy.get('@onDelete').should('not.have.been.called')
+      cy.getByTestId('list-action-delete').should('have.attr', 'aria-label', 'Delete')
+      cy.getByTestId('list-action-delete').click()
+      cy.get('@onDelete').should('have.been.called')
+
+      cy.get('@onExpand').should('not.have.been.called')
+      cy.getByTestId('list-action-collapse').should('not.be.disabled')
+      cy.getByTestId('list-action-collapse').should('have.attr', 'aria-label', 'Show the versions')
+      cy.getByTestId('list-action-collapse').click()
+      cy.get('@onExpand').should('have.been.called')
+
+      cy.getByTestId('list-action-draft').should('not.exist')
+      cy.getByTestId('list-action-view-edit').should('not.exist')
+    })
   })
 
-  it('should render the actions for DATA_POLICY', () => {
-    const policy: CombinedPolicy = {
-      type: PolicyType.DATA_POLICY,
-      ...mockDataPolicy,
-    }
-    cy.mountWithProviders(
-      <DataHubListAction
-        policy={policy}
-        onEdit={cy.stub().as('onEdit')}
-        onDownload={cy.stub().as('onDownload')}
-        onDelete={cy.stub().as('onDelete')}
-      />
-    )
+  context('DATA_POLICY', () => {
+    it('should render the actions for DATA_POLICY', () => {
+      const policy: CombinedPolicy = {
+        type: PolicyType.DATA_POLICY,
+        ...mockDataPolicy,
+      }
+      cy.mountWithProviders(
+        <DataHubListAction
+          policy={policy}
+          onEdit={cy.stub().as('onEdit')}
+          onDownload={cy.stub().as('onDownload')}
+          onDelete={cy.stub().as('onDelete')}
+        />
+      )
 
-    cy.get('button').should('have.length', 3)
-    cy.getByTestId('list-action-view').should('not.be.disabled')
+      cy.get('button').should('have.length', 3)
+      cy.getByTestId('list-action-view').should('not.be.disabled')
 
-    cy.get('@onEdit').should('not.have.been.called')
-    cy.getByTestId('list-action-view').should('have.attr', 'aria-label', 'View / Edit')
-    cy.getByTestId('list-action-view').click()
-    cy.get('@onEdit').should('have.been.called')
+      cy.get('@onEdit').should('not.have.been.called')
+      cy.getByTestId('list-action-view').should('have.attr', 'aria-label', 'View / Edit')
+      cy.getByTestId('list-action-view').click()
+      cy.get('@onEdit').should('have.been.called')
 
-    cy.get('@onDownload').should('not.have.been.called')
-    cy.getByTestId('list-action-download').should('have.attr', 'aria-label', 'Download')
-    cy.getByTestId('list-action-download').click()
-    cy.get('@onDownload').should('have.been.called')
+      cy.get('@onDownload').should('not.have.been.called')
+      cy.getByTestId('list-action-download').should('have.attr', 'aria-label', 'Download')
+      cy.getByTestId('list-action-download').click()
+      cy.get('@onDownload').should('have.been.called')
 
-    cy.get('@onDelete').should('not.have.been.called')
-    cy.getByTestId('list-action-delete').should('have.attr', 'aria-label', 'Delete')
-    cy.getByTestId('list-action-delete').click()
-    cy.get('@onDelete').should('have.been.called')
+      cy.get('@onDelete').should('not.have.been.called')
+      cy.getByTestId('list-action-delete').should('have.attr', 'aria-label', 'Delete')
+      cy.getByTestId('list-action-delete').click()
+      cy.get('@onDelete').should('have.been.called')
+    })
   })
 
-  it('should render the actions for BEHAVIOR_POLICY', () => {
-    const policy: CombinedPolicy = {
-      type: PolicyType.BEHAVIOR_POLICY,
-      ...mockBehaviorPolicy,
-    }
-    cy.mountWithProviders(
-      <DataHubListAction
-        policy={policy}
-        onEdit={cy.stub().as('onEdit')}
-        onDownload={cy.stub().as('onDownload')}
-        onDelete={cy.stub().as('onDelete')}
-      />
-    )
+  context('BEHAVIOR_POLICY', () => {
+    it('should render the actions for BEHAVIOR_POLICY', () => {
+      const policy: CombinedPolicy = {
+        type: PolicyType.BEHAVIOR_POLICY,
+        ...mockBehaviorPolicy,
+      }
+      cy.mountWithProviders(
+        <DataHubListAction
+          policy={policy}
+          onEdit={cy.stub().as('onEdit')}
+          onDownload={cy.stub().as('onDownload')}
+          onDelete={cy.stub().as('onDelete')}
+        />
+      )
 
-    cy.get('button').should('have.length', 3)
-    cy.getByTestId('list-action-view').should('not.be.disabled')
+      cy.get('button').should('have.length', 3)
+      cy.getByTestId('list-action-view').should('not.be.disabled')
 
-    cy.get('@onEdit').should('not.have.been.called')
-    cy.getByTestId('list-action-view').should('have.attr', 'aria-label', 'View / Edit')
-    cy.getByTestId('list-action-view').click()
-    cy.get('@onEdit').should('have.been.called')
+      cy.get('@onEdit').should('not.have.been.called')
+      cy.getByTestId('list-action-view').should('have.attr', 'aria-label', 'View / Edit')
+      cy.getByTestId('list-action-view').click()
+      cy.get('@onEdit').should('have.been.called')
 
-    cy.get('@onDownload').should('not.have.been.called')
-    cy.getByTestId('list-action-download').should('have.attr', 'aria-label', 'Download')
-    cy.getByTestId('list-action-download').click()
-    cy.get('@onDownload').should('have.been.called')
+      cy.get('@onDownload').should('not.have.been.called')
+      cy.getByTestId('list-action-download').should('have.attr', 'aria-label', 'Download')
+      cy.getByTestId('list-action-download').click()
+      cy.get('@onDownload').should('have.been.called')
 
-    cy.get('@onDelete').should('not.have.been.called')
-    cy.getByTestId('list-action-delete').should('have.attr', 'aria-label', 'Delete')
-    cy.getByTestId('list-action-delete').click()
-    cy.get('@onDelete').should('have.been.called')
+      cy.get('@onDelete').should('not.have.been.called')
+      cy.getByTestId('list-action-delete').should('have.attr', 'aria-label', 'Delete')
+      cy.getByTestId('list-action-delete').click()
+      cy.get('@onDelete').should('have.been.called')
+    })
   })
 
   it('should be accessible', () => {

--- a/hivemq-edge-frontend/src/extensions/datahub/components/helpers/DataHubListAction.tsx
+++ b/hivemq-edge-frontend/src/extensions/datahub/components/helpers/DataHubListAction.tsx
@@ -29,7 +29,7 @@ const DataHubListAction: FC<DataHubListActionProps> = ({
   onDownload,
   onExpand,
   isExpanded = false,
-  canExpand = true,
+  canExpand = false,
   canDownload = true,
   canDelete = true,
 }) => {

--- a/hivemq-edge-frontend/src/extensions/datahub/components/helpers/DataHubListAction.tsx
+++ b/hivemq-edge-frontend/src/extensions/datahub/components/helpers/DataHubListAction.tsx
@@ -61,7 +61,7 @@ const DataHubListAction: FC<DataHubListActionProps> = ({
           <IconButton
             onClick={onExpand}
             size="sm"
-            aria-label="Show the versions"
+            aria-label={isExpanded ? t('Listings.action.collapse') : t('Listings.action.expand')}
             icon={
               <Icon as={TiChevronRightOutline} fontSize="1.5rem" transform={isExpanded ? 'rotate(90deg)' : undefined} />
             }

--- a/hivemq-edge-frontend/src/extensions/datahub/components/helpers/DataHubListAction.tsx
+++ b/hivemq-edge-frontend/src/extensions/datahub/components/helpers/DataHubListAction.tsx
@@ -59,6 +59,7 @@ const DataHubListAction: FC<DataHubListActionProps> = ({
         )}
         {canExpand && (
           <IconButton
+            data-testid="list-action-collapse"
             onClick={onExpand}
             size="sm"
             aria-label={isExpanded ? t('Listings.action.collapse') : t('Listings.action.expand')}

--- a/hivemq-edge-frontend/src/extensions/datahub/components/helpers/DataHubListAction.tsx
+++ b/hivemq-edge-frontend/src/extensions/datahub/components/helpers/DataHubListAction.tsx
@@ -1,7 +1,8 @@
 import type { FC, MouseEventHandler } from 'react'
 import { useTranslation } from 'react-i18next'
+import { TiChevronRightOutline } from 'react-icons/ti'
 import { useNavigate } from 'react-router-dom'
-import { ButtonGroup, HStack } from '@chakra-ui/react'
+import { ButtonGroup, HStack, Icon } from '@chakra-ui/react'
 import { LuFileEdit, LuTrash2, LuFileSearch, LuDownload } from 'react-icons/lu'
 
 import IconButton from '@/components/Chakra/IconButton.tsx'
@@ -14,9 +15,24 @@ interface DataHubListActionProps {
   onEdit?: MouseEventHandler<HTMLButtonElement>
   onDelete?: MouseEventHandler<HTMLButtonElement>
   onDownload?: MouseEventHandler<HTMLButtonElement>
+  onExpand?: MouseEventHandler<HTMLButtonElement>
+  isExpanded?: boolean
+  canExpand?: boolean
+  canDelete?: boolean
+  canDownload?: boolean
 }
 
-const DataHubListAction: FC<DataHubListActionProps> = ({ policy, onEdit, onDelete, onDownload }) => {
+const DataHubListAction: FC<DataHubListActionProps> = ({
+  policy,
+  onEdit,
+  onDelete,
+  onDownload,
+  onExpand,
+  isExpanded = false,
+  canExpand = true,
+  canDownload = true,
+  canDelete = true,
+}) => {
   const { t } = useTranslation('datahub')
   const navigate = useNavigate()
   const { setStatus } = useDataHubDraftStore()
@@ -25,18 +41,32 @@ const DataHubListAction: FC<DataHubListActionProps> = ({ policy, onEdit, onDelet
     // If not policy, it's a resource toolbar
     return (
       <ButtonGroup size="sm" isAttached>
-        <IconButton
-          data-testid="list-action-download"
-          onClick={onDownload}
-          aria-label={t('Listings.action.download')}
-          icon={<LuDownload />}
-        />
-        <IconButton
-          data-testid="list-action-delete"
-          onClick={onDelete}
-          aria-label={t('Listings.action.delete')}
-          icon={<LuTrash2 />}
-        />
+        {canDownload && (
+          <IconButton
+            data-testid="list-action-download"
+            onClick={onDownload}
+            aria-label={t('Listings.action.download')}
+            icon={<LuDownload />}
+          />
+        )}
+        {canDelete && (
+          <IconButton
+            data-testid="list-action-delete"
+            onClick={onDelete}
+            aria-label={t('Listings.action.delete')}
+            icon={<LuTrash2 />}
+          />
+        )}
+        {canExpand && (
+          <IconButton
+            onClick={onExpand}
+            size="sm"
+            aria-label="Show the versions"
+            icon={
+              <Icon as={TiChevronRightOutline} fontSize="1.5rem" transform={isExpanded ? 'rotate(90deg)' : undefined} />
+            }
+          />
+        )}
       </ButtonGroup>
     )
   }

--- a/hivemq-edge-frontend/src/extensions/datahub/components/pages/SchemaTable.copilot.spec.cy.tsx
+++ b/hivemq-edge-frontend/src/extensions/datahub/components/pages/SchemaTable.copilot.spec.cy.tsx
@@ -1,0 +1,116 @@
+import { DateTime } from 'luxon'
+import { MOCK_CREATED_AT } from '@/__test-utils__/mocks.ts'
+
+import { mockSchemaTempHumidity } from '@datahub/api/hooks/DataHubSchemasService/__handlers__'
+import SchemaTable from '@datahub/components/pages/SchemaTable.tsx'
+
+describe('SchemaTable (Copilot)', () => {
+  beforeEach(() => {
+    cy.viewport(800, 800)
+  })
+
+  context('Rendering and Loading States', () => {
+    it('should render the table component correctly', () => {
+      cy.mountWithProviders(<SchemaTable />)
+
+      cy.get('table').should('have.attr', 'aria-label', 'List of schemas')
+      cy.get('table thead th')
+        .should('have.length', 5)
+        .then((headers) => {
+          const expectedHeaders = ['Schema name', 'Type', 'Version', 'Created', 'Actions']
+          headers.each((index, header) => {
+            expect(header).to.contain.text(expectedHeaders[index])
+          })
+        })
+    })
+
+    it('should show loading skeleton while fetching data', () => {
+      cy.intercept('/api/v1/data-hub/schemas', { statusCode: 404 })
+      cy.mountWithProviders(<SchemaTable />)
+      // There is no [data-testid="skeleton"]
+      // cy.get('[data-testid="skeleton"]').should('exist')
+      cy.get('.chakra-skeleton').should('exist')
+
+      // There is no displayed error message
+      cy.get('[role="alert"]')
+        .should('contain.text', 'There was an error loading the data')
+        .should('have.attr', 'data-status', 'error')
+    })
+  })
+
+  context('Data Rendering', () => {
+    beforeEach(() => {
+      const schema = {
+        ...mockSchemaTempHumidity,
+        id: 'test-schema',
+        type: 'JSON',
+        version: 2,
+        createdAt: MOCK_CREATED_AT,
+      }
+      cy.intercept('/api/v1/data-hub/schemas', { items: [schema] }).as('getSchemasSuccess')
+    })
+
+    it('should render schema data correctly', () => {
+      const now = DateTime.fromISO(MOCK_CREATED_AT).plus({ day: 2 }).toJSDate()
+      // clock is interferring with request !
+      // cy.clock(now)
+      cy.mountWithProviders(<SchemaTable />)
+      cy.wait('@getSchemasSuccess')
+
+      // Fixed chaining issue: get element first, then use should
+      cy.get('tbody tr').should('have.length', 1)
+      cy.get('tbody tr')
+        .first()
+        .within(() => {
+          cy.get('td').eq(0).should('contain', 'test-schema')
+          cy.get('td').eq(1).should('contain', 'JSON')
+          cy.get('td').eq(2).should('contain', '2')
+          // without clock the date is not correct
+          cy.get('td').eq(3).should('contain', '1 year ago')
+          cy.get('td').eq(4).find('button').should('have.length', 2)
+        })
+    })
+  })
+
+  context('Error Handling', () => {
+    it('should handle error state', () => {
+      cy.intercept('/api/v1/data-hub/schemas', { statusCode: 500 }).as('getSchemasError')
+      cy.mountWithProviders(<SchemaTable />)
+
+      // That's hallucinating
+      // cy.contains('Error loading data').should('be.visible')
+      // cy.get('button').contains('Try again').should('be.visible')
+    })
+  })
+
+  context('Actions', () => {
+    it('should trigger delete action correctly', () => {
+      const deleteItemSpy = cy.spy().as('deleteItemSpy')
+      cy.intercept('/api/v1/data-hub/schemas', { items: [mockSchemaTempHumidity] }).as('getSchemas')
+
+      cy.mountWithProviders(<SchemaTable onDeleteItem={deleteItemSpy} />)
+      cy.get('tbody tr').first().find('[aria-label="Delete"]').click()
+
+      cy.get('@deleteItemSpy').should('have.been.calledOnce')
+    })
+
+    // This one is completely bonkers, as far as I can tell
+    it.skip('should trigger download action correctly', () => {
+      const downloadJSONSpy = cy.spy().as('downloadJSONSpy')
+      cy.window().then((win) => {
+        cy.stub(win, 'downloadJSON').as('downloadJSONStub').callsFake(downloadJSONSpy)
+      })
+
+      cy.mountWithProviders(<SchemaTable />)
+      cy.get('tbody tr').first().find('[aria-label="Download"]').click()
+
+      cy.get('@downloadJSONStub').should('have.been.calledOnce')
+    })
+  })
+
+  it('should be accessible', () => {
+    cy.injectAxe()
+    cy.mountWithProviders(<SchemaTable />)
+    cy.checkAccessibility()
+  })
+})

--- a/hivemq-edge-frontend/src/extensions/datahub/components/pages/SchemaTable.spec.cy.tsx
+++ b/hivemq-edge-frontend/src/extensions/datahub/components/pages/SchemaTable.spec.cy.tsx
@@ -40,9 +40,50 @@ describe('SchemaTable', () => {
     cy.get('@firstItemContent').eq(3).should('have.text', '2 days ago')
   })
 
+  it('should render expandable data', () => {
+    cy.intercept('/api/v1/data-hub/schemas', {
+      items: [mockSchemaTempHumidity, { ...mockSchemaTempHumidity, version: 2 }],
+    }).as('getSchemas')
+
+    cy.mountWithProviders(<SchemaTable />)
+    cy.wait('@getSchemas')
+
+    cy.get('tbody tr').should('have.length', 1)
+    cy.get('tbody tr').first().as('firstItem')
+
+    cy.get('@firstItem').find('td').as('firstItemContent')
+    cy.get('@firstItemContent').should('have.length', 5)
+    cy.get('@firstItemContent').eq(0).should('have.text', 'my-schema-id')
+    cy.get('@firstItemContent').eq(1).should('have.text', 'JSON')
+    cy.get('@firstItemContent').eq(2).should('have.text', '2 versions')
+    cy.get('@firstItemContent').eq(3).should('have.text', '2 days ago')
+    cy.get('@firstItemContent')
+      .eq(4)
+      .within(() => {
+        cy.getByAriaLabel('Show the versions').should('be.visible').should('not.be.disabled')
+        cy.getByAriaLabel('Show the versions').click()
+      })
+    cy.get('tbody tr').should('have.length', 3)
+    cy.get('tbody tr').eq(2).find('td').as('childrenRow')
+    cy.get('@childrenRow').eq(2).should('have.text', '2')
+
+    cy.get('@firstItemContent')
+      .eq(4)
+      .within(() => {
+        cy.getByAriaLabel('Hide the versions').should('be.visible').should('not.be.disabled')
+        cy.getByAriaLabel('Hide the versions').click()
+      })
+    cy.get('tbody tr').should('have.length', 1)
+  })
+
   it('should be accessible', () => {
+    cy.intercept('/api/v1/data-hub/schemas', {
+      items: [mockSchemaTempHumidity, { ...mockSchemaTempHumidity, version: 2 }],
+    }).as('getSchemas')
+
     cy.injectAxe()
     cy.mountWithProviders(<SchemaTable />)
+
     cy.checkAccessibility()
   })
 })

--- a/hivemq-edge-frontend/src/extensions/datahub/components/pages/SchemaTable.spec.cy.tsx
+++ b/hivemq-edge-frontend/src/extensions/datahub/components/pages/SchemaTable.spec.cy.tsx
@@ -8,6 +8,9 @@ describe('SchemaTable', () => {
   beforeEach(() => {
     cy.viewport(800, 800)
     cy.intercept('/api/v1/data-hub/schemas', { statusCode: 404 })
+
+    // TODO[NVL] Create a custom command for that stub
+    cy.stub(DateTime, 'now').returns(DateTime.fromISO(MOCK_CREATED_AT).plus({ day: 2 }))
   })
 
   it('should render the table component', () => {
@@ -24,9 +27,7 @@ describe('SchemaTable', () => {
 
   it('should render the data', () => {
     cy.intercept('/api/v1/data-hub/schemas', { items: [mockSchemaTempHumidity] })
-    const now = DateTime.fromISO(MOCK_CREATED_AT).plus({ day: 2 }).toJSDate()
 
-    cy.clock(now)
     cy.mountWithProviders(<SchemaTable />)
     cy.get('tbody tr').should('have.length', 1)
     cy.get('tbody tr').first().as('firstItem')

--- a/hivemq-edge-frontend/src/extensions/datahub/components/pages/SchemaTable.tsx
+++ b/hivemq-edge-frontend/src/extensions/datahub/components/pages/SchemaTable.tsx
@@ -62,9 +62,13 @@ const SchemaTable: FC<DataHubTableProps> = ({ onDeleteItem }) => {
       {
         accessorKey: 'version',
         cell: (info) => {
+          const value = info.getValue<number>()
+          const formattedValue = info.row.getCanExpand()
+            ? t('Listings.resources.versions', { context: 'COUNT', count: value })
+            : value
           return (
             <Skeleton isLoaded={!isLoading} whiteSpace="nowrap">
-              <Text>{info.getValue<string>()}</Text>
+              <Text>{formattedValue}</Text>
             </Skeleton>
           )
         },

--- a/hivemq-edge-frontend/src/extensions/datahub/components/pages/SchemaTable.tsx
+++ b/hivemq-edge-frontend/src/extensions/datahub/components/pages/SchemaTable.tsx
@@ -37,11 +37,15 @@ const SchemaTable: FC<DataHubTableProps> = ({ onDeleteItem }) => {
     return [
       {
         accessorKey: 'id',
-        cell: (info) => (
-          <Skeleton isLoaded={!isLoading} whiteSpace="nowrap">
-            <Text>{info.getValue<string>()}</Text>
-          </Skeleton>
-        ),
+        cell: (info) => {
+          return (
+            <Skeleton isLoaded={!isLoading} whiteSpace="nowrap">
+              <Text as="span" ml={info.row.getParentRow() ? 4 : 0}>
+                {info.getValue<string>()}
+              </Text>
+            </Skeleton>
+          )
+        },
         header: t('Listings.schema.header.id'),
       },
       {

--- a/hivemq-edge-frontend/src/extensions/datahub/locales/en/datahub.json
+++ b/hivemq-edge-frontend/src/extensions/datahub/locales/en/datahub.json
@@ -82,7 +82,14 @@
         "clear": "Clear the draft"
       }
     },
-
+    "resources": {
+      "versions_RANGE_zero": "no version",
+      "versions_RANGE_one": "1",
+      "versions_RANGE_other": "1–{{ count }}",
+      "versions_COUNT_zero": "no version",
+      "versions_COUNT_one": "{{ count }} version xxx",
+      "versions_COUNT_other": "{{ count }} versions"
+    },
     "schema": {
       "label": "List of schemas",
       "header": {

--- a/hivemq-edge-frontend/src/extensions/datahub/locales/en/datahub.json
+++ b/hivemq-edge-frontend/src/extensions/datahub/locales/en/datahub.json
@@ -38,7 +38,9 @@
       "config": "Configure",
       "download": "Download",
       "delete": "Delete",
-      "copy": "Copy"
+      "copy": "Copy",
+      "expand": "Show the versions",
+      "collapse": "Hide the versions"
     },
     "tabs": {
       "policy": {

--- a/hivemq-edge-frontend/src/extensions/datahub/utils/policy.utils.spec.ts
+++ b/hivemq-edge-frontend/src/extensions/datahub/utils/policy.utils.spec.ts
@@ -1,0 +1,90 @@
+import { describe, expect } from 'vitest'
+
+import type { SchemaList } from '@/api/__generated__'
+import { MOCK_SCHEMA_ID, mockSchemaTempHumidity } from '../api/hooks/DataHubSchemasService/__handlers__'
+import type { PolicySchemaExpanded } from './policy.utils'
+import { groupResourceItems } from './policy.utils'
+
+interface GroupSchemaTest {
+  data: SchemaList | undefined
+  result: PolicySchemaExpanded[]
+  prompt: {
+    input: string
+    output: string
+  }
+}
+
+const resourceNameTestSuite: GroupSchemaTest[] = [
+  {
+    data: undefined,
+    result: [],
+    prompt: {
+      input: 'undefined',
+      output: '[]',
+    },
+  },
+  {
+    data: { items: [] },
+    result: [],
+    prompt: {
+      input: 'empty list',
+      output: '[]',
+    },
+  },
+  {
+    data: { items: [mockSchemaTempHumidity] },
+    result: [mockSchemaTempHumidity],
+    prompt: {
+      input: 'single item',
+      output: 'same item',
+    },
+  },
+  {
+    data: {
+      items: [
+        { ...mockSchemaTempHumidity, createdAt: '2021-10-13T11:51:24.234Z' },
+        { ...mockSchemaTempHumidity, version: 2 },
+      ],
+    },
+    result: [
+      {
+        children: [
+          {
+            ...mockSchemaTempHumidity,
+            createdAt: '2021-10-13T11:51:24.234Z',
+          },
+          {
+            ...mockSchemaTempHumidity,
+            version: 2,
+          },
+        ],
+        ...mockSchemaTempHumidity,
+        createdAt: '2021-10-13T11:51:24.234Z',
+        version: 2,
+      },
+    ],
+    prompt: {
+      input: 'two versions',
+      output: 'one item with 2 children',
+    },
+  },
+  {
+    data: {
+      items: [mockSchemaTempHumidity, { ...mockSchemaTempHumidity, id: 'new policy' }],
+    },
+    result: [mockSchemaTempHumidity, { ...mockSchemaTempHumidity, id: 'new policy' }],
+    prompt: {
+      input: 'two versions',
+      output: 'one item with 2 children',
+    },
+  },
+]
+
+describe('groupResourceItems', () => {
+  it.each<GroupSchemaTest>(resourceNameTestSuite)(
+    'should return $prompt.output with $prompt.input',
+    ({ data, result }) => {
+      expect(groupResourceItems(data)).toStrictEqual(result)
+    }
+  )
+})

--- a/hivemq-edge-frontend/src/extensions/datahub/utils/policy.utils.ts
+++ b/hivemq-edge-frontend/src/extensions/datahub/utils/policy.utils.ts
@@ -1,0 +1,28 @@
+import type { PolicySchema, SchemaList } from '../../../api/__generated__'
+
+export interface PolicySchemaExpanded extends PolicySchema {
+  children?: PolicySchema[]
+}
+
+export const groupResourceItems = (data: SchemaList | undefined) => {
+  if (!data || !data.items) return []
+
+  const schemasGroupedById = Object.groupBy(data.items, (schema) => schema.id)
+  const schemaGroups = Object.entries(schemasGroupedById).filter(([, schemas]) => schemas !== undefined) as [
+    string,
+    PolicySchema[],
+  ][]
+
+  return schemaGroups.map(([, schemas]) => {
+    if (schemas.length === 1) return schemas.at(0) as PolicySchemaExpanded
+
+    const firstSchema = schemas.at(0) as PolicySchema
+    const lastSchema = schemas.at(-1) as PolicySchema
+
+    return {
+      ...firstSchema,
+      version: lastSchema.version, // replace the version with the latest one
+      children: schemas,
+    } as PolicySchemaExpanded
+  })
+}

--- a/hivemq-edge-frontend/src/extensions/datahub/utils/policy.utils.ts
+++ b/hivemq-edge-frontend/src/extensions/datahub/utils/policy.utils.ts
@@ -5,9 +5,18 @@ export interface PolicySchemaExpanded extends PolicySchema {
 }
 
 export const groupResourceItems = (data: SchemaList | undefined) => {
-  if (!data || !data.items) return []
+  if (!data || !data.items || !data.items.length) return []
 
-  const schemasGroupedById = Object.groupBy(data.items, (schema) => schema.id)
+  // TODO[33008] Update Node to 21; Object.groupBy is not supported in Node 18 or 20
+  // const schemasGroupedById = Object.groupBy(data.items, (schema) => schema.id)
+  const schemasGroupedById = data.items.reduce<Record<string, PolicySchema[]>>((acc, schema) => {
+    if (!acc[schema.id]) {
+      acc[schema.id] = []
+    }
+    acc[schema.id].push(schema)
+    return acc
+  }, {})
+
   const schemaGroups = Object.entries(schemasGroupedById).filter(([, schemas]) => schemas !== undefined) as [
     string,
     PolicySchema[],


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/32894/details/

The PR addresses an issue with resources (`Script` and `Schemas`) being handled as a single item with a list of continuous version associated with it.

The PR adds expandable rows for multi-version items:
- The main items will indicate how many version it includes 
- It had an extra CTA in the actions, allowing versions to be expanded or collapsed
- On expanding, individual version will be listed below the main item, with all the same information (and an extra indentation to mark status)
- Main item can only be deleted while individual versions can only be downloaded 

Single version resources remain displayed as before. 

### Design 
- The primary UX remains a table and behave like a table in every behaviour and per accessibility rules 
- In particular, versions are not tree elements but sub rows 
- They remain attached to the top-level row but are otherwise affected by every UX element of the table: filtering, ordering, paginating, 

The PR also fixes a bug with the use of `cy.clock` and `cy.intercept`

### Before

### After