### PR TITLE
refactor(33305): Redesign the openAPI specs for the datahub functions

### DIFF
--- a/ext/hivemq-edge-openapi-2025.9-SNAPSHOT.yaml
+++ b/ext/hivemq-edge-openapi-2025.9-SNAPSHOT.yaml
@@ -14,7 +14,7 @@ info:
     ## OpenAPI
     HiveMQ's REST API provides an OpenAPI 3.0 schema definition that can imported into popular API tooling (e.g. Postman) or can be used to generate client-code for multiple programming languages.
   title: HiveMQ Edge REST API
-  version: 2025.4-SNAPSHOT
+  version: 2025.9-SNAPSHOT
   x-logo:
     url: https://www.hivemq.com/img/svg/hivemq-bee.svg
 tags:

--- a/ext/openAPI/components/schemas/BehaviorPolicyTransitionEvent.yaml
+++ b/ext/openAPI/components/schemas/BehaviorPolicyTransitionEvent.yaml
@@ -1,0 +1,9 @@
+type: string
+description: Accepted event in transition
+enum:
+  - Event.OnAny
+  - Connection.OnDisconnect
+  - Mqtt.OnInboundConnect
+  - Mqtt.OnInboundDisconnect
+  - Mqtt.OnInboundPublish
+  - Mqtt.OnInboundSubscribe

--- a/ext/openAPI/components/schemas/FunctionMetadata.yaml
+++ b/ext/openAPI/components/schemas/FunctionMetadata.yaml
@@ -1,0 +1,17 @@
+description: Metadata for operation functions
+type: object
+properties:
+  isTerminal:
+    type: boolean
+    description: The function is a terminal element of a pipeline
+  isDataOnly:
+    type: boolean
+    description: The function is only abvailable for Data Policies
+  hasArguments:
+    type: boolean
+    description: The function has extra arguments
+  inLicenseAllowed:
+    type: boolean
+    description: The function can be used with the current user's license
+    
+

--- a/ext/openAPI/components/schemas/FunctionMetadata.yaml
+++ b/ext/openAPI/components/schemas/FunctionMetadata.yaml
@@ -13,5 +13,9 @@ properties:
   inLicenseAllowed:
     type: boolean
     description: The function can be used with the current user's license
+  supportedEvents:
+    type: array
+    items:
+      $ref: ./BehaviorPolicyTransitionEvent.yaml
     
 

--- a/ext/openAPI/components/schemas/FunctionMetadata.yaml
+++ b/ext/openAPI/components/schemas/FunctionMetadata.yaml
@@ -6,7 +6,7 @@ properties:
     description: The function is a terminal element of a pipeline
   isDataOnly:
     type: boolean
-    description: The function is only abvailable for Data Policies
+    description: The function is only available for Data Policies
   hasArguments:
     type: boolean
     description: The function has extra arguments

--- a/ext/openAPI/components/schemas/FunctionSpecs.yaml
+++ b/ext/openAPI/components/schemas/FunctionSpecs.yaml
@@ -1,0 +1,18 @@
+type: array
+description: List of function configurations
+items:
+  type: object
+  properties:
+    functionId:
+      type: string
+      description: The unique name of the function
+    metadata:
+      $ref: ./FunctionMetadata.yaml
+    schema:
+      $ref: ./JsonNode.yaml
+    uiSchema:
+      $ref: ./JsonNode.yaml
+  required:
+    - functionId
+    - metadata
+    - schema

--- a/ext/openAPI/components/schemas/FunctionSpecs.yaml
+++ b/ext/openAPI/components/schemas/FunctionSpecs.yaml
@@ -1,18 +1,19 @@
-type: array
-description: List of function configurations
-items:
-  type: object
-  properties:
-    functionId:
-      type: string
-      description: The unique name of the function
-    metadata:
-      $ref: ./FunctionMetadata.yaml
-    schema:
-      $ref: ./JsonNode.yaml
-    uiSchema:
-      $ref: ./JsonNode.yaml
-  required:
-    - functionId
-    - metadata
-    - schema
+description: The configuration of a DataHub operation function
+type: object
+properties:
+  functionId:
+    type: string
+    description: The unique name of the function
+  metadata:
+    $ref: ./FunctionMetadata.yaml
+    description: The metadata associated with the function
+  schema:
+    $ref: ./JsonNode.yaml
+    description: the full JSON-Schema describimng the function and its arguments
+  uiSchema:
+    $ref: ./JsonNode.yaml
+    description: An optional UI Schema to customise the rendering of the configuraton form
+required:
+  - functionId
+  - metadata
+  - schema

--- a/ext/openAPI/components/schemas/FunctionSpecsList.yaml
+++ b/ext/openAPI/components/schemas/FunctionSpecsList.yaml
@@ -1,0 +1,10 @@
+type: object
+description: List of function configurations
+properties:
+  items:
+    type: array
+    description: List of function configurations
+    items:
+      $ref: ./FunctionSpecs.yaml
+required:
+  - items

--- a/ext/openAPI/openapi.yaml
+++ b/ext/openAPI/openapi.yaml
@@ -30,7 +30,7 @@ info:
     imported into popular API tooling (e.g. Postman) or can be used to generate
     client-code for multiple programming languages.
   title: HiveMQ Edge REST API
-  version: 2025.4-SNAPSHOT
+  version: 2025.9-SNAPSHOT
   x-logo:
     url: https://www.hivemq.com/img/svg/hivemq-bee.svg
 tags:

--- a/ext/openAPI/openapi.yaml
+++ b/ext/openAPI/openapi.yaml
@@ -176,6 +176,8 @@ paths:
     $ref: paths/api_v1_data-hub_fsm.yaml
   /api/v1/data-hub/functions:
     $ref: paths/api_v1_data-hub_functions.yaml
+  /api/v1/data-hub/function-specs:
+    $ref: paths/api_v1_data-hub_function-specs.yaml
   /api/v1/data-hub/schemas:
     $ref: paths/api_v1_data-hub_schemas.yaml
   /api/v1/data-hub/schemas/{schemaId}:

--- a/ext/openAPI/paths/api_v1_data-hub_function-specs.yaml
+++ b/ext/openAPI/paths/api_v1_data-hub_function-specs.yaml
@@ -8,7 +8,7 @@ get:
       content:
         application/json:
           schema:
-            $ref: ../components/schemas/FunctionSpecs.yaml
+            $ref: ../components/schemas/FunctionSpecsList.yaml
       description: Success
     '500':
       content:

--- a/ext/openAPI/paths/api_v1_data-hub_function-specs.yaml
+++ b/ext/openAPI/paths/api_v1_data-hub_function-specs.yaml
@@ -1,0 +1,21 @@
+get:
+  description: >-
+    This endpoints provides the means to get information on the available
+    Functions for the HiveMQ Data Hub.
+  operationId: getFunctionSpecs
+  responses:
+    '200':
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/FunctionSpecs.yaml
+      description: Success
+    '500':
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/ProblemDetails.yaml
+      description: Internal server error
+  summary: Get all functions as a list of function specifications
+  tags:
+    - Data Hub - Functions

--- a/ext/openAPI/paths/api_v1_data-hub_functions.yaml
+++ b/ext/openAPI/paths/api_v1_data-hub_functions.yaml
@@ -1,4 +1,5 @@
 get:
+  deprecated: true
   description: >-
     This endpoints provides the means to get information on the available
     Functions for the HiveMQ Data Hub. The information is provided in form of a


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/33305/details/

The PR proposes a different implementation of the API endpoints, delivering the list of functions to the Datahub Designer. The API was designed to replace the hard-coded elements in the frontend, but was never utilised.

The existing APi, `GET   /api/v1/data-hub/functions` returns a complete JSON-Schema of every function in the system but suffers from a few flaws:
- It includes the user-defined transformation functions
- As a JSON-Schema block, it is expected to be used as such (e.g. in a form with RJSF) but cannot be reused in other elements (e.g. in a selector)
- It contains the metadata as an undocumented property of JSON-Schema
- It cannot be filtered out easily 

The PR deprecates the old endpoint to add a new dedicated API, `GET   /api/v1/data-hub/function-specs`
- The endpoint returns a list of  `FunctionSpecs`, with the usual items-based pattern
- The `FunctionSpecs` contains the full JSON-Schema, an optional UI Schema and the metadata as a type element
- The `FunctionMetadata` summarises the possible metadata of a function
- The `BehaviorPolicyTransitionEvent` enums the list of supported transition events

### Out-of-scope
- The old endpoint should not be used by end-user, as its relevance is questionable. It has been marked as `deprecated` and must be removed from the API at the earliest opportunity
- frontend and backend implementation have their tickets:
  - https://hivemq.kanbanize.com/ctrl_board/57/cards/29945/details/
  - https://hivemq.kanbanize.com/ctrl_board/57/cards/33331/details/ 

