### PR TITLE
fix(29930): Fix the toolbox dropdown not closing

### DIFF
--- a/hivemq-edge-frontend/src/extensions/datahub/components/controls/DesignerToolbox.tsx
+++ b/hivemq-edge-frontend/src/extensions/datahub/components/controls/DesignerToolbox.tsx
@@ -30,7 +30,7 @@ const DesignerToolbox: FC = () => {
     <Panel position="top-left">
       <HStack role="group" aria-label={t('workspace.toolbars.draft.aria-label')} p={1}>
         <Popover>
-          {({ isOpen }) => (
+          {({ isOpen, onClose }) => (
             <>
               <PopoverTrigger>
                 <IconButton
@@ -53,7 +53,7 @@ const DesignerToolbox: FC = () => {
                 <PopoverHeader>{t('workspace.toolbox.panel.aria-label')}</PopoverHeader>
                 <PopoverBody as={VStack} alignItems="flex-start" maxWidth="12rem">
                   <Text fontSize="sm">{t('workspace.toolbox.panel.helper')}</Text>
-                  <ToolboxNodes direction="vertical" />
+                  <ToolboxNodes direction="vertical" callback={onClose} />
                 </PopoverBody>
               </PopoverContent>
             </>

--- a/hivemq-edge-frontend/src/extensions/datahub/components/controls/ToolItem.tsx
+++ b/hivemq-edge-frontend/src/extensions/datahub/components/controls/ToolItem.tsx
@@ -17,6 +17,10 @@ interface ToolProps extends ButtonProps {
 const ToolItem: FC<ToolProps> = ({ nodeType, isDisabled, callback }) => {
   const { t } = useTranslation('datahub')
 
+  const onButtonDragEnd = useCallback((event: React.DragEvent<HTMLButtonElement>) => {
+    event.dataTransfer.clearData(DND_DESIGNER_NODE_TYPE)
+  }, [])
+
   const onButtonDragStart = useCallback(
     (event: React.DragEvent<HTMLButtonElement>) => {
       if (isDisabled) {
@@ -34,6 +38,7 @@ const ToolItem: FC<ToolProps> = ({ nodeType, isDisabled, callback }) => {
     <IconButton
       size="lg"
       onDragStart={onButtonDragStart}
+      onDragEnd={onButtonDragEnd}
       draggable
       isDisabled={isDisabled}
       icon={<NodeIcon type={nodeType} />}

--- a/hivemq-edge-frontend/src/extensions/datahub/components/controls/ToolItem.tsx
+++ b/hivemq-edge-frontend/src/extensions/datahub/components/controls/ToolItem.tsx
@@ -10,6 +10,7 @@ import { NodeIcon } from '@datahub/components/helpers'
 
 interface ToolProps extends ButtonProps {
   nodeType: DataHubNodeType
+  callback?: () => void
 }
 
 const ToolItem: FC<ToolProps> = ({ nodeType, isDisabled }) => {
@@ -22,9 +23,10 @@ const ToolItem: FC<ToolProps> = ({ nodeType, isDisabled }) => {
       } else if (event && !isDisabled) {
         event.dataTransfer.setData('application/reactflow', nodeType.toString())
         event.dataTransfer.effectAllowed = 'move'
+        callback?.()
       }
     },
-    [nodeType, isDisabled]
+    [isDisabled, nodeType, callback]
   )
 
   return (

--- a/hivemq-edge-frontend/src/extensions/datahub/components/controls/ToolItem.tsx
+++ b/hivemq-edge-frontend/src/extensions/datahub/components/controls/ToolItem.tsx
@@ -7,13 +7,14 @@ import IconButton from '@/components/Chakra/IconButton.tsx'
 
 import type { DataHubNodeType } from '@datahub/types.ts'
 import { NodeIcon } from '@datahub/components/helpers'
+import { DND_DESIGNER_NODE_TYPE } from '@datahub/utils/datahub.utils.ts'
 
 interface ToolProps extends ButtonProps {
   nodeType: DataHubNodeType
   callback?: () => void
 }
 
-const ToolItem: FC<ToolProps> = ({ nodeType, isDisabled }) => {
+const ToolItem: FC<ToolProps> = ({ nodeType, isDisabled, callback }) => {
   const { t } = useTranslation('datahub')
 
   const onButtonDragStart = useCallback(
@@ -21,7 +22,7 @@ const ToolItem: FC<ToolProps> = ({ nodeType, isDisabled }) => {
       if (isDisabled) {
         event.preventDefault()
       } else if (event && !isDisabled) {
-        event.dataTransfer.setData('application/reactflow', nodeType.toString())
+        event.dataTransfer.setData(DND_DESIGNER_NODE_TYPE, nodeType.toString())
         event.dataTransfer.effectAllowed = 'move'
         callback?.()
       }

--- a/hivemq-edge-frontend/src/extensions/datahub/components/controls/ToolboxNodes.tsx
+++ b/hivemq-edge-frontend/src/extensions/datahub/components/controls/ToolboxNodes.tsx
@@ -10,9 +10,10 @@ import { usePolicyGuards } from '@datahub/hooks/usePolicyGuards.ts'
 
 interface ToolboxNodesProps {
   direction?: 'horizontal' | 'vertical'
+  callback?: () => void
 }
 
-export const ToolboxNodes: FC<ToolboxNodesProps> = ({ direction = 'horizontal' }) => {
+export const ToolboxNodes: FC<ToolboxNodesProps> = ({ direction = 'horizontal', callback }) => {
   const { t } = useTranslation('datahub')
   const { nodes, isPolicyInDraft } = useDataHubDraftStore()
   const { isPolicyEditable } = usePolicyGuards()
@@ -31,21 +32,58 @@ export const ToolboxNodes: FC<ToolboxNodesProps> = ({ direction = 'horizontal' }
       alignItems={direction === 'horizontal' ? 'center' : 'flex-start'}
     >
       <ToolGroup title={t('workspace.toolbox.group.integration.edge')} id="group-integrations">
-        <ToolItem nodeType={DataHubNodeType.TOPIC_FILTER} isDisabled={isDraftEmpty || !isPolicyEditable} />
-        <ToolItem nodeType={DataHubNodeType.CLIENT_FILTER} isDisabled={isDraftEmpty || !isPolicyEditable} />
+        <ToolItem
+          data-testid="toolbox-trigger"
+          nodeType={DataHubNodeType.TOPIC_FILTER}
+          isDisabled={isDraftEmpty || !isPolicyEditable}
+          callback={callback}
+        />
+        <ToolItem
+          nodeType={DataHubNodeType.CLIENT_FILTER}
+          isDisabled={isDraftEmpty || !isPolicyEditable}
+          callback={callback}
+        />
       </ToolGroup>
       <ToolGroup title={t('workspace.toolbox.group.dataPolicy')} id="group-dataPolicy">
-        <ToolItem nodeType={DataHubNodeType.DATA_POLICY} isDisabled={!isPolicyEditable || isPolicyInDraft()} />
-        <ToolItem nodeType={DataHubNodeType.VALIDATOR} isDisabled={isDraftEmpty || !isPolicyEditable} />
-        <ToolItem nodeType={DataHubNodeType.SCHEMA} isDisabled={isDraftEmpty || !isPolicyEditable} />
+        <ToolItem
+          nodeType={DataHubNodeType.DATA_POLICY}
+          isDisabled={!isPolicyEditable || isPolicyInDraft()}
+          callback={callback}
+        />
+        <ToolItem
+          nodeType={DataHubNodeType.VALIDATOR}
+          isDisabled={isDraftEmpty || !isPolicyEditable}
+          callback={callback}
+        />
+        <ToolItem
+          nodeType={DataHubNodeType.SCHEMA}
+          isDisabled={isDraftEmpty || !isPolicyEditable}
+          callback={callback}
+        />
       </ToolGroup>
       <ToolGroup title={t('workspace.toolbox.group.behaviorPolicy')} id="group-behaviorPolicy">
-        <ToolItem nodeType={DataHubNodeType.BEHAVIOR_POLICY} isDisabled={!isPolicyEditable || isPolicyInDraft()} />
-        <ToolItem nodeType={DataHubNodeType.TRANSITION} isDisabled={isDraftEmpty || !isPolicyEditable} />
+        <ToolItem
+          nodeType={DataHubNodeType.BEHAVIOR_POLICY}
+          isDisabled={!isPolicyEditable || isPolicyInDraft()}
+          callback={callback}
+        />
+        <ToolItem
+          nodeType={DataHubNodeType.TRANSITION}
+          isDisabled={isDraftEmpty || !isPolicyEditable}
+          callback={callback}
+        />
       </ToolGroup>
       <ToolGroup title={t('workspace.toolbox.group.operation')} id="group-operation">
-        <ToolItem nodeType={DataHubNodeType.OPERATION} isDisabled={isDraftEmpty || !isPolicyEditable} />
-        <ToolItem nodeType={DataHubNodeType.FUNCTION} isDisabled={isDraftEmpty || !isPolicyEditable} />
+        <ToolItem
+          nodeType={DataHubNodeType.OPERATION}
+          isDisabled={isDraftEmpty || !isPolicyEditable}
+          callback={callback}
+        />
+        <ToolItem
+          nodeType={DataHubNodeType.FUNCTION}
+          isDisabled={isDraftEmpty || !isPolicyEditable}
+          callback={callback}
+        />
       </ToolGroup>
     </Wrapper>
   )

--- a/hivemq-edge-frontend/src/extensions/datahub/components/pages/PolicyEditor.tsx
+++ b/hivemq-edge-frontend/src/extensions/datahub/components/pages/PolicyEditor.tsx
@@ -23,6 +23,7 @@ import { CANVAS_GRID } from '@datahub/utils/theme.utils.ts'
 import { DataHubNodeType } from '@datahub/types.ts'
 import { usePolicyGuards } from '@datahub/hooks/usePolicyGuards.ts'
 import { CANVAS_DROP_DELTA } from '@datahub/designer/checks.utils.ts'
+import { DND_DESIGNER_NODE_TYPE } from '@datahub/utils/datahub.utils.ts'
 
 export type OnConnectStartParams = {
   nodeId: string | null
@@ -63,7 +64,7 @@ const PolicyEditor: FC = () => {
         event.preventDefault()
 
         // check if the dropped element is valid
-        const type = event.dataTransfer.getData('application/reactflow')
+        const type = event.dataTransfer.getData(DND_DESIGNER_NODE_TYPE)
         if (typeof type === 'undefined' || !type) {
           return
         }

--- a/hivemq-edge-frontend/src/extensions/datahub/components/pages/PolicyEditor.tsx
+++ b/hivemq-edge-frontend/src/extensions/datahub/components/pages/PolicyEditor.tsx
@@ -83,6 +83,8 @@ const PolicyEditor: FC = () => {
         onAddNodes([{ item: newNode, type: 'add' }])
         if (type === DataHubNodeType.DATA_POLICY || type === DataHubNodeType.BEHAVIOR_POLICY)
           setStatus(status, { type })
+
+        event.dataTransfer.clearData(DND_DESIGNER_NODE_TYPE)
       }
     },
     [onAddNodes, reactFlowInstance, setStatus, status]

--- a/hivemq-edge-frontend/src/extensions/datahub/utils/datahub.utils.ts
+++ b/hivemq-edge-frontend/src/extensions/datahub/utils/datahub.utils.ts
@@ -1,5 +1,7 @@
 import type { HotKeyItem } from '@datahub/types.ts'
 
+export const DND_DESIGNER_NODE_TYPE = 'application/reactflow;type=designer-node'
+
 export const SCRIPT_FUNCTION_SEPARATOR = ':'
 export const SCRIPT_FUNCTION_PREFIX = 'fn'
 export const SCRIPT_FUNCTION_LATEST = 'latest'


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/29930/details/

The PR fixes a bug with the toolbox dropdown, not properly closing when dragging an item on the `Designer` canvas. The bug also has an effect on the ability to operate the DnD in Cypress-based tests

The dropdown now closes at the onset of the drag-and-drop operation, clearing the canvas of all obstacles

The PR also fixes a potential bug with the DnD transfer data not being cleared after usage or cancellation.

### Before
![HiveMQ-Edge-05-29-2025_11_55 (1)](https://github.com/user-attachments/assets/a4fe49cb-b8ec-429b-aeb2-013fa25182b2)


### After 
![HiveMQ-Edge-05-29-2025_11_55](https://github.com/user-attachments/assets/98935fe1-fa29-4be9-8e27-e34269b1769a)
