### PR TITLE
fix(24800): Add the selector widget for topics in Delivery.redirectTo

### DIFF
--- a/hivemq-edge-frontend/src/extensions/datahub/api/hooks/DataHubFunctionsService/__handlers__/index.ts
+++ b/hivemq-edge-frontend/src/extensions/datahub/api/hooks/DataHubFunctionsService/__handlers__/index.ts
@@ -59,7 +59,7 @@ export const MOCK_DATAHUB_FUNCTIONS_DELIVERY_REDIRECT: FunctionSpecs = {
         type: 'string',
         title: 'Topic',
         description: 'The destination MQTT topic according to the MQTT specification.',
-        format: 'interpolation',
+        format: 'mqtt-topic',
       },
       applyPolicies: {
         type: 'boolean',

--- a/hivemq-edge-frontend/src/extensions/datahub/designer/operation/OperationData.ts
+++ b/hivemq-edge-frontend/src/extensions/datahub/designer/operation/OperationData.ts
@@ -1,4 +1,6 @@
 /* istanbul ignore file -- @preserve */
+import { CustomFormat } from '@/api/types/json-schema.ts'
+import { registerEntitySelectWidget } from '@/components/rjsf/Widgets/EntitySelectWidget.tsx'
 import type { PanelSpecs } from '@/extensions/datahub/types.ts'
 import type { RJSFSchema } from '@rjsf/utils'
 
@@ -21,6 +23,12 @@ export const MOCK_OPERATION_SCHEMA: PanelSpecs = {
       },
       message: {
         'ui:widget': 'datahub:message-interpolation',
+      },
+      topic: {
+        'ui:widget': registerEntitySelectWidget(CustomFormat.MQTT_TOPIC),
+        'ui:options': {
+          create: true,
+        },
       },
       incrementBy: {
         'ui:widget': 'updown',


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/24800/details/

The PR fixes the rendering of the `topic` property of the `Delivery.redirectTo` function by associating it with the custom format `mqqtt-topic` and select-based custom widget

### Out-of-scope
- The `interpolation` format associated with the topic filters is not supported yet. It will be dealt with in a subsequent ticket, see https://hivemq.kanbanize.com/ctrl_board/57/cards/33325/details/
- The fetching of existing topics for the selector options is not prtoperly implemented, see  https://hivemq.kanbanize.com/ctrl_board/57/cards/31942/details/

### Before 

### After
