### PR TITLE
fix(24801): Fix error with the validation of behavior policies

### DIFF
--- a/hivemq-edge-frontend/src/components/rjsf/Form/validation.utils.ts
+++ b/hivemq-edge-frontend/src/components/rjsf/Form/validation.utils.ts
@@ -129,6 +129,8 @@ export const customFormatsValidator = customizeValidator(
     customFormats: {
       // TODO[26559] This is a hack to remove the error; fix at source
       ['boolean']: () => true,
+      // TODO[33325] This is a hack to remove the error; fix at source
+      interpolation: () => true,
       'mqtt-topic': (topic) => validationTopic(topic) === undefined,
       'mqtt-tag': (tag) => validationTag(tag) === undefined,
       'mqtt-topic-filter': (topicFilter) => validationTopicFilter(topicFilter) === undefined,

--- a/hivemq-edge-frontend/src/extensions/datahub/api/__generated__/schemas/BehaviorPolicyData.json
+++ b/hivemq-edge-frontend/src/extensions/datahub/api/__generated__/schemas/BehaviorPolicyData.json
@@ -78,7 +78,7 @@
       "properties": {
         "arguments": {
           "title": "Publish.quota options",
-          "description": "When you configure a publish-quota model, at least one of the available arguments must be present. Data Hub uses the default value for the missing parameter.\\nThe default value for minimum is 0. The default value for maxPublishes is -1 (UNLIMITED).",
+          "description": "When you configure a publish-quota model, at least one of the available arguments must be present. Data Hub uses the default value for the missing parameter.",
           "type": "object",
           "required": ["minPublishes", "maxPublishes"],
           "properties": {
@@ -86,15 +86,25 @@
               "title": "minPublishes",
               "description": "Defines the minimal number of published messages that must be reached",
               "type": "integer",
-              "minimum": 0.0,
-              "default": 0.0
+              "minimum": 0,
+              "default": 0
             },
             "maxPublishes": {
               "title": "maxPublishes",
               "description": "Defines the maximum number of published messages that must be reached",
-              "type": "integer",
-              "minimum": -1.0,
-              "default": -1.0
+              "oneOf": [
+                {
+                  "title": "No limit",
+                  "enum": ["UNLIMITED"],
+                  "default": "UNLIMITED"
+                },
+                {
+                  "title": "Limit the maximum number of published messages",
+                  "type": "integer",
+                  "minimum": 0,
+                  "default": 10
+                }
+              ]
             }
           }
         }

--- a/hivemq-edge-frontend/src/extensions/datahub/api/__generated__/schemas/BehaviorPolicyData.json
+++ b/hivemq-edge-frontend/src/extensions/datahub/api/__generated__/schemas/BehaviorPolicyData.json
@@ -78,7 +78,7 @@
       "properties": {
         "arguments": {
           "title": "Publish.quota options",
-          "description": "When you configure a publish-quota model, at least one of the available arguments must be present. Data Hub uses the default value for the missing parameter.",
+          "description": "When you configure a publish-quota model, at least one of the available arguments must be present",
           "type": "object",
           "required": ["minPublishes", "maxPublishes"],
           "properties": {
@@ -91,20 +91,10 @@
             },
             "maxPublishes": {
               "title": "maxPublishes",
-              "description": "Defines the maximum number of published messages that must be reached",
-              "oneOf": [
-                {
-                  "title": "No limit",
-                  "enum": ["UNLIMITED"],
-                  "default": "UNLIMITED"
-                },
-                {
-                  "title": "Limit the maximum number of published messages",
-                  "type": "integer",
-                  "minimum": 0,
-                  "default": 10
-                }
-              ]
+              "description": "Defines the maximum number of published messages that must be reached. Use -1 for no limit.",
+              "type": "integer",
+              "minimum": -1,
+              "default": -1
             }
           }
         }

--- a/hivemq-edge-frontend/src/extensions/datahub/components/forms/CodeEditor.spec.cy.tsx
+++ b/hivemq-edge-frontend/src/extensions/datahub/components/forms/CodeEditor.spec.cy.tsx
@@ -37,7 +37,7 @@ describe('CodeEditor', () => {
     cy.mountWithProviders(<JSONSchemaEditor {...MOCK_WIDGET_PROPS} value={MOCK_JSONSCHEMA_SCHEMA} />)
   })
 
-  it.only('should render the fallback editor', () => {
+  it('should render the fallback editor', () => {
     Cypress.on('uncaught:exception', () => {
       // returning false here prevents Cypress from failing the test
       return false

--- a/hivemq-edge-frontend/src/extensions/datahub/components/forms/ReactFlowSchemaForm.tsx
+++ b/hivemq-edge-frontend/src/extensions/datahub/components/forms/ReactFlowSchemaForm.tsx
@@ -12,12 +12,12 @@ import type {
 } from '@rjsf/utils'
 import { getTemplate, getUiOptions, TranslatableString } from '@rjsf/utils'
 import type { GenericObjectType } from '@rjsf/utils'
-import validator from '@rjsf/validator-ajv8'
 import { Alert, AlertTitle, Box, Divider, FormControl, Heading, List, ListIcon, ListItem, Text } from '@chakra-ui/react'
 import { WarningIcon } from '@chakra-ui/icons'
 
 import { ArrayFieldItemTemplate } from '@/components/rjsf/ArrayFieldItemTemplate.tsx'
 import { ArrayFieldTemplate } from '@/components/rjsf/ArrayFieldTemplate.tsx'
+import { customFormatsValidator } from '@/components/rjsf/Form/validation.utils.ts'
 
 // overriding the heading definition
 function TitleFieldTemplate<T = unknown, S extends StrictRJSFSchema = RJSFSchema>({
@@ -171,7 +171,7 @@ export const ReactFlowSchemaForm: FC<ReactFlowSchemaFormProps> = (props) => {
         ErrorListTemplate,
         TitleFieldTemplate,
       }}
-      validator={validator}
+      validator={customFormatsValidator}
       // TODO[NVL] Not sure we want to hide the validation when readonly
       noValidate={!isNodeEditable}
       uiSchema={{

--- a/hivemq-edge-frontend/src/extensions/datahub/designer/behavior_policy/BehaviorPolicyPanel.spec.cy.tsx
+++ b/hivemq-edge-frontend/src/extensions/datahub/designer/behavior_policy/BehaviorPolicyPanel.spec.cy.tsx
@@ -25,17 +25,23 @@ const wrapper: React.JSXElementConstructor<{ children: React.ReactNode }> = ({ c
   >
     {children}
     <Button variant="primary" type="submit" form="datahub-node-form">
-      SUBMIT{' '}
+      SUBMIT
     </Button>
   </MockStoreWrapper>
 )
+
+const cy_selectBehaviourModel = (index: number) => {
+  cy.get('label#root_model-label + div').click()
+
+  cy.get('label#root_model-label + div').find("[role='listbox']").find("[role='option']").eq(index).click()
+}
 
 describe('BehaviorPolicyPanel', () => {
   beforeEach(() => {
     cy.viewport(800, 800)
     cy.intercept('/api/v1/data-hub/behavior-validation/policies', {
       items: [mockBehaviorPolicy],
-    })
+    }).as('getNodePayload')
   })
 
   it('should render the fields for the panel', () => {
@@ -61,26 +67,6 @@ describe('BehaviorPolicyPanel', () => {
     cy.get('label#root_model-label + div').find("[role='listbox']").find("[role='option']").eq(0).click()
 
     cy.get('h2').eq(0).should('contain.text', 'Publish')
-    cy.get('label#field-\\:r9\\:-label').should('contain.text', 'minPublishes')
-    cy.get('label#field-\\:r9\\:-label + div > input').should('have.value', '0')
-    cy.get('label#field-\\:rb\\:-label').should('contain.text', 'maxPublishes')
-    cy.get('label#field-\\:rb\\:-label + div > input').should('have.value', '-1')
-
-    cy.get("button[type='submit']").click()
-    cy.get('@onSubmit')
-      .should('have.been.calledOnceWith', Cypress.sinon.match.object)
-      .its('firstCall.args.0')
-      .should('deep.include', {
-        status: 'submitted',
-        formData: {
-          id: 'a123',
-          model: 'Publish.quota',
-          arguments: {
-            minPublishes: 0,
-            maxPublishes: -1,
-          },
-        },
-      })
   })
 
   it('should be accessible', () => {
@@ -89,5 +75,91 @@ describe('BehaviorPolicyPanel', () => {
 
     cy.checkAccessibility()
     cy.percySnapshot('Component: BehaviorPolicyPanel')
+  })
+
+  context('Behaviour models', () => {
+    it('should render the Quota options', () => {
+      const onSubmit = cy.stub().as('onSubmit')
+
+      cy.mountWithProviders(<BehaviorPolicyPanel selectedNode="3" onFormSubmit={onSubmit} />, { wrapper })
+      cy.get('#root_id').type('a123')
+
+      cy_selectBehaviourModel(0)
+
+      cy.get('h2').eq(0).should('contain.text', 'Publish.quota options')
+      cy.get('label[for="root_arguments_minPublishes"]').should('contain.text', 'minPublishes')
+      cy.get('label[for="root_arguments_minPublishes"] + div > input').should('have.value', '0')
+      cy.get('label[for="root_arguments_maxPublishes"]').should('contain.text', 'maxPublishes')
+      cy.get('label[for="root_arguments_maxPublishes"] + div > input').should('have.value', '-1')
+
+      cy.get("button[type='submit']").click()
+      cy.get('@onSubmit')
+        .should('have.been.calledOnceWith', Cypress.sinon.match.object)
+        .its('firstCall.args.0')
+        .should('deep.include', {
+          status: 'submitted',
+          formData: {
+            id: 'a123',
+            model: 'Publish.quota',
+            arguments: {
+              minPublishes: 0,
+              maxPublishes: -1,
+            },
+          },
+        })
+    })
+
+    it('should render id errors', () => {
+      cy.mountWithProviders(<BehaviorPolicyPanel selectedNode="3" onFormSubmit={cy.stub} />, { wrapper })
+      cy.get("button[type='submit']").click()
+
+      cy.get('[role="group"]:has(> label#root_id-label) + ul > li').as('idErrors')
+      cy.get('@idErrors').should('have.length', 2)
+      cy.get('@idErrors').eq(0).should('contain.text', "must have required property 'id'")
+      cy.get('@idErrors').eq(1).should('contain.text', 'Cannot load the existing policies for checking ids')
+
+      cy.get('[role="alert"]')
+        .should('contain.text', "must have required property 'id'")
+        .should('contain.text', 'Cannot load the existing policies for checking ids')
+    })
+
+    it('should render arguments errors', () => {
+      cy.mountWithProviders(<BehaviorPolicyPanel selectedNode="3" onFormSubmit={cy.stub} />, { wrapper })
+
+      cy.get('#root_id').type('a123')
+      cy_selectBehaviourModel(0)
+
+      cy.get('label[for="root_arguments_minPublishes"] + div > input').clear()
+      cy.get('label[for="root_arguments_minPublishes"] + div > input').type('-50')
+      cy.get('label[for="root_arguments_maxPublishes"] + div > input').clear()
+      cy.get('label[for="root_arguments_maxPublishes"] + div > input').type('-50')
+      cy.get("button[type='submit']").click()
+
+      cy.get('[role="group"]:has(> label[for="root_arguments_minPublishes"]) + ul > li').as('minPublishesErrors')
+      cy.get('@minPublishesErrors').should('have.length', 1)
+      cy.get('@minPublishesErrors').eq(0).should('contain.text', 'must be >= 0')
+
+      cy.get('[role="group"]:has(> label[for="root_arguments_maxPublishes"]) + ul > li').as('maxPublishesErrors')
+      cy.get('@maxPublishesErrors').should('have.length', 1)
+      cy.get('@maxPublishesErrors').eq(0).should('contain.text', 'must be >= -1')
+
+      cy.get('label[for="root_arguments_minPublishes"] + div > input').clear()
+      cy.get('label[for="root_arguments_minPublishes"] + div > input').type('200')
+      cy.get('label[for="root_arguments_maxPublishes"] + div > input').clear()
+      cy.get('label[for="root_arguments_maxPublishes"] + div > input').type('100')
+      cy.get("button[type='submit']").click()
+
+      cy.get('[role="group"]:has(> label[for="root_arguments_minPublishes"]) + ul > li').as('minPublishesErrors')
+      cy.get('@minPublishesErrors').should('have.length', 1)
+      cy.get('@minPublishesErrors')
+        .eq(0)
+        .should('contain.text', 'The minimum publish quota must be lesser than the maximum publish quota')
+
+      cy.get('[role="group"]:has(> label[for="root_arguments_maxPublishes"]) + ul > li').as('maxPublishesErrors')
+      cy.get('@maxPublishesErrors').should('have.length', 1)
+      cy.get('@maxPublishesErrors')
+        .eq(0)
+        .should('contain.text', 'The maximum publish quota must be greater than the minimum publish quota')
+    })
   })
 })

--- a/hivemq-edge-frontend/src/extensions/datahub/designer/behavior_policy/BehaviorPolicyPanel.tsx
+++ b/hivemq-edge-frontend/src/extensions/datahub/designer/behavior_policy/BehaviorPolicyPanel.tsx
@@ -15,6 +15,8 @@ import { usePolicyGuards } from '@datahub/hooks/usePolicyGuards.ts'
 import type { BehaviorPolicyData, PanelProps, PublishQuotaArguments } from '@datahub/types.ts'
 import { BehaviorPolicyType } from '@datahub/types.ts'
 
+const UNLIMITED_PUBLISH = -1
+
 export const BehaviorPolicyPanel: FC<PanelProps> = ({ selectedNode, onFormSubmit }) => {
   const { t } = useTranslation('datahub')
   const { nodes } = useDataHubDraftStore()
@@ -34,7 +36,7 @@ export const BehaviorPolicyPanel: FC<PanelProps> = ({ selectedNode, onFormSubmit
     }
     if (formData?.model === BehaviorPolicyType.PUBLISH_QUOTA) {
       const { maxPublishes, minPublishes } = formData.arguments as PublishQuotaArguments
-      if (maxPublishes !== -1 && maxPublishes < minPublishes) {
+      if (maxPublishes !== UNLIMITED_PUBLISH && maxPublishes < minPublishes) {
         errors?.['arguments']?.['maxPublishes']?.addError(
           t('error.validation.behaviourPolicy.publishQuota.maxLessThanMin')
         )

--- a/hivemq-edge-frontend/src/extensions/datahub/designer/behavior_policy/BehaviorPolicyPanel.tsx
+++ b/hivemq-edge-frontend/src/extensions/datahub/designer/behavior_policy/BehaviorPolicyPanel.tsx
@@ -5,13 +5,15 @@ import { useTranslation } from 'react-i18next'
 import { Card, CardBody } from '@chakra-ui/react'
 import type { CustomValidator } from '@rjsf/utils'
 
-import type { BehaviorPolicyData, PanelProps } from '@datahub/types.ts'
+import ErrorMessage from '@/components/ErrorMessage.tsx'
+
 import { useGetAllBehaviorPolicies } from '@datahub/api/hooks/DataHubBehaviorPoliciesService/useGetAllBehaviorPolicies.ts'
 import { ReactFlowSchemaForm } from '@datahub/components/forms/ReactFlowSchemaForm.tsx'
 import { MOCK_BEHAVIOR_POLICY_SCHEMA } from '@datahub/designer/behavior_policy/BehaviorPolicySchema.ts'
 import useDataHubDraftStore from '@datahub/hooks/useDataHubDraftStore.ts'
 import { usePolicyGuards } from '@datahub/hooks/usePolicyGuards.ts'
-import ErrorMessage from '@/components/ErrorMessage.tsx'
+import type { BehaviorPolicyData, PanelProps, PublishQuotaArguments } from '@datahub/types.ts'
+import { BehaviorPolicyType } from '@datahub/types.ts'
 
 export const BehaviorPolicyPanel: FC<PanelProps> = ({ selectedNode, onFormSubmit }) => {
   const { t } = useTranslation('datahub')
@@ -29,6 +31,17 @@ export const BehaviorPolicyPanel: FC<PanelProps> = ({ selectedNode, onFormSubmit
     else {
       const isIdNotUnique = Boolean(allPolicies.items?.find((e) => e.id === formData?.id))
       if (isIdNotUnique) errors['id']?.addError(t('error.validation.behaviourPolicy.notUnique'))
+    }
+    if (formData?.model === BehaviorPolicyType.PUBLISH_QUOTA) {
+      const { maxPublishes, minPublishes } = formData.arguments as PublishQuotaArguments
+      if (maxPublishes !== -1 && maxPublishes < minPublishes) {
+        errors?.['arguments']?.['maxPublishes']?.addError(
+          t('error.validation.behaviourPolicy.publishQuota.maxLessThanMin')
+        )
+        errors?.['arguments']?.['minPublishes']?.addError(
+          t('error.validation.behaviourPolicy.publishQuota.minMoreThanMax')
+        )
+      }
     }
     return errors
   }

--- a/hivemq-edge-frontend/src/extensions/datahub/designer/behavior_policy/BehaviorPolicySchema.ts
+++ b/hivemq-edge-frontend/src/extensions/datahub/designer/behavior_policy/BehaviorPolicySchema.ts
@@ -12,16 +12,7 @@ export const MOCK_BEHAVIOR_POLICY_SCHEMA: PanelSpecs = {
         'ui:widget': 'updown',
       },
       maxPublishes: {
-        'ui:widget': 'radio', // Hide the enum field since it's fixed
-        // This is to reflect the use of oneOf on the definition of maxPublish
-        oneOf: [
-          {
-            'ui:widget': 'hidden', // Hide the enum field since it's fixed
-          },
-          {
-            // must be there for the second element,
-          },
-        ],
+        'ui:widget': 'updown',
       },
     },
   },

--- a/hivemq-edge-frontend/src/extensions/datahub/designer/behavior_policy/BehaviorPolicySchema.ts
+++ b/hivemq-edge-frontend/src/extensions/datahub/designer/behavior_policy/BehaviorPolicySchema.ts
@@ -12,7 +12,16 @@ export const MOCK_BEHAVIOR_POLICY_SCHEMA: PanelSpecs = {
         'ui:widget': 'updown',
       },
       maxPublishes: {
-        'ui:widget': 'updown',
+        'ui:widget': 'radio', // Hide the enum field since it's fixed
+        // This is to reflect the use of oneOf on the definition of maxPublish
+        oneOf: [
+          {
+            'ui:widget': 'hidden', // Hide the enum field since it's fixed
+          },
+          {
+            // must be there for the second element,
+          },
+        ],
       },
     },
   },

--- a/hivemq-edge-frontend/src/extensions/datahub/designer/operation/OperationPanel.spec.cy.tsx
+++ b/hivemq-edge-frontend/src/extensions/datahub/designer/operation/OperationPanel.spec.cy.tsx
@@ -170,7 +170,7 @@ describe('OperationPanel', () => {
       },
     }
 
-    it.only('should render the form', () => {
+    it('should render the form', () => {
       cy.mountWithProviders(<OperationPanel selectedNode="my-node" />, {
         wrapper: getWrapperWith([node]),
       })

--- a/hivemq-edge-frontend/src/extensions/datahub/locales/en/datahub.json
+++ b/hivemq-edge-frontend/src/extensions/datahub/locales/en/datahub.json
@@ -369,7 +369,11 @@
       },
       "behaviourPolicy": {
         "notLoading": "Cannot load the existing policies for checking ids",
-        "notUnique": "The id is already in use by another behavior policy"
+        "notUnique": "The id is already in use by another behavior policy",
+        "publishQuota": {
+          "maxLessThanMin": "The maximum publish quota must be greater than the minimum publish quota",
+          "minMoreThanMax": "The minimum publish quota must be lesser than the maximum publish quota"
+        }
       },
       "operation": {
         "notLoading": "Cannot load the existing operations for checking ids",

--- a/hivemq-edge-frontend/src/extensions/datahub/locales/en/datahub.json
+++ b/hivemq-edge-frontend/src/extensions/datahub/locales/en/datahub.json
@@ -371,8 +371,8 @@
         "notLoading": "Cannot load the existing policies for checking ids",
         "notUnique": "The id is already in use by another behavior policy",
         "publishQuota": {
-          "maxLessThanMin": "The maximum publish quota must be greater than the minimum publish quota",
-          "minMoreThanMax": "The minimum publish quota must be lesser than the maximum publish quota"
+          "maxLessThanMin": "The maximum publish quota must be greater than or equal to the minimum publish quota",
+          "minMoreThanMax": "The minimum publish quota must be less than or equal to the maximum publish quota"
         }
       },
       "operation": {

--- a/hivemq-edge-frontend/src/extensions/datahub/types.ts
+++ b/hivemq-edge-frontend/src/extensions/datahub/types.ts
@@ -277,17 +277,23 @@ export namespace OperationData {
   }
 }
 
-// TODO[18757] Add to the OpenAPI specs; see https://hivemq.kanbanize.com/ctrl_board/4/cards/18757/details/
+// TODO[33539] Add to the OpenAPI specs; see https://hivemq.kanbanize.com/ctrl_board/4/cards/18757/details/
 export enum BehaviorPolicyType {
   MQTT_EVENT = 'Mqtt.events',
   PUBLISH_DUPLICATE = 'Publish.duplicate',
   PUBLISH_QUOTA = 'Publish.quota',
 }
 
+// TODO[33539] Add to the OpenAPI specs; see https://hivemq.kanbanize.com/ctrl_board/4/cards/18757/details/
+export interface PublishQuotaArguments {
+  minPublishes: number
+  maxPublishes: number
+}
+
 export interface BehaviorPolicyData extends DataHubNodeData {
   id: string
   model: BehaviorPolicyType
-  arguments?: Record<string, string | number>
+  arguments?: PublishQuotaArguments | Record<string, string | number>
   core?: BehaviorPolicy
 }
 

--- a/hivemq-edge-frontend/src/extensions/datahub/utils/node.utils.ts
+++ b/hivemq-edge-frontend/src/extensions/datahub/utils/node.utils.ts
@@ -2,12 +2,16 @@ import type { Connection, Edge, HandleProps, Node } from '@xyflow/react'
 import { getConnectedEdges, getIncomers, getOutgoers } from '@xyflow/react'
 import { v4 as uuidv4 } from 'uuid'
 import type { TFunction } from 'i18next'
-import validator from '@rjsf/validator-ajv8'
 import { RiPassExpiredLine, RiPassPendingLine, RiPassValidLine } from 'react-icons/ri'
 
 import i18n from '@/config/i18n.config.ts'
 
-import { MOCK_JSONSCHEMA_SCHEMA } from '../__test-utils__/schema.mocks.ts'
+import { DataPolicyValidator } from '@/api/__generated__'
+import { customFormatsValidator } from '@/components/rjsf/Form/validation.utils.ts'
+
+import { MOCK_JSONSCHEMA_SCHEMA } from '@datahub/__test-utils__/schema.mocks.ts'
+import { CustomNodeJSONSchema } from '@datahub/config/schemas.config.ts'
+import { PolicyCheckErrors } from '@datahub/designer/validation.errors.ts'
 import type {
   ClientFilterData,
   DataHubNodeData,
@@ -17,7 +21,7 @@ import type {
   TopicFilterData,
   ValidatorData,
   ValidDropConnection,
-} from '../types.ts'
+} from '@datahub/types.ts'
 import {
   BehaviorPolicyData,
   DataHubNodeType,
@@ -30,10 +34,7 @@ import {
   SchemaType,
   StrategyType,
   TransitionData,
-} from '../types.ts'
-import { DataPolicyValidator } from '@/api/__generated__'
-import { CustomNodeJSONSchema } from '@datahub/config/schemas.config.ts'
-import { PolicyCheckErrors } from '@datahub/designer/validation.errors.ts'
+} from '@datahub/types.ts'
 
 export const getNodeId = (stub = 'node') => `${stub}_${uuidv4()}`
 
@@ -392,7 +393,7 @@ export const renderResourceName = (name: string | undefined, version: number | u
 export const validateNode = (newNode: Node) => {
   if (!newNode.type) return { isValid: false }
   const schema = CustomNodeJSONSchema[newNode.type]
-  const validate = validator.ajv.compile(schema)
+  const validate = customFormatsValidator.ajv.compile(schema)
   const isValid = validate(newNode.data)
   return {
     isValid,


### PR DESCRIPTION
see https://hivemq.kanbanize.com/ctrl_board/57/cards/24801/details/

The PR fixes some of the bugs preventing the validation of a behaviour policy 
- Illegal functions: events are used to filter invalid functions in the first place
- illegal value: the design of the ' maxPublish` option has been fixed

The custom format validation has also been added to the policy check, ensuring proper verification of string-based elements such as topics, interpolations, etc. 

See also https://github.com/hivemq/hivemq-edge-commercial-modules/pull/166

### Out-of-scope
- The exact design of the `maxFunction` will need to change in the backend; it will be done in a subsequent ticket

### Before 
![HiveMQ-Edge-06-04-2025_12_14](https://github.com/user-attachments/assets/8462d344-02f1-46c3-8c76-a008c281caff)


### After
![HiveMQ-Edge-06-04-2025_12_13 (1)](https://github.com/user-attachments/assets/b8468f68-9711-4972-9e67-4c78ed18321b)
