### PR TITLE
fix(29734): Fix a series of bugs when publishing policies with multiple resources 

### DIFF
--- a/hivemq-edge-frontend/src/__test-utils__/hooks/WrapperAccessibleDraggableProvider.tsx
+++ b/hivemq-edge-frontend/src/__test-utils__/hooks/WrapperAccessibleDraggableProvider.tsx
@@ -1,0 +1,10 @@
+import { AccessibleDraggableProvider } from '@/hooks/useAccessibleDraggable'
+import type { FC, PropsWithChildren } from 'react'
+
+export const getAccessibleDraggableProvider = () => {
+  const WrapperEdgeProvider: FC<PropsWithChildren> = ({ children }) => {
+    return <AccessibleDraggableProvider>{children}</AccessibleDraggableProvider>
+  }
+
+  return WrapperEdgeProvider
+}

--- a/hivemq-edge-frontend/src/extensions/datahub/__test-utils__/transform.mocks.ts
+++ b/hivemq-edge-frontend/src/extensions/datahub/__test-utils__/transform.mocks.ts
@@ -1,4 +1,5 @@
 import { OperationData } from '@datahub/types.ts'
+import { SCRIPT_FUNCTION_LATEST } from '@datahub/utils/datahub.utils.ts'
 
 const NODE1_ID = 'node_07280ae8-6470-48f8-87da-84cc4bcb6d2b'
 const NODE2_ID = 'node_4ad0412f-e773-49d3-81e3-d5f54f9fbd09'
@@ -68,7 +69,7 @@ export const MOCK_TRANSFORM = {
         functionId: 'Serdes.deserialize',
         formData: {
           schemaId: 'dfdffd',
-          schemaVersion: 'latest',
+          schemaVersion: SCRIPT_FUNCTION_LATEST,
         },
         metadata: {
           isTerminal: false,

--- a/hivemq-edge-frontend/src/extensions/datahub/__test-utils__/vitest.utils.ts
+++ b/hivemq-edge-frontend/src/extensions/datahub/__test-utils__/vitest.utils.ts
@@ -1,0 +1,5 @@
+import type { DataHubNodeType } from '@datahub/types.ts'
+
+export const vitest_ExpectStringContainingUUIDFromNodeType = (type: DataHubNodeType) => {
+  return expect.stringContaining(`${type}_`)
+}

--- a/hivemq-edge-frontend/src/extensions/datahub/components/pages/DataHubListings.tsx
+++ b/hivemq-edge-frontend/src/extensions/datahub/components/pages/DataHubListings.tsx
@@ -90,14 +90,16 @@ const DataHubListings: FC = () => {
           <ScriptTable onDeleteItem={handleOnDelete} />
         </TabPanel>
       </TabPanels>
-      <ConfirmationDialog
-        isOpen={isConfirmDeleteOpen}
-        onClose={handleConfirmOnClose}
-        onSubmit={handleConfirmOnSubmit}
-        header={t('Listings.modal.delete.header', { context: deleteItem?.type })}
-        message={t('Listings.modal.delete.message', { context: deleteItem?.type })}
-        prompt={t('Listings.modal.delete.prompt')}
-      />
+      {deleteItem && (
+        <ConfirmationDialog
+          isOpen={isConfirmDeleteOpen}
+          onClose={handleConfirmOnClose}
+          onSubmit={handleConfirmOnSubmit}
+          header={t('Listings.modal.delete.header', { context: deleteItem?.type })}
+          message={t('Listings.modal.delete.message', { context: deleteItem?.type })}
+          prompt={t('Listings.modal.delete.prompt')}
+        />
+      )}
     </Tabs>
   )
 }

--- a/hivemq-edge-frontend/src/extensions/datahub/designer/behavior_policy/BehaviorPolicyNode.utils.ts
+++ b/hivemq-edge-frontend/src/extensions/datahub/designer/behavior_policy/BehaviorPolicyNode.utils.ts
@@ -61,7 +61,7 @@ export const loadBehaviorPolicy = (behaviorPolicy: BehaviorPolicy): NodeAddChang
   }
 
   const behaviorPolicyNode: Node<BehaviorPolicyData> = {
-    id: getNodeId(),
+    id: getNodeId(DataHubNodeType.BEHAVIOR_POLICY),
     type: DataHubNodeType.BEHAVIOR_POLICY,
     position,
     data: {

--- a/hivemq-edge-frontend/src/extensions/datahub/designer/client_filter/ClientFilterNode.utils.spec.ts
+++ b/hivemq-edge-frontend/src/extensions/datahub/designer/client_filter/ClientFilterNode.utils.spec.ts
@@ -145,7 +145,7 @@ describe('loadClientFilter', () => {
           data: {
             clients: ['*.*'],
           },
-          id: expect.stringContaining('node_'),
+          id: expect.stringContaining('CLIENT_FILTER_'),
           position: {
             x: -320,
             y: 0,
@@ -155,7 +155,7 @@ describe('loadClientFilter', () => {
         type: 'add',
       }),
       expect.objectContaining({
-        source: expect.stringContaining('node_'),
+        source: expect.stringContaining('CLIENT_FILTER_'),
         target: 'node-id',
       }),
     ])

--- a/hivemq-edge-frontend/src/extensions/datahub/designer/client_filter/ClientFilterNode.utils.spec.ts
+++ b/hivemq-edge-frontend/src/extensions/datahub/designer/client_filter/ClientFilterNode.utils.spec.ts
@@ -1,6 +1,7 @@
 import { expect } from 'vitest'
 import type { Connection, Node, NodeAddChange } from '@xyflow/react'
 import { MOCK_DEFAULT_NODE } from '@/__test-utils__/react-flow/nodes.ts'
+import { vitest_ExpectStringContainingUUIDFromNodeType } from '@datahub/__test-utils__/vitest.utils.ts'
 
 import type { BehaviorPolicyData, ClientFilterData, WorkspaceState } from '@datahub/types.ts'
 import { BehaviorPolicyType, DataHubNodeType } from '@datahub/types.ts'
@@ -145,7 +146,7 @@ describe('loadClientFilter', () => {
           data: {
             clients: ['*.*'],
           },
-          id: expect.stringContaining('CLIENT_FILTER_'),
+          id: vitest_ExpectStringContainingUUIDFromNodeType(DataHubNodeType.CLIENT_FILTER),
           position: {
             x: -320,
             y: 0,
@@ -155,7 +156,7 @@ describe('loadClientFilter', () => {
         type: 'add',
       }),
       expect.objectContaining({
-        source: expect.stringContaining('CLIENT_FILTER_'),
+        source: vitest_ExpectStringContainingUUIDFromNodeType(DataHubNodeType.CLIENT_FILTER),
         target: 'node-id',
       }),
     ])

--- a/hivemq-edge-frontend/src/extensions/datahub/designer/client_filter/ClientFilterNode.utils.ts
+++ b/hivemq-edge-frontend/src/extensions/datahub/designer/client_filter/ClientFilterNode.utils.ts
@@ -49,7 +49,7 @@ export const loadClientFilter = (
   }
 
   const topicNode: Node<ClientFilterData> = {
-    id: getNodeId(),
+    id: getNodeId(DataHubNodeType.CLIENT_FILTER),
     type: DataHubNodeType.CLIENT_FILTER,
     position,
     data: {

--- a/hivemq-edge-frontend/src/extensions/datahub/designer/data_policy/DataPolicyNode.utils.spec.ts
+++ b/hivemq-edge-frontend/src/extensions/datahub/designer/data_policy/DataPolicyNode.utils.spec.ts
@@ -147,7 +147,7 @@ describe('loadDataPolicy', () => {
   it('should return nodes', () => {
     expect(loadDataPolicy(dataPolicy)).toStrictEqual<NodeAddChange>({
       item: expect.objectContaining<Node<DataPolicyData>>({
-        id: expect.stringContaining('node_'),
+        id: expect.stringContaining('DATA_POLICY_'),
         type: DataHubNodeType.DATA_POLICY,
         data: { id: 'string' },
         position: { x: 0, y: 0 },

--- a/hivemq-edge-frontend/src/extensions/datahub/designer/data_policy/DataPolicyNode.utils.spec.ts
+++ b/hivemq-edge-frontend/src/extensions/datahub/designer/data_policy/DataPolicyNode.utils.spec.ts
@@ -1,11 +1,12 @@
 import { expect } from 'vitest'
 import type { Node, NodeAddChange } from '@xyflow/react'
 import { MOCK_DEFAULT_NODE } from '@/__test-utils__/react-flow/nodes.ts'
+import { vitest_ExpectStringContainingUUIDFromNodeType } from '@datahub/__test-utils__/vitest.utils.ts'
 
+import type { DataPolicy } from '@/api/__generated__'
 import type { DataPolicyData, TopicFilterData, WorkspaceState } from '@datahub/types.ts'
 import { DataHubNodeType } from '@datahub/types.ts'
 import { checkValidityFilter, loadDataPolicy } from '@datahub/designer/data_policy/DataPolicyNode.utils.ts'
-import type { DataPolicy } from '@/api/__generated__'
 
 const NODE_DATA_ID = 'my-policy-id'
 
@@ -147,7 +148,7 @@ describe('loadDataPolicy', () => {
   it('should return nodes', () => {
     expect(loadDataPolicy(dataPolicy)).toStrictEqual<NodeAddChange>({
       item: expect.objectContaining<Node<DataPolicyData>>({
-        id: expect.stringContaining('DATA_POLICY_'),
+        id: vitest_ExpectStringContainingUUIDFromNodeType(DataHubNodeType.DATA_POLICY),
         type: DataHubNodeType.DATA_POLICY,
         data: { id: 'string' },
         position: { x: 0, y: 0 },

--- a/hivemq-edge-frontend/src/extensions/datahub/designer/data_policy/DataPolicyNode.utils.ts
+++ b/hivemq-edge-frontend/src/extensions/datahub/designer/data_policy/DataPolicyNode.utils.ts
@@ -123,7 +123,7 @@ export const loadDataPolicy = (policy: DataPolicy): NodeAddChange => {
   }
 
   const dataPolicyNode: Node<DataPolicyData> = {
-    id: getNodeId(),
+    id: getNodeId(DataHubNodeType.DATA_POLICY),
     type: DataHubNodeType.DATA_POLICY,
     position,
     data: { id: policy.id },

--- a/hivemq-edge-frontend/src/extensions/datahub/designer/operation/OperationNode.utils.spec.ts
+++ b/hivemq-edge-frontend/src/extensions/datahub/designer/operation/OperationNode.utils.spec.ts
@@ -538,7 +538,7 @@ describe('loadPipeline', () => {
 
     // The transform node is created with a UI ID that starts with 'node_'
     const transformNode = (results[1] as Connection).target
-    expect(transformNode).toMatch('node_')
+    expect(transformNode).toMatch('OPERATION_')
 
     expect(results).toStrictEqual(
       expect.arrayContaining<NodeAddChange | Connection>([

--- a/hivemq-edge-frontend/src/extensions/datahub/designer/operation/OperationNode.utils.spec.ts
+++ b/hivemq-edge-frontend/src/extensions/datahub/designer/operation/OperationNode.utils.spec.ts
@@ -735,13 +735,13 @@ describe('loadPipeline', () => {
         }),
         {
           item: expect.objectContaining<Partial<Node<FunctionData>>>({
-            id: 'script1',
+            id: expect.stringContaining('FUNCTION_'),
             type: DataHubNodeType.FUNCTION,
           }),
           type: 'add',
         },
         expect.objectContaining<Connection>({
-          source: 'script1',
+          source: expect.stringContaining('FUNCTION_'),
           sourceHandle: null,
           target: expect.stringContaining(transformNode),
           targetHandle: 'function',

--- a/hivemq-edge-frontend/src/extensions/datahub/designer/operation/OperationNode.utils.spec.ts
+++ b/hivemq-edge-frontend/src/extensions/datahub/designer/operation/OperationNode.utils.spec.ts
@@ -1,7 +1,8 @@
 import { expect } from 'vitest'
 import type { Connection, Node, NodeAddChange } from '@xyflow/react'
-
 import { MOCK_DEFAULT_NODE } from '@/__test-utils__/react-flow/nodes.ts'
+import { vitest_ExpectStringContainingUUIDFromNodeType } from '@datahub/__test-utils__/vitest.utils.ts'
+
 import { type BehaviorPolicyOnTransition, type DataPolicy, type PolicyOperation, Script } from '@/api/__generated__'
 import { mockSchemaTempHumidity } from '@datahub/api/hooks/DataHubSchemasService/__handlers__'
 
@@ -709,39 +710,39 @@ describe('loadPipeline', () => {
       expect.arrayContaining<NodeAddChange | Connection>([
         {
           item: expect.objectContaining<Partial<Node<SchemaData>>>({
-            id: expect.stringContaining('SCHEMA_'),
+            id: vitest_ExpectStringContainingUUIDFromNodeType(DataHubNodeType.SCHEMA),
             type: DataHubNodeType.SCHEMA,
           }),
           type: 'add',
         },
         expect.objectContaining<Connection>({
-          source: expect.stringContaining('SCHEMA_'),
+          source: vitest_ExpectStringContainingUUIDFromNodeType(DataHubNodeType.SCHEMA),
           sourceHandle: null,
           target: expect.stringContaining(transformNode),
           targetHandle: 'deserialiser',
         }),
         {
           item: expect.objectContaining<Partial<Node<SchemaData>>>({
-            id: expect.stringContaining('SCHEMA_'),
+            id: vitest_ExpectStringContainingUUIDFromNodeType(DataHubNodeType.SCHEMA),
             type: DataHubNodeType.SCHEMA,
           }),
           type: 'add',
         },
         expect.objectContaining<Connection>({
-          source: expect.stringContaining('SCHEMA_'),
+          source: vitest_ExpectStringContainingUUIDFromNodeType(DataHubNodeType.SCHEMA),
           sourceHandle: null,
           target: expect.stringContaining(transformNode),
           targetHandle: 'serialiser',
         }),
         {
           item: expect.objectContaining<Partial<Node<FunctionData>>>({
-            id: expect.stringContaining('FUNCTION_'),
+            id: vitest_ExpectStringContainingUUIDFromNodeType(DataHubNodeType.FUNCTION),
             type: DataHubNodeType.FUNCTION,
           }),
           type: 'add',
         },
         expect.objectContaining<Connection>({
-          source: expect.stringContaining('FUNCTION_'),
+          source: vitest_ExpectStringContainingUUIDFromNodeType(DataHubNodeType.FUNCTION),
           sourceHandle: null,
           target: expect.stringContaining(transformNode),
           targetHandle: 'function',

--- a/hivemq-edge-frontend/src/extensions/datahub/designer/operation/OperationNode.utils.spec.ts
+++ b/hivemq-edge-frontend/src/extensions/datahub/designer/operation/OperationNode.utils.spec.ts
@@ -482,7 +482,7 @@ describe('checkValidityTransformFunction', () => {
       expect(data).toEqual(
         expect.objectContaining({
           arguments: {},
-          functionId: 'fn:the_function:latest',
+          functionId: 'fn:the_function:1',
           id: NODE_FUNCTION_ID,
         })
       )
@@ -709,26 +709,26 @@ describe('loadPipeline', () => {
       expect.arrayContaining<NodeAddChange | Connection>([
         {
           item: expect.objectContaining<Partial<Node<SchemaData>>>({
-            id: NODE_DESERIALISER_ID,
+            id: expect.stringContaining('SCHEMA_'),
             type: DataHubNodeType.SCHEMA,
           }),
           type: 'add',
         },
         expect.objectContaining<Connection>({
-          source: NODE_DESERIALISER_ID,
+          source: expect.stringContaining('SCHEMA_'),
           sourceHandle: null,
           target: expect.stringContaining(transformNode),
           targetHandle: 'deserialiser',
         }),
         {
           item: expect.objectContaining<Partial<Node<SchemaData>>>({
-            id: NODE_SERIALISER_ID,
+            id: expect.stringContaining('SCHEMA_'),
             type: DataHubNodeType.SCHEMA,
           }),
           type: 'add',
         },
         expect.objectContaining<Connection>({
-          source: NODE_SERIALISER_ID,
+          source: expect.stringContaining('SCHEMA_'),
           sourceHandle: null,
           target: expect.stringContaining(transformNode),
           targetHandle: 'serialiser',

--- a/hivemq-edge-frontend/src/extensions/datahub/designer/operation/OperationNode.utils.ts
+++ b/hivemq-edge-frontend/src/extensions/datahub/designer/operation/OperationNode.utils.ts
@@ -324,7 +324,7 @@ export const loadPipeline = (
           const [deserializer, ...functions] = operationNode as PolicyOperation[]
 
           operationNode = {
-            id: getNodeId(),
+            id: getNodeId(DataHubNodeType.OPERATION),
             type: DataHubNodeType.OPERATION,
             position: { ...shiftPositionRight() },
             data: {
@@ -364,7 +364,7 @@ export const loadPipeline = (
       default:
         if (operationNode) throw new Error(i18n.t('datahub:error.loading.operation.unknown') as string)
         operationNode = {
-          id: getNodeId(),
+          id: getNodeId(DataHubNodeType.OPERATION),
           type: DataHubNodeType.OPERATION,
           position: { ...shiftPositionRight() },
           data: {

--- a/hivemq-edge-frontend/src/extensions/datahub/designer/operation/OperationNode.utils.ts
+++ b/hivemq-edge-frontend/src/extensions/datahub/designer/operation/OperationNode.utils.ts
@@ -3,14 +3,7 @@ import { getConnectedEdges, getIncomers } from '@xyflow/react'
 
 import i18n from '@/config/i18n.config.ts'
 
-import type {
-  BehaviorPolicyOnTransition,
-  DataPolicy,
-  PolicyOperation,
-  PolicySchema,
-  SchemaReference,
-  Script,
-} from '@/api/__generated__'
+import type { BehaviorPolicyOnTransition, DataPolicy, PolicyOperation, PolicySchema, Script } from '@/api/__generated__'
 import type {
   DryRunResults,
   FunctionData,
@@ -30,6 +23,7 @@ import { PolicyCheckErrors } from '@datahub/designer/validation.errors.ts'
 import { getNodeId, isFunctionNodeType, isSchemaNodeType } from '@datahub/utils/node.utils.ts'
 import { getActiveTransition } from '@datahub/designer/transition/TransitionNode.utils.ts'
 import { CANVAS_POSITION } from '@datahub/designer/checks.utils.ts'
+import { SCRIPT_FUNCTION_LATEST } from '@datahub/utils/datahub.utils.ts'
 
 export function checkValidityTransformFunction(
   operationNode: Node<OperationData>,
@@ -155,7 +149,7 @@ export function checkValidityTransformFunction(
       schemaVersion:
         sourceDeserial.data.version === ResourceWorkingVersion.DRAFT ||
         sourceDeserial.data.version === ResourceWorkingVersion.MODIFIED
-          ? 'latest'
+          ? SCRIPT_FUNCTION_LATEST
           : sourceDeserial.data.version.toString(),
     } as PolicyOperationArguments,
     id: `${operationNode.id}-deserializer`,
@@ -178,7 +172,7 @@ export function checkValidityTransformFunction(
       schemaVersion:
         sourceSerial.data.version === ResourceWorkingVersion.DRAFT ||
         sourceSerial.data.version === ResourceWorkingVersion.MODIFIED
-          ? 'latest'
+          ? SCRIPT_FUNCTION_LATEST
           : sourceSerial.data.version.toString(),
     } as PolicyOperationArguments,
     id: `${operationNode.id}-serializer`,
@@ -364,14 +358,14 @@ export const loadPipeline = (
             operationNode,
             OperationData.Handle.DESERIALISER,
             1,
-            deserializer.arguments as SchemaReference,
+            deserializer.arguments as PolicyOperationArguments,
             schemas
           )
           const serialisers = loadSchema(
             operationNode,
             OperationData.Handle.SERIALISER,
             nbItems,
-            policyOperation.arguments as SchemaReference,
+            policyOperation.arguments as PolicyOperationArguments,
             schemas
           )
 

--- a/hivemq-edge-frontend/src/extensions/datahub/designer/operation/OperationNode.utils.ts
+++ b/hivemq-edge-frontend/src/extensions/datahub/designer/operation/OperationNode.utils.ts
@@ -61,7 +61,9 @@ export function checkValidityTransformFunction(
   const serialisers = getIncomers(operationNode, nodes, edges).filter(isSchemaNodeType)
   const connectedEdges = getConnectedEdges([...serialisers], edges).filter(
     (edge) =>
-      edge.targetHandle === OperationData.Handle.SERIALISER || edge.targetHandle === OperationData.Handle.DESERIALISER
+      (edge.targetHandle === OperationData.Handle.SERIALISER ||
+        edge.targetHandle === OperationData.Handle.DESERIALISER) &&
+      edge.target === operationNode.id
   )
   const [serial, ...restSerial] = connectedEdges.filter((edge) => edge.targetHandle === OperationData.Handle.SERIALISER)
   const [deserial, ...restDeserial] = connectedEdges.filter(

--- a/hivemq-edge-frontend/src/extensions/datahub/designer/schema/SchemaNode.utils.spec.ts
+++ b/hivemq-edge-frontend/src/extensions/datahub/designer/schema/SchemaNode.utils.spec.ts
@@ -1,12 +1,18 @@
+import type { SchemaReference } from '@/api/__generated__'
 import { MOCK_PROTOBUF_SCHEMA } from '@datahub/__test-utils__/schema.mocks.ts'
 import { expect } from 'vitest'
 import type { Node } from '@xyflow/react'
 import { MOCK_DEFAULT_NODE } from '@/__test-utils__/react-flow/nodes.ts'
 
 import { mockSchemaTempHumidity } from '@datahub/api/hooks/DataHubSchemasService/__handlers__'
-import type { SchemaData } from '@datahub/types.ts'
+import type { PolicyOperationArguments, SchemaData } from '@datahub/types.ts'
 import { DataHubNodeType, SchemaType } from '@datahub/types.ts'
-import { checkValiditySchema, getSchemaFamilies, getScriptFamilies } from '@datahub/designer/schema/SchemaNode.utils.ts'
+import {
+  checkValiditySchema,
+  getSchemaFamilies,
+  getScriptFamilies,
+  getSchemaRefVersion,
+} from '@datahub/designer/schema/SchemaNode.utils.ts'
 import { mockScript } from '@datahub/api/hooks/DataHubScriptsService/__handlers__'
 
 const NODE_ID = 'the other id'
@@ -68,6 +74,19 @@ describe('getScriptFamilies', () => {
         [NODE_ID]: expect.objectContaining({ name: NODE_ID, versions: [1] }),
       })
     )
+  })
+})
+
+describe('getSchemaRefVersion', () => {
+  const MOCK_SCHEMA_REF: SchemaReference = { schemaId: 'test', version: '1' }
+  const MOCK_SCHEMA_POLICY_REF: PolicyOperationArguments = { schemaId: 'test', schemaVersion: '1' }
+
+  it('should deal with an empty list of schemas', () => {
+    expect(getSchemaRefVersion(MOCK_SCHEMA_REF)).toStrictEqual('1')
+  })
+
+  it('should deal with an empty list of schemas', () => {
+    expect(getSchemaRefVersion(MOCK_SCHEMA_POLICY_REF)).toEqual('1')
   })
 })
 

--- a/hivemq-edge-frontend/src/extensions/datahub/designer/schema/SchemaNode.utils.ts
+++ b/hivemq-edge-frontend/src/extensions/datahub/designer/schema/SchemaNode.utils.ts
@@ -5,11 +5,18 @@ import descriptor from 'protobufjs/ext/descriptor'
 import i18n from '@/config/i18n.config.ts'
 
 import type { PolicySchema, SchemaReference, Script } from '@/api/__generated__'
-import type { DataHubNodeData, DryRunResults, ResourceFamily, SchemaData } from '@datahub/types.ts'
+import type {
+  DataHubNodeData,
+  DryRunResults,
+  PolicyOperationArguments,
+  ResourceFamily,
+  SchemaData,
+} from '@datahub/types.ts'
 import { DataHubNodeType, ResourceWorkingVersion, SchemaType } from '@datahub/types.ts'
 import { PolicyCheckErrors } from '@datahub/designer/validation.errors.ts'
 import { enumFromStringValue } from '@/utils/types.utils.ts'
 import { CANVAS_POSITION } from '@datahub/designer/checks.utils.ts'
+import { SCRIPT_FUNCTION_LATEST } from '@datahub/utils/datahub.utils.ts'
 
 export const getScriptFamilies = (items: Script[]) => {
   return items.reduce<Record<string, ResourceFamily>>((acc, script) => {
@@ -110,14 +117,34 @@ export function checkValiditySchema(schemaNode: Node<SchemaData>): DryRunResults
   }
 }
 
+/**
+ * Get the version of a schema reference from either the validator or the argument of the script operation.
+ * TODO[20139] Remove the PolicyOperationArguments type when the OpenAPI specs are updated. Both should use the same type.
+ * @param schemaRef
+ */
+export const getSchemaRefVersion = (schemaRef: SchemaReference | PolicyOperationArguments): string => {
+  return (schemaRef as SchemaReference).version || (schemaRef as PolicyOperationArguments).schemaVersion
+}
+
 export function loadSchema(
   parentNode: Node<DataHubNodeData>,
   targetHandle: string | null,
   positionInGroup: number,
-  schemaRef: SchemaReference,
+  schemaRef: SchemaReference | PolicyOperationArguments,
   schemas: PolicySchema[]
 ): (NodeAddChange | Connection)[] {
-  const schema = schemas.find((schema) => schema.id === schemaRef.schemaId)
+  const schemaFamily = schemas.filter((schema) => schema.id === schemaRef.schemaId)
+  if (!schemaFamily.length)
+    throw new Error(i18n.t('datahub:error.loading.connection.notFound', { type: DataHubNodeType.SCHEMA }) as string)
+
+  let schema: PolicySchema | undefined
+  const version = getSchemaRefVersion(schemaRef)
+  if (version === SCRIPT_FUNCTION_LATEST) {
+    schema = schemaFamily.slice(-1)[0]
+  } else {
+    schema = schemaFamily.find((s) => s.version?.toString() === version)
+  }
+
   if (!schema)
     throw new Error(i18n.t('datahub:error.loading.connection.notFound', { type: DataHubNodeType.SCHEMA }) as string)
 

--- a/hivemq-edge-frontend/src/extensions/datahub/designer/schema/SchemaNode.utils.ts
+++ b/hivemq-edge-frontend/src/extensions/datahub/designer/schema/SchemaNode.utils.ts
@@ -17,6 +17,7 @@ import { PolicyCheckErrors } from '@datahub/designer/validation.errors.ts'
 import { enumFromStringValue } from '@/utils/types.utils.ts'
 import { CANVAS_POSITION } from '@datahub/designer/checks.utils.ts'
 import { SCRIPT_FUNCTION_LATEST } from '@datahub/utils/datahub.utils.ts'
+import { getNodeId } from '@datahub/utils/node.utils.ts'
 
 export const getScriptFamilies = (items: Script[]) => {
   return items.reduce<Record<string, ResourceFamily>>((acc, script) => {
@@ -150,7 +151,7 @@ export function loadSchema(
 
   if (schema.type === SchemaType.JSON) {
     const schemaNode: Node<SchemaData> = {
-      id: schemaRef.schemaId,
+      id: getNodeId(DataHubNodeType.SCHEMA),
       type: DataHubNodeType.SCHEMA,
       position: {
         x: parentNode.position.x + CANVAS_POSITION.PolicySchema.x,

--- a/hivemq-edge-frontend/src/extensions/datahub/designer/schema/SchemaPanel.tsx
+++ b/hivemq-edge-frontend/src/extensions/datahub/designer/schema/SchemaPanel.tsx
@@ -3,7 +3,7 @@ import { useCallback, useState } from 'react'
 import type { Node } from '@xyflow/react'
 import { parse } from 'protobufjs'
 import type { CustomValidator, UiSchema } from '@rjsf/utils'
-import type { IChangeEvent } from '@rjsf/core/src/components/Form.tsx'
+import type { IChangeEvent } from '@rjsf/core'
 import { Card, CardBody } from '@chakra-ui/react'
 
 import { enumFromStringValue } from '@/utils/types.utils.ts'

--- a/hivemq-edge-frontend/src/extensions/datahub/designer/script/FunctionNode.utils.spec.ts
+++ b/hivemq-edge-frontend/src/extensions/datahub/designer/script/FunctionNode.utils.spec.ts
@@ -1,7 +1,8 @@
 import { expect } from 'vitest'
 import type { Connection, Node, NodeAddChange } from '@xyflow/react'
-
 import { MOCK_DEFAULT_NODE } from '@/__test-utils__/react-flow/nodes.ts'
+import { vitest_ExpectStringContainingUUIDFromNodeType } from '@datahub/__test-utils__/vitest.utils.ts'
+
 import type { PolicyOperation } from '@/api/__generated__'
 import { Script } from '@/api/__generated__'
 import type { FunctionData } from '@datahub/types.ts'
@@ -148,7 +149,7 @@ describe('loadScripts', () => {
             type: 'Javascript',
             version: 1,
           },
-          id: expect.stringContaining('FUNCTION_'),
+          id: vitest_ExpectStringContainingUUIDFromNodeType(DataHubNodeType.FUNCTION),
           position: {
             x: -320,
             y: 0,
@@ -158,7 +159,7 @@ describe('loadScripts', () => {
         type: 'add',
       }),
       expect.objectContaining({
-        source: expect.stringContaining('FUNCTION_'),
+        source: vitest_ExpectStringContainingUUIDFromNodeType(DataHubNodeType.FUNCTION),
         target: 'node-id',
       }),
     ])

--- a/hivemq-edge-frontend/src/extensions/datahub/designer/script/FunctionNode.utils.spec.ts
+++ b/hivemq-edge-frontend/src/extensions/datahub/designer/script/FunctionNode.utils.spec.ts
@@ -148,7 +148,7 @@ describe('loadScripts', () => {
             type: 'Javascript',
             version: 1,
           },
-          id: 'script1',
+          id: expect.stringContaining('FUNCTION_'),
           position: {
             x: -320,
             y: 0,
@@ -158,7 +158,7 @@ describe('loadScripts', () => {
         type: 'add',
       }),
       expect.objectContaining({
-        source: 'script1',
+        source: expect.stringContaining('FUNCTION_'),
         target: 'node-id',
       }),
     ])

--- a/hivemq-edge-frontend/src/extensions/datahub/designer/script/FunctionNode.utils.spec.ts
+++ b/hivemq-edge-frontend/src/extensions/datahub/designer/script/FunctionNode.utils.spec.ts
@@ -5,7 +5,7 @@ import { MOCK_DEFAULT_NODE } from '@/__test-utils__/react-flow/nodes.ts'
 import type { PolicyOperation } from '@/api/__generated__'
 import { Script } from '@/api/__generated__'
 import type { FunctionData } from '@datahub/types.ts'
-import { DataHubNodeType } from '@datahub/types.ts'
+import { DataHubNodeType, ResourceWorkingVersion } from '@datahub/types.ts'
 import {
   checkValidityJSScript,
   formatScriptName,
@@ -85,6 +85,22 @@ describe('formatScriptName', () => {
         type: 'Javascript',
         name: 'my-name',
         version: 1,
+      },
+      ...MOCK_DEFAULT_NODE,
+      position: { x: 0, y: 0 },
+    }
+
+    expect(formatScriptName(MOCK_NODE_SCRIPT)).toEqual('fn:my-name:1')
+  })
+
+  it('should format the draft id of the script', async () => {
+    const MOCK_NODE_SCRIPT: Node<FunctionData> = {
+      id: 'node-id',
+      type: DataHubNodeType.FUNCTION,
+      data: {
+        type: 'Javascript',
+        name: 'my-name',
+        version: ResourceWorkingVersion.DRAFT,
       },
       ...MOCK_DEFAULT_NODE,
       position: { x: 0, y: 0 },

--- a/hivemq-edge-frontend/src/extensions/datahub/designer/script/FunctionNode.utils.ts
+++ b/hivemq-edge-frontend/src/extensions/datahub/designer/script/FunctionNode.utils.ts
@@ -65,7 +65,7 @@ export const loadScripts = (
       throw new Error(i18n.t('datahub:error.loading.connection.notFound', { type: DataHubNodeType.FUNCTION }) as string)
 
     const scriptFamily = scripts.filter((script) => script.id === functionName)
-    if (!scriptFamily)
+    if (scriptFamily.length === 0)
       throw new Error(i18n.t('datahub:error.loading.connection.notFound', { type: DataHubNodeType.FUNCTION }) as string)
 
     let functionScript: Script | undefined

--- a/hivemq-edge-frontend/src/extensions/datahub/designer/script/FunctionNode.utils.ts
+++ b/hivemq-edge-frontend/src/extensions/datahub/designer/script/FunctionNode.utils.ts
@@ -1,3 +1,4 @@
+import { getNodeId } from '@datahub/utils/node.utils.ts'
 import type { Connection, Node, NodeAddChange, XYPosition } from '@xyflow/react'
 
 import type { PolicyOperation } from '@/api/__generated__'
@@ -78,7 +79,7 @@ export const loadScripts = (
       throw new Error(i18n.t('datahub:error.loading.connection.notFound', { type: DataHubNodeType.FUNCTION }) as string)
 
     const functionScriptNode: Node<FunctionData> = {
-      id: functionScript.id,
+      id: getNodeId(DataHubNodeType.FUNCTION),
       type: DataHubNodeType.FUNCTION,
       position: { ...shiftLeft() },
       data: {

--- a/hivemq-edge-frontend/src/extensions/datahub/designer/script/FunctionNode.utils.ts
+++ b/hivemq-edge-frontend/src/extensions/datahub/designer/script/FunctionNode.utils.ts
@@ -60,8 +60,20 @@ export const loadScripts = (
 
   const newNodes: (NodeAddChange | Connection)[] = []
   for (const fct of functions) {
-    const [, functionName] = fct.functionId.split(':')
-    const functionScript = scripts.find((script) => script.id === functionName)
+    const [, functionName, functionVersion] = fct.functionId.split(':')
+    if (!functionName || !functionVersion)
+      throw new Error(i18n.t('datahub:error.loading.connection.notFound', { type: DataHubNodeType.FUNCTION }) as string)
+
+    const scriptFamily = scripts.filter((script) => script.id === functionName)
+    if (!scriptFamily)
+      throw new Error(i18n.t('datahub:error.loading.connection.notFound', { type: DataHubNodeType.FUNCTION }) as string)
+
+    let functionScript: Script | undefined
+    if (functionVersion === SCRIPT_FUNCTION_LATEST) {
+      functionScript = scriptFamily.slice(-1)[0]
+    } else {
+      functionScript = scriptFamily.find((s) => s.version?.toString() === functionVersion)
+    }
     if (!functionScript)
       throw new Error(i18n.t('datahub:error.loading.connection.notFound', { type: DataHubNodeType.FUNCTION }) as string)
 

--- a/hivemq-edge-frontend/src/extensions/datahub/designer/script/FunctionNode.utils.ts
+++ b/hivemq-edge-frontend/src/extensions/datahub/designer/script/FunctionNode.utils.ts
@@ -5,7 +5,7 @@ import { Script } from '@/api/__generated__'
 import i18n from '@/config/i18n.config.ts'
 
 import type { DataHubNodeData, DryRunResults, FunctionData } from '@datahub/types.ts'
-import { DataHubNodeType, OperationData } from '@datahub/types.ts'
+import { DataHubNodeType, OperationData, ResourceWorkingVersion } from '@datahub/types.ts'
 import { PolicyCheckErrors } from '@datahub/designer/validation.errors.ts'
 import { CANVAS_POSITION } from '@datahub/designer/checks.utils.ts'
 import {
@@ -15,7 +15,7 @@ import {
 } from '@datahub/utils/datahub.utils.ts'
 
 export const formatScriptName = (functionNode: Node<FunctionData>): string => {
-  return `${SCRIPT_FUNCTION_PREFIX}:${functionNode.data.name}:${SCRIPT_FUNCTION_LATEST}`
+  return `${SCRIPT_FUNCTION_PREFIX}:${functionNode.data.name}:${functionNode.data.version === ResourceWorkingVersion.DRAFT ? SCRIPT_FUNCTION_LATEST : functionNode.data.version}`
 }
 
 export const parseScriptName = (operation: PolicyOperation): string => {

--- a/hivemq-edge-frontend/src/extensions/datahub/designer/script/FunctionPanel.tsx
+++ b/hivemq-edge-frontend/src/extensions/datahub/designer/script/FunctionPanel.tsx
@@ -3,7 +3,7 @@ import { useCallback, useState } from 'react'
 import type { Node } from '@xyflow/react'
 import { Card, CardBody } from '@chakra-ui/react'
 import type { UiSchema } from '@rjsf/utils'
-import type { IChangeEvent } from '@rjsf/core/src/components/Form.tsx'
+import type { IChangeEvent } from '@rjsf/core'
 
 import { MOCK_JAVASCRIPT_SCHEMA } from '@datahub/__test-utils__/schema.mocks.ts'
 import type { FunctionData, PanelProps } from '@datahub/types.ts'

--- a/hivemq-edge-frontend/src/extensions/datahub/designer/topic_filter/TopicFilterNode.utils.spec.ts
+++ b/hivemq-edge-frontend/src/extensions/datahub/designer/topic_filter/TopicFilterNode.utils.spec.ts
@@ -28,7 +28,7 @@ describe('loadTopicFilter', () => {
             adapter: undefined,
             topics: ['*.*'],
           },
-          id: expect.stringContaining('node_'),
+          id: expect.stringContaining('TOPIC_FILTER_'),
           position: {
             x: -320,
             y: 0,
@@ -38,7 +38,7 @@ describe('loadTopicFilter', () => {
         type: 'add',
       }),
       expect.objectContaining({
-        source: expect.stringContaining('node_'),
+        source: expect.stringContaining('TOPIC_FILTER_'),
         target: 'node-id',
       }),
     ])

--- a/hivemq-edge-frontend/src/extensions/datahub/designer/topic_filter/TopicFilterNode.utils.spec.ts
+++ b/hivemq-edge-frontend/src/extensions/datahub/designer/topic_filter/TopicFilterNode.utils.spec.ts
@@ -1,7 +1,8 @@
 import { expect } from 'vitest'
 import type { Connection, Node, NodeAddChange } from '@xyflow/react'
-
 import { MOCK_DEFAULT_NODE } from '@/__test-utils__/react-flow/nodes.ts'
+import { vitest_ExpectStringContainingUUIDFromNodeType } from '@datahub/__test-utils__/vitest.utils.ts'
+
 import { type DataPolicy } from '@/api/__generated__'
 import type { DataPolicyData } from '@datahub/types.ts'
 import { DataHubNodeType } from '@datahub/types.ts'
@@ -28,7 +29,7 @@ describe('loadTopicFilter', () => {
             adapter: undefined,
             topics: ['*.*'],
           },
-          id: expect.stringContaining('TOPIC_FILTER_'),
+          id: vitest_ExpectStringContainingUUIDFromNodeType(DataHubNodeType.TOPIC_FILTER),
           position: {
             x: -320,
             y: 0,
@@ -38,7 +39,7 @@ describe('loadTopicFilter', () => {
         type: 'add',
       }),
       expect.objectContaining({
-        source: expect.stringContaining('TOPIC_FILTER_'),
+        source: vitest_ExpectStringContainingUUIDFromNodeType(DataHubNodeType.TOPIC_FILTER),
         target: 'node-id',
       }),
     ])

--- a/hivemq-edge-frontend/src/extensions/datahub/designer/topic_filter/TopicFilterNode.utils.ts
+++ b/hivemq-edge-frontend/src/extensions/datahub/designer/topic_filter/TopicFilterNode.utils.ts
@@ -17,7 +17,7 @@ export const loadTopicFilter = (
   }
 
   const topicNode: Node<TopicFilterData> = {
-    id: getNodeId(),
+    id: getNodeId(DataHubNodeType.TOPIC_FILTER),
     type: DataHubNodeType.TOPIC_FILTER,
     position,
     data: {

--- a/hivemq-edge-frontend/src/extensions/datahub/designer/transition/TransitionNode.utils.ts
+++ b/hivemq-edge-frontend/src/extensions/datahub/designer/transition/TransitionNode.utils.ts
@@ -129,7 +129,7 @@ export const loadTransitions = (
   const newNodes: (NodeAddChange | Connection)[] = []
   for (const behaviorPolicyTransition of behaviorPolicy.onTransitions || []) {
     const transitionNode: Node<TransitionData> = {
-      id: getNodeId(),
+      id: getNodeId(DataHubNodeType.TRANSITION),
       type: DataHubNodeType.TRANSITION,
       position: { ...shiftBottom() },
       data: extractEventStates(model, behaviorPolicyTransition),

--- a/hivemq-edge-frontend/src/extensions/datahub/designer/validator/ValidatorNode.utils.spec.ts
+++ b/hivemq-edge-frontend/src/extensions/datahub/designer/validator/ValidatorNode.utils.spec.ts
@@ -201,7 +201,7 @@ describe('loadValidators', () => {
             strategy: 'ALL_OF',
             type: 'SCHEMA',
           },
-          id: expect.stringContaining('node_'), //'node_0bf21139-7f2c-41d0-98b5-6024af1b31e4',
+          id: expect.stringContaining('VALIDATOR_'),
           position: {
             x: -320,
             y: 160,
@@ -211,7 +211,7 @@ describe('loadValidators', () => {
         type: 'add',
       }),
       expect.objectContaining({
-        source: expect.stringContaining('node_'), //'node_0bf21139-7f2c-41d0-98b5-6024af1b31e4',
+        source: expect.stringContaining('VALIDATOR_'),
         target: 'node-id',
         targetHandle: 'validation',
       }),
@@ -235,7 +235,7 @@ describe('loadValidators', () => {
       }),
       expect.objectContaining({
         source: 'test',
-        target: expect.stringContaining('node_'), //'node_0bf21139-7f2c-41d0-98b5-6024af1b31e4',
+        target: expect.stringContaining('VALIDATOR_'),
       }),
       expect.objectContaining({
         item: {
@@ -257,7 +257,7 @@ describe('loadValidators', () => {
       }),
       expect.objectContaining({
         source: 'test',
-        target: expect.stringContaining('node_'), //'node_0bf21139-7f2c-41d0-98b5-6024af1b31e4',
+        target: expect.stringContaining('VALIDATOR_'),
       }),
     ])
   })

--- a/hivemq-edge-frontend/src/extensions/datahub/designer/validator/ValidatorNode.utils.spec.ts
+++ b/hivemq-edge-frontend/src/extensions/datahub/designer/validator/ValidatorNode.utils.spec.ts
@@ -1,6 +1,7 @@
 import { expect } from 'vitest'
 import type { Connection, Node, NodeAddChange } from '@xyflow/react'
 import { MOCK_DEFAULT_NODE } from '@/__test-utils__/react-flow/nodes.ts'
+import { vitest_ExpectStringContainingUUIDFromNodeType } from '@datahub/__test-utils__/vitest.utils.ts'
 
 import type { DataPolicy, PolicySchema } from '@/api/__generated__'
 import { DataPolicyValidator } from '@/api/__generated__'
@@ -201,7 +202,7 @@ describe('loadValidators', () => {
             strategy: 'ALL_OF',
             type: 'SCHEMA',
           },
-          id: expect.stringContaining('VALIDATOR_'),
+          id: vitest_ExpectStringContainingUUIDFromNodeType(DataHubNodeType.VALIDATOR),
           position: {
             x: -320,
             y: 160,
@@ -211,7 +212,7 @@ describe('loadValidators', () => {
         type: 'add',
       }),
       expect.objectContaining({
-        source: expect.stringContaining('VALIDATOR_'),
+        source: vitest_ExpectStringContainingUUIDFromNodeType(DataHubNodeType.VALIDATOR),
         target: 'node-id',
         targetHandle: 'validation',
       }),
@@ -224,7 +225,7 @@ describe('loadValidators', () => {
             type: 'JSON',
             version: 1,
           },
-          id: expect.stringContaining('SCHEMA_'),
+          id: vitest_ExpectStringContainingUUIDFromNodeType(DataHubNodeType.SCHEMA),
           position: {
             x: -640,
             y: 160,
@@ -234,8 +235,8 @@ describe('loadValidators', () => {
         type: 'add',
       }),
       expect.objectContaining({
-        source: expect.stringContaining('SCHEMA_'),
-        target: expect.stringContaining('VALIDATOR_'),
+        source: vitest_ExpectStringContainingUUIDFromNodeType(DataHubNodeType.SCHEMA),
+        target: vitest_ExpectStringContainingUUIDFromNodeType(DataHubNodeType.VALIDATOR),
       }),
       expect.objectContaining({
         item: {
@@ -246,7 +247,7 @@ describe('loadValidators', () => {
             type: 'JSON',
             version: 1,
           },
-          id: expect.stringContaining('SCHEMA_'),
+          id: vitest_ExpectStringContainingUUIDFromNodeType(DataHubNodeType.SCHEMA),
           position: {
             x: -640,
             y: 320,
@@ -256,8 +257,8 @@ describe('loadValidators', () => {
         type: 'add',
       }),
       expect.objectContaining({
-        source: expect.stringContaining('SCHEMA_'),
-        target: expect.stringContaining('VALIDATOR_'),
+        source: vitest_ExpectStringContainingUUIDFromNodeType(DataHubNodeType.SCHEMA),
+        target: vitest_ExpectStringContainingUUIDFromNodeType(DataHubNodeType.VALIDATOR),
       }),
     ])
   })

--- a/hivemq-edge-frontend/src/extensions/datahub/designer/validator/ValidatorNode.utils.spec.ts
+++ b/hivemq-edge-frontend/src/extensions/datahub/designer/validator/ValidatorNode.utils.spec.ts
@@ -224,7 +224,7 @@ describe('loadValidators', () => {
             type: 'JSON',
             version: 1,
           },
-          id: 'test',
+          id: expect.stringContaining('SCHEMA_'),
           position: {
             x: -640,
             y: 160,
@@ -234,7 +234,7 @@ describe('loadValidators', () => {
         type: 'add',
       }),
       expect.objectContaining({
-        source: 'test',
+        source: expect.stringContaining('SCHEMA_'),
         target: expect.stringContaining('VALIDATOR_'),
       }),
       expect.objectContaining({
@@ -246,7 +246,7 @@ describe('loadValidators', () => {
             type: 'JSON',
             version: 1,
           },
-          id: 'test',
+          id: expect.stringContaining('SCHEMA_'),
           position: {
             x: -640,
             y: 320,
@@ -256,7 +256,7 @@ describe('loadValidators', () => {
         type: 'add',
       }),
       expect.objectContaining({
-        source: 'test',
+        source: expect.stringContaining('SCHEMA_'),
         target: expect.stringContaining('VALIDATOR_'),
       }),
     ])

--- a/hivemq-edge-frontend/src/extensions/datahub/designer/validator/ValidatorNode.utils.ts
+++ b/hivemq-edge-frontend/src/extensions/datahub/designer/validator/ValidatorNode.utils.ts
@@ -76,7 +76,7 @@ export const loadValidators = (policy: DataPolicy, schemas: PolicySchema[], data
       )
 
     const validatorNode: Node<ValidatorData> = {
-      id: getNodeId(),
+      id: getNodeId(DataHubNodeType.VALIDATOR),
       type: DataHubNodeType.VALIDATOR,
       position,
       data: {

--- a/hivemq-edge-frontend/src/extensions/datahub/designer/validator/ValidatorNode.utils.ts
+++ b/hivemq-edge-frontend/src/extensions/datahub/designer/validator/ValidatorNode.utils.ts
@@ -13,6 +13,7 @@ import { checkValiditySchema, loadSchema } from '@datahub/designer/schema/Schema
 import { PolicyCheckErrors } from '@datahub/designer/validation.errors.ts'
 import { getNodeId, isSchemaNodeType, isValidatorNodeType } from '@datahub/utils/node.utils.ts'
 import { CANVAS_POSITION } from '@datahub/designer/checks.utils.ts'
+import { SCRIPT_FUNCTION_LATEST } from '@datahub/utils/datahub.utils.ts'
 
 export function checkValidityPolicyValidator(
   validator: Node<ValidatorData>,
@@ -38,7 +39,7 @@ export function checkValidityPolicyValidator(
         const version =
           schema.data.version === ResourceWorkingVersion.DRAFT ||
           schema.data.version === ResourceWorkingVersion.MODIFIED
-            ? 'latest'
+            ? SCRIPT_FUNCTION_LATEST
             : schema.data.version.toString()
         return { schemaId: schema.data.name, version }
       }),

--- a/hivemq-edge-frontend/src/extensions/datahub/hooks/usePolicyDryRun.spec.ts
+++ b/hivemq-edge-frontend/src/extensions/datahub/hooks/usePolicyDryRun.spec.ts
@@ -7,26 +7,36 @@ import { MOCK_DEFAULT_NODE } from '@/__test-utils__/react-flow/nodes.ts'
 import { SimpleWrapper as wrapper } from '@/__test-utils__/hooks/SimpleWrapper.tsx'
 
 import { handlers } from '@datahub/api/hooks/DataHubFunctionsService/__handlers__'
-import { onlyNonNullResources, usePolicyDryRun } from '@datahub/hooks/usePolicyDryRun.ts'
+import { onlyNonNullResources, onlyUniqueResources, usePolicyDryRun } from '@datahub/hooks/usePolicyDryRun.ts'
 import type { BehaviorPolicyData, DataPolicyData, DryRunResults } from '@datahub/types.ts'
 import { BehaviorPolicyType, DataHubNodeType } from '@datahub/types.ts'
 
+const MOCK_NODE_DATA_POLICY: Node<DataPolicyData> = {
+  id: 'node-data-id',
+  type: DataHubNodeType.DATA_POLICY,
+  data: { id: 'node-data-id' },
+  ...MOCK_DEFAULT_NODE,
+  position: { x: 0, y: 0 },
+}
+
+const MOCK_NODE_BEHAVIOUR_POLICY: Node<BehaviorPolicyData> = {
+  id: 'node-behaviour-id',
+  type: DataHubNodeType.BEHAVIOR_POLICY,
+  data: { id: 'node-behaviour-id', model: BehaviorPolicyType.PUBLISH_DUPLICATE },
+  ...MOCK_DEFAULT_NODE,
+  position: { x: 0, y: 0 },
+}
+
+const MOCK_NODE_TEST: Node<DataPolicyData> = {
+  id: 'node-test',
+  type: DataHubNodeType.DATA_POLICY,
+  data: { id: 'my-other-policy-id' },
+  ...MOCK_DEFAULT_NODE,
+  position: { x: 0, y: 0 },
+}
+
 describe('onlyNonNullResources', () => {
   it('should return an async function', async () => {
-    const MOCK_NODE_DATA_POLICY: Node<DataPolicyData> = {
-      id: 'node-id',
-      type: DataHubNodeType.DATA_POLICY,
-      data: { id: 'my-policy-id' },
-      ...MOCK_DEFAULT_NODE,
-      position: { x: 0, y: 0 },
-    }
-    const MOCK_NODE_TEST: Node<DataPolicyData> = {
-      id: 'node-test',
-      type: DataHubNodeType.DATA_POLICY,
-      data: { id: 'my-other-policy-id' },
-      ...MOCK_DEFAULT_NODE,
-      position: { x: 0, y: 0 },
-    }
     const result: DryRunResults<Node<DataPolicyData>, never> = {
       node: MOCK_NODE_DATA_POLICY,
       resources: [{ node: MOCK_NODE_TEST }],
@@ -37,20 +47,28 @@ describe('onlyNonNullResources', () => {
   })
 })
 
+describe('onlyUniqueResources', () => {
+  it('should test for unique node id', async () => {
+    const test: DryRunResults<Node<DataPolicyData>, never> = {
+      node: MOCK_NODE_DATA_POLICY,
+    }
+
+    const test2: DryRunResults<Node<DataPolicyData>, never> = {
+      node: MOCK_NODE_BEHAVIOUR_POLICY,
+    }
+
+    expect(onlyUniqueResources([], test)).toStrictEqual([test])
+    expect(onlyUniqueResources([test], test)).toStrictEqual([test])
+    expect(onlyUniqueResources([test], test2)).toStrictEqual([test, test2])
+  })
+})
+
 describe('usePolicyDryRun', () => {
   beforeEach(() => {
     server.use(...handlers)
   })
 
   it('should validate a Data Policy', async () => {
-    const MOCK_NODE_DATA_POLICY: Node<DataPolicyData> = {
-      id: 'node-id',
-      type: DataHubNodeType.DATA_POLICY,
-      data: { id: 'my-policy-id' },
-      ...MOCK_DEFAULT_NODE,
-      position: { x: 0, y: 0 },
-    }
-
     const { result } = renderHook(usePolicyDryRun, { wrapper })
     await act(async () => {
       const results = await result.current.checkPolicyAsync(MOCK_NODE_DATA_POLICY)
@@ -61,25 +79,17 @@ describe('usePolicyDryRun', () => {
   })
 
   it('should validate a Behaviour Policy', async () => {
-    const MOCK_NODE_DATA_POLICY: Node<BehaviorPolicyData> = {
-      id: 'node-id',
-      type: DataHubNodeType.BEHAVIOR_POLICY,
-      data: { id: 'my-policy-id', model: BehaviorPolicyType.PUBLISH_DUPLICATE },
-      ...MOCK_DEFAULT_NODE,
-      position: { x: 0, y: 0 },
-    }
-
     const { result } = renderHook(usePolicyDryRun, { wrapper })
     await act(async () => {
-      const results = await result.current.checkPolicyAsync(MOCK_NODE_DATA_POLICY)
+      const results = await result.current.checkPolicyAsync(MOCK_NODE_BEHAVIOUR_POLICY)
       expect(results).toHaveLength(3)
       const { node } = results[0]
-      expect(node).toStrictEqual(MOCK_NODE_DATA_POLICY)
+      expect(node).toStrictEqual(MOCK_NODE_BEHAVIOUR_POLICY)
     })
   })
 
   it('should return an error otherwise', async () => {
-    const MOCK_NODE_DATA_POLICY: Node<DataPolicyData> = {
+    const fakePolicy: Node<DataPolicyData> = {
       id: 'node-id',
       type: 'test',
       data: { id: 'node-id' },
@@ -88,8 +98,6 @@ describe('usePolicyDryRun', () => {
     }
 
     const { result } = renderHook(usePolicyDryRun, { wrapper })
-    await expect(result.current.checkPolicyAsync(MOCK_NODE_DATA_POLICY)).rejects.toEqual(
-      Error('Policy Type not supported : test')
-    )
+    await expect(result.current.checkPolicyAsync(fakePolicy)).rejects.toEqual(Error('Policy Type not supported : test'))
   })
 })

--- a/hivemq-edge-frontend/src/extensions/datahub/hooks/usePolicyDryRun.ts
+++ b/hivemq-edge-frontend/src/extensions/datahub/hooks/usePolicyDryRun.ts
@@ -50,7 +50,6 @@ export const usePolicyDryRun = () => {
   const { nodes, edges, onUpdateNodes } = store
   const { getFilteredFunctions } = useFilteredFunctionsFetcher()
 
-  /* istanbul ignore next -- @preserve */
   const updateNodeStatus = async (results: DryRunResults<unknown>) => {
     const currentNode = nodes.find((node) => node.id === results.node.id)
 
@@ -66,7 +65,6 @@ export const usePolicyDryRun = () => {
     await mockDelay(DRYRUN_VALIDATION_DELAY)
   }
 
-  /* istanbul ignore next -- @preserve */
   const runPolicyChecks = async (
     allNodes: Node<DataHubNodeData>[],
     processedNodes: DryRunResults<unknown, never>[]
@@ -129,7 +127,6 @@ export const usePolicyDryRun = () => {
   }
 
   const checkBehaviorPolicyAsync = (behaviourPolicyNode: Node<BehaviorPolicyData>) => {
-    /* istanbul ignore next -- @preserve */
     const incomers = getIncomers(behaviourPolicyNode, nodes, edges).filter(isClientFilterNodeType)
     const allNodes = getSubFlow(
       behaviourPolicyNode,

--- a/hivemq-edge-frontend/src/extensions/datahub/locales/en/datahub.json
+++ b/hivemq-edge-frontend/src/extensions/datahub/locales/en/datahub.json
@@ -393,7 +393,7 @@
       "operation": {
         "unknown": "Something is wrong with the operation",
         "noTransition": "there is no transition pipeline for the operation",
-        "noExistingTransition": "cannot create the node for the transition pipeline - {{ source }}"
+        "noExistingTransition": "Cannot create the node for the transition pipeline - {{ source }}"
       }
     },
     "dryRun": {

--- a/hivemq-edge-frontend/src/extensions/datahub/locales/en/datahub.json
+++ b/hivemq-edge-frontend/src/extensions/datahub/locales/en/datahub.json
@@ -392,7 +392,8 @@
       },
       "operation": {
         "unknown": "Something is wrong with the operation",
-        "noTransition": "cannot create the node for the transition pipeline - {{ source }}"
+        "noTransition": "there is no transition pipeline for the operation",
+        "noExistingTransition": "cannot create the node for the transition pipeline - {{ source }}"
       }
     },
     "dryRun": {

--- a/hivemq-edge-frontend/src/extensions/datahub/utils/theme.utils.spec.ts
+++ b/hivemq-edge-frontend/src/extensions/datahub/utils/theme.utils.spec.ts
@@ -1,0 +1,24 @@
+import { describe, expect } from 'vitest'
+import { getHandlePosition } from '@datahub/utils/theme.utils.ts'
+
+interface Suite {
+  index: number
+  expected: string
+}
+
+const validationSuite = [
+  {
+    index: 0,
+    expected: 'calc(var(--chakra-space-3) + var(--chakra-sizes-12) + 12px + 0px + 0rem)',
+  },
+  {
+    index: 2,
+    expected: 'calc(var(--chakra-space-3) + var(--chakra-sizes-12) + 12px + 48px + 1rem)',
+  },
+]
+
+describe('getHandlePosition', () => {
+  it.each<Suite>(validationSuite)('should get handle for index $index', ({ index, expected }) => {
+    expect(getHandlePosition(index)).toStrictEqual(expected)
+  })
+})

--- a/hivemq-edge-frontend/src/extensions/datahub/utils/theme.utils.spec.ts
+++ b/hivemq-edge-frontend/src/extensions/datahub/utils/theme.utils.spec.ts
@@ -6,6 +6,9 @@ interface Suite {
   expected: string
 }
 
+/**
+ * @see getHandlePosition for the definition of the expected parts
+ */
 const validationSuite = [
   {
     index: 0,

--- a/hivemq-edge-frontend/src/hooks/useAccessibleDraggable/useAccessibleDraggable.spec.ts
+++ b/hivemq-edge-frontend/src/hooks/useAccessibleDraggable/useAccessibleDraggable.spec.ts
@@ -1,0 +1,32 @@
+import { renderHook } from '@testing-library/react'
+import { describe, expect } from 'vitest'
+
+import { getAccessibleDraggableProvider } from '@/__test-utils__/hooks/WrapperAccessibleDraggableProvider.tsx'
+
+import type { AccessibleDraggableProps } from '@/hooks/useAccessibleDraggable/type.ts'
+import { useAccessibleDraggable } from '@/hooks/useAccessibleDraggable/useAccessibleDraggable.ts'
+
+describe('useAccessibleDraggable', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+  })
+
+  it('should be used in the right context', () => {
+    expect(() => {
+      renderHook(() => useAccessibleDraggable())
+    }).toThrow('useAccessibleDraggable must be used within AccessibleDraggableContext')
+  })
+
+  it('should return the canvas options', () => {
+    const { result } = renderHook(() => useAccessibleDraggable(), { wrapper: getAccessibleDraggableProvider() })
+    expect(result.current).toStrictEqual<AccessibleDraggableProps>(
+      expect.objectContaining({
+        isDragging: false,
+        ref: {
+          current: null,
+        },
+        source: undefined,
+      })
+    )
+  })
+})


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/29734/details/

The PR fixes a series of different issues that prevented policies, both Data and Behaviour, from being properly published. Most of the errors resolve around the use of multiple resources at a given point, e.g. multiple schemas with the same (or different) name (or version) in a validator. 

- The loaded elements of a policy have a proper UUID assigned to their node (with a type-based prefix)
- The determination of connected nodes now correctly handles version, source and target  
- Function name and version are now properly handled, from `1` to `latest`
- The detection of a script or schema version at load time is now properly identifying multiple versions of the same resource

### Design decision
The changes introduce a strong identification of the nodes in the `Designer`, mapping individual elements of the policy payload. In particular, different instances of the same resource used across the policy (e.g. in different `Datahub.Transform` operations) are materialised with different nodes, even if they were created from the same node.

### Out-of-scope
- Concerning the uniqueness of resource nodes, we cannot anticipate the end-users' preferred usage. A choice to recombine duplicated resources into a single node will have to be offered. It will be done in a subsequent ticket, see https://hivemq.kanbanize.com/ctrl_board/57/cards/33959/details/

### Aim
![HiveMQ-Edge-06-13-2025_11_15](https://github.com/user-attachments/assets/03e5ccd4-b42e-4e01-9659-da846da7050e)

### Before
![HiveMQ-Edge-06-13-2025_11_20](https://github.com/user-attachments/assets/cf7371b4-b956-4444-9cb5-c0775f0b2222)

### After
![HiveMQ-Edge-06-13-2025_11_16](https://github.com/user-attachments/assets/645139a6-a438-44ca-8d2c-66b01681d2da)


