### PR TITLE
feat(33975): Add the openAPI specs for the interpolation service

### DIFF
--- a/ext/openAPI/components/schemas/InterpolationVariable.yaml
+++ b/ext/openAPI/components/schemas/InterpolationVariable.yaml
@@ -1,0 +1,31 @@
+type: object
+required:
+  - variable
+  - type
+  - description
+  - isDataPolicy
+  - isBehaviorPolicy
+properties:
+  variable:
+    type: string
+    description: The unique variable name
+  type:
+    type: string
+    enum: ["string", "long"]
+  description:
+    type: string
+    description: The description of the variable name
+  isDataPolicy:
+    type: boolean
+    description: Indicate whether the variable can be used in a Data Policy
+    default: true
+  isBehaviorPolicy:
+    type: boolean
+    description: Indicate whether the variable can be used in a Behavior Policy
+    default: true
+example:
+  variable: clientId
+  type: string
+  description: The MQTT client ID
+  isDataPolicy: true
+  isBehaviorPolicy: true

--- a/ext/openAPI/components/schemas/InterpolationVariableList.yaml
+++ b/ext/openAPI/components/schemas/InterpolationVariableList.yaml
@@ -1,0 +1,21 @@
+type: object
+description: The list of interpolation variables that can been used in this Datahub instance
+properties:
+  items:
+    type: array
+    items:
+      $ref: ./InterpolationVariable.yaml
+required:
+  - items
+example:
+  items:
+    - variable: clientId
+      type: string
+      description: The MQTT client ID
+      isDataPolicy: true
+      isBehaviorPolicy: true
+    - variable: topic
+      type: string
+      description: The MQTT topic to which the MQTT message was published
+      isDataPolicy: true
+      isBehaviorPolicy: false

--- a/ext/openAPI/openapi.yaml
+++ b/ext/openAPI/openapi.yaml
@@ -30,7 +30,7 @@ info:
     imported into popular API tooling (e.g. Postman) or can be used to generate
     client-code for multiple programming languages.
   title: HiveMQ Edge REST API
-  version: 2025.9-SNAPSHOT
+  version: 2025.10-SNAPSHOT
   x-logo:
     url: https://www.hivemq.com/img/svg/hivemq-bee.svg
 tags:

--- a/ext/openAPI/openapi.yaml
+++ b/ext/openAPI/openapi.yaml
@@ -63,6 +63,8 @@ tags:
       This resource bundles endpoints for the available Functions for the HiveMQ
       Data Hub. Currently this is limited to getting the available Functions.
     name: Data Hub - Functions
+  - description: This resource bundles endpoints for the interpolation features.
+    name: Data Hub - Interpolation
   - description: >-
       Policies describe how you want the HiveMQ broker to validate the behavior
       of MQTT clients.

--- a/ext/openAPI/openapi.yaml
+++ b/ext/openAPI/openapi.yaml
@@ -176,6 +176,8 @@ paths:
     $ref: paths/api_v1_data-hub_fsm.yaml
   /api/v1/data-hub/functions:
     $ref: paths/api_v1_data-hub_functions.yaml
+  /api/v1/data-hub/interpolation-variables:
+    $ref: paths/api_v1_data-hub_interpolation-variables.yaml
   /api/v1/data-hub/function-specs:
     $ref: paths/api_v1_data-hub_function-specs.yaml
   /api/v1/data-hub/schemas:

--- a/ext/openAPI/paths/api_v1_data-hub_interpolation-variables.yaml
+++ b/ext/openAPI/paths/api_v1_data-hub_interpolation-variables.yaml
@@ -1,0 +1,19 @@
+get:
+  description: This endpoint provides the means to get information on the interpolation variables available for the HiveMQ Data Hub.
+  operationId: getVariables
+  responses:
+    '200':
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/InterpolationVariableList.yaml
+      description: Success
+    '500':
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/ProblemDetails.yaml
+      description: Internal server error
+  summary: Get all interpolation variables
+  tags:
+    - Data Hub - Interpolation


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/33975/details/

The PR adds the OpenAPI specs required to implemented the endpoint that returns the list of interpolation variables used in the Data Hub instance

### Out-of-scope
- The backend endpoints will be implemented in a separate ticket, see https://hivemq.kanbanize.com/ctrl_board/57/cards/33977/details/
- The variables are currently hardcoded (and wrongly defined) in the frontend; they will be properly implemented in a separated ticket, see https://hivemq.kanbanize.com/ctrl_board/57/cards/33325/details/