### PR TITLE
fix(29929): Fix toast management in Policy publish

### DIFF
--- a/hivemq-edge-frontend/src/extensions/datahub/components/toolbar/ToolbarPublish.tsx
+++ b/hivemq-edge-frontend/src/extensions/datahub/components/toolbar/ToolbarPublish.tsx
@@ -75,15 +75,17 @@ export const ToolbarPublish: FC = () => {
   }
 
   const reportMutation = (promise: Promise<unknown>, type?: string) => {
-    promise.then(() => {
-      toast({
-        ...dataHubToastOption,
-        title: t('publish.success.title', { source: type || selectedNode?.type }),
-        description: t('publish.success.description', { source: type || selectedNode?.type, context: status }),
-        status: 'success',
-        id: 'publish-success',
+    promise
+      .then(() => {
+        toast({
+          ...dataHubToastOption,
+          title: t('publish.success.title', { source: type || selectedNode?.type }),
+          description: t('publish.success.description', { source: type || selectedNode?.type, context: status }),
+          status: 'success',
+          id: 'publish-success',
+        })
       })
-    })
+      .catch(() => {})
     return promise
   }
 


### PR DESCRIPTION
See  https://hivemq.kanbanize.com/ctrl_board/57/cards/29929/details/


The PR fixes a bug when notifying that a publishing task has failed. The duplicated error message has been removed, and the correct title has been added. 

### Before 
![HiveMQ-Edge-06-17-2025_14_36](https://github.com/user-attachments/assets/4254440b-84b6-4d02-89ab-f30a067a2260)



### After
![HiveMQ-Edge-06-17-2025_14_15](https://github.com/user-attachments/assets/66131b27-4a38-4b4e-8484-e78e6fd0c32d)

