### PR TITLE
fix(33994): Fix persistence with name and version of resources

### DIFF
--- a/hivemq-edge-frontend/src/extensions/datahub/designer/script/FunctionPanel.tsx
+++ b/hivemq-edge-frontend/src/extensions/datahub/designer/script/FunctionPanel.tsx
@@ -30,10 +30,6 @@ export const FunctionPanel: FC<PanelProps> = ({ selectedNode, onFormSubmit }) =>
     const sourceNode = nodes.find((node) => node.id === selectedNode) as Node<FunctionData> | undefined
     if (!sourceNode) return null
 
-    // const internalStatus =
-    //   typeof sourceNode?.data.version === 'number' ? ResourceStatus.LOADED : sourceNode?.data.version
-    //
-    // return sourceNode ? { ...sourceNode.data, internalStatus } : null
     const internalState = getResourceInternalStatus<Script>(sourceNode.data.name, allScripts, getScriptFamilies)
     const intData: FunctionData = { ...sourceNode.data, ...internalState }
 
@@ -46,10 +42,6 @@ export const FunctionPanel: FC<PanelProps> = ({ selectedNode, onFormSubmit }) =>
       type: {
         'ui:widget': 'hidden',
       },
-      // 'ui:order':
-      //   internalStatus === ResourceStatus.DRAFT || !internalStatus
-      //     ? ['name', 'type', 'schemaSource', 'messageType', 'version']
-      //     : ['name', 'version', 'schemaSource', 'messageType', 'type'],
       name: {
         'ui:widget': 'datahub:function-name',
         'ui:options': {

--- a/hivemq-edge-frontend/src/extensions/datahub/designer/script/FunctionPanel.tsx
+++ b/hivemq-edge-frontend/src/extensions/datahub/designer/script/FunctionPanel.tsx
@@ -5,17 +5,20 @@ import { Card, CardBody } from '@chakra-ui/react'
 import type { UiSchema } from '@rjsf/utils'
 import type { IChangeEvent } from '@rjsf/core'
 
+import type { Script } from '@/api/__generated__'
+import ErrorMessage from '@/components/ErrorMessage.tsx'
+
 import { MOCK_JAVASCRIPT_SCHEMA } from '@datahub/__test-utils__/schema.mocks.ts'
-import type { FunctionData, PanelProps } from '@datahub/types.ts'
-import { ResourceStatus, ResourceWorkingVersion } from '@datahub/types.ts'
-import useDataHubDraftStore from '@datahub/hooks/useDataHubDraftStore.ts'
-import { useGetAllScripts } from '@datahub/api/hooks/DataHubScriptsService/useGetAllScripts.ts'
 import { ReactFlowSchemaForm } from '@datahub/components/forms/ReactFlowSchemaForm.tsx'
 import { datahubRJSFWidgets } from '@datahub/designer/datahubRJSFWidgets.tsx'
 import { MOCK_FUNCTION_SCHEMA } from '@datahub/designer/script/FunctionData.ts'
 import { getScriptFamilies } from '@datahub/designer/schema/SchemaNode.utils.ts'
+import useDataHubDraftStore from '@datahub/hooks/useDataHubDraftStore.ts'
+import { useGetAllScripts } from '@datahub/api/hooks/DataHubScriptsService/useGetAllScripts.ts'
 import { usePolicyGuards } from '@datahub/hooks/usePolicyGuards.ts'
-import ErrorMessage from '@/components/ErrorMessage.tsx'
+import type { FunctionData, PanelProps } from '@datahub/types.ts'
+import { ResourceStatus, ResourceWorkingVersion } from '@datahub/types.ts'
+import { getResourceInternalStatus } from '@datahub/utils/policy.utils.ts'
 
 export const FunctionPanel: FC<PanelProps> = ({ selectedNode, onFormSubmit }) => {
   const { data: allScripts } = useGetAllScripts({})
@@ -23,12 +26,18 @@ export const FunctionPanel: FC<PanelProps> = ({ selectedNode, onFormSubmit }) =>
   const { guardAlert, isNodeEditable } = usePolicyGuards(selectedNode)
 
   const [formData, setFormData] = useState<FunctionData | null>(() => {
+    if (!allScripts) return null
     const sourceNode = nodes.find((node) => node.id === selectedNode) as Node<FunctionData> | undefined
+    if (!sourceNode) return null
 
-    const internalStatus =
-      typeof sourceNode?.data.version === 'number' ? ResourceStatus.LOADED : sourceNode?.data.version
+    // const internalStatus =
+    //   typeof sourceNode?.data.version === 'number' ? ResourceStatus.LOADED : sourceNode?.data.version
+    //
+    // return sourceNode ? { ...sourceNode.data, internalStatus } : null
+    const internalState = getResourceInternalStatus<Script>(sourceNode.data.name, allScripts, getScriptFamilies)
+    const intData: FunctionData = { ...sourceNode.data, ...internalState }
 
-    return sourceNode ? { ...sourceNode.data, internalStatus } : null
+    return intData
   })
 
   const getUISchema = (script: FunctionData | null): UiSchema => {

--- a/hivemq-edge-frontend/src/extensions/datahub/utils/policy.utils.spec.ts
+++ b/hivemq-edge-frontend/src/extensions/datahub/utils/policy.utils.spec.ts
@@ -1,8 +1,11 @@
+import { MOCK_SCRIPT_ID, mockScript } from '@datahub/api/hooks/DataHubScriptsService/__handlers__'
+import { getSchemaFamilies, getScriptFamilies } from '@datahub/designer/schema/SchemaNode.utils.ts'
+import { ResourceStatus, ResourceWorkingVersion } from '@datahub/types.ts'
 import { describe, expect } from 'vitest'
 
-import type { PolicySchema, SchemaList } from '@/api/__generated__'
-import { mockSchemaTempHumidity } from '@datahub/api/hooks/DataHubSchemasService/__handlers__'
-import { type ExpandableGroupedResource, groupResourceItems } from './policy.utils'
+import type { PolicySchema, SchemaList, Script } from '@/api/__generated__'
+import { MOCK_SCHEMA_ID, mockSchemaTempHumidity } from '@datahub/api/hooks/DataHubSchemasService/__handlers__'
+import { type ExpandableGroupedResource, getResourceInternalStatus, groupResourceItems } from './policy.utils'
 
 interface GroupSchemaTest {
   data: SchemaList | undefined
@@ -87,4 +90,34 @@ describe('groupResourceItems', () => {
       expect(groupResourceItems<SchemaList, PolicySchema>(data)).toStrictEqual(result)
     }
   )
+})
+
+describe('getResourceInternalStatus', () => {
+  it('should work for Schemas', () => {
+    expect(getResourceInternalStatus<PolicySchema>('my-schema', {}, getSchemaFamilies)).toStrictEqual({
+      internalStatus: ResourceStatus.DRAFT,
+      version: ResourceWorkingVersion.DRAFT,
+    })
+
+    expect(
+      getResourceInternalStatus<PolicySchema>(MOCK_SCHEMA_ID, { items: [mockSchemaTempHumidity] }, getSchemaFamilies)
+    ).toStrictEqual({
+      internalStatus: ResourceStatus.LOADED,
+      internalVersions: [1],
+      version: 1,
+    })
+  })
+  it('should work for Scripts', () => {
+    expect(getResourceInternalStatus<Script>('my-script', {}, getScriptFamilies)).toStrictEqual({
+      internalStatus: ResourceStatus.DRAFT,
+      version: ResourceWorkingVersion.DRAFT,
+    })
+
+    expect(getResourceInternalStatus<Script>(MOCK_SCRIPT_ID, { items: [mockScript] }, getScriptFamilies)).toStrictEqual(
+      {
+        internalStatus: ResourceStatus.DRAFT,
+        version: ResourceWorkingVersion.DRAFT,
+      }
+    )
+  })
 })

--- a/hivemq-edge-frontend/src/extensions/datahub/utils/policy.utils.spec.ts
+++ b/hivemq-edge-frontend/src/extensions/datahub/utils/policy.utils.spec.ts
@@ -115,8 +115,9 @@ describe('getResourceInternalStatus', () => {
 
     expect(getResourceInternalStatus<Script>(MOCK_SCRIPT_ID, { items: [mockScript] }, getScriptFamilies)).toStrictEqual(
       {
-        internalStatus: ResourceStatus.DRAFT,
-        version: ResourceWorkingVersion.DRAFT,
+        internalStatus: ResourceStatus.LOADED,
+        internalVersions: [1],
+        version: 1,
       }
     )
   })

--- a/hivemq-edge-frontend/src/extensions/datahub/utils/policy.utils.ts
+++ b/hivemq-edge-frontend/src/extensions/datahub/utils/policy.utils.ts
@@ -56,10 +56,9 @@ export const getResourceInternalStatus = <U extends ResourceBase>(
       internalVersions: formatter(allResources?.items || [])[schema.id].versions,
       internalStatus: ResourceStatus.LOADED,
     }
-  } else {
-    return {
-      internalStatus: ResourceStatus.DRAFT,
-      version: ResourceWorkingVersion.DRAFT,
-    }
+  }
+  return {
+    internalStatus: ResourceStatus.DRAFT,
+    version: ResourceWorkingVersion.DRAFT,
   }
 }

--- a/hivemq-edge-frontend/src/extensions/datahub/utils/policy.utils.ts
+++ b/hivemq-edge-frontend/src/extensions/datahub/utils/policy.utils.ts
@@ -1,8 +1,12 @@
-// TODO[OpenAPI] This MUST be the common properties of DataHub resources, i.e. Script and Schema
-export interface ResourceBase {
-  id: string
-  readonly version?: number
-}
+import type { PolicySchema, Script } from '@/api/__generated__'
+import { type ResourceFamily, ResourceStatus } from '@datahub/types.ts'
+import type { ResourceState } from '@datahub/types.ts'
+import { ResourceWorkingVersion } from '@datahub/types.ts'
+
+// TODO[OpenAPI]
+//  - This MUST be the common properties of DataHub resources, i.e. Script and Schema
+//  - Assuming that Script and Schema both have the same properties
+export type ResourceBase = Pick<PolicySchema, 'id' | 'version'> | Pick<Script, 'id' | 'version'>
 
 export type ExpandableGroupedResource<T extends ResourceBase> = T & {
   children?: T[]
@@ -38,4 +42,24 @@ export const groupResourceItems = <T extends { items?: Array<U> }, U extends Res
       children: schemas,
     } as ExpandableGroupedResource<U>
   })
+}
+
+export const getResourceInternalStatus = <U extends ResourceBase>(
+  id: string,
+  allResources: { items?: U[] },
+  formatter: (items: U[]) => Record<string, ResourceFamily>
+): ResourceState | undefined => {
+  const schema = allResources.items?.findLast((resource) => resource.id === id)
+  if (schema) {
+    return {
+      version: schema.version || ResourceWorkingVersion.MODIFIED,
+      internalVersions: formatter(allResources?.items || [])[schema.id].versions,
+      internalStatus: ResourceStatus.LOADED,
+    }
+  } else {
+    return {
+      internalStatus: ResourceStatus.DRAFT,
+      version: ResourceWorkingVersion.DRAFT,
+    }
+  }
 }


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/33994/details/

The PR fixes a small bug when resources (script and schema) are loaded and their configuration panel is opened for the first time. Both name and version are now properly detected and instantiated

### Before 
![HiveMQ-Edge-06-19-2025_12_36 (1)](https://github.com/user-attachments/assets/049ca44b-3127-4ec2-b9e4-55efc5748eb4)

### After

![HiveMQ-Edge-06-19-2025_12_36](https://github.com/user-attachments/assets/04468098-74bb-4b9a-b3a4-18d5b86849b7)