### PR TITLE
refactor(33943): Implement optimistic policy nodes update

### DIFF
--- a/hivemq-edge-frontend/src/extensions/datahub/components/toolbar/ToolbarPublish.spec.cy.tsx
+++ b/hivemq-edge-frontend/src/extensions/datahub/components/toolbar/ToolbarPublish.spec.cy.tsx
@@ -19,8 +19,11 @@ describe('ToolbarPublish', () => {
     cy.get('button').click()
     cy.wait('@getPolicies')
     cy.get('[role="status"] div').should('have.attr', 'data-status', 'error')
-    cy.get('[role="status"] div#toast-publish-error-title').should('have.text', 'Error publishing Data Policy')
-    cy.get('[role="status"] div#toast-publish-error-description').should('have.text', 'Not Found')
+    cy.get('[role="status"] div#toast-publish-error-DATA_POLICY-title').should(
+      'have.text',
+      'Error publishing Data Policy'
+    )
+    cy.get('[role="status"] div#toast-publish-error-DATA_POLICY-description').should('have.text', 'Not Found')
   })
 
   it('should handle success', () => {
@@ -31,8 +34,8 @@ describe('ToolbarPublish', () => {
     cy.get('button').click()
     cy.wait('@getPolicies')
     cy.get('[role="status"] div').should('have.attr', 'data-status', 'success')
-    cy.get('[role="status"] div#toast-publish-success-title').should('have.text', 'Data Policy published')
-    cy.get('[role="status"] div#toast-publish-success-description').should(
+    cy.get('[role="status"] div#toast-publish-success-DATA_POLICY-title').should('have.text', 'Data Policy published')
+    cy.get('[role="status"] div#toast-publish-success-DATA_POLICY-description').should(
       'have.text',
       "We've created a new Data Policy for you."
     )

--- a/hivemq-edge-frontend/src/extensions/datahub/components/toolbar/ToolbarPublish.tsx
+++ b/hivemq-edge-frontend/src/extensions/datahub/components/toolbar/ToolbarPublish.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
 import type { Node } from '@xyflow/react'
 import type { UseMutateAsyncFunction } from '@tanstack/react-query'
+import type { UseToastOptions } from '@chakra-ui/react'
 import { Button, Icon, useToast } from '@chakra-ui/react'
 import { MdPublishedWithChanges } from 'react-icons/md'
 
@@ -65,25 +66,29 @@ export const ToolbarPublish: FC = () => {
 
   const isValid = !!report && report.length >= 1 && report?.every((e) => !e.error)
 
+  const manageToast = (id: string, conf: UseToastOptions) => {
+    const { id: _, ...cleanConfig } = conf
+    if (!toast.isActive(id)) toast({ ...cleanConfig, id })
+    else toast.update(id, cleanConfig)
+  }
+
   const toastInternalError = (message: string) => {
-    toast({
+    manageToast(`publish-internal-${selectedNode?.type}`, {
       ...dataHubToastOption,
       title: t('publish.internal.title', { source: selectedNode?.type }),
       description: message,
       status: 'error',
-      id: 'publish-internal',
     })
   }
 
   const reportMutation = (promise: Promise<unknown>, type?: string) => {
     promise
       .then(() => {
-        toast({
+        manageToast(`publish-success-${type || selectedNode?.type}`, {
           ...dataHubToastOption,
           title: t('publish.success.title', { source: type || selectedNode?.type }),
           description: t('publish.success.description', { source: type || selectedNode?.type, context: status }),
           status: 'success',
-          id: 'publish-success',
         })
       })
       .catch(() => {})
@@ -208,16 +213,15 @@ export const ToolbarPublish: FC = () => {
         navigate(`/datahub/${selectedNode?.type}/${selectedNode?.data.id}`, { replace: true })
       })
       .catch((error) => {
-        console.log('XXXXXXXXXXXX, error', { ...error })
         let message
         if (error instanceof Error) message = error.message
         else message = String(error)
-        return toast({
+
+        manageToast(`publish-error-${selectedNode?.type}`, {
           ...dataHubToastOption,
           title: t('publish.error.title', { source: selectedNode?.type }),
           description: message.toString(),
           status: 'error',
-          id: 'publish-error',
         })
       })
   }

--- a/hivemq-edge-frontend/src/extensions/datahub/components/toolbar/ToolbarPublish.tsx
+++ b/hivemq-edge-frontend/src/extensions/datahub/components/toolbar/ToolbarPublish.tsx
@@ -66,6 +66,7 @@ export const ToolbarPublish: FC = () => {
 
   const isValid = !!report && report.length >= 1 && report?.every((e) => !e.error)
 
+  // TODO[NVL] The routine doesn't change title/description based on the number of resources published
   const manageToast = (id: string, conf: UseToastOptions) => {
     const { id: _, ...cleanConfig } = conf
     if (!toast.isActive(id)) toast({ ...cleanConfig, id })

--- a/hivemq-edge-frontend/src/extensions/datahub/components/toolbar/ToolbarPublish.tsx
+++ b/hivemq-edge-frontend/src/extensions/datahub/components/toolbar/ToolbarPublish.tsx
@@ -1,6 +1,7 @@
 import type { FC } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
+import type { Node } from '@xyflow/react'
 import type { UseMutateAsyncFunction } from '@tanstack/react-query'
 import { Button, Icon, useToast } from '@chakra-ui/react'
 import { MdPublishedWithChanges } from 'react-icons/md'
@@ -19,7 +20,7 @@ import { usePolicyChecksStore } from '@datahub/hooks/usePolicyChecksStore.ts'
 import { usePolicyGuards } from '@datahub/hooks/usePolicyGuards.ts'
 
 import { dataHubToastOption } from '@datahub/utils/toast.utils.ts'
-import type { DryRunResults, ResourceState } from '@datahub/types.ts'
+import type { DryRunResults, ResourceState, SchemaData } from '@datahub/types.ts'
 import { DataHubNodeType, ResourceWorkingVersion, DesignerStatus } from '@datahub/types.ts'
 
 // Should be PolicySchema | Script | DataPolicy | BehaviorPolicy
@@ -50,7 +51,7 @@ const resourceReducer =
 
 export const ToolbarPublish: FC = () => {
   const { t } = useTranslation('datahub')
-  const { status } = useDataHubDraftStore()
+  const { status, nodes, onUpdateNodes } = useDataHubDraftStore()
   const { report, node: selectedNode, setNode, reset } = usePolicyChecksStore()
   const createSchema = useCreateSchema()
   const createScript = useCreateScript()
@@ -89,6 +90,32 @@ export const ToolbarPublish: FC = () => {
     return promise
   }
 
+  /**
+   * This routine is called on successful publish of a resource node (script or schema), in order to update a draft node to its published version.
+   * In case the main policy fails, the graph will be holding the newly published resource nodes, but the main policy will not be updated.
+   * TODO[NVL] This is so much a hack, but we need to update the draft resource nodes and we lost the link between nodes and mutation requests
+   *  The whole publish process needs to be refactored
+   */
+  const updateDraftResourceNodes = (request: Mutate<PolicySchema> | Mutate<Script>) => (value: unknown) => {
+    if (request.type === DataHubNodeType.SCHEMA) {
+      const draftSchemaNodes = nodes.filter(
+        (node): node is Node<SchemaData> =>
+          node.type === DataHubNodeType.SCHEMA &&
+          node.data.name === request.payload.id &&
+          // if this is a draft, versions MUST be 1 AND ResourceWorkingVersion.DRAFT
+          node.data.version === ResourceWorkingVersion.DRAFT &&
+          (value as PolicySchema).version === 1
+      )
+
+      draftSchemaNodes.forEach((node) => {
+        onUpdateNodes<SchemaData>(node.id, {
+          ...node.data,
+          version: 1,
+        })
+      })
+    }
+  }
+
   const publishResources = (resources?: DryRunResults<never>[]) => {
     const allSchemas =
       resources
@@ -107,7 +134,7 @@ export const ToolbarPublish: FC = () => {
       })) || []
 
     return [...allSchemas, ...allScripts].map((request) =>
-      reportMutation(request.mutation(request.payload), request.type)
+      reportMutation(request.mutation(request.payload), request.type).then(updateDraftResourceNodes(request))
     )
   }
 
@@ -181,6 +208,7 @@ export const ToolbarPublish: FC = () => {
         navigate(`/datahub/${selectedNode?.type}/${selectedNode?.data.id}`, { replace: true })
       })
       .catch((error) => {
+        console.log('XXXXXXXXXXXX, error', { ...error })
         let message
         if (error instanceof Error) message = error.message
         else message = String(error)


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/33943/details/

The Pr fixes a destructive behaviour, where a policy publish request might fail but the resources contained will be published. The policy, as displayed in the `Designer` is therefore wrong

The publish process was redesigned to change, on the success of the requests, the status of resource nodes from `DRAFT` to `PUBLISHED`. This "optimistic" update has two advantages
- if the whole policy is successfully published, the automatic reloading of the `Designer` will recreate the policy from a clean slate
- If the policy fails however, the draft is still valid, ready for potential correction since the various resources have now all been converted to an existing saved script (or schema)

The PR also refactors the handling of toasts in the publishing process, updating existng toasts rather than adding new ones for every request processed. It will significantly reduce the overcrowding of the `Designer`

### Initial
![HiveMQ-Edge-06-23-2025_09_17](https://github.com/user-attachments/assets/fd5de681-3e82-4c22-b4d3-6279a74ed906)

### Before 
![HiveMQ-Edge-06-23-2025_09_20](https://github.com/user-attachments/assets/a028e4d7-31c5-4547-8f55-f22ff833147b)
### After 
![HiveMQ-Edge-06-23-2025_09_18](https://github.com/user-attachments/assets/b653f16a-657f-4b48-a4ee-e893a26f1b38)

