### PR TITLE
refactor(34191): Improve loading and error management in the configuration panels

### DIFF
--- a/hivemq-edge-frontend/cypress/support/commands.ts
+++ b/hivemq-edge-frontend/cypress/support/commands.ts
@@ -1,6 +1,8 @@
 /// <reference types="cypress" />
 import type { ContextObject } from 'axe-core'
 import type { Options } from 'cypress-axe'
+import type * as Sinon from 'sinon'
+
 import { getByTestId } from './commands/getByTestId'
 import { getByAriaLabel } from './commands/getByAriaLabel'
 import { checkAccessibility } from './commands/checkAccessibility'
@@ -29,3 +31,26 @@ Cypress.Commands.add('getByTestId', getByTestId)
 Cypress.Commands.add('getByAriaLabel', getByAriaLabel)
 Cypress.Commands.add('checkAccessibility', checkAccessibility)
 Cypress.Commands.add('clearInterceptList', clearInterceptList)
+
+// eslint-disable-next-line @typescript-eslint/no-namespace, @typescript-eslint/no-unused-vars
+declare namespace Chai {
+  interface Assertion {
+    calledWithErrorMessage(expectedMessage: string): Assertion
+  }
+}
+
+/**
+ * Check if a stub has been called an Error that has a specific message.
+ */
+chai.Assertion.addMethod('calledWithErrorMessage', function (expectedMessage: string) {
+  const stub = this._obj as Sinon.SinonSpy
+
+  this.assert(
+    typeof stub.getCall === 'function' &&
+      stub.getCalls().some((call) => call.args.some((arg) => arg instanceof Error && arg.message === expectedMessage)),
+    'expected stub to have been called with Error(message=#{exp}), but got #{act}',
+    'expected stub not to have been called with Error(message=#{exp})',
+    expectedMessage,
+    stub.getCalls().map((call) => call.args)
+  )
+})

--- a/hivemq-edge-frontend/package.json
+++ b/hivemq-edge-frontend/package.json
@@ -77,6 +77,7 @@
     "@types/d3-scale-chromatic": "3.1.0",
     "@types/d3-shape": "3.1.7",
     "@types/json-schema": "7.0.15",
+    "@types/sinon": "^17.0.4",
     "@uidotdev/usehooks": "2.4.1",
     "@vitest/coverage-v8": "3.1.1",
     "@xyflow/react": "12.5.4",

--- a/hivemq-edge-frontend/pnpm-lock.yaml
+++ b/hivemq-edge-frontend/pnpm-lock.yaml
@@ -140,6 +140,9 @@ importers:
       '@types/json-schema':
         specifier: 7.0.15
         version: 7.0.15
+      '@types/sinon':
+        specifier: ^17.0.4
+        version: 17.0.4
       '@uidotdev/usehooks':
         specifier: 2.4.1
         version: 2.4.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -3042,6 +3045,9 @@ packages:
 
   '@types/scheduler@0.26.0':
     resolution: {integrity: sha512-WFHp9YUJQ6CKshqoC37iOlHnQSmxNc795UhB26CyBBttrN9svdIrUjl/NjnNmfcwtncN0h/0PPAFWv9ovP8mLA==}
+
+  '@types/sinon@17.0.4':
+    resolution: {integrity: sha512-RHnIrhfPO3+tJT0s7cFaXGZvsL4bbR3/k7z3P312qMS4JaS2Tk+KiwiLx1S0rQ56ERj00u1/BtdyVd0FY+Pdew==}
 
   '@types/sinonjs__fake-timers@8.1.1':
     resolution: {integrity: sha512-0kSuKjAS0TrGLJ0M/+8MaFkGsQhZpB6pxOmvS3K8FYI72K//YmdfoW9X2qPsAKh1mkwxGD5zib9s1FIFed6E8g==}
@@ -11113,6 +11119,10 @@ snapshots:
       safe-buffer: 5.1.2
 
   '@types/scheduler@0.26.0': {}
+
+  '@types/sinon@17.0.4':
+    dependencies:
+      '@types/sinonjs__fake-timers': 8.1.1
 
   '@types/sinonjs__fake-timers@8.1.1': {}
 

--- a/hivemq-edge-frontend/src/extensions/datahub/api/hooks/DataHubFunctionsService/__handlers__/index.ts
+++ b/hivemq-edge-frontend/src/extensions/datahub/api/hooks/DataHubFunctionsService/__handlers__/index.ts
@@ -66,6 +66,7 @@ export const MOCK_DATAHUB_FUNCTIONS_DELIVERY_REDIRECT: FunctionSpecs = {
         title: 'Apply Policies',
         description: 'Defines whether policies are executed after publishing to a different topic.',
         format: 'interpolation',
+        default: false,
       },
     },
   },

--- a/hivemq-edge-frontend/src/extensions/datahub/components/controls/PropertyPanelController.tsx
+++ b/hivemq-edge-frontend/src/extensions/datahub/components/controls/PropertyPanelController.tsx
@@ -97,7 +97,12 @@ const PropertyPanelController = () => {
         <DrawerFooter borderTopWidth="1px">
           {isEditorValid && (
             <Flex flexGrow={1} justifyContent="flex-end">
-              <Button variant="primary" type="submit" form="datahub-node-form" isDisabled={!isNodeEditable}>
+              <Button
+                variant="primary"
+                type="submit"
+                form="datahub-node-form"
+                isDisabled={!isNodeEditable || !!formError}
+              >
                 {t('workspace.panel.submit')}
               </Button>
             </Flex>

--- a/hivemq-edge-frontend/src/extensions/datahub/components/controls/PropertyPanelController.tsx
+++ b/hivemq-edge-frontend/src/extensions/datahub/components/controls/PropertyPanelController.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { useLocation, useNavigate, useParams } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import type { IChangeEvent } from '@rjsf/core'
@@ -35,6 +35,7 @@ const PropertyPanelController = () => {
   const { isOpen, onOpen, onClose } = useDisclosure()
   const { onUpdateNodes } = useDataHubDraftStore()
   const { isNodeEditable } = usePolicyGuards(nodeId)
+  const [formError, setFormError] = useState<Error | null>(null)
 
   useEffect(() => {
     if (type && nodeId) {
@@ -86,7 +87,7 @@ const PropertyPanelController = () => {
 
         <DrawerBody>
           {isEditorValid ? (
-            <Editor selectedNode={nodeId} onFormSubmit={onFormSubmit} />
+            <Editor selectedNode={nodeId} onFormSubmit={onFormSubmit} onFormError={setFormError} />
           ) : (
             <AbsoluteCenter axis="both" data-testid="node-editor-under-construction">
               <Icon as={LuConstruction} boxSize={100} />

--- a/hivemq-edge-frontend/src/extensions/datahub/designer/behavior_policy/BehaviorPolicyPanel.tsx
+++ b/hivemq-edge-frontend/src/extensions/datahub/designer/behavior_policy/BehaviorPolicyPanel.tsx
@@ -1,11 +1,12 @@
 import type { FC } from 'react'
-import { useMemo } from 'react'
+import { useEffect, useMemo } from 'react'
 import type { Node } from '@xyflow/react'
 import { useTranslation } from 'react-i18next'
 import { Card, CardBody } from '@chakra-ui/react'
 import type { CustomValidator } from '@rjsf/utils'
 
 import ErrorMessage from '@/components/ErrorMessage.tsx'
+import LoaderSpinner from '@/components/Chakra/LoaderSpinner.tsx'
 
 import { useGetAllBehaviorPolicies } from '@datahub/api/hooks/DataHubBehaviorPoliciesService/useGetAllBehaviorPolicies.ts'
 import { ReactFlowSchemaForm } from '@datahub/components/forms/ReactFlowSchemaForm.tsx'
@@ -17,16 +18,20 @@ import { BehaviorPolicyType } from '@datahub/types.ts'
 
 const UNLIMITED_PUBLISH = -1
 
-export const BehaviorPolicyPanel: FC<PanelProps> = ({ selectedNode, onFormSubmit }) => {
+export const BehaviorPolicyPanel: FC<PanelProps> = ({ selectedNode, onFormSubmit, onFormError }) => {
   const { t } = useTranslation('datahub')
   const { nodes } = useDataHubDraftStore()
-  const { data: allPolicies } = useGetAllBehaviorPolicies({})
+  const { data: allPolicies, isSuccess, isLoading, error } = useGetAllBehaviorPolicies({})
   const { guardAlert, isNodeEditable } = usePolicyGuards(selectedNode)
 
   const data = useMemo(() => {
     const adapterNode = nodes.find((e) => e.id === selectedNode) as Node<BehaviorPolicyData> | undefined
     return adapterNode ? adapterNode.data : null
   }, [selectedNode, nodes])
+
+  useEffect(() => {
+    if (error) onFormError?.(error)
+  }, [error, onFormError])
 
   const customValidate: CustomValidator<BehaviorPolicyData> = (formData, errors) => {
     if (!allPolicies) errors['id']?.addError(t('error.validation.behaviourPolicy.notLoading'))
@@ -50,17 +55,21 @@ export const BehaviorPolicyPanel: FC<PanelProps> = ({ selectedNode, onFormSubmit
 
   return (
     <Card>
+      {isLoading && <LoaderSpinner />}
       {guardAlert && <ErrorMessage status="info" type={guardAlert.title} message={guardAlert.description} />}
-      <CardBody>
-        <ReactFlowSchemaForm
-          isNodeEditable={isNodeEditable}
-          schema={MOCK_BEHAVIOR_POLICY_SCHEMA.schema}
-          uiSchema={MOCK_BEHAVIOR_POLICY_SCHEMA.uiSchema}
-          customValidate={customValidate}
-          formData={data}
-          onSubmit={onFormSubmit}
-        />
-      </CardBody>
+      {error && <ErrorMessage status="error" message={error.message} />}
+      {isSuccess && (
+        <CardBody>
+          <ReactFlowSchemaForm
+            isNodeEditable={isNodeEditable}
+            schema={MOCK_BEHAVIOR_POLICY_SCHEMA.schema}
+            uiSchema={MOCK_BEHAVIOR_POLICY_SCHEMA.uiSchema}
+            customValidate={customValidate}
+            formData={data}
+            onSubmit={onFormSubmit}
+          />
+        </CardBody>
+      )}
     </Card>
   )
 }

--- a/hivemq-edge-frontend/src/extensions/datahub/designer/behavior_policy/BehaviorPolicyPanel.tsx
+++ b/hivemq-edge-frontend/src/extensions/datahub/designer/behavior_policy/BehaviorPolicyPanel.tsx
@@ -31,7 +31,8 @@ export const BehaviorPolicyPanel: FC<PanelProps> = ({ selectedNode, onFormSubmit
 
   useEffect(() => {
     if (error) onFormError?.(error)
-  }, [error, onFormError])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [error])
 
   const customValidate: CustomValidator<BehaviorPolicyData> = (formData, errors) => {
     if (!allPolicies) errors['id']?.addError(t('error.validation.behaviourPolicy.notLoading'))

--- a/hivemq-edge-frontend/src/extensions/datahub/designer/client_filter/ClientFilterPanel.spec.cy.tsx
+++ b/hivemq-edge-frontend/src/extensions/datahub/designer/client_filter/ClientFilterPanel.spec.cy.tsx
@@ -36,6 +36,18 @@ describe('ClientFilterPanel', () => {
     cy.viewport(800, 800)
   })
 
+  it('should render loading and error states', () => {
+    const onFormError = cy.stub().as('onFormError')
+    cy.mountWithProviders(<ClientFilterPanel selectedNode="fakenosde" onFormError={onFormError} />, { wrapper })
+
+    cy.get('[role="alert"]')
+      .should('be.visible')
+      .should('have.attr', 'data-status', 'error')
+      .should('contain.text', 'The Client Filter is not a valid element')
+
+    cy.get('@onFormError').should('have.been.calledWithErrorMessage', 'The Client Filter is not a valid element')
+  })
+
   it('should render the fields for a Validator', () => {
     const onSubmit = cy.stub().as('onSubmit')
 

--- a/hivemq-edge-frontend/src/extensions/datahub/designer/client_filter/ClientFilterPanel.tsx
+++ b/hivemq-edge-frontend/src/extensions/datahub/designer/client_filter/ClientFilterPanel.tsx
@@ -27,7 +27,8 @@ export const ClientFilterPanel: FC<PanelProps> = ({ selectedNode, onFormSubmit, 
     if (!clients) {
       onFormError?.(new Error(t('error.elementNotDefined.description', { nodeType: DataHubNodeType.CLIENT_FILTER })))
     }
-  }, [clients, onFormError, t])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [clients])
 
   return (
     <Card>

--- a/hivemq-edge-frontend/src/extensions/datahub/designer/client_filter/ClientFilterPanel.tsx
+++ b/hivemq-edge-frontend/src/extensions/datahub/designer/client_filter/ClientFilterPanel.tsx
@@ -1,16 +1,20 @@
 import type { FC } from 'react'
-import { useMemo } from 'react'
+import { useEffect, useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
 import type { Node } from '@xyflow/react'
 import { Card, CardBody } from '@chakra-ui/react'
 
-import type { ClientFilterData, PanelProps } from '@datahub/types.ts'
-import useDataHubDraftStore from '@datahub/hooks/useDataHubDraftStore.ts'
-import { MOCK_CLIENT_FILTER_SCHEMA } from '@datahub/designer/client_filter/ClientFilterSchema.ts'
-import { ReactFlowSchemaForm } from '@datahub/components/forms/ReactFlowSchemaForm.tsx'
-import { usePolicyGuards } from '@datahub/hooks/usePolicyGuards.ts'
 import ErrorMessage from '@/components/ErrorMessage.tsx'
 
-export const ClientFilterPanel: FC<PanelProps> = ({ selectedNode, onFormSubmit }) => {
+import { ReactFlowSchemaForm } from '@datahub/components/forms/ReactFlowSchemaForm.tsx'
+import { MOCK_CLIENT_FILTER_SCHEMA } from '@datahub/designer/client_filter/ClientFilterSchema.ts'
+import useDataHubDraftStore from '@datahub/hooks/useDataHubDraftStore.ts'
+import { usePolicyGuards } from '@datahub/hooks/usePolicyGuards.ts'
+import type { ClientFilterData, PanelProps } from '@datahub/types.ts'
+import { DataHubNodeType } from '@datahub/types.ts'
+
+export const ClientFilterPanel: FC<PanelProps> = ({ selectedNode, onFormSubmit, onFormError }) => {
+  const { t } = useTranslation('datahub')
   const { nodes } = useDataHubDraftStore()
   const { guardAlert, isNodeEditable } = usePolicyGuards(selectedNode)
 
@@ -19,18 +23,32 @@ export const ClientFilterPanel: FC<PanelProps> = ({ selectedNode, onFormSubmit }
     return adapterNode ? adapterNode.data.clients : null
   }, [selectedNode, nodes])
 
+  useEffect(() => {
+    if (!clients) {
+      onFormError?.(new Error(t('error.elementNotDefined.description', { nodeType: DataHubNodeType.CLIENT_FILTER })))
+    }
+  }, [clients, onFormError, t])
+
   return (
     <Card>
       {guardAlert && <ErrorMessage status="info" type={guardAlert.title} message={guardAlert.description} />}
-      <CardBody>
-        <ReactFlowSchemaForm
-          isNodeEditable={isNodeEditable}
-          schema={MOCK_CLIENT_FILTER_SCHEMA.schema}
-          uiSchema={MOCK_CLIENT_FILTER_SCHEMA.uiSchema}
-          formData={{ clients: clients }}
-          onSubmit={onFormSubmit}
+      {!clients && (
+        <ErrorMessage
+          type={t('error.elementNotDefined.title')}
+          message={t('error.elementNotDefined.description', { nodeType: DataHubNodeType.CLIENT_FILTER })}
         />
-      </CardBody>
+      )}
+      {clients && (
+        <CardBody>
+          <ReactFlowSchemaForm
+            isNodeEditable={isNodeEditable}
+            schema={MOCK_CLIENT_FILTER_SCHEMA.schema}
+            uiSchema={MOCK_CLIENT_FILTER_SCHEMA.uiSchema}
+            formData={{ clients: clients }}
+            onSubmit={onFormSubmit}
+          />
+        </CardBody>
+      )}
     </Card>
   )
 }

--- a/hivemq-edge-frontend/src/extensions/datahub/designer/data_policy/DataPolicyPanel.spec.cy.tsx
+++ b/hivemq-edge-frontend/src/extensions/datahub/designer/data_policy/DataPolicyPanel.spec.cy.tsx
@@ -38,6 +38,24 @@ describe('DataPolicyPanel', () => {
     })
   })
 
+  it('should render loading and error states', () => {
+    const onFormError = cy.stub().as('onFormError')
+    cy.intercept('/api/v1/data-hub/data-validation/policies', { statusCode: 404 }).as('getPolicies')
+
+    cy.mountWithProviders(<DataPolicyPanel selectedNode="3" onFormError={onFormError} />, {
+      wrapper,
+    })
+    cy.getByTestId('loading-spinner').should('be.visible')
+
+    cy.wait('@getPolicies')
+    cy.get('[role="alert"]')
+      .should('be.visible')
+      .should('have.attr', 'data-status', 'error')
+      .should('have.text', 'DataPolicy not found')
+
+    cy.get('@onFormError').should('have.been.calledWithErrorMessage', 'DataPolicy not found')
+  })
+
   it('should render the fields for the panel', () => {
     const onSubmit = cy.stub().as('onSubmit')
 

--- a/hivemq-edge-frontend/src/extensions/datahub/designer/data_policy/DataPolicyPanel.tsx
+++ b/hivemq-edge-frontend/src/extensions/datahub/designer/data_policy/DataPolicyPanel.tsx
@@ -28,7 +28,8 @@ export const DataPolicyPanel: FC<PanelProps> = ({ selectedNode, onFormSubmit, on
 
   useEffect(() => {
     if (error) onFormError?.(error)
-  }, [error, onFormError])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [error])
 
   const customValidate: CustomValidator<DataPolicyData> = (formData, errors) => {
     if (isError) errors['id']?.addError(t('error.validation.dataPolicy.notLoading'))

--- a/hivemq-edge-frontend/src/extensions/datahub/designer/operation/OperationPanel.tsx
+++ b/hivemq-edge-frontend/src/extensions/datahub/designer/operation/OperationPanel.tsx
@@ -96,7 +96,8 @@ export const OperationPanel: FC<PanelProps> = ({ selectedNode, onFormSubmit, onF
 
   useEffect(() => {
     if (error) onFormError?.(error)
-  }, [error, onFormError])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [error])
 
   const customValidate: CustomValidator<DataPolicyData> = (formData, errors) => {
     const isIdNotUnique = Boolean(pipelineIds?.find((id) => id === formData?.id))

--- a/hivemq-edge-frontend/src/extensions/datahub/designer/operation/OperationPanel.tsx
+++ b/hivemq-edge-frontend/src/extensions/datahub/designer/operation/OperationPanel.tsx
@@ -1,4 +1,4 @@
-import { type FC, useCallback, useMemo } from 'react'
+import { type FC, useCallback, useEffect, useMemo } from 'react'
 import { type Node, getIncomers } from '@xyflow/react'
 import type { IChangeEvent } from '@rjsf/core'
 import type { CustomValidator } from '@rjsf/utils'
@@ -7,6 +7,7 @@ import { Card, CardBody } from '@chakra-ui/react'
 
 import type { BehaviorPolicyTransitionEvent } from '@/api/__generated__'
 import ErrorMessage from '@/components/ErrorMessage.tsx'
+import LoaderSpinner from '@/components/Chakra/LoaderSpinner.tsx'
 
 import { ReactFlowSchemaForm } from '@datahub/components/forms/ReactFlowSchemaForm.tsx'
 import { datahubRJSFWidgets } from '@datahub/designer/datahubRJSFWidgets.tsx'
@@ -23,7 +24,7 @@ interface OperationPanelContext {
   transition: BehaviorPolicyTransitionEvent | undefined
 }
 
-export const OperationPanel: FC<PanelProps> = ({ selectedNode, onFormSubmit }) => {
+export const OperationPanel: FC<PanelProps> = ({ selectedNode, onFormSubmit, onFormError }) => {
   const { t } = useTranslation('datahub')
   const { nodes, edges } = useDataHubDraftStore()
   const { guardAlert, isNodeEditable } = usePolicyGuards(selectedNode)
@@ -44,7 +45,7 @@ export const OperationPanel: FC<PanelProps> = ({ selectedNode, onFormSubmit }) =
     return { type, transition }
   }, [edges, nodes, selectedNode])
 
-  const { getFilteredFunctions } = useFilteredFunctionsFetcher()
+  const { getFilteredFunctions, isLoading, isSuccess, error } = useFilteredFunctionsFetcher()
   const functions = getFilteredFunctions(context.type, context.transition)
 
   const formData = useMemo(() => {
@@ -93,6 +94,10 @@ export const OperationPanel: FC<PanelProps> = ({ selectedNode, onFormSubmit }) =
     return getOperationSchema(functions)
   }, [functions])
 
+  useEffect(() => {
+    if (error) onFormError?.(error)
+  }, [error, onFormError])
+
   const customValidate: CustomValidator<DataPolicyData> = (formData, errors) => {
     const isIdNotUnique = Boolean(pipelineIds?.find((id) => id === formData?.id))
     if (isIdNotUnique) errors['id']?.addError(t('error.validation.operation.notUnique'))
@@ -101,20 +106,24 @@ export const OperationPanel: FC<PanelProps> = ({ selectedNode, onFormSubmit }) =
 
   return (
     <Card>
+      {isLoading && <LoaderSpinner />}
       {guardAlert && <ErrorMessage status="info" type={guardAlert.title} message={guardAlert.description} />}
-      <CardBody>
-        <ReactFlowSchemaForm
-          isNodeEditable={isNodeEditable}
-          schema={schema}
-          uiSchema={uiSchema}
-          formData={formData}
-          formContext={{ functions }}
-          widgets={datahubRJSFWidgets}
-          noHtml5Validate={true}
-          onSubmit={onFixFormSubmit}
-          customValidate={customValidate}
-        />
-      </CardBody>
+      {error && <ErrorMessage status="error" message={error.message} />}
+      {isSuccess && (
+        <CardBody>
+          <ReactFlowSchemaForm
+            isNodeEditable={isNodeEditable}
+            schema={schema}
+            uiSchema={uiSchema}
+            formData={formData}
+            formContext={{ functions }}
+            widgets={datahubRJSFWidgets}
+            noHtml5Validate={true}
+            onSubmit={onFixFormSubmit}
+            customValidate={customValidate}
+          />
+        </CardBody>
+      )}
     </Card>
   )
 }

--- a/hivemq-edge-frontend/src/extensions/datahub/designer/schema/SchemaPanel.tsx
+++ b/hivemq-edge-frontend/src/extensions/datahub/designer/schema/SchemaPanel.tsx
@@ -1,13 +1,14 @@
 import type { FC } from 'react'
-import { useCallback, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import type { Node } from '@xyflow/react'
-import { parse } from 'protobufjs'
 import type { CustomValidator, UiSchema } from '@rjsf/utils'
 import type { IChangeEvent } from '@rjsf/core'
 import { Card, CardBody } from '@chakra-ui/react'
+import { parse } from 'protobufjs'
 
 import type { PolicySchema } from '@/api/__generated__'
 import ErrorMessage from '@/components/ErrorMessage.tsx'
+import LoaderSpinner from '@/components/Chakra/LoaderSpinner.tsx'
 import { enumFromStringValue } from '@/utils/types.utils.ts'
 
 import { MOCK_JSONSCHEMA_SCHEMA, MOCK_PROTOBUF_SCHEMA } from '@datahub/__test-utils__/schema.mocks.ts'
@@ -22,20 +23,25 @@ import { ResourceStatus, ResourceWorkingVersion, SchemaType } from '@datahub/typ
 import type { PanelProps, SchemaData } from '@datahub/types.ts'
 import { getResourceInternalStatus } from '@datahub/utils/policy.utils.ts'
 
-export const SchemaPanel: FC<PanelProps> = ({ selectedNode, onFormSubmit }) => {
-  const { data: allSchemas } = useGetAllSchemas()
+export const SchemaPanel: FC<PanelProps> = ({ selectedNode, onFormSubmit, onFormError }) => {
+  const { data: allSchemas, isLoading, isSuccess, error } = useGetAllSchemas()
   const { nodes } = useDataHubDraftStore()
   const { guardAlert, isNodeEditable } = usePolicyGuards(selectedNode)
-  const [formData, setFormData] = useState<SchemaData | null>(() => {
-    if (!allSchemas) return null
+  const [formData, setFormData] = useState<SchemaData | null>(null)
+
+  useEffect(() => {
+    if (!allSchemas) return
     const adapterNode = nodes.find((e) => e.id === selectedNode) as Node<SchemaData> | undefined
-    if (!adapterNode) return null
+    if (!adapterNode) return
 
     const internalState = getResourceInternalStatus<PolicySchema>(adapterNode.data.name, allSchemas, getSchemaFamilies)
     const intData: SchemaData = { ...adapterNode.data, ...internalState }
+    setFormData(intData)
+  }, [allSchemas, nodes, selectedNode])
 
-    return intData
-  })
+  useEffect(() => {
+    if (error) onFormError?.(error)
+  }, [error, onFormError])
 
   const onReactFlowSchemaFormChange = useCallback(
     (changeEvent: IChangeEvent, id?: string | undefined) => {
@@ -165,19 +171,23 @@ export const SchemaPanel: FC<PanelProps> = ({ selectedNode, onFormSubmit }) => {
 
   return (
     <Card>
+      {isLoading && <LoaderSpinner />}
       {guardAlert && <ErrorMessage status="info" type={guardAlert.title} message={guardAlert.description} />}
-      <CardBody>
-        <ReactFlowSchemaForm
-          isNodeEditable={isNodeEditable}
-          schema={MOCK_SCHEMA_SCHEMA.schema}
-          uiSchema={getUISchema(formData)}
-          formData={formData}
-          widgets={datahubRJSFWidgets}
-          customValidate={customValidate}
-          onSubmit={onFormSubmit}
-          onChange={onReactFlowSchemaFormChange}
-        />
-      </CardBody>
+      {error && <ErrorMessage status="error" message={error.message} />}
+      {isSuccess && (
+        <CardBody>
+          <ReactFlowSchemaForm
+            isNodeEditable={isNodeEditable}
+            schema={MOCK_SCHEMA_SCHEMA.schema}
+            uiSchema={getUISchema(formData)}
+            formData={formData}
+            widgets={datahubRJSFWidgets}
+            customValidate={customValidate}
+            onSubmit={onFormSubmit}
+            onChange={onReactFlowSchemaFormChange}
+          />
+        </CardBody>
+      )}
     </Card>
   )
 }

--- a/hivemq-edge-frontend/src/extensions/datahub/designer/schema/SchemaPanel.tsx
+++ b/hivemq-edge-frontend/src/extensions/datahub/designer/schema/SchemaPanel.tsx
@@ -41,7 +41,8 @@ export const SchemaPanel: FC<PanelProps> = ({ selectedNode, onFormSubmit, onForm
 
   useEffect(() => {
     if (error) onFormError?.(error)
-  }, [error, onFormError])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [error])
 
   const onReactFlowSchemaFormChange = useCallback(
     (changeEvent: IChangeEvent, id?: string | undefined) => {

--- a/hivemq-edge-frontend/src/extensions/datahub/designer/script/FunctionPanel.tsx
+++ b/hivemq-edge-frontend/src/extensions/datahub/designer/script/FunctionPanel.tsx
@@ -46,7 +46,8 @@ export const FunctionPanel: FC<PanelProps> = ({ selectedNode, onFormSubmit, onFo
 
   useEffect(() => {
     if (error) onFormError?.(error)
-  }, [error, onFormError])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [error])
 
   const getUISchema = (script: FunctionData | null): UiSchema => {
     const { internalStatus, internalVersions } = script || {}

--- a/hivemq-edge-frontend/src/extensions/datahub/designer/script/FunctionPanel.tsx
+++ b/hivemq-edge-frontend/src/extensions/datahub/designer/script/FunctionPanel.tsx
@@ -1,5 +1,5 @@
 import type { FC } from 'react'
-import { useCallback, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import type { Node } from '@xyflow/react'
 import { Card, CardBody } from '@chakra-ui/react'
 import type { UiSchema } from '@rjsf/utils'
@@ -7,6 +7,7 @@ import type { IChangeEvent } from '@rjsf/core'
 
 import type { Script } from '@/api/__generated__'
 import ErrorMessage from '@/components/ErrorMessage.tsx'
+import LoaderSpinner from '@/components/Chakra/LoaderSpinner.tsx'
 
 import { MOCK_JAVASCRIPT_SCHEMA } from '@datahub/__test-utils__/schema.mocks.ts'
 import { ReactFlowSchemaForm } from '@datahub/components/forms/ReactFlowSchemaForm.tsx'
@@ -20,21 +21,26 @@ import type { FunctionData, PanelProps } from '@datahub/types.ts'
 import { ResourceStatus, ResourceWorkingVersion } from '@datahub/types.ts'
 import { getResourceInternalStatus } from '@datahub/utils/policy.utils.ts'
 
-export const FunctionPanel: FC<PanelProps> = ({ selectedNode, onFormSubmit }) => {
-  const { data: allScripts } = useGetAllScripts({})
+export const FunctionPanel: FC<PanelProps> = ({ selectedNode, onFormSubmit, onFormError }) => {
+  const { data: allScripts, isLoading, isSuccess, error } = useGetAllScripts({})
   const { nodes } = useDataHubDraftStore()
   const { guardAlert, isNodeEditable } = usePolicyGuards(selectedNode)
+  const [formData, setFormData] = useState<FunctionData | null>(null)
 
-  const [formData, setFormData] = useState<FunctionData | null>(() => {
-    if (!allScripts) return null
+  useEffect(() => {
+    if (!allScripts) return
     const sourceNode = nodes.find((node) => node.id === selectedNode) as Node<FunctionData> | undefined
-    if (!sourceNode) return null
+    if (!sourceNode) return
 
     const internalState = getResourceInternalStatus<Script>(sourceNode.data.name, allScripts, getScriptFamilies)
     const intData: FunctionData = { ...sourceNode.data, ...internalState }
 
-    return intData
-  })
+    setFormData(intData)
+  }, [allScripts, nodes, selectedNode])
+
+  useEffect(() => {
+    if (error) onFormError?.(error)
+  }, [error, onFormError])
 
   const getUISchema = (script: FunctionData | null): UiSchema => {
     const { internalStatus, internalVersions } = script || {}
@@ -124,18 +130,22 @@ export const FunctionPanel: FC<PanelProps> = ({ selectedNode, onFormSubmit }) =>
 
   return (
     <Card>
+      {isLoading && <LoaderSpinner />}
       {guardAlert && <ErrorMessage status="info" type={guardAlert.title} message={guardAlert.description} />}
-      <CardBody>
-        <ReactFlowSchemaForm
-          isNodeEditable={isNodeEditable}
-          widgets={datahubRJSFWidgets}
-          schema={MOCK_FUNCTION_SCHEMA.schema}
-          uiSchema={getUISchema(formData)}
-          formData={formData}
-          onSubmit={onFormSubmit}
-          onChange={onReactFlowSchemaFormChange}
-        />
-      </CardBody>
+      {error && <ErrorMessage status="error" message={error.message} />}
+      {isSuccess && (
+        <CardBody>
+          <ReactFlowSchemaForm
+            isNodeEditable={isNodeEditable}
+            widgets={datahubRJSFWidgets}
+            schema={MOCK_FUNCTION_SCHEMA.schema}
+            uiSchema={getUISchema(formData)}
+            formData={formData}
+            onSubmit={onFormSubmit}
+            onChange={onReactFlowSchemaFormChange}
+          />
+        </CardBody>
+      )}
     </Card>
   )
 }

--- a/hivemq-edge-frontend/src/extensions/datahub/designer/script/FunctionPanel.tsx
+++ b/hivemq-edge-frontend/src/extensions/datahub/designer/script/FunctionPanel.tsx
@@ -4,6 +4,7 @@ import type { Node } from '@xyflow/react'
 import { Card, CardBody } from '@chakra-ui/react'
 import type { UiSchema } from '@rjsf/utils'
 import type { IChangeEvent } from '@rjsf/core'
+import debug from 'debug'
 
 import type { Script } from '@/api/__generated__'
 import ErrorMessage from '@/components/ErrorMessage.tsx'
@@ -21,6 +22,8 @@ import type { FunctionData, PanelProps } from '@datahub/types.ts'
 import { ResourceStatus, ResourceWorkingVersion } from '@datahub/types.ts'
 import { getResourceInternalStatus } from '@datahub/utils/policy.utils.ts'
 
+const datahubLog = debug('DataHub:FunctionPanel')
+
 export const FunctionPanel: FC<PanelProps> = ({ selectedNode, onFormSubmit, onFormError }) => {
   const { data: allScripts, isLoading, isSuccess, error } = useGetAllScripts({})
   const { nodes } = useDataHubDraftStore()
@@ -30,7 +33,10 @@ export const FunctionPanel: FC<PanelProps> = ({ selectedNode, onFormSubmit, onFo
   useEffect(() => {
     if (!allScripts) return
     const sourceNode = nodes.find((node) => node.id === selectedNode) as Node<FunctionData> | undefined
-    if (!sourceNode) return
+    if (!sourceNode) {
+      datahubLog(`Node with ID ${selectedNode} not found in the current nodes list`)
+      return
+    }
 
     const internalState = getResourceInternalStatus<Script>(sourceNode.data.name, allScripts, getScriptFamilies)
     const intData: FunctionData = { ...sourceNode.data, ...internalState }

--- a/hivemq-edge-frontend/src/extensions/datahub/designer/topic_filter/TopicFilterPanel.spec.cy.tsx
+++ b/hivemq-edge-frontend/src/extensions/datahub/designer/topic_filter/TopicFilterPanel.spec.cy.tsx
@@ -4,10 +4,11 @@ import { Button } from '@chakra-ui/react'
 import type { Node } from '@xyflow/react'
 
 import { MockStoreWrapper } from '@datahub/__test-utils__/MockStoreWrapper.tsx'
+import { mockDataPolicy } from '@datahub/api/hooks/DataHubDataPoliciesService/__handlers__'
 import type { TopicFilterData } from '@datahub/types.ts'
 import { DataHubNodeType } from '@datahub/types.ts'
+
 import { TopicFilterPanel } from './TopicFilterPanel.tsx'
-import { mockDataPolicy } from '@datahub/api/hooks/DataHubDataPoliciesService/__handlers__'
 
 const MOCK_TOPIC_FILTER: Node<TopicFilterData> = {
   id: '3',
@@ -34,11 +35,28 @@ const wrapper: React.JSXElementConstructor<{ children: React.ReactNode }> = ({ c
 describe('TopicFilterPanel', () => {
   beforeEach(() => {
     cy.viewport(800, 800)
-    cy.intercept('/api/v1/management/protocol-adapters/adapters', { statusCode: 404 })
-    cy.intercept('/api/v1/data-hub/data-validation/policies', { statusCode: 404 })
+  })
+
+  it('should render loading and error states', () => {
+    cy.intercept('/api/v1/data-hub/data-validation/policies', { statusCode: 404 }).as('getPolicies')
+    const onFormError = cy.stub().as('onFormError')
+    cy.intercept('/api/v1/data-hub/scripts', { statusCode: 404 }).as('getScripts')
+    cy.mountWithProviders(<TopicFilterPanel selectedNode="3" onFormError={onFormError} />, { wrapper })
+    cy.getByTestId('loading-spinner').should('be.visible')
+
+    cy.wait('@getPolicies')
+    cy.get('[role="alert"]')
+      .should('be.visible')
+      .should('have.attr', 'data-status', 'error')
+      .should('have.text', 'DataPolicy not found')
+
+    cy.get('@onFormError').should('have.been.calledWithErrorMessage', 'DataPolicy not found')
   })
 
   it('should render the fields for a Validator', () => {
+    cy.intercept('/api/v1/data-hub/data-validation/policies', {
+      items: [mockDataPolicy],
+    }).as('getPolicies')
     cy.mountWithProviders(<TopicFilterPanel selectedNode="3" />, { wrapper })
 
     cy.get('label#root_adapter-label').should('contain.text', 'Adapter source')
@@ -58,7 +76,7 @@ describe('TopicFilterPanel', () => {
     cy.get('label#root_topics_0-label').should('have.attr', 'data-invalid')
     cy.get('label#root_topics_1-label').should('not.have.attr', 'data-invalid')
     cy.get('label#root_topics_2-label').should('have.attr', 'data-invalid')
-    cy.get('label#root_topics_3-label').should('not.have.attr', 'data-invalid')
+    cy.get('label#root_topics_3-label').should('have.attr', 'data-invalid')
 
     cy.wait('@getPolicies')
 
@@ -67,6 +85,9 @@ describe('TopicFilterPanel', () => {
   })
 
   it('should be accessible', () => {
+    cy.intercept('/api/v1/data-hub/data-validation/policies', {
+      items: [mockDataPolicy],
+    }).as('getPolicies')
     cy.injectAxe()
     cy.mountWithProviders(<TopicFilterPanel selectedNode="3" />, { wrapper })
 

--- a/hivemq-edge-frontend/src/extensions/datahub/designer/topic_filter/TopicFilterPanel.tsx
+++ b/hivemq-edge-frontend/src/extensions/datahub/designer/topic_filter/TopicFilterPanel.tsx
@@ -1,4 +1,6 @@
+import LoaderSpinner from '@/components/Chakra/LoaderSpinner.tsx'
 import type { FC } from 'react'
+import { useEffect } from 'react'
 import { useMemo } from 'react'
 import type { Node } from '@xyflow/react'
 import type { CustomValidator } from '@rjsf/utils'
@@ -15,9 +17,9 @@ import { useGetAllDataPolicies } from '@datahub/api/hooks/DataHubDataPoliciesSer
 import { usePolicyGuards } from '@datahub/hooks/usePolicyGuards.ts'
 import ErrorMessage from '@/components/ErrorMessage.tsx'
 
-export const TopicFilterPanel: FC<PanelProps> = ({ selectedNode, onFormSubmit }) => {
+export const TopicFilterPanel: FC<PanelProps> = ({ selectedNode, onFormSubmit, onFormError }) => {
   const { t } = useTranslation('datahub')
-  const { isLoading, data } = useGetAllDataPolicies()
+  const { isLoading, data, isSuccess, error } = useGetAllDataPolicies()
   const { nodes } = useDataHubDraftStore()
   const { guardAlert, isNodeEditable } = usePolicyGuards(selectedNode)
 
@@ -30,6 +32,10 @@ export const TopicFilterPanel: FC<PanelProps> = ({ selectedNode, onFormSubmit })
     const adapterNode = nodes.find((e) => e.id === selectedNode) as Node<TopicFilterData> | undefined
     return adapterNode ? adapterNode.data : null
   }, [selectedNode, nodes])
+
+  useEffect(() => {
+    if (error) onFormError?.(error)
+  }, [error, onFormError])
 
   const customValidate: CustomValidator<TopicFilterData> = (formData, errors) => {
     const duplicates = validateDuplicates(formData?.['topics'] || [])
@@ -53,18 +59,22 @@ export const TopicFilterPanel: FC<PanelProps> = ({ selectedNode, onFormSubmit })
 
   return (
     <Card>
+      {isLoading && <LoaderSpinner />}
       {guardAlert && <ErrorMessage status="info" type={guardAlert.title} message={guardAlert.description} />}
-      <CardBody>
-        <ReactFlowSchemaForm
-          isNodeEditable={isNodeEditable}
-          schema={MOCK_TOPIC_FILTER_SCHEMA.schema}
-          uiSchema={MOCK_TOPIC_FILTER_SCHEMA.uiSchema}
-          formData={formData}
-          customValidate={customValidate}
-          widgets={datahubRJSFWidgets}
-          onSubmit={onFormSubmit}
-        />
-      </CardBody>
+      {error && <ErrorMessage status="error" message={error.message} />}
+      {isSuccess && formData && (
+        <CardBody>
+          <ReactFlowSchemaForm
+            isNodeEditable={isNodeEditable}
+            schema={MOCK_TOPIC_FILTER_SCHEMA.schema}
+            uiSchema={MOCK_TOPIC_FILTER_SCHEMA.uiSchema}
+            formData={formData}
+            customValidate={customValidate}
+            widgets={datahubRJSFWidgets}
+            onSubmit={onFormSubmit}
+          />
+        </CardBody>
+      )}
     </Card>
   )
 }

--- a/hivemq-edge-frontend/src/extensions/datahub/designer/topic_filter/TopicFilterPanel.tsx
+++ b/hivemq-edge-frontend/src/extensions/datahub/designer/topic_filter/TopicFilterPanel.tsx
@@ -35,7 +35,8 @@ export const TopicFilterPanel: FC<PanelProps> = ({ selectedNode, onFormSubmit, o
 
   useEffect(() => {
     if (error) onFormError?.(error)
-  }, [error, onFormError])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [error])
 
   const customValidate: CustomValidator<TopicFilterData> = (formData, errors) => {
     const duplicates = validateDuplicates(formData?.['topics'] || [])

--- a/hivemq-edge-frontend/src/extensions/datahub/designer/transition/TransitionPanel.spec.cy.tsx
+++ b/hivemq-edge-frontend/src/extensions/datahub/designer/transition/TransitionPanel.spec.cy.tsx
@@ -42,6 +42,18 @@ describe('TransitionPanel', () => {
     cy.viewport(800, 800)
   })
 
+  it('should render loading and error states', () => {
+    const onFormError = cy.stub().as('onFormError')
+    cy.mountWithProviders(<TransitionPanel selectedNode="fakenosde" onFormError={onFormError} />, { wrapper })
+
+    cy.get('[role="alert"]')
+      .should('be.visible')
+      .should('have.attr', 'data-status', 'error')
+      .should('contain.text', 'The Transition is not a valid element')
+
+    cy.get('@onFormError').should('have.been.calledWithErrorMessage', 'The Transition is not a valid element')
+  })
+
   it('should render the fields for a Validator', () => {
     cy.mountWithProviders(<TransitionPanel selectedNode="3" />, { wrapper })
 

--- a/hivemq-edge-frontend/src/extensions/datahub/designer/transition/TransitionPanel.tsx
+++ b/hivemq-edge-frontend/src/extensions/datahub/designer/transition/TransitionPanel.tsx
@@ -1,9 +1,10 @@
 import type { FC } from 'react'
-import { useCallback, useMemo } from 'react'
+import { useCallback, useEffect, useMemo } from 'react'
 import type { Node } from '@xyflow/react'
 import { getIncomers } from '@xyflow/react'
 import { Card, CardBody } from '@chakra-ui/react'
 import type { IChangeEvent } from '@rjsf/core'
+import { useTranslation } from 'react-i18next'
 
 import type { BehaviorPolicyTransitionEvent } from '@/api/__generated__'
 import type {
@@ -24,7 +25,8 @@ import { FiniteStateMachineFlow } from '@datahub/components/fsm/FiniteStateMachi
 import { usePolicyGuards } from '@datahub/hooks/usePolicyGuards.ts'
 import ErrorMessage from '@/components/ErrorMessage.tsx'
 
-export const TransitionPanel: FC<PanelProps> = ({ selectedNode, onFormSubmit }) => {
+export const TransitionPanel: FC<PanelProps> = ({ selectedNode, onFormSubmit, onFormError }) => {
+  const { t } = useTranslation('datahub')
   const { nodes, edges } = useDataHubDraftStore()
   const { guardAlert, isNodeEditable } = usePolicyGuards(selectedNode)
 
@@ -116,28 +118,42 @@ export const TransitionPanel: FC<PanelProps> = ({ selectedNode, onFormSubmit }) 
     [onFormSubmit]
   )
 
+  useEffect(() => {
+    if (!data) {
+      onFormError?.(new Error(t('error.elementNotDefined.description', { nodeType: DataHubNodeType.TRANSITION })))
+    }
+  }, [data, onFormError, t])
+
   return (
     <Card>
       {guardAlert && <ErrorMessage status="info" type={guardAlert.title} message={guardAlert.description} />}
-      <CardBody>
-        <ReactFlowSchemaForm
-          isNodeEditable={isNodeEditable}
-          schema={MOCK_TRANSITION_SCHEMA.schema}
-          uiSchema={{
-            ...MOCK_TRANSITION_SCHEMA.uiSchema,
-            event: {
-              ...MOCK_TRANSITION_SCHEMA.uiSchema?.event,
-              'ui:options': {
-                metadata: options,
-              },
-            },
-          }}
-          formData={data}
-          widgets={datahubRJSFWidgets}
-          onSubmit={onSafeFormSubmit}
+      {!data && (
+        <ErrorMessage
+          type={t('error.elementNotDefined.title')}
+          message={t('error.elementNotDefined.description', { nodeType: DataHubNodeType.TRANSITION })}
         />
-        {options && <FiniteStateMachineFlow transitions={options.transitions} states={options.states} />}
-      </CardBody>
+      )}
+      {data && (
+        <CardBody>
+          <ReactFlowSchemaForm
+            isNodeEditable={isNodeEditable}
+            schema={MOCK_TRANSITION_SCHEMA.schema}
+            uiSchema={{
+              ...MOCK_TRANSITION_SCHEMA.uiSchema,
+              event: {
+                ...MOCK_TRANSITION_SCHEMA.uiSchema?.event,
+                'ui:options': {
+                  metadata: options,
+                },
+              },
+            }}
+            formData={data}
+            widgets={datahubRJSFWidgets}
+            onSubmit={onSafeFormSubmit}
+          />
+          {options && <FiniteStateMachineFlow transitions={options.transitions} states={options.states} />}
+        </CardBody>
+      )}
     </Card>
   )
 }

--- a/hivemq-edge-frontend/src/extensions/datahub/designer/transition/TransitionPanel.tsx
+++ b/hivemq-edge-frontend/src/extensions/datahub/designer/transition/TransitionPanel.tsx
@@ -122,7 +122,8 @@ export const TransitionPanel: FC<PanelProps> = ({ selectedNode, onFormSubmit, on
     if (!data) {
       onFormError?.(new Error(t('error.elementNotDefined.description', { nodeType: DataHubNodeType.TRANSITION })))
     }
-  }, [data, onFormError, t])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data])
 
   return (
     <Card>

--- a/hivemq-edge-frontend/src/extensions/datahub/designer/validator/ValidatorPanel.spec.cy.tsx
+++ b/hivemq-edge-frontend/src/extensions/datahub/designer/validator/ValidatorPanel.spec.cy.tsx
@@ -34,6 +34,18 @@ describe('ValidatorPanel', () => {
     cy.viewport(800, 800)
   })
 
+  it('should render loading and error states', () => {
+    const onFormError = cy.stub().as('onFormError')
+    cy.mountWithProviders(<ValidatorPanel selectedNode="fakenosde" onFormError={onFormError} />, { wrapper })
+
+    cy.get('[role="alert"]')
+      .should('be.visible')
+      .should('have.attr', 'data-status', 'error')
+      .should('contain.text', 'The Policy Validator is not a valid element')
+
+    cy.get('@onFormError').should('have.been.calledWithErrorMessage', 'The Policy Validator is not a valid element')
+  })
+
   it('should render the fields for a Validator', () => {
     cy.mountWithProviders(<ValidatorPanel selectedNode="3" />, { wrapper })
 

--- a/hivemq-edge-frontend/src/extensions/datahub/designer/validator/ValidatorPanel.tsx
+++ b/hivemq-edge-frontend/src/extensions/datahub/designer/validator/ValidatorPanel.tsx
@@ -28,7 +28,8 @@ export const ValidatorPanel: FC<PanelProps> = ({ selectedNode, onFormSubmit, onF
     if (!data) {
       onFormError?.(new Error(t('error.elementNotDefined.description', { nodeType: DataHubNodeType.VALIDATOR })))
     }
-  }, [data, onFormError, t])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data])
 
   return (
     <Card>

--- a/hivemq-edge-frontend/src/extensions/datahub/designer/validator/ValidatorPanel.tsx
+++ b/hivemq-edge-frontend/src/extensions/datahub/designer/validator/ValidatorPanel.tsx
@@ -1,4 +1,5 @@
 import type { FC } from 'react'
+import { useEffect } from 'react'
 import { useMemo } from 'react'
 import type { Node } from '@xyflow/react'
 import { useTranslation } from 'react-i18next'
@@ -13,7 +14,7 @@ import { ReactFlowSchemaForm } from '@datahub/components/forms/ReactFlowSchemaFo
 import { MOCK_VALIDATOR_SCHEMA } from '@datahub/designer/validator/DataPolicyValidator.ts'
 import { usePolicyGuards } from '@datahub/hooks/usePolicyGuards.ts'
 
-export const ValidatorPanel: FC<PanelProps> = ({ selectedNode, onFormSubmit }) => {
+export const ValidatorPanel: FC<PanelProps> = ({ selectedNode, onFormSubmit, onFormError }) => {
   const { t } = useTranslation('datahub')
   const { nodes } = useDataHubDraftStore()
   const { guardAlert, isNodeEditable } = usePolicyGuards(selectedNode)
@@ -23,26 +24,32 @@ export const ValidatorPanel: FC<PanelProps> = ({ selectedNode, onFormSubmit }) =
     return adapterNode ? adapterNode.data : null
   }, [selectedNode, nodes])
 
-  if (!data)
-    return (
-      <ErrorMessage
-        type={t('error.elementNotDefined.title')}
-        message={t('error.elementNotDefined.description', { nodeType: DataHubNodeType.VALIDATOR })}
-      />
-    )
+  useEffect(() => {
+    if (!data) {
+      onFormError?.(new Error(t('error.elementNotDefined.description', { nodeType: DataHubNodeType.VALIDATOR })))
+    }
+  }, [data, onFormError, t])
 
   return (
     <Card>
       {guardAlert && <ErrorMessage status="info" type={guardAlert.title} message={guardAlert.description} />}
-      <CardBody>
-        <ReactFlowSchemaForm
-          isNodeEditable={isNodeEditable}
-          schema={MOCK_VALIDATOR_SCHEMA.schema}
-          // uiSchema={MOCK_TOPIC_FILTER_SCHEMA.uiSchema}
-          formData={data}
-          onSubmit={onFormSubmit}
+      {!data && (
+        <ErrorMessage
+          type={t('error.elementNotDefined.title')}
+          message={t('error.elementNotDefined.description', { nodeType: DataHubNodeType.VALIDATOR })}
         />
-      </CardBody>
+      )}
+      {data && (
+        <CardBody>
+          <ReactFlowSchemaForm
+            isNodeEditable={isNodeEditable}
+            schema={MOCK_VALIDATOR_SCHEMA.schema}
+            // uiSchema={MOCK_TOPIC_FILTER_SCHEMA.uiSchema}
+            formData={data}
+            onSubmit={onFormSubmit}
+          />
+        </CardBody>
+      )}
     </Card>
   )
 }

--- a/hivemq-edge-frontend/src/extensions/datahub/designer/validator/ValidatorPanel.tsx
+++ b/hivemq-edge-frontend/src/extensions/datahub/designer/validator/ValidatorPanel.tsx
@@ -45,7 +45,6 @@ export const ValidatorPanel: FC<PanelProps> = ({ selectedNode, onFormSubmit, onF
           <ReactFlowSchemaForm
             isNodeEditable={isNodeEditable}
             schema={MOCK_VALIDATOR_SCHEMA.schema}
-            // uiSchema={MOCK_TOPIC_FILTER_SCHEMA.uiSchema}
             formData={data}
             onSubmit={onFormSubmit}
           />

--- a/hivemq-edge-frontend/src/extensions/datahub/types.ts
+++ b/hivemq-edge-frontend/src/extensions/datahub/types.ts
@@ -29,6 +29,7 @@ export interface PanelSpecs {
 export interface PanelProps {
   selectedNode: string
   onFormSubmit?: (data: IChangeEvent) => void
+  onFormError?: (error: Error) => void
 }
 
 export enum DesignerStatus {


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/34191/details/

The PR adds the missing loading state and error management for all the policy node's configuration panels. It will prevent many JSON Schema-based forms from being displayed when required validation elements are not fully or properly loaded.

### Out-of-scope
- The error messages are mostly in a non-user-friendly state. They will be fixed as part of the Problem Detail initiative

### Before
![HiveMQ-Edge-06-23-2025_11_45](https://github.com/user-attachments/assets/1d96d861-08ae-435e-b9bb-6307953e36f2)
![HiveMQ-Edge-06-23-2025_11_44 (1)](https://github.com/user-attachments/assets/ff782536-1cca-4847-8e3d-802a43c1c15c)


### After
![HiveMQ-Edge-06-23-2025_11_46](https://github.com/user-attachments/assets/7eb5f835-6341-4096-8518-72bc12071411)

![HiveMQ-Edge-06-23-2025_11_44](https://github.com/user-attachments/assets/3358b40f-dd2a-4ce4-9bdc-0e8b0c67b440)

