### PR TITLE
Enable transfering of all opcua tag properties

### DIFF
--- a/hivemq-edge/src/main/java/com/hivemq/protocols/northbound/NorthboundTagConsumer.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/northbound/NorthboundTagConsumer.java
@@ -112,12 +112,14 @@ public class NorthboundTagConsumer implements TagConsumer{
                 try {
                     final var jsonMap=objectMapper.readValue((String)jsonDataPoint.getTagValue(), typeRef);
                     final var value = jsonMap.get("value");
-                    if(value!=null) {
+                    if(value!=null && jsonMap.size() == 1) {
                         return dataPointFactory.create(jsonDataPoint.getTagName(), value);
-                    } else {
+                    } else if(value!=null && jsonMap.size() > 1) {
+                        return dataPointFactory.create(jsonDataPoint.getTagName(), jsonMap);
+                    }else {
                         throw new RuntimeException("No value entry in JSON message");
                     }
-                } catch (JsonProcessingException e) {
+                } catch (final JsonProcessingException e) {
                     throw new RuntimeException(e);
                 }
             }).toList();

--- a/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/OpcUaClientConnection.java
+++ b/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/OpcUaClientConnection.java
@@ -15,6 +15,8 @@
  */
 package com.hivemq.edge.adapters.opcua;
 
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.hivemq.adapter.sdk.api.events.EventService;
 import com.hivemq.adapter.sdk.api.factories.DataPointFactory;
 import com.hivemq.adapter.sdk.api.services.ProtocolAdapterMetricsService;
@@ -55,6 +57,7 @@ import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.
 
 class OpcUaClientConnection {
     private static final @NotNull Logger log = LoggerFactory.getLogger(OpcUaClientConnection.class);
+    private static final @NotNull Gson GSON = new GsonBuilder().disableHtmlEscaping().create();
 
     private final @NotNull OpcUaSpecificAdapterConfig config;
     private final @NotNull List<OpcuaTag> tags;
@@ -206,7 +209,7 @@ class OpcUaClientConnection {
         log.debug("Creating new OPC UA subscription");
         final OpcUaSubscription subscription = new OpcUaSubscription(client);
         subscription.setPublishingInterval((double) config.getOpcuaToMqttConfig().publishingInterval());
-        subscription.setSubscriptionListener(new OpcUaSubscriptionListener(protocolAdapterMetricsService, tagStreamingService, eventService, adapterId, tags, client, dataPointFactory));
+        subscription.setSubscriptionListener(new OpcUaSubscriptionListener(protocolAdapterMetricsService, tagStreamingService, eventService, adapterId, tags, client, dataPointFactory, GSON));
         try {
             subscription.create();
             return subscription

--- a/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/config/tag/OpcuaTagDefinition.java
+++ b/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/config/tag/OpcuaTagDefinition.java
@@ -22,6 +22,8 @@ import com.hivemq.adapter.sdk.api.tag.TagDefinition;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Objects;
+
 public class OpcuaTagDefinition implements TagDefinition {
 
     @JsonProperty(value = "node", required = true)
@@ -30,35 +32,45 @@ public class OpcuaTagDefinition implements TagDefinition {
                        required = true)
     private final @NotNull String node;
 
+    @JsonProperty(value = "collectAllProperties")
+    @ModuleConfigField(title = "Collect all properties of the node",
+                       description = "OPC UA defines a set of properties for each node. If this is enabled, all properties will be collected and sent to the MQTT broker.")
+    private final @NotNull boolean collectAllProperties;
+
     @JsonCreator
-    public OpcuaTagDefinition(@JsonProperty(value = "node", required = true) final @NotNull String node) {
+    public OpcuaTagDefinition(
+            @JsonProperty(value = "node", required = true) final @NotNull String node,
+            @JsonProperty(value = "collectAllProperties", defaultValue = "false") final @Nullable Boolean collectAllProperties) {
         this.node = node;
+        if(collectAllProperties == null) {
+            this.collectAllProperties = false;
+        } else {
+            this.collectAllProperties = collectAllProperties;
+        }
     }
 
     public @NotNull String getNode() {
         return node;
     }
 
-    @Override
-    public boolean equals(final @Nullable Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
+    public boolean isCollectAllProperties() {
+        return collectAllProperties;
+    }
 
+    @Override
+    public boolean equals(final Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
         final OpcuaTagDefinition that = (OpcuaTagDefinition) o;
-        return node.equals(that.node);
+        return isCollectAllProperties() == that.isCollectAllProperties() && Objects.equals(getNode(), that.getNode());
     }
 
     @Override
     public int hashCode() {
-        return node.hashCode();
+        return Objects.hash(getNode(), isCollectAllProperties());
     }
 
     @Override
-    public @NotNull String toString() {
-        return "OpcuaTagDefinition{" + "node='" + node + '\'' + '}';
+    public String toString() {
+        return "OpcuaTagDefinition{" + "node='" + node + '\'' + ", collectAllProperties=" + collectAllProperties + '}';
     }
 }

--- a/modules/hivemq-edge-module-opcua/src/test/java/com/hivemq/edge/adapters/opcua/northbound/AbstractOpcUaPayloadConverterTest.java
+++ b/modules/hivemq-edge-module-opcua/src/test/java/com/hivemq/edge/adapters/opcua/northbound/AbstractOpcUaPayloadConverterTest.java
@@ -93,7 +93,7 @@ abstract class AbstractOpcUaPayloadConverterTest {
     }
 
     @NotNull
-    protected OpcUaProtocolAdapter createAndStartAdapter(final @NotNull String subcribedNodeId)
+    protected OpcUaProtocolAdapter createAndStartAdapter(final @NotNull String subcribedNodeId, final @Nullable Boolean collectAllProperties)
             throws Exception {
 
         final OpcUaToMqttConfig opcuaToMqttConfig =
@@ -107,7 +107,7 @@ abstract class AbstractOpcUaPayloadConverterTest {
                 null);
 
         when(protocolAdapterInput.getConfig()).thenReturn(config);
-        when(protocolAdapterInput.getTags()).thenReturn(List.of(new OpcuaTag(subcribedNodeId, "", new OpcuaTagDefinition(subcribedNodeId))));
+        when(protocolAdapterInput.getTags()).thenReturn(List.of(new OpcuaTag(subcribedNodeId, "", new OpcuaTagDefinition(subcribedNodeId, collectAllProperties))));
         final OpcUaProtocolAdapter protocolAdapter =
                 new OpcUaProtocolAdapter(OpcUaProtocolAdapterInformation.INSTANCE, protocolAdapterInput);
 

--- a/modules/hivemq-edge-module-opcua/src/test/java/com/hivemq/edge/adapters/opcua/northbound/OpcUaStringPayloadConverterTest.java
+++ b/modules/hivemq-edge-module-opcua/src/test/java/com/hivemq/edge/adapters/opcua/northbound/OpcUaStringPayloadConverterTest.java
@@ -83,7 +83,7 @@ class OpcUaStringPayloadConverterTest extends AbstractOpcUaPayloadConverterTest 
         final String nodeId =
                 opcUaServerExtension.getTestNamespace().addNode("Test" + name + "Node", typeId, () -> serverValue, 999);
 
-        final OpcUaProtocolAdapter protocolAdapter = createAndStartAdapter(nodeId);
+        final OpcUaProtocolAdapter protocolAdapter = createAndStartAdapter(nodeId, null);
         assertEquals(ProtocolAdapterState.ConnectionStatus.CONNECTED,
                 protocolAdapter.getProtocolAdapterState().getConnectionStatus());
         final var received = expectAdapterPublish();


### PR DESCRIPTION
**Motivation**

Resolves #31480

**Changes**
A OPC UA tag provides several read only properties on top of the actual value which this PR makes available for OpcUaTags where collectAllProperties is set to true:

- serverPicoseconds
- sourcePicoseconds
- sourceTime
- serverTime