### PR TITLE
Rework bridge handling to fix a bug

### DIFF
--- a/hivemq-edge/src/main/java/com/hivemq/bridge/BridgeService.java
+++ b/hivemq-edge/src/main/java/com/hivemq/bridge/BridgeService.java
@@ -35,6 +35,7 @@ import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -55,8 +56,8 @@ public class BridgeService {
 
     private final @NotNull Map<String, Throwable> bridgeNameToLastError = new ConcurrentHashMap<>(0);
 
-    private final @NotNull Map<String, MqttBridgeAndClient> activeBridgeNamesToClient = new ConcurrentHashMap<>();
-    private final @NotNull Map<String, MqttBridge> allKnownBridgeConfigs = new ConcurrentHashMap<>();
+    private final @NotNull Map<String, MqttBridgeAndClient> activeBridgeNamesToClient = new HashMap<>();
+    private final @NotNull Map<String, MqttBridge> allKnownBridgeConfigs = new HashMap<>();
 
     @Inject
     public BridgeService(
@@ -154,7 +155,7 @@ public class BridgeService {
         return bridgeNameToLastError.get(bridgeName);
     }
 
-    public boolean isConnected(final @NotNull String bridgeName) {
+    public synchronized boolean isConnected(final @NotNull String bridgeName) {
         final var mqttBridgeAndClient = activeBridgeNamesToClient.get(bridgeName);
         if(mqttBridgeAndClient != null) {
             return mqttBridgeAndClient.mqttClient().isConnected();
@@ -162,7 +163,7 @@ public class BridgeService {
         return false;
     }
 
-    public boolean isRunning(final @NotNull String bridgeName) {
+    public synchronized boolean isRunning(final @NotNull String bridgeName) {
         return activeBridgeNamesToClient.containsKey(bridgeName);
     }
 

--- a/hivemq-edge/src/main/java/com/hivemq/bridge/BridgeService.java
+++ b/hivemq-edge/src/main/java/com/hivemq/bridge/BridgeService.java
@@ -197,7 +197,9 @@ public class BridgeService {
             activeBridgeNamesToClient.put(
                     bridgeId,
                     mqttBridgeAndClient);
-            allKnownBridgeConfigs.put(bridgeId, newBridgeConfig);
+            if(newBridgeConfig != null) {
+                allKnownBridgeConfigs.put(bridgeId, newBridgeConfig);
+            }
             return true;
         } else {
             log.debug("Not restarting bridge '{}' since it wasn't active", bridgeId);

--- a/hivemq-edge/src/main/java/com/hivemq/bridge/BridgeService.java
+++ b/hivemq-edge/src/main/java/com/hivemq/bridge/BridgeService.java
@@ -188,7 +188,7 @@ public class BridgeService {
             final @NotNull String bridgeId, final @Nullable MqttBridge newBridgeConfig) {
         final var bridgeToClient = activeBridgeNamesToClient.get(bridgeId);
         if (bridgeToClient != null) {
-            log.info("Restarting bridge '{}'", bridgeToClient);
+            log.info("Restarting bridge '{}'", bridgeId);
             final List<String> unchangedForwarders = newForwarderIds(newBridgeConfig);
             stopBridge(bridgeId, true, unchangedForwarders);
             final var mqttBridgeAndClient = new MqttBridgeAndClient(

--- a/hivemq-edge/src/main/java/com/hivemq/bridge/BridgeService.java
+++ b/hivemq-edge/src/main/java/com/hivemq/bridge/BridgeService.java
@@ -123,10 +123,9 @@ public class BridgeService {
             final var newBridge = bridgeIdToConfig.get(bridgeId);
             if(active != null) {
                 if(active.bridge().equals(newBridge)) {
-                    log.debug("Not restarting bridge {} because config  is unchanged", bridgeId);
+                    log.debug("Not restarting bridge {} because config is unchanged", bridgeId);
                 } else {
                     log.info("Restarting bridge {} because config has changed", bridgeId);
-                    allKnownBridgeConfigs.remove(bridgeId);
                     allKnownBridgeConfigs.put(bridgeId, newBridge);
                     internalStopBridge(active, true, List.of());
                     activeBridgeNamesToClient.put(

--- a/hivemq-edge/src/main/java/com/hivemq/bridge/BridgeService.java
+++ b/hivemq-edge/src/main/java/com/hivemq/bridge/BridgeService.java
@@ -200,7 +200,7 @@ public class BridgeService {
             allKnownBridgeConfigs.put(bridgeId, newBridgeConfig);
             return true;
         } else {
-            log.debug("Not restarting bridge '{}' since it wasn't active", bridgeToClient);
+            log.debug("Not restarting bridge '{}' since it wasn't active", bridgeId);
             return false;
         }
     }

--- a/hivemq-edge/src/main/java/com/hivemq/configuration/reader/BridgeExtractor.java
+++ b/hivemq-edge/src/main/java/com/hivemq/configuration/reader/BridgeExtractor.java
@@ -112,10 +112,10 @@ public class BridgeExtractor implements ReloadableExtractor<List<@NotNull MqttBr
 
     @Override
     public synchronized Configurator.ConfigResult updateConfig(final HiveMQConfigEntity config) {
-        var bridgeEntities = convertBridgeConfigs(config);
+        final var bridgeEntities = convertBridgeConfigs(config);
 
-        Set<String> bridgeIds = new HashSet<>();
-        var duplicates = bridgeEntities.stream()
+        final Set<String> bridgeIds = new HashSet<>();
+        final var duplicates = bridgeEntities.stream()
             .filter(n -> !bridgeIds.add(n.getId()))
             .toList();
 
@@ -207,7 +207,7 @@ public class BridgeExtractor implements ReloadableExtractor<List<@NotNull MqttBr
     }
 
     private @NotNull List<LocalSubscription> convertLocalSubscriptions(
-            final @NotNull String name, @NotNull List<ForwardedTopicEntity> forwardedTopics) {
+            final @NotNull String name, final @NotNull List<ForwardedTopicEntity> forwardedTopics) {
         final ImmutableList.Builder<LocalSubscription> builder = ImmutableList.builder();
         for (final ForwardedTopicEntity forwardedTopic : forwardedTopics) {
             validateTopicFilters(name, forwardedTopic.getFilters());
@@ -283,7 +283,7 @@ public class BridgeExtractor implements ReloadableExtractor<List<@NotNull MqttBr
             final @NotNull String name, final @NotNull List<CustomUserPropertyEntity> customUserProperties) {
         final ImmutableList.Builder<CustomUserProperty> builder = ImmutableList.builder();
 
-        for (CustomUserPropertyEntity customUserProperty : customUserProperties) {
+        for (final CustomUserPropertyEntity customUserProperty : customUserProperties) {
             if (customUserProperty.getKey() != null && customUserProperty.getValue() != null) {
                 builder.add(CustomUserProperty.of(customUserProperty.getKey(), customUserProperty.getValue()));
             } else {


### PR DESCRIPTION
**Motivation**

Resolves #34787

**Changes**
Editing a bridge via the UI would lead to a broken bridge.
Breakage happened because the client wasn't correctly stopped.

This PR reworks the bridge restart code and fixes the issue by correctly stopping the existing bridge and then restarzing it.