### PR TITLE
Added support for zipping fragment content in k8s

### DIFF
--- a/hivemq-edge/src/main/java/com/hivemq/api/model/adapters/AdapterStatusModelConversionUtils.java
+++ b/hivemq-edge/src/main/java/com/hivemq/api/model/adapters/AdapterStatusModelConversionUtils.java
@@ -47,29 +47,20 @@ public class AdapterStatusModelConversionUtils {
 
     public static @NotNull Status.ConnectionEnum convertConnectionStatus(final @NotNull ProtocolAdapterState.ConnectionStatus connectionStatus) {
         Preconditions.checkNotNull(connectionStatus);
-        switch (connectionStatus) {
-            case DISCONNECTED:
-                return Status.ConnectionEnum.DISCONNECTED;
-            case CONNECTED:
-                return Status.ConnectionEnum.CONNECTED;
-            case ERROR:
-                return Status.ConnectionEnum.ERROR;
-            case STATELESS:
-                return Status.ConnectionEnum.STATELESS;
-            default:
-            case UNKNOWN:
-                return Status.ConnectionEnum.UNKNOWN;
-        }
+        return switch (connectionStatus) {
+            case DISCONNECTED -> Status.ConnectionEnum.DISCONNECTED;
+            case CONNECTED -> Status.ConnectionEnum.CONNECTED;
+            case ERROR -> Status.ConnectionEnum.ERROR;
+            case STATELESS -> Status.ConnectionEnum.STATELESS;
+            default -> Status.ConnectionEnum.UNKNOWN;
+        };
     }
 
     public static @NotNull Status.RuntimeEnum convertRuntimeStatus(final @NotNull ProtocolAdapterState.RuntimeStatus runtimeStatus) {
         Preconditions.checkNotNull(runtimeStatus);
-        switch (runtimeStatus) {
-            case STARTED:
-                return Status.RuntimeEnum.STARTED;
-            default:
-            case STOPPED:
-                return Status.RuntimeEnum.STOPPED;
+        if(ProtocolAdapterState.RuntimeStatus.STARTED.equals(runtimeStatus)) {
+            return Status.RuntimeEnum.STARTED;
         }
+        return Status.RuntimeEnum.STOPPED;
     }
 }

--- a/hivemq-edge/src/main/java/com/hivemq/configuration/ConfigurationBootstrap.java
+++ b/hivemq-edge/src/main/java/com/hivemq/configuration/ConfigurationBootstrap.java
@@ -70,7 +70,9 @@ public class ConfigurationBootstrap {
 
         final ConfigurationFile configurationFile = ConfigurationFileProvider.get(systemInformation);
 
-        final ConfigFileReaderWriter configFileReader = new ConfigFileReaderWriter(configurationFile,
+        final ConfigFileReaderWriter configFileReader = new ConfigFileReaderWriter(
+                systemInformation,
+                configurationFile,
                 List.of(
                         new RestrictionConfigurator(configurationService.restrictionsConfiguration()),
                         new SecurityConfigurator(configurationService.securityConfiguration()),

--- a/hivemq-edge/src/main/java/com/hivemq/configuration/EnvironmentVariables.java
+++ b/hivemq-edge/src/main/java/com/hivemq/configuration/EnvironmentVariables.java
@@ -59,6 +59,11 @@ public class EnvironmentVariables {
     public static final String CONFIG_WRITEABLE = "HIVEMQ_CONFIG_WRITEABLE";
 
     /**
+     * Name of the environment variable for indicating that the config fragment will be zipped and base64 encoded
+     */
+    public static final String CONFIG_FRAGMENT_BASE64ZIP = "HIVEMQ_CONFIG_FRAGMENT_BASE64ZIP";
+
+    /**
      * Name of the environment variable for configuring the data folder.
      */
     public static final String DATA_FOLDER = "HIVEMQ_DATA_FOLDER";

--- a/hivemq-edge/src/main/java/com/hivemq/configuration/SystemProperties.java
+++ b/hivemq-edge/src/main/java/com/hivemq/configuration/SystemProperties.java
@@ -28,6 +28,7 @@ public class SystemProperties {
     public static final String CONFIG_FOLDER_SECONDARY = "hivemq.config.secondary";
     public static final String CONFIG_REFRESH_INTERVAL = "hivemq.config.refreshinterval";
     public static final String CONFIG_WRITEABLE = "hivemq.config.writeable";
+    public static final String CONFIG_FRAGMENT_BASE64ZIP = "hivemq.config.fragment.base64zip";
     public static final String LICENSE_FOLDER = "hivemq.license.folder";
 
     public static final String DATA_FOLDER = "hivemq.data.folder";

--- a/hivemq-edge/src/main/java/com/hivemq/configuration/info/SystemInformation.java
+++ b/hivemq-edge/src/main/java/com/hivemq/configuration/info/SystemInformation.java
@@ -105,6 +105,11 @@ public interface SystemInformation {
     boolean isEmbedded();
 
     /**
+     * @return should the fragment config be treated as bing zipped and base64 encoded
+     */
+    boolean isConfigFragmentBase64Zip();
+
+    /**
      * @return the interval between refreshing config files, 0 means no refreshing
      */
     long configRefreshIntervalInMs();

--- a/hivemq-edge/src/main/java/com/hivemq/configuration/info/SystemInformationImpl.java
+++ b/hivemq-edge/src/main/java/com/hivemq/configuration/info/SystemInformationImpl.java
@@ -59,6 +59,8 @@ public class SystemInformationImpl implements SystemInformation {
 
     private final boolean configWriteable;
 
+    private final boolean configFragmentBase64Zip;
+
     public SystemInformationImpl() {
         this(false);
     }
@@ -78,6 +80,7 @@ public class SystemInformationImpl implements SystemInformation {
             final @Nullable File licenseFolder) {
         final String refreshInterval = getSystemPropertyOrEnvironmentVariable(SystemProperties.CONFIG_REFRESH_INTERVAL, EnvironmentVariables.CONFIG_REFRESH_INTERVAL);
         final String configWriteable = getSystemPropertyOrEnvironmentVariable(SystemProperties.CONFIG_WRITEABLE, EnvironmentVariables.CONFIG_WRITEABLE);
+        final String configFragmentBase64ZipString = getSystemPropertyOrEnvironmentVariable(SystemProperties.CONFIG_FRAGMENT_BASE64ZIP, EnvironmentVariables.CONFIG_FRAGMENT_BASE64ZIP);
         this.usePathOfRunningJar = usePathOfRunningJar;
         this.embedded = embedded;
         this.configFolder = configFolder;
@@ -89,6 +92,7 @@ public class SystemInformationImpl implements SystemInformation {
         this.runningSince = System.currentTimeMillis();
         this.configRefreshIntervalInMs = Long.parseLong(Objects.requireNonNullElse(refreshInterval, "-1"));
         this.configWriteable = Boolean.parseBoolean((configWriteable == null || configWriteable.isEmpty()) ? "true" : configWriteable );
+        this.configFragmentBase64Zip = Boolean.parseBoolean((configFragmentBase64ZipString == null || configFragmentBase64ZipString.isEmpty()) ? "false" : configFragmentBase64ZipString );
         processorCount = getPhysicalProcessorCount();
     }
 
@@ -365,5 +369,10 @@ public class SystemInformationImpl implements SystemInformation {
     @Override
     public boolean isConfigWriteable() {
         return configWriteable;
+    }
+
+    @Override
+    public boolean isConfigFragmentBase64Zip() {
+        return configFragmentBase64Zip;
     }
 }

--- a/hivemq-edge/src/test/java/com/hivemq/configuration/reader/AbstractConfigurationTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/configuration/reader/AbstractConfigurationTest.java
@@ -88,6 +88,7 @@ public class AbstractConfigurationTest {
 
         final ConfigurationFile configurationFile = new ConfigurationFile(xmlFile);
         reader = new ConfigFileReaderWriter(
+                systemInformation,
                 configurationFile,
                 List.of(
                         new RestrictionConfigurator(restrictionsConfigurationService),

--- a/hivemq-edge/src/test/java/com/hivemq/configuration/reader/ConfigFileReaderTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/configuration/reader/ConfigFileReaderTest.java
@@ -19,6 +19,7 @@ import com.google.common.io.Files;
 import com.hivemq.configuration.entity.HiveMQConfigEntity;
 import com.hivemq.configuration.entity.adapter.MqttUserPropertyEntity;
 import com.hivemq.configuration.entity.adapter.ProtocolAdapterEntity;
+import com.hivemq.configuration.info.SystemInformation;
 import com.hivemq.exceptions.UnrecoverableException;
 import org.apache.commons.io.FileUtils;
 import org.jetbrains.annotations.NotNull;
@@ -145,7 +146,7 @@ public class ConfigFileReaderTest {
         assertTrue(userPropertiesAfterReload.contains(new MqttUserPropertyEntity("my-name", "my-value2")));
     }
 
-    private static @NotNull ConfigFileReaderWriter getConfigFileReaderWriter(File tempFile) {
+    private static @NotNull ConfigFileReaderWriter getConfigFileReaderWriter(final File tempFile) {
         final ConfigurationFile configurationFile = new ConfigurationFile(tempFile);
 
         final RestrictionConfigurator restrictionConfigurator = mock(RestrictionConfigurator.class);
@@ -184,10 +185,12 @@ public class ConfigFileReaderTest {
         final InternalConfigurator internalConfigurator = mock(InternalConfigurator.class);
         when(internalConfigurator.applyConfig(any())).thenReturn(Configurator.ConfigResult.SUCCESS);
 
-
-        final ConfigFileReaderWriter configFileReader = new ConfigFileReaderWriter(
+        final var sysInfo = mock(SystemInformation.class);
+        //ALways set to true for the test to ensure the fragment zipping code doesn't interfer with regular file rendering
+        when(sysInfo.isConfigFragmentBase64Zip()).thenReturn(true);
+        return new ConfigFileReaderWriter(
+                sysInfo,
                 configurationFile,
                 List.of());
-        return configFileReader;
     }
 }

--- a/hivemq-edge/src/test/java/com/hivemq/configuration/reader/ConfigFileReaderWriterTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/configuration/reader/ConfigFileReaderWriterTest.java
@@ -15,36 +15,45 @@
  */
 package com.hivemq.configuration.reader;
 
+import com.hivemq.configuration.info.SystemInformation;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class ConfigFileReaderWriterTest {
 
     @Test
     public void test_alltags() throws Exception{
-        var reader = new ConfigFileReaderWriter(null, List.of());
-        var configFile = new File(getClass().getClassLoader().getResource("configs/testing/alltags.xml").toURI());
-        var configEntity = reader.readConfigFromXML(configFile);
+        final var systemInformation = mock(SystemInformation.class);
+        when(systemInformation.isConfigFragmentBase64Zip()).thenReturn(false);
+        final var reader = new ConfigFileReaderWriter(systemInformation, null, List.of());
+        final var configFile = new File(getClass().getClassLoader().getResource("configs/testing/alltags.xml").toURI());
+        final var configEntity = reader.readConfigFromXML(configFile);
         assertThat(configEntity).isNotNull();
     }
 
     @Test
     public void test_empty() throws Exception{
-        var reader = new ConfigFileReaderWriter(null, List.of());
-        var configFile = new File(getClass().getClassLoader().getResource("configs/testing/empty.xml").toURI());
-        var configEntity = reader.readConfigFromXML(configFile);
+        final var systemInformation = mock(SystemInformation.class);
+        when(systemInformation.isConfigFragmentBase64Zip()).thenReturn(false);
+        final var reader = new ConfigFileReaderWriter(systemInformation, null, List.of());
+        final var configFile = new File(getClass().getClassLoader().getResource("configs/testing/empty.xml").toURI());
+        final var configEntity = reader.readConfigFromXML(configFile);
         assertThat(configEntity).isNotNull();
     }
 
     @Test
     public void test_datacombiners_no_source() throws Exception{
-        var reader = new ConfigFileReaderWriter(null, List.of());
-        var configFile = new File(getClass().getClassLoader().getResource("configs/testing/datacombiners_no_source.xml").toURI());
-        var configEntity = reader.readConfigFromXML(configFile);
+        final var systemInformation = mock(SystemInformation.class);
+        when(systemInformation.isConfigFragmentBase64Zip()).thenReturn(false);
+        final var reader = new ConfigFileReaderWriter(systemInformation, null, List.of());
+        final var configFile = new File(getClass().getClassLoader().getResource("configs/testing/datacombiners_no_source.xml").toURI());
+        final var configEntity = reader.readConfigFromXML(configFile);
         //This will break as soon as the xsd is fixed
         assertThat(configEntity).isNotNull();
     }

--- a/hivemq-edge/src/test/java/com/hivemq/configuration/reader/ProtocolAdapterExtractorTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/configuration/reader/ProtocolAdapterExtractorTest.java
@@ -22,6 +22,7 @@ import com.hivemq.configuration.entity.adapter.ProtocolAdapterEntity;
 import com.hivemq.configuration.entity.adapter.SouthboundMappingEntity;
 import com.hivemq.configuration.entity.adapter.TagEntity;
 import com.hivemq.configuration.entity.adapter.fieldmapping.FieldMappingEntity;
+import com.hivemq.configuration.info.SystemInformation;
 import com.hivemq.exceptions.UnrecoverableException;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -38,6 +39,7 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
 
 public class ProtocolAdapterExtractorTest {
     @TempDir
@@ -53,7 +55,7 @@ public class ProtocolAdapterExtractorTest {
         }
         final File tempFile = new File(tempDir, "conf.xml");
         Files.writeString(tempFile.toPath(), xmlString);
-        return new ConfigFileReaderWriter(new ConfigurationFile(tempFile), List.of());
+        return new ConfigFileReaderWriter(mock(SystemInformation.class), new ConfigurationFile(tempFile), List.of());
     }
 
     @Test

--- a/hivemq-edge/src/test/java/com/hivemq/configuration/writer/AbstractConfigWriterTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/configuration/writer/AbstractConfigWriterTest.java
@@ -16,6 +16,7 @@
 
 package com.hivemq.configuration.writer;
 
+import com.hivemq.configuration.info.SystemInformation;
 import com.hivemq.configuration.reader.ApiConfigurator;
 import com.hivemq.configuration.reader.BridgeExtractor;
 import com.hivemq.configuration.reader.ConfigFileReaderWriter;
@@ -79,6 +80,7 @@ public abstract class AbstractConfigWriterTest {
 
         final ConfigurationFile configurationFile = new ConfigurationFile(file);
         final ConfigFileReaderWriter configFileReader = new ConfigFileReaderWriter(
+                mock(SystemInformation.class),
                 configurationFile,
                 List.of(
                     restrictionConfigurator,

--- a/hivemq-edge/src/test/java/com/hivemq/edge/modules/adapters/simulation/config/SimulationProtocolAdapterConfigTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/edge/modules/adapters/simulation/config/SimulationProtocolAdapterConfigTest.java
@@ -21,6 +21,7 @@ import com.hivemq.adapter.sdk.api.events.EventService;
 import com.hivemq.adapter.sdk.api.factories.ProtocolAdapterFactoryInput;
 import com.hivemq.configuration.entity.HiveMQConfigEntity;
 import com.hivemq.configuration.entity.adapter.ProtocolAdapterEntity;
+import com.hivemq.configuration.info.SystemInformation;
 import com.hivemq.configuration.reader.ApiConfigurator;
 import com.hivemq.configuration.reader.BridgeExtractor;
 import com.hivemq.configuration.reader.ConfigFileReaderWriter;
@@ -263,6 +264,7 @@ class SimulationProtocolAdapterConfigTest {
         when(internalConfigurator.applyConfig(any())).thenReturn(Configurator.ConfigResult.SUCCESS);
 
         final ConfigFileReaderWriter readerWriter = new ConfigFileReaderWriter(
+                mock(SystemInformation.class),
                 new ConfigurationFile(configFile),
                 List.of(restrictionConfigurator,
                     securityConfigurator,

--- a/hivemq-edge/src/test/java/com/hivemq/util/render/FileFragmentUtilTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/util/render/FileFragmentUtilTest.java
@@ -30,9 +30,21 @@ public class FileFragmentUtilTest {
 
         Files.writeString(fragment, "THE FRAGMENT");
         final String fragmented = "<hallo>${FRAGMENT:" + fragment.toFile() + "}</hallo>";
-        final FileFragmentUtil.FragmentResult resolved = FileFragmentUtil.replaceFragmentPlaceHolders(fragmented);
+        final FileFragmentUtil.FragmentResult resolved = FileFragmentUtil.replaceFragmentPlaceHolders(fragmented, false);
 
         assertThat(resolved.getRenderResult()).isEqualTo("<hallo>THE FRAGMENT</hallo>");
+        assertThat(resolved.getFragmentToModificationTime()).containsKey(fragment);
+    }
+
+    @Test
+    public void testRender_zipped() throws Exception {
+        final Path fragment = Files.createTempFile("fragment", ".xml");
+
+        Files.writeString(fragment, "UEsDBAoAAAAAAHZc8VpKQ28aDQAAAA0AAAAHABwAdHN0LnR4dFVUCQAD8MN4aPHDeGh1eAsAAQT2AQAABBQAAABUSEUgRlJBR01FTlQKUEsBAh4DCgAAAAAAdlzxWkpDbxoNAAAADQAAAAcAGAAAAAAAAQAAAKSBAAAAAHRzdC50eHRVVAUAA/DDeGh1eAsAAQT2AQAABBQAAABQSwUGAAAAAAEAAQBNAAAATgAAAAAA");
+        final String fragmented = "<hallo>${FRAGMENT:" + fragment.toFile() + "}</hallo>";
+        final FileFragmentUtil.FragmentResult resolved = FileFragmentUtil.replaceFragmentPlaceHolders(fragmented, true);
+
+        assertThat(resolved.getRenderResult()).isEqualTo("<hallo>THE FRAGMENT\n</hallo>");
         assertThat(resolved.getFragmentToModificationTime()).containsKey(fragment);
     }
 }

--- a/modules/hivemq-edge-module-etherip/src/test/java/com/hivemq/edge/adapters/etherip/config/EipProtocolAdapterConfigTest.java
+++ b/modules/hivemq-edge-module-etherip/src/test/java/com/hivemq/edge/adapters/etherip/config/EipProtocolAdapterConfigTest.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hivemq.adapter.sdk.api.factories.ProtocolAdapterFactoryInput;
 import com.hivemq.configuration.entity.HiveMQConfigEntity;
 import com.hivemq.configuration.entity.adapter.ProtocolAdapterEntity;
+import com.hivemq.configuration.info.SystemInformation;
 import com.hivemq.configuration.reader.ConfigFileReaderWriter;
 import com.hivemq.configuration.reader.ConfigurationFile;
 import com.hivemq.edge.adapters.etherip.EipProtocolAdapterFactory;
@@ -158,7 +159,7 @@ class EipProtocolAdapterConfigTest {
     }
 
     private @NotNull HiveMQConfigEntity loadConfig(final @NotNull File configFile) {
-        final ConfigFileReaderWriter readerWriter = new ConfigFileReaderWriter(new ConfigurationFile(configFile), List.of());
+        final ConfigFileReaderWriter readerWriter = new ConfigFileReaderWriter(mock(SystemInformation.class), new ConfigurationFile(configFile), List.of());
         return readerWriter.applyConfig();
     }
 

--- a/modules/hivemq-edge-module-file/src/test/java/com/hivemq/edge/adapters/file/config/FileProtocolAdapterConfigTest.java
+++ b/modules/hivemq-edge-module-file/src/test/java/com/hivemq/edge/adapters/file/config/FileProtocolAdapterConfigTest.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hivemq.adapter.sdk.api.factories.ProtocolAdapterFactoryInput;
 import com.hivemq.configuration.entity.HiveMQConfigEntity;
 import com.hivemq.configuration.entity.adapter.ProtocolAdapterEntity;
+import com.hivemq.configuration.info.SystemInformation;
 import com.hivemq.configuration.reader.ConfigFileReaderWriter;
 import com.hivemq.configuration.reader.ConfigurationFile;
 import com.hivemq.edge.adapters.file.FileProtocolAdapterFactory;
@@ -204,7 +205,7 @@ class FileProtocolAdapterConfigTest {
     }
 
     private @NotNull HiveMQConfigEntity loadConfig(final @NotNull File configFile) {
-        final ConfigFileReaderWriter readerWriter = new ConfigFileReaderWriter(new ConfigurationFile(configFile), List.of());
+        final ConfigFileReaderWriter readerWriter = new ConfigFileReaderWriter(mock(SystemInformation.class), new ConfigurationFile(configFile), List.of());
         return readerWriter.applyConfig();
     }
 }

--- a/modules/hivemq-edge-module-http/src/test/java/com/hivemq/edge/adapters/http/config/HttpProtocolAdapterConfigTest.java
+++ b/modules/hivemq-edge-module-http/src/test/java/com/hivemq/edge/adapters/http/config/HttpProtocolAdapterConfigTest.java
@@ -22,6 +22,7 @@ import com.hivemq.configuration.entity.HiveMQConfigEntity;
 import com.hivemq.configuration.entity.adapter.NorthboundMappingEntity;
 import com.hivemq.configuration.entity.adapter.ProtocolAdapterEntity;
 import com.hivemq.configuration.entity.adapter.SouthboundMappingEntity;
+import com.hivemq.configuration.info.SystemInformation;
 import com.hivemq.configuration.reader.ConfigFileReaderWriter;
 import com.hivemq.configuration.reader.ConfigurationFile;
 import com.hivemq.edge.adapters.http.HttpProtocolAdapterFactory;
@@ -376,7 +377,7 @@ public class HttpProtocolAdapterConfigTest {
     }
 
     private @NotNull HiveMQConfigEntity loadConfig(final @NotNull File configFile) {
-        final ConfigFileReaderWriter readerWriter = new ConfigFileReaderWriter(new ConfigurationFile(configFile), List.of());
+        final ConfigFileReaderWriter readerWriter = new ConfigFileReaderWriter(mock(SystemInformation.class), new ConfigurationFile(configFile), List.of());
         return readerWriter.applyConfig();
     }
 }

--- a/modules/hivemq-edge-module-modbus/src/test/java/com/hivemq/edge/adapters/modbus/config/ModbusProtocolAdapterConfigTest.java
+++ b/modules/hivemq-edge-module-modbus/src/test/java/com/hivemq/edge/adapters/modbus/config/ModbusProtocolAdapterConfigTest.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hivemq.adapter.sdk.api.factories.ProtocolAdapterFactoryInput;
 import com.hivemq.configuration.entity.HiveMQConfigEntity;
 import com.hivemq.configuration.entity.adapter.ProtocolAdapterEntity;
+import com.hivemq.configuration.info.SystemInformation;
 import com.hivemq.configuration.reader.ConfigFileReaderWriter;
 import com.hivemq.configuration.reader.ConfigurationFile;
 import com.hivemq.edge.adapters.modbus.ModbusProtocolAdapterFactory;
@@ -220,7 +221,7 @@ public class ModbusProtocolAdapterConfigTest {
     }
 
     private @NotNull HiveMQConfigEntity loadConfig(final @NotNull File configFile) {
-        final ConfigFileReaderWriter readerWriter = new ConfigFileReaderWriter(new ConfigurationFile(configFile), List.of());
+        final ConfigFileReaderWriter readerWriter = new ConfigFileReaderWriter(mock(SystemInformation.class), new ConfigurationFile(configFile), List.of());
         return readerWriter.applyConfig();
     }
 }

--- a/modules/hivemq-edge-module-opcua/src/test/java/com/hivemq/edge/adapters/opcua/config/OpcUaProtocolAdapterConfigTest.java
+++ b/modules/hivemq-edge-module-opcua/src/test/java/com/hivemq/edge/adapters/opcua/config/OpcUaProtocolAdapterConfigTest.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hivemq.adapter.sdk.api.factories.ProtocolAdapterFactoryInput;
 import com.hivemq.configuration.entity.HiveMQConfigEntity;
 import com.hivemq.configuration.entity.adapter.ProtocolAdapterEntity;
+import com.hivemq.configuration.info.SystemInformation;
 import com.hivemq.configuration.reader.ConfigFileReaderWriter;
 import com.hivemq.configuration.reader.ConfigurationFile;
 import com.hivemq.edge.adapters.opcua.OpcUaProtocolAdapterFactory;
@@ -268,7 +269,7 @@ class OpcUaProtocolAdapterConfigTest {
     }
 
     private @NotNull HiveMQConfigEntity loadConfig(final @NotNull File configFile) {
-        final ConfigFileReaderWriter readerWriter = new ConfigFileReaderWriter(new ConfigurationFile(configFile), List.of());
+        final ConfigFileReaderWriter readerWriter = new ConfigFileReaderWriter(mock(SystemInformation.class), new ConfigurationFile(configFile), List.of());
         return readerWriter.applyConfig();
     }
 }

--- a/modules/hivemq-edge-module-plc4x/src/test/java/com/hivemq/edge/adapters/plc4x/types/ads/config/ADSProtocolAdapterConfigTest.java
+++ b/modules/hivemq-edge-module-plc4x/src/test/java/com/hivemq/edge/adapters/plc4x/types/ads/config/ADSProtocolAdapterConfigTest.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hivemq.adapter.sdk.api.factories.ProtocolAdapterFactoryInput;
 import com.hivemq.configuration.entity.HiveMQConfigEntity;
 import com.hivemq.configuration.entity.adapter.ProtocolAdapterEntity;
+import com.hivemq.configuration.info.SystemInformation;
 import com.hivemq.configuration.reader.ConfigFileReaderWriter;
 import com.hivemq.configuration.reader.ConfigurationFile;
 import com.hivemq.edge.adapters.plc4x.config.Plc4xDataType;
@@ -205,7 +206,7 @@ class ADSProtocolAdapterConfigTest {
     }
 
     private @NotNull HiveMQConfigEntity loadConfig(final @NotNull File configFile) {
-        final ConfigFileReaderWriter readerWriter = new ConfigFileReaderWriter(new ConfigurationFile(configFile), List.of());
+        final ConfigFileReaderWriter readerWriter = new ConfigFileReaderWriter(mock(SystemInformation.class), new ConfigurationFile(configFile), List.of());
         return readerWriter.applyConfig();
     }
 

--- a/modules/hivemq-edge-module-plc4x/src/test/java/com/hivemq/edge/adapters/plc4x/types/siemens/config/S7ProtocolAdapterConfigTest.java
+++ b/modules/hivemq-edge-module-plc4x/src/test/java/com/hivemq/edge/adapters/plc4x/types/siemens/config/S7ProtocolAdapterConfigTest.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hivemq.adapter.sdk.api.factories.ProtocolAdapterFactoryInput;
 import com.hivemq.configuration.entity.HiveMQConfigEntity;
 import com.hivemq.configuration.entity.adapter.ProtocolAdapterEntity;
+import com.hivemq.configuration.info.SystemInformation;
 import com.hivemq.configuration.reader.ConfigFileReaderWriter;
 import com.hivemq.configuration.reader.ConfigurationFile;
 import com.hivemq.edge.adapters.plc4x.config.Plc4xDataType;
@@ -196,7 +197,7 @@ class S7ProtocolAdapterConfigTest {
     }
 
     private @NotNull HiveMQConfigEntity loadConfig(final @NotNull File configFile) {
-        final ConfigFileReaderWriter readerWriter = new ConfigFileReaderWriter(new ConfigurationFile(configFile), List.of());
+        final ConfigFileReaderWriter readerWriter = new ConfigFileReaderWriter(mock(SystemInformation.class), new ConfigurationFile(configFile), List.of());
         return readerWriter.applyConfig();
     }
 }


### PR DESCRIPTION
**Motivation**

Resolves #34792

**Changes**
Fragments (parts of the config stored in configmaps in k8s) can now be zipped.