### PR TITLE
fix(35265): Fix bug with interpolation in the Bridge's subscription destinations

### DIFF
--- a/hivemq-edge-frontend/src/api/schemas/bridge.json-schema.ts
+++ b/hivemq-edge-frontend/src/api/schemas/bridge.json-schema.ts
@@ -36,7 +36,8 @@ export const bridgeSchema: JSONSchema7 = {
         destination: {
           type: 'string',
           description: `The destination topic for this filter set.`,
-          format: 'mqtt-topic',
+          // TODO[NVL] Topic validation removed because of need for interpolation; implement the custom validation
+          // format: 'mqtt-topic',
         },
         excludes: {
           type: 'array',
@@ -77,7 +78,8 @@ export const bridgeSchema: JSONSchema7 = {
         destination: {
           type: 'string',
           description: `The destination topic for this filter set.`,
-          format: 'mqtt-topic',
+          // TODO[NVL] Topic validation removed because of need for interpolation; implement the custom validation
+          // format: 'mqtt-topic',
         },
         filters: {
           type: 'array',

--- a/hivemq-edge-frontend/src/modules/Bridges/components/BridgeEditorDrawer.spec.cy.tsx
+++ b/hivemq-edge-frontend/src/modules/Bridges/components/BridgeEditorDrawer.spec.cy.tsx
@@ -108,4 +108,56 @@ describe('BridgeEditorDrawer', () => {
       cy_bridgeShouldBeDefinedProperly()
     })
   })
+
+  describe('RJSF Editor', () => {
+    it('should support interpolation for destinations', () => {
+      cy.mountWithProviders(<BridgeEditorDrawer isNew={true} />, {
+        wrapper: getWrapperWith('/mqtt-bridges/new'),
+        routerProps: { initialEntries: [`/mqtt-bridges/new`] },
+      })
+      cy.wait('@getBridges')
+
+      cy.getByTestId('root_id').within(() => {
+        cy.get('input').type('123')
+      })
+
+      cy.getByTestId('root_host').within(() => {
+        cy.get('input').type('abc')
+      })
+
+      cy.get('[role="tablist"] button').eq(2).click()
+
+      cy.getByTestId('root_localSubscriptions').within(() => {
+        cy.getByTestId('array-item-add').click()
+      })
+
+      cy.getByTestId('root_localSubscriptions_0_destination').within(() => {
+        cy.get('input').type('topic/{{}#{}}{enter}')
+      })
+
+      cy.getByTestId('root_localSubscriptions_0_destination').should('not.have.attr', 'data-invalid')
+      cy.get('#root_localSubscriptions_0_destination__error').should('not.exist')
+
+      cy.getByTestId('root_remoteSubscriptions').within(() => {
+        cy.getByTestId('array-item-add').click()
+      })
+
+      cy.getByTestId('root_remoteSubscriptions_0_destination').within(() => {
+        cy.get('input').type('topic/remote/{{}#{}}{enter}')
+      })
+
+      cy.getByTestId('root_remoteSubscriptions_0_destination').should('not.have.attr', 'data-invalid')
+      cy.get('#root_remoteSubscriptions_0_destination__error').should('not.exist')
+    })
+  })
+
+  it('should be accessible', () => {
+    cy.injectAxe()
+    cy.mountWithProviders(<BridgeEditorDrawer isNew={true} />, {
+      wrapper: getWrapperWith('/mqtt-bridges/new'),
+      routerProps: { initialEntries: [`/mqtt-bridges/new`] },
+    })
+    cy.wait('@getBridges')
+    cy.checkAccessibility()
+  })
 })


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/35265/details/

The PR fixes a bug in the Bridge subscriptions, preventing end-users from utilising interpolation strings (such as `{#}`). Note that the "fix" consists of removing the custom validation of MQTT topics, therefore allowing users to type incorrect topics. 

### Out-of-scope
- The fix removes the `mqtt-topic` format for the string, disabling the validation of an MQTT topic (hence the problem with the wildcard `'#`). This weakens the validation of a bridge and will need to be reintroduced in a subsequent ticket.
- The interpolation patterns are not fully documented. The re-implementation of a properly validated topic + interpolation (e.g. `mqtt-topic-interpolation`) will need to be designed and implemented properly for both backend and frontend


### Before 
<img width="1280" height="934" alt="HiveMQ-Edge-08-05-2025_10_43" src="https://github.com/user-attachments/assets/34133520-002c-4dd1-aefe-d31c12daecf8" />

### After
<img width="1280" height="934" alt="HiveMQ-Edge-08-05-2025_10_42" src="https://github.com/user-attachments/assets/d0f83079-cd3f-4d81-b086-861a604488cd" />
