### PR TITLE
chore(35266): Add a CI check workflow for the openAPI specs

### DIFF
--- a/.github/workflows/check-openapi.yml
+++ b/.github/workflows/check-openapi.yml
@@ -1,0 +1,28 @@
+name: OpenAPI validation
+
+on:
+  workflow_dispatch:
+  workflow_call:
+
+defaults:
+  run:
+    working-directory: ./hivemq-edge-openapi/
+
+jobs:
+  linting:
+    name: OpenAPI specs linting
+    runs-on: ubuntu-latest
+    steps:
+      - name: 👓 Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: 🏗️ Setup node environment
+        uses: ./.github/actions/setup_node
+        with:
+          working-directory: ./hivemq-edge-openapi/
+
+      - name: Install Redocly CLI
+        run: npm install -g @redocly/cli@latest
+
+      - name: Run linting
+        run: redocly lint openapi/openapi.yaml --format=github-actions

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -19,6 +19,7 @@ jobs:
     outputs:
       frontend-changed: ${{ steps.frontend.outputs.changed }}
       backend-changed: ${{ steps.backend.outputs.changed }}
+      openapi-changed: ${{ steps.openapi.outputs.changed }}
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -46,8 +47,22 @@ jobs:
               - 'hivemq-edge-frontend/**'
               - '.github/**'
 
-  check-frontend:
+      - name: Check for openAPI changes
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: openapi
+        with:
+          filters: |
+            changed:
+              - 'hivemq-edge-openapi/**'
+              - '.github/**'
+
+  check-openapi:
     needs: check-for-changes
+    uses: ./.github/workflows/check-openapi.yml
+    if: needs.check-for-changes.outputs.openapi-changed == 'true'
+
+  check-frontend:
+    needs: [ check-for-changes, check-openapi ]
     uses: ./.github/workflows/check-frontend.yml
     if: needs.check-for-changes.outputs.frontend-changed == 'true'
     secrets:
@@ -55,15 +70,24 @@ jobs:
       PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
 
   check-backend:
-    needs: check-for-changes
+    needs: [ check-for-changes, check-openapi ]
     uses: ./.github/workflows/check-backend.yml
     if: needs.check-for-changes.outputs.backend-changed == 'true'
 
+
   check:
     runs-on: ubuntu-latest
-    needs: [check-for-changes, check-frontend, check-backend]
+    needs: [check-for-changes, check-openapi, check-frontend, check-backend]
     if: always()
     steps:
+      - name: Check if openapi job succeeded
+        if: needs.check-for-changes.outputs.openapi-changed == 'true'
+        run: |
+          if [[ "${{ needs.check-openapi.result }}" != "success" ]]; then
+          echo "OpenAPI check failed"
+          exit 0
+          fi
+
       - name: Check if frontend job succeeded
         if: needs.check-for-changes.outputs.frontend-changed == 'true'
         run: |


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/35266/details/

The PR adds a simple job in the `check` pipeline, triggering the `Redocly lint` operation on the OpenAPI specs. 

The job will fail if errors are found in the specs, not with warnings. It will then fail the whole check pipeline.

