### PR TITLE
feat(35452): Create the Asset Mapping UX flow

### DIFF
--- a/hivemq-edge-frontend/cypress/e2e/pulse/activation.spec.cy.ts
+++ b/hivemq-edge-frontend/cypress/e2e/pulse/activation.spec.cy.ts
@@ -7,7 +7,7 @@ import { cy_interceptCoreE2E } from 'cypress/utils/intercept.utils.ts'
 import { loginPage, homePage, pulseActivationPanel } from 'cypress/pages'
 import { ONBOARDING } from '../../utils/constants.utils.ts'
 
-describe('Pulse Client Activation', () => {
+describe('Pulse Agent Activation', () => {
   const mswDB = factory({
     capabilities: {
       id: primaryKey(String),
@@ -92,7 +92,7 @@ describe('Pulse Client Activation', () => {
       pulseActivationPanel.status.should('contain.text', 'Pulse is not activated')
     })
 
-    it('should activate the pulse client', () => {
+    it('should activate the Pulse Agent', () => {
       cy.location().should((loc) => {
         expect(loc.pathname).to.eq('/app')
       })
@@ -122,7 +122,7 @@ describe('Pulse Client Activation', () => {
       pulseActivationPanel.submitButton.should('not.be.disabled')
       pulseActivationPanel.submitButton.click()
 
-      homePage.toast.success.should('contain.text', 'The Pulse Client has been successfully activated')
+      homePage.toast.success.should('contain.text', 'The Pulse Agent has been successfully activated')
       homePage.toast.close()
 
       homePage.taskSection(ONBOARDING.TASK_PULSE, 0).within(() => {

--- a/hivemq-edge-frontend/cypress/e2e/pulse/activation.spec.cy.ts
+++ b/hivemq-edge-frontend/cypress/e2e/pulse/activation.spec.cy.ts
@@ -54,7 +54,7 @@ describe('Pulse Agent Activation', () => {
         },
       })
       req.reply(200)
-    }).as('activatePulse')
+    })
 
     // There seems to be a bug in the CI without something in the path
     loginPage.visit('/app/workspace')

--- a/hivemq-edge-frontend/cypress/pages/Pulse/ActivationFormPage.ts
+++ b/hivemq-edge-frontend/cypress/pages/Pulse/ActivationFormPage.ts
@@ -6,7 +6,7 @@ export class ActivationFormPage extends RJSFomField {
   }
 
   get form() {
-    return cy.get('[role="dialog"][aria-label="Pulse Client Activation"]')
+    return cy.get('[role="dialog"][aria-label="Pulse Agent Activation"]')
   }
 
   get status() {

--- a/hivemq-edge-frontend/package.json
+++ b/hivemq-edge-frontend/package.json
@@ -13,7 +13,7 @@
     "lint:prettier:write": "prettier --write .",
     "lint:stylelint": "stylelint './src/**/*.css'",
     "lint:all": "eslint src  --report-unused-disable-directives --max-warnings 0 && prettier --check .",
-    "dev:openAPI": "openapi --input '../ext/hivemq-edge-openapi-2025.12-SNAPSHOT.yaml' -o ./src/api/__generated__ -c axios --name HiveMqClient --exportSchemas true",
+    "dev:openAPI": "openapi --input '../hivemq-edge-openapi/dist/bundle.yaml' -o ./src/api/__generated__ -c axios --name HiveMqClient --exportSchemas true",
     "dev:chakra:types": "chakra-cli tokens './src/modules/Theme/themeHiveMQ.ts' --out 'node_modules/.pnpm/@chakra-ui+styled-system@2.9.2/node_modules/@chakra-ui/styled-system/dist/theming.types.d.ts'",
     "cypress:open": "cypress open",
     "cypress:open:component": "cypress open --component --browser chrome",

--- a/hivemq-edge-frontend/src/__test-utils__/react-flow/nodes.ts
+++ b/hivemq-edge-frontend/src/__test-utils__/react-flow/nodes.ts
@@ -89,7 +89,7 @@ export const MOCK_NODE_ASSETS: NodeProps<NodeAssetsType> = {
   id: 'idAssets',
   type: NodeTypes.ASSETS_NODE,
   sourcePosition: Position.Bottom,
-  data: { label: 'my assets' },
+  data: { label: 'my assets', id: 'idAssets' },
   ...MOCK_DEFAULT_NODE,
 }
 
@@ -97,6 +97,6 @@ export const MOCK_NODE_PULSE: NodeProps<NodePulseType> = {
   id: 'idPulseClient',
   type: NodeTypes.PULSE_NODE,
   sourcePosition: Position.Bottom,
-  data: { label: 'my pulse client' },
+  data: { label: 'my pulse client', id: 'idPulseClient' },
   ...MOCK_DEFAULT_NODE,
 }

--- a/hivemq-edge-frontend/src/__test-utils__/react-flow/nodes.ts
+++ b/hivemq-edge-frontend/src/__test-utils__/react-flow/nodes.ts
@@ -18,6 +18,7 @@ import type {
   NodePulseType,
 } from '@/modules/Workspace/types.ts'
 import { NodeTypes } from '@/modules/Workspace/types.ts'
+import { NODE_ASSET_DEFAULT_ID, NODE_PULSE_AGENT_DEFAULT_ID } from '@/modules/Workspace/utils/nodes-utils.ts'
 
 export const MOCK_DEFAULT_NODE = {
   selected: false,
@@ -86,17 +87,17 @@ export const MOCK_NODE_COMBINER: NodeProps<NodeCombinerType> = {
 }
 
 export const MOCK_NODE_ASSETS: NodeProps<NodeAssetsType> = {
-  id: 'idAssets',
+  id: NODE_ASSET_DEFAULT_ID,
   type: NodeTypes.ASSETS_NODE,
   sourcePosition: Position.Bottom,
-  data: { label: 'my assets', id: 'idAssets' },
+  data: { label: 'my assets', id: NODE_ASSET_DEFAULT_ID },
   ...MOCK_DEFAULT_NODE,
 }
 
 export const MOCK_NODE_PULSE: NodeProps<NodePulseType> = {
-  id: 'idPulseClient',
+  id: NODE_PULSE_AGENT_DEFAULT_ID,
   type: NodeTypes.PULSE_NODE,
   sourcePosition: Position.Bottom,
-  data: { label: 'my pulse client', id: 'idPulseClient' },
+  data: { label: 'my pulse client', id: NODE_PULSE_AGENT_DEFAULT_ID },
   ...MOCK_DEFAULT_NODE,
 }

--- a/hivemq-edge-frontend/src/api/__generated__/HiveMqClient.ts
+++ b/hivemq-edge-frontend/src/api/__generated__/HiveMqClient.ts
@@ -65,7 +65,7 @@ export class HiveMqClient {
     constructor(config?: Partial<OpenAPIConfig>, HttpRequest: HttpRequestConstructor = AxiosHttpRequest) {
         this.request = new HttpRequest({
             BASE: config?.BASE ?? '',
-            VERSION: config?.VERSION ?? '2025.10-SNAPSHOT',
+            VERSION: config?.VERSION ?? '2025.14-SNAPSHOT',
             WITH_CREDENTIALS: config?.WITH_CREDENTIALS ?? false,
             CREDENTIALS: config?.CREDENTIALS ?? 'include',
             TOKEN: config?.TOKEN,

--- a/hivemq-edge-frontend/src/api/__generated__/core/OpenAPI.ts
+++ b/hivemq-edge-frontend/src/api/__generated__/core/OpenAPI.ts
@@ -21,7 +21,7 @@ export type OpenAPIConfig = {
 
 export const OpenAPI: OpenAPIConfig = {
     BASE: '',
-    VERSION: '2025.13-SNAPSHOT',
+    VERSION: '2025.14-SNAPSHOT',
     WITH_CREDENTIALS: false,
     CREDENTIALS: 'include',
     TOKEN: undefined,

--- a/hivemq-edge-frontend/src/api/__generated__/models/AssetMapping.ts
+++ b/hivemq-edge-frontend/src/api/__generated__/models/AssetMapping.ts
@@ -3,9 +3,6 @@
 /* tslint:disable */
 /* eslint-disable */
 
-import type { DataIdentifierReference } from './DataIdentifierReference';
-import type { Instruction } from './Instruction';
-
 /**
  * The definition of the mapping for a managed asset in Edge
  */
@@ -15,17 +12,9 @@ export type AssetMapping = {
      */
     status: AssetMapping.status;
     /**
-     * The list of sources used in the asset mapping
+     * The id of a DataCombining payload that describes the mapping of that particular asset
      */
-    sources: Array<DataIdentifierReference>;
-    /**
-     * The primary source used for triggering the streaming of the asset. It must be one of the sources.
-     */
-    primary: DataIdentifierReference;
-    /**
-     * List of mapping instructions to be applied between the sources and the asset schema
-     */
-    instructions: Array<Instruction>;
+    mappingId: string;
 };
 
 export namespace AssetMapping {

--- a/hivemq-edge-frontend/src/api/__generated__/models/DataCombining.ts
+++ b/hivemq-edge-frontend/src/api/__generated__/models/DataCombining.ts
@@ -26,6 +26,13 @@ export type DataCombining = {
         topicFilters?: Array<string>;
     };
     destination: {
+        /**
+         * The id of a mapped asset containing the topic and schema used for destination of the mapping
+         */
+        assetId?: string;
+        /**
+         * The MQTT topic used for destination of the mapping
+         */
         topic?: string;
         /**
          * The optional json schema for this topic filter in the data uri format.

--- a/hivemq-edge-frontend/src/api/__generated__/models/EntityType.ts
+++ b/hivemq-edge-frontend/src/api/__generated__/models/EntityType.ts
@@ -4,11 +4,12 @@
 /* eslint-disable */
 
 /**
- * These are the prime entities owning tags and topic filters
+ * These are the prime entities owning integration points such as tags and topic filters
  */
 export enum EntityType {
     ADAPTER = 'ADAPTER',
     DEVICE = 'DEVICE',
     BRIDGE = 'BRIDGE',
     EDGE_BROKER = 'EDGE_BROKER',
+    PULSE_AGENT = 'PULSE_AGENT',
 }

--- a/hivemq-edge-frontend/src/api/__generated__/models/PulseStatus.ts
+++ b/hivemq-edge-frontend/src/api/__generated__/models/PulseStatus.ts
@@ -9,42 +9,37 @@ import type { ProblemDetails } from './ProblemDetails';
  * Information on the activation status of the pulse agent and its connection to the platform.
  */
 export type PulseStatus = {
-    activation: {
-        /**
-         * Status of the pulse activation
-         */
-        status: PulseStatus.activationStatus;
-        message?: ProblemDetails;
-    };
-    runtime: {
-        /**
-         * Connection status of the pulse agent to the platform.
-         */
-        status: PulseStatus.runtimeStatus;
-        message?: ProblemDetails;
-    };
+    /**
+     * Status of the pulse activation
+     */
+    activation: PulseStatus.activation;
+    /**
+     * Connection status of the pulse agent to the platform.
+     */
+    runtime: PulseStatus.runtime;
+    message?: ProblemDetails;
 };
 
-// TODO[35484] There is a bug with the generation of the enums (because of the same "status" property; replace manually
 export namespace PulseStatus {
 
     /**
      * Status of the pulse activation
      */
-    export enum activationStatus {
+    export enum activation {
         ACTIVATED = 'ACTIVATED',
         DEACTIVATED = 'DEACTIVATED',
         ERROR = 'ERROR',
     }
 
     /**
-     * Status of the pulse runtime
+     * Connection status of the pulse agent to the platform.
      */
-    export enum runtimeStatus {
-      CONNECTED = 'CONNECTED',
-      DISCONNECTED = 'DISCONNECTED',
-      ERROR = 'ERROR',
+    export enum runtime {
+        CONNECTED = 'CONNECTED',
+        DISCONNECTED = 'DISCONNECTED',
+        ERROR = 'ERROR',
     }
+
 
 }
 

--- a/hivemq-edge-frontend/src/api/__generated__/schemas/$AssetMapping.ts
+++ b/hivemq-edge-frontend/src/api/__generated__/schemas/$AssetMapping.ts
@@ -9,24 +9,11 @@ export const $AssetMapping = {
             type: 'Enum',
             isRequired: true,
         },
-        sources: {
-            type: 'array',
-            contains: {
-                type: 'DataIdentifierReference',
-            },
+        mappingId: {
+            type: 'string',
+            description: `The id of a DataCombining payload that describes the mapping of that particular asset`,
             isRequired: true,
-        },
-        primary: {
-            type: 'DataIdentifierReference',
-            description: `The primary source used for triggering the streaming of the asset. It must be one of the sources.`,
-            isRequired: true,
-        },
-        instructions: {
-            type: 'array',
-            contains: {
-                type: 'Instruction',
-            },
-            isRequired: true,
+            format: 'uuid',
         },
     },
 } as const;

--- a/hivemq-edge-frontend/src/api/__generated__/schemas/$DataCombining.ts
+++ b/hivemq-edge-frontend/src/api/__generated__/schemas/$DataCombining.ts
@@ -34,8 +34,14 @@ export const $DataCombining = {
         },
         destination: {
             properties: {
+                assetId: {
+                    type: 'string',
+                    description: `The id of a mapped asset containing the topic and schema used for destination of the mapping`,
+                    format: 'uuid',
+                },
                 topic: {
                     type: 'string',
+                    description: `The MQTT topic used for destination of the mapping`,
                     format: 'mqtt-topic',
                 },
                 schema: {

--- a/hivemq-edge-frontend/src/api/__generated__/schemas/$PulseStatus.ts
+++ b/hivemq-edge-frontend/src/api/__generated__/schemas/$PulseStatus.ts
@@ -6,28 +6,15 @@ export const $PulseStatus = {
     description: `Information on the activation status of the pulse agent and its connection to the platform.`,
     properties: {
         activation: {
-            properties: {
-                status: {
-                    type: 'Enum',
-                    isRequired: true,
-                },
-                message: {
-                    type: 'ProblemDetails',
-                },
-            },
+            type: 'Enum',
             isRequired: true,
         },
         runtime: {
-            properties: {
-                status: {
-                    type: 'Enum',
-                    isRequired: true,
-                },
-                message: {
-                    type: 'ProblemDetails',
-                },
-            },
+            type: 'Enum',
             isRequired: true,
+        },
+        message: {
+            type: 'ProblemDetails',
         },
     },
 } as const;

--- a/hivemq-edge-frontend/src/api/__generated__/services/PulseService.ts
+++ b/hivemq-edge-frontend/src/api/__generated__/services/PulseService.ts
@@ -25,7 +25,9 @@ export class PulseService {
             method: 'DELETE',
             url: '/api/v1/management/pulse/activation-token',
             errors: {
-                503: `Pulse Agent not connected`,
+                409: `Activation token is already deleted.`,
+                500: `Internal server error.`,
+                503: `Activation token is not deleted successfully.`,
             },
         });
     }
@@ -46,8 +48,9 @@ export class PulseService {
             body: requestBody,
             mediaType: 'application/json',
             errors: {
-                422: `Activation token is invalid`,
-                503: `Pulse Agent not connected`,
+                400: `Pulse Agent is deactivated.`,
+                422: `Activation token is invalid.`,
+                500: `Internal server error.`,
             },
         });
     }

--- a/hivemq-edge-frontend/src/api/hooks/useCombiners/__handlers__/index.ts
+++ b/hivemq-edge-frontend/src/api/hooks/useCombiners/__handlers__/index.ts
@@ -84,6 +84,37 @@ export const mockCombinerMapping: DataCombining = {
   instructions: [],
 }
 
+export const MOCK_COMBINER_ASSET: Combiner = {
+  id: 'e9af7f82-bec1-4d07-8c0f-e4591148af19',
+  name: 'my-combiner-for-asset',
+  sources: {
+    items: [
+      {
+        type: EntityType.ADAPTER,
+        id: 'my-adapter',
+      },
+      {
+        type: EntityType.PULSE_AGENT,
+        id: 'the Pulse Agent',
+      },
+    ],
+  },
+  mappings: {
+    items: [
+      {
+        id: 'ff02efff-7b4c-4f8c-8bf6-74d0756283fb',
+        sources: {
+          primary: { id: '', type: DataIdentifierReference.type.TAG },
+          tags: ['my/tag/t1', 'my/tag/t3'],
+          topicFilters: ['my/topic/+/temp'],
+        },
+        destination: { topic: 'my/first/topic' },
+        instructions: [],
+      },
+    ],
+  },
+}
+
 export const handlers = [
   http.get('*/management/combiners', () => {
     return HttpResponse.json<CombinerList>(
@@ -145,5 +176,16 @@ export const handlers = [
 
   http.get<MappingParams>('*/management/combiners/:combinerId/mappings/:mappingId/instructions', () => {
     return HttpResponse.json<Array<Instruction>>([], { status: 200 })
+  }),
+]
+
+export const handlerCombinerAssets = [
+  http.get('*/management/combiners', () => {
+    return HttpResponse.json<CombinerList>(
+      {
+        items: [MOCK_COMBINER_ASSET],
+      },
+      { status: 200 }
+    )
   }),
 ]

--- a/hivemq-edge-frontend/src/api/hooks/useFrontendServices/__handlers__/index.ts
+++ b/hivemq-edge-frontend/src/api/hooks/useFrontendServices/__handlers__/index.ts
@@ -137,7 +137,7 @@ export const MOCK_CAPABILITY_PULSE_ASSETS: Capability = {
   id: Capability.id.PULSE_ASSET_MANAGEMENT,
   displayName: 'Pulse Asset Management',
   description:
-    'This enables HiveMQ Edge to make use of a Pulse Client, including the ability to create, update and map Pulse Assets.',
+    'This enables HiveMQ Edge to make use of a Pulse Agent, including the ability to create, update and map Pulse Assets.',
 }
 
 export const MOCK_CAPABILITIES: CapabilityList = {

--- a/hivemq-edge-frontend/src/api/hooks/usePulse/__handlers__/index.ts
+++ b/hivemq-edge-frontend/src/api/hooks/usePulse/__handlers__/index.ts
@@ -1,10 +1,9 @@
+import { delay, http, HttpResponse } from 'msw'
+
 import { MOCK_JWT } from '@/__test-utils__/mocks.ts'
 import { MOCK_SIMPLE_SCHEMA_URI } from '@/__test-utils__/rjsf/schema.mocks.ts'
 import type { ManagedAsset, ManagedAssetList, PulseActivationToken } from '@/api/__generated__'
-import { AssetMapping, DataIdentifierReference } from '@/api/__generated__'
-import { delay, http, HttpResponse } from 'msw'
-import status = AssetMapping.status
-import type = DataIdentifierReference.type
+import { AssetMapping } from '@/api/__generated__'
 
 export const MOCK_PULSE_ACTIVATION_TOKEN: PulseActivationToken = {
   token: MOCK_JWT,
@@ -25,14 +24,8 @@ export const MOCK_PULSE_ASSET_MAPPED: ManagedAsset = {
   topic: 'test/topic/2',
   schema: MOCK_SIMPLE_SCHEMA_URI,
   mapping: {
-    status: status.STREAMING,
-    sources: [
-      { id: 'test', type: type.TOPIC_FILTER },
-      { id: 'test/2', type: type.TAG },
-      { id: 'test/3', type: type.PULSE_ASSET },
-    ],
-    primary: { id: 'test', type: type.TOPIC_FILTER },
-    instructions: [],
+    mappingId: 'ff02efff-7b4c-4f8c-8bf6-74d0756283fb',
+    status: AssetMapping.status.STREAMING,
   },
 }
 
@@ -43,13 +36,8 @@ export const MOCK_PULSE_ASSET_MAPPED_DUPLICATE: ManagedAsset = {
   topic: 'test/topic/2',
   schema: MOCK_SIMPLE_SCHEMA_URI,
   mapping: {
-    status: status.REQUIRES_REMAPPING,
-    sources: [
-      { id: 'test/2', type: type.TAG },
-      { id: 'test/3', type: type.PULSE_ASSET },
-    ],
-    primary: { id: 'test/2', type: type.TAG },
-    instructions: [],
+    status: AssetMapping.status.REQUIRES_REMAPPING,
+    mappingId: 'ff02efff-7b4c-4f8c-8bf6-74d0756283fb',
   },
 }
 
@@ -60,13 +48,8 @@ export const MOCK_PULSE_ASSET_MAPPED_UNIQUE: ManagedAsset = {
   topic: 'test/topic/4',
   schema: MOCK_SIMPLE_SCHEMA_URI,
   mapping: {
-    status: status.REQUIRES_REMAPPING,
-    sources: [
-      { id: 'test/2', type: type.TAG },
-      { id: 'test/4', type: type.PULSE_ASSET },
-    ],
-    primary: { id: 'test/2', type: type.TAG },
-    instructions: [],
+    status: AssetMapping.status.REQUIRES_REMAPPING,
+    mappingId: '3009a8c5-dba5-40a5-857c-2d0a9cd71637',
   },
 }
 

--- a/hivemq-edge-frontend/src/api/hooks/usePulse/useListManagedAssets.spec.ts
+++ b/hivemq-edge-frontend/src/api/hooks/usePulse/useListManagedAssets.spec.ts
@@ -36,25 +36,7 @@ describe('useListManagedAssets', () => {
           name: 'Test mapped asset',
           topic: 'test/topic/2',
           mapping: {
-            instructions: [],
-            primary: {
-              id: 'test',
-              type: 'TOPIC_FILTER',
-            },
-            sources: [
-              {
-                id: 'test',
-                type: 'TOPIC_FILTER',
-              },
-              {
-                id: 'test/2',
-                type: 'TAG',
-              },
-              {
-                id: 'test/3',
-                type: 'PULSE_ASSET',
-              },
-            ],
+            mappingId: 'ff02efff-7b4c-4f8c-8bf6-74d0756283fb',
             status: 'STREAMING',
           },
         }),

--- a/hivemq-edge-frontend/src/api/schemas/combiner-mapping.json-schema.ts
+++ b/hivemq-edge-frontend/src/api/schemas/combiner-mapping.json-schema.ts
@@ -27,7 +27,7 @@ export const combinerMappingJsonSchema: JSONSchema7 = {
       description: 'A reference to one of the main entities in Edge (e.g. device, adapter, edge broker, bridge host)',
       properties: {
         type: {
-          enum: [EntityType.ADAPTER, EntityType.BRIDGE, EntityType.EDGE_BROKER],
+          enum: [EntityType.ADAPTER, EntityType.BRIDGE, EntityType.EDGE_BROKER, EntityType.PULSE_AGENT],
         },
         id: {
           type: 'string',
@@ -77,6 +77,9 @@ export const combinerMappingJsonSchema: JSONSchema7 = {
         destination: {
           type: 'object',
           properties: {
+            assetId: {
+              type: 'string',
+            },
             topic: {
               type: 'string',
               format: 'mqtt-topic',

--- a/hivemq-edge-frontend/src/api/schemas/combiner-mapping.ui-schema.ts
+++ b/hivemq-edge-frontend/src/api/schemas/combiner-mapping.ui-schema.ts
@@ -5,7 +5,7 @@ import { EntityReferenceTableWidget } from '@/modules/Mappings/combiner/EntityRe
 import { DataCombiningEditorField } from '@/modules/Mappings/combiner/DataCombiningEditorField'
 
 /* istanbul ignore next -- @preserve */
-export const combinerMappingUiSchema: UiSchema = {
+export const combinerMappingUiSchema = (isAssetManager = false): UiSchema => ({
   'ui:submitButtonOptions': {
     norender: true,
   },
@@ -22,7 +22,9 @@ export const combinerMappingUiSchema: UiSchema = {
     },
     {
       id: 'mappingsTab',
-      title: i18nConfig.t('combiner.schema.tabs.mappingsTab'),
+      title: isAssetManager
+        ? i18nConfig.t('combiner.schema.tabs.assetTabs')
+        : i18nConfig.t('combiner.schema.tabs.mappingsTab'),
       properties: ['mappings'],
     },
   ],
@@ -75,4 +77,4 @@ export const combinerMappingUiSchema: UiSchema = {
       },
     },
   },
-}
+})

--- a/hivemq-edge-frontend/src/locales/en/translation.json
+++ b/hivemq-edge-frontend/src/locales/en/translation.json
@@ -964,7 +964,7 @@
       "header_CLUSTER_NODE": "Group Overview",
       "header_EDGE_NODE": "Edge Overview",
       "header_DEVICE_NODE": "Device Overview",
-      "header_PULSE_NODE": "Pulse Client Overview",
+      "header_PULSE_NODE": "Pulse Agent Overview",
       "header_ASSETS_NODE": "Assets Overview",
       "modify_ADAPTER_NODE": "Modify the adapter",
       "modify_BRIDGE_NODE": "Modify the bridge",
@@ -979,7 +979,7 @@
       "header_BRIDGE_NODE": "Bridge Observability",
       "header_CLUSTER_NODE": "Group Observability",
       "header_COMBINER_NODE": "Combiner Observability",
-      "header_PULSE_NODE": "Pulse Client Observability",
+      "header_PULSE_NODE": "Pulse Agent Observability",
       "header_ASSETS_NODE": "Pulse Assets Observability"
     },
     "datahub": {
@@ -1475,7 +1475,7 @@
     "error": {
       "loading": "We cannot load the assets at this time. Please try again later",
       "notYetAvailable": "Pulse Assets are not yet available for HiveMQ Edge. <1>Please contact us for more information.</1",
-      "notActivated": "The Pulse Client is not connected to this Edge instance."
+      "notActivated": "The Pulse Agent is not connected to this Edge instance."
     },
     "activation": {
       "action": {
@@ -1484,7 +1484,7 @@
         "submit": "Activate"
       },
       "heading": {
-        "title": "Pulse Client Activation"
+        "title": "Pulse Agent Activation"
       },
       "error": {
         "noCapabilityLoaded": "Cannot check the Pulse capability. Please try again later"
@@ -1505,16 +1505,16 @@
         }
       },
       "activate": {
-        "title": "Pulse Client Activation",
-        "success": "The Pulse Client has been successfully activated",
-        "error": "The Pulse Client could not be activated: {{error}}. Please check the activation token and try again",
+        "title": "Pulse Agent Activation",
+        "success": "The Pulse Agent has been successfully activated",
+        "error": "The Pulse Agent could not be activated: {{error}}. Please check the activation token and try again",
         "loading": "Processing the request. Please wait ..."
       },
       "revoke": {
-        "title": "Pulse Client Deactivation",
-        "confirmation": "Do you really want to deactivate the Pulse Client? The operation cannot be reversed.",
-        "success": "The Pulse Client has been successfully deactivated",
-        "error": "The Pulse Client could not be deactivated: {{error}}. Please try again.",
+        "title": "Pulse Agent Deactivation",
+        "confirmation": "Do you really want to deactivate the Pulse Agent? The operation cannot be reversed.",
+        "success": "The Pulse Agent has been successfully deactivated",
+        "error": "The Pulse Agent could not be deactivated: {{error}}. Please try again.",
         "loading": "Processing the request. Please wait ..."
       }
     },
@@ -1560,7 +1560,7 @@
       "nodeClient": {
         "status_ACTIVATED": "Activated",
         "status_DEACTIVATED": "Not Activated",
-        "title": "Pulse Client"
+        "title": "Pulse Agent"
       }
     }
   }

--- a/hivemq-edge-frontend/src/locales/en/translation.json
+++ b/hivemq-edge-frontend/src/locales/en/translation.json
@@ -1545,7 +1545,7 @@
         },
         "sources": {
           "unset": "< unset >",
-          "norFound": "< notFound >",
+          "norFound": "< not found >",
           "more": "+{{ count }} more"
         }
       },

--- a/hivemq-edge-frontend/src/locales/en/translation.json
+++ b/hivemq-edge-frontend/src/locales/en/translation.json
@@ -1545,6 +1545,7 @@
         },
         "sources": {
           "unset": "< unset >",
+          "norFound": "< notFound >",
           "more": "+{{ count }} more"
         }
       },

--- a/hivemq-edge-frontend/src/locales/en/translation.json
+++ b/hivemq-edge-frontend/src/locales/en/translation.json
@@ -904,6 +904,9 @@
         "combiner": {
           "create": "Create a data combiner from selection"
         },
+        "assets": {
+          "create": "Create a new Asset Mapper from the selection"
+        },
         "edge": {
           "topicFilter": "Manage topic filters"
         }
@@ -1368,7 +1371,8 @@
       "tabs": {
         "combinerTab": "Configuration",
         "sourcesTab": "Sources",
-        "mappingsTab": "Mappings"
+        "mappingsTab": "Mappings",
+        "assetTabs": "Asset mappings"
       },
       "description": "A data combiner brings tags (adapters) and topic filters (bridges) together for further northbound data mapping",
       "config": {
@@ -1383,6 +1387,10 @@
         },
         "edge": {
           "description": "Always added as the owner of the topic filters"
+        },
+        "pulse": {
+          "name": "Pulse Agent",
+          "description": "Assets managed by the Pulse Agent"
         }
       },
       "mappings": {
@@ -1550,10 +1558,18 @@
         "map": "Map the asset",
         "delete": "Delete mapping",
         "mapper": "Open asset mapper"
+      },
+      "selector": {
+        "aria-label": "List of assets",
+        "placeholder": "Select an asset to map...",
+        "loading": "Loading the assets...",
+        "noAssetsFound": "No assets found",
+        "add": "Add the asset to the mappings"
       }
     },
     "mapper": {
-      "title": "Asset Mapper"
+      "title": "Asset Mapper",
+      "unnamed": "< unnamed asset mapper >"
     },
 
     "workspace": {

--- a/hivemq-edge-frontend/src/modules/Mappings/CombinerMappingManager.tsx
+++ b/hivemq-edge-frontend/src/modules/Mappings/CombinerMappingManager.tsx
@@ -54,14 +54,16 @@ const CombinerMappingManager: FC = () => {
     return nodes.find((node) => node.id === combinerId) as Node<Combiner> | undefined
   }, [combinerId, nodes])
 
+  if (!selectedNode) throw new Error('No combiner node found')
+
   const entities = useMemo(() => {
-    const entities = selectedNode?.data?.sources?.items || []
+    const entities = selectedNode.data.sources.items || []
     const isBridgeIn = Boolean(
       entities.find((entity) => entity.id === IdStubs.EDGE_NODE && entity.type === EntityType.EDGE_BROKER)
     )
     if (!isBridgeIn) entities.push({ id: IdStubs.EDGE_NODE, type: EntityType.EDGE_BROKER })
     return entities
-  }, [selectedNode?.data?.sources?.items])
+  }, [selectedNode.data.sources.items])
 
   const sources = useGetCombinedEntities(entities)
   const validator = useValidateCombiner(sources, entities)
@@ -80,7 +82,7 @@ const CombinerMappingManager: FC = () => {
 
     toast.promise(
       promise.then(() => {
-        if (selectedNode) onUpdateNode<Combiner>(selectedNode.id, data.formData)
+        onUpdateNode<Combiner>(selectedNode.id, data.formData)
         handleClose()
       }),
       {
@@ -96,7 +98,7 @@ const CombinerMappingManager: FC = () => {
     const promise = deleteCombiner.mutateAsync({ combinerId })
     toast.promise(
       promise.then(() => {
-        if (selectedNode) onNodesChange([{ id: selectedNode.id, type: 'remove' } as NodeRemoveChange])
+        onNodesChange([{ id: selectedNode.id, type: 'remove' } as NodeRemoveChange])
         handleClose()
       }),
       {
@@ -127,19 +129,16 @@ const CombinerMappingManager: FC = () => {
           />
         </DrawerHeader>
         <DrawerBody display="flex" flexDirection="column" gap={6}>
-          {!selectedNode && <ErrorMessage message={t('combiner.error.noDataUri')} status="error" />}
-          {selectedNode && (
-            <ChakraRJSForm
-              showNativeWidgets={showNativeWidgets}
-              id="combiner-main-form"
-              schema={combinerMappingJsonSchema}
-              uiSchema={combinerMappingUiSchema}
-              formData={selectedNode.data}
-              onSubmit={handleOnSubmit}
-              formContext={{ queries: sources, entities } as CombinerContext}
-              customValidate={validator?.validateCombiner}
-            />
-          )}
+          <ChakraRJSForm
+            showNativeWidgets={showNativeWidgets}
+            id="combiner-main-form"
+            schema={combinerMappingJsonSchema}
+            uiSchema={combinerMappingUiSchema}
+            formData={selectedNode.data}
+            onSubmit={handleOnSubmit}
+            formContext={{ queries: sources, entities } as CombinerContext}
+            customValidate={validator?.validateCombiner}
+          />
         </DrawerBody>
         <DrawerFooter justifyContent="space-between">
           <ButtonGroup>
@@ -151,13 +150,11 @@ const CombinerMappingManager: FC = () => {
                 <Switch id="email-alerts" isChecked={showNativeWidgets} onChange={setShowNativeWidgets.toggle} />
               </FormControl>
             )}
-            {selectedNode && <DangerZone onSubmit={handleOnDelete} />}
+            <DangerZone onSubmit={handleOnDelete} />
           </ButtonGroup>
-          {selectedNode && (
-            <Button variant="primary" type="submit" form="combiner-main-form" isLoading={updateCombiner.isPending}>
-              {t('combiner.actions.submit')}
-            </Button>
-          )}
+          <Button variant="primary" type="submit" form="combiner-main-form" isLoading={updateCombiner.isPending}>
+            {t('combiner.actions.submit')}
+          </Button>
         </DrawerFooter>
       </DrawerContent>
     </Drawer>

--- a/hivemq-edge-frontend/src/modules/Mappings/combiner/DataCombiningEditorField.tsx
+++ b/hivemq-edge-frontend/src/modules/Mappings/combiner/DataCombiningEditorField.tsx
@@ -15,8 +15,8 @@ import {
 import type { DataCombining, Instruction } from '@/api/__generated__'
 import { DataIdentifierReference } from '@/api/__generated__'
 import { SelectTopic } from '@/components/MQTT/EntityCreatableSelect'
+import { Topic } from '@/components/MQTT/EntityTag.tsx'
 import type { CombinerContext } from '@/modules/Mappings/types'
-
 import CombinedEntitySelect from './CombinedEntitySelect'
 import { CombinedSchemaLoader } from './CombinedSchemaLoader'
 import { AutoMapping } from './components/AutoMapping'
@@ -52,6 +52,8 @@ export const DataCombiningEditorField: FC<FieldProps<DataCombining, RJSFSchema, 
   const hasError = (field?: string[]) => {
     return Boolean(field?.length)
   }
+
+  const isDestinationAsset = formData?.destination.assetId
 
   return (
     <Grid templateColumns="1fr repeat(2, 1px) 1fr" rowGap={4} columnGap={6}>
@@ -135,20 +137,22 @@ export const DataCombiningEditorField: FC<FieldProps<DataCombining, RJSFSchema, 
       <GridItem colSpan={2} data-testid="combining-editor-destination-topic">
         <FormControl isInvalid={hasError(destinationErrors)}>
           <FormLabel>{destTopicOptions.title}</FormLabel>
-          <SelectTopic
-            isMulti={false}
-            isCreatable={true}
-            id="destination"
-            value={formData?.destination?.topic || null}
-            onChange={(topic) => {
-              if (!props.formData) return
+          {!isDestinationAsset && (
+            <SelectTopic
+              isMulti={false}
+              isCreatable={true}
+              id="destination"
+              value={formData?.destination?.topic || null}
+              onChange={(topic) => {
+                if (!props.formData) return
 
-              if (topic && typeof topic === 'string') props.onChange({ ...props.formData, destination: { topic } })
-              else if (!topic) props.onChange({ ...props.formData, destination: { topic: '' } })
-            }}
-          />
+                if (topic && typeof topic === 'string') props.onChange({ ...props.formData, destination: { topic } })
+                else if (!topic) props.onChange({ ...props.formData, destination: { topic: '' } })
+              }}
+            />
+          )}
+          {isDestinationAsset && <Topic tagTitle={formData?.destination?.topic} />}
           {!hasError(destinationErrors) && <FormHelperText>{destTopicOptions.description}</FormHelperText>}
-
           <FormErrorMessage>{destinationErrors}</FormErrorMessage>
         </FormControl>
       </GridItem>
@@ -193,6 +197,7 @@ export const DataCombiningEditorField: FC<FieldProps<DataCombining, RJSFSchema, 
       <GridItem colSpan={2} data-testid="combining-editor-destination-schema">
         <DestinationSchemaLoader
           isInvalid={hasError(destinationSchemaErrors)}
+          isEditable={!isDestinationAsset}
           title={destSchemaOptions.title}
           description={destSchemaOptions.description}
           formData={props.formData}

--- a/hivemq-edge-frontend/src/modules/Mappings/combiner/DataCombiningTableField.tsx
+++ b/hivemq-edge-frontend/src/modules/Mappings/combiner/DataCombiningTableField.tsx
@@ -150,6 +150,7 @@ export const DataCombiningTableField: FC<FieldProps<DataCombining[], RJSFSchema,
           )
         },
         footer: () => {
+          if (isAssetManager) return null
           return (
             <ButtonGroup isAttached size="sm">
               <IconButton

--- a/hivemq-edge-frontend/src/modules/Mappings/combiner/DataCombiningTableField.tsx
+++ b/hivemq-edge-frontend/src/modules/Mappings/combiner/DataCombiningTableField.tsx
@@ -3,23 +3,30 @@ import { useState, useMemo } from 'react'
 import { v4 as uuidv4 } from 'uuid'
 import { useTranslation } from 'react-i18next'
 import type { ColumnDef } from '@tanstack/react-table'
+import type { SingleValue } from 'chakra-react-select'
 import { ButtonGroup, HStack, Text } from '@chakra-ui/react'
 import type { FieldProps, RJSFSchema } from '@rjsf/utils'
 import { LuPencil, LuPlus, LuTrash } from 'react-icons/lu'
 
-import type { DataCombining } from '@/api/__generated__'
-import { DataIdentifierReference } from '@/api/__generated__'
+import type { DataCombining, ManagedAsset } from '@/api/__generated__'
+import { EntityType, DataIdentifierReference } from '@/api/__generated__'
 import PaginatedTable from '@/components/PaginatedTable/PaginatedTable'
 import IconButton from '@/components/Chakra/IconButton'
-import { PLCTag, Topic, TopicFilter } from '@/components/MQTT/EntityTag'
+import { AssetTag, PLCTag, Topic, TopicFilter } from '@/components/MQTT/EntityTag'
 
 import { PrimaryWrapper } from '@/modules/Mappings/combiner/components/PrimaryWrapper.tsx'
 import DataCombiningEditorDrawer from '@/modules/Mappings/combiner/DataCombiningEditorDrawer.tsx'
 import type { CombinerContext } from '@/modules/Mappings/types.ts'
+import ManagedAssetSelect from '@/modules/Pulse/components/assets/ManagedAssetSelect.tsx'
 
 export const DataCombiningTableField: FC<FieldProps<DataCombining[], RJSFSchema, CombinerContext>> = (props) => {
   const { t } = useTranslation()
   const [selectedItem, setSelectedItem] = useState<number | undefined>(undefined)
+
+  const isAssetManager = useMemo(() => {
+    // TODO[35769] This is a hack; PULSE_AGENT needs to be supported as a valid EntityType
+    return props.formContext?.entities?.some((e) => e.type === EntityType.DEVICE)
+  }, [props.formContext?.entities])
 
   const handleOnSubmit = (data: DataCombining | undefined) => {
     if (selectedItem === undefined) return
@@ -32,6 +39,21 @@ export const DataCombiningTableField: FC<FieldProps<DataCombining[], RJSFSchema,
       props.onChange(newValues)
     }
     setSelectedItem(undefined)
+  }
+
+  const handleAddAsset = (asset: SingleValue<ManagedAsset>) => {
+    if (!asset) return
+    const newMapping: DataCombining = {
+      id: uuidv4(),
+      sources: {
+        primary: { id: '', type: DataIdentifierReference.type.TAG },
+        tags: [],
+        topicFilters: [],
+      },
+      destination: { topic: asset.topic, assetId: asset.id, schema: asset.schema },
+      instructions: [],
+    }
+    props.onChange([...(props.formData || []), newMapping])
   }
 
   const displayColumns = useMemo<ColumnDef<DataCombining>[]>(() => {
@@ -55,7 +77,16 @@ export const DataCombiningTableField: FC<FieldProps<DataCombining[], RJSFSchema,
       props.onChange(newValues)
     }
 
+    const assetColumn: ColumnDef<DataCombining> = {
+      accessorKey: 'destination.assetId',
+      cell: (info) => {
+        if (info.row.original.destination.assetId) return <AssetTag tagTitle={info.row.original.destination.topic} />
+        return <Text>{t('combiner.unset')}</Text>
+      },
+    }
+
     return [
+      ...(isAssetManager ? [assetColumn] : []),
       {
         accessorKey: 'destination',
         cell: (info) => {
@@ -132,7 +163,7 @@ export const DataCombiningTableField: FC<FieldProps<DataCombining[], RJSFSchema,
         },
       },
     ]
-  }, [props, t])
+  }, [isAssetManager, props, t])
 
   return (
     <>
@@ -144,6 +175,8 @@ export const DataCombiningTableField: FC<FieldProps<DataCombining[], RJSFSchema,
         enablePaginationSizes={false}
         enableColumnFilters={false}
       />
+      {isAssetManager && <ManagedAssetSelect onChange={handleAddAsset} />}
+
       {selectedItem != undefined && props.formData?.[selectedItem] && (
         <DataCombiningEditorDrawer
           onClose={() => setSelectedItem(undefined)}

--- a/hivemq-edge-frontend/src/modules/Mappings/combiner/DestinationSchemaLoader.spec.cy.tsx
+++ b/hivemq-edge-frontend/src/modules/Mappings/combiner/DestinationSchemaLoader.spec.cy.tsx
@@ -26,6 +26,7 @@ describe('DestinationSchemaLoader', () => {
         formData={mockDataCombining}
         onChange={onChange}
         onChangeInstructions={onChangeInstructions}
+        isEditable
       />
     )
 
@@ -38,6 +39,24 @@ describe('DestinationSchemaLoader', () => {
     cy.get('[role="dialog"]#chakra-modal-destination-schema').should('not.exist')
     cy.getByTestId('combiner-destination-upload').click()
     cy.get('[role="dialog"]#chakra-modal-destination-schema').should('be.visible')
+  })
+
+  it('should render properly when non-editable', () => {
+    const onChange = cy.stub().as('onChange')
+    const onChangeInstructions = cy.stub().as('onChangeInstructions')
+    cy.mountWithProviders(
+      <DestinationSchemaLoader
+        formData={mockDataCombining}
+        onChange={onChange}
+        onChangeInstructions={onChangeInstructions}
+      />
+    )
+
+    cy.get('@onChange').should('have.not.been.called')
+
+    cy.getByTestId('combiner-destination-infer').should('not.exist')
+    cy.getByTestId('combiner-destination-upload').should('not.exist')
+    cy.getByTestId('combiner-destination-download').should('have.attr', 'aria-label', 'Download the schema')
   })
 
   it('should be accessible', () => {

--- a/hivemq-edge-frontend/src/modules/Mappings/combiner/DestinationSchemaLoader.tsx
+++ b/hivemq-edge-frontend/src/modules/Mappings/combiner/DestinationSchemaLoader.tsx
@@ -46,6 +46,7 @@ interface DestinationSchemaLoaderProps {
   title?: string
   description?: string
   isInvalid?: boolean
+  isEditable?: boolean
   formData?: DataCombining
   formContext?: CombinerContext
   onChange: (schema: string, v?: Instruction[]) => void
@@ -65,6 +66,7 @@ export const DestinationSchemaLoader: FC<DestinationSchemaLoaderProps> = ({
   title,
   description,
   isInvalid = false,
+  isEditable = false,
 }) => {
   const { t } = useTranslation()
   const { isOpen, onOpen, onClose } = useDisclosure()
@@ -123,20 +125,24 @@ export const DestinationSchemaLoader: FC<DestinationSchemaLoaderProps> = ({
           {title}
         </FormLabel>
         <ButtonGroup isAttached size="sm" variant="outline" justifyContent="flex-end" flexWrap="wrap" rowGap={2} mb={1}>
-          <IconButton
-            icon={<Icon as={RiAiGenerate} />}
-            data-testid="combiner-destination-infer"
-            isDisabled={!isTopicDefined}
-            onClick={() => handleSchemaEditor(EDITOR_MODE.INFERRER)}
-            aria-label={t('combiner.schema.schemaManager.action.infer')}
-          />
-          <IconButton
-            icon={<Icon as={LuUpload} />}
-            data-testid="combiner-destination-upload"
-            isDisabled={!isTopicDefined}
-            onClick={() => handleSchemaEditor(EDITOR_MODE.UPLOADER)}
-            aria-label={t('combiner.schema.schemaManager.action.upload')}
-          />
+          {isEditable && (
+            <IconButton
+              icon={<Icon as={RiAiGenerate} />}
+              data-testid="combiner-destination-infer"
+              isDisabled={!isTopicDefined}
+              onClick={() => handleSchemaEditor(EDITOR_MODE.INFERRER)}
+              aria-label={t('combiner.schema.schemaManager.action.infer')}
+            />
+          )}
+          {isEditable && (
+            <IconButton
+              icon={<Icon as={LuUpload} />}
+              data-testid="combiner-destination-upload"
+              isDisabled={!isTopicDefined}
+              onClick={() => handleSchemaEditor(EDITOR_MODE.UPLOADER)}
+              aria-label={t('combiner.schema.schemaManager.action.upload')}
+            />
+          )}
 
           <IconButton
             icon={<Icon as={LuDownload} />}

--- a/hivemq-edge-frontend/src/modules/Mappings/combiner/EntityRenderer.spec.cy.tsx
+++ b/hivemq-edge-frontend/src/modules/Mappings/combiner/EntityRenderer.spec.cy.tsx
@@ -33,7 +33,7 @@ describe('EntityRenderer', () => {
   })
 
   it('should render an bridge', () => {
-    cy.intercept('/api/v1/management/bridges/*', mockBridge).as('getBridges')
+    cy.intercept('/api/v1/management/bridges/*', mockBridge)
     const mockBridgeEntityReference: EntityReference = {
       type: EntityType.BRIDGE,
       id: mockBridgeId,

--- a/hivemq-edge-frontend/src/modules/Mappings/combiner/EntityRenderer.spec.cy.tsx
+++ b/hivemq-edge-frontend/src/modules/Mappings/combiner/EntityRenderer.spec.cy.tsx
@@ -1,5 +1,8 @@
 /// <reference types="cypress" />
 
+import type { EntityReference } from '@/api/__generated__'
+import { EntityType } from '@/api/__generated__'
+import { mockBridge, mockBridgeId } from '@/api/hooks/useGetBridges/__handlers__'
 import { EntityRenderer } from './EntityRenderer'
 import { mockEntityReference } from '@/api/hooks/useCombiners/__handlers__'
 import { mockAdapter, mockProtocolAdapter } from '@/api/hooks/useProtocolAdapters/__handlers__'
@@ -8,8 +11,6 @@ import { NodeTypes } from '@/modules/Workspace/types'
 describe('EntityRenderer', () => {
   beforeEach(() => {
     cy.viewport(800, 800)
-    cy.intercept('/api/v1/management/protocol-adapters/types', { items: [mockProtocolAdapter] })
-    cy.intercept('api/v1/management/protocol-adapters/adapters', { items: [mockAdapter] })
   })
 
   it('should render an error', () => {
@@ -22,12 +23,55 @@ describe('EntityRenderer', () => {
   })
 
   it('should render an adapter', () => {
+    cy.intercept('/api/v1/management/protocol-adapters/types', { items: [mockProtocolAdapter] })
+    cy.intercept('api/v1/management/protocol-adapters/adapters', { items: [mockAdapter] })
     cy.mountWithProviders(<EntityRenderer reference={mockEntityReference} />)
 
     cy.getByTestId('node-type-icon').should('exist').should('have.attr', 'data-nodeicon', NodeTypes.ADAPTER_NODE)
+    cy.getByTestId('node-name').should('have.text', 'my-adapter')
+    cy.getByTestId('node-description').should('have.text', 'Simulated Edge Device')
+  })
+
+  it('should render an bridge', () => {
+    cy.intercept('/api/v1/management/bridges/*', mockBridge).as('getBridges')
+    const mockBridgeEntityReference: EntityReference = {
+      type: EntityType.BRIDGE,
+      id: mockBridgeId,
+    }
+    cy.mountWithProviders(<EntityRenderer reference={mockBridgeEntityReference} />)
+
+    cy.getByTestId('node-type-icon').should('exist').should('have.attr', 'data-nodeicon', NodeTypes.BRIDGE_NODE)
+    cy.getByTestId('node-name').should('have.text', 'bridge-id-01')
+  })
+
+  it('should render an Edge broker', () => {
+    const mockEdgeEntityReference: EntityReference = {
+      type: EntityType.EDGE_BROKER,
+      id: mockBridgeId,
+    }
+    cy.mountWithProviders(<EntityRenderer reference={mockEdgeEntityReference} />)
+
+    cy.getByTestId('node-type-icon').should('exist').should('have.attr', 'data-nodeicon', NodeTypes.EDGE_NODE)
+    cy.getByTestId('node-name').should('have.text', 'HiveMQ Edge')
+    cy.getByTestId('node-description').should('have.text', 'Always added as the owner of the topic filters')
+  })
+
+  it('should render a Pulse Agent', () => {
+    const mockPulseEntityReference: EntityReference = {
+      // TODO[35769] This is a hack; PULSE_AGENT needs to be supported as a valid EntityType
+      type: EntityType.DEVICE,
+      id: mockBridgeId,
+    }
+    cy.mountWithProviders(<EntityRenderer reference={mockPulseEntityReference} />)
+
+    cy.getByTestId('node-type-icon').should('exist').should('have.attr', 'data-nodeicon', NodeTypes.PULSE_NODE)
+    cy.getByTestId('node-name').should('have.text', 'Pulse Agent')
+    cy.getByTestId('node-description').should('have.text', 'Assets managed by the Pulse Agent')
   })
 
   it('should be accessible', () => {
+    cy.intercept('/api/v1/management/protocol-adapters/types', { items: [mockProtocolAdapter] })
+    cy.intercept('api/v1/management/protocol-adapters/adapters', { items: [mockAdapter] })
     cy.injectAxe()
     cy.mountWithProviders(<EntityRenderer reference={mockEntityReference} />)
     cy.checkAccessibility()

--- a/hivemq-edge-frontend/src/modules/Mappings/combiner/EntityRenderer.tsx
+++ b/hivemq-edge-frontend/src/modules/Mappings/combiner/EntityRenderer.tsx
@@ -50,10 +50,23 @@ const BrokerEntityRenderer: FC<EntityRendererProps> = () => {
   )
 }
 
+const PulseAgentEntityRenderer: FC<EntityRendererProps> = () => {
+  const { t } = useTranslation()
+  return (
+    <NodeNameCard
+      type={NodeTypes.PULSE_NODE}
+      name={t('Pulse Client')}
+      description={t('Assets managed by the Pu;se Client')}
+    />
+  )
+}
+
 export const EntityRenderer: FC<EntityRendererProps> = ({ reference }) => {
   const { t } = useTranslation()
   if (reference.type === EntityType.BRIDGE) return <BridgeEntityRenderer reference={reference} />
   if (reference.type === EntityType.ADAPTER) return <AdapterEntityRenderer reference={reference} />
   if (reference.type === EntityType.EDGE_BROKER) return <BrokerEntityRenderer reference={reference} />
+  // TODO[35769] This is a hack; PULSE_AGENT needs to be supported as a valid EntityType
+  if (reference.type === EntityType.DEVICE) return <PulseAgentEntityRenderer reference={reference} />
   return <ErrorMessage message={t('combiner.error.noValidReference')} />
 }

--- a/hivemq-edge-frontend/src/modules/Mappings/combiner/EntityRenderer.tsx
+++ b/hivemq-edge-frontend/src/modules/Mappings/combiner/EntityRenderer.tsx
@@ -55,8 +55,8 @@ const PulseAgentEntityRenderer: FC<EntityRendererProps> = () => {
   return (
     <NodeNameCard
       type={NodeTypes.PULSE_NODE}
-      name={t('Pulse Client')}
-      description={t('Assets managed by the Pu;se Client')}
+      name={t('combiner.schema.sources.pulse.name')}
+      description={t('combiner.schema.sources.pulse.description')}
     />
   )
 }

--- a/hivemq-edge-frontend/src/modules/Mappings/combiner/EntityRenderer.tsx
+++ b/hivemq-edge-frontend/src/modules/Mappings/combiner/EntityRenderer.tsx
@@ -68,5 +68,6 @@ export const EntityRenderer: FC<EntityRendererProps> = ({ reference }) => {
   if (reference.type === EntityType.EDGE_BROKER) return <BrokerEntityRenderer reference={reference} />
   // TODO[35769] This is a hack; PULSE_AGENT needs to be supported as a valid EntityType
   if (reference.type === EntityType.DEVICE) return <PulseAgentEntityRenderer reference={reference} />
+  if (reference.type === EntityType.PULSE_AGENT) return <PulseAgentEntityRenderer reference={reference} />
   return <ErrorMessage message={t('combiner.error.noValidReference')} />
 }

--- a/hivemq-edge-frontend/src/modules/Pulse/components/activation/ActivationPanel.spec.cy.tsx
+++ b/hivemq-edge-frontend/src/modules/Pulse/components/activation/ActivationPanel.spec.cy.tsx
@@ -25,7 +25,7 @@ describe('ActivationPanel', () => {
     cy.getByTestId('pulse-activation-trigger').click()
     cy.get("[role='dialog']").should('be.visible')
     cy.get("[role='dialog']").within(() => {
-      cy.get('header').should('have.text', 'Pulse Client Activation')
+      cy.get('header').should('have.text', 'Pulse Agent Activation')
 
       cy.get('[role="alert"]')
         .should('have.attr', 'data-status', 'info')

--- a/hivemq-edge-frontend/src/modules/Pulse/components/activation/PulseStatusBadge.spec.cy.tsx
+++ b/hivemq-edge-frontend/src/modules/Pulse/components/activation/PulseStatusBadge.spec.cy.tsx
@@ -15,94 +15,94 @@ describe('PulseStatusBadge', () => {
   const testCases: TestStatus[] = [
     {
       status: {
-        activation: { status: PulseStatus.activationStatus.ERROR },
-        runtime: { status: PulseStatus.runtimeStatus.ERROR },
+        activation: PulseStatus.activation.ERROR,
+        runtime: PulseStatus.runtime.ERROR,
       },
       expected: 'Error',
     },
     {
       status: {
-        activation: { status: PulseStatus.activationStatus.ERROR },
-        runtime: { status: PulseStatus.runtimeStatus.CONNECTED },
+        activation: PulseStatus.activation.ERROR,
+        runtime: PulseStatus.runtime.CONNECTED,
       },
       expected: 'Error',
     },
     {
       status: {
-        activation: { status: PulseStatus.activationStatus.ERROR },
-        runtime: { status: PulseStatus.runtimeStatus.DISCONNECTED },
+        activation: PulseStatus.activation.ERROR,
+        runtime: PulseStatus.runtime.DISCONNECTED,
       },
       expected: 'Error',
     },
     {
       status: {
-        activation: { status: PulseStatus.activationStatus.ERROR },
-        runtime: { status: PulseStatus.runtimeStatus.ERROR },
+        activation: PulseStatus.activation.ERROR,
+        runtime: PulseStatus.runtime.ERROR,
       },
       expected: 'Error',
     },
 
     {
       status: {
-        activation: { status: PulseStatus.activationStatus.ACTIVATED },
-        runtime: { status: PulseStatus.runtimeStatus.ERROR },
+        activation: PulseStatus.activation.ACTIVATED,
+        runtime: PulseStatus.runtime.ERROR,
       },
       expected: 'Error',
     },
     {
       status: {
-        activation: { status: PulseStatus.activationStatus.ACTIVATED },
-        runtime: { status: PulseStatus.runtimeStatus.CONNECTED },
+        activation: PulseStatus.activation.ACTIVATED,
+        runtime: PulseStatus.runtime.CONNECTED,
       },
       expected: 'Connected',
     },
     {
       status: {
-        activation: { status: PulseStatus.activationStatus.ACTIVATED },
-        runtime: { status: PulseStatus.runtimeStatus.DISCONNECTED },
+        activation: PulseStatus.activation.ACTIVATED,
+        runtime: PulseStatus.runtime.DISCONNECTED,
       },
       expected: 'Disconnected',
     },
     {
       status: {
-        activation: { status: PulseStatus.activationStatus.ACTIVATED },
-        runtime: { status: PulseStatus.runtimeStatus.ERROR },
+        activation: PulseStatus.activation.ACTIVATED,
+        runtime: PulseStatus.runtime.ERROR,
       },
       expected: 'Error',
     },
 
     {
       status: {
-        activation: { status: PulseStatus.activationStatus.DEACTIVATED },
-        runtime: { status: PulseStatus.runtimeStatus.ERROR },
+        activation: PulseStatus.activation.DEACTIVATED,
+        runtime: PulseStatus.runtime.ERROR,
       },
       expected: 'Deactivated',
     },
     {
       status: {
-        activation: { status: PulseStatus.activationStatus.DEACTIVATED },
-        runtime: { status: PulseStatus.runtimeStatus.CONNECTED },
+        activation: PulseStatus.activation.DEACTIVATED,
+        runtime: PulseStatus.runtime.CONNECTED,
       },
       expected: 'Deactivated',
     },
     {
       status: {
-        activation: { status: PulseStatus.activationStatus.DEACTIVATED },
-        runtime: { status: PulseStatus.runtimeStatus.DISCONNECTED },
+        activation: PulseStatus.activation.DEACTIVATED,
+        runtime: PulseStatus.runtime.DISCONNECTED,
       },
       expected: 'Deactivated',
     },
     {
       status: {
-        activation: { status: PulseStatus.activationStatus.DEACTIVATED },
-        runtime: { status: PulseStatus.runtimeStatus.ERROR },
+        activation: PulseStatus.activation.DEACTIVATED,
+        runtime: PulseStatus.runtime.ERROR,
       },
       expected: 'Deactivated',
     },
   ]
 
   it.each(testCases)(
-    ({ status }) => `should render  ${status.activation.status} / ${status.runtime.status}`,
+    ({ status }) => `should render  ${status.activation} / ${status.runtime}`,
     ({ status, expected }) => {
       cy.injectAxe()
       cy.mountWithProviders(
@@ -115,11 +115,11 @@ describe('PulseStatusBadge', () => {
       cy.getByTestId('pulse-status').then((w) => {
         cy.wrap(w[0])
           .should('have.text', expected)
-          .should('have.attr', 'data-activation', status.activation.status)
-          .should('have.attr', 'data-runtime', status.runtime.status)
+          .should('have.attr', 'data-activation', status.activation)
+          .should('have.attr', 'data-runtime', status.runtime)
         cy.wrap(w[1])
-          .should('have.attr', 'data-activation', status.activation.status)
-          .should('have.attr', 'data-runtime', status.runtime.status)
+          .should('have.attr', 'data-activation', status.activation)
+          .should('have.attr', 'data-runtime', status.runtime)
       })
     }
   )

--- a/hivemq-edge-frontend/src/modules/Pulse/components/activation/PulseStatusBadge.tsx
+++ b/hivemq-edge-frontend/src/modules/Pulse/components/activation/PulseStatusBadge.tsx
@@ -5,15 +5,15 @@ import { Badge, SkeletonCircle } from '@chakra-ui/react'
 import { PulseStatus } from '@/api/__generated__'
 
 const statusMapping = {
-  [PulseStatus.activationStatus.ERROR]: { text: PulseStatus.activationStatus.ERROR, color: 'status.error' },
-  [PulseStatus.activationStatus.DEACTIVATED]: {
-    text: PulseStatus.activationStatus.DEACTIVATED,
+  [PulseStatus.activation.ERROR]: { text: PulseStatus.activation.ERROR, color: 'status.error' },
+  [PulseStatus.activation.DEACTIVATED]: {
+    text: PulseStatus.activation.DEACTIVATED,
     color: 'status.unknown',
   },
-  [PulseStatus.activationStatus.ACTIVATED]: { text: PulseStatus.activationStatus.ACTIVATED, color: 'status.connected' },
-  [PulseStatus.runtimeStatus.CONNECTED]: { text: PulseStatus.runtimeStatus.CONNECTED, color: 'status.connected' },
-  [PulseStatus.runtimeStatus.DISCONNECTED]: {
-    text: PulseStatus.runtimeStatus.DISCONNECTED,
+  [PulseStatus.activation.ACTIVATED]: { text: PulseStatus.activation.ACTIVATED, color: 'status.connected' },
+  [PulseStatus.runtime.CONNECTED]: { text: PulseStatus.runtime.CONNECTED, color: 'status.connected' },
+  [PulseStatus.runtime.DISCONNECTED]: {
+    text: PulseStatus.runtime.DISCONNECTED,
     color: 'status.disconnected',
   },
 } as const
@@ -27,11 +27,7 @@ const PulseStatusBadge: FC<ConnectionStatusBadgeProps> = ({ status, skeleton = f
   const { t } = useTranslation()
 
   const mapping =
-    statusMapping[
-      status.activation.status === PulseStatus.activationStatus.ACTIVATED
-        ? status.runtime.status
-        : status.activation.status
-    ]
+    statusMapping[status.activation === PulseStatus.activation.ACTIVATED ? status.runtime : status.activation]
 
   if (skeleton)
     return (
@@ -39,8 +35,8 @@ const PulseStatusBadge: FC<ConnectionStatusBadgeProps> = ({ status, skeleton = f
         size="8"
         startColor={`${mapping.color}.300`}
         endColor={`${mapping.color}.500`}
-        data-activation={status.activation.status}
-        data-runtime={status.runtime.status}
+        data-activation={status.activation}
+        data-runtime={status.runtime}
         data-testid="pulse-status"
       />
     )
@@ -51,8 +47,8 @@ const PulseStatusBadge: FC<ConnectionStatusBadgeProps> = ({ status, skeleton = f
       colorScheme={mapping.color}
       borderRadius={15}
       data-testid="pulse-status"
-      data-activation={status.activation.status}
-      data-runtime={status.runtime.status}
+      data-activation={status.activation}
+      data-runtime={status.runtime}
     >
       {t('pulse.status', { context: mapping.text })}
     </Badge>

--- a/hivemq-edge-frontend/src/modules/Pulse/components/assets/AssetsTable.spec.cy.tsx
+++ b/hivemq-edge-frontend/src/modules/Pulse/components/assets/AssetsTable.spec.cy.tsx
@@ -131,7 +131,7 @@ describe('AssetsTable', () => {
     cy.get('table tbody tr').should('have.length', 1)
   })
 
-  it.only('should render the summary version properly', () => {
+  it('should render the summary version properly', () => {
     cy.intercept('/api/v1/management/pulse/managed-assets', MOCK_PULSE_ASSET_LIST).as('getStatus')
 
     cy.mountWithProviders(<AssetsTable variant="summary" />)

--- a/hivemq-edge-frontend/src/modules/Pulse/components/assets/AssetsTable.spec.cy.tsx
+++ b/hivemq-edge-frontend/src/modules/Pulse/components/assets/AssetsTable.spec.cy.tsx
@@ -1,4 +1,6 @@
 import { WrapperTestRoute } from '@/__test-utils__/hooks/WrapperTestRoute.tsx'
+import { MOCK_COMBINER_ASSET } from '@/api/hooks/useCombiners/__handlers__'
+import { mockAdapter, mockProtocolAdapter } from '@/api/hooks/useProtocolAdapters/__handlers__'
 import { MOCK_PULSE_ASSET_LIST } from '@/api/hooks/usePulse/__handlers__'
 import AssetsTable from '@/modules/Pulse/components/assets/AssetsTable.tsx'
 import { NodeTypes, WorkspaceNavigationCommand } from '@/modules/Workspace/types.ts'
@@ -8,7 +10,7 @@ const cy_getHeader = (column: number) => cy.get('table thead th').eq(column)
 
 describe('AssetsTable', () => {
   beforeEach(() => {
-    cy.viewport(800, 600)
+    cy.viewport(1000, 600)
   })
 
   it('should render errors', () => {
@@ -41,6 +43,11 @@ describe('AssetsTable', () => {
 
   it('should render properly', () => {
     cy.intercept('/api/v1/management/pulse/managed-assets', MOCK_PULSE_ASSET_LIST).as('getStatus')
+    cy.intercept('GET', '/api/v1/management/combiners', {
+      items: [MOCK_COMBINER_ASSET],
+    })
+    cy.intercept('/api/v1/management/protocol-adapters/types', { items: [mockProtocolAdapter] })
+    cy.intercept('api/v1/management/protocol-adapters/adapters', { items: [mockAdapter] })
 
     cy.mountWithProviders(<AssetsTable />)
 
@@ -65,7 +72,7 @@ describe('AssetsTable', () => {
     cy_getCell(2, 2).should('have.text', 'test / topic / 2')
     cy_getCell(3, 3).should('have.text', 'Requires Remapping')
     cy_getCell(0, 4).should('have.text', '< unset >')
-    cy_getCell(3, 4).find('[data-testid="topic-wrapper"]').should('have.length', 2)
+    // cy_getCell(3, 4).find('[data-testid="topic-wrapper"]').should('have.length', 2)
     cy_getCell(0, 5).find('button').should('have.attr', 'aria-label', 'Actions')
 
     cy.get('table tbody tr').should('have.length', 4)
@@ -90,9 +97,9 @@ describe('AssetsTable', () => {
     cy.get('table tbody tr').find('mark').should('have.length', 0)
 
     // Test the column filters
-    cy_getHeader(4).within(() => {
-      cy.get('#react-select-mapping_sources-placeholder').should('have.text', 'Search... (4)')
-    })
+    // cy_getHeader(4).within(() => {
+    //   cy.get('#react-select-mapping_sources-placeholder').should('have.text', 'Search... (4)')
+    // })
 
     cy_getHeader(2).within(() => {
       cy.get('input#topic').type('test/topic/2{enter}')
@@ -106,9 +113,9 @@ describe('AssetsTable', () => {
     cy.get('table tbody tr').should('have.length', 1)
     cy.get('table tbody tr').find('mark').should('have.length', 0)
 
-    cy_getHeader(4).within(() => {
-      cy.get('#react-select-mapping_sources-placeholder').should('have.text', 'Search... (1)')
-    })
+    // cy_getHeader(4).within(() => {
+    //   cy.get('#react-select-mapping_sources-placeholder').should('have.text', 'Search... (1)')
+    // })
 
     cy_getHeader(3).within(() => {
       cy.getByAriaLabel('Clear selected options').click()
@@ -117,18 +124,18 @@ describe('AssetsTable', () => {
     cy.get('table tbody tr').should('have.length', 2)
     cy.get('table tbody tr').find('mark').should('have.length', 0)
 
-    cy_getHeader(4).within(() => {
-      cy.get('#react-select-mapping_sources-placeholder').should('have.text', 'Search... (2)')
-    })
+    // cy_getHeader(4).within(() => {
+    //   cy.get('#react-select-mapping_sources-placeholder').should('have.text', 'Search... (2)')
+    // })
 
     cy.getByTestId('table-filters-clearAll').click()
     cy.get('table tbody tr').should('have.length', 4)
     cy.get('table tbody tr').find('mark').should('have.length', 0)
 
-    cy_getHeader(4).within(() => {
-      cy.get('input#mapping_sources').type('test/4{enter}')
-    })
-    cy.get('table tbody tr').should('have.length', 1)
+    // cy_getHeader(4).within(() => {
+    //   cy.get('input#mapping_sources').type('test/4{enter}')
+    // })
+    // cy.get('table tbody tr').should('have.length', 1)
   })
 
   it('should render the summary version properly', () => {

--- a/hivemq-edge-frontend/src/modules/Pulse/components/assets/AssetsTable.tsx
+++ b/hivemq-edge-frontend/src/modules/Pulse/components/assets/AssetsTable.tsx
@@ -1,6 +1,6 @@
 import type { FC } from 'react'
 import { useMemo } from 'react'
-import { Box, Skeleton } from '@chakra-ui/react'
+import { Box, Skeleton, Text } from '@chakra-ui/react'
 import type { ColumnDef } from '@tanstack/react-table'
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
@@ -121,10 +121,11 @@ const AssetsTable: FC<AssetTableProps> = ({ variant = 'full' }) => {
         },
         header: t('pulse.assets.listing.column.sources'),
         cell: (info) => {
-          const { sources, primary } = info.row.original.mapping || {}
+          const mappingId = info.row.original.mapping?.mappingId
           return (
             <Skeleton isLoaded={!isLoading}>
-              <SourcesCell sources={sources} primary={primary} />
+              {!mappingId && <Text whiteSpace="nowrap">{t('pulse.assets.listing.sources.unset')}</Text>}
+              {mappingId && <SourcesCell mappingId={mappingId} isLoading={isLoading} />}
             </Skeleton>
           )
         },

--- a/hivemq-edge-frontend/src/modules/Pulse/components/assets/AssetsTable.tsx
+++ b/hivemq-edge-frontend/src/modules/Pulse/components/assets/AssetsTable.tsx
@@ -110,15 +110,15 @@ const AssetsTable: FC<AssetTableProps> = ({ variant = 'full' }) => {
         } as FilterMetadata,
       },
       {
-        accessorFn: (row) => row.mapping?.sources ?? [],
-        accessorKey: 'mapping.sources',
+        // accessorFn: (row) => row.mapping?.sources ?? [],
+        accessorKey: 'combiner.sources',
         enableGlobalFilter: false,
-        enableColumnFilter: true,
+        enableColumnFilter: false,
         enableSorting: false,
         sortingFn: undefined,
-        filterFn: (row, _, filterValue) => {
-          return !!row.original.mapping?.sources.some((e) => e.id === filterValue)
-        },
+        // filterFn: (row, _, filterValue) => {
+        //   return !!row.original.mapping?.sources.some((e) => e.id === filterValue)
+        // },
         header: t('pulse.assets.listing.column.sources'),
         cell: (info) => {
           const mappingId = info.row.original.mapping?.mappingId

--- a/hivemq-edge-frontend/src/modules/Pulse/components/assets/ManagedAssetSelect.tsx
+++ b/hivemq-edge-frontend/src/modules/Pulse/components/assets/ManagedAssetSelect.tsx
@@ -51,9 +51,7 @@ const ManagedAssetSelect: FC<ManagedAssetSelectProps> = ({ onChange, ...boxProps
           isClearable
           placeholder={t('pulse.assets.selector.placeholder')}
           isOptionDisabled={(e) =>
-            e.mapping?.status === AssetMapping.status.STREAMING ||
-            // TODO[Rubish] DO NOT MERGE
-            e.mapping?.mappingId === 'ff02efff-7b4c-4f8c-8bf6-74d0756283fb'
+            e.mapping?.status === AssetMapping.status.STREAMING
           }
           filterOption={createFilter({
             stringify: (option) => {

--- a/hivemq-edge-frontend/src/modules/Pulse/components/assets/ManagedAssetSelect.tsx
+++ b/hivemq-edge-frontend/src/modules/Pulse/components/assets/ManagedAssetSelect.tsx
@@ -1,0 +1,104 @@
+import type { FC } from 'react'
+import { useState, useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+import type { GroupBase, SingleValue } from 'chakra-react-select'
+import { createFilter, chakraComponents, Select } from 'chakra-react-select'
+import type { BoxProps } from '@chakra-ui/react'
+import { Box, HStack, Text, VStack } from '@chakra-ui/react'
+import { LuPlus } from 'react-icons/lu'
+
+import type { ManagedAsset } from '@/api/__generated__'
+import { AssetMapping } from '@/api/__generated__'
+import { useListManagedAssets } from '@/api/hooks/usePulse/useListManagedAssets.ts'
+import IconButton from '@/components/Chakra/IconButton.tsx'
+
+interface ManagedAssetSelectProps extends Omit<BoxProps, 'onChange'> {
+  onChange?: (value: SingleValue<ManagedAsset>) => void
+}
+
+const ManagedAssetSelect: FC<ManagedAssetSelectProps> = ({ onChange, ...boxProps }) => {
+  const { t } = useTranslation()
+  const { isLoading, data } = useListManagedAssets()
+
+  const filteredData = useMemo(() => {
+    return data?.items || []
+  }, [data?.items])
+
+  const [selection, setSelection] = useState<ManagedAsset | null>(null)
+
+  const handleAddAsset = () => {
+    onChange?.(selection)
+  }
+
+  return (
+    <HStack mt={3}>
+      <Box {...boxProps} flex={1}>
+        <Select<ManagedAsset, false, GroupBase<ManagedAsset>>
+          // inputId="react-select-asset-input"
+          id="combiner-asset-select"
+          instanceId="asset"
+          options={filteredData}
+          isLoading={isLoading}
+          value={filteredData.find((e) => e.id === selection?.id) || null}
+          noOptionsMessage={() => t('pulse.assets.selector.noAssetsFound')}
+          aria-label={t('pulse.assets.selector.aria-label')}
+          onChange={(newValue) => {
+            if (newValue) {
+              // onChange?.(newValue)
+              setSelection(newValue)
+            } else setSelection(null)
+          }}
+          isClearable
+          placeholder={t('pulse.assets.selector.placeholder')}
+          isOptionDisabled={(e) =>
+            e.mapping?.status === AssetMapping.status.STREAMING ||
+            // TODO[Rubish] DO NOT MERGE
+            e.mapping?.mappingId === 'ff02efff-7b4c-4f8c-8bf6-74d0756283fb'
+          }
+          filterOption={createFilter({
+            stringify: (option) => {
+              return `${option.data.name || ''}${option.data.description || ''}`
+            },
+          })}
+          components={{
+            SingleValue: (props) => {
+              return (
+                <chakraComponents.SingleValue {...props}>
+                  <Text>{props.data.name}</Text>
+                </chakraComponents.SingleValue>
+              )
+            },
+            Option: ({ children, ...props }) => {
+              return (
+                <chakraComponents.Option {...props} isSelected={Boolean(selection && props.data.id === selection?.id)}>
+                  <VStack gap={0} alignItems="stretch" w="100%">
+                    <HStack>
+                      <Box flex={1}>
+                        <Text flex={1}>{props.data.name}</Text>
+                      </Box>
+                      <Box flex={1}>
+                        <Text flex={1}>{props.data.mapping?.status}</Text>
+                      </Box>
+                    </HStack>
+                    <Text fontSize="sm" noOfLines={3} ml={4} lineHeight="normal" textAlign="justify">
+                      {props.data.description}
+                    </Text>
+                  </VStack>
+                </chakraComponents.Option>
+              )
+            },
+          }}
+        />
+      </Box>
+      <IconButton
+        data-testid="combiner-mappings-add-asset"
+        aria-label={t('pulse.assets.selector.add')}
+        icon={<LuPlus />}
+        onClick={handleAddAsset}
+        isDisabled={!selection}
+      />
+    </HStack>
+  )
+}
+
+export default ManagedAssetSelect

--- a/hivemq-edge-frontend/src/modules/Pulse/components/assets/ManagedAssetSelect.tsx
+++ b/hivemq-edge-frontend/src/modules/Pulse/components/assets/ManagedAssetSelect.tsx
@@ -50,9 +50,7 @@ const ManagedAssetSelect: FC<ManagedAssetSelectProps> = ({ onChange, ...boxProps
           }}
           isClearable
           placeholder={t('pulse.assets.selector.placeholder')}
-          isOptionDisabled={(e) =>
-            e.mapping?.status === AssetMapping.status.STREAMING
-          }
+          isOptionDisabled={(e) => e.mapping?.status === AssetMapping.status.STREAMING}
           filterOption={createFilter({
             stringify: (option) => {
               return `${option.data.name || ''}${option.data.description || ''}`

--- a/hivemq-edge-frontend/src/modules/Pulse/components/assets/SourcesCell.spec.cy.tsx
+++ b/hivemq-edge-frontend/src/modules/Pulse/components/assets/SourcesCell.spec.cy.tsx
@@ -19,9 +19,10 @@ describe('SourcesCell', () => {
 
     cy.getByTestId('loading-spinner').should('be.visible')
     cy.wait('@getCombiner')
+    cy.getByTestId('sources-container').children().should('have.length', 1)
     cy.getByTestId('sources-container').within(() => {
       cy.getByTestId('node-name').should('have.text', 'my-adapter')
-      cy.getByTestId('node-name').should('have.text', 'Pulse Agent')
+      cy.getByTestId('node-description').should('have.text', 'Simulated Edge Device')
     })
   })
 })

--- a/hivemq-edge-frontend/src/modules/Pulse/components/assets/SourcesCell.spec.cy.tsx
+++ b/hivemq-edge-frontend/src/modules/Pulse/components/assets/SourcesCell.spec.cy.tsx
@@ -1,0 +1,27 @@
+import { MOCK_COMBINER_ASSET } from '@/api/hooks/useCombiners/__handlers__'
+import { mockAdapter, mockProtocolAdapter } from '@/api/hooks/useProtocolAdapters/__handlers__'
+import SourcesCell from '@/modules/Pulse/components/assets/SourcesCell.tsx'
+
+describe('SourcesCell', () => {
+  it('should render errors', () => {
+    cy.intercept('GET', '/api/v1/management/combiners', { items: [MOCK_COMBINER_ASSET] })
+    cy.mountWithProviders(<SourcesCell mappingId="wrong-combiner" />)
+    cy.getByTestId('loading-spinner').should('be.visible')
+    cy.getByTestId('sources-error').should('have.text', '< not found >')
+  })
+
+  it('should render properly', () => {
+    cy.intercept('GET', '/api/v1/management/combiners', { items: [MOCK_COMBINER_ASSET] }).as('getCombiner')
+    cy.intercept('/api/v1/management/protocol-adapters/types', { items: [mockProtocolAdapter] })
+    cy.intercept('api/v1/management/protocol-adapters/adapters', { items: [mockAdapter] })
+
+    cy.mountWithProviders(<SourcesCell mappingId="ff02efff-7b4c-4f8c-8bf6-74d0756283fb" />)
+
+    cy.getByTestId('loading-spinner').should('be.visible')
+    cy.wait('@getCombiner')
+    cy.getByTestId('sources-container').within(() => {
+      cy.getByTestId('node-name').should('have.text', 'my-adapter')
+      cy.getByTestId('node-name').should('have.text', 'Pulse Agent')
+    })
+  })
+})

--- a/hivemq-edge-frontend/src/modules/Pulse/components/assets/SourcesCell.tsx
+++ b/hivemq-edge-frontend/src/modules/Pulse/components/assets/SourcesCell.tsx
@@ -1,40 +1,48 @@
 import type { FC } from 'react'
+import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
-import { HStack, Text } from '@chakra-ui/react'
+import { Text, VStack } from '@chakra-ui/react'
 
-import { DataIdentifierReference } from '@/api/__generated__'
-import { AssetTag, PLCTag, TopicFilter } from '@/components/MQTT/EntityTag.tsx'
-import { PrimaryWrapper } from '@/modules/Mappings/combiner/components/PrimaryWrapper.tsx'
+import type { Combiner, EntityReference } from '@/api/__generated__'
+import { EntityType } from '@/api/__generated__'
+import { useListCombiners } from '@/api/hooks/useCombiners'
+
 import { MAX_SOURCES_PER_ROW } from '@/modules/Pulse/utils/pagination-utils.ts'
+import { EntityRenderer } from '@/modules/Mappings/combiner/EntityRenderer.tsx'
 
 interface SourcesCellProps {
-  sources?: DataIdentifierReference[]
-  primary?: DataIdentifierReference
+  mappingId: string
+  isLoading: boolean
 }
 
-const SourcesCell: FC<SourcesCellProps> = ({ sources, primary }) => {
+const SourcesCell: FC<SourcesCellProps> = ({ mappingId }) => {
   const { t } = useTranslation()
+  const { data } = useListCombiners()
 
-  const isPrimary = (type: DataIdentifierReference.type, id: string): boolean => {
-    return primary?.type === type && primary?.id === id
-  }
+  const sources = useMemo<EntityReference[] | undefined>(() => {
+    const combinersList: Combiner[] = data?.items ?? []
 
-  if (!sources?.length) return <Text>{t('pulse.assets.listing.sources.unset')}</Text>
+    const ownerCombiner = combinersList.find((combiner) =>
+      combiner.mappings?.items.some((mapping) => {
+        return mapping.id === mappingId
+      })
+    )
+
+    if (!ownerCombiner?.sources.items.length) return undefined
+    return ownerCombiner.sources.items.filter((e) => e.type !== EntityType.PULSE_AGENT)
+  }, [data?.items, mappingId])
+
+  if (!sources) return <Text whiteSpace="nowrap">{t('pulse.assets.listing.sources.norFound')}</Text>
+
   const extraItems = Math.max(sources.length - MAX_SOURCES_PER_ROW, 0)
 
   return (
-    <HStack flexWrap="wrap">
-      {sources?.slice(0, MAX_SOURCES_PER_ROW).map((tag) => (
-        <PrimaryWrapper key={tag.id} isPrimary={isPrimary(tag.type, tag.id)}>
-          <>
-            {tag.type === DataIdentifierReference.type.TOPIC_FILTER && <TopicFilter tagTitle={tag.id} />}
-            {tag.type === DataIdentifierReference.type.TAG && <PLCTag tagTitle={tag.id} />}
-            {tag.type === DataIdentifierReference.type.PULSE_ASSET && <AssetTag tagTitle={tag.id} />}
-          </>
-        </PrimaryWrapper>
+    <VStack>
+      {sources.slice(0, MAX_SOURCES_PER_ROW).map((reference) => (
+        <EntityRenderer key={reference.id} reference={reference} />
       ))}
       {extraItems > 0 && <Text>{t('pulse.assets.listing.sources.more', { count: extraItems })}</Text>}
-    </HStack>
+    </VStack>
   )
 }
 

--- a/hivemq-edge-frontend/src/modules/Pulse/components/assets/SourcesCell.tsx
+++ b/hivemq-edge-frontend/src/modules/Pulse/components/assets/SourcesCell.tsx
@@ -6,18 +6,19 @@ import { Text, VStack } from '@chakra-ui/react'
 import type { Combiner, EntityReference } from '@/api/__generated__'
 import { EntityType } from '@/api/__generated__'
 import { useListCombiners } from '@/api/hooks/useCombiners'
+import LoaderSpinner from '@/components/Chakra/LoaderSpinner.tsx'
 
 import { MAX_SOURCES_PER_ROW } from '@/modules/Pulse/utils/pagination-utils.ts'
 import { EntityRenderer } from '@/modules/Mappings/combiner/EntityRenderer.tsx'
 
 interface SourcesCellProps {
   mappingId: string
-  isLoading: boolean
+  isLoading?: boolean
 }
 
 const SourcesCell: FC<SourcesCellProps> = ({ mappingId }) => {
   const { t } = useTranslation()
-  const { data } = useListCombiners()
+  const { data, isLoading: isCombinersLoading } = useListCombiners()
 
   const sources = useMemo<EntityReference[] | undefined>(() => {
     const combinersList: Combiner[] = data?.items ?? []
@@ -32,12 +33,18 @@ const SourcesCell: FC<SourcesCellProps> = ({ mappingId }) => {
     return ownerCombiner.sources.items.filter((e) => e.type !== EntityType.PULSE_AGENT)
   }, [data?.items, mappingId])
 
-  if (!sources) return <Text whiteSpace="nowrap">{t('pulse.assets.listing.sources.norFound')}</Text>
+  if (isCombinersLoading) return <LoaderSpinner />
+  if (!sources)
+    return (
+      <Text data-testid="sources-error" whiteSpace="nowrap">
+        {t('pulse.assets.listing.sources.norFound')}
+      </Text>
+    )
 
   const extraItems = Math.max(sources.length - MAX_SOURCES_PER_ROW, 0)
 
   return (
-    <VStack>
+    <VStack data-testid="sources-container">
       {sources.slice(0, MAX_SOURCES_PER_ROW).map((reference) => (
         <EntityRenderer key={reference.id} reference={reference} />
       ))}

--- a/hivemq-edge-frontend/src/modules/Pulse/hooks/useListManagedAssetMappings.spec.ts
+++ b/hivemq-edge-frontend/src/modules/Pulse/hooks/useListManagedAssetMappings.spec.ts
@@ -1,0 +1,148 @@
+import { http, HttpResponse } from 'msw'
+import { expect } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+
+import { server } from '@/__test-utils__/msw/mockServer.ts'
+import { SimpleWrapper as wrapper } from '@/__test-utils__/hooks/SimpleWrapper.tsx'
+import type { ApiError } from '@/api/__generated__'
+import { handlers as combinerHandlers, handlerCombinerAssets } from '@/api/hooks/useCombiners/__handlers__'
+import { handlers as pulseHandlers } from '@/api/hooks/usePulse/__handlers__'
+
+import type { ManagedAssetExtended } from '@/modules/Pulse/types.ts'
+import { useCombinedAssetsAndCombiners } from '@/modules/Pulse/hooks/useListManagedAssetMappings.ts'
+
+describe('useCombinedAssetsAndCombiners', () => {
+  afterEach(() => {
+    server.resetHandlers()
+  })
+
+  it('should handle errors', async () => {
+    server.use(
+      http.get('*/management/combiners', () => {
+        return HttpResponse.json({ error: 'combiners' }, { status: 500 })
+      }),
+      http.get('**/management/pulse/managed-assets', () => {
+        return HttpResponse.json({ error: 'managed-assets' }, { status: 500 })
+      })
+    )
+
+    const { result } = renderHook(() => useCombinedAssetsAndCombiners(), { wrapper })
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBeFalsy()
+      expect(result.current.isError).toBeTruthy()
+    })
+
+    expect(result.current.data).toStrictEqual<ManagedAssetExtended[] | undefined>(undefined)
+    const { status, statusText, body } = result.current.error as ApiError
+    expect(status).toStrictEqual(500)
+    expect(statusText).toStrictEqual('Internal Server Error')
+    expect(body).toStrictEqual({ error: 'managed-assets' })
+  })
+
+  it('should handle errors', async () => {
+    server.use(
+      http.get('*/management/combiners', () => {
+        return HttpResponse.json({ error: 'combiners' }, { status: 500 })
+      }),
+      ...pulseHandlers
+    )
+
+    const { result } = renderHook(() => useCombinedAssetsAndCombiners(), { wrapper })
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBeFalsy()
+      expect(result.current.isError).toBeTruthy()
+    })
+
+    expect(result.current.data).toStrictEqual<ManagedAssetExtended[] | undefined>(undefined)
+    const { status, statusText, body } = result.current.error as ApiError
+    expect(status).toStrictEqual(500)
+    expect(statusText).toStrictEqual('Internal Server Error')
+    expect(body).toStrictEqual({ error: 'combiners' })
+  })
+
+  it('should handle errors', async () => {
+    server.use(
+      ...combinerHandlers,
+      http.get('**/management/pulse/managed-assets', () => {
+        return HttpResponse.json({ error: 'managed-assets' }, { status: 500 })
+      })
+    )
+
+    const { result } = renderHook(() => useCombinedAssetsAndCombiners(), { wrapper })
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBeFalsy()
+      expect(result.current.isError).toBeTruthy()
+    })
+
+    expect(result.current.data).toStrictEqual<ManagedAssetExtended[] | undefined>(undefined)
+    const { status, statusText, body } = result.current.error as ApiError
+    expect(status).toStrictEqual(500)
+    expect(statusText).toStrictEqual('Internal Server Error')
+    expect(body).toStrictEqual({ error: 'managed-assets' })
+  })
+
+  it('should load the data', async () => {
+    server.use(...handlerCombinerAssets, ...pulseHandlers)
+
+    const { result } = renderHook(() => useCombinedAssetsAndCombiners(), { wrapper })
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBeFalsy()
+      expect(result.current.isSuccess).toBeTruthy()
+    })
+
+    expect(result.current.data).toStrictEqual<ManagedAssetExtended[]>(
+      expect.arrayContaining([
+        {
+          asset: expect.objectContaining({
+            id: '3b028f58-f949-4de1-9b8b-c1a35b1643a4',
+            name: 'Test asset',
+          }),
+          mapping: undefined,
+        },
+        {
+          asset: expect.objectContaining({
+            id: '3b028f58-f949-4de1-9b8b-c1a35b1643a5',
+            name: 'Test mapped asset',
+            mapping: {
+              mappingId: 'ff02efff-7b4c-4f8c-8bf6-74d0756283fb',
+              status: 'STREAMING',
+            },
+          }),
+          mapping: expect.objectContaining({
+            id: 'ff02efff-7b4c-4f8c-8bf6-74d0756283fb',
+            destination: {
+              topic: 'my/first/topic',
+            },
+          }),
+        },
+        {
+          asset: expect.objectContaining({
+            id: '3b028f58-f949-4de1-9b8b-c1a35b1643a9',
+            name: 'Test other asset',
+            mapping: {
+              mappingId: 'ff02efff-7b4c-4f8c-8bf6-74d0756283fb',
+              status: 'REQUIRES_REMAPPING',
+            },
+          }),
+          mapping: expect.objectContaining({
+            id: 'ff02efff-7b4c-4f8c-8bf6-74d0756283fb',
+            destination: {
+              topic: 'my/first/topic',
+            },
+          }),
+        },
+        {
+          asset: expect.objectContaining({
+            id: '3b028f58-f949-4de1-9b8b-c1a35b1643a7',
+            name: 'Almost the same asset',
+          }),
+          mapping: undefined,
+        },
+      ])
+    )
+  })
+})

--- a/hivemq-edge-frontend/src/modules/Pulse/hooks/useListManagedAssetMappings.ts
+++ b/hivemq-edge-frontend/src/modules/Pulse/hooks/useListManagedAssetMappings.ts
@@ -27,7 +27,6 @@ export const useCombinedAssetsAndCombiners = (): PartialUseQueryResult => {
     const combinersList: Combiner[] = combiners.data?.items ?? []
 
     const allMappings: DataCombining[] = combinersList.flatMap((combiner) => combiner.mappings.items ?? [])
-    console.log('XXXXXX', allMappings)
 
     return assets.map<ManagedAssetExtended>((asset) => {
       const mapping = asset.mapping?.mappingId ? allMappings.find((m) => m.id === asset.mapping?.mappingId) : undefined

--- a/hivemq-edge-frontend/src/modules/Pulse/hooks/useListManagedAssetMappings.ts
+++ b/hivemq-edge-frontend/src/modules/Pulse/hooks/useListManagedAssetMappings.ts
@@ -1,0 +1,49 @@
+import { useMemo } from 'react'
+import type { UseQueryResult } from '@tanstack/react-query'
+
+import type { ApiError, Combiner, DataCombining, ManagedAsset } from '@/api/__generated__'
+import { useListCombiners } from '@/api/hooks/useCombiners/useListCombiners'
+import { useListManagedAssets } from '@/api/hooks/usePulse/useListManagedAssets.ts'
+import type { ManagedAssetExtended } from '@/modules/Pulse/types.ts'
+
+type PartialUseQueryResult = Pick<
+  UseQueryResult<ManagedAssetExtended[], ApiError>,
+  'isError' | 'error' | 'isSuccess' | 'isLoading' | 'data'
+>
+
+export const useCombinedAssetsAndCombiners = (): PartialUseQueryResult => {
+  const managedAssets = useListManagedAssets()
+  const combiners = useListCombiners()
+
+  const isLoading = managedAssets.isLoading || combiners.isLoading
+  const isError = managedAssets.isError || combiners.isError
+  const error = managedAssets.error || combiners.error
+  const isSuccess = managedAssets.isSuccess && combiners.isSuccess
+
+  const data = useMemo<ManagedAssetExtended[] | undefined>(() => {
+    if (!isSuccess) return undefined
+
+    const assets: ManagedAsset[] = managedAssets.data?.items ?? []
+    const combinersList: Combiner[] = combiners.data?.items ?? []
+
+    const allMappings: DataCombining[] = combinersList.flatMap((combiner) => combiner.mappings.items ?? [])
+    console.log('XXXXXX', allMappings)
+
+    return assets.map<ManagedAssetExtended>((asset) => {
+      const mapping = asset.mapping?.mappingId ? allMappings.find((m) => m.id === asset.mapping?.mappingId) : undefined
+
+      return {
+        asset,
+        mapping,
+      }
+    })
+  }, [combiners.data?.items, isSuccess, managedAssets.data?.items])
+
+  return {
+    isLoading,
+    isError,
+    error,
+    isSuccess,
+    data,
+  }
+}

--- a/hivemq-edge-frontend/src/modules/Pulse/types.ts
+++ b/hivemq-edge-frontend/src/modules/Pulse/types.ts
@@ -1,0 +1,8 @@
+import type { DataCombining, ManagedAsset } from '@/api/__generated__'
+
+export interface ManagedAssetExtended {
+  asset: ManagedAsset
+  // combinerId?: Combiner
+  combinerId?: string
+  mapping?: DataCombining
+}

--- a/hivemq-edge-frontend/src/modules/Workspace/components/ReactFlowWrapper.tsx
+++ b/hivemq-edge-frontend/src/modules/Workspace/components/ReactFlowWrapper.tsx
@@ -27,7 +27,6 @@ import {
   NodeDevice,
   NodeCombiner,
   NodePulse,
-  NodeAssets,
 } from '@/modules/Workspace/components/nodes'
 import { getGluedPosition, gluedNodeDefinition } from '@/modules/Workspace/utils/nodes-utils.ts'
 import { proOptions } from '@/components/react-flow/react-flow.utils.ts'
@@ -47,7 +46,6 @@ const ReactFlowWrapper = () => {
       [NodeTypes.DEVICE_NODE]: NodeDevice,
       [NodeTypes.COMBINER_NODE]: NodeCombiner,
       [NodeTypes.PULSE_NODE]: NodePulse,
-      [NodeTypes.ASSETS_NODE]: NodeAssets,
     }),
     []
   )

--- a/hivemq-edge-frontend/src/modules/Workspace/components/controls/NodePanelController.tsx
+++ b/hivemq-edge-frontend/src/modules/Workspace/components/controls/NodePanelController.tsx
@@ -140,13 +140,7 @@ const NodePanelController: FC = () => {
         />
       )}
       {selectedAssets && (
-        <PulsePropertyDrawer
-          nodeId={nodeId}
-          selectedNode={selectedAssets}
-          isOpen={isOpen}
-          onClose={handleClose}
-          onEditEntity={handleEditEntity}
-        />
+        <PulsePropertyDrawer nodeId={nodeId} selectedNode={selectedAssets} isOpen={isOpen} onClose={handleClose} />
       )}
     </Suspense>
   )

--- a/hivemq-edge-frontend/src/modules/Workspace/components/drawers/DevicePropertyDrawer.tsx
+++ b/hivemq-edge-frontend/src/modules/Workspace/components/drawers/DevicePropertyDrawer.tsx
@@ -15,13 +15,12 @@ import {
   Text,
 } from '@chakra-ui/react'
 
-import type { Adapter } from '@/api/__generated__'
 import { useGetAdapterTypes } from '@/api/hooks/useProtocolAdapters/useGetAdapterTypes.ts'
 import LoaderSpinner from '@/components/Chakra/LoaderSpinner.tsx'
 import ErrorMessage from '@/components/ErrorMessage.tsx'
 import DeviceTagList from '@/modules/Device/components/DeviceTagList.tsx'
 import useWorkspaceStore from '@/modules/Workspace/hooks/useWorkspaceStore.ts'
-import type { DeviceMetadata, NodeTypes } from '@/modules/Workspace/types.ts'
+import type { DeviceMetadata, NodeAdapterType, NodeTypes } from '@/modules/Workspace/types.ts'
 import NodeNameCard from '@/modules/Workspace/components/parts/NodeNameCard.tsx'
 
 interface DevicePropertyDrawerProps {
@@ -37,9 +36,9 @@ const DevicePropertyDrawer: FC<DevicePropertyDrawerProps> = ({ isOpen, selectedN
   const { nodes, edges } = useWorkspaceStore()
   const { data, isError, isLoading } = useGetAdapterTypes()
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const incomers = getIncomers<Adapter, any>(selectedNode, nodes, edges)
-  const adapter = incomers.find(Boolean)?.data
+  const incomers = getIncomers(selectedNode, nodes, edges)
+  const adapterNode = incomers.find(Boolean) as NodeAdapterType | undefined
+  const adapter = adapterNode?.data
   const protocol = data?.items?.find((e) => e.id === adapter?.type)
 
   if (isLoading) return <LoaderSpinner />

--- a/hivemq-edge-frontend/src/modules/Workspace/components/drawers/PulsePropertyDrawer.spec.cy.tsx
+++ b/hivemq-edge-frontend/src/modules/Workspace/components/drawers/PulsePropertyDrawer.spec.cy.tsx
@@ -26,7 +26,7 @@ describe('PulsePropertyDrawer', () => {
       <PulsePropertyDrawer nodeId="pulseId" selectedNode={mockNode} isOpen={true} onClose={onClose} />
     )
 
-    cy.get('header').should('contain.text', 'Pulse Client Overview')
+    cy.get('header').should('contain.text', 'Pulse Agent Overview')
     cy.get('h2').should('contain.text', 'Pulse Assets are not yet available for HiveMQ Edge.')
   })
 
@@ -45,7 +45,7 @@ describe('PulsePropertyDrawer', () => {
     cy.getByAriaLabel('Close').click()
     cy.get('@onClose').should('have.been.calledOnce')
 
-    cy.get('header').should('contain.text', 'Pulse Client Overview')
+    cy.get('header').should('contain.text', 'Pulse Agent Overview')
     cy.getByTestId('table-container').within(() => {
       // check the table is in "summary" mode
       cy.get('table thead tr th').should('have.length', 4)

--- a/hivemq-edge-frontend/src/modules/Workspace/components/nodes/ContextualToolbar.tsx
+++ b/hivemq-edge-frontend/src/modules/Workspace/components/nodes/ContextualToolbar.tsx
@@ -62,7 +62,7 @@ const ContextualToolbar: FC<ContextualToolbarProps> = ({
   }, [nodes])
 
   const topSelectedNode = useMemo(() => {
-    const [firstNode] = selectedNodes.sort((a, b) => {
+    const [firstNode] = selectedNodes.toSorted((a, b) => {
       return a.position.y - b.position.y < 0 ? -1 : 1
     })
 

--- a/hivemq-edge-frontend/src/modules/Workspace/components/nodes/NodeCombiner.tsx
+++ b/hivemq-edge-frontend/src/modules/Workspace/components/nodes/NodeCombiner.tsx
@@ -4,7 +4,9 @@ import type { NodeProps } from '@xyflow/react'
 import { Handle, Position } from '@xyflow/react'
 import { Icon, Text, useColorModeValue, VStack } from '@chakra-ui/react'
 
-import { HqCombiner } from '@/components/Icons'
+import { EntityType } from '@/api/__generated__'
+
+import { HqAssets, HqCombiner } from '@/components/Icons'
 import { SelectEntityType } from '@/components/MQTT/types'
 import NodeWrapper from '@/modules/Workspace/components/parts/NodeWrapper.tsx'
 import { useContextMenu } from '@/modules/Workspace/hooks/useContextMenu.ts'
@@ -20,6 +22,11 @@ const NodeCombiner: FC<NodeProps<NodeCombinerType>> = ({ id, selected, data, dra
   const topics = useMemo(() => {
     return data.mappings.items.map((e) => e.destination.topic as string)
   }, [data.mappings.items])
+
+  const isAssetManager = useMemo(() => {
+    // TODO[35769] This is a hack; PULSE_AGENT needs to be supported as a valid EntityType
+    return data.sources.items.some((e) => e.type === EntityType.DEVICE)
+  }, [data.sources.items])
 
   return (
     <>
@@ -46,7 +53,7 @@ const NodeCombiner: FC<NodeProps<NodeCombinerType>> = ({ id, selected, data, dra
           borderBottomLeftRadius={30}
           justifyContent="center"
         >
-          <Icon as={HqCombiner} boxSize={10} />
+          <Icon as={isAssetManager ? HqAssets : HqCombiner} boxSize={10} />
         </VStack>
         <VStack p={2} h="100%" justifyContent="space-evenly">
           <Text data-testid="combiner-description" noOfLines={1}>

--- a/hivemq-edge-frontend/src/modules/Workspace/components/nodes/NodePulse.spec.cy.tsx
+++ b/hivemq-edge-frontend/src/modules/Workspace/components/nodes/NodePulse.spec.cy.tsx
@@ -22,7 +22,7 @@ describe('NodePulse', () => {
     cy.mountWithProviders(mockReactFlow(<NodePulse {...MOCK_NODE_PULSE} />))
     cy.getByTestId('pulse-client-description').should('have.text', 'Pulse Client')
     cy.getByTestId('pulse-client-capabilities').within(() => {
-      cy.get('svg').should('have.attr', 'data-type', PulseStatus.activationStatus.ACTIVATED)
+      cy.get('svg').should('have.attr', 'data-type', PulseStatus.activation.ACTIVATED)
       cy.getByTestId('pulse-client-unmapped').should('have.text', 1)
       cy.getByTestId('pulse-client-mapped').should('have.text', 3)
     })
@@ -38,7 +38,7 @@ describe('NodePulse', () => {
     cy.intercept('/api/v1/frontend/capabilities', { items: [] })
     cy.mountWithProviders(mockReactFlow(<NodePulse {...MOCK_NODE_PULSE} />))
     cy.getByTestId('pulse-client-capabilities').within(() => {
-      cy.get('svg').should('have.attr', 'data-type', PulseStatus.activationStatus.DEACTIVATED)
+      cy.get('svg').should('have.attr', 'data-type', PulseStatus.activation.DEACTIVATED)
     })
   })
 

--- a/hivemq-edge-frontend/src/modules/Workspace/components/nodes/NodePulse.spec.cy.tsx
+++ b/hivemq-edge-frontend/src/modules/Workspace/components/nodes/NodePulse.spec.cy.tsx
@@ -16,7 +16,7 @@ describe('NodePulse', () => {
     cy.intercept('/api/v1/management/protocol-adapters/types', { statusCode: 202, log: false })
     cy.intercept('/api/v1/management/combiners', { statusCode: 202, log: false })
     cy.intercept('/api/v1/frontend/capabilities', MOCK_CAPABILITIES)
-    cy.intercept('/api/v1/management/pulse/managed-assets', MOCK_PULSE_ASSET_LIST).as('getStatus')
+    cy.intercept('/api/v1/management/pulse/managed-assets', MOCK_PULSE_ASSET_LIST)
   })
 
   it('should render properly', () => {

--- a/hivemq-edge-frontend/src/modules/Workspace/components/nodes/NodePulse.spec.cy.tsx
+++ b/hivemq-edge-frontend/src/modules/Workspace/components/nodes/NodePulse.spec.cy.tsx
@@ -7,6 +7,7 @@ import { MOCK_PULSE_ASSET_LIST } from '@/api/hooks/usePulse/__handlers__'
 
 import NodePulse from '@/modules/Workspace/components/nodes/NodePulse.tsx'
 import { NodeTypes } from '@/modules/Workspace/types.ts'
+import { NODE_PULSE_AGENT_DEFAULT_ID } from '@/modules/Workspace/utils/nodes-utils.ts'
 
 describe('NodePulse', () => {
   beforeEach(() => {
@@ -20,7 +21,7 @@ describe('NodePulse', () => {
 
   it('should render properly', () => {
     cy.mountWithProviders(mockReactFlow(<NodePulse {...MOCK_NODE_PULSE} />))
-    cy.getByTestId('pulse-client-description').should('have.text', 'Pulse Client')
+    cy.getByTestId('pulse-client-description').should('have.text', 'Pulse Agent')
     cy.getByTestId('pulse-client-capabilities').within(() => {
       cy.get('svg').should('have.attr', 'data-type', PulseStatus.activation.ACTIVATED)
       cy.getByTestId('pulse-client-unmapped').should('have.text', 1)
@@ -49,7 +50,9 @@ describe('NodePulse', () => {
         nodeTypes={{ [NodeTypes.PULSE_NODE]: NodePulse }}
       />
     )
-    cy.get('[role="toolbar"][data-id="idPulseClient"]').within(() => {
+
+    cy.get('[role="toolbar"]').should('have.attr', 'data-id', NODE_PULSE_AGENT_DEFAULT_ID)
+    cy.get('[role="toolbar"]').within(() => {
       cy.getByTestId('toolbar-title').should('have.text', 'my pulse client')
       cy.getByTestId('node-group-toolbar-panel').should('have.attr', 'aria-label', 'Open the overview panel')
     })

--- a/hivemq-edge-frontend/src/modules/Workspace/components/nodes/NodePulse.tsx
+++ b/hivemq-edge-frontend/src/modules/Workspace/components/nodes/NodePulse.tsx
@@ -39,9 +39,9 @@ const NodePulse: FC<NodeProps<NodePulseType>> = ({ id, data, selected, dragging 
 
   const { onContextMenu } = useContextMenu(id, selected, `/workspace/node/pulse-assets`)
 
-  const pulseStatus: PulseStatus.activationStatus = hasPulseCapability
-    ? PulseStatus.activationStatus.ACTIVATED
-    : PulseStatus.activationStatus.DEACTIVATED
+  const pulseStatus: PulseStatus.activation = hasPulseCapability
+    ? PulseStatus.activation.ACTIVATED
+    : PulseStatus.activation.DEACTIVATED
 
   return (
     <>

--- a/hivemq-edge-frontend/src/modules/Workspace/components/parts/NodeNameCard.spec.cy.tsx
+++ b/hivemq-edge-frontend/src/modules/Workspace/components/parts/NodeNameCard.spec.cy.tsx
@@ -59,4 +59,22 @@ describe('NodeNameCard', () => {
     cy.getByTestId('node-name').should('not.exist')
     cy.getByTestId('node-description').should('not.exist')
   })
+
+  it('should render the pulse agent properly', () => {
+    cy.mountWithProviders(<NodeNameCard type={NodeTypes.PULSE_NODE} name="Pulse Agent" description="the description" />)
+
+    cy.getByTestId('node-type-icon').should('exist').should('have.attr', 'data-nodeicon', NodeTypes.PULSE_NODE)
+    cy.getByTestId('node-name').should('have.text', 'Pulse Agent')
+    cy.getByTestId('node-description').should('have.text', 'the description')
+  })
+
+  it('should render the assets properly', () => {
+    cy.mountWithProviders(
+      <NodeNameCard type={NodeTypes.ASSETS_NODE} name="Asset Mapper" description="the description" />
+    )
+
+    cy.getByTestId('node-type-icon').should('exist').should('have.attr', 'data-nodeicon', NodeTypes.ASSETS_NODE)
+    cy.getByTestId('node-name').should('have.text', 'Asset Mapper')
+    cy.getByTestId('node-description').should('have.text', 'the description')
+  })
 })

--- a/hivemq-edge-frontend/src/modules/Workspace/components/parts/NodeNameCard.tsx
+++ b/hivemq-edge-frontend/src/modules/Workspace/components/parts/NodeNameCard.tsx
@@ -4,7 +4,7 @@ import { Card, CardBody, HStack, Icon, Image, StackDivider, Text, VStack } from 
 import { PiBridgeThin } from 'react-icons/pi'
 import { GrStatusUnknown } from 'react-icons/gr'
 import { ImMakeGroup } from 'react-icons/im'
-import { HqAssets, HqCombiner } from '@/components/Icons'
+import { HqCombiner, PulseAgentIcon, HqAssets } from '@/components/Icons'
 
 import edgeLogo from '@/assets/edge/05-icon-industrial-hivemq-edge.svg'
 
@@ -43,8 +43,10 @@ const NodeNameCard: FC<NodeNameCardProps> = ({ name, type, description, icon }) 
         )
       case NodeTypes.COMBINER_NODE:
         return <Icon data-testid="node-type-icon" data-nodeicon={type} as={HqCombiner} fontSize="24px" />
-      case NodeTypes.PULSE_NODE:
+      case NodeTypes.ASSETS_NODE:
         return <Icon data-testid="node-type-icon" data-nodeicon={type} as={HqAssets} fontSize="24px" />
+      case NodeTypes.PULSE_NODE:
+        return <Icon data-testid="node-type-icon" data-nodeicon={type} as={PulseAgentIcon} fontSize="24px" />
 
       case NodeTypes.DEVICE_NODE:
         return (

--- a/hivemq-edge-frontend/src/modules/Workspace/components/parts/NodeNameCard.tsx
+++ b/hivemq-edge-frontend/src/modules/Workspace/components/parts/NodeNameCard.tsx
@@ -4,7 +4,7 @@ import { Card, CardBody, HStack, Icon, Image, StackDivider, Text, VStack } from 
 import { PiBridgeThin } from 'react-icons/pi'
 import { GrStatusUnknown } from 'react-icons/gr'
 import { ImMakeGroup } from 'react-icons/im'
-import { HqCombiner } from '@/components/Icons'
+import { HqAssets, HqCombiner } from '@/components/Icons'
 
 import edgeLogo from '@/assets/edge/05-icon-industrial-hivemq-edge.svg'
 
@@ -43,6 +43,8 @@ const NodeNameCard: FC<NodeNameCardProps> = ({ name, type, description, icon }) 
         )
       case NodeTypes.COMBINER_NODE:
         return <Icon data-testid="node-type-icon" data-nodeicon={type} as={HqCombiner} fontSize="24px" />
+      case NodeTypes.PULSE_NODE:
+        return <Icon data-testid="node-type-icon" data-nodeicon={type} as={HqAssets} fontSize="24px" />
 
       case NodeTypes.DEVICE_NODE:
         return (

--- a/hivemq-edge-frontend/src/modules/Workspace/hooks/useGetFlowElements.spec.ts
+++ b/hivemq-edge-frontend/src/modules/Workspace/hooks/useGetFlowElements.spec.ts
@@ -49,9 +49,9 @@ describe('useGetFlowElements', () => {
   })
 
   it.each<[Partial<EdgeFlowOptions>, number, number]>([
-    [{}, 10, 10],
-    [{ showGateway: true }, 11, 11],
-    [{ showGateway: false }, 10, 10],
+    [{}, 9, 9],
+    [{ showGateway: true }, 10, 10],
+    [{ showGateway: false }, 9, 9],
   ])('should consider %s for %s nodes and %s edges', async (defaults, countNode, countEdge) => {
     const { result } = renderHook(() => useGetFlowElements(), { wrapper: getWrapperEdgeProvider(defaults) })
 

--- a/hivemq-edge-frontend/src/modules/Workspace/hooks/useGetFlowElements.ts
+++ b/hivemq-edge-frontend/src/modules/Workspace/hooks/useGetFlowElements.ts
@@ -91,10 +91,10 @@ const useGetFlowElements = () => {
     const deltaPosition = Math.floor((nbCombiners - 1) / 2)
 
     if (hasPulse) {
-      const { nodePulse, edgeConnector, nodeAssets, pulseConnector } = createPulseNode(theme)
+      const { nodePulse, pulseConnector } = createPulseNode(theme)
 
-      nodes.push(nodePulse, nodeAssets)
-      edges.push(edgeConnector, pulseConnector)
+      nodes.push(nodePulse)
+      edges.push(pulseConnector)
     }
 
     combinerList?.items?.forEach((combiner, index) => {

--- a/hivemq-edge-frontend/src/modules/Workspace/hooks/useGetFlowElements.ts
+++ b/hivemq-edge-frontend/src/modules/Workspace/hooks/useGetFlowElements.ts
@@ -90,13 +90,20 @@ const useGetFlowElements = () => {
     const nbCombiners = combinerList?.items?.length || 1
     const deltaPosition = Math.floor((nbCombiners - 1) / 2)
 
+    if (hasPulse) {
+      const { nodePulse, edgeConnector, nodeAssets, pulseConnector } = createPulseNode(theme)
+
+      nodes.push(nodePulse, nodeAssets)
+      edges.push(edgeConnector, pulseConnector)
+    }
+
     combinerList?.items?.forEach((combiner, index) => {
       const sources =
         combiner.sources?.items
           ?.map((entity) => {
             return nodes.find((node) => node.data.id === entity.id)
           })
-          // TODO[] Error message for missing references
+          // TODO[xxxxxx] Error message for missing references
           .filter((node) => node) || []
 
       const { nodeCombiner, edgeConnector, sourceConnectors } = createCombinerNode(
@@ -109,13 +116,6 @@ const useGetFlowElements = () => {
       nodes.push(nodeCombiner)
       edges.push(edgeConnector, ...sourceConnectors)
     })
-
-    if (hasPulse) {
-      const { nodePulse, edgeConnector, nodeAssets, pulseConnector } = createPulseNode(theme)
-
-      nodes.push(nodePulse, nodeAssets)
-      edges.push(edgeConnector, pulseConnector)
-    }
 
     setNodes([nodeEdge, ...applyLayout(nodes, groups)])
     setEdges([...edges])

--- a/hivemq-edge-frontend/src/modules/Workspace/utils/nodes-utils.spec.ts
+++ b/hivemq-edge-frontend/src/modules/Workspace/utils/nodes-utils.spec.ts
@@ -298,17 +298,9 @@ describe('createPulseNode', () => {
 
     expect(actual).toStrictEqual(
       expect.objectContaining({
-        nodeAssets: expect.objectContaining({
-          data: {
-            label: 'Assets',
-            id: 'idPulseAssets',
-          },
-          id: 'idPulseAssets',
-          type: NodeTypes.ASSETS_NODE,
-        }),
         nodePulse: expect.objectContaining({
           data: {
-            label: 'Pulse Client',
+            label: 'Pulse Agent',
             id: 'idPulse',
           },
           id: 'idPulse',
@@ -323,18 +315,10 @@ describe('createPulseNode', () => {
 
     expect(actual).toStrictEqual(
       expect.objectContaining({
-        edgeConnector: expect.objectContaining({
-          id: 'connect-edge-idPulseAssets',
-          source: 'idPulseAssets',
-          target: 'edge',
-          type: 'DYNAMIC_EDGE',
-          animated: false,
-          focusable: false,
-        }),
         pulseConnector: expect.objectContaining({
-          id: 'connect-idPulseAssets-idPulse',
+          id: 'connect-idPulse-edge',
           source: 'idPulse',
-          target: 'idPulseAssets',
+          target: 'edge',
           type: 'DYNAMIC_EDGE',
           animated: false,
           focusable: false,

--- a/hivemq-edge-frontend/src/modules/Workspace/utils/nodes-utils.ts
+++ b/hivemq-edge-frontend/src/modules/Workspace/utils/nodes-utils.ts
@@ -7,7 +7,7 @@ import { MarkerType, Position } from '@xyflow/react'
 import type { Adapter, Bridge, Combiner, Listener, ProtocolAdapter } from '@/api/__generated__'
 import { Status } from '@/api/__generated__'
 
-import type { DeviceMetadata, NodeAssetsType, NodeEdgeType } from '../types.ts'
+import type { DeviceMetadata, NodeEdgeType } from '../types.ts'
 import type { NodePulseType } from '../types.ts'
 import { EdgeTypes, IdStubs, NodeTypes } from '../types.ts'
 import { discoverAdapterTopics, getBridgeTopics } from './topics-utils'
@@ -306,49 +306,21 @@ export const createCombinerNode = (
 export const createPulseNode = (theme: Partial<WithCSSVar<Dict>>, positionStorage?: Record<string, XYPosition>) => {
   const pulseStatus = { connection: Status.connection.UNKNOWN, runtime: Status.runtime.STOPPED }
 
-  const nodeAssets: NodeAssetsType = {
-    id: NODE_ASSET_DEFAULT_ID,
-    type: NodeTypes.ASSETS_NODE,
-    data: { label: 'Assets', id: NODE_ASSET_DEFAULT_ID },
-    position: positionStorage?.[NODE_ASSET_DEFAULT_ID] ?? {
-      x: POS_EDGE.x + POS_NODE_INC.x,
-      y: POS_EDGE.y - POS_NODE_INC.y,
-    },
-  }
-
-  const edgeConnector: Edge = {
-    id: `${IdStubs.CONNECTOR}-${IdStubs.EDGE_NODE}-${NODE_ASSET_DEFAULT_ID}`,
-    source: NODE_ASSET_DEFAULT_ID,
-    target: IdStubs.EDGE_NODE,
-    focusable: false,
-    type: EdgeTypes.DYNAMIC_EDGE,
-    markerEnd: {
-      type: MarkerType.ArrowClosed,
-      width: 20,
-      height: 20,
-      color: getThemeForStatus(theme, pulseStatus),
-    },
-    animated: false,
-    style: {
-      strokeWidth: 1.5,
-      stroke: getThemeForStatus(theme, pulseStatus),
-    },
-  }
-
   const nodePulse: NodePulseType = {
-    id: NODE_PULSE_CLIENT_DEFAULT_ID,
+    id: NODE_PULSE_AGENT_DEFAULT_ID,
     type: NodeTypes.PULSE_NODE,
-    data: { label: 'Pulse Client', id: NODE_PULSE_CLIENT_DEFAULT_ID },
-    position: positionStorage?.[NODE_PULSE_CLIENT_DEFAULT_ID] ?? {
+    data: { label: 'Pulse Agent', id: NODE_PULSE_AGENT_DEFAULT_ID },
+    position: positionStorage?.[NODE_PULSE_AGENT_DEFAULT_ID] ?? {
       x: POS_EDGE.x + POS_NODE_INC.x,
       y: POS_EDGE.y - POS_NODE_INC.y - GLUE_SEPARATOR,
     },
   }
 
+  // TODO[NVL] This connector should only be created if there is no asset mappers created yet
   const pulseConnector: Edge = {
-    id: `${IdStubs.CONNECTOR}-${NODE_ASSET_DEFAULT_ID}-${NODE_PULSE_CLIENT_DEFAULT_ID}`,
-    source: NODE_PULSE_CLIENT_DEFAULT_ID,
-    target: NODE_ASSET_DEFAULT_ID,
+    id: `${IdStubs.CONNECTOR}-${NODE_PULSE_AGENT_DEFAULT_ID}-${IdStubs.EDGE_NODE}`,
+    source: NODE_PULSE_AGENT_DEFAULT_ID,
+    target: IdStubs.EDGE_NODE,
     type: EdgeTypes.DYNAMIC_EDGE,
     focusable: false,
     markerEnd: {
@@ -364,7 +336,7 @@ export const createPulseNode = (theme: Partial<WithCSSVar<Dict>>, positionStorag
     },
   }
 
-  return { nodeAssets, edgeConnector, nodePulse, pulseConnector }
+  return { nodePulse, pulseConnector }
 }
 
 export const getDefaultMetricsFor = (node: Node): string[] => {

--- a/hivemq-edge-frontend/src/modules/Workspace/utils/nodes-utils.ts
+++ b/hivemq-edge-frontend/src/modules/Workspace/utils/nodes-utils.ts
@@ -22,7 +22,7 @@ const POS_NODE_INC: XYPosition = { x: CONFIG_ADAPTER_WIDTH + POS_SEPARATOR, y: 4
 const MAX_ADAPTERS = 10
 
 export const NODE_ASSET_DEFAULT_ID = 'idPulseAssets'
-export const NODE_PULSE_CLIENT_DEFAULT_ID = 'idPulse'
+export const NODE_PULSE_AGENT_DEFAULT_ID = 'idPulse'
 
 export const gluedNodeDefinition: Record<string, [NodeTypes, number, 'target' | 'source']> = {
   [NodeTypes.BRIDGE_NODE]: [NodeTypes.HOST_NODE, -GLUE_SEPARATOR, 'target'],


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/35452/details/

The PR implements the UX flow supporintg the mapping of Pulse Assets in Edge.

The new flow is based on the `Combiner` and leverages both the existing OpenAPI and UI component to support the process. 

### Design
- The new flow is based on the `Workspace` and the handling of `Combiners`
- The `Pulse Agent` has been added to the list of potential entity `sources`
- When the `Create a Combiner` is actioned on a selection of nodes that includes the `Pulse Agent`, a new `Asset Mapper` node is created instead
- The `Asset Mapper` has all the features of the `Combiner`
   - user-facing definition of metadata (description, name)
   - list of `sources` from where the `integration points` will be extracted
   - a list of `mappings`, now named `asset mappings`
- The `asset mapping` enables the mapping interface implemented for the `Combiner`, with a few differences
   - The `Add a new mapping`button is now based on selecting an existing asset from the list
   - The mapping form automatically extracts the `topic` and the `schema` from the asset, not allowing the end-user to change any of these  

### Out-of-scope
- The API endpoints for the `Asset Mapper` will be differentiated from the `Combiner` in a separate ticket. See https://hivemq.kanbanize.com/ctrl_board/57/cards/35801/details/
- Publishing is not supported yet, as a bug with the `Combiner` and the new `Pulse Agent` entity is blocking it.

### Before 

### After 
<img width="1280" height="940" alt="HiveMQ-Edge-08-26-2025_11_31_AM" src="https://github.com/user-attachments/assets/a637fb77-c1a2-4684-99e0-5b0947fd018c" />

<img width="1280" height="940" alt="HiveMQ-Edge-08-26-2025_11_32_AM" src="https://github.com/user-attachments/assets/b4efc029-3ac6-45d0-9a02-df9905b3e0b7" />

<img width="1280" height="940" alt="HiveMQ-Edge-08-26-2025_11_32_AM (1)" src="https://github.com/user-attachments/assets/3c902d6d-46fb-4533-90b8-be01bb173a2a" />

<img width="1280" height="940" alt="HiveMQ-Edge-08-26-2025_11_32_AM (2)" src="https://github.com/user-attachments/assets/b353a400-e4a0-473a-b2cb-8b16c59ca41d" />

<img width="1280" height="940" alt="HiveMQ-Edge-08-26-2025_11_33_AM" src="https://github.com/user-attachments/assets/828bc6d2-4dcb-42b4-a841-34357d6ec10b" />

<img width="1280" height="940" alt="HiveMQ-Edge-08-26-2025_11_33_AM (2)" src="https://github.com/user-attachments/assets/4ce5710f-5e43-4581-960e-df99c2283a11" />
