### PR TITLE
Added log messages for ADS failures since some require an edge restart

### DIFF
--- a/modules/hivemq-edge-module-plc4x/src/main/java/com/hivemq/edge/adapters/plc4x/impl/AbstractPlc4xAdapter.java
+++ b/modules/hivemq-edge-module-plc4x/src/main/java/com/hivemq/edge/adapters/plc4x/impl/AbstractPlc4xAdapter.java
@@ -153,7 +153,7 @@ public abstract class AbstractPlc4xAdapter<T extends Plc4XSpecificAdapterConfig<
                         output.startedSuccessfully();
                         CompletableFuture.runAsync(() -> {
                             try {
-                                tempConnection.startConnection();
+                                tempConnection.startConnection(input.moduleServices().eventService(), adapterId, getProtocolAdapterInformation().getProtocolId());
                                 protocolAdapterState.setConnectionStatus(CONNECTED);
                             } catch (final Plc4xException e) {
                                 log.error("Plc4x connection failed to start", e);


### PR DESCRIPTION
**Motivation**

Resolves #35888

We discovered that ADS sometimes gets "stuck".
Turns out PLC4X sometimes fails to react properly to a broken ADS connection.
This happens when the connection is being acquired and blocks on 
`plcDriverManager.getConnectionManager().getConnection(connectionString)`
This block doesn't time out and essentially breaks any fruther attempt.

**Changes**
Add logging that indicates the requirement for a restart when the call doesn't return.