### PR TITLE
Fixed a situation where rappidly restarting the adapter could lead to two open clients producing multiple tag reads

### DIFF
--- a/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/OpcUaClientConnection.java
+++ b/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/OpcUaClientConnection.java
@@ -90,7 +90,7 @@ class OpcUaClientConnection {
         this.lastKnownSubscriptionId = lastSubscriptionId;
     }
 
-    @NotNull boolean start(final ParsedConfig parsedConfig) {
+    @NotNull synchronized boolean start(final ParsedConfig parsedConfig) {
         final var subscriptionIdOptional = Optional.ofNullable(lastKnownSubscriptionId.get());
         log.debug("Subscribing to OPC UA client with subscriptionId: {}", subscriptionIdOptional.orElse(null));
         final OpcUaClient client;
@@ -141,7 +141,7 @@ class OpcUaClientConnection {
         return true;
     }
 
-    void stop() {
+    synchronized void stop() {
         log.info("Stopping OPC UA client");
         final ConnectionContext ctx = context.get();
         if(ctx != null) {

--- a/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/listeners/OpcUaSubscriptionListener.java
+++ b/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/listeners/OpcUaSubscriptionListener.java
@@ -107,6 +107,7 @@ public class OpcUaSubscriptionListener implements OpcUaSubscription.Subscription
             try {
                 protocolAdapterMetricsService.increment(Constants.METRIC_SUBSCRIPTION_DATA_RECEIVED_COUNT);
                 final String payload = extractPayload(client, values.get(i));
+                log.error("RECEIVED " + payload.replace("\n","") + " " + this.hashCode());
                 tagStreamingService.feed(tn, List.of(dataPointFactory.createJsonDataPoint(tn, payload)));
             } catch (final Throwable e) {
                 protocolAdapterMetricsService.increment(Constants.METRIC_SUBSCRIPTION_DATA_ERROR_COUNT);


### PR DESCRIPTION
**Motivation**

We saw tags being sent north twice instead of one time

**Changes**

With a rapid succession of restarts it could happen that a connection wasn't closed correctly, leading to multiple reads of the same tag happening in parallel.