### PR TITLE
feat(35496): Add custom renderer for the table filters

### DIFF
--- a/hivemq-edge-frontend/src/components/PaginatedTable/components/Filter.tsx
+++ b/hivemq-edge-frontend/src/components/PaginatedTable/components/Filter.tsx
@@ -106,6 +106,7 @@ export const Filter = <T,>({
         isMulti={false}
         components={{
           DropdownIndicator: null,
+          ...filterOptions?.components,
         }}
         styles={{
           menuPortal: (provided) => ({ ...provided, zIndex: 'var(--chakra-zIndices-popover)' }),

--- a/hivemq-edge-frontend/src/components/PaginatedTable/components/Filter.tsx
+++ b/hivemq-edge-frontend/src/components/PaginatedTable/components/Filter.tsx
@@ -97,7 +97,7 @@ export const Filter = <T,>({
         value={columnValue ? { value: columnValue, label: columnValue } : null}
         onChange={(item) => setFilterValue(item?.value)}
         // TODO[35494] The label/renderer for the options need customisation per column
-        options={sortedUniqueValues.map((value: string) => ({ value: value, label: value, group: 'DDD' }))}
+        options={sortedUniqueValues.map((value: string) => ({ value: value, label: value }))}
         placeholder={placeholder}
         noOptionsMessage={noOptionsMessage}
         formatCreateLabel={formatCreateLabel}

--- a/hivemq-edge-frontend/src/components/PaginatedTable/components/Filter.tsx
+++ b/hivemq-edge-frontend/src/components/PaginatedTable/components/Filter.tsx
@@ -108,6 +108,12 @@ export const Filter = <T,>({
           DropdownIndicator: null,
           ...filterOptions?.components,
         }}
+        chakraStyles={{
+          menuList: (provided) => ({
+            ...provided,
+            width: 'fit-content',
+          }),
+        }}
         styles={{
           menuPortal: (provided) => ({ ...provided, zIndex: 'var(--chakra-zIndices-popover)' }),
         }}

--- a/hivemq-edge-frontend/src/components/PaginatedTable/components/Filter.tsx
+++ b/hivemq-edge-frontend/src/components/PaginatedTable/components/Filter.tsx
@@ -96,7 +96,6 @@ export const Filter = <T,>({
         menuPortalTarget={document.body}
         value={columnValue ? { value: columnValue, label: columnValue } : null}
         onChange={(item) => setFilterValue(item?.value)}
-        // TODO[35494] The label/renderer for the options need customisation per column
         options={sortedUniqueValues.map((value: string) => ({ value: value, label: value }))}
         placeholder={placeholder}
         noOptionsMessage={noOptionsMessage}

--- a/hivemq-edge-frontend/src/components/PaginatedTable/types.ts
+++ b/hivemq-edge-frontend/src/components/PaginatedTable/types.ts
@@ -1,5 +1,6 @@
 import type { BuiltInSortingFn } from '@tanstack/react-table'
 import type { AriaAttributes, ReactNode } from 'react'
+import type { SelectComponentsConfig, GroupBase } from 'chakra-react-select'
 
 export interface FilterMetadata {
   filterOptions: {
@@ -9,5 +10,6 @@ export interface FilterMetadata {
     noOptionsMessage?: (obj: { inputValue: string }) => ReactNode
     formatCreateLabel?: (inputValue: string) => ReactNode
     'aria-label'?: AriaAttributes['aria-label']
+    components?: SelectComponentsConfig<unknown, boolean, GroupBase<unknown>>
   }
 }

--- a/hivemq-edge-frontend/src/modules/Pulse/components/assets/AssetsTable.tsx
+++ b/hivemq-edge-frontend/src/modules/Pulse/components/assets/AssetsTable.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
 import { Box, Skeleton, Text } from '@chakra-ui/react'
 import type { ColumnDef } from '@tanstack/react-table'
+import { chakraComponents } from 'chakra-react-select'
 
 import type { ManagedAsset } from '@/api/__generated__'
 import { AssetMapping } from '@/api/__generated__'
@@ -107,6 +108,18 @@ const AssetsTable: FC<AssetTableProps> = ({ variant = 'full' }) => {
         meta: {
           filterOptions: {
             canCreate: false,
+            components: {
+              Option: ({ children, ...props }) => (
+                <chakraComponents.Option {...props}>
+                  <AssetStatusBadge status={children as AssetMapping.status} />
+                </chakraComponents.Option>
+              ),
+              SingleValue: ({ children, ...props }) => (
+                <chakraComponents.SingleValue {...props}>
+                  <AssetStatusBadge status={children as AssetMapping.status} />
+                </chakraComponents.SingleValue>
+              ),
+            },
           },
         } as FilterMetadata,
       },


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/35449/details/

The PR improves the rendering of column-based filters by enabling custom components of the React Select widget in the column specification of a paginated table 

The feature is applied to the `Asset` status filter, where the values in the filter are now properly rendered as the visual tag, rather than the internal value (string)

### Before 
<img width="1280" height="940" alt="HiveMQ-Edge-09-05-2025_04_56_PM" src="https://github.com/user-attachments/assets/1edbbcf9-227d-4aee-8a11-d35de21ba4de" />

### After
<img width="1280" height="940" alt="HiveMQ-Edge-09-05-2025_04_55_PM" src="https://github.com/user-attachments/assets/93a879c2-1d1a-4aca-92d4-f8041aa46612" />
