### PR TITLE
fix(36222) Fix the headers in the mapper's mappings list

### DIFF
--- a/hivemq-edge-frontend/src/modules/Mappings/combiner/DataCombiningTableField.spec.cy.tsx
+++ b/hivemq-edge-frontend/src/modules/Mappings/combiner/DataCombiningTableField.spec.cy.tsx
@@ -45,8 +45,8 @@ describe('DataCombiningTableField', () => {
 
     cy.get('form table').within(() => {
       cy.get('thead tr th').should('have.length', 3)
-      cy.get('thead tr th').eq(0).should('have.text', 'destination')
-      cy.get('thead tr th').eq(1).should('have.text', 'sources')
+      cy.get('thead tr th').eq(0).should('have.text', 'Topic')
+      cy.get('thead tr th').eq(1).should('have.text', 'Sources')
       cy.get('thead tr th').eq(2).should('have.text', 'Actions')
 
       cy.get('tbody tr').should('have.length', 1)

--- a/hivemq-edge-frontend/src/modules/Mappings/combiner/DataCombiningTableField.tsx
+++ b/hivemq-edge-frontend/src/modules/Mappings/combiner/DataCombiningTableField.tsx
@@ -12,12 +12,13 @@ import type { DataCombining, ManagedAsset } from '@/api/__generated__'
 import { EntityType, DataIdentifierReference } from '@/api/__generated__'
 import PaginatedTable from '@/components/PaginatedTable/PaginatedTable'
 import IconButton from '@/components/Chakra/IconButton'
-import { AssetTag, PLCTag, Topic, TopicFilter } from '@/components/MQTT/EntityTag'
+import { PLCTag, Topic, TopicFilter } from '@/components/MQTT/EntityTag'
 
 import { PrimaryWrapper } from '@/modules/Mappings/combiner/components/PrimaryWrapper.tsx'
 import DataCombiningEditorDrawer from '@/modules/Mappings/combiner/DataCombiningEditorDrawer.tsx'
 import type { CombinerContext } from '@/modules/Mappings/types.ts'
 import ManagedAssetSelect from '@/modules/Pulse/components/assets/ManagedAssetSelect.tsx'
+import AssetNameCell from '@/modules/Pulse/components/assets/AssetNameCell.tsx'
 
 export const DataCombiningTableField: FC<FieldProps<DataCombining[], RJSFSchema, CombinerContext>> = (props) => {
   const { t } = useTranslation()
@@ -81,19 +82,22 @@ export const DataCombiningTableField: FC<FieldProps<DataCombining[], RJSFSchema,
       cell: (info) => {
         return <AssetNameCell assetId={info.row.original.destination.assetId} />
       },
+      header: t('pulse.assets.listing.column.name'),
     }
 
     return [
       ...(isAssetManager ? [assetColumn] : []),
       {
-        accessorKey: 'destination',
+        accessorKey: 'destination.topic',
         cell: (info) => {
           if (info.row.original.destination.topic) return <Topic tagTitle={info.row.original.destination.topic} />
           return <Text>{t('combiner.unset')}</Text>
         },
+        header: t('pulse.assets.listing.column.topic'),
       },
       {
         accessorKey: 'sources',
+        header: t('pulse.assets.listing.column.sources'),
         cell: (info) => {
           const { sources } = info.row.original
           const nbItems = (sources?.tags?.length || 0) + (sources?.topicFilters?.length || 0)

--- a/hivemq-edge-frontend/src/modules/Mappings/combiner/DataCombiningTableField.tsx
+++ b/hivemq-edge-frontend/src/modules/Mappings/combiner/DataCombiningTableField.tsx
@@ -79,8 +79,7 @@ export const DataCombiningTableField: FC<FieldProps<DataCombining[], RJSFSchema,
     const assetColumn: ColumnDef<DataCombining> = {
       accessorKey: 'destination.assetId',
       cell: (info) => {
-        if (info.row.original.destination.assetId) return <AssetTag tagTitle={info.row.original.destination.topic} />
-        return <Text>{t('combiner.unset')}</Text>
+        return <AssetNameCell assetId={info.row.original.destination.assetId} />
       },
     }
 

--- a/hivemq-edge-frontend/src/modules/Pulse/components/assets/AssetNameCell.spec.cy.tsx
+++ b/hivemq-edge-frontend/src/modules/Pulse/components/assets/AssetNameCell.spec.cy.tsx
@@ -1,0 +1,64 @@
+import { MOCK_PULSE_ASSET_LIST, MOCK_PULSE_ASSET_MAPPED_UNIQUE } from '@/api/hooks/usePulse/__handlers__'
+import AssetNameCell from '@/modules/Pulse/components/assets/AssetNameCell.tsx'
+
+describe('AssetNameCell', () => {
+  beforeEach(() => {
+    cy.viewport(1000, 600)
+  })
+
+  it('should render errors', () => {
+    cy.intercept('/api/v1/management/pulse/managed-assets', { statusCode: 404 }).as('getStatus')
+
+    cy.mountWithProviders(<AssetNameCell assetId={MOCK_PULSE_ASSET_MAPPED_UNIQUE.id} />)
+
+    cy.getByTestId('loading-spinner').should('be.visible')
+    cy.wait('@getStatus')
+
+    cy.getByTestId('asset-error').should('have.text', '< not found >')
+  })
+
+  it('should render errors', () => {
+    cy.intercept('/api/v1/management/pulse/managed-assets', MOCK_PULSE_ASSET_LIST).as('getStatus')
+
+    cy.mountWithProviders(<AssetNameCell />)
+
+    cy.getByTestId('loading-spinner').should('be.visible')
+    cy.wait('@getStatus')
+
+    cy.getByTestId('asset-error').should('have.text', '< unset >')
+  })
+
+  it('should render properly', () => {
+    cy.intercept('/api/v1/management/pulse/managed-assets', MOCK_PULSE_ASSET_LIST).as('getStatus')
+
+    cy.mountWithProviders(<AssetNameCell assetId={MOCK_PULSE_ASSET_MAPPED_UNIQUE.id} />)
+
+    cy.getByTestId('loading-spinner').should('be.visible')
+    cy.wait('@getStatus')
+
+    cy.getByTestId('asset-name').should('have.text', 'Almost the same asset')
+  })
+
+  it('should render description properly', () => {
+    cy.intercept('/api/v1/management/pulse/managed-assets', MOCK_PULSE_ASSET_LIST).as('getStatus')
+
+    cy.mountWithProviders(<AssetNameCell assetId={MOCK_PULSE_ASSET_MAPPED_UNIQUE.id} showDescription />)
+
+    cy.getByTestId('loading-spinner').should('be.visible')
+    cy.wait('@getStatus')
+
+    cy.getByTestId('asset-name').should('have.text', 'Almost the same asset')
+    cy.getByTestId('asset-description').should('have.text', 'Not sure how to describe that re-mapped asset')
+  })
+
+  it('should be accessible', () => {
+    cy.intercept('/api/v1/management/pulse/managed-assets', MOCK_PULSE_ASSET_LIST).as('getStatus')
+    cy.injectAxe()
+
+    cy.mountWithProviders(<AssetNameCell assetId={MOCK_PULSE_ASSET_MAPPED_UNIQUE.id} showDescription />)
+
+    cy.getByTestId('loading-spinner').should('be.visible')
+    cy.wait('@getStatus')
+    cy.checkAccessibility()
+  })
+})

--- a/hivemq-edge-frontend/src/modules/Pulse/components/assets/AssetNameCell.tsx
+++ b/hivemq-edge-frontend/src/modules/Pulse/components/assets/AssetNameCell.tsx
@@ -1,0 +1,53 @@
+import type { FC } from 'react'
+import { useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Text } from '@chakra-ui/react'
+
+import { useListManagedAssets } from '@/api/hooks/usePulse/useListManagedAssets.ts'
+import LoaderSpinner from '@/components/Chakra/LoaderSpinner.tsx'
+
+interface AssetNameCellProps {
+  assetId?: string
+  showDescription?: boolean
+}
+
+const AssetNameCell: FC<AssetNameCellProps> = ({ assetId, showDescription = false }) => {
+  const { t } = useTranslation()
+  const { data, isLoading } = useListManagedAssets()
+
+  const asset = useMemo(() => {
+    if (!data?.items) return undefined
+
+    return data.items.find((e) => e.id === assetId)
+  }, [assetId, data?.items])
+
+  if (isLoading) return <LoaderSpinner />
+  if (!assetId)
+    return (
+      <Text data-testid="asset-error" whiteSpace="nowrap">
+        {t('pulse.assets.listing.sources.unset')}
+      </Text>
+    )
+
+  if (!asset)
+    return (
+      <Text data-testid="asset-error" whiteSpace="nowrap">
+        {t('pulse.assets.listing.sources.notFound')}
+      </Text>
+    )
+
+  return (
+    <>
+      <Text data-testid="asset-name" whiteSpace="nowrap">
+        {asset.name}
+      </Text>
+      {showDescription && (
+        <Text data-testid="asset-description" noOfLines={1} fontStyle="italic">
+          {asset.description}
+        </Text>
+      )}
+    </>
+  )
+}
+
+export default AssetNameCell

--- a/hivemq-edge-frontend/src/modules/Pulse/components/assets/AssetsTable.spec.cy.tsx
+++ b/hivemq-edge-frontend/src/modules/Pulse/components/assets/AssetsTable.spec.cy.tsx
@@ -189,7 +189,7 @@ describe('AssetsTable', () => {
       })
   })
 
-  it.only('should handle navigation', () => {
+  it('should handle navigation', () => {
     cy.intercept('/api/v1/management/pulse/managed-assets', MOCK_PULSE_ASSET_LIST).as('getStatus')
 
     cy.mountWithProviders(<AssetsTable />, {


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/36222/details/

The PR fixes the following issues in the `asset mapping` list in the `Asset Mapper `:
- the headers of the columns
- the rendering of the `asset name` cells 

### Before 
<img width="1280" height="940" alt="HiveMQ-Edge-09-12-2025_04_02_PM" src="https://github.com/user-attachments/assets/10cec858-6b7d-46ae-b658-fa1216b9c341" />

### After
<img width="1280" height="940" alt="HiveMQ-Edge-09-12-2025_03_34_PM" src="https://github.com/user-attachments/assets/e482c422-da72-4f17-8c4e-1648ab03c99a" />
