### PR TITLE
fix(36401) Improve the handling of Pulse when (not) activated

### DIFF
--- a/hivemq-edge-frontend/cypress/e2e/pulse/activation.spec.cy.ts
+++ b/hivemq-edge-frontend/cypress/e2e/pulse/activation.spec.cy.ts
@@ -82,7 +82,7 @@ describe('Pulse Agent Activation', () => {
       homePage.task(ONBOARDING.TASK_CLOUD).should('contain.text', 'Connect To HiveMQ Cloud')
       homePage.task(ONBOARDING.TASK_PULSE).should('contain.text', 'Connect to HiveMQ Pulse')
 
-      homePage.taskSections(ONBOARDING.TASK_PULSE).should('have.length', 3)
+      homePage.taskSections(ONBOARDING.TASK_PULSE).should('have.length', 1)
       homePage.taskSection(ONBOARDING.TASK_PULSE, 0).within(() => {
         pulseActivationPanel.trigger.should('have.text', 'Activate Pulse')
         pulseActivationPanel.trigger.click()

--- a/hivemq-edge-frontend/src/api/hooks/usePulse/useGetPulseStatus.spec.ts
+++ b/hivemq-edge-frontend/src/api/hooks/usePulse/useGetPulseStatus.spec.ts
@@ -31,7 +31,7 @@ describe('useGetPulseStatus', () => {
     })
   })
 
-  it('should not load data is disabled', async () => {
+  it('should not load data when disabled', async () => {
     server.use(...handlerCapabilities({ items: [] }))
     const { result } = renderHook(() => useGetPulseStatus(), { wrapper })
 

--- a/hivemq-edge-frontend/src/api/hooks/usePulse/useListManagedAssets.spec.ts
+++ b/hivemq-edge-frontend/src/api/hooks/usePulse/useListManagedAssets.spec.ts
@@ -1,3 +1,4 @@
+import { handlerCapabilities, MOCK_CAPABILITIES } from '@/api/hooks/useFrontendServices/__handlers__'
 import { beforeEach, expect } from 'vitest'
 import { renderHook, waitFor } from '@testing-library/react'
 
@@ -9,7 +10,7 @@ import { handlers as pulseAssetsHandlers } from '@/api/hooks/usePulse/__handlers
 
 describe('useListManagedAssets', () => {
   beforeEach(() => {
-    server.use(...pulseAssetsHandlers)
+    server.use(...pulseAssetsHandlers, ...handlerCapabilities(MOCK_CAPABILITIES))
   })
 
   afterEach(() => {

--- a/hivemq-edge-frontend/src/api/hooks/usePulse/useListManagedAssets.ts
+++ b/hivemq-edge-frontend/src/api/hooks/usePulse/useListManagedAssets.ts
@@ -8,7 +8,7 @@ import { QUERY_KEYS } from '@/api/utils.ts'
 
 export const useListManagedAssets = () => {
   const appClient = useHttpClient()
-  const { data: hasPulse, isLoading } = useGetCapability(Capability.id.PULSE_ASSET_MANAGEMENT)
+  const { data: hasPulse, isLoading: isCapacityLoading } = useGetCapability(Capability.id.PULSE_ASSET_MANAGEMENT)
 
   const query = useQuery<ManagedAssetList, ApiError>({
     queryKey: [QUERY_KEYS.PULSE_ASSETS],
@@ -19,6 +19,6 @@ export const useListManagedAssets = () => {
   return {
     // eslint-disable-next-line @tanstack/query/no-rest-destructuring
     ...query,
-    isLoading: isLoading || query.isLoading,
+    isLoading: isCapacityLoading || query.isLoading,
   }
 }

--- a/hivemq-edge-frontend/src/api/hooks/usePulse/useListManagedAssets.ts
+++ b/hivemq-edge-frontend/src/api/hooks/usePulse/useListManagedAssets.ts
@@ -1,14 +1,24 @@
 import { useQuery } from '@tanstack/react-query'
 
 import type { ApiError, ManagedAssetList } from '@/api/__generated__'
+import { Capability } from '@/api/__generated__'
 import { useHttpClient } from '@/api/hooks/useHttpClient/useHttpClient.ts'
+import { useGetCapability } from '@/api/hooks/useFrontendServices/useGetCapability.ts'
 import { QUERY_KEYS } from '@/api/utils.ts'
 
 export const useListManagedAssets = () => {
   const appClient = useHttpClient()
+  const { data: hasPulse, isLoading } = useGetCapability(Capability.id.PULSE_ASSET_MANAGEMENT)
 
-  return useQuery<ManagedAssetList, ApiError>({
+  const query = useQuery<ManagedAssetList, ApiError>({
     queryKey: [QUERY_KEYS.PULSE_ASSETS],
     queryFn: () => appClient.pulse.getManagedAssets(),
+    enabled: hasPulse !== undefined,
   })
+
+  return {
+    // eslint-disable-next-line @tanstack/query/no-rest-destructuring
+    ...query,
+    isLoading: isLoading || query.isLoading,
+  }
 }

--- a/hivemq-edge-frontend/src/extensions/datahub/components/pages/SchemaTable.copilot.spec.cy.tsx
+++ b/hivemq-edge-frontend/src/extensions/datahub/components/pages/SchemaTable.copilot.spec.cy.tsx
@@ -2,6 +2,7 @@ import { MOCK_CREATED_AT } from '@/__test-utils__/mocks.ts'
 
 import { mockSchemaTempHumidity } from '@datahub/api/hooks/DataHubSchemasService/__handlers__'
 import SchemaTable from '@datahub/components/pages/SchemaTable.tsx'
+import { DateTime } from 'luxon'
 
 describe('SchemaTable (Copilot)', () => {
   beforeEach(() => {
@@ -47,6 +48,7 @@ describe('SchemaTable (Copilot)', () => {
         createdAt: MOCK_CREATED_AT,
       }
       cy.intercept('/api/v1/data-hub/schemas', { items: [schema] }).as('getSchemasSuccess')
+      cy.stub(DateTime, 'now').returns(DateTime.fromISO(MOCK_CREATED_AT).plus({ day: 2 }))
     })
 
     it('should render schema data correctly', () => {
@@ -62,7 +64,7 @@ describe('SchemaTable (Copilot)', () => {
           cy.get('td').eq(1).should('contain', 'JSON')
           cy.get('td').eq(2).should('contain', '2')
           // without clock the date is not correct
-          cy.get('td').eq(3).should('contain', '1 year ago')
+          cy.get('td').eq(3).should('contain', '2 days ago')
           cy.get('td').eq(4).find('button').should('have.length', 2)
         })
     })
@@ -88,19 +90,6 @@ describe('SchemaTable (Copilot)', () => {
       cy.get('tbody tr').first().find('[aria-label="Delete"]').click()
 
       cy.get('@deleteItemSpy').should('have.been.calledOnce')
-    })
-
-    // This one is completely bonkers, as far as I can tell
-    it.skip('should trigger download action correctly', () => {
-      const downloadJSONSpy = cy.spy().as('downloadJSONSpy')
-      cy.window().then((win) => {
-        cy.stub(win, 'downloadJSON').as('downloadJSONStub').callsFake(downloadJSONSpy)
-      })
-
-      cy.mountWithProviders(<SchemaTable />)
-      cy.get('tbody tr').first().find('[aria-label="Download"]').click()
-
-      cy.get('@downloadJSONStub').should('have.been.calledOnce')
     })
   })
 

--- a/hivemq-edge-frontend/src/extensions/datahub/components/pages/SchemaTable.copilot.spec.cy.tsx
+++ b/hivemq-edge-frontend/src/extensions/datahub/components/pages/SchemaTable.copilot.spec.cy.tsx
@@ -70,21 +70,10 @@ describe('SchemaTable (Copilot)', () => {
     })
   })
 
-  context('Error Handling', () => {
-    it('should handle error state', () => {
-      cy.intercept('/api/v1/data-hub/schemas', { statusCode: 500 }).as('getSchemasError')
-      cy.mountWithProviders(<SchemaTable />)
-
-      // That's hallucinating
-      // cy.contains('Error loading data').should('be.visible')
-      // cy.get('button').contains('Try again').should('be.visible')
-    })
-  })
-
   context('Actions', () => {
     it('should trigger delete action correctly', () => {
       const deleteItemSpy = cy.spy().as('deleteItemSpy')
-      cy.intercept('/api/v1/data-hub/schemas', { items: [mockSchemaTempHumidity] }).as('getSchemas')
+      cy.intercept('/api/v1/data-hub/schemas', { items: [mockSchemaTempHumidity] })
 
       cy.mountWithProviders(<SchemaTable onDeleteItem={deleteItemSpy} />)
       cy.get('tbody tr').first().find('[aria-label="Delete"]').click()

--- a/hivemq-edge-frontend/src/modules/Pulse/components/assets/AssetMapperWizard.spec.cy.tsx
+++ b/hivemq-edge-frontend/src/modules/Pulse/components/assets/AssetMapperWizard.spec.cy.tsx
@@ -1,11 +1,13 @@
 import { WrapperTestRoute } from '@/__test-utils__/hooks/WrapperTestRoute.tsx'
 import { MOCK_COMBINER_ASSET } from '@/api/hooks/useCombiners/__handlers__'
+import { MOCK_CAPABILITY_PULSE_ASSETS } from '@/api/hooks/useFrontendServices/__handlers__'
 import { MOCK_PULSE_ASSET, MOCK_PULSE_ASSET_LIST } from '@/api/hooks/usePulse/__handlers__'
 import AssetMapperWizard from '@/modules/Pulse/components/assets/AssetMapperWizard.tsx'
 
 describe('AssetMapperWizard', () => {
   beforeEach(() => {
     cy.viewport(800, 600)
+    cy.intercept('/api/v1/frontend/capabilities', { items: [MOCK_CAPABILITY_PULSE_ASSETS] })
   })
 
   it('should render properly', () => {

--- a/hivemq-edge-frontend/src/modules/Pulse/components/assets/AssetMonitoringBadge.spec.cy.tsx
+++ b/hivemq-edge-frontend/src/modules/Pulse/components/assets/AssetMonitoringBadge.spec.cy.tsx
@@ -36,8 +36,7 @@ describe('AssetMonitoringBadge', () => {
 
   it('should be accessible', () => {
     cy.intercept('/api/v1/frontend/capabilities', MOCK_CAPABILITIES)
-    cy.intercept('/api/v1/management/pulse/managed-assets', MOCK_PULSE_ASSET_LIST)
-    cy.intercept('/api/v1/management/pulse/managed-assets', { statusCode: 404 }).as('getAssets')
+    cy.intercept('/api/v1/management/pulse/managed-assets', MOCK_PULSE_ASSET_LIST).as('getAssets')
     cy.injectAxe()
     cy.mountWithProviders(<AssetMonitoringBadge />)
     cy.wait('@getAssets')

--- a/hivemq-edge-frontend/src/modules/Pulse/components/assets/AssetMonitoringBadge.spec.cy.tsx
+++ b/hivemq-edge-frontend/src/modules/Pulse/components/assets/AssetMonitoringBadge.spec.cy.tsx
@@ -8,15 +8,15 @@ describe('AssetMonitoringBadge', () => {
   })
 
   it('should render properly', () => {
-    cy.intercept('/api/v1/frontend/capabilities', MOCK_CAPABILITIES).as('getCapabilities')
-    cy.intercept('/api/v1/management/pulse/managed-assets', MOCK_PULSE_ASSET_LIST).as('getAssets')
+    cy.intercept('/api/v1/frontend/capabilities', MOCK_CAPABILITIES)
+    cy.intercept('/api/v1/management/pulse/managed-assets', MOCK_PULSE_ASSET_LIST)
     cy.mountWithProviders(<AssetMonitoringBadge />)
 
     cy.getByTestId('asset-monitoring-unattended').should('have.text', '3')
   })
 
   it('should handle errors', () => {
-    cy.intercept('/api/v1/frontend/capabilities', MOCK_CAPABILITIES).as('getCapabilities')
+    cy.intercept('/api/v1/frontend/capabilities', MOCK_CAPABILITIES)
     cy.intercept('/api/v1/management/pulse/managed-assets', { statusCode: 404 }).as('getAssets')
     cy.mountWithProviders(<AssetMonitoringBadge />)
     cy.wait('@getAssets')
@@ -26,7 +26,7 @@ describe('AssetMonitoringBadge', () => {
   })
 
   it('should handle errors', () => {
-    cy.intercept('/api/v1/frontend/capabilities', { items: [] }).as('getCapabilities')
+    cy.intercept('/api/v1/frontend/capabilities', { items: [] })
     cy.intercept('/api/v1/management/pulse/managed-assets', { statusCode: 404 }).as('getAssets')
     cy.mountWithProviders(<AssetMonitoringBadge />)
     cy.get('@getAssets').should('not.exist')
@@ -35,7 +35,7 @@ describe('AssetMonitoringBadge', () => {
   })
 
   it('should be accessible', () => {
-    cy.intercept('/api/v1/frontend/capabilities', MOCK_CAPABILITIES).as('getCapabilities')
+    cy.intercept('/api/v1/frontend/capabilities', MOCK_CAPABILITIES)
     cy.intercept('/api/v1/management/pulse/managed-assets', MOCK_PULSE_ASSET_LIST)
     cy.intercept('/api/v1/management/pulse/managed-assets', { statusCode: 404 }).as('getAssets')
     cy.injectAxe()

--- a/hivemq-edge-frontend/src/modules/Pulse/components/assets/AssetMonitoringBadge.spec.cy.tsx
+++ b/hivemq-edge-frontend/src/modules/Pulse/components/assets/AssetMonitoringBadge.spec.cy.tsx
@@ -1,3 +1,4 @@
+import { MOCK_CAPABILITIES } from '@/api/hooks/useFrontendServices/__handlers__'
 import { MOCK_PULSE_ASSET_LIST } from '@/api/hooks/usePulse/__handlers__'
 import AssetMonitoringBadge from '@/modules/Pulse/components/assets/AssetMonitoringBadge.tsx'
 
@@ -7,27 +8,39 @@ describe('AssetMonitoringBadge', () => {
   })
 
   it('should render properly', () => {
+    cy.intercept('/api/v1/frontend/capabilities', MOCK_CAPABILITIES).as('getCapabilities')
     cy.intercept('/api/v1/management/pulse/managed-assets', MOCK_PULSE_ASSET_LIST).as('getAssets')
     cy.mountWithProviders(<AssetMonitoringBadge />)
 
-    cy.getByTestId('loading-spinner').should('be.visible')
-    cy.wait('@getAssets')
     cy.getByTestId('asset-monitoring-unattended').should('have.text', '3')
   })
 
   it('should handle errors', () => {
+    cy.intercept('/api/v1/frontend/capabilities', MOCK_CAPABILITIES).as('getCapabilities')
     cy.intercept('/api/v1/management/pulse/managed-assets', { statusCode: 404 }).as('getAssets')
     cy.mountWithProviders(<AssetMonitoringBadge />)
+    cy.wait('@getAssets')
 
     cy.getByTestId('loading-spinner').should('be.visible')
-    cy.wait('@getAssets')
     cy.getByTestId('asset-monitoring-unattended').should('have.text', '?')
   })
 
+  it('should handle errors', () => {
+    cy.intercept('/api/v1/frontend/capabilities', { items: [] }).as('getCapabilities')
+    cy.intercept('/api/v1/management/pulse/managed-assets', { statusCode: 404 }).as('getAssets')
+    cy.mountWithProviders(<AssetMonitoringBadge />)
+    cy.get('@getAssets').should('not.exist')
+
+    cy.getByTestId('asset-monitoring-unattended').should('not.exist')
+  })
+
   it('should be accessible', () => {
+    cy.intercept('/api/v1/frontend/capabilities', MOCK_CAPABILITIES).as('getCapabilities')
     cy.intercept('/api/v1/management/pulse/managed-assets', MOCK_PULSE_ASSET_LIST)
+    cy.intercept('/api/v1/management/pulse/managed-assets', { statusCode: 404 }).as('getAssets')
     cy.injectAxe()
     cy.mountWithProviders(<AssetMonitoringBadge />)
+    cy.wait('@getAssets')
     cy.checkAccessibility()
   })
 })

--- a/hivemq-edge-frontend/src/modules/Pulse/components/assets/AssetMonitoringBadge.tsx
+++ b/hivemq-edge-frontend/src/modules/Pulse/components/assets/AssetMonitoringBadge.tsx
@@ -9,7 +9,7 @@ import LoaderSpinner from '@/components/Chakra/LoaderSpinner.tsx'
 const BADGE_ERROR_CONTENT = '?'
 
 const AssetMonitoringBadge: FC = () => {
-  const { data: assets, isLoading, error } = useListManagedAssets()
+  const { data: assets, isLoading, error, isEnabled } = useListManagedAssets()
 
   const unattendedAssets = useMemo(() => {
     if (!assets?.items || error) return undefined
@@ -21,6 +21,7 @@ const AssetMonitoringBadge: FC = () => {
   }, [assets?.items, error])
 
   if (isLoading) return <LoaderSpinner boxSize={4} />
+  if (!isEnabled) return null
 
   return (
     <Badge data-testid="asset-monitoring-unattended" colorScheme={unattendedAssets ? undefined : 'red'}>

--- a/hivemq-edge-frontend/src/modules/Pulse/components/assets/AssetMonitoringOnboardingTask.spec.cy.tsx
+++ b/hivemq-edge-frontend/src/modules/Pulse/components/assets/AssetMonitoringOnboardingTask.spec.cy.tsx
@@ -1,10 +1,12 @@
 import { WrapperTestRoute } from '@/__test-utils__/hooks/WrapperTestRoute.tsx'
+import { MOCK_CAPABILITY_PULSE_ASSETS } from '@/api/hooks/useFrontendServices/__handlers__'
 import { MOCK_PULSE_ASSET_LIST, MOCK_PULSE_ASSET_MAPPED } from '@/api/hooks/usePulse/__handlers__'
 import AssetMonitoringOnboardingTask from '@/modules/Pulse/components/assets/AssetMonitoringOnboardingTask.tsx'
 
 describe('AssetMonitoringOnboardingTask', () => {
   beforeEach(() => {
     cy.viewport(500, 600)
+    cy.intercept('/api/v1/frontend/capabilities', { items: [MOCK_CAPABILITY_PULSE_ASSETS] })
   })
 
   it('should render properly', () => {

--- a/hivemq-edge-frontend/src/modules/Pulse/components/assets/AssetMonitoringOnboardingTask.spec.cy.tsx
+++ b/hivemq-edge-frontend/src/modules/Pulse/components/assets/AssetMonitoringOnboardingTask.spec.cy.tsx
@@ -91,7 +91,7 @@ describe('AssetMonitoringOnboardingTask', () => {
 
   it('should be accessible', () => {
     cy.injectAxe()
-    cy.intercept('/api/v1/management/pulse/managed-assets', MOCK_PULSE_ASSET_LIST).as('getAssets')
+    cy.intercept('/api/v1/management/pulse/managed-assets', MOCK_PULSE_ASSET_LIST)
     cy.mountWithProviders(<AssetMonitoringOnboardingTask />)
     cy.checkAccessibility()
   })

--- a/hivemq-edge-frontend/src/modules/Pulse/components/assets/AssetNameCell.spec.cy.tsx
+++ b/hivemq-edge-frontend/src/modules/Pulse/components/assets/AssetNameCell.spec.cy.tsx
@@ -1,9 +1,11 @@
+import { MOCK_CAPABILITY_PULSE_ASSETS } from '@/api/hooks/useFrontendServices/__handlers__'
 import { MOCK_PULSE_ASSET_LIST, MOCK_PULSE_ASSET_MAPPED_UNIQUE } from '@/api/hooks/usePulse/__handlers__'
 import AssetNameCell from '@/modules/Pulse/components/assets/AssetNameCell.tsx'
 
 describe('AssetNameCell', () => {
   beforeEach(() => {
     cy.viewport(1000, 600)
+    cy.intercept('/api/v1/frontend/capabilities', { items: [MOCK_CAPABILITY_PULSE_ASSETS] })
   })
 
   it('should render errors', () => {

--- a/hivemq-edge-frontend/src/modules/Pulse/components/assets/AssetsTable.spec.cy.tsx
+++ b/hivemq-edge-frontend/src/modules/Pulse/components/assets/AssetsTable.spec.cy.tsx
@@ -2,6 +2,8 @@ import { WrapperTestRoute } from '@/__test-utils__/hooks/WrapperTestRoute.tsx'
 
 import type { ManagedAsset } from '@/api/__generated__'
 import { AssetMapping } from '@/api/__generated__'
+import { MOCK_COMBINER_ASSET } from '@/api/hooks/useCombiners/__handlers__'
+import { MOCK_CAPABILITY_PULSE_ASSETS } from '@/api/hooks/useFrontendServices/__handlers__'
 import { mockAdapter, mockProtocolAdapter } from '@/api/hooks/useProtocolAdapters/__handlers__'
 import {
   MOCK_PULSE_EXT_ASSET_MAPPERS_LIST,
@@ -16,6 +18,8 @@ const cy_getHeader = (column: number) => cy.get('table thead th').eq(column)
 describe('AssetsTable', () => {
   beforeEach(() => {
     cy.viewport(1000, 700)
+    cy.intercept('/api/v1/frontend/capabilities', { items: [MOCK_CAPABILITY_PULSE_ASSETS] })
+    cy.intercept('GET', '/api/v1/management/pulse/asset-mappers', { items: [MOCK_COMBINER_ASSET] })
   })
 
   it('should render errors', () => {

--- a/hivemq-edge-frontend/src/modules/Pulse/components/assets/ManagedAssetDrawer.spec.cy.tsx
+++ b/hivemq-edge-frontend/src/modules/Pulse/components/assets/ManagedAssetDrawer.spec.cy.tsx
@@ -5,6 +5,7 @@ import { Route, Routes } from 'react-router-dom'
 
 import { WrapperTestRoute } from '@/__test-utils__/hooks/WrapperTestRoute.tsx'
 import { MOCK_PULSE_ASSET_LIST } from '@/api/hooks/usePulse/__handlers__'
+import { MOCK_CAPABILITY_PULSE_ASSETS } from '@/api/hooks/useFrontendServices/__handlers__'
 import ManagedAssetDrawer from '@/modules/Pulse/components/assets/ManagedAssetDrawer.tsx'
 
 const wrapper: FC<PropsWithChildren> = ({ children }) => (
@@ -19,6 +20,7 @@ const wrapper: FC<PropsWithChildren> = ({ children }) => (
 describe('ManagedAssetDrawer', () => {
   beforeEach(() => {
     cy.viewport(800, 800)
+    cy.intercept('/api/v1/frontend/capabilities', { items: [MOCK_CAPABILITY_PULSE_ASSETS] })
   })
 
   it('should handle errors', () => {

--- a/hivemq-edge-frontend/src/modules/Pulse/hooks/useListManagedAssetMappings.spec.ts
+++ b/hivemq-edge-frontend/src/modules/Pulse/hooks/useListManagedAssetMappings.spec.ts
@@ -1,3 +1,4 @@
+import { handlerCapabilities, MOCK_CAPABILITIES } from '@/api/hooks/useFrontendServices/__handlers__'
 import { http, HttpResponse } from 'msw'
 import { expect } from 'vitest'
 import { renderHook, waitFor } from '@testing-library/react'
@@ -12,6 +13,10 @@ import type { ManagedAssetExtended } from '@/modules/Pulse/types.ts'
 import { useCombinedAssetsAndCombiners } from '@/modules/Pulse/hooks/useListManagedAssetMappings.ts'
 
 describe('useCombinedAssetsAndCombiners', () => {
+  beforeEach(() => {
+    server.use(...handlerCapabilities(MOCK_CAPABILITIES))
+  })
+
   afterEach(() => {
     server.resetHandlers()
   })

--- a/hivemq-edge-frontend/src/modules/Welcome/WelcomePage.spec.cy.tsx
+++ b/hivemq-edge-frontend/src/modules/Welcome/WelcomePage.spec.cy.tsx
@@ -1,0 +1,88 @@
+import { MOCK_CAPABILITIES, mockGatewayConfiguration } from '@/api/hooks/useFrontendServices/__handlers__'
+import WelcomePage from '@/modules/Welcome/WelcomePage.tsx'
+
+describe('WelcomePage', () => {
+  beforeEach(() => {
+    cy.viewport(960, 800)
+    cy.intercept('/api/v1/frontend/configuration', mockGatewayConfiguration)
+    cy.intercept('/api/v1/frontend/capabilities', { items: [] })
+  })
+
+  it('should be accessible', () => {
+    cy.injectAxe()
+    cy.mountWithProviders(<WelcomePage />)
+    cy.checkAccessibility()
+    cy.percySnapshot('Component: Onboarding')
+  })
+
+  it('should render properly', () => {
+    cy.mountWithProviders(<WelcomePage />)
+    cy.get('header h1').should('have.text', 'Welcome to HiveMQ Edge')
+    cy.get('header h1 + p').should(
+      'have.text',
+      'Connect to and from any device for seamless data streaming to your enterprise infrastructure.'
+    )
+
+    cy.getByTestId('onboarding-container').within(() => {
+      cy.get('h2').should('have.text', 'Get data flowing')
+      cy.get('aside').should('have.length', 4)
+    })
+  })
+
+  describe('Pulse Onboarding', () => {
+    it('should render activation properly', () => {
+      cy.mountWithProviders(<WelcomePage />)
+
+      cy.getByTestId('onboarding-container').within(() => {
+        cy.get('h2').should('have.text', 'Get data flowing')
+        cy.get('aside[aria-labelledby="heading-task-3"]').within(() => {
+          cy.get('h3').should('have.text', 'Connect to HiveMQ Pulse')
+
+          cy.get('section').within(() => {
+            cy.get('p').should(
+              'have.text',
+              'To access the features of HiveMQ Edge Pulse, you need to activate it first.'
+            )
+            cy.get('button').should('have.text', 'Activate Pulse')
+          })
+        })
+      })
+    })
+
+    it('should render todos properly', () => {
+      cy.intercept('/api/v1/frontend/capabilities', MOCK_CAPABILITIES)
+      cy.intercept('/api/v1/management/pulse/managed-assets', { statusCode: 404 })
+      cy.mountWithProviders(<WelcomePage />)
+
+      cy.getByTestId('onboarding-container').within(() => {
+        cy.get('h2').should('have.text', 'Get data flowing')
+        cy.get('aside[aria-labelledby="heading-task-3"]').within(() => {
+          cy.get('h3').should('have.text', 'Connect to HiveMQ Pulse')
+          cy.get('section')
+            .eq(0)
+            .within(() => {
+              cy.get('p').should(
+                'have.text',
+                'To access the features of HiveMQ Edge Pulse, you need to activate it first.'
+              )
+              cy.get('button').should('have.text', 'Activate Pulse')
+            })
+
+          cy.get('section')
+            .eq(1)
+            .within(() => {
+              cy.get('p').should('have.text', 'Use HiveMQ Edge Pulse to manage and publish assets to your HiveMQ Edge')
+              cy.get('a').should('have.text', 'Manage Pulse Assets')
+            })
+
+          cy.get('section')
+            .eq(2)
+            .within(() => {
+              cy.get('p').should('have.text', 'Stay up-to-date with your asset mappings')
+              cy.get('[role="alert"]').should('have.text', 'Not Found').should('have.attr', 'data-status', 'error')
+            })
+        })
+      })
+    })
+  })
+})

--- a/hivemq-edge-frontend/src/modules/Welcome/components/Onboarding.tsx
+++ b/hivemq-edge-frontend/src/modules/Welcome/components/Onboarding.tsx
@@ -28,7 +28,7 @@ const Onboarding: FC<OnboardingProps> = ({ tasks, ...props }) => {
   const { t } = useTranslation()
 
   return (
-    <Box mt={6} {...props}>
+    <Box mt={6} {...props} data-testid="onboarding-container">
       <Heading>{t('welcome.onboarding.title')}</Heading>
       <SimpleGrid spacing={6} templateColumns="repeat(auto-fill, minmax(33vw, 10fr))">
         {tasks?.map((task, index) => (

--- a/hivemq-edge-frontend/src/modules/Welcome/hooks/useOnboarding.spec.ts
+++ b/hivemq-edge-frontend/src/modules/Welcome/hooks/useOnboarding.spec.ts
@@ -16,7 +16,7 @@ import { useOnboarding } from './useOnboarding.tsx'
 describe('useOnboarding()', () => {
   beforeEach(() => {
     window.localStorage.clear()
-    server.use(...handlerGatewayConfiguration, ...handlerCapabilities(MOCK_CAPABILITIES))
+    server.use(...handlerGatewayConfiguration)
   })
 
   afterEach(() => {
@@ -24,6 +24,7 @@ describe('useOnboarding()', () => {
   })
 
   it('should return the correct list of tasks', async () => {
+    server.use(...handlerCapabilities({ items: [] }))
     const { result } = renderHook(() => useOnboarding(), { wrapper })
 
     await waitFor(() => {
@@ -41,10 +42,28 @@ describe('useOnboarding()', () => {
     )
 
     expect(pulse).toStrictEqual(expect.objectContaining({ header: 'Connect to HiveMQ Pulse' }))
-    expect(pulse.sections).toStrictEqual([
-      expect.objectContaining({ label: 'Activate Pulse' }),
-      expect.objectContaining({ label: 'Manage Pulse Assets' }),
-      expect.objectContaining({ title: 'Stay up-to-date with your asset mappings' }),
-    ])
+  })
+
+  describe('Pulse', () => {
+    it('should return the Pulse todo list', async () => {
+      server.use(...handlerCapabilities(MOCK_CAPABILITIES))
+
+      const { result } = renderHook(() => useOnboarding(), { wrapper })
+
+      await waitFor(() => {
+        const data = result.current
+        expect(data?.[2].isLoading).toEqual(false)
+      })
+
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const [_adapter, _bridge, _cloud, pulse] = result.current
+
+      expect(pulse).toStrictEqual(expect.objectContaining({ header: 'Connect to HiveMQ Pulse' }))
+      expect(pulse.sections).toStrictEqual([
+        expect.objectContaining({ label: 'Activate Pulse' }),
+        expect.objectContaining({ label: 'Manage Pulse Assets' }),
+        expect.objectContaining({ title: 'Stay up-to-date with your asset mappings' }),
+      ])
+    })
   })
 })

--- a/hivemq-edge-frontend/src/modules/Welcome/hooks/useOnboarding.tsx
+++ b/hivemq-edge-frontend/src/modules/Welcome/hooks/useOnboarding.tsx
@@ -13,7 +13,11 @@ import AssetMonitoringOnboardingTask from '@/modules/Pulse/components/assets/Ass
 export const useOnboarding = (): OnboardingTask[] => {
   const { t } = useTranslation()
   const { data: config, isLoading: isConfigLoading, error: configError } = useGetConfiguration()
-  const { error: pulseError, isLoading: isPulseLoading } = useGetCapability(Capability.id.PULSE_ASSET_MANAGEMENT)
+  const {
+    data: hasPulse,
+    error: pulseError,
+    isLoading: isPulseLoading,
+  } = useGetCapability(Capability.id.PULSE_ASSET_MANAGEMENT)
 
   const cloud: OnboardingTask = {
     isLoading: isConfigLoading,
@@ -41,19 +45,23 @@ export const useOnboarding = (): OnboardingTask[] => {
         content: <ActivationPanel />,
         leftIcon: <PulseAgentIcon />,
       },
-      {
-        title: t('welcome.onboarding.pulse.section.assets.title'),
-        label: t('welcome.onboarding.pulse.section.assets.label'),
-        to: '/pulse-assets',
-        leftIcon: <PulseAgentIcon boxSize={6} />,
-      },
+      ...(hasPulse
+        ? [
+            {
+              title: t('welcome.onboarding.pulse.section.assets.title'),
+              label: t('welcome.onboarding.pulse.section.assets.label'),
+              to: '/pulse-assets',
+              leftIcon: <PulseAgentIcon boxSize={6} />,
+            },
 
-      {
-        title: t('pulse.onboarding.monitoring.task'),
-        label: '',
-        leftIcon: <PulseAgentIcon boxSize={6} />,
-        content: <AssetMonitoringOnboardingTask />,
-      },
+            {
+              title: t('pulse.onboarding.monitoring.task'),
+              label: '',
+              leftIcon: <PulseAgentIcon boxSize={6} />,
+              content: <AssetMonitoringOnboardingTask />,
+            },
+          ]
+        : []),
     ],
   }
 

--- a/hivemq-edge-frontend/src/modules/Workspace/components/nodes/NodeAssets.spec.cy.tsx
+++ b/hivemq-edge-frontend/src/modules/Workspace/components/nodes/NodeAssets.spec.cy.tsx
@@ -1,5 +1,7 @@
 import { mockReactFlow } from '@/__test-utils__/react-flow/providers.tsx'
 import { MOCK_NODE_ASSETS } from '@/__test-utils__/react-flow/nodes.ts'
+import { MOCK_COMBINER_ASSET } from '@/api/hooks/useCombiners/__handlers__'
+import { MOCK_CAPABILITIES } from '@/api/hooks/useFrontendServices/__handlers__'
 import { MOCK_PULSE_ASSET_LIST } from '@/api/hooks/usePulse/__handlers__'
 
 import NodeAssets from '@/modules/Workspace/components/nodes/NodeAssets.tsx'
@@ -8,6 +10,8 @@ describe('NodeAssets', () => {
   beforeEach(() => {
     cy.viewport(600, 400)
     cy.intercept('/api/v1/management/pulse/managed-assets', MOCK_PULSE_ASSET_LIST).as('getStatus')
+    cy.intercept('GET', '/api/v1/management/pulse/asset-mappers', { items: [MOCK_COMBINER_ASSET] }).as('getCombiner')
+    cy.intercept('/api/v1/frontend/capabilities', MOCK_CAPABILITIES)
 
     cy.intercept('/api/v1/management/protocol-adapters/types', { statusCode: 202, log: false })
     cy.intercept('/api/v1/management/combiners', { statusCode: 202, log: false })

--- a/hivemq-edge-frontend/src/modules/Workspace/components/nodes/NodeAssets.spec.cy.tsx
+++ b/hivemq-edge-frontend/src/modules/Workspace/components/nodes/NodeAssets.spec.cy.tsx
@@ -9,8 +9,8 @@ import NodeAssets from '@/modules/Workspace/components/nodes/NodeAssets.tsx'
 describe('NodeAssets', () => {
   beforeEach(() => {
     cy.viewport(600, 400)
-    cy.intercept('/api/v1/management/pulse/managed-assets', MOCK_PULSE_ASSET_LIST).as('getStatus')
-    cy.intercept('GET', '/api/v1/management/pulse/asset-mappers', { items: [MOCK_COMBINER_ASSET] }).as('getCombiner')
+    cy.intercept('/api/v1/management/pulse/managed-assets', MOCK_PULSE_ASSET_LIST)
+    cy.intercept('GET', '/api/v1/management/pulse/asset-mappers', { items: [MOCK_COMBINER_ASSET] })
     cy.intercept('/api/v1/frontend/capabilities', MOCK_CAPABILITIES)
 
     cy.intercept('/api/v1/management/protocol-adapters/types', { statusCode: 202, log: false })


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/36401/details/ and https://hivemq.kanbanize.com/ctrl_board/57/cards/36412/details/

The PR fixes a few issues with the Pulse integration
- The onboarding todos are now (properly) rendered only when Pulse is activated
- The Asset badge in the navigation link is only rendered when Pulse is activated
- The Pulse GET requests are enabled only when the `pulse-asset-management` capability is present (fix 36412)

### Before
<img width="1280" height="940" alt="HiveMQ-Edge-09-17-2025_06_48_PM" src="https://github.com/user-attachments/assets/39972175-dfff-48b6-8788-af19df00fc06" />

### After
<img width="1280" height="940" alt="HiveMQ-Edge-09-17-2025_06_48_PM (1)" src="https://github.com/user-attachments/assets/24a6730e-4334-4c60-8452-49bab32adab4" />
<img width="1280" height="940" alt="HiveMQ-Edge-09-17-2025_06_50_PM" src="https://github.com/user-attachments/assets/8b3ec0e1-468e-4126-8cd2-36ece8c5c6d0" />
