### PR TITLE
Added env and property to control pulse token location

### DIFF
--- a/hivemq-edge/src/main/java/com/hivemq/configuration/EnvironmentVariables.java
+++ b/hivemq-edge/src/main/java/com/hivemq/configuration/EnvironmentVariables.java
@@ -37,7 +37,6 @@ public class EnvironmentVariables {
      */
     public static final String LICENSE_FOLDER = "HIVEMQ_LICENSE_FOLDER";
 
-
     /**
      * Name of the environment variable for configuring the config folder.
      */
@@ -67,6 +66,11 @@ public class EnvironmentVariables {
      * Name of the environment variable for configuring the data folder.
      */
     public static final String DATA_FOLDER = "HIVEMQ_DATA_FOLDER";
+
+    /**
+     * Name of the environment variable for configuring the data folder.
+     */
+    public static final String PULSE_TOKEN_FOLDER = "HIVEMQ_PULSE_TOKEN_FOLDER";
 
     /**
      * Name of the environment variable for configuring the extension folder.

--- a/hivemq-edge/src/main/java/com/hivemq/configuration/SystemProperties.java
+++ b/hivemq-edge/src/main/java/com/hivemq/configuration/SystemProperties.java
@@ -34,6 +34,7 @@ public class SystemProperties {
     public static final String DATA_FOLDER = "hivemq.data.folder";
 
     public static final String EXTENSIONS_FOLDER = "hivemq.extensions.folder";
+    public static final String PULSE_TOKEN_FOLDER = "hivemq.pulse.token.folder";
     public static final String CORE_FOLDER = "hivemq.core.folder";
 
     public static final String MODULES_FOLDER = "hivemq.modules.folder";

--- a/hivemq-edge/src/main/java/com/hivemq/configuration/info/SystemInformation.java
+++ b/hivemq-edge/src/main/java/com/hivemq/configuration/info/SystemInformation.java
@@ -71,8 +71,6 @@ public interface SystemInformation {
     File getDataFolder();
 
     /**
-     * /**
-     *
      * @return the config folder of HiveMQ
      */
     @NotNull
@@ -83,6 +81,12 @@ public interface SystemInformation {
      */
     @NotNull
     File getExtensionsFolder();
+
+    /**
+     * @return the folder where HiveMQ stores pulse related data
+     */
+    @NotNull
+    File getPulseTokenFolder();
 
     /**
      * @return the modules folder of HiveMQ

--- a/hivemq-edge/src/main/java/com/hivemq/embedded/internal/EmbeddedHiveMQImpl.java
+++ b/hivemq-edge/src/main/java/com/hivemq/embedded/internal/EmbeddedHiveMQImpl.java
@@ -98,7 +98,7 @@ class EmbeddedHiveMQImpl implements EmbeddedHiveMQ {
         log.info("Setting default authentication behavior to ALLOW ALL");
         InternalConfigurations.AUTH_DENY_UNAUTHENTICATED_CONNECTIONS.set(false);
 
-        systemInformation = new SystemInformationImpl(true, true, conf, conf, data, extensions, null, license);
+        systemInformation = new SystemInformationImpl(true, true, conf, conf, data, extensions, null, license, null);
         // we create the metric registry here to make it accessible before start
         metricRegistry = new MetricRegistry();
 


### PR DESCRIPTION
**Motivation**

Resolves #36770

**Changes**
Add an env and a property to SystemInformation which can be used to control the persistence location for the pulse token.