### PR TITLE
fix(36931): Fix missing mappingId

### DIFF
--- a/hivemq-edge-frontend/src/modules/Pulse/components/assets/AssetMapperWizard.spec.cy.tsx
+++ b/hivemq-edge-frontend/src/modules/Pulse/components/assets/AssetMapperWizard.spec.cy.tsx
@@ -128,7 +128,7 @@ describe('AssetMapperWizard', () => {
     // This is a hack but will do for the time being
     cy.getByAriaLabel('Clear selected options').eq(1).click()
 
-    cy.get('@onSubmit').should('have.been.called').its('lastCall.args.1').should('be.true')
+    cy.get('@onSubmit').should('have.been.called').its('lastCall.args.2').should('be.true')
     cy.get('@onSubmit')
       .should('have.been.called')
       .its('lastCall.args.0')

--- a/hivemq-edge-frontend/src/modules/Pulse/components/assets/AssetMapperWizard.tsx
+++ b/hivemq-edge-frontend/src/modules/Pulse/components/assets/AssetMapperWizard.tsx
@@ -45,7 +45,7 @@ import { DEFAULT_ASSET_MAPPER_SOURCES } from '@/modules/Pulse/utils/assets.utils
 interface AssetMapperWizardProps {
   assetId: string
   onClose: () => void
-  onSubmit?: (assetMapper: Combiner, isNew: boolean) => void
+  onSubmit?: (assetMapper: Combiner, mappingId: string, isNew: boolean) => void
   isOpen: boolean
 }
 
@@ -216,7 +216,7 @@ const AssetMapperWizard: FC<AssetMapperWizardProps> = ({ assetId, isOpen, onClos
                     instructions: [],
                   }
                   rest.mappings.items.unshift(newMapping)
-                  onSubmit(rest, Boolean(__isNew__))
+                  onSubmit(rest, newMapping.id, Boolean(__isNew__))
                 }
               }}
               isDisabled={!selectedValue}

--- a/hivemq-edge-frontend/src/modules/Pulse/components/assets/AssetsTable.tsx
+++ b/hivemq-edge-frontend/src/modules/Pulse/components/assets/AssetsTable.tsx
@@ -76,7 +76,7 @@ const AssetsTable: FC<AssetTableProps> = ({ variant = 'full' }) => {
     onClose()
   }
 
-  const handleConfirmWizard = (assetMapper: Combiner, isNew: boolean = false) => {
+  const handleConfirmWizard = (assetMapper: Combiner, mappingId: string, isNew: boolean = false) => {
     if (!selectedAssetOperation || !selectedAssetOperation.asset) return combinerLog('Cannot find the asset')
 
     const promises: Promise<unknown>[] = []
@@ -92,7 +92,7 @@ const AssetsTable: FC<AssetTableProps> = ({ variant = 'full' }) => {
         ...selectedAssetOperation.asset,
         mapping: {
           status: AssetMapping.status.DRAFT,
-          mappingId: selectedAssetOperation.asset.mapping.mappingId,
+          mappingId: mappingId,
         },
       },
     })


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/36931/details/

The PR fixes a bug when creating a new asset mapper (or updating an existing one), where the `id` of the new mapping associated with the asset is not properly sent to the `updateManagedAsset` API