### PR TITLE
fix(36963) Fix bug with tags and asset/mapper query updates

### DIFF
--- a/hivemq-edge-frontend/src/api/hooks/useAssetMapper/useCreateAssetMapper.ts
+++ b/hivemq-edge-frontend/src/api/hooks/useAssetMapper/useCreateAssetMapper.ts
@@ -20,6 +20,7 @@ export const useCreateAssetMapper = () => {
     mutationFn: createCombiner,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.ASSET_MAPPER] })
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.PULSE_ASSETS] })
     },
   })
 }

--- a/hivemq-edge-frontend/src/api/hooks/useAssetMapper/useDeleteAssetMapper.ts
+++ b/hivemq-edge-frontend/src/api/hooks/useAssetMapper/useDeleteAssetMapper.ts
@@ -20,6 +20,7 @@ export const useDeleteAssetMapper = () => {
     mutationFn: deleteAssetMapper,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.ASSET_MAPPER] })
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.PULSE_ASSETS] })
     },
   })
 }

--- a/hivemq-edge-frontend/src/api/hooks/useAssetMapper/useUpdateAssetMapper.ts
+++ b/hivemq-edge-frontend/src/api/hooks/useAssetMapper/useUpdateAssetMapper.ts
@@ -21,6 +21,7 @@ export const useUpdateAssetMapper = () => {
     mutationFn: updateAssetMapper,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.ASSET_MAPPER] })
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.PULSE_ASSETS] })
     },
   })
 }

--- a/hivemq-edge-frontend/src/api/hooks/usePulse/useCreateManagedAsset.ts
+++ b/hivemq-edge-frontend/src/api/hooks/usePulse/useCreateManagedAsset.ts
@@ -20,6 +20,7 @@ export const useCreateManagedAsset = () => {
     mutationFn: createManagedAsset,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.PULSE_ASSETS] })
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.ASSET_MAPPER] })
     },
   })
 }

--- a/hivemq-edge-frontend/src/api/hooks/usePulse/useDeleteManagedAsset.ts
+++ b/hivemq-edge-frontend/src/api/hooks/usePulse/useDeleteManagedAsset.ts
@@ -16,6 +16,7 @@ export const useDeleteManagedAsset = () => {
     mutationFn: deleteManagedAsset,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.PULSE_ASSETS] })
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.ASSET_MAPPER] })
     },
   })
 }

--- a/hivemq-edge-frontend/src/api/hooks/usePulse/useUpdateManagedAsset.ts
+++ b/hivemq-edge-frontend/src/api/hooks/usePulse/useUpdateManagedAsset.ts
@@ -21,6 +21,7 @@ export const useUpdateManagedAsset = () => {
     mutationFn: updateManagedAsset,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.PULSE_ASSETS] })
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.ASSET_MAPPER] })
     },
   })
 }

--- a/hivemq-edge-frontend/src/modules/Mappings/AdapterMappingManager.tsx
+++ b/hivemq-edge-frontend/src/modules/Mappings/AdapterMappingManager.tsx
@@ -87,10 +87,10 @@ const AdapterMappingManager: FC<AdapterMappingManagerProps> = ({ type }) => {
           />
         </DrawerHeader>
         <DrawerBody display="flex" flexDirection="column" gap={6}>
-          {!adapterId && <ErrorMessage message={t('protocolAdapter.error.loading')} />}
-          {adapterId && (
+          {!selectedNode && <ErrorMessage message={t('protocolAdapter.error.loading')} />}
+          {selectedNode && (
             <MappingForm
-              adapterId={adapterId}
+              adapterId={selectedNode.data.id}
               adapterType={selectedNode?.data.type}
               onSubmit={handleClose}
               useManager={manager}

--- a/hivemq-edge-frontend/src/modules/Mappings/hooks/useValidateCombiner.ts
+++ b/hivemq-edge-frontend/src/modules/Mappings/hooks/useValidateCombiner.ts
@@ -48,17 +48,21 @@ export const useValidateCombiner = (
 
   // TODO[NVL] This is a duplicate from CombinedSchemaLoader; refactor
   const allReferences = useMemo<DataReference[]>(() => {
+    const dataSources = entities.filter((e) => e.type === EntityType.ADAPTER || e.type === EntityType.EDGE_BROKER)
     return queries?.reduce<DataReference[]>((acc, cur, currentIndex) => {
       const firstItem = cur.data?.items?.[0]
       if (!firstItem) return acc
+
       if ((firstItem as DomainTag).name) {
+        // This is a domain tag
         const tagDataReferences = (cur.data?.items as DomainTag[]).map<DataReference>((tag) => ({
           id: tag.name,
           type: DataIdentifierReference.type.TAG,
-          adapterId: entities?.[currentIndex]?.id,
+          adapterId: dataSources?.[currentIndex]?.id,
         }))
         acc.push(...tagDataReferences)
       } else if ((firstItem as TopicFilter).topicFilter) {
+        // This is a topic filter
         const topicFilterDataReferences = (cur.data?.items as TopicFilter[]).map<DataReference>((topicFilter) => ({
           id: topicFilter.topicFilter,
           type: DataIdentifierReference.type.TOPIC_FILTER,

--- a/hivemq-edge-frontend/src/modules/Mappings/utils/combining.utils.ts
+++ b/hivemq-edge-frontend/src/modules/Mappings/utils/combining.utils.ts
@@ -7,6 +7,7 @@ import {
   type EntityReference,
   type JsonNode,
   type TopicFilter,
+  EntityType,
 } from '@/api/__generated__'
 import type { DataReference } from '@/api/hooks/useDomainModel/useGetCombinedDataSchemas'
 import { AUTO_MATCH_DISTANCE } from '@/components/rjsf/BatchModeMappings/utils/config.utils'
@@ -38,19 +39,23 @@ export const getCombinedDataEntityReference = (
   content: (DomainTag[] | TopicFilter[])[],
   entities: EntityReference[]
 ): DataReference[] => {
+  const dataSources = entities.filter((e) => e.type === EntityType.ADAPTER || e.type === EntityType.EDGE_BROKER)
   return content.reduce<DataReference[]>((acc, cur, currentIndex) => {
     const firstItem = cur[0]
     if (!firstItem) return acc
+
     if ((firstItem as DomainTag).name) {
+      // This is a domain tag
       const tagDataReferences = (cur as DomainTag[]).map<DataReference>((tag) => {
         return {
           id: tag.name,
           type: DataIdentifierReference.type.TAG,
-          adapterId: entities?.[currentIndex]?.id,
+          adapterId: dataSources?.[currentIndex]?.id,
         }
       })
       acc.push(...tagDataReferences)
     } else if ((firstItem as TopicFilter).topicFilter) {
+      // This is a topic filter
       const topicFilterDataReferences = (cur as TopicFilter[]).map<DataReference>((topicFilter) => ({
         id: topicFilter.topicFilter,
         type: DataIdentifierReference.type.TOPIC_FILTER,


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/36963/details/

The PR fixes three bugs:
- Fetching the `Tags` of an adapter was based on the wrong `id` (must be an adapter!)
- Associating `Tags` and `integration point` was based on a flawed logic that didn't take into account the possible existence of `Pulse` as a source (`Asset Mappers` are based on `Combiner`) 
- Changes to `Asset Mappers` (update, delete) now trigger the invalidity (i.e. stale state, therefore refetch) of the data store for `Assets`, and vice-versa. This is to ensure that the two connected data sources are kept up-to-date

### Out-of-scope
- The validation of `Combiner` and `Asset Mapper` is based on a flawed process that does not ensure proper identification of data sources and integration points. This will be fixed for both entities in a future epic.

### Before 
<img width="1280" height="940" alt="HiveMQ-Edge-10-01-2025_02_16_PM" src="https://github.com/user-attachments/assets/b238e5d7-3548-4838-8d50-0b0948b5ccc5" />
<img width="1280" height="940" alt="HiveMQ-Edge-10-01-2025_02_17_PM" src="https://github.com/user-attachments/assets/e8d96892-43cd-4cab-a82c-b09eb0fc1c39" />


### After
<img width="1280" height="940" alt="HiveMQ-Edge-10-01-2025_02_18_PM" src="https://github.com/user-attachments/assets/5bc5c9f9-0735-43ab-891c-1a8a4a4ac784" />
<img width="1280" height="940" alt="HiveMQ-Edge-10-01-2025_02_19_PM" src="https://github.com/user-attachments/assets/922d7165-e2ba-4749-b295-40d00e9c9b19" />
