### PR TITLE
Make sure nullable attributes security and auth bi-directional adapters are considered null when no structure is defined

### DIFF
--- a/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/config/Auth.java
+++ b/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/config/Auth.java
@@ -17,9 +17,19 @@ package com.hivemq.edge.adapters.opcua.config;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.hivemq.adapter.sdk.api.annotations.ModuleConfigField;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.io.IOException;
+import java.util.Map;
+
+@JsonDeserialize(using = Auth.AuthDeserializer.class)
 public record Auth(@JsonProperty("basic") @ModuleConfigField(title = "Basic Authentication",
                                                              description = "Username / password based authentication") @Nullable BasicAuth basicAuth,
                    @JsonProperty("x509") @ModuleConfigField(title = "X509 Authentication",
@@ -27,6 +37,14 @@ public record Auth(@JsonProperty("basic") @ModuleConfigField(title = "Basic Auth
 
     @JsonCreator
     public Auth {
+    }
+
+    private static <T> @Nullable T fetch(
+            final @NotNull Map<String, Object> map,
+            final @NotNull String key,
+            final @NotNull Class<T> clazz,
+            final @NotNull ObjectMapper mapper) {
+        return map.containsKey(key) ? mapper.convertValue(map.get(key), clazz) : null;
     }
 
     @Override
@@ -37,5 +55,30 @@ public record Auth(@JsonProperty("basic") @ModuleConfigField(title = "Basic Auth
     @Override
     public @Nullable X509Auth x509Auth() {
         return x509Auth;
+    }
+
+    static class AuthDeserializer extends JsonDeserializer<Auth> {
+        @Override
+        public @NotNull Auth deserialize(final @NotNull JsonParser parser, final @NotNull DeserializationContext context)
+                throws IOException {
+            final String text = parser.getText();
+            if (text != null && text.isEmpty()) {
+                return new Auth(null, null);
+            }
+
+            try {
+                final Map<String, Object> map = parser.readValueAs(Map.class);
+                if (map == null || map.isEmpty()) {
+                    return new Auth(null, null);
+                }
+
+                final ObjectMapper mapper = (ObjectMapper) parser.getCodec();
+                final BasicAuth basicAuth = fetch(map, "basic", BasicAuth.class, mapper);
+                final X509Auth x509Auth = fetch(map, "x509", X509Auth.class, mapper);
+                return new Auth(basicAuth, x509Auth);
+            } catch (final IOException e) {
+                return new Auth(null, null);
+            }
+        }
     }
 }


### PR DESCRIPTION
**card**: https://hivemq.kanbanize.com/ctrl_board/57/cards/36965/details/