### PR TITLE
fix(38059): Ensure dry-run reports are cleaned up

### DIFF
--- a/hivemq-edge-frontend/src/extensions/datahub/components/pages/PolicyEditorLoader.tsx
+++ b/hivemq-edge-frontend/src/extensions/datahub/components/pages/PolicyEditorLoader.tsx
@@ -19,6 +19,7 @@ import { loadTopicFilter } from '@datahub/designer/topic_filter/TopicFilterNode.
 import { loadValidators } from '@datahub/designer/validator/ValidatorNode.utils.ts'
 import { loadDataPolicyPipelines } from '@datahub/designer/operation/OperationNode.utils.ts'
 import useDataHubDraftStore from '@datahub/hooks/useDataHubDraftStore.ts'
+import { usePolicyChecksStore } from '@datahub/hooks/usePolicyChecksStore.ts'
 import { DATAHUB_TOAST_ID, dataHubToastOption } from '@datahub/utils/toast.utils.ts'
 import { loadBehaviorPolicy } from '@datahub/designer/behavior_policy/BehaviorPolicyNode.utils.ts'
 import { loadClientFilter } from '@datahub/designer/client_filter/ClientFilterNode.utils.ts'
@@ -170,6 +171,13 @@ export const BehaviorPolicyLoader: FC<PolicyLoaderProps> = ({ policyId }) => {
 const PolicyEditorLoader: FC = () => {
   const { t } = useTranslation('datahub')
   const { policyType, policyId } = useParams()
+  const { reset } = usePolicyChecksStore()
+
+  useEffect(() => {
+    if (policyType) {
+      reset()
+    }
+  }, [policyType, reset])
 
   if (!policyType || !(policyType in DesignerPolicyType))
     return <ErrorMessage type={t('error.notDefined.title')} message={t('error.notDefined.description')} />


### PR DESCRIPTION
See https://hivemq.kanbanize.com/ctrl_board/57/cards/38059/details/

The PR is a quick fix ensuring that any publish dry-runs and their report are being cleanup before a new policy is loaded. 

This is to ensure that a report from a previously loaded policy is not still available through the "Show Report" action

A drawback is that genuine reloading of the same polocy will not preserve any dry-run made before