### PR TITLE
Ignore json-schema-inferrer for the javadocLinks task so it doesn't break the build because of its missing javadoc

### DIFF
--- a/hivemq-edge/build.gradle.kts
+++ b/hivemq-edge/build.gradle.kts
@@ -90,6 +90,26 @@ metadata {
     }
 }
 
+// Create a configuration for javadocLinks that excludes json-schema-inferrer
+val javadocLinksClasspath: Configuration by configurations.creating {
+    isCanBeConsumed = false
+    isCanBeResolved = true
+    extendsFrom(configurations.compileClasspath.get())
+    exclude(group = "com.github.saasquatch", module = "json-schema-inferrer")
+        // Copy attributes from compileClasspath to ensure proper resolution
+    attributes {
+        attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage::class.java, Usage.JAVA_API))
+        attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category::class.java, Category.LIBRARY))
+        attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements::class.java, LibraryElements.JAR))
+        attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling::class.java, Bundling.EXTERNAL))
+        attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 21)
+    }
+}
+
+tasks.javadocLinks {
+    useConfiguration(javadocLinksClasspath)
+}
+
 /* ******************** java ******************** */
 
 java {


### PR DESCRIPTION
**Motivation**

json-schema-inferrer breaks the build in the javadocLinks task.

**Changes**

json-schema-inferrer has no javadoc which breaks the task.
Since the task doesn't allow excluding certain deps I added a new configuration to run the task against which filters out the offending dependency.