### PR TITLE
fix: Add scope check, tag dup check

### DIFF
--- a/hivemq-edge/src/main/java/com/hivemq/api/errors/adapters/DuplicateTagError.java
+++ b/hivemq-edge/src/main/java/com/hivemq/api/errors/adapters/DuplicateTagError.java
@@ -13,20 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hivemq.api.errors.adapters;
 
 import com.hivemq.http.HttpStatus;
 import com.hivemq.http.error.ProblemDetails;
-import org.jetbrains.annotations.NotNull;
-
 import java.util.List;
+import org.jetbrains.annotations.NotNull;
 
 public class DuplicateTagError extends ProblemDetails {
     public DuplicateTagError(final @NotNull String adapterId, final @NotNull String tagName) {
-        super("DuplicateTagError",
+        super(
+                "DuplicateTagError",
                 "Duplicate Tag Name",
-                "The tag name '" + tagName + "' is duplicated in adapter '" + adapterId + "'. Tag names must be unique within an adapter.",
+                "The tag name '" + tagName + "' is duplicated in adapter '" + adapterId
+                        + "'. Tag names must be unique within an adapter.",
                 HttpStatus.CONFLICT_409,
                 List.of());
     }

--- a/hivemq-edge/src/main/java/com/hivemq/api/errors/combiners/TagNotFoundError.java
+++ b/hivemq-edge/src/main/java/com/hivemq/api/errors/combiners/TagNotFoundError.java
@@ -1,30 +1,29 @@
 /*
- *  Copyright 2019-present HiveMQ GmbH
+ * Copyright 2019-present HiveMQ GmbH
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package com.hivemq.api.errors.combiners;
 
 import com.hivemq.http.HttpStatus;
 import com.hivemq.http.error.ProblemDetails;
-import org.jetbrains.annotations.NotNull;
-
 import java.util.List;
+import org.jetbrains.annotations.NotNull;
 
 public class TagNotFoundError extends ProblemDetails {
     public TagNotFoundError(final @NotNull String tagId, final @NotNull String scope) {
-        super("TagNotFoundError",
+        super(
+                "TagNotFoundError",
                 "Tag Not Found",
                 "The tag '" + tagId + "' does not exist in adapter '" + scope + "'.",
                 HttpStatus.BAD_REQUEST_400,

--- a/hivemq-edge/src/main/java/com/hivemq/api/errors/combiners/UnexpectedScopeError.java
+++ b/hivemq-edge/src/main/java/com/hivemq/api/errors/combiners/UnexpectedScopeError.java
@@ -1,35 +1,33 @@
 /*
- *  Copyright 2019-present HiveMQ GmbH
+ * Copyright 2019-present HiveMQ GmbH
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package com.hivemq.api.errors.combiners;
 
 import com.hivemq.combining.model.DataIdentifierReference;
 import com.hivemq.http.HttpStatus;
 import com.hivemq.http.error.ProblemDetails;
+import java.util.List;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.List;
-
 public class UnexpectedScopeError extends ProblemDetails {
-    public UnexpectedScopeError(
-            final @NotNull DataIdentifierReference.Type type,
-            final @NotNull String id) {
-        super("UnexpectedScopeError",
+    public UnexpectedScopeError(final @NotNull DataIdentifierReference.Type type, final @NotNull String id) {
+        super(
+                "UnexpectedScopeError",
                 "Unexpected Scope for " + type + " Reference",
-                "The " + type + " reference '" + id + "' should not have a scope. Scope is only valid for TAG references.",
+                "The " + type + " reference '" + id
+                        + "' should not have a scope. Scope is only valid for TAG references.",
                 HttpStatus.BAD_REQUEST_400,
                 List.of());
     }

--- a/hivemq-edge/src/main/java/com/hivemq/api/resources/impl/CombinersResourceImpl.java
+++ b/hivemq-edge/src/main/java/com/hivemq/api/resources/impl/CombinersResourceImpl.java
@@ -228,8 +228,8 @@ public class CombinersResourceImpl implements CombinersApi {
             // Validate primary TOPIC_FILTER reference has no scope
             if (primaryRef.type() == DataIdentifierReference.Type.TOPIC_FILTER) {
                 if (primaryRef.scope() != null && !primaryRef.scope().isBlank()) {
-                    return Optional.of(ErrorResponseUtil.errorResponse(new UnexpectedScopeError(primaryRef.type(),
-                            primaryRef.id())));
+                    return Optional.of(ErrorResponseUtil.errorResponse(
+                            new UnexpectedScopeError(primaryRef.type(), primaryRef.id())));
                 }
             }
             if (dataCombining.instructions().stream()
@@ -254,8 +254,8 @@ public class CombinersResourceImpl implements CombinersApi {
                         }
                     } else if (ref.type() == DataIdentifierReference.Type.TOPIC_FILTER) {
                         if (ref.scope() != null && !ref.scope().isBlank()) {
-                            return Optional.of(ErrorResponseUtil.errorResponse(new UnexpectedScopeError(ref.type(),
-                                    ref.id())));
+                            return Optional.of(
+                                    ErrorResponseUtil.errorResponse(new UnexpectedScopeError(ref.type(), ref.id())));
                         }
                     }
                 }
@@ -265,8 +265,7 @@ public class CombinersResourceImpl implements CombinersApi {
     }
 
     private @NotNull Optional<Response> validateTagExists(
-            final @NotNull DataIdentifierReference ref,
-            final @NotNull Map<String, Set<String>> adapterToTags) {
+            final @NotNull DataIdentifierReference ref, final @NotNull Map<String, Set<String>> adapterToTags) {
         final Set<String> tags = adapterToTags.get(ref.scope());
         if (tags == null) {
             return Optional.of(ErrorResponseUtil.errorResponse(new InvalidScopeForTagError(ref.scope(), ref.id())));

--- a/hivemq-edge/src/main/java/com/hivemq/api/resources/impl/ProtocolAdaptersResourceImpl.java
+++ b/hivemq-edge/src/main/java/com/hivemq/api/resources/impl/ProtocolAdaptersResourceImpl.java
@@ -469,11 +469,14 @@ public class ProtocolAdaptersResourceImpl extends AbstractApi implements Protoco
         if (log.isDebugEnabled()) {
             log.debug("Adding adapter domain tag {} for adapter {}", domainTag.getName(), adapterId);
         }
-        return systemInformation.isConfigWriteable() ?
-                configExtractor.getAdapterByAdapterId(adapterId).map(oldInstance -> {
-                    if (oldInstance.getTags().stream().anyMatch(tag -> tag.getName().equals(domainTag.getName()))) {
-                        return errorResponse(new DuplicateTagError(adapterId, domainTag.getName()));
-                    }
+        return systemInformation.isConfigWriteable()
+                ? configExtractor
+                        .getAdapterByAdapterId(adapterId)
+                        .map(oldInstance -> {
+                            if (oldInstance.getTags().stream()
+                                    .anyMatch(tag -> tag.getName().equals(domainTag.getName()))) {
+                                return errorResponse(new DuplicateTagError(adapterId, domainTag.getName()));
+                            }
 
                             final List<TagEntity> newTagList = new ArrayList<>(oldInstance.getTags());
                             newTagList.add(toTagEntity(domainTag));
@@ -549,21 +552,21 @@ public class ProtocolAdaptersResourceImpl extends AbstractApi implements Protoco
                             // Check if this is a rename operation (tag name is changing)
                             final boolean isRename = !decodedTagName.equals(domainTag.getName());
 
-                    if (isRename) {
-                        // Check if new tag name already exists in the adapter
-                        final boolean newNameExists = oldInstance.getTags()
-                                .stream()
-                                .anyMatch(tag -> tag.getName().equals(domainTag.getName()));
-                        if (newNameExists) {
-                            return errorResponse(new DuplicateTagError(adapterId, domainTag.getName()));
-                        }
+                            if (isRename) {
+                                // Check if new tag name already exists in the adapter
+                                final boolean newNameExists = oldInstance.getTags().stream()
+                                        .anyMatch(tag -> tag.getName().equals(domainTag.getName()));
+                                if (newNameExists) {
+                                    return errorResponse(new DuplicateTagError(adapterId, domainTag.getName()));
+                                }
 
-                        // Validate that old tag name is not in use before allowing rename
-                        final Optional<Response> validationError = validateTagNotInUse(oldInstance, decodedTagName);
-                        if (validationError.isPresent()) {
-                            return validationError.get();
-                        }
-                    }
+                                // Validate that old tag name is not in use before allowing rename
+                                final Optional<Response> validationError =
+                                        validateTagNotInUse(oldInstance, decodedTagName);
+                                if (validationError.isPresent()) {
+                                    return validationError.get();
+                                }
+                            }
 
                             // Proceed with update
                             final AtomicBoolean updated = new AtomicBoolean(false);
@@ -605,21 +608,21 @@ public class ProtocolAdaptersResourceImpl extends AbstractApi implements Protoco
 
     @Override
     public @NotNull Response updateAdapterDomainTags(
-            final @NotNull String adapterId,
-            final @NotNull DomainTagList domainTagList) {
-        return systemInformation.isConfigWriteable() ?
-                configExtractor.getAdapterByAdapterId(adapterId).map(oldInstance -> {
-                    // Check for duplicate tag names in the new list
-                    final Optional<String> duplicateTag = findDuplicateTagName(domainTagList.getItems());
-                    if (duplicateTag.isPresent()) {
-                        return errorResponse(new DuplicateTagError(adapterId, duplicateTag.get()));
-                    }
+            final @NotNull String adapterId, final @NotNull DomainTagList domainTagList) {
+        return systemInformation.isConfigWriteable()
+                ? configExtractor
+                        .getAdapterByAdapterId(adapterId)
+                        .map(oldInstance -> {
+                            // Check for duplicate tag names in the new list
+                            final Optional<String> duplicateTag = findDuplicateTagName(domainTagList.getItems());
+                            if (duplicateTag.isPresent()) {
+                                return errorResponse(new DuplicateTagError(adapterId, duplicateTag.get()));
+                            }
 
-                    // Find tags that are being removed (exist in old list but not in new list)
-                    final Set<String> newTagNames = domainTagList.getItems()
-                            .stream()
-                            .map(com.hivemq.edge.api.model.DomainTag::getName)
-                            .collect(Collectors.toSet());
+                            // Find tags that are being removed (exist in old list but not in new list)
+                            final Set<String> newTagNames = domainTagList.getItems().stream()
+                                    .map(com.hivemq.edge.api.model.DomainTag::getName)
+                                    .collect(Collectors.toSet());
 
                             final List<String> removedTags = oldInstance.getTags().stream()
                                     .map(TagEntity::getName)

--- a/hivemq-edge/src/main/java/com/hivemq/api/resources/impl/PulseApiImpl.java
+++ b/hivemq-edge/src/main/java/com/hivemq/api/resources/impl/PulseApiImpl.java
@@ -72,11 +72,6 @@ import com.hivemq.util.ErrorResponseUtil;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import jakarta.ws.rs.core.Response;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -642,8 +637,9 @@ public class PulseApiImpl implements PulseApi {
             adapterToTags.put(adapter.getAdapterId(), tagNames);
         });
 
-        final Set<String> oldAssetIdSet =
-                Optional.ofNullable(oldDataCombiner).map(DataCombiner::getAssetIdSet).orElseGet(Set::of);
+        final Set<String> oldAssetIdSet = Optional.ofNullable(oldDataCombiner)
+                .map(DataCombiner::getAssetIdSet)
+                .orElseGet(Set::of);
         final Set<String> allAssetIdSet = assetMappingExtractor.getAssetIdSet();
         final Set<String> unusableAssetIdSet = Sets.difference(allAssetIdSet, oldAssetIdSet);
         final Set<String> usedAssetIdSet = new HashSet<>();
@@ -690,17 +686,17 @@ public class PulseApiImpl implements PulseApi {
             if (primaryRef != null) {
                 if (primaryRef.type() == DataIdentifierReference.Type.TAG) {
                     if (primaryRef.scope() == null || primaryRef.scope().isBlank()) {
-                        return Optional.of(ErrorResponseUtil.errorResponse(new MissingScopeForTagError(primaryRef.id())));
+                        return Optional.of(
+                                ErrorResponseUtil.errorResponse(new MissingScopeForTagError(primaryRef.id())));
                     }
-                    final Optional<Response> tagValidationError =
-                            validateTagExists(primaryRef, adapterToTags);
+                    final Optional<Response> tagValidationError = validateTagExists(primaryRef, adapterToTags);
                     if (tagValidationError.isPresent()) {
                         return tagValidationError;
                     }
                 } else if (primaryRef.type() == DataIdentifierReference.Type.TOPIC_FILTER) {
                     if (primaryRef.scope() != null && !primaryRef.scope().isBlank()) {
-                        return Optional.of(ErrorResponseUtil.errorResponse(new UnexpectedScopeError(primaryRef.type(),
-                                primaryRef.id())));
+                        return Optional.of(ErrorResponseUtil.errorResponse(
+                                new UnexpectedScopeError(primaryRef.type(), primaryRef.id())));
                     }
                 }
             }
@@ -712,15 +708,14 @@ public class PulseApiImpl implements PulseApi {
                         if (ref.scope() == null || ref.scope().isBlank()) {
                             return Optional.of(ErrorResponseUtil.errorResponse(new MissingScopeForTagError(ref.id())));
                         }
-                        final Optional<Response> tagValidationError =
-                                validateTagExists(ref, adapterToTags);
+                        final Optional<Response> tagValidationError = validateTagExists(ref, adapterToTags);
                         if (tagValidationError.isPresent()) {
                             return tagValidationError;
                         }
                     } else if (ref.type() == DataIdentifierReference.Type.TOPIC_FILTER) {
                         if (ref.scope() != null && !ref.scope().isBlank()) {
-                            return Optional.of(ErrorResponseUtil.errorResponse(new UnexpectedScopeError(ref.type(),
-                                    ref.id())));
+                            return Optional.of(
+                                    ErrorResponseUtil.errorResponse(new UnexpectedScopeError(ref.type(), ref.id())));
                         }
                     }
                 }
@@ -730,8 +725,7 @@ public class PulseApiImpl implements PulseApi {
     }
 
     private @NotNull Optional<Response> validateTagExists(
-            final @NotNull DataIdentifierReference ref,
-            final @NotNull Map<String, Set<String>> adapterToTags) {
+            final @NotNull DataIdentifierReference ref, final @NotNull Map<String, Set<String>> adapterToTags) {
         final Set<String> tags = adapterToTags.get(ref.scope());
         if (tags == null) {
             return Optional.of(ErrorResponseUtil.errorResponse(new InvalidScopeForTagError(ref.scope(), ref.id())));

--- a/hivemq-edge/src/test/java/com/hivemq/api/resources/impl/ProtocolAdaptersResourceImplTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/api/resources/impl/ProtocolAdaptersResourceImplTest.java
@@ -743,21 +743,25 @@ class ProtocolAdaptersResourceImplTest {
         // Adapter has two tags: "tag1" and "tag2"
         final var protocolAdapterEntity = mock(ProtocolAdapterEntity.class);
         when(protocolAdapterEntity.getAdapterId()).thenReturn(adapterId);
-        when(protocolAdapterEntity.getTags()).thenReturn(List.of(
-                new TagEntity("tag1", "description1", Map.of("address", "address1")),
-                new TagEntity("tag2", "description2", Map.of("address", "address2"))));
+        when(protocolAdapterEntity.getTags())
+                .thenReturn(List.of(
+                        new TagEntity("tag1", "description1", Map.of("address", "address1")),
+                        new TagEntity("tag2", "description2", Map.of("address", "address2"))));
         when(protocolAdapterEntity.getNorthboundMappings()).thenReturn(List.of());
         when(protocolAdapterEntity.getSouthboundMappings()).thenReturn(List.of());
 
         when(protocolAdapterExtractor.getAdapterByAdapterId(adapterId)).thenReturn(Optional.of(protocolAdapterEntity));
 
         // Try to rename "tag1" to "tag2" (which already exists)
-        final Response response = protocolAdaptersResource.updateAdapterDomainTag(adapterId,
+        final Response response = protocolAdaptersResource.updateAdapterDomainTag(
+                adapterId,
                 URLEncoder.encode("tag1", StandardCharsets.UTF_8),
-                new DomainTag("tag2",
-                        adapterId,
-                        "new description",
-                        objectMapper.valueToTree(Map.of("address", "address1"))).toModel());
+                new DomainTag(
+                                "tag2",
+                                adapterId,
+                                "new description",
+                                objectMapper.valueToTree(Map.of("address", "address1")))
+                        .toModel());
 
         assertEquals(409, response.getStatus());
     }
@@ -770,21 +774,22 @@ class ProtocolAdaptersResourceImplTest {
 
         final var protocolAdapterEntity = mock(ProtocolAdapterEntity.class);
         when(protocolAdapterEntity.getAdapterId()).thenReturn(adapterId);
-        when(protocolAdapterEntity.getTags()).thenReturn(List.of(
-                new TagEntity("tag1", "description1", Map.of("address", "address1"))));
+        when(protocolAdapterEntity.getTags())
+                .thenReturn(List.of(new TagEntity("tag1", "description1", Map.of("address", "address1"))));
 
         when(protocolAdapterExtractor.getAdapterByAdapterId(adapterId)).thenReturn(Optional.of(protocolAdapterEntity));
 
         // Try to update with a list containing duplicate tag names
-        final DomainTagList duplicateTagList = new DomainTagList().items(List.of(
-                new com.hivemq.edge.api.model.DomainTag()
-                        .name("temperature")
-                        .description("desc1")
-                        .definition(objectMapper.valueToTree(Map.of("address", "addr1"))),
-                new com.hivemq.edge.api.model.DomainTag()
-                        .name("temperature")  // Duplicate!
-                        .description("desc2")
-                        .definition(objectMapper.valueToTree(Map.of("address", "addr2")))));
+        final DomainTagList duplicateTagList = new DomainTagList()
+                .items(List.of(
+                        new com.hivemq.edge.api.model.DomainTag()
+                                .name("temperature")
+                                .description("desc1")
+                                .definition(objectMapper.valueToTree(Map.of("address", "addr1"))),
+                        new com.hivemq.edge.api.model.DomainTag()
+                                .name("temperature") // Duplicate!
+                                .description("desc2")
+                                .definition(objectMapper.valueToTree(Map.of("address", "addr2")))));
 
         final Response response = protocolAdaptersResource.updateAdapterDomainTags(adapterId, duplicateTagList);
 
@@ -799,8 +804,8 @@ class ProtocolAdaptersResourceImplTest {
 
         final var protocolAdapterEntity = mock(ProtocolAdapterEntity.class);
         when(protocolAdapterEntity.getAdapterId()).thenReturn(adapterId);
-        when(protocolAdapterEntity.getTags()).thenReturn(List.of(
-                new TagEntity("tag1", "description1", Map.of("address", "address1"))));
+        when(protocolAdapterEntity.getTags())
+                .thenReturn(List.of(new TagEntity("tag1", "description1", Map.of("address", "address1"))));
         when(protocolAdapterEntity.getNorthboundMappings()).thenReturn(List.of());
         when(protocolAdapterEntity.getSouthboundMappings()).thenReturn(List.of());
 
@@ -808,15 +813,16 @@ class ProtocolAdaptersResourceImplTest {
         when(protocolAdapterExtractor.updateAdapter(any())).thenReturn(true);
 
         // Update with a list containing unique tag names
-        final DomainTagList uniqueTagList = new DomainTagList().items(List.of(
-                new com.hivemq.edge.api.model.DomainTag()
-                        .name("temperature")
-                        .description("desc1")
-                        .definition(objectMapper.valueToTree(Map.of("address", "addr1"))),
-                new com.hivemq.edge.api.model.DomainTag()
-                        .name("pressure")
-                        .description("desc2")
-                        .definition(objectMapper.valueToTree(Map.of("address", "addr2")))));
+        final DomainTagList uniqueTagList = new DomainTagList()
+                .items(List.of(
+                        new com.hivemq.edge.api.model.DomainTag()
+                                .name("temperature")
+                                .description("desc1")
+                                .definition(objectMapper.valueToTree(Map.of("address", "addr1"))),
+                        new com.hivemq.edge.api.model.DomainTag()
+                                .name("pressure")
+                                .description("desc2")
+                                .definition(objectMapper.valueToTree(Map.of("address", "addr2")))));
 
         final Response response = protocolAdaptersResource.updateAdapterDomainTags(adapterId, uniqueTagList);
 


### PR DESCRIPTION
https://hivemq.kanbanize.com/ctrl_board/57/cards/38973/details/

Features:
- Validate TAG references have scope (adapter ID) in Combiner and Asset Mapper APIs
- Validate TOPIC_FILTER references do NOT have scope in Combiner and Asset Mapper APIs
- Validate that TAG references point to existing adapters and tags
- Add duplicate tag detection in Protocol Adapters API

Bug Fixes:
- Fix addAdapterDomainTags returning wrong error (403) for duplicate tags, now returns 409
- Fix updateAdapterDomainTag not checking for duplicate name when renaming
- Fix updateAdapterDomainTags not checking for duplicate names in new list
- Fix createCompleteAdapter not checking for duplicate tags in incoming list

New Error Classes:
- DuplicateTagError (409): Tag name is duplicated within an adapter
- UnexpectedScopeError (400): Scope provided for TOPIC_FILTER (scope only valid for TAG)
- TagNotFoundError (400): Tag does not exist in the specified adapter

Refactoring:
- Extract validateTagExists helper method in CombinersResourceImpl and PulseApiImpl
- Extract findDuplicateTagName helper method in ProtocolAdaptersResourceImpl
- Use InvalidScopeForTagError when adapter (scope) doesn't exist

Tests:
- Add updateDomainTag_whenRenamingToDuplicateName_thenReturn409
- Add updateDomainTags_whenDuplicateTagNamesInList_thenReturn409
- Add updateDomainTags_whenNoDuplicateTagNames_thenReturn200
- Update addAdapterDomainTag_whenAlreadyExists_thenReturn409 (was 403)