### PR TITLE
Fix startFuture never resolving in BridgeMqttClient error paths. Early return paths didn't resolve the startFuture

### DIFF
--- a/hivemq-edge/src/main/java/com/hivemq/bridge/mqtt/BridgeMqttClient.java
+++ b/hivemq-edge/src/main/java/com/hivemq/bridge/mqtt/BridgeMqttClient.java
@@ -181,18 +181,22 @@ public class BridgeMqttClient {
                                 return null;
                             }
                             if (mqtt5ConnAck.getReasonCode().isError()) {
+                                final String reasonString = mqtt5ConnAck
+                                        .getReasonString()
+                                        .map(Objects::toString)
+                                        .orElse("");
                                 log.error(
                                         "Failed to connect bridge '{}', CONNACK returned reason code {}, reason string: '{}'",
                                         bridge.getId(),
                                         mqtt5ConnAck.getReasonCode(),
-                                        mqtt5ConnAck
-                                                .getReasonString()
-                                                .map(Objects::toString)
-                                                .orElse(""));
+                                        reasonString);
                                 final var future = startFutureRef.getAndSet(null);
                                 if (future != null) {
-                                    future.setException(new RuntimeException("CONNACK error for bridge '"
-                                            + bridge.getId() + "': " + mqtt5ConnAck.getReasonCode()));
+                                    future.setException(new RuntimeException(
+                                            "CONNACK error for bridge '" + bridge.getId() + "' connecting to "
+                                                    + bridge.getHost() + ":" + bridge.getPort()
+                                                    + " - reason code: " + mqtt5ConnAck.getReasonCode()
+                                                    + ", reason string: '" + reasonString + "'"));
                                 }
                                 operationState.compareAndSet(OperationState.STARTING, OperationState.IDLE);
                                 return null;


### PR DESCRIPTION
**Motivation**

Fix flaky tests for bridges

**Changes**

The handleAsync callback in BridgeMqttClient.start() had three early-return paths:
- stopped
- connection failure
- CONNACK error 
These returned without resolving the startFuture or resetting operationState. 
This left the SettableFuture permanently pending, so BridgeService.onSuccess never fired and the bridge appeared stuck in STARTING state. Under certain timing conditions this caused flaky test timeouts (e.g. BridgeNoPersistIT).

tests: https://github.com/hivemq/hivemq-edge-test/pull/297