### PR TITLE
Fix OpenAPI spec: restore full paths section

### DIFF
--- a/ext/hivemq-edge-openapi.yaml
+++ b/ext/hivemq-edge-openapi.yaml
@@ -17,3 +17,8759 @@ info:
   version: 2026.5-SNAPSHOT
   x-logo:
     url: https://www.hivemq.com/img/svg/hivemq-bee.svg
+tags:
+  - description: Services to obtain and validate security tokens with the HiveMQ Edge API.
+    name: Authentication Endpoint
+  - description: Explore and interact with the Bridges configured on your Gateway.
+    name: Bridges
+  - description: Interact with the system event sub-system.
+    name: Events
+  - description: Services relating to the use of the portal.
+    name: Frontend
+  - description: Services to interact with the gateway configuration.
+    name: Gateway Endpoint
+  - description: Gain insight and system metrics.
+    name: Metrics Endpoint
+  - description: Interact with protocol adapters.
+    name: Protocol Adapters
+  - description: Manage samples of payloads.
+    name: Payload Sampling
+  - description: Interact with topic filters.
+    name: Topic Filters
+  - description: Configure Unified Namespace.
+    name: UNS
+  - description: This resource bundles endpoints for the available Finite State Machines (FSMs) for Behavior Policies for the HiveMQ Data Hub. Currently this is limited to getting the available FSMs.
+    name: Data Hub - FSM
+  - description: This resource bundles endpoints for the available Functions for the HiveMQ Data Hub. Currently this is limited to getting the available Functions.
+    name: Data Hub - Functions
+  - description: This resource bundles endpoints for the interpolation features.
+    name: Data Hub - Interpolation
+  - description: |-
+      Policies describe how you want the HiveMQ broker to validate the behavior of MQTT clients.
+      Each policy has four sections:
+
+      - Matching: Specifies which clients the policy engine validates.
+      - Deserialization: Specifies deserializers for different message payloads.
+      - Behavior: Specifies the behavior that is considered valid for matched clients.
+      - onTransitions: Specifies custom actions that are executed when a client transitions to a different state within the specified behavior model that is valid for that client.
+      These endpoints can be used to create, update, delete, and list behavior policies.
+
+      For more information on all capabilities the HiveMQ Data Hub offers, see the [HiveMQ documentation](https://docs.hivemq.com/hivemq/latest/data-hub/index.html).
+    name: Data Hub - Behavior Policies
+  - description: |-
+      Data Policies describe how you want the HiveMQ broker to apply schemas to incoming MQTT message payload data and act on the validation results.
+      Each policy has four sections:
+
+      - Matching: Specifies which packets the policy engine validates.
+      - Validation: Specifies how the packets are validated. For example, based on a JSON Schema.
+      - OnSuccess: Defines which actions are executed when the outcome of a validation is successful.
+      - OnFailure: Defines which actions are executed when the validation fails.
+
+      These endpoints can be used to create, update, delete, and list data policies.
+
+      For more information on all capabilities the HiveMQ Data Hub offers, see the [HiveMQ documentation](https://docs.hivemq.com/hivemq/latest/data-hub/index.html).
+    name: Data Hub - Data Policies
+  - description: |-
+      A schema defines the expected structure and format of incoming MQTT message payload data.
+
+      This endpoint can be used to create, get, and delete schemas.
+
+      Schemas can be enforced with the use of a policy.
+
+      Currently, the following schema definitions are supported:
+
+      - [JSON Schema](https://json-schema.org/)
+      - [Protocol Buffers (Protobuf)](https://protobuf.dev/)
+
+      For more information on how to define and use a schema in HiveMQ, see [Schemas](https://docs.hivemq.com/hivemq/latest/data-hub/schemas.html).
+    name: Data Hub - Schemas
+  - description: |-
+      A script represents custom logic that can be executed in response to MQTT messages.
+
+      This endpoint can be used to create, get, and delete scripts.
+
+      For more information on how to define and use a script in HiveMQ, see [Scripts](https://docs.hivemq.com/hivemq/latest/data-hub/scripts.html).
+    name: Data Hub - Scripts
+  - description: |+
+      These endpoints can be used to retrieve states of clients for the Data Hub.
+
+    name: Data Hub - State
+  - description: |
+      These endpoints can be used to retrieve the different elements of the Edge topology
+    name: Domain
+  - description: |
+      These endpoints can be used to manage Pulse and its assets.
+    name: Pulse
+paths:
+  /:
+    get:
+      operationId: getRoot
+      x-roles-allowed:
+        - NO_AUTH_REQUIRED
+      responses:
+        default:
+          content:
+            '*/*': {}
+          description: default response
+  /api/v1/auth/authenticate:
+    post:
+      description: Authorize the presented user to obtain a secure token for use on the API.
+      operationId: authenticate
+      x-roles-allowed:
+        - NO_AUTH_REQUIRED
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UsernamePasswordCredentials'
+      responses:
+        '200':
+          content:
+            application/json:
+              examples:
+                example-authentication:
+                  description: Example Authentication configuration.
+                  summary: Example authentication
+                  value:
+                    token: eyJraWQiOiIwMDAwMSIsImFsZyI6IlJTMjU2In0.eyJqdGkiOiJpb09YbmdWQW1ncl9rSGxZMlRPNWx3IiwiaWF0IjoxNjg3OTQ2MzkwLCJhdWQiOiJIaXZlTVEtRWRnZS1BcGkiLCJpc3MiOiJIaXZlTVEtRWRnZSIsImV4cCI6MTY4Nzk0ODE5MCwibmJmIjoxNjg3OTQ2MjcwLCJzdWIiOiJhZG1pbiIsInJvbGVzIjpbImFkbWluIl19.F4fCJcLobUJXR8rcER_sXVR2l6LhGc6LrnpDlBfuCmVQI22UjLjh-GBYPJV_VF17at_ChBS0UePN9dF4U0i5SsuLcLbrl6QMyI3kmiDxvZCKPWPJGJfiqljVysbQS5vK2F8eJmVFWr0Bb5rXjTtClLIfDGTLEoETbUOMfmic5EzPdWwLN7i3NbuE3xl9u0RepJwVNf0eZrvwIQjpeLZ8vNx9eIVUeMhXpylrQGlDeikJn_F6K89hc1igl2hzN4aU9oT-WOLeQ82oRq7IhL1Rzi1K9NdKMS_xrpV951basq_419oyGyQ6zcxORyC7vsGLZPGi0sHsSJdQ-j12xhPsMg
+              schema:
+                $ref: '#/components/schemas/ApiBearerToken'
+          description: Username & Password Credentials to Authenticate as.
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Error in request.
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: The requested credentials could not be authenticated.
+      summary: Authorize the presented user to obtain a secure token for use on the API.
+      tags:
+        - Authentication
+        - Authentication Endpoint
+  /api/v1/auth/refresh-token:
+    post:
+      description: Authorize the presented user to obtain a secure token for use on the API.
+      operationId: refresh-token
+      x-roles-allowed:
+        - NO_AUTH_REQUIRED
+      responses:
+        '200':
+          content:
+            application/json:
+              examples:
+                example-authentication:
+                  description: Example Authentication configuration.
+                  summary: Example authentication
+                  value:
+                    token: eyJraWQiOiIwMDAwMSIsImFsZyI6IlJTMjU2In0.eyJqdGkiOiJpb09YbmdWQW1ncl9rSGxZMlRPNWx3IiwiaWF0IjoxNjg3OTQ2MzkwLCJhdWQiOiJIaXZlTVEtRWRnZS1BcGkiLCJpc3MiOiJIaXZlTVEtRWRnZSIsImV4cCI6MTY4Nzk0ODE5MCwibmJmIjoxNjg3OTQ2MjcwLCJzdWIiOiJhZG1pbiIsInJvbGVzIjpbImFkbWluIl19.F4fCJcLobUJXR8rcER_sXVR2l6LhGc6LrnpDlBfuCmVQI22UjLjh-GBYPJV_VF17at_ChBS0UePN9dF4U0i5SsuLcLbrl6QMyI3kmiDxvZCKPWPJGJfiqljVysbQS5vK2F8eJmVFWr0Bb5rXjTtClLIfDGTLEoETbUOMfmic5EzPdWwLN7i3NbuE3xl9u0RepJwVNf0eZrvwIQjpeLZ8vNx9eIVUeMhXpylrQGlDeikJn_F6K89hc1igl2hzN4aU9oT-WOLeQ82oRq7IhL1Rzi1K9NdKMS_xrpV951basq_419oyGyQ6zcxORyC7vsGLZPGi0sHsSJdQ-j12xhPsMg
+              schema:
+                $ref: '#/components/schemas/ApiBearerToken'
+          description: Obtain a new JWT from a previously authentication token.
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: The requested credentials could not be authenticated.
+      summary: Obtain a fresh JWT for the previously authenticated user.
+      tags:
+        - Authentication
+        - Authentication Endpoint
+  /api/v1/auth/validate-token:
+    post:
+      description: Authorize the presented user to obtain a secure token for use on the API.
+      operationId: validate-token
+      x-roles-allowed:
+        - NO_AUTH_REQUIRED
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ApiBearerToken'
+      responses:
+        '200':
+          description: The token was valid
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: The token was invalid
+      summary: Authorize the presented user to obtain a secure token for use on the API.
+      tags:
+        - Authentication
+        - Authentication Endpoint
+  /api/v1/data-hub/behavior-validation/policies:
+    get:
+      description: |-
+        Get all policies. 
+
+         This endpoint returns the content of the policies with the content-type `application/json`. 
+
+         
+      operationId: getAllBehaviorPolicies
+      x-roles-allowed:
+        - admin
+        - super
+        - user
+      parameters:
+        - description: 'Comma-separated list of fields to include in the response. Allowed values are: id, createdAt, lastUpdatedAt, deserialization, matching, behavior, onTransitions'
+          example: id,createdAt
+          in: query
+          name: fields
+          schema:
+            type: string
+        - description: Comma-separated list of policy ids used for filtering. Multiple filters can be applied together.
+          example: policy1,policy2
+          in: query
+          name: policyIds
+          schema:
+            type: string
+        - description: Comma-separated list of MQTT client identifiers that are used for filtering. Client identifiers are matched by the retrieved policies. Multiple filters can be applied together.
+          example: client1,client2
+          in: query
+          name: clientIds
+          schema:
+            type: string
+        - description: Specifies the page size for the returned results. Has to be between 10 and 500. Default page size is 50. Limit is ignored if the 'topic' query parameter is set.
+          example: 100
+          in: query
+          name: limit
+          schema:
+            type: integer
+            format: int32
+        - description: The cursor that has been returned by the previous result page. Do not pass this parameter if you want to fetch the first page.
+          in: query
+          name: cursor
+          schema:
+            type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              examples:
+                list-response-a:
+                  description: Example response with multiple policies. No more pages left
+                  summary: Multiple results, last page
+                  value:
+                    items:
+                      - id: P18
+                        createdAt: '2023-07-28T07:27:24.531Z'
+                        lastUpdatedAt: '2023-07-28T07:27:24.531Z'
+                        matching:
+                          clientIdRegex: .*
+                        behavior:
+                          id: Mqtt.events
+                          arguments: {}
+                        onTransitions:
+                          - fromState: Any.*
+                            toState: Any.*
+                            Event.OnAny:
+                              pipeline:
+                                - id: log1
+                                  functionId: System.log
+                                  arguments:
+                                    level: INFO
+                                    message: transition happened
+                      - id: P19
+                        createdAt: '2023-07-28T07:27:24.532Z'
+                        lastUpdatedAt: '2023-07-28T07:27:24.532Z'
+                        matching:
+                          clientIdRegex: .*
+                        behavior:
+                          id: Mqtt.events
+                          arguments: {}
+                        onTransitions:
+                          - fromState: Any.*
+                            toState: Any.*
+                            Event.OnAny:
+                              pipeline:
+                                - id: log1
+                                  functionId: System.log
+                                  arguments:
+                                    level: INFO
+                                    message: transition happened
+                list-response-b:
+                  description: Example response with multiple policies. More pages left
+                  summary: Multiple results, more pages left
+                  value:
+                    items:
+                      - id: P0
+                        createdAt: '2023-07-28T07:44:35.382Z'
+                        lastUpdatedAt: '2023-07-28T07:44:35.382Z'
+                        matching:
+                          clientIdRegex: .*
+                        behavior:
+                          id: Mqtt.events
+                          arguments: {}
+                        onTransitions:
+                          - fromState: Any.*
+                            toState: Any.*
+                            Event.OnAny:
+                              pipeline:
+                                - id: log1
+                                  functionId: System.log
+                                  arguments:
+                                    level: INFO
+                                    message: transition happened
+                      - id: P1
+                        createdAt: '2023-07-28T07:44:35.405Z'
+                        lastUpdatedAt: '2023-07-28T07:44:35.405Z'
+                        matching:
+                          clientIdRegex: .*
+                        behavior:
+                          id: Mqtt.events
+                          arguments: {}
+                        onTransitions:
+                          - fromState: Any.*
+                            toState: Any.*
+                            Event.OnAny:
+                              pipeline:
+                                - id: log1
+                                  functionId: System.log
+                                  arguments:
+                                    level: INFO
+                                    message: transition happened
+                    _links:
+                      next: /api/v1/data-hub/behavior-validation/policies?cursor=a-Wva-QBoB5yAX_HJ0WRQ8ng==&limit=2
+                list-response-c:
+                  description: Example response with requested fields and multiple policies. More pages left
+                  summary: Multiple results, requested 'id' field
+                  value:
+                    items:
+                      - id: P0
+                      - id: P1
+                    _links:
+                      next: /api/v1/data-hub/behavior-validation/policies?cursor=a-Wva-QBoB5yAX_HZxWBM9mQ==&limit=2&fields=id
+                list-response-d:
+                  description: Example response with a single policy
+                  summary: Single Result
+                  value:
+                    items:
+                      - id: policy1
+                        createdAt: '2023-07-28T07:34:14.150Z'
+                        lastUpdatedAt: '2023-07-28T07:34:14.150Z'
+                        matching:
+                          clientIdRegex: .*
+                        behavior:
+                          id: Mqtt.events
+                          arguments: {}
+                        onTransitions:
+                          - fromState: Any.*
+                            toState: Any.*
+                            Event.OnAny:
+                              pipeline:
+                                - id: log1
+                                  functionId: System.log
+                                  arguments:
+                                    level: INFO
+                                    message: transition happened
+              schema:
+                $ref: '#/components/schemas/BehaviorPolicyList'
+          description: Success
+        '400':
+          content:
+            application/problem+json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/InvalidQueryParameterError'
+                discriminator:
+                  propertyName: type
+                  mapping:
+                    https://hivemq.com/edge/api/model/InvalidQueryParameterError: '#/components/schemas/InvalidQueryParameterError'
+          description: URL parameter missing
+        '503':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/TemporaryNotAvailableError'
+          description: Request resource temporary unavailable
+      summary: Get all policies
+      tags:
+        - Data Hub - Behavior Policies
+    post:
+      description: |+
+        Create a behavior policy
+
+      operationId: createBehaviorPolicy
+      x-roles-allowed:
+        - admin
+      requestBody:
+        content:
+          application/json:
+            example:
+              id: wildcardLogBehaviorPolicy
+              createdAt: '2023-08-23T10:14:38.447Z'
+              matching:
+                clientIdRegex: .*
+              deserialization:
+                publish:
+                  schema:
+                    schemaId: schema
+                    version: latest
+                will:
+                  schema:
+                    schemaId: schema
+                    version: latest
+              behavior:
+                id: Mqtt.events
+                arguments: {}
+              onTransitions:
+                - fromState: Any.*
+                  toState: Any.*
+                  Event.OnAny:
+                    pipeline:
+                      - id: log1
+                        functionId: System.log
+                        arguments:
+                          level: INFO
+                          message: transition happened
+            schema:
+              $ref: '#/components/schemas/BehaviorPolicy'
+        description: The policy that should be created.
+        required: true
+      responses:
+        '201':
+          content:
+            application/json:
+              examples:
+                response-example:
+                  description: Example response.
+                  summary: Policy was created successfully
+                  value:
+                    id: wildcardLogBehaviorPolicy
+                    createdAt: '2023-08-23T10:14:38.447Z'
+                    lastUpdatedAt: '2023-08-23T10:14:38.447Z'
+                    matching:
+                      clientIdRegex: .*
+                    deserialization:
+                      publish:
+                        schema:
+                          schemaId: schema
+                          version: latest
+                      will:
+                        schema:
+                          schemaId: schema
+                          version: latest
+                        arguments: {}
+                    behavior:
+                      id: Mqtt.events
+                      arguments: {}
+                    onTransitions:
+                      - fromState: Any.*
+                        toState: Any.*
+                        Event.OnAny:
+                          pipeline:
+                            - id: log1
+                              functionId: System.log
+                              arguments:
+                                level: INFO
+                                message: transition happened
+              schema:
+                $ref: '#/components/schemas/BehaviorPolicy'
+          description: Success
+        '400':
+          content:
+            application/problem+json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/BehaviorPolicyCreationFailureError'
+                  - $ref: '#/components/schemas/BehaviorPolicyInvalidErrors'
+                  - $ref: '#/components/schemas/BehaviorPolicyRejectedError'
+                  - $ref: '#/components/schemas/RequestBodyMissingError'
+                discriminator:
+                  propertyName: type
+                  mapping:
+                    https://hivemq.com/edge/api/model/BehaviorPolicyCreationFailureError: '#/components/schemas/BehaviorPolicyCreationFailureError'
+                    https://hivemq.com/edge/api/model/BehaviorPolicyInvalidErrors: '#/components/schemas/BehaviorPolicyInvalidErrors'
+                    https://hivemq.com/edge/api/model/BehaviorPolicyRejectedError: '#/components/schemas/BehaviorPolicyRejectedError'
+                    https://hivemq.com/edge/api/model/RequestBodyMissingError: '#/components/schemas/RequestBodyMissingError'
+          description: Policy creation failed
+        '409':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BehaviorPolicyAlreadyPresentError'
+          description: Behavior policy already present
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerError'
+          description: Internal server error
+        '503':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/TemporaryNotAvailableError'
+          description: Request resource temporary unavailable
+        '507':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/PolicyInsufficientStorageError'
+          description: Insufficient storage
+      summary: Create a new policy
+      tags:
+        - Data Hub - Behavior Policies
+  /api/v1/data-hub/behavior-validation/policies/{policyId}:
+    delete:
+      description: |-
+        Deletes an existing policy. 
+
+         
+      operationId: deleteBehaviorPolicy
+      x-roles-allowed:
+        - admin
+      parameters:
+        - description: The identifier of the policy to delete.
+          example: policy1
+          in: path
+          name: policyId
+          required: true
+          schema:
+            type: string
+        - description: The entity tag
+          in: header
+          name: If-Match
+          required: false
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success, no response body
+        '400':
+          content:
+            application/problem+json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/UrlParameterMissingError'
+                discriminator:
+                  propertyName: type
+                  mapping:
+                    https://hivemq.com/edge/api/model/UrlParameterMissingError: '#/components/schemas/UrlParameterMissingError'
+          description: URL parameter missing
+        '404':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/PolicyNotFoundError'
+          description: Behavior policy not found
+        '412':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/PreconditionFailedError'
+          description: Precondition failed
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerError'
+          description: Internal server error
+        '503':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/TemporaryNotAvailableError'
+          description: Request resource temporary unavailable
+      summary: Delete a behavior policy
+      tags:
+        - Data Hub - Behavior Policies
+    get:
+      description: |-
+        Get a specific policy. 
+
+         This endpoint returns the content of the policy with the content-type `application/json`. 
+
+         
+      operationId: getBehaviorPolicy
+      x-roles-allowed:
+        - admin
+        - super
+        - user
+      parameters:
+        - description: The identifier of the policy.
+          example: policy1
+          in: path
+          name: policyId
+          required: true
+          schema:
+            type: string
+        - description: 'Comma-separated list of fields to include in the response. Allowed values are: id, createdAt, lastUpdatedAt, deserialization, matching, behavior, onTransitions'
+          example: id,createdAt
+          in: query
+          name: fields
+          schema:
+            type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              examples:
+                get-response:
+                  description: Get Policy
+                  summary: Get  Policy
+                  value:
+                    id: wildcardLogBehaviorPolicy
+                    createdAt: '2023-08-23T10:14:38.447Z'
+                    lastUpdatedAt: '2023-08-23T10:14:38.447Z'
+                    matching:
+                      clientIdRegex: .*
+                    deserialization:
+                      publish:
+                        schema:
+                          schemaId: schema
+                          version: latest
+                      will:
+                        schema:
+                          schemaId: schema
+                          version: latest
+                        arguments: {}
+                    behavior:
+                      id: Mqtt.events
+                      arguments: {}
+                    onTransitions:
+                      - fromState: Any.*
+                        toState: Any.*
+                        Event.OnAny:
+                          pipeline:
+                            - id: log1
+                              functionId: System.log
+                              arguments:
+                                level: INFO
+                                message: transition happened
+              schema:
+                $ref: '#/components/schemas/BehaviorPolicy'
+          description: Success
+        '400':
+          content:
+            application/problem+json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/UrlParameterMissingError'
+                discriminator:
+                  propertyName: type
+                  mapping:
+                    https://hivemq.com/edge/api/model/UrlParameterMissingError: '#/components/schemas/UrlParameterMissingError'
+          description: Bad request
+        '404':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BehaviorPolicyNotFoundError'
+          description: Policy not found
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerError'
+          description: Internal server error
+        '503':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/TemporaryNotAvailableError'
+          description: Request resource temporary unavailable
+      summary: Get a  policy
+      tags:
+        - Data Hub - Behavior Policies
+    put:
+      description: |-
+        Update a behavior policy
+
+        The path parameter 'policyId' must match the 'id' of the policy in the request body.
+         
+      operationId: updateBehaviorPolicy
+      x-roles-allowed:
+        - admin
+      parameters:
+        - description: The identifier of the policy.
+          example: policy1
+          in: path
+          name: policyId
+          required: true
+          schema:
+            type: string
+        - description: The entity tag
+          in: header
+          name: If-Match
+          required: false
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            example:
+              id: wildcardLogBehaviorPolicy
+              createdAt: '2023-08-23T10:14:38.447Z'
+              matching:
+                clientIdRegex: .*
+              deserialization:
+                publish:
+                  schema:
+                    schemaId: schema
+                    version: latest
+                will:
+                  schema:
+                    schemaId: schema
+                    version: latest
+              behavior:
+                id: Mqtt.events
+                arguments: {}
+              onTransitions:
+                - fromState: Any.*
+                  toState: Any.*
+                  Event.OnAny:
+                    pipeline:
+                      - id: log1
+                        functionId: System.log
+                        arguments:
+                          level: INFO
+                          message: transition happened
+            schema:
+              $ref: '#/components/schemas/BehaviorPolicy'
+        description: The policy that should be updated.
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              examples:
+                response-example:
+                  description: Example response.
+                  summary: Policy was updated successfully
+                  value:
+                    id: wildcardLogBehaviorPolicy
+                    createdAt: '2023-08-23T10:14:38.447Z'
+                    lastUpdatedAt: '2023-09-26T11:17:22.311Z'
+                    matching:
+                      clientIdRegex: .*
+                    deserialization:
+                      publish:
+                        schema:
+                          schemaId: schema
+                          version: latest
+                      will:
+                        schema:
+                          schemaId: schema
+                          version: latest
+                        arguments: {}
+                    behavior:
+                      id: Mqtt.events
+                      arguments: {}
+                    onTransitions:
+                      - fromState: Any.*
+                        toState: Any.*
+                        Event.OnAny:
+                          pipeline:
+                            - id: log1
+                              functionId: System.log
+                              arguments:
+                                level: INFO
+                                message: transition happened
+              schema:
+                $ref: '#/components/schemas/BehaviorPolicy'
+          description: Success
+        '400':
+          content:
+            application/problem+json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/RequestBodyMissingError'
+                  - $ref: '#/components/schemas/UrlParameterMissingError'
+                  - $ref: '#/components/schemas/BehaviorPolicyCreationFailureError'
+                  - $ref: '#/components/schemas/BehaviorPolicyInvalidErrors'
+                  - $ref: '#/components/schemas/BehaviorPolicyUpdateFailureError'
+                  - $ref: '#/components/schemas/PolicyIdMismatchError'
+                discriminator:
+                  propertyName: type
+                  mapping:
+                    https://hivemq.com/edge/api/model/RequestBodyMissingError: '#/components/schemas/RequestBodyMissingError'
+                    https://hivemq.com/edge/api/model/UrlParameterMissingError: '#/components/schemas/UrlParameterMissingError'
+                    https://hivemq.com/edge/api/model/BehaviorPolicyCreationFailureError: '#/components/schemas/BehaviorPolicyCreationFailureError'
+                    https://hivemq.com/edge/api/model/BehaviorPolicyInvalidErrors: '#/components/schemas/BehaviorPolicyInvalidErrors'
+                    https://hivemq.com/edge/api/model/BehaviorPolicyUpdateFailureError: '#/components/schemas/BehaviorPolicyUpdateFailureError'
+                    https://hivemq.com/edge/api/model/PolicyIdMismatchError: '#/components/schemas/PolicyIdMismatchError'
+          description: Behavior policy creation failed
+        '404':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BehaviorPolicyNotFoundError'
+          description: Data policy not found
+        '412':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/PreconditionFailedError'
+          description: Precondition failed
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerError'
+          description: Internal server error
+        '503':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/TemporaryNotAvailableError'
+          description: Request resource temporary unavailable
+        '507':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/PolicyInsufficientStorageError'
+          description: Insufficient storage
+      summary: Update an existing behavior policy
+      tags:
+        - Data Hub - Behavior Policies
+  /api/v1/data-hub/behavior-validation/states/{clientId}:
+    get:
+      description: |+
+        Use this endpoint to get the stored state of a client for DataHub.
+
+      operationId: getClientState
+      x-roles-allowed:
+        - admin
+        - super
+        - user
+      parameters:
+        - description: The client identifier.
+          example: client1
+          in: path
+          name: clientId
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              examples:
+                get-response:
+                  description: Get client State
+                  summary: Get the state of a client
+                  value:
+                    items:
+                      - policyId: reallyCoolBehaviorPolicy
+                        behaviorId: Publish.quota
+                        stateType: INTERMEDIATE
+                        stateName: Connected
+                        firstSetAt: '2023-09-05T09:46:47.854Z'
+                        arguments:
+                          minPublishes: 5
+                          maxPublishes: 10
+                        variables:
+                          minPublishes: '5'
+                          publishCount: '0'
+                          maxPublishes: '10'
+              schema:
+                $ref: '#/components/schemas/FsmStatesInformationListItem'
+          description: Success
+        '400':
+          content:
+            application/problem+json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/UrlParameterMissingError'
+                discriminator:
+                  propertyName: type
+                  mapping:
+                    https://hivemq.com/edge/api/model/UrlParameterMissingError: '#/components/schemas/UrlParameterMissingError'
+          description: URL parameter missing
+        '404':
+          content:
+            application/problem+json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/ClientDisconnectedError'
+                  - $ref: '#/components/schemas/ClientNotFoundError'
+                discriminator:
+                  propertyName: type
+                  mapping:
+                    https://hivemq.com/edge/api/model/ClientDisconnectedError: '#/components/schemas/ClientDisconnectedError'
+                    https://hivemq.com/edge/api/model/ClientNotFoundError: '#/components/schemas/ClientNotFoundError'
+          description: Client error
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerError'
+          description: Internal server error
+      summary: Get the state of a client
+      tags:
+        - Data Hub - State
+  /api/v1/data-hub/data-validation/policies:
+    get:
+      description: |-
+        Get all data policies. 
+
+         This endpoint returns the content of the policies with the content-type `application/json`. 
+
+         
+      operationId: getAllDataPolicies
+      x-roles-allowed:
+        - admin
+        - super
+        - user
+      parameters:
+        - description: 'Comma-separated list of fields to include in the response. Allowed values are: id, createdAt, lastUpdatedAt, matching, validation, onSuccess, onFailure'
+          example: id,createdAt
+          in: query
+          name: fields
+          schema:
+            type: string
+        - description: Comma-separated list of policy IDs used for filtering. Multiple filters can be applied together.
+          example: policy1,policy2
+          in: query
+          name: policyIds
+          schema:
+            type: string
+        - description: Comma-separated list of schema IDs used for filtering. Multiple filters can be applied together.
+          example: schema1,schema2
+          in: query
+          name: schemaIds
+          schema:
+            type: string
+        - description: MQTT topic string that the retrieved policies must match. Returned policies are sorted in the same way as they are applied to matching publishes. 'topic' filtering does not support pagination
+          example: topic/my-topic
+          in: query
+          name: topic
+          schema:
+            type: string
+        - description: Specifies the page size for the returned results. The value must be between 10 and 500. The default page size is 50. The limit is ignored if the 'topic' query parameter is set.
+          example: 100
+          in: query
+          name: limit
+          schema:
+            type: integer
+            format: int32
+        - description: The cursor that has been returned by the previous result page. Do not pass this parameter if you want to fetch the first page.
+          in: query
+          name: cursor
+          schema:
+            type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              examples:
+                list-response-a:
+                  description: Example response with multiple policies. No more pages left
+                  summary: Multiple results, last page
+                  value:
+                    items:
+                      - id: policy1
+                        createdAt: '2023-04-26T13:32:47.032Z'
+                        lastUpdatedAt: '2023-04-26T13:32:47.032Z'
+                        matching:
+                          topicFilter: topic1
+                        validation:
+                          validators:
+                            - type: schema
+                              arguments:
+                                strategy: ALL_OF
+                                schemas:
+                                  - schemaId: schema
+                                    version: '1'
+                        onSuccess:
+                          pipeline:
+                            - id: logSuccessOperation
+                              functionId: System.log
+                              arguments:
+                                level: DEBUG
+                                message: ${clientId} sent a publish on topic '${topic}' with result '${validationResult}'
+                        onFailure:
+                          pipeline:
+                            - id: logFailureOperation
+                              functionId: System.log
+                              arguments:
+                                level: WARN
+                                message: ${clientId} sent an invalid publish on topic '${topic}' with result '${validationResult}'
+                      - id: policy2
+                        createdAt: '2023-04-26T13:32:47.049Z'
+                        lastUpdatedAt: '2023-04-26T13:32:47.049Z'
+                        matching:
+                          topicFilter: topic2
+                        validation:
+                          validators:
+                            - type: schema
+                              arguments:
+                                strategy: ALL_OF
+                                schemas:
+                                  - schemaId: schema
+                                    version: '1'
+                        onSuccess:
+                          pipeline:
+                            - id: logSuccessOperation
+                              functionId: System.log
+                              arguments:
+                                level: DEBUG
+                                message: ${clientId} sent a publish on topic '${topic}' with result '${validationResult}'
+                        onFailure:
+                          pipeline:
+                            - id: logSuccessOperation
+                              functionId: System.log
+                              arguments:
+                                level: WARN
+                                message: ${clientId} sent an invalid publish on topic '${topic}' with result '${validationResult}'
+                list-response-b:
+                  description: Example response with multiple policies. More pages left
+                  summary: Multiple results, more pages left
+                  value:
+                    items:
+                      - id: policy1
+                        createdAt: '2023-04-26T13:32:47.032Z'
+                        lastUpdatedAt: '2023-04-26T13:32:47.032Z'
+                        matching:
+                          topicFilter: topic1
+                        validation:
+                          validators:
+                            - type: schema
+                              arguments:
+                                strategy: ALL_OF
+                                schemas:
+                                  - schemaId: schema
+                                    version: '1'
+                        onSuccess:
+                          pipeline:
+                            - id: logSuccessOperation
+                              functionId: System.log
+                              arguments:
+                                level: DEBUG
+                                message: $clientId sent a publish on topic '$topic' with result '$validationResult'
+                        onFailure:
+                          pipeline:
+                            - id: logFailureOperation
+                              functionId: System.log
+                              arguments:
+                                level: WARN
+                                message: $clientId sent an invalid publish on topic '$topic' with result '$validationResult'
+                      - id: policy2
+                        createdAt: '2023-04-26T13:32:47.049Z'
+                        lastUpdatedAt: '2023-04-26T13:32:47.049Z'
+                        matching:
+                          topicFilter: topic2
+                        validation:
+                          validators:
+                            - type: schema
+                              arguments:
+                                strategy: ALL_OF
+                                schemas:
+                                  - schemaId: schema
+                                    version: '1'
+                        onSuccess:
+                          pipeline:
+                            - id: logSuccessOperation
+                              functionId: System.log
+                              arguments:
+                                level: DEBUG
+                                message: $clientId sent a publish on topic '$topic' with result '$validationResult'
+                        onFailure:
+                          pipeline:
+                            - id: logSuccessOperation
+                              functionId: System.log
+                              arguments:
+                                level: WARN
+                                message: $clientId sent an invalid publish on topic '$topic' with result '$validationResult'
+                      - id: policy3
+                        createdAt: '2023-04-26T13:32:47.049Z'
+                        lastUpdatedAt: '2023-04-26T13:32:47.049Z'
+                        matching:
+                          topicFilter: topic3
+                        validation:
+                          validators:
+                            - type: schema
+                              arguments:
+                                strategy: ALL_OF
+                                schemas:
+                                  - schemaId: schema
+                                    version: '1'
+                        onSuccess:
+                          pipeline:
+                            - id: logSuccessOperation
+                              functionId: System.log
+                              arguments:
+                                level: DEBUG
+                                message: $clientId sent a publish on topic '$topic' with result '$validationResult'
+                        onFailure:
+                          pipeline:
+                            - id: logSuccessOperation
+                              functionId: System.log
+                              arguments:
+                                level: WARN
+                                message: $clientId sent an invalid publish on topic '$topic' with result '$validationResult'
+                    _links:
+                      next: /api/v1/data-validation/policies?cursor=a-eqj-GE9B5DkV-nhwVBk-nTL807ty&limit=3
+                list-response-c:
+                  description: Example response with requested fields and multiple policies. More pages left
+                  summary: Multiple results, requested 'id' field
+                  value:
+                    items:
+                      - id: policy1
+                      - id: policy2
+                      - id: policy3
+                    _links:
+                      next: /api/v1/data-validation/policies?cursor=a-eqj-GE9B5DkV-nhwVBk-nTL807ty&limit=3&fields=id
+                list-response-d:
+                  description: Example response with a single policy
+                  summary: Single Result
+                  value:
+                    items:
+                      - id: policy1
+                        createdAt: '2023-04-26T13:32:47.032Z'
+                        lastUpdatedAt: '2023-04-26T13:32:47.032Z'
+                        matching:
+                          topicFilter: topic1
+                        validation:
+                          validators:
+                            - type: schema
+                              arguments:
+                                strategy: ALL_OF
+                                schemas:
+                                  - schemaId: schema
+                                    version: '1'
+                        onSuccess:
+                          pipeline:
+                            - id: logSuccessOperation
+                              functionId: System.log
+                              arguments:
+                                level: DEBUG
+                                message: $clientId sent a publish on topic '$topic' with result '$validationResult'
+                        onFailure:
+                          pipeline:
+                            - id: logFailureOperation
+                              functionId: System.log
+                              arguments:
+                                level: WARN
+                                message: $clientId sent an invalid publish on topic '$topic' with result '$validationResult'
+              schema:
+                $ref: '#/components/schemas/DataPolicyList'
+          description: Success
+        '400':
+          content:
+            application/problem+json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/InvalidQueryParameterError'
+                discriminator:
+                  propertyName: type
+                  mapping:
+                    https://hivemq.com/edge/api/model/InvalidQueryParameterError: '#/components/schemas/InvalidQueryParameterError'
+          description: URL parameter missing
+        '503':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/TemporaryNotAvailableError'
+          description: Request resource temporary unavailable
+      summary: Get all data policies
+      tags:
+        - Data Hub - Data Policies
+    post:
+      description: |+
+        Create a data policy
+
+      operationId: createDataPolicy
+      x-roles-allowed:
+        - admin
+      requestBody:
+        content:
+          application/json:
+            example:
+              id: policy1
+              matching:
+                topicFilter: topic/+
+              validation:
+                validators:
+                  - type: schema
+                    arguments:
+                      strategy: ALL_OF
+                      schemas:
+                        - schemaId: schema
+                          version: '1'
+              onSuccess:
+                pipeline:
+                  - id: logOperationSuccess
+                    functionId: System.log
+                    arguments:
+                      level: DEBUG
+                      message: ${clientId} sent a publish on topic '${topic}' with result '${validationResult}'
+              onFailure:
+                pipeline:
+                  - id: logOperationFailure
+                    functionId: System.log
+                    arguments:
+                      level: WARN
+                      message: ${clientId} sent an invalid publish on topic '${topic}' with result '${validationResult}'
+            schema:
+              $ref: '#/components/schemas/DataPolicy'
+        description: The data policy to create.
+        required: true
+      responses:
+        '201':
+          content:
+            application/json:
+              examples:
+                response-example:
+                  description: Example response.
+                  summary: Policy was created successfully
+                  value:
+                    id: policy1
+                    createdAt: '2023-04-19T13:35:00.930Z'
+                    lastUpdatedAt: '2023-04-19T13:35:00.930Z'
+                    matching:
+                      topicFilter: topic/+
+                    validation:
+                      validators:
+                        - type: schema
+                          arguments:
+                            strategy: ALL_OF
+                            schemas:
+                              - schemaId: schema1
+                                version: '1'
+                    onSuccess:
+                      pipeline:
+                        - id: logOperationSuccess
+                          functionId: System.log
+                          arguments:
+                            level: DEBUG
+                            message: ${clientId} sent a publish on topic '${topic}' with result '${validationResult}'
+                    onFailure:
+                      pipeline:
+                        - id: logOperationFailure
+                          functionId: System.log
+                          arguments:
+                            level: WARN
+                            message: ${clientId} sent an invalid publish on topic '${topic}' with result '${validationResult}'
+              schema:
+                $ref: '#/components/schemas/DataPolicy'
+          description: Success
+        '400':
+          content:
+            application/problem+json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/RequestBodyMissingError'
+                  - $ref: '#/components/schemas/DataPolicyCreationFailureError'
+                  - $ref: '#/components/schemas/DataPolicyInvalidErrors'
+                  - $ref: '#/components/schemas/DataPolicyRejectedError'
+                discriminator:
+                  propertyName: type
+                  mapping:
+                    https://hivemq.com/edge/api/model/RequestBodyMissingError: '#/components/schemas/RequestBodyMissingError'
+                    https://hivemq.com/edge/api/model/DataPolicyCreationFailureError: '#/components/schemas/DataPolicyCreationFailureError'
+                    https://hivemq.com/edge/api/model/DataPolicyInvalidErrors: '#/components/schemas/DataPolicyInvalidErrors'
+                    https://hivemq.com/edge/api/model/DataPolicyRejectedError: '#/components/schemas/DataPolicyRejectedError'
+          description: Data policy creation failed
+        '409':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/DataPolicyAlreadyPresentError'
+          description: Data policy already present
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerError'
+          description: Internal server error
+        '503':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/TemporaryNotAvailableError'
+          description: Request resource temporary unavailable
+        '507':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/PolicyInsufficientStorageError'
+          description: Insufficient storage
+      summary: Create a new data policy
+      tags:
+        - Data Hub - Data Policies
+  /api/v1/data-hub/data-validation/policies/{policyId}:
+    delete:
+      description: |-
+        Deletes an existing data policy. 
+
+         
+      operationId: deleteDataPolicy
+      x-roles-allowed:
+        - admin
+      parameters:
+        - description: The identifier of the data policy to delete.
+          example: policy1
+          in: path
+          name: policyId
+          required: true
+          schema:
+            type: string
+        - description: The entity tag
+          in: header
+          name: If-Match
+          required: false
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success, no response body
+        '400':
+          content:
+            application/problem+json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/UrlParameterMissingError'
+                discriminator:
+                  propertyName: type
+                  mapping:
+                    https://hivemq.com/edge/api/model/UrlParameterMissingError: '#/components/schemas/UrlParameterMissingError'
+          description: URL parameter missing
+        '404':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/PolicyNotFoundError'
+          description: Data policy not found
+        '412':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/PreconditionFailedError'
+          description: Precondition failed
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerError'
+          description: Internal server error
+        '503':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/TemporaryNotAvailableError'
+          description: Request resource temporary unavailable
+      summary: Delete a data policy
+      tags:
+        - Data Hub - Data Policies
+    get:
+      description: |-
+        Get a specific data policy. 
+
+         This endpoint returns the content of the policy with the content-type `application/json`. 
+
+         
+      operationId: getDataPolicy
+      x-roles-allowed:
+        - admin
+        - super
+        - user
+      parameters:
+        - description: The identifier of the policy.
+          example: policy1
+          in: path
+          name: policyId
+          required: true
+          schema:
+            type: string
+        - description: 'Comma-separated list of fields to include in the response. Allowed values are: id, createdAt, lastUpdatedAt, matching, validation, onSuccess, onFailure'
+          example: id,createdAt
+          in: query
+          name: fields
+          schema:
+            type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              examples:
+                get-response:
+                  description: Get Policy
+                  summary: Get Policy
+                  value:
+                    id: policy1
+                    createdAt: '2023-04-19T13:35:00.930Z'
+                    lastUpdatedAt: '2023-04-19T13:35:00.930Z'
+                    matching:
+                      topicFilter: topic/+
+                    validation:
+                      validators:
+                        - type: schema
+                          arguments:
+                            strategy: ALL_OF
+                            schemas:
+                              - schemaId: schema1
+                                version: '1'
+                    onSuccess:
+                      pipeline:
+                        - id: logOperationSuccess
+                          functionId: System.log
+                          arguments:
+                            level: DEBUG
+                            message: ${clientId} sent a publish on topic '${topic}' with result '${validationResult}'
+                    onFailure:
+                      pipeline:
+                        - id: logOperationFailure
+                          functionId: System.log
+                          arguments:
+                            level: WARN
+                            message: ${clientId} sent an invalid publish on topic '${topic}' with result '${validationResult}'
+              schema:
+                $ref: '#/components/schemas/DataPolicy'
+          description: Success
+        '400':
+          content:
+            application/problem+json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/UrlParameterMissingError'
+                discriminator:
+                  propertyName: type
+                  mapping:
+                    https://hivemq.com/edge/api/model/UrlParameterMissingError: '#/components/schemas/UrlParameterMissingError'
+          description: Bad request
+        '404':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/PolicyNotFoundError'
+          description: Resource not found
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerError'
+          description: Internal server error
+        '503':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/TemporaryNotAvailableError'
+          description: Request resource temporary unavailable
+      summary: Get a data policy
+      tags:
+        - Data Hub - Data Policies
+    put:
+      description: |-
+        Update a data policy
+
+        The path parameter 'policyId' must match the 'id' of the policy in the request body.
+         The matching part of policies cannot be changed with an update.
+         
+      operationId: updateDataPolicy
+      x-roles-allowed:
+        - admin
+      parameters:
+        - description: The identifier of the policy.
+          example: policy1
+          in: path
+          name: policyId
+          required: true
+          schema:
+            type: string
+        - description: The entity tag
+          in: header
+          name: If-Match
+          required: false
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            example:
+              id: policy1
+              matching:
+                topicFilter: topic/+
+              validation:
+                validators:
+                  - type: schema
+                    arguments:
+                      strategy: ALL_OF
+                      schemas:
+                        - schemaId: schema
+                          version: '1'
+              onSuccess:
+                pipeline:
+                  - id: logOperationSuccess
+                    functionId: System.log
+                    arguments:
+                      level: DEBUG
+                      message: ${clientId} sent a publish on topic '${topic}' with result '${validationResult}'
+              onFailure:
+                pipeline:
+                  - id: logOperationFailure
+                    functionId: System.log
+                    arguments:
+                      level: WARN
+                      message: ${clientId} sent an invalid publish on topic '${topic}' with result '${validationResult}'
+            schema:
+              $ref: '#/components/schemas/DataPolicy'
+        description: The data policy that should be updated.
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              examples:
+                response-example:
+                  description: Example response.
+                  summary: Policy was updated successfully
+                  value:
+                    id: policy1
+                    createdAt: '2023-04-19T13:35:00.930Z'
+                    lastUpdatedAt: '2023-09-26T11:17:22.311Z'
+                    matching:
+                      topicFilter: topic/+
+                    validation:
+                      validators:
+                        - type: schema
+                          arguments:
+                            strategy: ALL_OF
+                            schemas:
+                              - schemaId: schema1
+                                version: '1'
+                    onSuccess:
+                      pipeline:
+                        - id: logOperationSuccess
+                          functionId: System.log
+                          arguments:
+                            level: DEBUG
+                            message: ${clientId} sent a publish on topic '${topic}' with result '${validationResult}'
+                    onFailure:
+                      pipeline:
+                        - id: logOperationFailure
+                          functionId: System.log
+                          arguments:
+                            level: WARN
+                            message: ${clientId} sent an invalid publish on topic '${topic}' with result '${validationResult}'
+              schema:
+                $ref: '#/components/schemas/DataPolicy'
+          description: Success
+        '400':
+          content:
+            application/problem+json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/RequestBodyMissingError'
+                  - $ref: '#/components/schemas/UrlParameterMissingError'
+                  - $ref: '#/components/schemas/DataPolicyCreationFailureError'
+                  - $ref: '#/components/schemas/DataPolicyInvalidErrors'
+                  - $ref: '#/components/schemas/DataPolicyUpdateFailureError'
+                  - $ref: '#/components/schemas/PolicyIdMismatchError'
+                  - $ref: '#/components/schemas/TopicFilterMismatchError'
+                discriminator:
+                  propertyName: type
+                  mapping:
+                    https://hivemq.com/edge/api/model/RequestBodyMissingError: '#/components/schemas/RequestBodyMissingError'
+                    https://hivemq.com/edge/api/model/UrlParameterMissingError: '#/components/schemas/UrlParameterMissingError'
+                    https://hivemq.com/edge/api/model/DataPolicyCreationFailureError: '#/components/schemas/DataPolicyCreationFailureError'
+                    https://hivemq.com/edge/api/model/DataPolicyInvalidErrors: '#/components/schemas/DataPolicyInvalidErrors'
+                    https://hivemq.com/edge/api/model/DataPolicyUpdateFailureError: '#/components/schemas/DataPolicyUpdateFailureError'
+                    https://hivemq.com/edge/api/model/PolicyIdMismatchError: '#/components/schemas/PolicyIdMismatchError'
+                    https://hivemq.com/edge/api/model/TopicFilterMismatchError: '#/components/schemas/TopicFilterMismatchError'
+          description: Data policy creation failed
+        '404':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/DataPolicyNotFoundError'
+          description: Data policy not found
+        '412':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/PreconditionFailedError'
+          description: Precondition failed
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerError'
+          description: Internal server error
+        '503':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/TemporaryNotAvailableError'
+          description: Request resource temporary unavailable
+        '507':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/PolicyInsufficientStorageError'
+          description: Insufficient storage
+      summary: Update an existing data policy
+      tags:
+        - Data Hub - Data Policies
+  /api/v1/data-hub/fsm:
+    get:
+      description: This endpoints provides the means to get information on the available Finite State Machines (FSMs) for Behavior Policies for the HiveMQ Data Hub. The information is provided in form of a Json Schema.
+      operationId: getFsms
+      x-roles-allowed:
+        - admin
+        - super
+        - user
+      responses:
+        '200':
+          content:
+            application/json:
+              examples:
+                get-response:
+                  description: Get FSMs
+                  summary: Get schema
+                  value:
+                    type: object
+                    required:
+                      - model
+                    properties:
+                      model:
+                        title: Behavior Model
+                        default: Mqtt.events
+                        enum:
+                          - Publish.quota
+                          - Mqtt.events
+                          - Publish.duplicate
+                    allOf:
+                      - if:
+                          type: object
+                          properties:
+                            model:
+                              const: Publish.quota
+                        then:
+                          type: object
+                          properties:
+                            arguments:
+                              title: Publish.quota options
+                              description: When you configure a publish-quota model, at least one of the available arguments must be present. Data Hub uses the default value for the missing parameter.\nThe default value for minimum is 0. The default value for maxPublishes is UNLIMITED.
+                              type: object
+                              required:
+                                - minPublishes
+                              properties:
+                                minPublishes:
+                                  type: number
+                                  title: minPublishes
+                                  description: Defines the minimal number of published messages that must be reached
+                                maxPublishes:
+                                  type: number
+                                  title: maxPublishes
+                                  description: Defines the maximum number of published messages that must be reached
+                      - if:
+                          type: object
+                          properties:
+                            model:
+                              const: Mqtt.events
+                        then:
+                          type: object
+                          properties:
+                            arguments:
+                              title: Mqtt.events
+                              description: This FSM does not require any arguments.
+                              type: object
+                              required: []
+                              properties: {}
+                      - if:
+                          type: object
+                          properties:
+                            model:
+                              const: Publish.duplicate
+                        then:
+                          type: object
+                          properties:
+                            arguments:
+                              title: Publish.duplicate options
+                              description: This FSM does not require any arguments.
+                              type: object
+                              required: []
+                              properties: {}
+              schema:
+                $ref: '#/components/schemas/JsonNode'
+          description: Success
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerError'
+          description: Internal server error
+      summary: Get all FSMs as a JSON Schema
+      tags:
+        - Data Hub - FSM
+  /api/v1/data-hub/functions:
+    get:
+      deprecated: true
+      description: This endpoints provides the means to get information on the available Functions for the HiveMQ Data Hub. The information is provided in form of a Json Schema.
+      operationId: getFunctions
+      x-roles-allowed:
+        - admin
+        - super
+        - user
+      responses:
+        '200':
+          content:
+            application/json:
+              examples:
+                get-response:
+                  description: Get Functions
+                  summary: Get Functions
+                  value:
+                    anyOf:
+                      - title: Mqtt.UserProperties.add
+                        description: Adds a user property to the MQTT message.
+                        type: object
+                        required:
+                          - name
+                          - value
+                        metaData:
+                          isTerminal: false
+                          isDataOnly: false
+                          hasArguments: true
+                        properties:
+                          name:
+                            type: string
+                            title: name
+                            description: Specifies the name of the user property. Multiple user properties with the same name are allowed.
+                          value:
+                            type: string
+                            title: value
+                            description: Specifies the value of the user property.
+                      - title: Delivery.redirectTo
+                        description: Redirects an MQTT PUBLISH message to a specified topic
+                        type: object
+                        required:
+                          - topic
+                        metaData:
+                          isTerminal: true
+                          isDataOnly: true
+                          hasArguments: true
+                        properties:
+                          topic:
+                            type: string
+                            title: topic
+                            description: The destination MQTT topic according to MQTT specification
+                          applyPolicies:
+                            type: string
+                            title: applyPolicies
+                            description: Defines whether policies are executed after publishing to a different topic.
+                      - title: Mqtt.drop
+                        description: Drops the MQTT packet that is currently processed
+                        type: object
+                        required: []
+                        metaData:
+                          isTerminal: false
+                          isDataOnly: false
+                          hasArguments: true
+                        properties:
+                          reasonString:
+                            type: string
+                            title: reasonString
+                            description: Specifies the reason string that is responded to MQTT5 clients.
+                      - title: System.log
+                        description: Logs a message on the given level
+                        type: object
+                        required:
+                          - level
+                          - message
+                        metaData:
+                          isTerminal: false
+                          isDataOnly: false
+                          hasArguments: true
+                        properties:
+                          level:
+                            type: string
+                            title: Log Level
+                            description: Specifies the log level of the function in the hivemq.log file
+                          message:
+                            type: string
+                            title: Message
+                            description: Adds a user-defined string that prints to the log file. For more information, see Example log message
+                      - title: Mqtt.disconnect
+                        description: Disconnects the client
+                        type: object
+                        required: []
+                        metaData:
+                          isTerminal: true
+                          isDataOnly: false
+                          hasArguments: false
+                        properties: {}
+                      - title: Serdes.deserialize
+                        description: Deserializes a binary MQTT message payload into a data object based on the configured JSON Schema or Protobuf schema.
+                        type: object
+                        required:
+                          - schemaId
+                          - schemaVersion
+                        metaData:
+                          isTerminal: false
+                          isDataOnly: false
+                          hasArguments: true
+                        properties:
+                          schemaId:
+                            type: string
+                            title: schemaId
+                            description: The identifier of the JSON Schema to be used for deserialization.
+                          schemaVersion:
+                            type: string
+                            title: schemaVersion
+                            description: The version of the schema to be used for deserialization.
+                      - title: Metrics.Counter.increment
+                        description: Increments a metric of type counter, which can be accessed with monitoring
+                        type: object
+                        required:
+                          - metricName
+                          - incrementBy
+                        metaData:
+                          isTerminal: false
+                          isDataOnly: false
+                          hasArguments: true
+                        properties:
+                          metricName:
+                            type: string
+                            title: metricName
+                            description: Specifies the name of the metric to be incremented.
+                          incrementBy:
+                            type: string
+                            title: incrementBy
+                            description: Specifies the amount by which the counter should be incremented. Negative values are supported.
+                      - title: Serdes.serialize
+                        description: Serializes a data object into a binary MQTT message payload based on the configured JSON Schema (PROTOBUF currently not supported).
+                        type: object
+                        required:
+                          - schemaId
+                          - schemaVersion
+                        metaData:
+                          isTerminal: false
+                          isDataOnly: true
+                          hasArguments: true
+                        properties:
+                          schemaId:
+                            type: string
+                            title: schemaId
+                            description: The identifier of the JSON Schema to be used for serialization
+                          schemaVersion:
+                            type: string
+                            title: schemaVersion
+                            description: The version of the schema to be used for serialization.
+              schema:
+                $ref: '#/components/schemas/JsonNode'
+          description: Success
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerError'
+          description: Internal server error
+      summary: Get all functions as a JSON Schema
+      tags:
+        - Data Hub - Functions
+  /api/v1/data-hub/interpolation-variables:
+    get:
+      description: This endpoint provides the means to get information on the interpolation variables available for the HiveMQ Data Hub.
+      operationId: getVariables
+      x-roles-allowed:
+        - admin
+        - super
+        - user
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InterpolationVariableList'
+          description: Success
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerError'
+          description: Internal server error
+      summary: Get all interpolation variables
+      tags:
+        - Data Hub - Interpolation
+  /api/v1/data-hub/function-specs:
+    get:
+      description: This endpoints provides the means to get information on the available Functions for the HiveMQ Data Hub.
+      operationId: getFunctionSpecs
+      x-roles-allowed:
+        - admin
+        - super
+        - user
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FunctionSpecsList'
+          description: Success
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerError'
+          description: Internal server error
+      summary: Get all functions as a list of function specifications
+      tags:
+        - Data Hub - Functions
+  /api/v1/data-hub/schemas:
+    get:
+      description: |-
+        Get all schemas. 
+
+         This endpoint returns the content of the schemas with the content-type `application/json`. 
+
+         
+      operationId: getAllSchemas
+      x-roles-allowed:
+        - admin
+        - super
+        - user
+      parameters:
+        - description: 'Comma-separated list of fields to include in the response. Allowed values are: id, type, schemaDefinition, createdAt'
+          example: id,createdAt
+          in: query
+          name: fields
+          schema:
+            type: string
+        - description: Comma-separated list of schema types used for filtering. Multiple filters can be applied together.
+          example: JSON,PROTOBUF
+          in: query
+          name: types
+          schema:
+            type: string
+        - description: Comma-separated list of schema ids used for filtering. Multiple filters can be applied together.
+          example: schema1,schema2
+          in: query
+          name: schemaIds
+          schema:
+            type: string
+        - description: Specifies the page size for the returned results. Has to be between 10 and 500. Default page size is 50.
+          example: 100
+          in: query
+          name: limit
+          schema:
+            type: integer
+            format: int32
+        - description: The cursor that has been returned by the previous result page. Do not pass this parameter if you want to fetch the first page.
+          in: query
+          name: cursor
+          schema:
+            type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              examples:
+                list-response-a:
+                  description: Example response with multiple schemas. No more pages left
+                  summary: Multiple results, last page
+                  value:
+                    items:
+                      - id: schema1
+                        version: 1
+                        type: JSON
+                        schemaDefinition: ewogICIkaWQiOiAiaHR0cHM6Ly9leGFtcGxlLmNvbS9hZGRyZXNzLmpzb24iLAogICIkc2NoZW1hIjogImh0dHA6Ly9qc29uLXNjaGVtYS5vcmcvZHJhZnQtMDcvc2NoZW1hIiwKICAidHlwZSI6ICJvYmplY3QiLAogICJwcm9wZXJ0aWVzIjogewogICAgInN0cmVldF9hZGRyZXNzIjogeyAidHlwZSI6ICJzdHJpbmciIH0sCiAgICAiY2l0eSI6IHsgInR5cGUiOiAic3RyaW5nIiB9LAogICAgInN0YXRlIjogeyAidHlwZSI6ICJzdHJpbmciIH0KICB9LAogICJyZXF1aXJlZCI6IFsic3RyZWV0X2FkZHJlc3MiLCAiY2l0eSIsICJzdGF0ZSJdCn0=
+                        createdAt: '2023-03-01T13:28:35.164Z'
+                      - id: schema2
+                        version: 1
+                        type: JSON
+                        schemaDefinition: ewogICIkaWQiOiAiaHR0cHM6Ly9leGFtcGxlLmNvbS9hZGRyZXNzLmpzb24iLAogICIkc2NoZW1hIjogImh0dHA6Ly9qc29uLXNjaGVtYS5vcmcvZHJhZnQtMDcvc2NoZW1hIiwKICAidHlwZSI6ICJvYmplY3QiLAogICJwcm9wZXJ0aWVzIjogewogICAgInN0cmVldF9hZGRyZXNzIjogeyAidHlwZSI6ICJzdHJpbmciIH0sCiAgICAiY2l0eSI6IHsgInR5cGUiOiAic3RyaW5nIiB9LAogICAgInN0YXRlIjogeyAidHlwZSI6ICJzdHJpbmciIH0KICB9LAogICJyZXF1aXJlZCI6IFsic3RyZWV0X2FkZHJlc3MiLCAiY2l0eSIsICJzdGF0ZSJdCn0=
+                        createdAt: '2023-03-01T13:38:35.164Z'
+                      - id: schema3
+                        version: 1
+                        type: JSON
+                        schemaDefinition: ewogICIkaWQiOiAiaHR0cHM6Ly9leGFtcGxlLmNvbS9hZGRyZXNzLmpzb24iLAogICIkc2NoZW1hIjogImh0dHA6Ly9qc29uLXNjaGVtYS5vcmcvZHJhZnQtMDcvc2NoZW1hIiwKICAidHlwZSI6ICJvYmplY3QiLAogICJwcm9wZXJ0aWVzIjogewogICAgInN0cmVldF9hZGRyZXNzIjogeyAidHlwZSI6ICJzdHJpbmciIH0sCiAgICAiY2l0eSI6IHsgInR5cGUiOiAic3RyaW5nIiB9LAogICAgInN0YXRlIjogeyAidHlwZSI6ICJzdHJpbmciIH0KICB9LAogICJyZXF1aXJlZCI6IFsic3RyZWV0X2FkZHJlc3MiLCAiY2l0eSIsICJzdGF0ZSJdCn0=
+                        createdAt: '2023-03-01T13:48:35.164Z'
+                list-response-b:
+                  description: Example response with multiple schemas. More pages left
+                  summary: Multiple results, more pages left
+                  value:
+                    items:
+                      - id: schema1
+                        version: 1
+                        type: JSON
+                        schemaDefinition: ewogICIkaWQiOiAiaHR0cHM6Ly9leGFtcGxlLmNvbS9hZGRyZXNzLmpzb24iLAogICIkc2NoZW1hIjogImh0dHA6Ly9qc29uLXNjaGVtYS5vcmcvZHJhZnQtMDcvc2NoZW1hIiwKICAidHlwZSI6ICJvYmplY3QiLAogICJwcm9wZXJ0aWVzIjogewogICAgInN0cmVldF9hZGRyZXNzIjogeyAidHlwZSI6ICJzdHJpbmciIH0sCiAgICAiY2l0eSI6IHsgInR5cGUiOiAic3RyaW5nIiB9LAogICAgInN0YXRlIjogeyAidHlwZSI6ICJzdHJpbmciIH0KICB9LAogICJyZXF1aXJlZCI6IFsic3RyZWV0X2FkZHJlc3MiLCAiY2l0eSIsICJzdGF0ZSJdCn0=
+                        createdAt: '2023-03-01T13:28:35.164Z'
+                      - id: schema2
+                        version: 1
+                        type: JSON
+                        schemaDefinition: ewogICIkaWQiOiAiaHR0cHM6Ly9leGFtcGxlLmNvbS9hZGRyZXNzLmpzb24iLAogICIkc2NoZW1hIjogImh0dHA6Ly9qc29uLXNjaGVtYS5vcmcvZHJhZnQtMDcvc2NoZW1hIiwKICAidHlwZSI6ICJvYmplY3QiLAogICJwcm9wZXJ0aWVzIjogewogICAgInN0cmVldF9hZGRyZXNzIjogeyAidHlwZSI6ICJzdHJpbmciIH0sCiAgICAiY2l0eSI6IHsgInR5cGUiOiAic3RyaW5nIiB9LAogICAgInN0YXRlIjogeyAidHlwZSI6ICJzdHJpbmciIH0KICB9LAogICJyZXF1aXJlZCI6IFsic3RyZWV0X2FkZHJlc3MiLCAiY2l0eSIsICJzdGF0ZSJdCn0=
+                        createdAt: '2023-03-01T13:38:35.164Z'
+                      - id: schema3
+                        version: 1
+                        type: JSON
+                        schemaDefinition: ewogICIkaWQiOiAiaHR0cHM6Ly9leGFtcGxlLmNvbS9hZGRyZXNzLmpzb24iLAogICIkc2NoZW1hIjogImh0dHA6Ly9qc29uLXNjaGVtYS5vcmcvZHJhZnQtMDcvc2NoZW1hIiwKICAidHlwZSI6ICJvYmplY3QiLAogICJwcm9wZXJ0aWVzIjogewogICAgInN0cmVldF9hZGRyZXNzIjogeyAidHlwZSI6ICJzdHJpbmciIH0sCiAgICAiY2l0eSI6IHsgInR5cGUiOiAic3RyaW5nIiB9LAogICAgInN0YXRlIjogeyAidHlwZSI6ICJzdHJpbmciIH0KICB9LAogICJyZXF1aXJlZCI6IFsic3RyZWV0X2FkZHJlc3MiLCAiY2l0eSIsICJzdGF0ZSJdCn0=
+                        createdAt: '2023-03-01T13:48:35.164Z'
+                    _links:
+                      next: /api/v1/data-hub/schemas?cursor=a-eqj-GE9B5DkV-nhwVBk-nTL807ty&limit=3
+                list-response-c:
+                  description: Example response with requested fields and multiple schemas. More pages left
+                  summary: Multiple results, requested 'id' field
+                  value:
+                    items:
+                      - id: schema1
+                      - id: schema2
+                      - id: schema3
+                    _links:
+                      next: /api/v1/data-hub/schemas?cursor=a-eqj-GE9B5DkV-nhwVBk-nTL807ty&limit=3&fields=id
+                list-response-d:
+                  description: Example response with a single schema
+                  summary: Single Result
+                  value:
+                    items:
+                      - id: schema1
+                        version: 1
+                        type: JSON
+                        schemaDefinition: ewogICIkaWQiOiAiaHR0cHM6Ly9leGFtcGxlLmNvbS9hZGRyZXNzLmpzb24iLAogICIkc2NoZW1hIjogImh0dHA6Ly9qc29uLXNjaGVtYS5vcmcvZHJhZnQtMDcvc2NoZW1hIiwKICAidHlwZSI6ICJvYmplY3QiLAogICJwcm9wZXJ0aWVzIjogewogICAgInN0cmVldF9hZGRyZXNzIjogeyAidHlwZSI6ICJzdHJpbmciIH0sCiAgICAiY2l0eSI6IHsgInR5cGUiOiAic3RyaW5nIiB9LAogICAgInN0YXRlIjogeyAidHlwZSI6ICJzdHJpbmciIH0KICB9LAogICJyZXF1aXJlZCI6IFsic3RyZWV0X2FkZHJlc3MiLCAiY2l0eSIsICJzdGF0ZSJdCn0=
+                        createdAt: '2023-03-01T13:28:35.164Z'
+                list-response-e:
+                  description: Example response with all versions of specific schema id.
+                  summary: List versions of one schema, last page
+                  value:
+                    items:
+                      - id: schema1
+                        version: 1
+                        type: JSON
+                        schemaDefinition: ewogICIkaWQiOiAiaHR0cHM6Ly9leGFtcGxlLmNvbS9hZGRyZXNzLmpzb24iLAogICIkc2NoZW1hIjogImh0dHA6Ly9qc29uLXNjaGVtYS5vcmcvZHJhZnQtMDcvc2NoZW1hIiwKICAidHlwZSI6ICJvYmplY3QiLAogICJwcm9wZXJ0aWVzIjogewogICAgInN0cmVldF9hZGRyZXNzIjogeyAidHlwZSI6ICJzdHJpbmciIH0sCiAgICAiY2l0eSI6IHsgInR5cGUiOiAic3RyaW5nIiB9LAogICAgInN0YXRlIjogeyAidHlwZSI6ICJzdHJpbmciIH0KICB9LAogICJyZXF1aXJlZCI6IFsic3RyZWV0X2FkZHJlc3MiLCAiY2l0eSIsICJzdGF0ZSJdCn0=
+                        createdAt: '2023-03-01T13:28:35.164Z'
+                      - id: schema1
+                        version: 2
+                        type: JSON
+                        schemaDefinition: ewogICIkaWQiOiAiaHR0cHM6Ly9leGFtcGxlLmNvbS9hZGRyZXNzLmpzb24iLAogICIkc2NoZW1hIjogImh0dHA6Ly9qc29uLXNjaGVtYS5vcmcvZHJhZnQtMDcvc2NoZW1hIiwKICAidHlwZSI6ICJvYmplY3QiLAogICJwcm9wZXJ0aWVzIjogewogICAgInN0cmVldF9hZGRyZXNzIjogeyAidHlwZSI6ICJzdHJpbmciIH0sCiAgICAiY2l0eSI6IHsgInR5cGUiOiAic3RyaW5nIiB9LAogICAgInN0YXRlIjogeyAidHlwZSI6ICJzdHJpbmciIH0KICB9LAogICJyZXF1aXJlZCI6IFsic3RyZWV0X2FkZHJlc3MiLCAiY2l0eSIsICJzdGF0ZSJdCn0=
+                        createdAt: '2023-03-01T13:38:35.164Z'
+                      - id: schema1
+                        version: 3
+                        type: JSON
+                        schemaDefinition: ewogICIkaWQiOiAiaHR0cHM6Ly9leGFtcGxlLmNvbS9hZGRyZXNzLmpzb24iLAogICIkc2NoZW1hIjogImh0dHA6Ly9qc29uLXNjaGVtYS5vcmcvZHJhZnQtMDcvc2NoZW1hIiwKICAidHlwZSI6ICJvYmplY3QiLAogICJwcm9wZXJ0aWVzIjogewogICAgInN0cmVldF9hZGRyZXNzIjogeyAidHlwZSI6ICJzdHJpbmciIH0sCiAgICAiY2l0eSI6IHsgInR5cGUiOiAic3RyaW5nIiB9LAogICAgInN0YXRlIjogeyAidHlwZSI6ICJzdHJpbmciIH0KICB9LAogICJyZXF1aXJlZCI6IFsic3RyZWV0X2FkZHJlc3MiLCAiY2l0eSIsICJzdGF0ZSJdCn0=
+                        createdAt: '2023-03-01T13:48:35.164Z'
+              schema:
+                $ref: '#/components/schemas/SchemaList'
+          description: Success
+        '400':
+          content:
+            application/problem+json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/InvalidQueryParameterError'
+                discriminator:
+                  propertyName: type
+                  mapping:
+                    https://hivemq.com/edge/api/model/InvalidQueryParameterError: '#/components/schemas/InvalidQueryParameterError'
+          description: URL parameter missing
+        '503':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/TemporaryNotAvailableError'
+          description: Request resource temporary unavailable
+      summary: Get all schemas
+      tags:
+        - Data Hub - Schemas
+    post:
+      description: |+
+        Creates a schema
+
+      operationId: createSchema
+      x-roles-allowed:
+        - admin
+      parameters:
+        - description: The entity tag
+          in: header
+          name: If-Match
+          required: false
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            example:
+              id: schema
+              type: JSON
+              schemaDefinition: ewogICIkaWQiOiAiaHR0cHM6Ly9leGFtcGxlLmNvbS9hZGRyZXNzLmpzb24iLAogICIkc2NoZW1hIjogImh0dHA6Ly9qc29uLXNjaGVtYS5vcmcvZHJhZnQtMDcvc2NoZW1hIiwKICAidHlwZSI6ICJvYmplY3QiLAogICJwcm9wZXJ0aWVzIjogewogICAgInN0cmVldF9hZGRyZXNzIjogeyAidHlwZSI6ICJzdHJpbmciIH0sCiAgICAiY2l0eSI6IHsgInR5cGUiOiAic3RyaW5nIiB9LAogICAgInN0YXRlIjogeyAidHlwZSI6ICJzdHJpbmciIH0KICB9LAogICJyZXF1aXJlZCI6IFsic3RyZWV0X2FkZHJlc3MiLCAiY2l0eSIsICJzdGF0ZSJdCn0=
+            schema:
+              $ref: '#/components/schemas/PolicySchema'
+        description: The schema that should be created.
+        required: true
+      responses:
+        '201':
+          content:
+            application/json:
+              examples:
+                response-example:
+                  description: Example response.
+                  summary: Schema was created successfully
+                  value:
+                    id: schema
+                    version: 1
+                    type: JSON
+                    schemaDefinition: ewogICIkaWQiOiAiaHR0cHM6Ly9leGFtcGxlLmNvbS9hZGRyZXNzLmpzb24iLAogICIkc2NoZW1hIjogImh0dHA6Ly9qc29uLXNjaGVtYS5vcmcvZHJhZnQtMDcvc2NoZW1hIiwKICAidHlwZSI6ICJvYmplY3QiLAogICJwcm9wZXJ0aWVzIjogewogICAgInN0cmVldF9hZGRyZXNzIjogeyAidHlwZSI6ICJzdHJpbmciIH0sCiAgICAiY2l0eSI6IHsgInR5cGUiOiAic3RyaW5nIiB9LAogICAgInN0YXRlIjogeyAidHlwZSI6ICJzdHJpbmciIH0KICB9LAogICJyZXF1aXJlZCI6IFsic3RyZWV0X2FkZHJlc3MiLCAiY2l0eSIsICJzdGF0ZSJdCn0=
+                    createdAt: '2023-03-01T13:28:35.164Z'
+              schema:
+                $ref: '#/components/schemas/PolicySchema'
+          description: Success
+        '400':
+          content:
+            application/problem+json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/RequestBodyParameterMissingError'
+                  - $ref: '#/components/schemas/SchemaInvalidErrors'
+                  - $ref: '#/components/schemas/SchemaParsingFailureError'
+                discriminator:
+                  propertyName: type
+                  mapping:
+                    https://hivemq.com/edge/api/model/RequestBodyParameterMissingError: '#/components/schemas/RequestBodyParameterMissingError'
+                    https://hivemq.com/edge/api/model/SchemaInvalidErrors: '#/components/schemas/SchemaInvalidErrors'
+                    https://hivemq.com/edge/api/model/SchemaParsingFailureError: '#/components/schemas/SchemaParsingFailureError'
+          description: Schema creation failed
+        '409':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/SchemaAlreadyPresentError'
+          description: Schema is already present
+        '412':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/SchemaEtagMismatchError'
+          description: Schema doesn't match etag
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerError'
+          description: Internal server error
+        '503':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/TemporaryNotAvailableError'
+          description: Request resource temporary unavailable
+        '507':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/SchemaInsufficientStorageError'
+          description: Insufficient storage
+      summary: Create a new schema
+      tags:
+        - Data Hub - Schemas
+  /api/v1/data-hub/schemas/{schemaId}:
+    delete:
+      description: |-
+        Deletes the selected schema and all associated versions of the schema. 
+
+         
+      operationId: deleteSchema
+      x-roles-allowed:
+        - admin
+      parameters:
+        - description: The schema identifier of the schema versions to delete.
+          example: schema1
+          in: path
+          name: schemaId
+          required: true
+          schema:
+            type: string
+        - description: The entity tag
+          in: header
+          name: If-Match
+          required: false
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success, no response body
+        '400':
+          content:
+            application/problem+json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/UrlParameterMissingError'
+                  - $ref: '#/components/schemas/SchemaReferencedError'
+                discriminator:
+                  propertyName: type
+                  mapping:
+                    https://hivemq.com/edge/api/model/UrlParameterMissingError: '#/components/schemas/UrlParameterMissingError'
+                    https://hivemq.com/edge/api/model/SchemaReferencedError: '#/components/schemas/SchemaReferencedError'
+          description: URL parameter missing
+        '404':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/SchemaNotFoundError'
+          description: Schema not found
+        '412':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/SchemaEtagMismatchError'
+          description: Schema doesn't match etag
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerError'
+          description: Internal Server error
+        '503':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/TemporaryNotAvailableError'
+          description: Request resource temporary unavailable
+      summary: Delete all versions of the schema
+      tags:
+        - Data Hub - Schemas
+    get:
+      description: |-
+        Get a specific schema. 
+
+         This endpoint returns the content of the latest version of the schema with the content-type `application/json`. 
+
+         
+      operationId: getSchema
+      x-roles-allowed:
+        - admin
+        - super
+        - user
+      parameters:
+        - description: The identifier of the schema.
+          example: schema1
+          in: path
+          name: schemaId
+          required: true
+          schema:
+            type: string
+        - description: 'Comma-separated list of fields to include in the response. Allowed values are: id, type, schemaDefinition, createdAt'
+          example: id,type
+          in: query
+          name: fields
+          schema:
+            type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              examples:
+                get-response:
+                  description: Get schema
+                  summary: Get schema
+                  value:
+                    id: schema
+                    version: 1
+                    type: JSON
+                    schemaDefinition: ewogICIkaWQiOiAiaHR0cHM6Ly9leGFtcGxlLmNvbS9hZGRyZXNzLmpzb24iLAogICIkc2NoZW1hIjogImh0dHA6Ly9qc29uLXNjaGVtYS5vcmcvZHJhZnQtMDcvc2NoZW1hIiwKICAidHlwZSI6ICJvYmplY3QiLAogICJwcm9wZXJ0aWVzIjogewogICAgInN0cmVldF9hZGRyZXNzIjogeyAidHlwZSI6ICJzdHJpbmciIH0sCiAgICAiY2l0eSI6IHsgInR5cGUiOiAic3RyaW5nIiB9LAogICAgInN0YXRlIjogeyAidHlwZSI6ICJzdHJpbmciIH0KICB9LAogICJyZXF1aXJlZCI6IFsic3RyZWV0X2FkZHJlc3MiLCAiY2l0eSIsICJzdGF0ZSJdCn0=
+                    createdAt: '2023-03-01T13:28:35.164Z'
+              schema:
+                $ref: '#/components/schemas/PolicySchema'
+          description: Success
+        '400':
+          content:
+            application/problem+json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/UrlParameterMissingError'
+                discriminator:
+                  propertyName: type
+                  mapping:
+                    https://hivemq.com/edge/api/model/UrlParameterMissingError: '#/components/schemas/UrlParameterMissingError'
+          description: URL parameter missing
+        '404':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/SchemaNotFoundError'
+          description: Schema not found
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerError'
+          description: Internal server error
+        '503':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/TemporaryNotAvailableError'
+          description: Request resource temporary unavailable
+      summary: Get a schema
+      tags:
+        - Data Hub - Schemas
+  /api/v1/data-hub/scripts:
+    get:
+      description: Get all scripts.
+      operationId: getAllScripts
+      x-roles-allowed:
+        - admin
+        - super
+        - user
+      parameters:
+        - description: 'Comma-separated list of fields to include in the response. Allowed values are: id, version, description, runtime, functionType, createdAt'
+          example: id,createdAt,source
+          in: query
+          name: fields
+          schema:
+            type: string
+        - description: Comma-separated list of function types used for filtering. Multiple filters can be applied together.
+          example: TRANSFORMATION
+          in: query
+          name: functionTypes
+          schema:
+            type: string
+        - description: Comma-separated list of script ids used for filtering. Multiple filters can be applied together.
+          example: script1,script2
+          in: query
+          name: scriptIds
+          schema:
+            type: string
+        - description: Specifies the page size for the returned results. Has to be between 10 and 500. Default page size is 50.
+          example: 100
+          in: query
+          name: limit
+          schema:
+            type: integer
+            format: int32
+        - description: The cursor that has been returned by the previous result page. Do not pass this parameter if you want to fetch the first page.
+          in: query
+          name: cursor
+          schema:
+            type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              examples:
+                list-response-1:
+                  description: Example response with a single script
+                  summary: Single Result
+                  value:
+                    items:
+                      - id: my-transform.js
+                        version: 1
+                        createdAt: '2023-11-21T13:08:09.898Z'
+                        description: This script prefixes topics with 'transformed/'
+                        functionType: TRANSFORMATION
+                        source: ZnVuY3Rpb24gdHJhbnNmb3JtKHB1Ymxpc2gsIGNvbnRleHQpIHsKICAgcHVibGlzaC50b3BpYyA9ICJ0cmFuc2Zvcm1lZC8iICsgcHVibGlzaC50b3BpYzsKICAgcmV0dXJuIHB1Ymxpc2g7Cn0=
+                list-response-b:
+                  description: Example response with multiple sripts. More pages left
+                  summary: Multiple results, more pages left
+                  value:
+                    items:
+                      - id: my-transform.js
+                        version: 1
+                        createdAt: '2023-11-21T13:08:09.898Z'
+                        description: This script prefixes topics with 'transformed/'
+                        functionType: TRANSFORMATION
+                        source: ZnVuY3Rpb24gdHJhbnNmb3JtKHB1Ymxpc2gsIGNvbnRleHQpIHsKICAgcHVibGlzaC50b3BpYyA9ICJ0cmFuc2Zvcm1lZC8iICsgcHVibGlzaC50b3BpYzsKICAgcmV0dXJuIHB1Ymxpc2g7Cn0=
+                      - id: my-transform-new.js
+                        version: 1
+                        createdAt: '2023-11-21T13:17:53.085Z'
+                        description: This script adds the user property ('foo', 'bar') to a publish
+                        functionType: TRANSFORMATION
+                        source: ZnVuY3Rpb24gdHJhbnNmb3JtKHB1Ymxpc2gsIGNvbnRleHQpIHsgcHVibGlzaC51c2VyUHJvcGVydGllcy5wdXNoKHtuYW1lOiAnZm9vJywgdmFsdWU6ICdiYXInfSk7IHJldHVybiBwdWJsaXNoOyB9
+                    _links:
+                      next: /api/v1/data-hub/scripts?cursor=a-WfW-QB4L4Q==&limit=3
+                list-response-c:
+                  description: Example response with requested fields and multiple scripts. More pages left
+                  summary: Multiple results, requested 'id' field
+                  value:
+                    items:
+                      - id: script1
+                      - id: script2
+                      - id: script3
+                    _links:
+                      next: /api/v1/data-hub/scripts?cursor=a-eqj-GE9B5DkV-nhwVBk-nTL807ty&limit=3&fields=id
+                list-response-e:
+                  description: Example response with all versions of specific script id.
+                  summary: List versions of one script, last page
+                  value:
+                    items:
+                      - id: my-transform.js
+                        version: 1
+                        createdAt: '2023-11-21T13:08:09.898Z'
+                        description: This script prefixes topics with 'transformed/'
+                        functionType: TRANSFORMATION
+                        source: ZnVuY3Rpb24gdHJhbnNmb3JtKHB1Ymxpc2gsIGNvbnRleHQpIHsKICAgcHVibGlzaC50b3BpYyA9ICJ0cmFuc2Zvcm1lZC8iICsgcHVibGlzaC50b3BpYzsKICAgcmV0dXJuIHB1Ymxpc2g7Cn0=
+                      - id: my-transform.js
+                        version: 2
+                        createdAt: '2023-11-21T13:17:53.085Z'
+                        description: This script prefixes topics with 'transformed/'
+                        functionType: TRANSFORMATION
+                        source: ZnVuY3Rpb24gdHJhbnNmb3JtKHB1Ymxpc2gsIGNvbnRleHQpIHsgcHVibGlzaC51c2VyUHJvcGVydGllcy5wdXNoKHtuYW1lOiAnZm9vJywgdmFsdWU6ICdiYXInfSk7IHJldHVybiBwdWJsaXNoOyB9
+                list-response-many:
+                  description: Example response with multiple scripts
+                  summary: Multiple results
+                  value:
+                    items:
+                      - id: my-transform.js
+                        version: 1
+                        createdAt: '2023-11-21T13:08:09.898Z'
+                        description: This script prefixes topics with 'transformed/'
+                        functionType: TRANSFORMATION
+                        source: ZnVuY3Rpb24gdHJhbnNmb3JtKHB1Ymxpc2gsIGNvbnRleHQpIHsKICAgcHVibGlzaC50b3BpYyA9ICJ0cmFuc2Zvcm1lZC8iICsgcHVibGlzaC50b3BpYzsKICAgcmV0dXJuIHB1Ymxpc2g7Cn0=
+                      - id: my-transform-new.js
+                        version: 1
+                        createdAt: '2023-11-21T13:17:53.085Z'
+                        description: This script adds the user property ('foo', 'bar') to a publish
+                        functionType: TRANSFORMATION
+                        source: ZnVuY3Rpb24gdHJhbnNmb3JtKHB1Ymxpc2gsIGNvbnRleHQpIHsgcHVibGlzaC51c2VyUHJvcGVydGllcy5wdXNoKHtuYW1lOiAnZm9vJywgdmFsdWU6ICdiYXInfSk7IHJldHVybiBwdWJsaXNoOyB9
+              schema:
+                $ref: '#/components/schemas/ScriptList'
+          description: Success
+        '400':
+          content:
+            application/problem+json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/InvalidQueryParameterError'
+                discriminator:
+                  propertyName: type
+                  mapping:
+                    https://hivemq.com/edge/api/model/InvalidQueryParameterError: '#/components/schemas/InvalidQueryParameterError'
+          description: URL parameter missing
+        '503':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/TemporaryNotAvailableError'
+          description: Request resource temporary unavailable
+      summary: Get all scripts
+      tags:
+        - Data Hub - Scripts
+    post:
+      description: Creates a script
+      operationId: createScript
+      x-roles-allowed:
+        - admin
+      parameters:
+        - description: The entity tag
+          in: header
+          name: If-Match
+          required: false
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            example:
+              id: my-transform.js
+              description: This script prefixes topics with 'transformed/'
+              functionType: TRANSFORMATION
+              source: ZnVuY3Rpb24gdHJhbnNmb3JtKHB1Ymxpc2gsIGNvbnRleHQpIHsKICAgcHVibGlzaC50b3BpYyA9ICJ0cmFuc2Zvcm1lZC8iICsgcHVibGlzaC50b3BpYzsKICAgcmV0dXJuIHB1Ymxpc2g7Cn0=
+            schema:
+              $ref: '#/components/schemas/Script'
+        description: The script that should be created.
+        required: true
+      responses:
+        '201':
+          content:
+            application/json:
+              examples:
+                response-example:
+                  description: Example response.
+                  summary: Script was created successfully
+                  value:
+                    id: my-transform.js
+                    version: 1
+                    createdAt: '2023-11-21T13:08:09.898Z'
+                    description: This script prefixes topics with 'transformed/'
+                    functionType: TRANSFORMATION
+                    source: ZnVuY3Rpb24gdHJhbnNmb3JtKHB1Ymxpc2gsIGNvbnRleHQpIHsKICAgcHVibGlzaC50b3BpYyA9ICJ0cmFuc2Zvcm1lZC8iICsgcHVibGlzaC50b3BpYzsKICAgcmV0dXJuIHB1Ymxpc2g7Cn0=
+              schema:
+                $ref: '#/components/schemas/Script'
+          description: Success
+        '400':
+          content:
+            application/problem+json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/RequestBodyParameterMissingError'
+                  - $ref: '#/components/schemas/ScriptCreationFailureError'
+                  - $ref: '#/components/schemas/ScriptInvalidErrors'
+                  - $ref: '#/components/schemas/ScriptParsingFailureError'
+                  - $ref: '#/components/schemas/ScriptSanitationFailureError'
+                discriminator:
+                  propertyName: type
+                  mapping:
+                    https://hivemq.com/edge/api/model/RequestBodyParameterMissingError: '#/components/schemas/RequestBodyParameterMissingError'
+                    https://hivemq.com/edge/api/model/ScriptCreationFailureError: '#/components/schemas/ScriptCreationFailureError'
+                    https://hivemq.com/edge/api/model/ScriptInvalidErrors: '#/components/schemas/ScriptInvalidErrors'
+                    https://hivemq.com/edge/api/model/ScriptParsingFailureError: '#/components/schemas/ScriptParsingFailureError'
+                    https://hivemq.com/edge/api/model/ScriptSanitationFailureError: '#/components/schemas/ScriptSanitationFailureError'
+          description: Script creation failed
+        '409':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ScriptAlreadyPresentError'
+          description: Script is already present
+        '412':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ScriptEtagMismatchError'
+          description: Script doesn't match etag
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerError'
+          description: Internal server error
+        '503':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/TemporaryNotAvailableError'
+          description: Request resource temporary unavailable
+        '507':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ScriptInsufficientStorageError'
+          description: Insufficient storage
+      summary: Create a new script
+      tags:
+        - Data Hub - Scripts
+  /api/v1/data-hub/scripts/{scriptId}:
+    delete:
+      description: Deletes the selected script.
+      operationId: deleteScript
+      x-roles-allowed:
+        - admin
+      parameters:
+        - description: The script identifier of the script to delete.
+          example: hello_world_function
+          in: path
+          name: scriptId
+          required: true
+          schema:
+            type: string
+        - description: The entity tag
+          in: header
+          name: If-Match
+          required: false
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Success, no response body
+        '400':
+          content:
+            application/problem+json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/UrlParameterMissingError'
+                  - $ref: '#/components/schemas/ScriptReferencedError'
+                discriminator:
+                  propertyName: type
+                  mapping:
+                    https://hivemq.com/edge/api/model/UrlParameterMissingError: '#/components/schemas/UrlParameterMissingError'
+                    https://hivemq.com/edge/api/model/ScriptReferencedError: '#/components/schemas/ScriptReferencedError'
+          description: URL parameter missing
+        '404':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ScriptNotFoundError'
+          description: Script not found
+        '412':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ScriptEtagMismatchError'
+          description: Script doesn't match etag
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerError'
+          description: Internal Server error
+        '503':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/TemporaryNotAvailableError'
+          description: Request resource temporary unavailable
+      summary: Delete a script
+      tags:
+        - Data Hub - Scripts
+    get:
+      description: Get a specific script.
+      operationId: getScript
+      x-roles-allowed:
+        - admin
+        - super
+        - user
+      parameters:
+        - description: The identifier of the script.
+          example: hello_world_function
+          in: path
+          name: scriptId
+          required: true
+          schema:
+            type: string
+        - description: 'Comma-separated list of fields to include in the response. Allowed values are: id, version, description, runtime, functionType, createdAt'
+          example: id,createdAt,source
+          in: query
+          name: fields
+          schema:
+            type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              examples:
+                get-response:
+                  description: Get script
+                  summary: Get script
+                  value:
+                    id: my-transform.js
+                    version: 1
+                    createdAt: '2023-11-21T13:08:09.898Z'
+                    description: This script prefixes topics with 'transformed/'
+                    functionType: TRANSFORMATION
+                    source: ZnVuY3Rpb24gdHJhbnNmb3JtKHB1Ymxpc2gsIGNvbnRleHQpIHsKICAgcHVibGlzaC50b3BpYyA9ICJ0cmFuc2Zvcm1lZC8iICsgcHVibGlzaC50b3BpYzsKICAgcmV0dXJuIHB1Ymxpc2g7Cn0=
+              schema:
+                $ref: '#/components/schemas/Script'
+          description: Success
+        '400':
+          content:
+            application/problem+json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/UrlParameterMissingError'
+                discriminator:
+                  propertyName: type
+                  mapping:
+                    https://hivemq.com/edge/api/model/UrlParameterMissingError: '#/components/schemas/UrlParameterMissingError'
+          description: URL parameter missing
+        '404':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ScriptNotFoundError'
+          description: Script not found
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerError'
+          description: Internal Server error
+        '503':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/TemporaryNotAvailableError'
+          description: Request resource temporary unavailable
+      summary: Get a script
+      tags:
+        - Data Hub - Scripts
+  /api/v1/frontend/capabilities:
+    get:
+      description: Obtain gateway capabilities.
+      operationId: get-capabilities
+      x-roles-allowed:
+        - admin
+        - super
+        - user
+      responses:
+        '200':
+          content:
+            application/json:
+              examples:
+                capabilities:
+                  description: An example capability list.
+                  summary: Example capabilities
+                  value: |-
+                    {
+                        "items": [
+                            {
+                                "id": "test-capability"
+                                "displayName": "Super useful Capability"
+                                "description": "This capability is really useful for so many reasons."
+                            }
+                        ]
+                    }
+              schema:
+                $ref: '#/components/schemas/CapabilityList'
+          description: Success
+      summary: Obtain Capabilities of the HiveMQ Edge Installation
+      tags:
+        - Frontend
+  /api/v1/frontend/configuration:
+    get:
+      description: Obtain configuration.
+      operationId: get-configuration
+      x-roles-allowed:
+        - NO_AUTH_REQUIRED
+      responses:
+        '200':
+          content:
+            application/json:
+              examples:
+                default-configuration:
+                  description: An example default gateway configuration.
+                  summary: Example gateway configuration
+                  value:
+                    environment:
+                      properties:
+                        environment-type: TEST
+                    cloudLink:
+                      displayText: HiveMQ Cloud
+                      url: https://hivemq.com/cloud
+                      description: Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren,
+                      external: true
+                    gitHubLink:
+                      displayText: GitHub
+                      url: https://github.com/hivemq/hivemq-edge
+                      description: Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren,
+                      external: true
+                    documentationLink:
+                      displayText: Documentation
+                      url: https://github.com/hivemq/hivemq-edge/README.MD
+                      description: Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren,
+                      external: true
+                    firstUseInformation:
+                      firstUse: false
+                      prefillUsername: admin
+                      prefillPassword: password
+                      firstUseTitle: Welcome To HiveMQ Edge
+                      firstUseDescription: Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
+                    ctas:
+                      items:
+                        - displayText: Connect My First Device
+                          url: ./protocol-adapters?from=dashboard-cta
+                          description: Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren,
+                          external: false
+                        - displayText: Connect To My MQTT Broker
+                          url: ./bridges?from=dashboard-cta
+                          description: Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren,
+                          external: false
+                        - displayText: Learn More
+                          url: resources?from=dashboard-cta
+                          description: Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren,
+                          external: false
+                    resources:
+                      items:
+                        - displayText: Power Of Smart Manufacturing
+                          url: https://www.hivemq.com/articles/power-of-iot-data-management-in-smart-manufacturing/
+                          description: ''
+                          target: ''
+                          imageUrl: ''
+                          external: true
+                        - displayText: Power Of Smart Manufacturing
+                          url: https://www.hivemq.com/articles/power-of-iot-data-management-in-smart-manufacturing/
+                          description: ''
+                          target: ''
+                          imageUrl: ''
+                          external: true
+                    modules:
+                      items: []
+                    extensions:
+                      items:
+                        - id: extension-1
+                          version: 1.0.0
+                          name: My First Extension
+                          description: Some extension description here which could span multiple lines
+                          author: HiveMQ
+                          priority: 0
+                        - id: hivemq-allow-all-extension
+                          version: 1.0.0
+                          name: Allow All Extension
+                          author: HiveMQ
+                          priority: 0
+                          installed: true
+              schema:
+                $ref: '#/components/schemas/GatewayConfiguration'
+          description: Success
+      summary: Obtain frontend configuration
+      tags:
+        - Frontend
+  /api/v1/frontend/notifications:
+    get:
+      description: Obtain gateway notifications.
+      operationId: get-notifications
+      x-roles-allowed:
+        - admin
+        - super
+        - user
+      responses:
+        '200':
+          content:
+            application/json:
+              examples:
+                notifications:
+                  description: An example notification list.
+                  summary: Example notifications
+                  value:
+                    items:
+                      - level: WARNING
+                        title: Default Credentials Need Changing!
+                        description: Your gateway access is configured to use the default username/password combination. This is a security risk. Please ensure you modify your access credentials in your configuration.xml file.
+              schema:
+                $ref: '#/components/schemas/NotificationList'
+          description: Success
+      summary: Obtain Notifications
+      tags:
+        - Frontend
+  /api/v1/gateway/configuration:
+    get:
+      description: Obtain gateway configuration.
+      operationId: get-xml-configuration
+      x-roles-allowed:
+        - admin
+        - super
+        - user
+      responses:
+        '200':
+          content:
+            application/xml:
+              schema:
+                type: string
+          description: Success
+        '405':
+          content:
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Error - function not supported
+      summary: Obtain HiveMQ Edge Configuration
+      tags:
+        - Gateway Endpoint
+  /api/v1/gateway/listeners:
+    get:
+      description: Obtain listener.
+      operationId: get-listeners
+      x-roles-allowed:
+        - admin
+        - super
+        - user
+      responses:
+        '200':
+          content:
+            application/json:
+              examples:
+                listener-configuration:
+                  description: A list of listeners configured in the gateway
+                  summary: Listener configuration
+                  value:
+                    items:
+                      - name: tcp-listener-1883
+                        hostName: localhost
+                        port: 1883
+                      - name: udp-listener-2442
+                        hostName: localhost
+                        port: 2442
+              schema:
+                $ref: '#/components/schemas/ListenerList'
+          description: Success
+      summary: 'Obtain the listeners configured '
+      tags:
+        - Gateway Endpoint
+  /api/v1/health/liveness:
+    get:
+      description: Endpoint to determine whether the gateway is considered UP.
+      operationId: liveness
+      x-roles-allowed:
+        - NO_AUTH_REQUIRED
+      responses:
+        '200':
+          content:
+            application/json:
+              examples:
+                success-health:
+                  description: An example success health response.
+                  value:
+                    status: UP
+              schema:
+                $ref: '#/components/schemas/HealthStatus'
+          description: Success
+      summary: Endpoint to determine whether the gateway is considered UP
+      tags:
+        - Health Check Endpoint
+  /api/v1/health/readiness:
+    get:
+      description: Endpoint to determine whether the gateway is considered ready.
+      operationId: readiness
+      x-roles-allowed:
+        - NO_AUTH_REQUIRED
+      responses:
+        '200':
+          content:
+            application/json:
+              examples:
+                success-health:
+                  description: An example success health response.
+                  value:
+                    status: UP
+              schema:
+                $ref: '#/components/schemas/HealthStatus'
+          description: Success
+      summary: Endpoint to determine whether the gateway is considered ready
+      tags:
+        - Health Check Endpoint
+  /api/v1/management/bridges:
+    get:
+      description: Get all bridges configured in the system.
+      operationId: getBridges
+      x-roles-allowed:
+        - admin
+        - super
+        - user
+      responses:
+        '200':
+          content:
+            application/json:
+              examples:
+                bridge-list-result:
+                  description: Example response with several bridges.
+                  summary: Bridge List result
+                  value:
+                    items:
+                      - id: cloud
+                        host: REDACTED.cloud
+                        port: 8883
+                        clientId: cloud
+                        keepAlive: 60
+                        sessionExpiry: 3600
+                        cleanStart: false
+                        username: username
+                        password: '*****'
+                        loopPreventionEnabled: true
+                        loopPreventionHopCount: 1
+                        remoteSubscriptions: []
+                        localSubscriptions:
+                          - filters:
+                              - '#'
+                            destination: prefix/{#}/bridge/${bridge.name}
+                            excludes: []
+                            customUserProperties:
+                              - key: test1
+                                value: test2
+                            preserveRetain: true
+                            maxQoS: 0
+                        tlsConfiguration:
+                          enabled: true
+                          keystorePassword: ''
+                          privateKeyPassword: ''
+                          truststorePassword: ''
+                          protocols: []
+                          cipherSuites: []
+                          keystoreType: JKS
+                          truststoreType: JKS
+                          verifyHostname: true
+                          handshakeTimeout: 10
+                        bridgeRuntimeInformation:
+                          connectionStatus:
+                            status: CONNECTED
+                            id: cloud
+                            type: bridge
+              schema:
+                $ref: '#/components/schemas/BridgeList'
+          description: Success
+      summary: List all bridges in the system
+      tags:
+        - Bridges
+    post:
+      description: Add bridge configured in the system.
+      operationId: addBridge
+      x-roles-allowed:
+        - admin
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Bridge'
+        description: The new bridge.
+        required: true
+      responses:
+        '200':
+          description: Success
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Bridge is invalid
+      summary: Add a new Bridge
+      tags:
+        - Bridges
+  /api/v1/management/bridges/status:
+    get:
+      description: Obtain the details.
+      operationId: get-bridges-status
+      x-roles-allowed:
+        - admin
+        - super
+        - user
+      responses:
+        '200':
+          content:
+            application/json:
+              examples:
+                example-connection-status:
+                  description: Example connection status list.
+                  summary: Example connection status
+                  value:
+                    items:
+                      - status: CONNECTED
+                        id: cloud
+                        type: bridge
+              schema:
+                $ref: '#/components/schemas/StatusList'
+          description: The Connection Details Verification Result.
+      summary: Get the status of all the bridges in the system.
+      tags:
+        - Bridges
+  /api/v1/management/bridges/{bridgeId}:
+    delete:
+      description: Remove bridge configured in the system.
+      operationId: removeBridge
+      x-roles-allowed:
+        - admin
+      parameters:
+        - description: The id of the bridge to delete.
+          in: path
+          name: bridgeId
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Success
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Query parameters invalid
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Bridge not found
+      summary: Remove a Bridge
+      tags:
+        - Bridges
+    get:
+      description: Get a bridge by ID.
+      operationId: getBridgeByName
+      x-roles-allowed:
+        - admin
+        - super
+        - user
+      parameters:
+        - description: The id of the bridge to query.
+          in: path
+          name: bridgeId
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              examples:
+                bridge-get-result:
+                  description: Example Bridge.
+                  summary: Get Bridge Result
+                  value:
+                    id: cloud
+                    host: REDACTED.cloud
+                    port: 8883
+                    clientId: cloud
+                    keepAlive: 60
+                    sessionExpiry: 3600
+                    cleanStart: false
+                    username: username
+                    password: password
+                    loopPreventionEnabled: true
+                    loopPreventionHopCount: 1
+                    remoteSubscriptions: []
+                    localSubscriptions:
+                      - filters:
+                          - '#'
+                        destination: prefix/{#}/bridge/${bridge.name}
+                        excludes: []
+                        customUserProperties:
+                          - key: test1
+                            value: test2
+                        preserveRetain: true
+                        maxQoS: 0
+                    tlsConfiguration:
+                      enabled: true
+                      keystorePassword: ''
+                      privateKeyPassword: ''
+                      truststorePassword: ''
+                      protocols: []
+                      cipherSuites: []
+                      keystoreType: JKS
+                      truststoreType: JKS
+                      verifyHostname: true
+                      handshakeTimeout: 10
+                    bridgeRuntimeInformation:
+                      connectionStatus:
+                        status: CONNECTED
+                        id: simons-cloud
+                        type: bridge
+              schema:
+                $ref: '#/components/schemas/Bridge'
+          description: Success
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Query parameters invalid
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Bridge not found
+      summary: Get a bridge by ID
+      tags:
+        - Bridges
+    put:
+      description: Update bridge configured in the system.
+      operationId: updateBridge
+      x-roles-allowed:
+        - admin
+      parameters:
+        - description: The bridge to update.
+          in: path
+          name: bridgeId
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Bridge'
+      responses:
+        '200':
+          description: Success
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Query parameters invalid
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Bridge not found
+      summary: Update a Bridge
+      tags:
+        - Bridges
+  /api/v1/management/bridges/{bridgeId}/connection-status:
+    get:
+      description: Get the up to date status of a bridge.
+      operationId: get-bridge-status
+      x-roles-allowed:
+        - admin
+        - super
+        - user
+      parameters:
+        - description: The name of the bridge to query.
+          in: path
+          name: bridgeId
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              examples:
+                bridge-connection-status-result:
+                  description: Example response with CONNECTED status.
+                  summary: Bridge Connection Status Result
+                  value:
+                    status: CONNECTED
+                    id: cloud
+                    type: bridge
+              schema:
+                $ref: '#/components/schemas/Status'
+          description: Success
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Query parameters invalid
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Bridge not found
+      summary: Get the up to date status of a bridge
+      tags:
+        - Bridges
+  /api/v1/management/bridges/{bridgeId}/status:
+    put:
+      description: Transition the connection status of a bridge.
+      operationId: transition-bridge-status
+      x-roles-allowed:
+        - admin
+        - super
+      parameters:
+        - description: The id of the bridge whose runtime-status will change.
+          in: path
+          name: bridgeId
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/StatusTransitionCommand'
+        description: The command to transition the bridge runtime status.
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              examples:
+                transition-status-result:
+                  description: Example response with PENDING status.
+                  summary: Bridge Connection Transition Result
+                  value:
+                    status: PENDING
+                    callbackTimeoutMillis: 1000
+              schema:
+                $ref: '#/components/schemas/StatusTransitionResult'
+          description: Success
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Query parameters invalid
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Bridge not found
+      summary: Transition the runtime status of a bridge
+      tags:
+        - Bridges
+  /api/v1/management/events:
+    get:
+      description: Get all bridges configured in the system.
+      operationId: getEvents
+      x-roles-allowed:
+        - admin
+        - super
+        - user
+      parameters:
+        - description: Obtain all events since the specified epoch.
+          in: query
+          name: limit
+          schema:
+            type: integer
+            format: int32
+            default: 100
+        - description: Obtain all events since the specified epoch.
+          in: query
+          name: since
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          content:
+            application/json:
+              examples:
+                event-list-result:
+                  description: Example response with several events.
+                  summary: Event List result
+                  value: {}
+              schema:
+                $ref: '#/components/schemas/EventList'
+          description: Success
+      summary: List most recent events in the system
+      tags:
+        - Events
+  /api/v1/management/protocol-adapters/adapterconfigs/{adaptertype}/{adaptername}:
+    put:
+      description: Add an adapter and all related parts like e.g. tags to the system.
+      operationId: create-complete-adapter
+      x-roles-allowed:
+        - admin
+      parameters:
+        - description: The adapter type.
+          in: path
+          name: adaptertype
+          required: true
+          schema:
+            type: string
+        - description: The adapter name.
+          in: path
+          name: adaptername
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AdapterConfig'
+        description: The new adapter.
+        required: true
+      responses:
+        '200':
+          description: Success
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Adapter failed validation
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Adapter type not found
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Internal Server Error
+      summary: Add a new Adapter and all related parts like e.g. tags
+      tags:
+        - Protocol Adapters
+  /api/v1/management/protocol-adapters/adapters:
+    get:
+      description: Obtain a list of configured adapters.
+      operationId: getAdapters
+      x-roles-allowed:
+        - admin
+        - super
+        - user
+      responses:
+        '200':
+          content:
+            application/json:
+              examples:
+                adapter-list:
+                  description: An example adapter list.
+                  value:
+                    items:
+                      - id: test-simulation-server
+                        type: simulation
+                        config:
+                          id: test-simulation-server
+                          port: 5021
+                          host: 127.0.0.1
+                          pollingIntervalMillis: 1000
+                          subscriptions:
+                            - filter: my-simulation-server/my-simulation-path-100
+                              destination: test
+                              qos: 0
+                        adapterRuntimeInformation:
+                          lastStartedAttemptTime: '2023-06-28T10:57:18.707+01'
+                          numberOfDaemonProcesses: 1
+                          connectionStatus:
+                            status: CONNECTED
+                            id: test-simulation-server
+                            type: adapter
+              schema:
+                $ref: '#/components/schemas/AdaptersList'
+          description: Success
+      summary: Obtain a list of configured adapters
+      tags:
+        - Protocol Adapters
+  /api/v1/management/protocol-adapters/adapters/{adapterId}:
+    delete:
+      description: Delete adapter configured in the system.
+      operationId: deleteAdapter
+      x-roles-allowed:
+        - admin
+      parameters:
+        - description: The adapter Id.
+          in: path
+          name: adapterId
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Success
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Adapter not found
+      summary: Delete an adapter
+      tags:
+        - Protocol Adapters
+    get:
+      description: Obtain the details for a configured adapter for the specified type".
+      operationId: getAdapter
+      x-roles-allowed:
+        - admin
+        - super
+        - user
+      parameters:
+        - description: The adapter Id.
+          in: path
+          name: adapterId
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              examples:
+                adapter:
+                  description: An example adapter.
+                  value:
+                    id: test-simulation-server
+                    type: simulation
+                    config:
+                      id: test-simulation-server
+                      port: 5021
+                      host: 127.0.0.1
+                      pollingIntervalMillis: 1000
+                      subscriptions:
+                        - filter: my-simulation-server/my-simulation-path-100
+                          destination: test
+                          qos: 0
+                    adapterRuntimeInformation:
+                      lastStartedAttemptTime: '2023-06-28T10:57:18.707+01'
+                      numberOfDaemonProcesses: 1
+                      connectionStatus:
+                        status: CONNECTED
+                        id: test-simulation-server
+                        type: adapter
+              schema:
+                $ref: '#/components/schemas/Adapter'
+          description: Success
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Adapter not found
+      summary: Obtain the details for a configured adapter for the specified type
+      tags:
+        - Protocol Adapters
+    put:
+      description: Update adapter configured in the system.
+      operationId: updateAdapter
+      x-roles-allowed:
+        - admin
+      parameters:
+        - description: The adapter Id.
+          in: path
+          name: adapterId
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Adapter'
+      responses:
+        '200':
+          description: Success
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Adapter is invalid
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Adapter not found
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Internal Server Error
+      summary: Update an adapter
+      tags:
+        - Protocol Adapters
+  /api/v1/management/protocol-adapters/adapters/{adapterId}/discover:
+    get:
+      description: Obtain a list of available values accessible via this protocol adapter.
+      operationId: discoverDataPoints
+      x-roles-allowed:
+        - admin
+        - super
+        - user
+      parameters:
+        - description: The adapter Id.
+          in: path
+          name: adapterId
+          required: true
+          schema:
+            type: string
+        - description: The root to browse.
+          in: query
+          name: root
+          schema:
+            type: string
+        - description: The recursive depth to include. Must be larger than 0.
+          in: query
+          name: depth
+          schema:
+            type: integer
+            format: int32
+      responses:
+        '200':
+          content:
+            application/json:
+              examples:
+                discover:
+                  description: An example discovery request.
+                  value:
+                    items:
+                      - id: holding-registers
+                        name: Holding Registers
+                        description: Holding Registers
+                        nodeType: FOLDER
+                        selectable: false
+                        children:
+                          - id: grouping-1
+                            name: Addresses 1-16
+                            description: ''
+                            nodeType: FOLDER
+                            selectable: false
+                            children:
+                              - id: address-location-1
+                                name: '1'
+                                description: ''
+                                nodeType: VALUE
+                                selectable: true
+                                children: []
+              schema:
+                $ref: '#/components/schemas/ValuesTree'
+          description: Success
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Protocol adapter does not support discovery
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Adapter not found
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Internal Server Error
+      summary: Discover a list of available data points
+      tags:
+        - Protocol Adapters
+  /api/v1/management/protocol-adapters/adapters/{adapterId}/northboundMappings:
+    get:
+      description: Get the northbound mappings of the adapter.
+      operationId: get-adapter-northboundMappings
+      x-roles-allowed:
+        - admin
+        - super
+        - user
+      parameters:
+        - description: The adapter id.
+          in: path
+          name: adapterId
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NorthboundMappingList'
+          description: Success
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Adapter not found
+      summary: Get the mappings for northbound messages.
+      tags:
+        - Protocol Adapters
+    put:
+      description: Update all northbound mappings of an adapter.
+      operationId: update-adapter-northboundMappings
+      x-roles-allowed:
+        - admin
+      parameters:
+        - description: The id of the adapter whose northbound mappings will be updated.
+          in: path
+          name: adapterId
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NorthboundMappingList'
+      responses:
+        '200':
+          description: Success
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Missing tags
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Adapter not found
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Internal Server Error
+      summary: Update the from mappings of an adapter.
+      tags:
+        - Protocol Adapters
+  /api/v1/management/protocol-adapters/adapters/{adapterId}/southboundMappings:
+    get:
+      description: Get the southbound mappings.
+      operationId: get-adapter-southboundMappings
+      x-roles-allowed:
+        - admin
+        - super
+        - user
+      parameters:
+        - description: The adapter id.
+          in: path
+          name: adapterId
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SouthboundMappingList'
+          description: Success
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Adapter not found
+      summary: Get the southbound mappings.
+      tags:
+        - Protocol Adapters
+    put:
+      description: Update all southbound mappings of an adapter.
+      operationId: update-adapter-southboundMappings
+      x-roles-allowed:
+        - admin
+      parameters:
+        - description: The id of the adapter whose southbound mappings will be updated.
+          in: path
+          name: adapterId
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SouthboundMappingList'
+      responses:
+        '200':
+          description: Success
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Missing tags
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Adapter not found
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Internal Server Error
+      summary: Update the to southbound mappings of an adapter.
+      tags:
+        - Protocol Adapters
+  /api/v1/management/protocol-adapters/adapters/{adapterId}/status:
+    get:
+      description: Get the up to date status an adapter.
+      operationId: get-adapter-status
+      x-roles-allowed:
+        - admin
+        - super
+        - user
+      parameters:
+        - description: The name of the adapter to query.
+          in: path
+          name: adapterId
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              examples:
+                example-connection-status:
+                  description: Example connection status.
+                  summary: Example connection status
+                  value:
+                    status: CONNECTED
+                    id: cloud
+                    type: bridge
+              schema:
+                $ref: '#/components/schemas/Status'
+          description: Success
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Adapter is invalid
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Adapter not found
+      summary: Get the up to date status of an adapter
+      tags:
+        - Protocol Adapters
+    put:
+      description: Transition the runtime status of an adapter.
+      operationId: transition-adapter-status
+      x-roles-allowed:
+        - admin
+        - super
+      parameters:
+        - description: The id of the adapter whose runtime status will change.
+          in: path
+          name: adapterId
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/StatusTransitionCommand'
+        description: The command to transition the adapter runtime status.
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              examples:
+                transition-status-result:
+                  description: Example response with PENDING status.
+                  summary: Adapter Connection Transition Result
+                  value:
+                    status: PENDING
+                    callbackTimeoutMillis: 1000
+              schema:
+                $ref: '#/components/schemas/StatusTransitionResult'
+          description: Success
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Adapter is invalid
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Adapter not found
+      summary: Transition the runtime status of an adapter
+      tags:
+        - Protocol Adapters
+  /api/v1/management/protocol-adapters/adapters/{adapterId}/tags:
+    get:
+      description: Get the domain tags for the device connected through this adapter.
+      operationId: get-adapter-domainTags
+      x-roles-allowed:
+        - admin
+        - super
+        - user
+      parameters:
+        - description: The adapter id.
+          in: path
+          name: adapterId
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              examples:
+                opc ua domain tags example:
+                  description: An example for domain tags in opc ua
+                  summary: 'Example for domain tags for opc ua '
+                  value:
+                    items:
+                      - definition:
+                          node: ns=2;i=test
+                        name: tag1
+                      - definition:
+                          node: ns=2;i=test2
+                        name: tag2
+              schema:
+                $ref: '#/components/schemas/DomainTagList'
+          description: Success
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Adapter not found
+      summary: Get the domain tags for the device connected through this adapter.
+      tags:
+        - Protocol Adapters
+    post:
+      description: Add a new domain tag to the specified adapter.
+      operationId: add-adapter-domainTags
+      x-roles-allowed:
+        - admin
+      parameters:
+        - description: The adapter id.
+          in: path
+          name: adapterId
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DomainTag'
+        description: The domain tag.
+        required: true
+      responses:
+        '200':
+          description: Success
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Adapter not found
+        '409':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Tag already exists
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Internal Server Error
+      summary: Add a new domain tag to the specified adapter
+      tags:
+        - Protocol Adapters
+    put:
+      description: Update all domain tags of an adapter.
+      operationId: update-adapter-domainTags
+      x-roles-allowed:
+        - admin
+      parameters:
+        - description: The id of the adapter whose domain tags will be updated.
+          in: path
+          name: adapterId
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DomainTagList'
+      responses:
+        '200':
+          description: Success
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Adapter not found
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Internal Server Error
+      summary: Update the domain tag of an adapter.
+      tags:
+        - Protocol Adapters
+  /api/v1/management/protocol-adapters/adapters/{adapterId}/tags/{tagName}:
+    delete:
+      description: Delete the specified domain tag on the given adapter.
+      operationId: delete-adapter-domainTags
+      x-roles-allowed:
+        - admin
+      parameters:
+        - description: The adapter Id.
+          in: path
+          name: adapterId
+          required: true
+          schema:
+            type: string
+        - description: The domain tag Id.
+          in: path
+          name: tagName
+          required: true
+          schema:
+            type: string
+            format: urlencoded
+      responses:
+        '200':
+          description: Success
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Tag not found
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Internal Server Error
+      summary: Delete an domain tag
+      tags:
+        - Protocol Adapters
+    put:
+      description: Update the domain tag of an adapter.
+      operationId: update-adapter-domainTag
+      x-roles-allowed:
+        - admin
+      parameters:
+        - description: The id of the adapter whose domain tag will be updated.
+          in: path
+          name: adapterId
+          required: true
+          schema:
+            type: string
+        - description: The name (urlencoded) of the domain tag that will be changed.
+          in: path
+          name: tagName
+          required: true
+          schema:
+            type: string
+            format: urlencoded
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DomainTag'
+      responses:
+        '200':
+          description: Success
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Adapter not found
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Tag not found
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Internal Server Error
+      summary: Update the domain tag of an adapter.
+      tags:
+        - Protocol Adapters
+  /api/v1/management/protocol-adapters/adapters/{adapterType}:
+    post:
+      description: Add adapter to the system.
+      operationId: addAdapter
+      x-roles-allowed:
+        - admin
+      parameters:
+        - description: The adapter type.
+          in: path
+          name: adapterType
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Adapter'
+        description: The new adapter.
+        required: true
+      responses:
+        '200':
+          description: Success
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Adapter is invalid
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Adapter type not found
+      summary: Add a new Adapter
+      tags:
+        - Protocol Adapters
+  /api/v1/management/protocol-adapters/mappings/northboundMappings:
+    get:
+      description: Get all northbound mappings
+      operationId: get-northboundMappings
+      x-roles-allowed:
+        - admin
+        - super
+        - user
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NorthboundMappingOwnerList'
+          description: Success
+      summary: Get all the northbound mappings.
+      tags:
+        - Protocol Adapters
+        - Domain
+  /api/v1/management/protocol-adapters/mappings/southboundMappings:
+    get:
+      description: Get all southbound mappings.
+      operationId: get-southboundMappings
+      x-roles-allowed:
+        - admin
+        - super
+        - user
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SouthboundMappingOwnerList'
+          description: Success
+      summary: Get all the southbound mappings.
+      tags:
+        - Protocol Adapters
+        - Domain
+  /api/v1/management/protocol-adapters/status:
+    get:
+      description: Obtain the details.
+      operationId: get-adapters-status
+      x-roles-allowed:
+        - admin
+        - super
+        - user
+      responses:
+        '200':
+          content:
+            application/json:
+              examples:
+                example-connection-status:
+                  description: Example connection status list.
+                  summary: Example connection status
+                  value:
+                    items:
+                      - status: CONNECTED
+                        id: cloud
+                        type: bridge
+              schema:
+                $ref: '#/components/schemas/StatusList'
+          description: The Connection Details Verification Result.
+      summary: Get the status of all the adapters in the system.
+      tags:
+        - Protocol Adapters
+  /api/v1/management/protocol-adapters/tag-schemas/{protocolId}:
+    get:
+      description: Obtain the tag schema for a specific portocol adapter.
+      operationId: getTagSchema
+      x-roles-allowed:
+        - admin
+        - super
+        - user
+      parameters:
+        - description: The protocol id.
+          in: path
+          name: protocolId
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TagSchema'
+          description: Success
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Adapter type not found
+      summary: Obtain the JSON schema for a tag for a specific protocol adapter.
+      tags:
+        - Protocol Adapters
+  /api/v1/management/protocol-adapters/tags:
+    get:
+      description: Get the list of all domain tags created in this Edge instance
+      operationId: get-domain-tags
+      x-roles-allowed:
+        - admin
+        - super
+        - user
+      responses:
+        '200':
+          content:
+            application/json:
+              examples:
+                opc ua domain tags example:
+                  description: An example for domain tags in opc ua
+                  summary: 'Example for domain tags for opc ua '
+                  value:
+                    items:
+                      - definition:
+                          node: ns=2;i=test
+                        name: tag1
+                      - definition:
+                          node: ns=2;i=test2
+                        name: tag2
+              schema:
+                $ref: '#/components/schemas/DomainTagOwnerList'
+          description: Success
+      summary: Get the list of all tags created in this Edge instance
+      tags:
+        - Protocol Adapters
+        - Domain
+  /api/v1/management/protocol-adapters/tags/{tagName}:
+    get:
+      description: Get a domain tag created in this Edge instance
+      operationId: get-domain-tag
+      x-roles-allowed:
+        - admin
+        - super
+        - user
+      parameters:
+        - description: The tag name (urlencoded).
+          in: path
+          name: tagName
+          required: true
+          schema:
+            type: string
+            format: urlencoded
+      responses:
+        '200':
+          content:
+            application/json:
+              examples:
+                opc ua domain tags example:
+                  description: An example for domain tags in opc ua
+                  summary: 'Example for domain tags for opc ua '
+                  value:
+                    items:
+                      - definition:
+                          node: ns=2;i=test
+                        name: tag1
+                      - definition:
+                          node: ns=2;i=test2
+                        name: tag2
+              schema:
+                $ref: '#/components/schemas/DomainTag'
+          description: Success
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Tag not found
+      summary: Get the domain tag with the given name in this Edge instance
+      tags:
+        - Protocol Adapters
+  /api/v1/management/protocol-adapters/types:
+    get:
+      description: Obtain a list of available protocol adapter types.
+      operationId: getAdapterTypes
+      x-roles-allowed:
+        - admin
+        - super
+        - user
+      parameters:
+        - name: X-Original-URI
+          in: header
+          required: false
+          schema:
+            type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProtocolAdaptersList'
+          description: Success
+      summary: Obtain a list of available protocol adapter types
+      tags:
+        - Protocol Adapters
+  /api/v1/management/protocol-adapters/types/{adapterType}:
+    get:
+      description: Obtain a list of configured adapters for the specified type.
+      operationId: getAdaptersForType
+      x-roles-allowed:
+        - admin
+        - super
+        - user
+      parameters:
+        - description: The adapter type.
+          in: path
+          name: adapterType
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              examples:
+                filtered-adapters:
+                  description: An example filtered adapter list.
+                  value:
+                    items:
+                      - id: test-simulation-server
+                        type: simulation
+                        config:
+                          id: test-simulation-server
+                          port: 5021
+                          host: 127.0.0.1
+                          pollingIntervalMillis: 1000
+                          subscriptions:
+                            - filter: my-simulation-server/my-simulation-path-100
+                              destination: test
+                              qos: 0
+                        adapterRuntimeInformation:
+                          lastStartedAttemptTime: '2023-06-28T10:57:18.707+01'
+                          numberOfDaemonProcesses: 1
+                          connectionStatus:
+                            status: CONNECTED
+                            id: test-simulation-server
+                            type: adapter
+              schema:
+                $ref: '#/components/schemas/AdaptersList'
+          description: Success
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Adapter type not found
+      summary: Obtain a list of configured adapters for the specified type
+      tags:
+        - Protocol Adapters
+  /api/v1/management/protocol-adapters/writing-schema/{adapterId}/{tagName}:
+    get:
+      description: Get a json schema that explains the json schema that is used to write to a PLC for the given tag name."
+      operationId: get-writing-schema
+      x-roles-allowed:
+        - admin
+        - super
+        - user
+      parameters:
+        - description: The id of the adapter for which the Json Schema for writing to a PLC gets created.
+          in: path
+          name: adapterId
+          required: true
+          schema:
+            type: string
+        - description: The tag name (urlencoded) for which the Json Schema for writing to a PLC gets created.
+          in: path
+          name: tagName
+          required: true
+          schema:
+            type: string
+            format: urlencoded
+      responses:
+        '200':
+          content:
+            application/json:
+              examples:
+                opc ua domain tags example:
+                  description: An example for domain tags in opc ua
+                  summary: 'Example for domain tags for opc ua '
+                  value:
+                    items:
+                      - definition:
+                          node: ns=2;i=test
+                        name: tag1
+                      - definition:
+                          node: ns=2;i=test2
+                        name: tag2
+              schema:
+                $ref: '#/components/schemas/JsonNode'
+          description: Success
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Adapter not found
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Internal Server Error
+      summary: Get a json schema that explains the json schema that is used to write to a PLC for the given tag name.
+      tags:
+        - Protocol Adapters
+  /api/v1/management/sampling/schema/{topic}:
+    get:
+      description: Obtain a JsonSchema based in the stored samples for a given topic.
+      operationId: getSchemaForTopic
+      x-roles-allowed:
+        - admin
+        - super
+        - user
+      parameters:
+        - description: The topic.
+          in: path
+          name: topic
+          required: true
+          schema:
+            type: string
+            format: urlencoded
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JsonNode'
+          description: Success
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: No samples found
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Internal Server Error
+      summary: Obtain a JsonSchema based in the stored samples for a given topic.
+      tags:
+        - Payload Sampling
+  /api/v1/management/sampling/topic/{topic}:
+    get:
+      description: Obtain a list of samples that their gathered for the given topic.
+      operationId: getSamplesForTopic
+      x-roles-allowed:
+        - admin
+        - super
+        - user
+      parameters:
+        - description: The topic.
+          in: path
+          name: topic
+          required: true
+          schema:
+            type: string
+            format: urlencoded
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PayloadSampleList'
+          description: Success
+      summary: Obtain a list of samples that their gathered for the given topic.
+      tags:
+        - Payload Sampling
+    post:
+      description: Start sampling for the given topic.
+      operationId: startSamplingForTopic
+      x-roles-allowed:
+        - admin
+      parameters:
+        - description: The topic.
+          in: path
+          name: topic
+          required: true
+          schema:
+            type: string
+            format: urlencoded
+      responses:
+        '200':
+          description: Success
+      summary: Start sampling for the given topic.
+      tags:
+        - Payload Sampling
+  /api/v1/management/topic-filters:
+    get:
+      description: Get the list of all topic filters created in this Edge instance
+      operationId: get-topicFilters
+      x-roles-allowed:
+        - admin
+        - super
+        - user
+      responses:
+        '200':
+          content:
+            application/json:
+              examples:
+                An example for the topic filter list:
+                  description: An example for the topic filter list
+                  summary: An example for the topic filter list
+                  value:
+                    items:
+                      - topicFilter: topic1
+                        description: filter1
+                      - topicFilter: topic2
+                        description: filter2
+              schema:
+                $ref: '#/components/schemas/TopicFilterList'
+          description: Success
+      summary: Get the list of all topic filters created in this Edge instance
+      tags:
+        - Topic Filters
+        - Domain
+    post:
+      description: Add a new topic filter.
+      operationId: add-topicFilters
+      x-roles-allowed:
+        - admin
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TopicFilter'
+        description: The topic filter.
+        required: true
+      responses:
+        '200':
+          description: Success
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Already Present
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Internal Server Error
+      summary: Add a new topic filter
+      tags:
+        - Topic Filters
+    put:
+      description: Update all topic filters
+      operationId: update-topicFilters
+      x-roles-allowed:
+        - admin
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TopicFilterList'
+      responses:
+        '200':
+          description: Success
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Internal Server Error
+      summary: Update all topic filters.
+      tags:
+        - Topic Filters
+  /api/v1/management/topic-filters/{filter}:
+    get:
+      description: Get the specified topic filter
+      operationId: get-topicFilter
+      x-roles-allowed:
+        - admin
+        - super
+        - user
+      parameters:
+        - $ref: '#/components/parameters/TopicFilterId'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TopicFilter'
+          description: Success
+      summary: Get the specified topic filter
+      tags:
+        - Topic Filters
+    delete:
+      description: Delete the specified topic filter.
+      operationId: delete-topicFilter
+      x-roles-allowed:
+        - admin
+      parameters:
+        - $ref: '#/components/parameters/TopicFilterId'
+      responses:
+        '200':
+          description: Success
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Already Present
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Topic filter not found
+      summary: Delete an topic filter
+      tags:
+        - Topic Filters
+    put:
+      description: Update a topic filter
+      operationId: update-topicFilter
+      x-roles-allowed:
+        - admin
+      parameters:
+        - $ref: '#/components/parameters/TopicFilterId'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TopicFilter'
+      responses:
+        '200':
+          description: Success
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Topic filter failed validation
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Internal Server Error
+      summary: Update a topic filter.
+      tags:
+        - Topic Filters
+  /api/v1/management/topic-filters/{filter}/schema:
+    get:
+      description: Get the schema of the specified topic filter
+      operationId: get-topicFilter-schema
+      x-roles-allowed:
+        - admin
+        - super
+        - user
+      parameters:
+        - $ref: '#/components/parameters/TopicFilterId'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: string
+                format: data-url
+                description: The optional json schema for this topic filter in the data uri format.
+          description: Success
+      summary: Get the schema of the specified topic filter
+      tags:
+        - Topic Filters
+  /api/v1/management/uns/isa95:
+    get:
+      description: Obtain isa95 config.
+      operationId: get-isa95
+      x-roles-allowed:
+        - admin
+        - super
+        - user
+      responses:
+        '200':
+          content:
+            application/json:
+              examples:
+                default-configuration:
+                  description: An example ISA 95 config.
+                  summary: Example configuration
+                  value:
+                    enabled: true
+                    prefixAllTopics: true
+                    enterprise: enterprise
+                    site: site
+                    area: area
+                    productionLine: production-line
+                    workCell: work-cell
+              schema:
+                $ref: '#/components/schemas/ISA95ApiBean'
+          description: Success
+      summary: Obtain isa95 config
+      tags:
+        - UNS
+    post:
+      description: Set isa95 config.
+      operationId: set-isa95
+      x-roles-allowed:
+        - admin
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ISA95ApiBean'
+        description: The updated isa95 configuration.
+        required: true
+      responses:
+        '200':
+          description: Success
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: isa95 config failed validation
+      summary: Set isa95 config
+      tags:
+        - UNS
+  /api/v1/metrics:
+    get:
+      description: Obtain the latest sample for the metric requested.
+      operationId: getMetrics
+      x-roles-allowed:
+        - admin
+        - super
+        - user
+      responses:
+        '200':
+          content:
+            application/json:
+              examples:
+                metrics-list-sample:
+                  description: Example response with metrics listed.
+                  summary: List Metrics
+                  value:
+                    items:
+                      - name: com.hivemq.edge.bridge.simons-cloud.local.publish.count
+                      - name: simulation
+                      - name: com.hivemq.edge.messages.dropped.count
+                      - name: com.hivemq.edge.mqtt.connection.not-writable.current
+                      - name: com.hivemq.edge.bridge.simons-cloud.forward.publish.count
+                      - name: com.hivemq.edge.bridge.simons-cloud.local.publish.received.count
+                      - name: com.hivemq.edge.messages.outgoing.publish.count
+                      - name: com.hivemq.edge.sessions.overall.current
+                      - name: com.hivemq.edge.bridge.simons-cloud.forward.publish.failed.count
+                      - name: com.hivemq.edge.networking.bytes.read.total
+                      - name: com.hivemq.edge.messages.outgoing.total.count
+                      - name: com.hivemq.messages.governance.count
+                      - name: com.hivemq.edge.bridge.simons-cloud.local.publish.failed.count
+                      - name: com.hivemq.edge.networking.connections.current
+                      - name: com.hivemq.edge.persistence.retained-messages.in-memory.total-size
+                      - name: com.hivemq.edge.bridge.simons-cloud.forward.publish.loop-hops-exceeded.count
+                      - name: com.hivemq.edge.messages.incoming.connect.count
+                      - name: com.hivemq.edge.bridge.simons-cloud.local.publish.no-subscriber-present.count
+                      - name: com.hivemq.edge.messages.incoming.publish.count
+                      - name: com.hivemq.edge.messages.incoming.total.count
+                      - name: com.hivemq.edge.messages.will.count.current
+                      - name: com.hivemq.edge.messages.will.published.count.total
+                      - name: com.hivemq.edge.persistence.client-session.subscriptions.in-memory.total-size
+                      - name: com.hivemq.edge.bridge.simons-cloud.remote.publish.loop-hops-exceeded.count
+                      - name: com.hivemq.edge.networking.bytes.write.total
+                      - name: com.hivemq.edge.bridge.simons-cloud.forward.publish.excluded.count
+                      - name: com.hivemq.edge.networking.connections-closed.total.count
+                      - name: com.hivemq.edge.bridge.simons-cloud.remote.publish.received.count
+                      - name: com.hivemq.edge.subscriptions.overall.current
+                      - name: com.hivemq.edge.persistence.queued-messages.in-memory.total-size
+                      - name: com.hivemq.edge.persistence.client-sessions.in-memory.total-size
+                      - name: com.hivemq.edge.messages.retained.current
+              schema:
+                $ref: '#/components/schemas/MetricList'
+          description: Success
+      summary: Obtain a list of available metrics
+      tags:
+        - Metrics
+        - Metrics Endpoint
+  /api/v1/metrics/{metricName}/latest:
+    get:
+      description: Obtain the latest sample for the metric requested.
+      operationId: getSample
+      x-roles-allowed:
+        - admin
+        - super
+        - user
+      parameters:
+        - description: The metric to search for.
+          in: path
+          name: metricName
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              examples:
+                metric-sample:
+                  description: Example response with metrics listed.
+                  summary: Metric Sample
+                  value:
+                    sampleTime: '2023-06-28T11:39:12.789+01'
+                    value: 0
+              schema:
+                $ref: '#/components/schemas/DataPoint'
+          description: Success
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: URL parameter missing
+      summary: Obtain the latest sample for the metric requested
+      tags:
+        - Metrics
+        - Metrics Endpoint
+  /api/v1/management/combiners:
+    get:
+      description: Get all combiners
+      summary: Get all combiners
+      operationId: get-combiners
+      x-roles-allowed:
+        - admin
+        - super
+        - user
+      tags:
+        - Combiners
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CombinerList'
+          description: Success
+    post:
+      description: Add a new combiner.
+      summary: Add a new combiner
+      operationId: add-combiner
+      x-roles-allowed:
+        - admin
+      tags:
+        - Combiners
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Combiner'
+        description: The combiner to add
+        required: true
+      responses:
+        '200':
+          description: Success
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Topic, schema, or mapping ID invalid
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Managed asset not found
+        '409':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Combiner already exists
+  /api/v1/management/combiners/{combinerId}:
+    get:
+      description: Get a combiner by its unique Id.
+      summary: Get a combiner
+      operationId: getCombinersById
+      x-roles-allowed:
+        - admin
+        - super
+        - user
+      tags:
+        - Combiners
+      parameters:
+        - $ref: '#/components/parameters/CombinerId'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Combiner'
+          description: Success
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Combiner not found
+    delete:
+      description: Delete the specified combiner.
+      summary: Delete a combiner
+      operationId: delete-combiner
+      x-roles-allowed:
+        - admin
+      tags:
+        - Combiners
+      parameters:
+        - $ref: '#/components/parameters/CombinerId'
+      responses:
+        '200':
+          description: Success
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Combiner not found
+    put:
+      description: Update a combiner.
+      summary: Update a combiner
+      operationId: update-combiner
+      x-roles-allowed:
+        - admin
+      tags:
+        - Combiners
+      parameters:
+        - $ref: '#/components/parameters/CombinerId'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Combiner'
+        description: The new content of the combiner
+        required: true
+      responses:
+        '200':
+          description: Success
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Topic, schema, or mapping ID invalid
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Managed asset not found
+        '409':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Combiner already exists
+  /api/v1/management/combiners/{combinerId}/mappings:
+    get:
+      description: Get all data combining mappings for the given combiner
+      summary: Get all mappings
+      operationId: getCombinerMappings
+      x-roles-allowed:
+        - admin
+        - super
+        - user
+      tags:
+        - Combiners
+      parameters:
+        - $ref: '#/components/parameters/CombinerId'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DataCombiningList'
+          description: Success
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Combiner not found
+  /api/v1/management/combiners/{combinerId}/mappings/{mappingId}/instructions:
+    get:
+      description: Get all the instructions for a designated mapping
+      summary: Get all instructions
+      operationId: getMappingInstructions
+      x-roles-allowed:
+        - admin
+        - super
+        - user
+      tags:
+        - Combiners
+      parameters:
+        - $ref: '#/components/parameters/CombinerId'
+        - $ref: '#/components/parameters/MappingId'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                description: List of instructions to be applied to incoming data
+                items:
+                  $ref: '#/components/schemas/Instruction'
+          description: Success
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Combiner not found
+  /api/v1/management/pulse/activation-token:
+    delete:
+      description: Delete the activation token from the Pulse Client
+      summary: Delete the Pulse activation token
+      operationId: delete-pulse-activation-token
+      x-roles-allowed:
+        - admin
+      tags:
+        - Pulse
+      responses:
+        '200':
+          description: Success
+        '409':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Activation token is already deleted.
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Internal server error.
+        '503':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Activation token is not deleted successfully.
+    post:
+      description: Send an activation token to the Pulse Client
+      summary: Update an activation token
+      operationId: update-pulse-activation-token
+      x-roles-allowed:
+        - admin
+      tags:
+        - Pulse
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PulseActivationToken'
+        description: The activation token to send to the Pulse Client.
+        required: true
+      responses:
+        '200':
+          description: Success
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Pulse Agent is deactivated.
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Activation token is invalid.
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Internal server error.
+  /api/v1/management/pulse/status:
+    get:
+      description: Get the status of the pulse agent
+      summary: Get the status of the integrated pulse agent.
+      operationId: get-pulse-status
+      x-roles-allowed:
+        - admin
+        - super
+        - user
+      tags:
+        - Pulse
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PulseStatus'
+          description: Success
+  /api/v1/management/pulse/managed-assets:
+    get:
+      description: Get all managed assets from the Pulse Client
+      summary: Get all managed assets
+      operationId: get-managed-assets
+      x-roles-allowed:
+        - admin
+        - super
+        - user
+      tags:
+        - Pulse
+        - Domain
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ManagedAssetList'
+          description: Success
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Pulse not activated
+        '503':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Pulse Agent not connected
+    post:
+      description: Add a new managed asset to the Pulse Client
+      summary: Add a new managed asset
+      operationId: add-managed-asset
+      x-roles-allowed:
+        - admin
+      tags:
+        - Pulse
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ManagedAsset'
+        description: The managed asset to add
+        required: true
+      responses:
+        '200':
+          description: Success
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Pulse not activated
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Managed asset not found
+        '409':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: The managed asset already exists
+        '503':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Pulse Agent not connected
+  /api/v1/management/pulse/managed-assets/{assetId}:
+    delete:
+      description: Delete the specified managed asset
+      summary: Delete a managed asset
+      operationId: delete-managed-asset
+      x-roles-allowed:
+        - admin
+      tags:
+        - Pulse
+      parameters:
+        - $ref: '#/components/parameters/AssetId'
+      responses:
+        '200':
+          description: Success
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Pulse not activated
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Managed asset not found
+        '503':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Pulse Agent not connected
+    put:
+      description: Update a managed asset
+      summary: Update a managed asset
+      operationId: update-managed-asset
+      x-roles-allowed:
+        - admin
+      tags:
+        - Pulse
+      parameters:
+        - $ref: '#/components/parameters/AssetId'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ManagedAsset'
+        description: The new content of the managed asset
+        required: true
+      responses:
+        '200':
+          description: Success
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Pulse not activated
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Managed asset not found
+        '503':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Pulse Agent not connected
+  /api/v1/management/pulse/asset-mappers:
+    get:
+      description: Get all asset mappers
+      summary: Get all asset mappers
+      operationId: get-asset-mappers
+      x-roles-allowed:
+        - admin
+        - super
+        - user
+      tags:
+        - Pulse
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CombinerList'
+          description: Success
+    post:
+      description: Add a new asset mapper.
+      summary: Add a new asset mapper
+      operationId: add-asset-mapper
+      x-roles-allowed:
+        - admin
+      tags:
+        - Pulse
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Combiner'
+        description: The combiner to add
+        required: true
+      responses:
+        '200':
+          description: Success
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Topic, schema, or mapping ID invalid
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Managed asset not found
+        '409':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Combiner already exists
+  /api/v1/management/pulse/asset-mappers/{combinerId}:
+    get:
+      description: Get an asset mapper by its unique Id.
+      summary: Get an asset mapper
+      operationId: get-asset-mapper
+      x-roles-allowed:
+        - admin
+        - super
+        - user
+      tags:
+        - Pulse
+      parameters:
+        - $ref: '#/components/parameters/CombinerId'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Combiner'
+          description: Success
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Combiner not found
+    delete:
+      description: Delete the specified asset mapper.
+      summary: Delete an asset mapper
+      operationId: delete-asset-mapper
+      x-roles-allowed:
+        - admin
+      tags:
+        - Pulse
+      parameters:
+        - $ref: '#/components/parameters/CombinerId'
+      responses:
+        '200':
+          description: Success
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Combiner not found
+    put:
+      description: Update an asset mapper.
+      summary: Update an asset mapper
+      operationId: update-asset-mapper
+      x-roles-allowed:
+        - admin
+      tags:
+        - Pulse
+      parameters:
+        - $ref: '#/components/parameters/CombinerId'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Combiner'
+        description: The new content of the asset mapper
+        required: true
+      responses:
+        '200':
+          description: Success
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Topic, schema, or mapping ID invalid
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Managed asset not found
+        '409':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Combiner already exists
+  /api/v1/management/pulse/asset-mappers/{combinerId}/mappings:
+    get:
+      description: Get all data combining mappings for the given combiner
+      summary: Get all mappings
+      operationId: get-asset-mapper-mappings
+      x-roles-allowed:
+        - admin
+        - super
+        - user
+      tags:
+        - Pulse
+      parameters:
+        - $ref: '#/components/parameters/CombinerId'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DataCombiningList'
+          description: Success
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Combiner not found
+  /api/v1/management/pulse/asset-mappers/{combinerId}/mappings/{mappingId}/instructions:
+    get:
+      description: Get all the instructions for a designated mapping
+      summary: Get all instructions
+      operationId: get-asset-mapper-instructions
+      x-roles-allowed:
+        - admin
+        - super
+        - user
+      tags:
+        - Pulse
+      parameters:
+        - $ref: '#/components/parameters/CombinerId'
+        - $ref: '#/components/parameters/MappingId'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                description: List of instructions to be applied to incoming data
+                items:
+                  $ref: '#/components/schemas/Instruction'
+          description: Success
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Combiner not found
+components:
+  schemas:
+    UsernamePasswordCredentials:
+      type: object
+      properties:
+        password:
+          type: string
+          description: The password associated with the user
+        userName:
+          type: string
+          description: The userName associated with the user
+    ApiBearerToken:
+      type: object
+      properties:
+        token:
+          type: string
+          description: The token associated a set of authenticated credentials
+    Error:
+      type: object
+      properties:
+        detail:
+          type: string
+          description: Detailed contextual description of this error
+        parameter:
+          type: string
+          description: The parameter causing the issue
+      required:
+        - detail
+    ProblemDetails:
+      type: object
+      properties:
+        code:
+          type: string
+          description: Correlation id
+        detail:
+          type: string
+        errors:
+          deprecated: true
+          type: array
+          items:
+            $ref: '#/components/schemas/Error'
+        status:
+          type: integer
+          format: int32
+        title:
+          type: string
+        type:
+          type: string
+          format: uri
+      required:
+        - title
+    PaginationCursor:
+      type: object
+      description: Links for pagination
+      nullable: true
+      properties:
+        next:
+          type: string
+    BehaviorPolicyBehavior:
+      type: object
+      description: The behavior referenced by the policy, that is validated by the policy.
+      properties:
+        arguments:
+          type: object
+          description: The  arguments that the referenced validator type requires.
+        id:
+          type: string
+          description: The unique identifier of a pre-defined behavior.
+      required:
+        - id
+    SchemaReference:
+      type: object
+      description: A schema reference is a unique identifier for a schema.
+      properties:
+        schemaId:
+          type: string
+          description: The identifier of the schema.
+        version:
+          type: string
+          description: The version of the schema. The value "latest" may be used to always refer to the latest schema.
+      required:
+        - schemaId
+        - version
+    BehaviorPolicyDeserializer:
+      type: object
+      description: The deserializer applied to a particular message or payload type.
+      properties:
+        schema:
+          $ref: '#/components/schemas/SchemaReference'
+      required:
+        - schema
+    BehaviorPolicyDeserialization:
+      type: object
+      description: The deserializers used by the policy for particular message and/or payload types.
+      properties:
+        publish:
+          $ref: '#/components/schemas/BehaviorPolicyDeserializer'
+        will:
+          $ref: '#/components/schemas/BehaviorPolicyDeserializer'
+    BehaviorPolicyMatching:
+      type: object
+      description: The matching rules the policy applies.
+      properties:
+        clientIdRegex:
+          type: string
+          description: The regex pattern to match the client id against.
+      required:
+        - clientIdRegex
+    PolicyOperation:
+      type: object
+      description: The pipeline to execute when this action is triggered. The operations in the pipeline are executed in order.
+      properties:
+        arguments:
+          type: object
+          description: The required arguments of the referenced function.
+        functionId:
+          type: string
+          description: The unique id of the referenced function to execute in this operation.
+        id:
+          type: string
+          description: The unique id of the operation in the pipeline.
+      required:
+        - arguments
+        - functionId
+        - id
+    BehaviorPolicyOnEvent:
+      type: object
+      description: One or more operations that are triggered on the event. When this field is empty, the transition does not trigger any operations.
+      properties:
+        pipeline:
+          type: array
+          items:
+            $ref: '#/components/schemas/PolicyOperation'
+      required:
+        - pipeline
+    BehaviorPolicyOnTransition:
+      type: object
+      description: The actions that are executed for the specified transition.
+      properties:
+        Connection.OnDisconnect:
+          $ref: '#/components/schemas/BehaviorPolicyOnEvent'
+        Event.OnAny:
+          $ref: '#/components/schemas/BehaviorPolicyOnEvent'
+        Mqtt.OnInboundConnect:
+          $ref: '#/components/schemas/BehaviorPolicyOnEvent'
+        Mqtt.OnInboundDisconnect:
+          $ref: '#/components/schemas/BehaviorPolicyOnEvent'
+        Mqtt.OnInboundPublish:
+          $ref: '#/components/schemas/BehaviorPolicyOnEvent'
+        Mqtt.OnInboundSubscribe:
+          $ref: '#/components/schemas/BehaviorPolicyOnEvent'
+        fromState:
+          type: string
+          description: The exact state from which the transition happened. Alternatively a state filter can be used.
+        toState:
+          type: string
+          description: The exact state to which the transition happened. Alternatively a state filter can be used.
+      required:
+        - fromState
+        - toState
+    BehaviorPolicy:
+      type: object
+      description: A policy which is used to validate and execute certain actions based on the validation result.
+      properties:
+        behavior:
+          $ref: '#/components/schemas/BehaviorPolicyBehavior'
+        createdAt:
+          type: string
+          format: date-time
+          description: The formatted UTC timestamp indicating when the policy was created.
+          readOnly: true
+        deserialization:
+          $ref: '#/components/schemas/BehaviorPolicyDeserialization'
+        id:
+          type: string
+          description: The unique identifier of the policy.
+        lastUpdatedAt:
+          type: string
+          format: date-time
+          description: The formatted UTC timestamp indicating when the policy was updated the last time.
+          readOnly: true
+        matching:
+          $ref: '#/components/schemas/BehaviorPolicyMatching'
+        onTransitions:
+          type: array
+          items:
+            $ref: '#/components/schemas/BehaviorPolicyOnTransition'
+      required:
+        - behavior
+        - id
+        - matching
+    BehaviorPolicyList:
+      type: object
+      description: A listing of behavior policies.
+      properties:
+        _links:
+          $ref: '#/components/schemas/PaginationCursor'
+        items:
+          type: array
+          description: List of result items that are returned by this endpoint
+          items:
+            $ref: '#/components/schemas/BehaviorPolicy'
+    ApiProblemDetails:
+      allOf:
+        - $ref: '#/components/schemas/ProblemDetails'
+        - type: object
+          required:
+            - detail
+            - status
+            - type
+      discriminator:
+        propertyName: type
+        mapping:
+          https://hivemq.com/edge/api/model/BehaviorPolicyAlreadyPresentError: '#/components/schemas/BehaviorPolicyAlreadyPresentError'
+          https://hivemq.com/edge/api/model/BehaviorPolicyCreationFailureError: '#/components/schemas/BehaviorPolicyCreationFailureError'
+          https://hivemq.com/edge/api/model/BehaviorPolicyInvalidErrors: '#/components/schemas/BehaviorPolicyInvalidErrors'
+          https://hivemq.com/edge/api/model/BehaviorPolicyNotFoundError: '#/components/schemas/BehaviorPolicyNotFoundError'
+          https://hivemq.com/edge/api/model/BehaviorPolicyRejectedError: '#/components/schemas/BehaviorPolicyRejectedError'
+          https://hivemq.com/edge/api/model/BehaviorPolicyUpdateFailureError: '#/components/schemas/BehaviorPolicyUpdateFailureError'
+          https://hivemq.com/edge/api/model/ClientDisconnectedError: '#/components/schemas/ClientDisconnectedError'
+          https://hivemq.com/edge/api/model/ClientNotFoundError: '#/components/schemas/ClientNotFoundError'
+          https://hivemq.com/edge/api/model/DataPolicyAlreadyPresentError: '#/components/schemas/DataPolicyAlreadyPresentError'
+          https://hivemq.com/edge/api/model/DataPolicyCreationFailureError: '#/components/schemas/DataPolicyCreationFailureError'
+          https://hivemq.com/edge/api/model/DataPolicyInvalidErrors: '#/components/schemas/DataPolicyInvalidErrors'
+          https://hivemq.com/edge/api/model/DataPolicyNotFoundError: '#/components/schemas/DataPolicyNotFoundError'
+          https://hivemq.com/edge/api/model/DataPolicyRejectedError: '#/components/schemas/DataPolicyRejectedError'
+          https://hivemq.com/edge/api/model/DataPolicyUpdateFailureError: '#/components/schemas/DataPolicyUpdateFailureError'
+          https://hivemq.com/edge/api/model/PolicyIdMismatchError: '#/components/schemas/PolicyIdMismatchError'
+          https://hivemq.com/edge/api/model/PolicyInsufficientStorageError: '#/components/schemas/PolicyInsufficientStorageError'
+          https://hivemq.com/edge/api/model/PolicyNotFoundError: '#/components/schemas/PolicyNotFoundError'
+          https://hivemq.com/edge/api/model/SchemaAlreadyPresentError: '#/components/schemas/SchemaAlreadyPresentError'
+          https://hivemq.com/edge/api/model/SchemaEtagMismatchError: '#/components/schemas/SchemaEtagMismatchError'
+          https://hivemq.com/edge/api/model/SchemaInsufficientStorageError: '#/components/schemas/SchemaInsufficientStorageError'
+          https://hivemq.com/edge/api/model/SchemaInvalidErrors: '#/components/schemas/SchemaInvalidErrors'
+          https://hivemq.com/edge/api/model/SchemaNotFoundError: '#/components/schemas/SchemaNotFoundError'
+          https://hivemq.com/edge/api/model/SchemaParsingFailureError: '#/components/schemas/SchemaParsingFailureError'
+          https://hivemq.com/edge/api/model/SchemaReferencedError: '#/components/schemas/SchemaReferencedError'
+          https://hivemq.com/edge/api/model/ScriptAlreadyPresentError: '#/components/schemas/ScriptAlreadyPresentError'
+          https://hivemq.com/edge/api/model/ScriptCreationFailureError: '#/components/schemas/ScriptCreationFailureError'
+          https://hivemq.com/edge/api/model/ScriptEtagMismatchError: '#/components/schemas/ScriptEtagMismatchError'
+          https://hivemq.com/edge/api/model/ScriptInsufficientStorageError: '#/components/schemas/ScriptInsufficientStorageError'
+          https://hivemq.com/edge/api/model/ScriptInvalidErrors: '#/components/schemas/ScriptInvalidErrors'
+          https://hivemq.com/edge/api/model/ScriptNotFoundError: '#/components/schemas/ScriptNotFoundError'
+          https://hivemq.com/edge/api/model/ScriptParsingFailureError: '#/components/schemas/ScriptParsingFailureError'
+          https://hivemq.com/edge/api/model/ScriptReferencedError: '#/components/schemas/ScriptReferencedError'
+          https://hivemq.com/edge/api/model/ScriptSanitationFailureError: '#/components/schemas/ScriptSanitationFailureError'
+          https://hivemq.com/edge/api/model/TopicFilterMismatchError: '#/components/schemas/TopicFilterMismatchError'
+          https://hivemq.com/edge/api/model/InsufficientStorageError: '#/components/schemas/InsufficientStorageError'
+          https://hivemq.com/edge/api/model/InternalServerError: '#/components/schemas/InternalServerError'
+          https://hivemq.com/edge/api/model/InvalidQueryParameterError: '#/components/schemas/InvalidQueryParameterError'
+          https://hivemq.com/edge/api/model/PreconditionFailedError: '#/components/schemas/PreconditionFailedError'
+          https://hivemq.com/edge/api/model/RequestBodyMissingError: '#/components/schemas/RequestBodyMissingError'
+          https://hivemq.com/edge/api/model/RequestBodyParameterMissingError: '#/components/schemas/RequestBodyParameterMissingError'
+          https://hivemq.com/edge/api/model/TemporaryNotAvailableError: '#/components/schemas/TemporaryNotAvailableError'
+          https://hivemq.com/edge/api/model/UrlParameterMissingError: '#/components/schemas/UrlParameterMissingError'
+    BehaviorPolicyAlreadyPresentError:
+      allOf:
+        - $ref: '#/components/schemas/ApiProblemDetails'
+        - type: object
+          properties:
+            id:
+              type: string
+              description: The behavior policy id.
+              example: abc
+          required:
+            - id
+      example:
+        general:
+          status: 409
+          title: Behavior Policy Already Present
+          detail: The given behavior policy 'abc' is already present.
+          id: abc
+          type: https://hivemq.com/edge/api/model/BehaviorPolicyAlreadyPresentError
+    BehaviorPolicyCreationFailureError:
+      allOf:
+        - $ref: '#/components/schemas/ApiProblemDetails'
+      example:
+        general:
+          status: 400
+          title: Behavior Policy Creation Failed
+          detail: 'Behavior policy creation failed: The policy was rejected.'
+          type: https://hivemq.com/edge/api/model/BehaviorPolicyCreationFailureError
+    AtLeastOneFieldMissingValidationError:
+      allOf:
+        - $ref: '#/components/schemas/ValidationError'
+        - type: object
+          properties:
+            paths:
+              type: array
+              description: The missing json paths.
+              items:
+                type: string
+                format: json-path
+                description: The json path.
+              example:
+                - $.field1
+                - $.field2
+          required:
+            - paths
+      example:
+        general:
+          detail: 'At least one of the fields must be present: ''$.field1'', ''$.field2''.'
+          paths:
+            - $.field1
+            - $.field2
+          type: https://hivemq.com/edge/api/model/AtLeastOneFieldMissingValidationError
+    ValidationError:
+      type: object
+      properties:
+        detail:
+          type: string
+          description: Detailed contextual description of the validation error.
+        type:
+          type: string
+          format: uri
+          description: Type of the validation error.
+      required:
+        - detail
+        - type
+      discriminator:
+        propertyName: type
+        mapping:
+          https://hivemq.com/edge/api/model/AtLeastOneFieldMissingValidationError: '#/components/schemas/AtLeastOneFieldMissingValidationError'
+          https://hivemq.com/edge/api/model/AtMostOneFunctionValidationError: '#/components/schemas/AtMostOneFunctionValidationError'
+          https://hivemq.com/edge/api/model/EmptyFieldValidationError: '#/components/schemas/EmptyFieldValidationError'
+          https://hivemq.com/edge/api/model/FunctionMustBePairedValidationError: '#/components/schemas/FunctionMustBePairedValidationError'
+          https://hivemq.com/edge/api/model/IllegalEventTransitionValidationError: '#/components/schemas/IllegalEventTransitionValidationError'
+          https://hivemq.com/edge/api/model/IllegalFunctionValidationError: '#/components/schemas/IllegalFunctionValidationError'
+          https://hivemq.com/edge/api/model/InvalidFieldLengthValidationError: '#/components/schemas/InvalidFieldLengthValidationError'
+          https://hivemq.com/edge/api/model/InvalidFieldValueValidationError: '#/components/schemas/InvalidFieldValueValidationError'
+          https://hivemq.com/edge/api/model/InvalidFunctionOrderValidationError: '#/components/schemas/InvalidFunctionOrderValidationError'
+          https://hivemq.com/edge/api/model/InvalidIdentifierValidationError: '#/components/schemas/InvalidIdentifierValidationError'
+          https://hivemq.com/edge/api/model/InvalidSchemaVersionValidationError: '#/components/schemas/InvalidSchemaVersionValidationError'
+          https://hivemq.com/edge/api/model/MissingFieldValidationError: '#/components/schemas/MissingFieldValidationError'
+          https://hivemq.com/edge/api/model/UnknownVariableValidationError: '#/components/schemas/UnknownVariableValidationError'
+          https://hivemq.com/edge/api/model/UnsupportedFieldValidationError: '#/components/schemas/UnsupportedFieldValidationError'
+    AtMostOneFunctionValidationError:
+      allOf:
+        - $ref: '#/components/schemas/ValidationError'
+        - type: object
+          properties:
+            function:
+              type: string
+              description: The function.
+              example: function1
+            occurrences:
+              type: integer
+              format: int32
+              description: The occurrences of the function.
+              minimum: 0
+              example: 3
+            paths:
+              type: array
+              items:
+                type: string
+                format: json-path
+              description: The json paths where the function occurs.
+              example:
+                - $.path1
+                - $.path2
+                - $.path3
+          required:
+            - function
+            - occurrences
+            - paths
+      example:
+        general:
+          detail: The pipeline must contain at most one 'function1' function, but 3 were found at ['$.path1', '$.path2', '$.path3'].
+          function: function1
+          occurrences: 3
+          paths:
+            - $.path1
+            - $.path2
+            - $.path3
+          type: https://hivemq.com/edge/api/model/AtMostOneFunctionValidationError
+    EmptyFieldValidationError:
+      allOf:
+        - $ref: '#/components/schemas/ValidationError'
+        - type: object
+          properties:
+            path:
+              type: string
+              format: json-path
+              description: The missing field.
+              example: $.field
+          required:
+            - path
+      example:
+        general:
+          detail: Required field '$.field' is empty.
+          path: $.field
+          type: https://hivemq.com/edge/api/model/EmptyFieldValidationError
+    FunctionMustBePairedValidationError:
+      allOf:
+        - $ref: '#/components/schemas/ValidationError'
+        - type: object
+          properties:
+            existingFunction:
+              type: string
+              description: The existing function.
+              example: function1
+            missingFunction:
+              type: string
+              description: The missing function.
+              example: function2
+          required:
+            - existingFunction
+            - missingFunction
+      example:
+        general:
+          detail: If 'function1' function is present in the pipeline, 'function2' function must be present as well.
+          existingFunction: function1
+          missingFunction: function2
+          type: https://hivemq.com/edge/api/model/FunctionMustBePairedValidationError
+    IllegalEventTransitionValidationError:
+      allOf:
+        - $ref: '#/components/schemas/ValidationError'
+        - type: object
+          properties:
+            event:
+              type: string
+              description: The event name.
+              example: event1
+            fromState:
+              type: string
+              description: The event from state.
+              example: state1
+            id:
+              type: string
+              description: The event id.
+              example: abc
+            path:
+              type: string
+              description: The path.
+              example: $.event
+            toState:
+              type: string
+              description: The event to state.
+              example: state2
+          required:
+            - event
+            - fromState
+            - id
+            - path
+            - toState
+      example:
+        general:
+          detail: The transition from state 'state1' to state 'state2' on event 'event1' in '$.event' is not defined for behavior 'abc'.
+          event: event1
+          fromState: state1
+          toState: state2
+          id: abc
+          path: $.event
+          type: https://hivemq.com/edge/api/model/IllegalEventTransitionValidationError
+    IllegalFunctionValidationError:
+      allOf:
+        - $ref: '#/components/schemas/ValidationError'
+        - type: object
+          properties:
+            event:
+              type: string
+              description: The event name.
+              example: event1
+            id:
+              type: string
+              description: The function id.
+              example: abc
+            path:
+              type: string
+              format: json-path
+              description: The json path.
+              example: $.event
+          required:
+            - event
+            - id
+            - path
+      example:
+        general:
+          detail: The function 'abc' is not allowed for event 'event1' in '$.event'.
+          event: event1
+          id: abc
+          path: $.event
+          type: https://hivemq.com/edge/api/model/IllegalFunctionValidationError
+    InvalidFieldLengthValidationError:
+      allOf:
+        - $ref: '#/components/schemas/ValidationError'
+        - type: object
+          properties:
+            actualLength:
+              type: integer
+              format: int32
+              description: The actual length of the field value.
+              example: 10
+            expectedMinimumLength:
+              type: integer
+              format: int32
+              description: The minimum length expected for the field value.
+              minimum: 0
+              example: 5
+            expectedMaximumLength:
+              type: integer
+              format: int32
+              description: The maximum length expected for the field value.
+              minimum: 0
+              example: 20
+            path:
+              type: string
+              format: json-path
+              description: The invalid json path.
+              example: $.field
+            value:
+              type: string
+              description: The invalid value.
+              example: function transform() { return 'Hello, World!'; }
+          required:
+            - actualLength
+            - expectedMinimumLength
+            - expectedMaximumLength
+            - path
+            - value
+      example:
+        general:
+          detail: The length of script field '$.transform' 48 must be between 0 and 20.
+          actualLength: 48
+          minimumLength: 0
+          maximumLength: 20
+          path: $.transform
+          value: function transform() { return 'Hello, World!'; }
+          type: https://hivemq.com/edge/api/model/InvalidFieldLengthValidationError
+    InvalidFieldValueValidationError:
+      allOf:
+        - $ref: '#/components/schemas/ValidationError'
+        - type: object
+          properties:
+            path:
+              type: string
+              format: json-path
+              description: The invalid json path.
+              example: $.action.pipeline[1].field
+            value:
+              type: string
+              description: The invalid value.
+              example: functionDoesNotExist
+          required:
+            - path
+      example:
+        general:
+          detail: Referenced function does not exist.
+          path: $.action.pipeline[1].field
+          value: functionDoesNotExist
+          type: https://hivemq.com/edge/api/model/InvalidFieldValueValidationError
+    InvalidFunctionOrderValidationError:
+      allOf:
+        - $ref: '#/components/schemas/ValidationError'
+        - type: object
+          properties:
+            function:
+              type: string
+              description: The function.
+              example: transform
+            path:
+              type: string
+              format: json-path
+              description: The json path.
+              example: $.path
+            previousFunction:
+              type: string
+              description: The previous function.
+              example: init
+          required:
+            - function
+            - path
+            - previousFunction
+      example:
+        general:
+          detail: The operation at '$.path' with the functionId 'transform' must be after a 'init' operation.
+          function: transform
+          path: $.path
+          previousFunction: init
+          type: https://hivemq.com/edge/api/model/InvalidFunctionOrderValidationError
+    InvalidIdentifierValidationError:
+      allOf:
+        - $ref: '#/components/schemas/ValidationError'
+        - type: object
+          properties:
+            path:
+              type: string
+              format: json-path
+              description: The invalid identifier path.
+              example: $.id
+            value:
+              type: string
+              description: The invalid identifier value.
+              example: invalidId
+          required:
+            - path
+            - value
+      example:
+        general:
+          detail: Identifier script 'id' must begin with a letter and may only consist of lowercase letters, uppercase letters, numbers, periods, hyphens, and underscores.
+          path: $.id
+          value: invalidId
+          type: https://hivemq.com/edge/api/model/InvalidIdentifierValidationError
+    InvalidSchemaVersionValidationError:
+      allOf:
+        - $ref: '#/components/schemas/ValidationError'
+        - type: object
+          properties:
+            id:
+              type: string
+              description: The schema id.
+              example: abc
+            version:
+              type: string
+              description: The schema version.
+              example: '2'
+          required:
+            - id
+            - version
+      example:
+        general:
+          detail: The referenced schema with id 'abc' and version '2' was not found.
+          id: abc
+          version: '2'
+          type: https://hivemq.com/edge/api/model/InvalidSchemaVersionValidationError
+    MissingFieldValidationError:
+      allOf:
+        - $ref: '#/components/schemas/ValidationError'
+        - type: object
+          properties:
+            path:
+              type: string
+              format: json-path
+              description: The missing path.
+              example: $.id
+          required:
+            - path
+      example:
+        general:
+          detail: Required field '$.id' is missing.
+          path: $.id
+          type: https://hivemq.com/edge/api/model/MissingFieldValidationError
+    UnknownVariableValidationError:
+      allOf:
+        - $ref: '#/components/schemas/ValidationError'
+        - type: object
+          properties:
+            path:
+              type: string
+              description: The json path of the field.
+              example: $.path
+            variables:
+              type: array
+              items:
+                type: string
+              description: The unknown variables.
+              example:
+                - a
+                - b
+                - c
+          required:
+            - path
+            - variables
+      example:
+        general:
+          detail: 'Field ''$.path'' contains unknown variables: [a, b, c].'
+          path: $.path
+          variables:
+            - a
+            - b
+            - c
+          type: https://hivemq.com/edge/api/model/UnknownVariableValidationError
+    UnsupportedFieldValidationError:
+      allOf:
+        - $ref: '#/components/schemas/ValidationError'
+        - type: object
+          properties:
+            actualValue:
+              type: string
+              description: The actual value.
+            expectedValue:
+              type: string
+              description: The expected value.
+            path:
+              type: string
+              format: json-path
+              description: The json path.
+              example: $.id
+          required:
+            - actualValue
+            - expectedValue
+            - path
+      example:
+        general:
+          detail: Unsupported type 'String' for field '$.id'. Expected type is 'Object'.
+          actualValue: String
+          expectedValue: Object
+          path: $.id
+          type: https://hivemq.com/edge/api/model/UnsupportedFieldValidationError
+    BehaviorPolicyValidationError:
+      allOf:
+        - $ref: '#/components/schemas/ValidationError'
+        - oneOf:
+            - $ref: '#/components/schemas/IllegalEventTransitionValidationError'
+            - $ref: '#/components/schemas/IllegalFunctionValidationError'
+            - $ref: '#/components/schemas/InvalidSchemaVersionValidationError'
+            - $ref: '#/components/schemas/AtLeastOneFieldMissingValidationError'
+            - $ref: '#/components/schemas/EmptyFieldValidationError'
+            - $ref: '#/components/schemas/InvalidFieldLengthValidationError'
+            - $ref: '#/components/schemas/InvalidFieldValueValidationError'
+            - $ref: '#/components/schemas/InvalidIdentifierValidationError'
+            - $ref: '#/components/schemas/MissingFieldValidationError'
+            - $ref: '#/components/schemas/UnsupportedFieldValidationError'
+      discriminator:
+        propertyName: type
+        mapping:
+          https://hivemq.com/edge/api/model/AtLeastOneFieldMissingValidationError: '#/components/schemas/AtLeastOneFieldMissingValidationError'
+          https://hivemq.com/edge/api/model/EmptyFieldValidationError: '#/components/schemas/EmptyFieldValidationError'
+          https://hivemq.com/edge/api/model/IllegalEventTransitionValidationError: '#/components/schemas/IllegalEventTransitionValidationError'
+          https://hivemq.com/edge/api/model/IllegalFunctionValidationError: '#/components/schemas/IllegalFunctionValidationError'
+          https://hivemq.com/edge/api/model/InvalidFieldLengthValidationError: '#/components/schemas/InvalidFieldLengthValidationError'
+          https://hivemq.com/edge/api/model/InvalidFieldValueValidationError: '#/components/schemas/InvalidFieldValueValidationError'
+          https://hivemq.com/edge/api/model/InvalidIdentifierValidationError: '#/components/schemas/InvalidIdentifierValidationError'
+          https://hivemq.com/edge/api/model/InvalidSchemaVersionValidationError: '#/components/schemas/InvalidSchemaVersionValidationError'
+          https://hivemq.com/edge/api/model/MissingFieldValidationError: '#/components/schemas/MissingFieldValidationError'
+          https://hivemq.com/edge/api/model/UnsupportedFieldValidationError: '#/components/schemas/UnsupportedFieldValidationError'
+    BehaviorPolicyInvalidErrors:
+      allOf:
+        - $ref: '#/components/schemas/ApiProblemDetails'
+        - type: object
+          properties:
+            childErrors:
+              type: array
+              description: List of child validation errors.
+              items:
+                $ref: '#/components/schemas/BehaviorPolicyValidationError'
+          required:
+            - childErrors
+      example:
+        general:
+          status: 400
+          title: Behavior Policy Invalid
+          detail: Behavior policy is invalid due to validation errors.
+          type: https://hivemq.com/edge/api/model/BehaviorPolicyInvalidErrors
+          childErrors:
+            - detail: The transition from state 'state1' to state 'state2' on event 'event1' in '$.path' is not defined for behavior 'id1'.
+              fromState: state1
+              toState: state2
+              path: $.path
+              id: id1
+              type: https://hivemq.com/edge/api/model/IllegalEventTransitionValidationError
+    BehaviorPolicyNotFoundError:
+      allOf:
+        - $ref: '#/components/schemas/ApiProblemDetails'
+        - type: object
+          properties:
+            id:
+              type: string
+              description: The data policy id.
+              example: abc
+          required:
+            - id
+      example:
+        general:
+          status: 404
+          title: Behavior Policy Not Found
+          detail: Behavior policy with ID 'abc' is not found.
+          id: abc
+          type: https://hivemq.com/edge/api/model/BehaviorPolicyNotFoundError
+    BehaviorPolicyRejectedError:
+      allOf:
+        - $ref: '#/components/schemas/ApiProblemDetails'
+      example:
+        general:
+          status: 400
+          title: Behavior Policy Rejected
+          detail: Behavior policy is rejected.
+          type: https://hivemq.com/edge/api/model/BehaviorPolicyRejectedError
+    BehaviorPolicyUpdateFailureError:
+      allOf:
+        - $ref: '#/components/schemas/ApiProblemDetails'
+        - type: object
+          properties:
+            id:
+              type: string
+              description: The ID of the policy that failed to update.
+              example: abc
+          required:
+            - id
+      example:
+        general:
+          status: 400
+          title: Behavior Policy Update Failed
+          detail: Behavior policy with ID 'abc' update failed.
+          id: abc
+          type: https://hivemq.com/edge/api/model/BehaviorPolicyUpdateFailureError
+    ClientDisconnectedError:
+      allOf:
+        - $ref: '#/components/schemas/ApiProblemDetails'
+        - type: object
+          properties:
+            id:
+              type: string
+              description: The client id.
+              example: abc
+          required:
+            - id
+      example:
+        general:
+          status: 404
+          title: Client Disconnected
+          detail: Client with ID 'abc' is disconnected.
+          id: abc
+          type: https://hivemq.com/edge/api/model/ClientDisconnectedError
+    ClientNotFoundError:
+      allOf:
+        - $ref: '#/components/schemas/ApiProblemDetails'
+        - type: object
+          properties:
+            id:
+              type: string
+              description: The client id.
+              example: abc
+          required:
+            - id
+      example:
+        general:
+          status: 404
+          title: Client Not Found
+          detail: Client with ID 'abc' is not found.
+          id: abc
+          type: https://hivemq.com/edge/api/model/ClientNotFoundError
+    DataPolicyAlreadyPresentError:
+      allOf:
+        - $ref: '#/components/schemas/ApiProblemDetails'
+        - type: object
+          properties:
+            id:
+              type: string
+              description: The data policy id.
+              example: abc
+          required:
+            - id
+      example:
+        general:
+          status: 409
+          title: Data Policy Already Present
+          detail: The given data policy 'abc' is already present.
+          id: abc
+          type: https://hivemq.com/edge/api/model/DataPolicyAlreadyPresentError
+    DataPolicyCreationFailureError:
+      allOf:
+        - $ref: '#/components/schemas/ApiProblemDetails'
+      example:
+        general:
+          status: 400
+          title: Data Policy Creation Failed
+          detail: 'Data policy creation failed: The policy was rejected.'
+          type: https://hivemq.com/edge/api/model/DataPolicyCreationFailureError
+    DataPolicyValidationError:
+      allOf:
+        - $ref: '#/components/schemas/ValidationError'
+        - oneOf:
+            - $ref: '#/components/schemas/AtMostOneFunctionValidationError'
+            - $ref: '#/components/schemas/FunctionMustBePairedValidationError'
+            - $ref: '#/components/schemas/InvalidFunctionOrderValidationError'
+            - $ref: '#/components/schemas/InvalidSchemaVersionValidationError'
+            - $ref: '#/components/schemas/UnknownVariableValidationError'
+            - $ref: '#/components/schemas/EmptyFieldValidationError'
+            - $ref: '#/components/schemas/InvalidFieldLengthValidationError'
+            - $ref: '#/components/schemas/InvalidFieldValueValidationError'
+            - $ref: '#/components/schemas/InvalidIdentifierValidationError'
+            - $ref: '#/components/schemas/MissingFieldValidationError'
+            - $ref: '#/components/schemas/UnsupportedFieldValidationError'
+      discriminator:
+        propertyName: type
+        mapping:
+          https://hivemq.com/edge/api/model/AtMostOneFunctionValidationError: '#/components/schemas/AtMostOneFunctionValidationError'
+          https://hivemq.com/edge/api/model/EmptyFieldValidationError: '#/components/schemas/EmptyFieldValidationError'
+          https://hivemq.com/edge/api/model/FunctionMustBePairedValidationError: '#/components/schemas/FunctionMustBePairedValidationError'
+          https://hivemq.com/edge/api/model/InvalidFieldLengthValidationError: '#/components/schemas/InvalidFieldLengthValidationError'
+          https://hivemq.com/edge/api/model/InvalidFieldValueValidationError: '#/components/schemas/InvalidFieldValueValidationError'
+          https://hivemq.com/edge/api/model/InvalidFunctionOrderValidationError: '#/components/schemas/InvalidFunctionOrderValidationError'
+          https://hivemq.com/edge/api/model/InvalidIdentifierValidationError: '#/components/schemas/InvalidIdentifierValidationError'
+          https://hivemq.com/edge/api/model/InvalidSchemaVersionValidationError: '#/components/schemas/InvalidSchemaVersionValidationError'
+          https://hivemq.com/edge/api/model/MissingFieldValidationError: '#/components/schemas/MissingFieldValidationError'
+          https://hivemq.com/edge/api/model/UnknownVariableValidationError: '#/components/schemas/UnknownVariableValidationError'
+          https://hivemq.com/edge/api/model/UnsupportedFieldValidationError: '#/components/schemas/UnsupportedFieldValidationError'
+    DataPolicyInvalidErrors:
+      allOf:
+        - $ref: '#/components/schemas/ApiProblemDetails'
+        - type: object
+          properties:
+            childErrors:
+              type: array
+              description: List of child validation errors.
+              items:
+                $ref: '#/components/schemas/DataPolicyValidationError'
+          required:
+            - childErrors
+      example:
+        general:
+          status: 400
+          title: Data Policy Invalid
+          detail: Data policy is invalid due to validation errors.
+          type: https://hivemq.com/edge/api/model/DataPolicyInvalidErrors
+          childErrors:
+            - detail: The pipeline must contain at most one 'function1' function, but 3 were found at ['$.path1', '$.path2', '$.path3'].
+              function: function1
+              occurrences: 3
+              paths:
+                - $.path1
+                - $.path2
+                - $.path3
+              type: https://hivemq.com/edge/api/model/AtMostOneFunctionValidationError
+    DataPolicyNotFoundError:
+      allOf:
+        - $ref: '#/components/schemas/ApiProblemDetails'
+        - type: object
+          properties:
+            id:
+              type: string
+              description: The data policy id.
+              example: abc
+          required:
+            - id
+      example:
+        general:
+          status: 404
+          title: Data Policy Not Found
+          detail: Data policy with ID 'abc' is not found.
+          id: abc
+          type: https://hivemq.com/edge/api/model/DataPolicyNotFoundError
+    DataPolicyRejectedError:
+      allOf:
+        - $ref: '#/components/schemas/ApiProblemDetails'
+      example:
+        general:
+          status: 400
+          title: Data Policy Rejected
+          detail: Data policy is rejected.
+          type: https://hivemq.com/edge/api/model/DataPolicyRejectedError
+    DataPolicyUpdateFailureError:
+      allOf:
+        - $ref: '#/components/schemas/ApiProblemDetails'
+        - type: object
+          properties:
+            id:
+              type: string
+              description: The ID of the policy that failed to update.
+              example: abc
+          required:
+            - id
+      example:
+        general:
+          status: 400
+          title: Data Policy Update Failed
+          detail: Data policy with ID 'abc' update failed.
+          id: abc
+          type: https://hivemq.com/edge/api/model/DataPolicyUpdateFailureError
+    PolicyIdMismatchError:
+      allOf:
+        - $ref: '#/components/schemas/ApiProblemDetails'
+        - type: object
+          properties:
+            actualId:
+              type: string
+              description: The actual id.
+              example: id1
+            expectedId:
+              type: string
+              description: The expected id.
+              example: id2
+          required:
+            - actualId
+            - expectedId
+      example:
+        general:
+          status: 400
+          title: Policy ID Mismatch
+          detail: The policy ID 'id1' in the request parameter does not match the policy ID 'id2' in the policy request body.
+          id: abc
+          type: https://hivemq.com/edge/api/model/PolicyIdMismatchError
+    PolicyInsufficientStorageError:
+      allOf:
+        - $ref: '#/components/schemas/ApiProblemDetails'
+        - type: object
+          properties:
+            id:
+              type: string
+              description: The policy id.
+              example: abc
+          required:
+            - id
+      example:
+        general:
+          status: 507
+          title: Policy Insufficient Storage
+          detail: Policy with ID '123' could not be added because of insufficient server storage.
+          id: abc
+          type: https://hivemq.com/edge/api/model/PolicyInsufficientStorageError
+    PolicyNotFoundError:
+      allOf:
+        - $ref: '#/components/schemas/ApiProblemDetails'
+        - type: object
+          properties:
+            id:
+              type: string
+              description: The policy id.
+              example: abc
+          required:
+            - id
+      example:
+        general:
+          status: 404
+          title: Policy Not Found
+          detail: Policy with ID 'abc' is not found.
+          id: abc
+          type: https://hivemq.com/edge/api/model/PolicyNotFoundError
+    SchemaAlreadyPresentError:
+      allOf:
+        - $ref: '#/components/schemas/ApiProblemDetails'
+        - type: object
+          properties:
+            id:
+              type: string
+              description: The schema id.
+              example: abc
+          required:
+            - id
+      example:
+        general:
+          status: 409
+          title: Schema Already Present
+          detail: The given schema is already present as the latest version for the schema id 'abc'.
+          id: abc
+          type: https://hivemq.com/edge/api/model/SchemaAlreadyPresentError
+    SchemaEtagMismatchError:
+      allOf:
+        - $ref: '#/components/schemas/ApiProblemDetails'
+        - type: object
+          properties:
+            id:
+              type: string
+              description: The schema id.
+              example: abc
+            eTag:
+              type: string
+              description: The eTag.
+              example: 33a64df551425fcc55e4d42a148795d9f25f89d4
+          required:
+            - id
+      example:
+        general:
+          status: 412
+          title: Schema eTag Mismatch
+          detail: Schema with id 'abc' does not match the given etag '33a64df551425fcc55e4d42a148795d9f25f89d4'.
+          id: abc
+          eTag: 33a64df551425fcc55e4d42a148795d9f25f89d4
+          type: https://hivemq.com/edge/api/model/SchemaEtagMismatchError
+    SchemaInsufficientStorageError:
+      allOf:
+        - $ref: '#/components/schemas/ApiProblemDetails'
+        - type: object
+          properties:
+            id:
+              type: string
+              description: The policy id.
+              example: abc
+          required:
+            - id
+      example:
+        general:
+          status: 507
+          title: Schema Insufficient Storage
+          detail: Schema with ID '123' could not be added because of insufficient server storage.
+          id: abc
+          type: https://hivemq.com/edge/api/model/SchemaInsufficientStorageError
+    SchemaValidationError:
+      allOf:
+        - $ref: '#/components/schemas/ValidationError'
+        - oneOf:
+            - $ref: '#/components/schemas/EmptyFieldValidationError'
+            - $ref: '#/components/schemas/InvalidFieldLengthValidationError'
+            - $ref: '#/components/schemas/InvalidFieldValueValidationError'
+            - $ref: '#/components/schemas/InvalidIdentifierValidationError'
+            - $ref: '#/components/schemas/MissingFieldValidationError'
+            - $ref: '#/components/schemas/UnsupportedFieldValidationError'
+      discriminator:
+        propertyName: type
+        mapping:
+          https://hivemq.com/edge/api/model/EmptyFieldValidationError: '#/components/schemas/EmptyFieldValidationError'
+          https://hivemq.com/edge/api/model/InvalidFieldLengthValidationError: '#/components/schemas/InvalidFieldLengthValidationError'
+          https://hivemq.com/edge/api/model/InvalidFieldValueValidationError: '#/components/schemas/InvalidFieldValueValidationError'
+          https://hivemq.com/edge/api/model/InvalidIdentifierValidationError: '#/components/schemas/InvalidIdentifierValidationError'
+          https://hivemq.com/edge/api/model/MissingFieldValidationError: '#/components/schemas/MissingFieldValidationError'
+          https://hivemq.com/edge/api/model/UnsupportedFieldValidationError: '#/components/schemas/UnsupportedFieldValidationError'
+    SchemaInvalidErrors:
+      allOf:
+        - $ref: '#/components/schemas/ApiProblemDetails'
+        - type: object
+          properties:
+            childErrors:
+              type: array
+              description: List of child validation errors.
+              items:
+                $ref: '#/components/schemas/SchemaValidationError'
+          required:
+            - childErrors
+      example:
+        general:
+          status: 400
+          title: Schema Invalid
+          detail: Schema is invalid due to validation errors.
+          type: https://hivemq.com/edge/api/model/SchemaInvalidErrors
+          childErrors:
+            - detail: The length of script field '$.id' 1025 must be between 0 and 1024.
+              paths: $.id
+              value: aaa...aaa
+              actualLength: 1025
+              expectedMinimumLength: 0
+              expectedMaximumLength: 1024
+              type: https://hivemq.com/edge/api/model/InvalidFieldLengthValidationError
+    SchemaNotFoundError:
+      allOf:
+        - $ref: '#/components/schemas/ApiProblemDetails'
+        - type: object
+          properties:
+            id:
+              type: string
+              description: The schema ID.
+              example: abc
+          required:
+            - id
+      example:
+        general:
+          status: 404
+          title: Schema Not Found
+          detail: Schema with ID 'abc' is not found.
+          id: abc
+          type: https://hivemq.com/edge/api/model/SchemaNotFoundError
+    SchemaParsingFailureError:
+      allOf:
+        - $ref: '#/components/schemas/ApiProblemDetails'
+        - type: object
+          properties:
+            alias:
+              type: string
+              description: The schema alias.
+              example: abc
+          required:
+            - alias
+      example:
+        general:
+          status: 400
+          title: Schema Parsing Failure
+          detail: The given schema 'abc' could not be parsed.
+          alias: abc
+          type: https://hivemq.com/edge/api/model/SchemaParsingFailureError
+    SchemaReferencedError:
+      allOf:
+        - $ref: '#/components/schemas/ApiProblemDetails'
+        - type: object
+          properties:
+            id:
+              type: string
+              description: The schema ID.
+              example: abc
+          required:
+            - id
+      example:
+        general:
+          status: 400
+          title: Schema Referenced
+          detail: Schema with ID 'abc' is referenced.
+          id: abc
+          type: https://hivemq.com/edge/api/model/SchemaReferencedError
+    ScriptAlreadyPresentError:
+      allOf:
+        - $ref: '#/components/schemas/ApiProblemDetails'
+        - type: object
+          properties:
+            id:
+              type: string
+              description: The script id.
+              example: abc
+          required:
+            - id
+      example:
+        general:
+          status: 409
+          title: Script Already Present
+          detail: The given script 'abc' is already present.
+          id: abc
+          type: https://hivemq.com/edge/api/model/ScriptAlreadyPresentError
+    ScriptCreationFailureError:
+      allOf:
+        - $ref: '#/components/schemas/ApiProblemDetails'
+      example:
+        general:
+          status: 400
+          title: Script Creation Failure
+          detail: The given script could not be created.
+          type: https://hivemq.com/edge/api/model/ScriptCreationFailureError
+    ScriptEtagMismatchError:
+      allOf:
+        - $ref: '#/components/schemas/ApiProblemDetails'
+        - type: object
+          properties:
+            id:
+              type: string
+              description: The script id.
+              example: abc
+            eTag:
+              type: string
+              description: The eTag.
+              example: 33a64df551425fcc55e4d42a148795d9f25f89d4
+          required:
+            - id
+      example:
+        general:
+          status: 412
+          title: Script eTag Mismatch
+          detail: Script with id 'abc' does not match the given etag '33a64df551425fcc55e4d42a148795d9f25f89d4'.
+          id: abc
+          eTag: 33a64df551425fcc55e4d42a148795d9f25f89d4
+          type: https://hivemq.com/edge/api/model/ScriptEtagMismatchError
+    ScriptInsufficientStorageError:
+      allOf:
+        - $ref: '#/components/schemas/ApiProblemDetails'
+        - type: object
+          properties:
+            id:
+              type: string
+              description: The policy id.
+              example: abc
+          required:
+            - id
+      example:
+        general:
+          status: 507
+          title: Script Insufficient Storage
+          detail: Script with ID '123' could not be added because of insufficient server storage.
+          id: abc
+          type: https://hivemq.com/edge/api/model/ScriptInsufficientStorageError
+    ScriptValidationError:
+      allOf:
+        - $ref: '#/components/schemas/ValidationError'
+        - oneOf:
+            - $ref: '#/components/schemas/InvalidFieldLengthValidationError'
+            - $ref: '#/components/schemas/InvalidFieldValueValidationError'
+            - $ref: '#/components/schemas/InvalidIdentifierValidationError'
+            - $ref: '#/components/schemas/MissingFieldValidationError'
+            - $ref: '#/components/schemas/UnsupportedFieldValidationError'
+      discriminator:
+        propertyName: type
+        mapping:
+          https://hivemq.com/edge/api/model/InvalidFieldLengthValidationError: '#/components/schemas/InvalidFieldLengthValidationError'
+          https://hivemq.com/edge/api/model/InvalidFieldValueValidationError: '#/components/schemas/InvalidFieldValueValidationError'
+          https://hivemq.com/edge/api/model/InvalidIdentifierValidationError: '#/components/schemas/InvalidIdentifierValidationError'
+          https://hivemq.com/edge/api/model/MissingFieldValidationError: '#/components/schemas/MissingFieldValidationError'
+          https://hivemq.com/edge/api/model/UnsupportedFieldValidationError: '#/components/schemas/UnsupportedFieldValidationError'
+    ScriptInvalidErrors:
+      allOf:
+        - $ref: '#/components/schemas/ApiProblemDetails'
+        - type: object
+          properties:
+            childErrors:
+              type: array
+              description: List of child validation errors.
+              items:
+                $ref: '#/components/schemas/ScriptValidationError'
+          required:
+            - childErrors
+      example:
+        general:
+          status: 400
+          title: Script Invalid
+          detail: Script is invalid due to validation errors.
+          type: https://hivemq.com/edge/api/model/ScriptInvalidErrors
+          childErrors:
+            - detail: The length of script field '$.id' 1025 must be between 0 and 1024.
+              paths: $.id
+              value: aaa...aaa
+              actualLength: 1025
+              expectedMinimumLength: 0
+              expectedMaximumLength: 1024
+              type: https://hivemq.com/edge/api/model/InvalidFieldLengthValidationError
+    ScriptNotFoundError:
+      allOf:
+        - $ref: '#/components/schemas/ApiProblemDetails'
+        - type: object
+          properties:
+            id:
+              type: string
+              description: The script ID.
+              example: abc
+          required:
+            - id
+      example:
+        general:
+          status: 404
+          title: Script Not Found
+          detail: Script with ID 'abc' is not found.
+          id: abc
+          type: https://hivemq.com/edge/api/model/ScriptNotFoundError
+    ScriptParsingFailureError:
+      allOf:
+        - $ref: '#/components/schemas/ApiProblemDetails'
+      example:
+        general:
+          status: 400
+          title: Script Parsing Failure
+          detail: The given script 'abc' could not be parsed.
+          type: https://hivemq.com/edge/api/model/ScriptParsingFailureError
+    ScriptReferencedError:
+      allOf:
+        - $ref: '#/components/schemas/ApiProblemDetails'
+        - type: object
+          properties:
+            id:
+              type: string
+              description: The script ID.
+              example: abc
+          required:
+            - id
+      example:
+        general:
+          status: 400
+          title: Script Referenced
+          detail: Script with ID 'abc' is referenced.
+          id: abc
+          type: https://hivemq.com/edge/api/model/ScriptReferencedError
+    ScriptSanitationFailureError:
+      allOf:
+        - $ref: '#/components/schemas/ApiProblemDetails'
+      example:
+        general:
+          status: 400
+          title: Script Sanitation Failure
+          detail: The given script could not be sanitized.
+          type: https://hivemq.com/edge/api/model/ScriptSanitationFailureError
+    TopicFilterMismatchError:
+      allOf:
+        - $ref: '#/components/schemas/ApiProblemDetails'
+        - type: object
+          properties:
+            path:
+              type: string
+              description: The json path of the topic filter.
+              example: $.filter
+          required:
+            - path
+      example:
+        general:
+          status: 400
+          title: Topic Filter Mismatch
+          detail: The topic filter '$.filter' mismatches.
+          type: https://hivemq.com/edge/api/model/TopicFilterMismatchError
+    InsufficientStorageError:
+      allOf:
+        - $ref: '#/components/schemas/ApiProblemDetails'
+      example:
+        general:
+          status: 507
+          title: Insufficient Storage
+          detail: Insufficient Storage.
+          type: https://hivemq.com/edge/api/model/InsufficientStorageError
+    InternalServerError:
+      allOf:
+        - $ref: '#/components/schemas/ApiProblemDetails'
+      example:
+        general:
+          status: 500
+          title: Internal Server Error
+          detail: An unexpected error occurred, check the logs.
+          type: https://hivemq.com/edge/api/model/InternalServerError
+        creation:
+          status: 500
+          title: Internal Server Error
+          detail: 'An unexpected error occurred: Exception during creation of the Json Schema for functions.'
+          type: https://hivemq.com/edge/api/model/InternalServerError
+    InvalidQueryParameterError:
+      allOf:
+        - $ref: '#/components/schemas/ApiProblemDetails'
+        - type: object
+          properties:
+            parameter:
+              type: string
+              description: The query parameter.
+          required:
+            - parameter
+      example:
+        general:
+          status: 400
+          title: Query Parameter is Invalid
+          detail: 'Query parameter ''a'' is invalid: ''a'' could not be parsed.'
+          parameter: a
+          type: https://hivemq.com/edge/api/model/InvalidQueryParameterError
+    PreconditionFailedError:
+      allOf:
+        - $ref: '#/components/schemas/ApiProblemDetails'
+      example:
+        general:
+          status: 412
+          title: Precondition Failed
+          detail: 'A precondition required for fulfilling the request was not fulfilled: Policy does not match the given etag ''abc''.'
+          type: https://hivemq.com/edge/api/model/PreconditionFailedError
+    RequestBodyMissingError:
+      allOf:
+        - $ref: '#/components/schemas/ApiProblemDetails'
+      example:
+        general:
+          status: 400
+          title: Required Request Body Missing
+          detail: Required request body is missing.
+          type: https://hivemq.com/edge/api/model/RequestBodyMissingError
+    RequestBodyParameterMissingError:
+      allOf:
+        - $ref: '#/components/schemas/ApiProblemDetails'
+        - type: object
+          properties:
+            parameter:
+              type: string
+              description: The the missing request body parameter.
+          required:
+            - parameter
+      example:
+        general:
+          status: 400
+          title: Required Request Body Parameter Missing
+          detail: Required request body parameter 'a' is missing.
+          parameter: a
+          type: https://hivemq.com/edge/api/model/RequestBodyParameterMissingError
+    TemporaryNotAvailableError:
+      allOf:
+        - $ref: '#/components/schemas/ApiProblemDetails'
+      example:
+        general:
+          status: 503
+          title: Endpoint Temporarily not Available
+          detail: The endpoint is temporarily not available, please try again later.
+          type: https://hivemq.com/edge/api/model/TemporaryNotAvailableError
+    UrlParameterMissingError:
+      allOf:
+        - $ref: '#/components/schemas/ApiProblemDetails'
+        - type: object
+          properties:
+            parameter:
+              type: string
+              description: The name of the missing parameter.
+          required:
+            - parameter
+      example:
+        general:
+          status: 400
+          title: Required URL Parameter Missing
+          detail: Required URL parameter 'a' is missing.
+          parameter: a
+          type: https://hivemq.com/edge/api/model/UrlParameterMissingError
+    JsonNode:
+      type: object
+      description: The arguments of the fsm derived from the behavior policy.
+    FsmStateInformationItem:
+      type: object
+      description: List of result items that are returned by this endpoint
+      properties:
+        arguments:
+          $ref: '#/components/schemas/JsonNode'
+        behaviorId:
+          type: string
+          description: The unique identifier of the policy.
+        firstSetAt:
+          type: string
+          description: The timestamp when this state was set the first time.
+        policyId:
+          type: string
+          description: The unique identifier of the policy.
+        stateName:
+          type: string
+          description: The name of the fsm state.
+        stateType:
+          type: string
+          description: The type of the fsm state.
+        variables:
+          type: object
+          additionalProperties:
+            type: string
+            description: The variables for this fsm.
+          description: The variables for this fsm.
+    FsmStatesInformationListItem:
+      type: object
+      properties:
+        items:
+          type: array
+          description: List of result items that are returned by this endpoint
+          items:
+            $ref: '#/components/schemas/FsmStateInformationItem'
+      required:
+        - items
+    DataPolicyMatching:
+      type: object
+      description: The matching rules the policy applies.
+      properties:
+        topicFilter:
+          type: string
+          description: The topic filter for which the policy is matched.
+      required:
+        - topicFilter
+    DataPolicyAction:
+      type: object
+      description: One or more operations the outcome of the validation triggers.  When this field is empty, the outcome of the policy validation does not trigger any operations.
+      properties:
+        pipeline:
+          type: array
+          description: The pipeline to execute, when this action is triggered. The operations in the pipeline are executed in-order.
+          items:
+            $ref: '#/components/schemas/PolicyOperation'
+    DataPolicyValidator:
+      type: object
+      description: A policy validator which executes the defined validation.
+      properties:
+        arguments:
+          type: object
+          description: The required arguments of the referenced validator type.
+        type:
+          type: string
+          description: The type of the validator.
+          enum:
+            - SCHEMA
+      required:
+        - arguments
+        - type
+    DataPolicyValidation:
+      type: object
+      description: The section of the policy that defines how incoming MQTT messages are validated. If this section is empty, the result of the policy validation is always successful.
+      properties:
+        validators:
+          type: array
+          description: The validators of the policy.
+          items:
+            $ref: '#/components/schemas/DataPolicyValidator'
+    DataPolicy:
+      type: object
+      description: A data policy which is used to validate and execute certain actions based on the validation result.
+      properties:
+        createdAt:
+          type: string
+          format: date-time
+          description: The formatted UTC timestamp indicating when the policy was created.
+          readOnly: true
+        id:
+          type: string
+          description: The unique identifier of the policy.
+        lastUpdatedAt:
+          type: string
+          format: date-time
+          description: The formatted UTC timestamp indicating when the policy was updated the last time.
+          readOnly: true
+        matching:
+          $ref: '#/components/schemas/DataPolicyMatching'
+        onFailure:
+          $ref: '#/components/schemas/DataPolicyAction'
+        onSuccess:
+          $ref: '#/components/schemas/DataPolicyAction'
+        validation:
+          $ref: '#/components/schemas/DataPolicyValidation'
+      required:
+        - id
+        - matching
+    DataPolicyList:
+      type: object
+      description: A listing of data policies.
+      properties:
+        _links:
+          $ref: '#/components/schemas/PaginationCursor'
+        items:
+          type: array
+          description: List of result items that are returned by this endpoint
+          items:
+            $ref: '#/components/schemas/DataPolicy'
+    PolicyType:
+      description: The type of policy in Data Hub
+      type: string
+      enum:
+        - DATA_POLICY
+        - BEHAVIOR_POLICY
+    InterpolationVariable:
+      type: object
+      required:
+        - variable
+        - type
+        - description
+        - policyType
+      properties:
+        variable:
+          type: string
+          description: The unique variable name
+        type:
+          type: string
+          enum:
+            - string
+            - long
+        description:
+          type: string
+          description: The description of the variable name
+        policyType:
+          type: array
+          description: The list of policy types this variable can be used with
+          uniqueItems: true
+          items:
+            $ref: '#/components/schemas/PolicyType'
+      example:
+        variable: clientId
+        type: string
+        description: The MQTT client ID
+        policyType:
+          - DATA_POLICY
+          - BEHAVIOR_POLICY
+    InterpolationVariableList:
+      type: object
+      description: The list of interpolation variables that can be used in this Datahub instance
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/InterpolationVariable'
+      required:
+        - items
+      example:
+        items:
+          - variable: clientId
+            type: string
+            description: The MQTT client ID.
+            policyType:
+              - BEHAVIOR_POLICY
+              - DATA_POLICY
+          - variable: topic
+            type: string
+            description: The MQTT topic to which the MQTT message was published.
+            policyType:
+              - DATA_POLICY
+          - variable: policyId
+            type: string
+            description: The id of the policy that is currently executed.
+            policyType:
+              - BEHAVIOR_POLICY
+              - DATA_POLICY
+          - variable: validationResult
+            type: string
+            description: A textual description of the validation result. This text can contain schema validation errors for further debugging.
+            policyType:
+              - BEHAVIOR_POLICY
+          - variable: fromState
+            type: string
+            description: Textual representation of the state of the state machine before the transition.
+            policyType:
+              - BEHAVIOR_POLICY
+          - variable: toState
+            type: string
+            description: Textual representation of the state to which the state machine transitions.
+            policyType:
+              - BEHAVIOR_POLICY
+          - variable: triggerEvent
+            type: string
+            description: Textual representation of the event that triggered the state machine transition.
+            policyType:
+              - BEHAVIOR_POLICY
+          - variable: timestamp
+            type: string
+            description: Current time in milliseconds since the UNIX epoch (Jan 1, 1970).
+            policyType:
+              - BEHAVIOR_POLICY
+              - DATA_POLICY
+    BehaviorPolicyTransitionEvent:
+      type: string
+      description: Accepted event in transition
+      enum:
+        - Event.OnAny
+        - Connection.OnDisconnect
+        - Mqtt.OnInboundConnect
+        - Mqtt.OnInboundDisconnect
+        - Mqtt.OnInboundPublish
+        - Mqtt.OnInboundSubscribe
+    FunctionMetadata:
+      description: Metadata for operation functions
+      type: object
+      properties:
+        isTerminal:
+          type: boolean
+          description: The function is a terminal element of a pipeline
+        isDataOnly:
+          type: boolean
+          description: The function is only available for Data Policies
+        hasArguments:
+          type: boolean
+          description: The function has extra arguments
+        inLicenseAllowed:
+          type: boolean
+          description: The function can be used with the current user's license
+        supportedEvents:
+          type: array
+          items:
+            $ref: '#/components/schemas/BehaviorPolicyTransitionEvent'
+    FunctionSpecs:
+      description: The configuration of a DataHub operation function
+      type: object
+      properties:
+        functionId:
+          type: string
+          description: The unique name of the function
+        metadata:
+          $ref: '#/components/schemas/FunctionMetadata'
+          description: The metadata associated with the function
+        schema:
+          $ref: '#/components/schemas/JsonNode'
+          description: the full JSON-Schema describing the function and its arguments
+        uiSchema:
+          $ref: '#/components/schemas/JsonNode'
+          description: An optional UI Schema to customise the rendering of the configuration form
+      required:
+        - functionId
+        - metadata
+        - schema
+    FunctionSpecsList:
+      type: object
+      description: List of function configurations
+      properties:
+        items:
+          type: array
+          description: List of function configurations
+          items:
+            $ref: '#/components/schemas/FunctionSpecs'
+      required:
+        - items
+    PolicySchema:
+      type: object
+      properties:
+        arguments:
+          type: object
+          additionalProperties:
+            type: string
+            description: The schema type dependent arguments.
+          description: The schema type dependent arguments.
+        createdAt:
+          type: string
+          description: The formatted UTC timestamp when the schema was created.
+          readOnly: true
+        id:
+          type: string
+          description: The unique identifier of the schema.
+        schemaDefinition:
+          type: string
+          description: The base64 encoded schema definition.
+        type:
+          type: string
+          description: The type of the schema.
+        version:
+          type: integer
+          format: int32
+          description: The version of the schema.
+          readOnly: true
+      required:
+        - id
+        - schemaDefinition
+        - type
+    SchemaList:
+      type: object
+      description: A listing of schemas.
+      properties:
+        _links:
+          $ref: '#/components/schemas/PaginationCursor'
+        items:
+          type: array
+          description: List of result items that are returned by this endpoint
+          items:
+            $ref: '#/components/schemas/PolicySchema'
+    Script:
+      type: object
+      properties:
+        createdAt:
+          type: string
+          description: The formatted UTC timestamp when the script was created.
+          readOnly: true
+        description:
+          type: string
+          description: A string of free-form text describing the function.
+        functionType:
+          type: string
+          description: The type of the function.
+          enum:
+            - TRANSFORMATION
+        id:
+          type: string
+          description: The unique identifier of the script.
+        source:
+          type: string
+          description: The base64 encoded function source code.
+        version:
+          type: integer
+          format: int32
+          description: The version of the script.
+          readOnly: true
+      required:
+        - functionType
+        - id
+        - source
+    ScriptList:
+      type: object
+      description: A listing of scripts.
+      properties:
+        _links:
+          $ref: '#/components/schemas/PaginationCursor'
+        items:
+          type: array
+          description: List of result items that are returned by this endpoint
+          items:
+            $ref: '#/components/schemas/Script'
+    Capability:
+      type: object
+      description: List of result items that are returned by this endpoint
+      properties:
+        description:
+          type: string
+          description: A description for the capability
+        displayName:
+          type: string
+          description: A human readable name, intended to be used to display at front end.
+        id:
+          type: string
+          enum:
+            - config-writeable
+            - bi-directional protocol adapters
+            - control-plane-connectivity
+            - data-hub
+            - mqtt-persistence
+            - pulse-asset-management
+          description: The identifier of this capability
+    CapabilityList:
+      type: object
+      properties:
+        items:
+          type: array
+          description: List of result items that are returned by this endpoint
+          items:
+            $ref: '#/components/schemas/Capability'
+      required:
+        - items
+    Link:
+      type: object
+      description: An associated link
+      nullable: true
+      properties:
+        description:
+          type: string
+          description: The optional link display description
+          nullable: true
+        displayText:
+          type: string
+          description: The link display text
+          nullable: true
+        external:
+          type: boolean
+          description: A mandatory Boolean indicating if the link is internal to the context or an external webLink
+        imageUrl:
+          type: string
+          description: An optional imageUrl associated with the Link
+          nullable: true
+        target:
+          type: string
+          description: An optional target associated with the Link
+          nullable: true
+        url:
+          type: string
+          description: A mandatory URL associated with the Link
+      required:
+        - url
+    LinkList:
+      type: object
+      description: A list of resources to render
+      properties:
+        items:
+          type: array
+          description: List of result items that are returned by this endpoint
+          items:
+            $ref: '#/components/schemas/Link'
+      required:
+        - items
+    EnvironmentProperties:
+      type: object
+      description: A map of properties relating to the installation
+      nullable: true
+      properties:
+        properties:
+          type: object
+          additionalProperties:
+            type: string
+            description: Map of properties that are returned by this endpoint
+          description: Map of properties that are returned by this endpoint
+    Extension:
+      type: object
+      description: List of result items that are returned by this endpoint
+      properties:
+        author:
+          type: string
+          description: The extension author
+        description:
+          type: string
+          description: The extension description
+          nullable: true
+        id:
+          type: string
+          description: A mandatory ID associated with the Extension
+        installed:
+          type: boolean
+          description: Is the extension installed
+          nullable: true
+        link:
+          $ref: '#/components/schemas/Link'
+        name:
+          type: string
+          description: The extension name
+        priority:
+          type: integer
+          format: int32
+          description: The extension priority
+        version:
+          type: string
+          description: The extension version
+    ExtensionList:
+      type: object
+      description: The extensions available for installation
+      properties:
+        items:
+          type: array
+          description: List of result items that are returned by this endpoint
+          items:
+            $ref: '#/components/schemas/Extension'
+      required:
+        - items
+    FirstUseInformation:
+      type: object
+      description: Information relating to the firstuse experience
+      properties:
+        firstUse:
+          type: boolean
+          description: A mandatory Boolean indicating if the gateway is in firstUse mode
+        firstUseDescription:
+          type: string
+          description: A description string to use when firstUse = true.
+          nullable: true
+        firstUseTitle:
+          type: string
+          description: A header string to use when firstUse = true.
+          nullable: true
+        prefillPassword:
+          type: string
+          description: A String indicating if the prefill data for the username/password page.
+          nullable: true
+        prefillUsername:
+          type: string
+          description: A String indicating if the prefill data for the username/password page.
+          nullable: true
+      required:
+        - firstUse
+    Module:
+      type: object
+      description: List of result items that are returned by this endpoint
+      properties:
+        author:
+          type: string
+          description: The module author
+        description:
+          type: string
+          description: The module description
+          nullable: true
+        documentationLink:
+          $ref: '#/components/schemas/Link'
+        id:
+          type: string
+          description: A mandatory ID associated with the Module
+        installed:
+          type: boolean
+          description: Is the module installed
+          nullable: true
+        logoUrl:
+          $ref: '#/components/schemas/Link'
+        moduleType:
+          type: string
+          description: The type of the module
+          nullable: true
+        name:
+          type: string
+          description: The module name
+        priority:
+          type: integer
+          format: int32
+          description: The module priority
+        provisioningLink:
+          $ref: '#/components/schemas/Link'
+        version:
+          type: string
+          description: The module version
+    ModuleList:
+      type: object
+      description: The modules available for installation
+      properties:
+        items:
+          type: array
+          description: List of result items that are returned by this endpoint
+          items:
+            $ref: '#/components/schemas/Module'
+      required:
+        - items
+    PreLoginNotice:
+      type: object
+      description: The definition of a notice to be presented to the users before login
+      properties:
+        enabled:
+          type: boolean
+          description: Indicates whether the pre-login notice is enabled or not
+          default: false
+        title:
+          type: string
+          description: The title of the pre-login notice, also presented to the user
+        message:
+          type: string
+          description: The full text of the pre-login notice
+        consent:
+          type: string
+          description: An optional text for a consent checkbox that, if present, users will need to check to continue to the login itself
+      required:
+        - enabled
+        - message
+        - title
+    GatewayConfiguration:
+      type: object
+      properties:
+        cloudLink:
+          $ref: '#/components/schemas/Link'
+        ctas:
+          $ref: '#/components/schemas/LinkList'
+        documentationLink:
+          $ref: '#/components/schemas/Link'
+        environment:
+          $ref: '#/components/schemas/EnvironmentProperties'
+        extensions:
+          $ref: '#/components/schemas/ExtensionList'
+        firstUseInformation:
+          $ref: '#/components/schemas/FirstUseInformation'
+        gitHubLink:
+          $ref: '#/components/schemas/Link'
+        hivemqId:
+          type: string
+          description: The current id of hivemq edge. Changes at restart.
+        modules:
+          $ref: '#/components/schemas/ModuleList'
+        resources:
+          $ref: '#/components/schemas/LinkList'
+        trackingAllowed:
+          type: boolean
+          description: Is the tracking of user actions allowed.
+        preLoginNotice:
+          $ref: '#/components/schemas/PreLoginNotice'
+    Notification:
+      type: object
+      description: List of result items that are returned by this endpoint
+      properties:
+        description:
+          type: string
+          description: The notification description
+          nullable: true
+        level:
+          type: string
+          description: The notification level
+          enum:
+            - NOTICE
+            - WARNING
+            - ERROR
+        link:
+          $ref: '#/components/schemas/Link'
+        title:
+          type: string
+          description: The notification title
+    NotificationList:
+      type: object
+      properties:
+        items:
+          type: array
+          description: List of result items that are returned by this endpoint
+          items:
+            $ref: '#/components/schemas/Notification'
+      required:
+        - items
+    Listener:
+      type: object
+      description: List of result items that are returned by this endpoint
+      properties:
+        description:
+          type: string
+          description: The extension description
+          nullable: true
+        externalHostname:
+          type: string
+          description: The external hostname
+          nullable: true
+        hostName:
+          type: string
+          description: A mandatory ID hostName with the Listener
+        name:
+          type: string
+          description: The listener name
+        port:
+          type: integer
+          format: int32
+          description: The listener port
+        protocol:
+          type: string
+          description: A protocol that this listener services
+          nullable: true
+        transport:
+          type: string
+          description: The underlying transport that this listener uses
+          enum:
+            - TCP
+            - UDP
+            - DCCP
+            - SCTP
+            - RSVP
+            - QUIC
+          nullable: true
+    ListenerList:
+      type: object
+      properties:
+        items:
+          type: array
+          description: List of result items that are returned by this endpoint
+          items:
+            $ref: '#/components/schemas/Listener'
+      required:
+        - items
+    HealthStatus:
+      type: object
+      properties:
+        status:
+          type: string
+    BridgeCustomUserProperty:
+      type: object
+      description: The customUserProperties for this subscription
+      properties:
+        key:
+          type: string
+          format: string
+          description: The key the from the property
+        value:
+          type: string
+          format: string
+          description: The value the from the property
+      required:
+        - key
+        - value
+    LocalBridgeSubscription:
+      type: object
+      description: localSubscriptions associated with the bridge
+      properties:
+        customUserProperties:
+          type: array
+          description: The customUserProperties for this subscription
+          items:
+            $ref: '#/components/schemas/BridgeCustomUserProperty'
+        destination:
+          type: string
+          description: The destination topic for this filter set.
+          example: some/topic/value
+        excludes:
+          type: array
+          description: The exclusion patterns
+          items:
+            type: string
+            description: The exclusion patterns
+            nullable: true
+          nullable: true
+        filters:
+          type: array
+          description: The filters for this subscription.
+          example: some/topic/value
+          items:
+            type: string
+            description: The filters for this subscription.
+            example: some/topic/value
+        maxQoS:
+          type: integer
+          format: int32
+          default: 0
+          description: The maxQoS for this subscription.
+          enum:
+            - 0
+            - 1
+            - 2
+          maximum: 2
+          minimum: 0
+        preserveRetain:
+          type: boolean
+          description: The preserveRetain for this subscription
+        queueLimit:
+          type: integer
+          format: int64
+          description: The limit of this bridge for QoS-1 and QoS-2 messages.
+          nullable: true
+      required:
+        - destination
+        - filters
+        - maxQoS
+    BridgeSubscription:
+      type: object
+      description: remoteSubscriptions associated with the bridge
+      properties:
+        customUserProperties:
+          type: array
+          description: The customUserProperties for this subscription
+          items:
+            $ref: '#/components/schemas/BridgeCustomUserProperty'
+        destination:
+          type: string
+          description: The destination topic for this filter set.
+          example: some/topic/value
+        filters:
+          type: array
+          description: The filters for this subscription.
+          example: some/topic/value
+          items:
+            type: string
+            description: The filters for this subscription.
+            example: some/topic/value
+        maxQoS:
+          type: integer
+          format: int32
+          default: 0
+          description: The maxQoS for this subscription.
+          enum:
+            - 0
+            - 1
+            - 2
+          maximum: 2
+          minimum: 0
+        preserveRetain:
+          type: boolean
+          description: The preserveRetain for this subscription
+      required:
+        - destination
+        - filters
+        - maxQoS
+    Status:
+      type: object
+      description: Information associated with the runtime of this adapter
+      properties:
+        connection:
+          type: string
+          description: A mandatory connection status field.
+          enum:
+            - CONNECTED
+            - DISCONNECTED
+            - STATELESS
+            - UNKNOWN
+            - ERROR
+        id:
+          type: string
+          description: The identifier of the object
+        lastActivity:
+          type: string
+          format: date-time
+          description: The datetime of the last activity through this connection
+        message:
+          type: string
+          description: A message associated with the state of a connection
+        runtime:
+          type: string
+          description: A object status field.
+          enum:
+            - STARTED
+            - STOPPED
+        startedAt:
+          type: string
+          format: date-time
+          description: The datetime the object was 'started' in the system.
+        type:
+          type: string
+          description: The type of the object
+    TlsConfiguration:
+      type: object
+      description: tlsConfiguration associated with the bridge
+      nullable: true
+      properties:
+        cipherSuites:
+          type: array
+          description: The cipherSuites from the config
+          items:
+            type: string
+            description: The cipherSuites from the config
+        enabled:
+          type: boolean
+          description: If TLS is used
+        handshakeTimeout:
+          type: integer
+          format: int32
+          description: The handshakeTimeout from the config
+        keystorePassword:
+          type: string
+          description: The keystorePassword from the config
+        keystorePath:
+          type: string
+          description: The keystorePath from the config
+          nullable: true
+        keystoreType:
+          type: string
+          description: The keystoreType from the config
+        privateKeyPassword:
+          type: string
+          description: The privateKeyPassword from the config
+        protocols:
+          type: array
+          description: The protocols from the config
+          items:
+            type: string
+            description: The protocols from the config
+        truststorePassword:
+          type: string
+          description: The truststorePassword from the config
+        truststorePath:
+          type: string
+          description: The truststorePath from the config
+          nullable: true
+        truststoreType:
+          type: string
+          description: The truststoreType from the config
+        verifyHostname:
+          type: boolean
+          default: false
+          description: The verifyHostname from the config
+    WebsocketConfiguration:
+      type: object
+      description: websocketConfiguration associated with the bridge
+      nullable: true
+      properties:
+        enabled:
+          type: boolean
+          default: false
+          description: If Websockets are used
+        serverPath:
+          type: string
+          default: /mqtt
+          description: The server path used by the bridge client. This must be setup as path at the remote broker
+        subProtocol:
+          type: string
+          default: mqtt
+          description: The sub-protocol used by the bridge client. This must be supported by the remote broker
+    Bridge:
+      type: object
+      properties:
+        cleanStart:
+          type: boolean
+          format: boolean
+          default: true
+          description: The cleanStart value associated the the MQTT connection.
+        clientId:
+          type: string
+          format: string
+          description: The client identifier associated the the MQTT connection.
+          example: my-example-client-id
+          maxLength: 65535
+          nullable: true
+        host:
+          type: string
+          description: The host the bridge connects to - a well formed hostname, ipv4 or ipv6 value.
+          maxLength: 255
+        id:
+          type: string
+          format: string
+          description: The bridge id, must be unique and only contain alpha numeric characters with spaces and hyphens.
+          maxLength: 500
+          minLength: 1
+          pattern: ^([a-zA-Z_0-9-_])*$
+        keepAlive:
+          type: integer
+          format: int32
+          default: 240
+          description: The keepAlive associated the the MQTT connection.
+          maximum: 65535
+          minimum: 0
+        localSubscriptions:
+          type: array
+          description: localSubscriptions associated with the bridge
+          items:
+            $ref: '#/components/schemas/LocalBridgeSubscription'
+        loopPreventionEnabled:
+          type: boolean
+          format: boolean
+          default: true
+          description: Is loop prevention enabled on the connection
+        loopPreventionHopCount:
+          type: integer
+          format: int32
+          default: 1
+          description: Loop prevention hop count
+          maximum: 100
+          minimum: 0
+        password:
+          type: string
+          format: string
+          description: The password value associated the the MQTT connection.
+          maxLength: 65535
+          nullable: true
+        persist:
+          type: boolean
+          description: If this flag is set to true, any outgoing mqtt messages with QoS-1 or QoS-2 will be persisted on disc in case disc persistence is active.If this flag is set to false, the QoS of any outgoing mqtt messages will be set to QoS-0 and no traffic will be persisted on disc.
+          nullable: true
+        port:
+          type: integer
+          format: int32
+          description: The port number to connect to
+          maximum: 65535
+          minimum: 1
+        remoteSubscriptions:
+          type: array
+          description: remoteSubscriptions associated with the bridge
+          items:
+            $ref: '#/components/schemas/BridgeSubscription'
+        sessionExpiry:
+          type: integer
+          format: int64
+          default: 3600
+          description: The sessionExpiry associated the the MQTT connection.
+          minimum: 0
+        status:
+          $ref: '#/components/schemas/Status'
+        tlsConfiguration:
+          $ref: '#/components/schemas/TlsConfiguration'
+        username:
+          type: string
+          format: string
+          description: The username value associated the the MQTT connection.
+          maxLength: 65535
+          nullable: true
+        websocketConfiguration:
+          $ref: '#/components/schemas/WebsocketConfiguration'
+      required:
+        - cleanStart
+        - host
+        - id
+        - keepAlive
+        - port
+        - sessionExpiry
+    BridgeList:
+      type: object
+      properties:
+        items:
+          type: array
+          description: List of result items that are returned by this endpoint
+          items:
+            $ref: '#/components/schemas/Bridge'
+      required:
+        - items
+    StatusList:
+      type: object
+      properties:
+        items:
+          type: array
+          description: List of result items that are returned by this endpoint
+          items:
+            $ref: '#/components/schemas/Status'
+      required:
+        - items
+    StatusTransitionCommand:
+      type: object
+      properties:
+        command:
+          type: string
+          description: The command to perform on the target connection.
+          enum:
+            - START
+            - STOP
+            - RESTART
+    StatusTransitionResult:
+      type: object
+      properties:
+        callbackTimeoutMillis:
+          type: integer
+          format: int32
+          description: The callback timeout specifies the minimum amount of time (in milliseconds) that the API advises the client to backoff before rechecking the (runtime or connection) status of this object. This is only applicable when the status is 'PENDING'.
+        identifier:
+          type: string
+          description: The identifier of the object in transition
+        status:
+          type: string
+          description: The status to perform on the target connection.
+          enum:
+            - PENDING
+            - COMPLETE
+        type:
+          type: string
+          description: The type of the object in transition
+    TypeIdentifier:
+      type: object
+      description: The unique id of the event object
+      properties:
+        fullQualifiedIdentifier:
+          type: string
+        identifier:
+          type: string
+          description: The identifier associated with the object, a combination of type and identifier is used to uniquely identify an object in the system
+        type:
+          type: string
+          description: The type of the associated object/entity
+          enum:
+            - BRIDGE
+            - ADAPTER
+            - ADAPTER_TYPE
+            - EVENT
+            - USER
+            - DATA_COMBINING
+            - COMBINER
+            - EDGE
+      required:
+        - type
+    Payload:
+      type: object
+      description: Object to denote the payload of the event
+      properties:
+        content:
+          type: string
+          description: The content of the payload encoded as a string
+        contentType:
+          type: string
+          description: The content type of the payload that the event contains
+          enum:
+            - JSON
+            - PLAIN_TEXT
+            - XML
+            - CSV
+      required:
+        - contentType
+    Event:
+      type: object
+      description: List of result items that are returned by this endpoint
+      properties:
+        associatedObject:
+          $ref: '#/components/schemas/TypeIdentifier'
+        created:
+          type: string
+          format: date-time
+          description: Time the event was in date format
+        identifier:
+          $ref: '#/components/schemas/TypeIdentifier'
+        message:
+          type: string
+          description: The message associated with the event. A message will be no more than 1024 characters in length
+        payload:
+          $ref: '#/components/schemas/Payload'
+        severity:
+          type: string
+          description: The severity that this log is considered to be
+          enum:
+            - INFO
+            - WARN
+            - ERROR
+            - CRITICAL
+        source:
+          $ref: '#/components/schemas/TypeIdentifier'
+        timestamp:
+          type: integer
+          format: int64
+          description: Time the event was generated in epoch format
+      required:
+        - created
+        - identifier
+        - message
+        - severity
+        - timestamp
+    EventList:
+      type: object
+      properties:
+        items:
+          type: array
+          description: List of result items that are returned by this endpoint
+          items:
+            $ref: '#/components/schemas/Event'
+      required:
+        - items
+    Adapter:
+      type: object
+      properties:
+        config:
+          $ref: '#/components/schemas/JsonNode'
+        id:
+          type: string
+          format: string
+          description: The adapter id, must be unique and only contain alpha numeric characters with spaces and hyphens.
+          maxLength: 500
+          minLength: 1
+          pattern: ^([a-zA-Z_0-9-_])*$
+        status:
+          $ref: '#/components/schemas/Status'
+        type:
+          type: string
+          description: The adapter type associated with this instance
+      required:
+        - id
+    QoS:
+      type: string
+      description: The maximum MQTT-QoS for the outgoing messages.
+      enum:
+        - AT_MOST_ONCE
+        - AT_LEAST_ONCE
+        - EXACTLY_ONCE
+      default: EXACTLY_ONCE
+    MqttUserProperty:
+      type: object
+      description: User properties to be added to each outgoing mqtt message.
+      properties:
+        name:
+          type: string
+        value:
+          type: string
+      required:
+        - name
+        - value
+    NorthboundMapping:
+      type: object
+      description: List of result items that are returned by this endpoint
+      properties:
+        includeTagNames:
+          type: boolean
+          description: Should tag names be included when sent out.
+          default: false
+        includeTimestamp:
+          type: boolean
+          description: Should the timestamp be included when sent out.
+          default: false
+        maxQoS:
+          $ref: '#/components/schemas/QoS'
+        messageExpiryInterval:
+          type: integer
+          format: int64
+          description: The message expiry interval.
+          default: 9007199254740991L
+        tagName:
+          type: string
+          format: mqtt-tag
+          description: The tag for which values hould be collected and sent out.
+        topic:
+          type: string
+          description: The target mqtt topic where received tags should be sent to.
+        userProperties:
+          type: array
+          description: User properties to be added to each outgoing mqtt message.
+          items:
+            $ref: '#/components/schemas/MqttUserProperty'
+      required:
+        - tagName
+        - topic
+    DataIdentifierReference:
+      type: object
+      description: A reference to one of the data identifiers (topic filter or tag) in Edge
+      required:
+        - id
+        - type
+      properties:
+        id:
+          type: string
+          description: The name (segmented) of the tag or topic filter
+        type:
+          type: string
+          enum:
+            - TAG
+            - TOPIC_FILTER
+            - PULSE_ASSET
+    Instruction:
+      type: object
+      description: List of instructions to be applied to incoming data
+      properties:
+        sourceRef:
+          $ref: '#/components/schemas/DataIdentifierReference'
+        destination:
+          type: string
+          description: The field in the output object where the data will be written to
+        source:
+          type: string
+          description: The field in the input object where the data will be read from
+      required:
+        - destination
+        - source
+    FieldMapping:
+      type: object
+      description: Defines how incoming data should be transformed before being sent out.
+      properties:
+        instructions:
+          type: array
+          description: List of instructions to be applied to incoming data
+          items:
+            $ref: '#/components/schemas/Instruction'
+      required:
+        - instructions
+    SouthboundMapping:
+      type: object
+      description: List of result items that are returned by this endpoint
+      properties:
+        fieldMapping:
+          $ref: '#/components/schemas/FieldMapping'
+        tagName:
+          type: string
+          format: mqtt-tag
+          description: The tag for which values hould be collected and sent out.
+        topicFilter:
+          type: string
+          description: The filter defining what topics we will receive messages from.
+      required:
+        - tagName
+        - topicFilter
+    DomainTag:
+      type: object
+      description: List of result items that are returned by this endpoint
+      properties:
+        definition:
+          $ref: '#/components/schemas/JsonNode'
+        description:
+          type: string
+          description: A user created description for this tag.
+        name:
+          type: string
+          format: mqtt-tag
+          description: The name of the tag that identifies it within this edge instance.
+      required:
+        - definition
+        - name
+    AdapterConfig:
+      type: object
+      properties:
+        config:
+          $ref: '#/components/schemas/Adapter'
+        northboundMappings:
+          type: array
+          description: The northbound mappings for this adapter
+          items:
+            $ref: '#/components/schemas/NorthboundMapping'
+        southboundMappings:
+          type: array
+          description: The southbound mappings for this adapter
+          items:
+            $ref: '#/components/schemas/SouthboundMapping'
+        tags:
+          type: array
+          description: The tags defined for this adapter
+          items:
+            $ref: '#/components/schemas/DomainTag'
+    AdaptersList:
+      type: object
+      properties:
+        items:
+          type: array
+          description: List of result items that are returned by this endpoint
+          items:
+            $ref: '#/components/schemas/Adapter'
+      required:
+        - items
+    ObjectNode:
+      type: object
+      description: List of result items that are returned by this endpoint
+      properties:
+        children:
+          type: array
+          items:
+            $ref: '#/components/schemas/ObjectNode'
+        description:
+          type: string
+        id:
+          type: string
+        name:
+          type: string
+        nodeType:
+          type: string
+          enum:
+            - FOLDER
+            - OBJECT
+            - VALUE
+        selectable:
+          type: boolean
+        value:
+          type: string
+    ValuesTree:
+      type: object
+      properties:
+        items:
+          type: array
+          description: List of result items that are returned by this endpoint
+          items:
+            $ref: '#/components/schemas/ObjectNode'
+      required:
+        - items
+    NorthboundMappingList:
+      type: object
+      properties:
+        items:
+          type: array
+          description: List of result items that are returned by this endpoint
+          items:
+            $ref: '#/components/schemas/NorthboundMapping'
+      required:
+        - items
+    SouthboundMappingList:
+      type: object
+      properties:
+        items:
+          type: array
+          description: List of result items that are returned by this endpoint
+          items:
+            $ref: '#/components/schemas/SouthboundMapping'
+      required:
+        - items
+    DomainTagList:
+      type: object
+      properties:
+        items:
+          type: array
+          description: List of result items that are returned by this endpoint
+          items:
+            $ref: '#/components/schemas/DomainTag'
+      required:
+        - items
+    NorthboundMappingOwner:
+      allOf:
+        - $ref: '#/components/schemas/NorthboundMapping'
+        - type: object
+          properties:
+            adapterId:
+              type: string
+              description: The id of the adapter owning the tag
+          required:
+            - adapterId
+    NorthboundMappingOwnerList:
+      type: object
+      properties:
+        items:
+          type: array
+          description: List of result items that are returned by this endpoint
+          items:
+            $ref: '#/components/schemas/NorthboundMappingOwner'
+      required:
+        - items
+    SouthboundMappingOwner:
+      allOf:
+        - $ref: '#/components/schemas/SouthboundMapping'
+        - type: object
+          properties:
+            adapterId:
+              type: string
+              description: The id of the adapter owning the tag
+          required:
+            - adapterId
+    SouthboundMappingOwnerList:
+      type: object
+      properties:
+        items:
+          type: array
+          description: List of result items that are returned by this endpoint
+          items:
+            $ref: '#/components/schemas/SouthboundMappingOwner'
+      required:
+        - items
+    TagSchema:
+      type: object
+      properties:
+        configSchema:
+          $ref: '#/components/schemas/JsonNode'
+        protocolId:
+          type: string
+          description: The id assigned to the protocol adapter type
+    DomainTagOwner:
+      allOf:
+        - $ref: '#/components/schemas/DomainTag'
+        - type: object
+          properties:
+            adapterId:
+              type: string
+              description: The id of the adapter owning the tag
+          required:
+            - adapterId
+    DomainTagOwnerList:
+      type: object
+      properties:
+        items:
+          type: array
+          description: List of result items that are returned by this endpoint
+          items:
+            $ref: '#/components/schemas/DomainTagOwner'
+      required:
+        - items
+    ProtocolAdapterCategory:
+      type: object
+      description: The category of the adapter
+      properties:
+        description:
+          type: string
+          format: string
+          description: The description associated with the category.
+        displayName:
+          type: string
+          format: string
+          description: The display name of the category to be used in HCIs.
+          minLength: 1
+        image:
+          type: string
+          format: string
+          description: The image associated with the category.
+        name:
+          type: string
+          format: string
+          description: The unique name of the category to be used in API communication.
+          maxLength: 256
+          minLength: 1
+          pattern: ^[A-Za-z0-9-_](?:[A-Za-z0-9_ -]*[A-Za-z0-9_-])$
+      required:
+        - displayName
+        - name
+    ProtocolAdapter:
+      type: object
+      description: List of result items that are returned by this endpoint
+      properties:
+        author:
+          type: string
+          description: The author of the adapter
+        capabilities:
+          type: array
+          description: The capabilities of this adapter
+          items:
+            type: string
+            description: The capabilities of this adapter
+            enum:
+              - READ
+              - DISCOVER
+              - WRITE
+              - COMBINE
+          uniqueItems: true
+        category:
+          $ref: '#/components/schemas/ProtocolAdapterCategory'
+        configSchema:
+          $ref: '#/components/schemas/JsonNode'
+        description:
+          type: string
+          description: The description
+        id:
+          type: string
+          description: The id assigned to the protocol adapter type
+        installed:
+          type: boolean
+          description: Is the adapter installed?
+        logoUrl:
+          type: string
+          description: The logo of the adapter
+        name:
+          type: string
+          description: The name of the adapter
+        protocol:
+          type: string
+          description: The supported protocol
+        provisioningUrl:
+          type: string
+          description: The provisioning url of the adapter
+        tags:
+          type: array
+          description: The search tags associated with this adapter
+          items:
+            type: string
+            description: The search tags associated with this adapter
+        uiSchema:
+          $ref: '#/components/schemas/JsonNode'
+        url:
+          type: string
+          description: The url of the adapter
+        version:
+          type: string
+          description: The installed version of the adapter
+    ProtocolAdaptersList:
+      type: object
+      properties:
+        items:
+          type: array
+          description: List of result items that are returned by this endpoint
+          items:
+            $ref: '#/components/schemas/ProtocolAdapter'
+      required:
+        - items
+    PayloadSample:
+      type: object
+      description: List of result items that are returned by this endpoint
+      properties:
+        payload:
+          type: string
+          description: The payload of the sample. The bytes are base64 encoded to ensure compatibility even if the payload is a arbitrary byte sequence.
+      required:
+        - payload
+    PayloadSampleList:
+      type: object
+      properties:
+        items:
+          type: array
+          description: List of result items that are returned by this endpoint
+          items:
+            $ref: '#/components/schemas/PayloadSample'
+      required:
+        - items
+    TopicFilter:
+      type: object
+      description: List of result items that are returned by this endpoint
+      properties:
+        description:
+          type: string
+          description: The name for this topic filter.
+        schema:
+          type: string
+          format: data-url
+          description: The optional json schema for this topic filter in the data uri format.
+        topicFilter:
+          type: string
+          format: mqtt-topic-filter
+          description: The topic filter according to the MQTT specification.
+      required:
+        - topicFilter
+    TopicFilterList:
+      type: object
+      properties:
+        items:
+          type: array
+          description: List of result items that are returned by this endpoint
+          items:
+            $ref: '#/components/schemas/TopicFilter'
+      required:
+        - items
+    ISA95ApiBean:
+      type: object
+      properties:
+        area:
+          type: string
+          description: The area
+          nullable: true
+          pattern: ^[a-zA-Z0-9 -_]*$
+        enabled:
+          type: boolean
+          description: Should UNS be available
+        enterprise:
+          type: string
+          description: The enterprise
+          nullable: true
+          pattern: ^[a-zA-Z0-9 -_]*
+        prefixAllTopics:
+          type: boolean
+          description: Should all topics be prefixed with UNS placeholders
+        productionLine:
+          type: string
+          description: The productionLine
+          nullable: true
+          pattern: ^[a-zA-Z0-9 -_]*$
+        site:
+          type: string
+          description: The site
+          nullable: true
+          pattern: ^[a-zA-Z0-9 -_]*$
+        workCell:
+          type: string
+          description: The workCell
+          nullable: true
+          pattern: ^[a-zA-Z0-9 -_]*$
+    Metric:
+      type: object
+      description: List of result items that are returned by this endpoint
+      properties:
+        name:
+          type: string
+          description: The name of the metric
+    MetricList:
+      type: object
+      properties:
+        items:
+          type: array
+          description: List of result items that are returned by this endpoint
+          items:
+            $ref: '#/components/schemas/Metric'
+      required:
+        - items
+    DataPoint:
+      type: object
+      properties:
+        sampleTime:
+          type: string
+          format: date-time
+          description: Time the data-point was generated
+          nullable: true
+        value:
+          type: integer
+          format: int64
+          description: The value of the data point
+    EntityType:
+      type: string
+      description: These are the prime entities owning integration points such as tags and topic filters
+      enum:
+        - ADAPTER
+        - DEVICE
+        - BRIDGE
+        - EDGE_BROKER
+        - PULSE_AGENT
+    EntityReference:
+      type: object
+      description: A reference to one of the main entities in Edge (e.g. device, adapter, edge broker, bridge host)
+      properties:
+        type:
+          $ref: '#/components/schemas/EntityType'
+        id:
+          description: The id of the entity being references in the combiner
+          type: string
+      required:
+        - id
+        - type
+    EntityReferenceList:
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/EntityReference'
+      required:
+        - items
+    DataCombining:
+      type: object
+      description: Define individual rules for data combining, based on the entities selected in the Orchestrator
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: The unique id of the data combining mapping
+        sources:
+          type: object
+          required:
+            - primary
+          properties:
+            primary:
+              $ref: '#/components/schemas/DataIdentifierReference'
+            tags:
+              type: array
+              description: The list of tags (names) used in the data combining
+              items:
+                type: string
+            topicFilters:
+              type: array
+              description: The list of topic filters (names) used in the data combining
+              items:
+                type: string
+        destination:
+          type: object
+          properties:
+            assetId:
+              type: string
+              format: uuid
+              description: The id of a mapped asset containing the topic and schema used for destination of the mapping
+            topic:
+              type: string
+              format: mqtt-topic
+              description: The MQTT topic used for destination of the mapping
+            schema:
+              type: string
+              format: data-url
+              description: The optional json schema for this topic filter in the data uri format.
+        instructions:
+          type: array
+          description: List of instructions to be applied to incoming data
+          items:
+            $ref: '#/components/schemas/Instruction'
+      required:
+        - id
+        - instructions
+        - destination
+        - sources
+    DataCombiningList:
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/DataCombining'
+      required:
+        - items
+    Combiner:
+      type: object
+      description: A data combiner, bringing tags (adapters) and topic filters (bridges) together for further northbound data mapping
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: The unique id of the data combiner
+        name:
+          type: string
+          description: The user-facing name of the combiner
+        description:
+          type: string
+          description: The user-facing description of the combiner
+        sources:
+          $ref: '#/components/schemas/EntityReferenceList'
+        mappings:
+          $ref: '#/components/schemas/DataCombiningList'
+      required:
+        - id
+        - name
+        - sources
+        - mappings
+    CombinerList:
+      type: object
+      description: The list of Combiner defined in this Edge instance
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/Combiner'
+      required:
+        - items
+    PulseActivationToken:
+      type: object
+      properties:
+        token:
+          type: string
+          format: jwt
+          description: The token used to activate the Pulse Client in Edge
+      required:
+        - token
+    PulseStatus:
+      type: object
+      description: Information on the activation status of the pulse agent and its connection to the platform.
+      required:
+        - activation
+        - runtime
+      properties:
+        activation:
+          type: string
+          description: Status of the pulse activation
+          enum:
+            - ACTIVATED
+            - DEACTIVATED
+            - ERROR
+        runtime:
+          type: string
+          description: Connection status of the pulse agent to the platform.
+          enum:
+            - CONNECTED
+            - DISCONNECTED
+            - ERROR
+        message:
+          $ref: '#/components/schemas/ProblemDetails'
+    Asset:
+      type: object
+      description: The definition of an asset as sourced from the Pulse Broker
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: The unique id of the asset
+          example: 123e4567-e89b-12d3-a456-426614174000
+          readOnly: true
+        name:
+          type: string
+          description: The user-facing name of the asset
+          readOnly: true
+          example: The fancy asset
+        description:
+          type: string
+          description: The user-facing description of the asset
+          readOnly: true
+        topic:
+          type: string
+          format: mqtt-topic
+          description: The topic associated with the asset
+          example: a/valid/mqtt/topic
+          readOnly: true
+        schema:
+          type: string
+          format: data-url
+          description: The schema associated with the asset, in a JSON Schema and data uri format.
+          readOnly: true
+          example: data:application/schema+json;base64,eyJ0eXBlIjoiT2JqZWN0IiwiaWQiOiJhc3NldC1zY2hlbWEifQ==
+      required:
+        - id
+        - name
+        - schema
+        - topic
+    AssetMapping:
+      type: object
+      description: The definition of the mapping for a managed asset in Edge
+      properties:
+        status:
+          type: string
+          description: The status of the asset mapping
+          enum:
+            - UNMAPPED
+            - DRAFT
+            - STREAMING
+            - REQUIRES_REMAPPING
+            - MISSING
+          default: UNMAPPED
+        mappingId:
+          type: string
+          format: uuid
+          description: The id of a DataCombining payload that describes the mapping of that particular asset
+      required:
+        - status
+    ManagedAsset:
+      type: object
+      description: The definition of an extended asset, as managed in Edge for the Pulse Client
+      allOf:
+        - $ref: '#/components/schemas/Asset'
+        - type: object
+          properties:
+            mapping:
+              $ref: '#/components/schemas/AssetMapping'
+          required:
+            - mapping
+      example:
+        id: 123e4567-e89b-12d3-a456-426614174000
+        name: The fancy asset
+        topic: a/valid/mqtt/topic
+        schema: data:application/schema+json;base64,eyJ0eXBlIjoiT2JqZWN0IiwiaWQiOiJhc3NldC1zY2hlbWEifQ==
+        mapping:
+          status: STREAMING
+          mappingId: 64a64c9a-1cd6-47b8-bec9-5a869ee824d4
+    ManagedAssetList:
+      type: object
+      description: A list of managed assets, as managed in Edge for the Pulse Client
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/ManagedAsset'
+      required:
+        - items
+  parameters:
+    TopicFilterId:
+      name: filter
+      description: The URL-encoded filter of the topic filter that should be deleted.
+      in: path
+      required: true
+      schema:
+        type: string
+        format: urlencoded
+    CombinerId:
+      name: combinerId
+      description: The unique id of the combiner to retrieve.
+      in: path
+      required: true
+      schema:
+        type: string
+        format: uuid
+    MappingId:
+      name: mappingId
+      description: The unique id of the mapping to retrieve.
+      in: path
+      required: true
+      schema:
+        type: string
+        format: uuid
+    AssetId:
+      name: assetId
+      description: The unique id of the managed asset to retrieve.
+      in: path
+      required: true
+      schema:
+        type: string
+        format: uuid


### PR DESCRIPTION
## Summary
- The `openApiSpecCopy` task in the release workflow produced a header-only stub (19 lines) instead of the full spec (8775 lines) because Java sources were not compiled before the Swagger resolve task ran
- Restores the complete spec with version `2026.5-SNAPSHOT`

## Context
This was caused by the automated release workflow (Phase 1) running `openApiSpecCopy` without a prior compilation step. The release branch `2026.4` has already been fixed with a direct push.