### PR TITLE
EDG-255 Reclaim Tag Ownership from Adapters, v2 - phase 1, introduce GenericTag (Edge)

### DIFF
--- a/hivemq-edge/src/main/java/com/hivemq/protocols/ProtocolAdapterConfigConverter.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/ProtocolAdapterConfigConverter.java
@@ -22,7 +22,6 @@ import com.hivemq.adapter.sdk.api.tag.Tag;
 import com.hivemq.adapter.sdk.api.tag.TagDefinition;
 import com.hivemq.configuration.entity.adapter.NorthboundMappingEntity;
 import com.hivemq.configuration.entity.adapter.ProtocolAdapterEntity;
-import com.hivemq.configuration.entity.adapter.TagEntity;
 import com.hivemq.persistence.domain.DomainTag;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
@@ -56,8 +55,13 @@ public class ProtocolAdapterConfigConverter {
                 entity.getNorthboundMappings().stream()
                         .map(NorthboundMappingEntity::toPersistence)
                         .toList(),
-                factory.convertTagDefinitionObjects(
-                        mapper, entity.getTags().stream().map(TagEntity::toMap).toList()));
+                entity.getTags().stream()
+                        .map(tagEntity -> {
+                            final Tag tag = factory.convertTagDefinitionObject(mapper, tagEntity.toMap());
+                            tag.setScope(entity.getAdapterId());
+                            return tag;
+                        })
+                        .toList());
     }
 
     private @NotNull ProtocolAdapterFactory<?> getProtocolAdapterFactory(final @NotNull String protocolId) {
@@ -70,8 +74,10 @@ public class ProtocolAdapterConfigConverter {
     @SuppressWarnings("TypeParameterUnusedInFormals")
     public @NotNull <T extends Tag> T domainTagToTag(
             final @NotNull String protocolId, final @NotNull DomainTag domainTag) {
+        final Tag tag = getProtocolAdapterFactory(protocolId).convertTagDefinitionObject(mapper, domainTag.toTagMap());
+        tag.setScope(domainTag.getAdapterId());
         //noinspection unchecked
-        return (T) getProtocolAdapterFactory(protocolId).convertTagDefinitionObject(mapper, domainTag.toTagMap());
+        return (T) tag;
     }
 
     public @NotNull JsonNode convertTagDefinitionToJsonNode(final @NotNull TagDefinition tagDefinition) {


### PR DESCRIPTION
# Plan: Introduce GenericTag — Edge reclaims ownership of Tag (v2)

## Motivation

A `Tag` is an Edge concept. It represents a named, described data point as Edge understands it — with a name, a description, and a lifecycle. A `TagDefinition` is the adapter's concern: it is the adapter-specific addressing information needed to locate that data point on a device (e.g. a Modbus register address, an OPC-UA node ID).

**Edge should have complete control over what a tag *is* and how it behaves.** Protocol adapters should only own what is necessary to address a tag on the device — i.e. the `TagDefinition`. Adapters receive `Tag` objects and pass them back to Edge, but they must not define or own the `Tag` implementation.

### Approach

The migration is done in phases. Phases 1 and 2 are **fully compatible** — no existing adapter needs to change. Phase 3 is **incompatible** and cleans up the SDK once all adapters have migrated. Phase 4 **seals** the interface to enforce the invariant permanently.

## Phase 1 — SDK and Edge changes (compatible, no adapter changes required)

### Step 1A — Add `GenericTag` to the SDK

### Step 1B — Add `getScope()` and `setScope()` to the `Tag` interface

### Step 1C — Add `tagDefinitionClass()` to `ProtocolAdapterInformation`

### Step 1D — Update `ProtocolAdapterFactory` default methods

### Step 1E — Set scope in `ProtocolAdapterConfigConverter`

### What Phase 1 does NOT change

- All `XxxTag` classes — untouched
- All `XxxTagDefinition` classes — untouched
- All `XxxProtocolAdapterInformation` classes — untouched
- All adapter constructors and cast sites — untouched
- `TagEntity.java`, `DomainTag.java`, `ProtocolAdapterEntity.java` — untouched

### Observable effect after Phase 1

- All adapters continue to work exactly as before (old-style path in dispatcher)
- `tag.getScope()` returns `""` for all tags (old-style `setScope()` is a no-op)
- `GenericTag` exists in the SDK, ready for adopters