### PR TITLE
EDG-255 Reclaim Tag Ownership from Adapters, v2 - phase 3 (Edge)

### DIFF
--- a/hivemq-edge/src/main/java/com/hivemq/api/resources/impl/ProtocolAdaptersResourceImpl.java
+++ b/hivemq-edge/src/main/java/com/hivemq/api/resources/impl/ProtocolAdaptersResourceImpl.java
@@ -680,12 +680,10 @@ public class ProtocolAdaptersResourceImpl extends AbstractApi implements Protoco
         return protocolAdapterManager
                 .getAdapterTypeById(protocolId)
                 .map(info -> {
-                    final Class<?> schemaClass = info.tagDefinitionClass() != null
-                            ? info.tagDefinitionClass()
-                            : info.tagConfigurationClass();
                     return Response.ok(new TagSchema()
                                     .protocolId(protocolId)
-                                    .configSchema(customConfigSchemaGenerator.generateJsonSchema(schemaClass)))
+                                    .configSchema(
+                                            customConfigSchemaGenerator.generateJsonSchema(info.tagDefinitionClass())))
                             .build();
                 })
                 .orElseGet(() -> {

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/ProtocolAdapterConfigConverter.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/ProtocolAdapterConfigConverter.java
@@ -18,6 +18,7 @@ package com.hivemq.protocols;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hivemq.adapter.sdk.api.factories.ProtocolAdapterFactory;
+import com.hivemq.adapter.sdk.api.tag.GenericTag;
 import com.hivemq.adapter.sdk.api.tag.Tag;
 import com.hivemq.adapter.sdk.api.tag.TagDefinition;
 import com.hivemq.configuration.entity.adapter.NorthboundMappingEntity;
@@ -25,6 +26,8 @@ import com.hivemq.configuration.entity.adapter.ProtocolAdapterEntity;
 import com.hivemq.persistence.domain.DomainTag;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
+import java.util.Map;
+import java.util.Objects;
 import org.jetbrains.annotations.NotNull;
 
 @Singleton
@@ -57,7 +60,12 @@ public class ProtocolAdapterConfigConverter {
                         .toList(),
                 entity.getTags().stream()
                         .map(tagEntity -> {
-                            final Tag tag = factory.convertTagDefinitionObject(mapper, tagEntity.toMap());
+                            final TagDefinition definition =
+                                    factory.convertTagDefinitionObject(mapper, tagEntity.getDefinition());
+                            final GenericTag tag = new GenericTag(
+                                    tagEntity.getName(),
+                                    Objects.requireNonNullElse(tagEntity.getDescription(), ""),
+                                    definition);
                             tag.setScope(entity.getAdapterId());
                             return tag;
                         })
@@ -74,7 +82,10 @@ public class ProtocolAdapterConfigConverter {
     @SuppressWarnings("TypeParameterUnusedInFormals")
     public @NotNull <T extends Tag> T domainTagToTag(
             final @NotNull String protocolId, final @NotNull DomainTag domainTag) {
-        final Tag tag = getProtocolAdapterFactory(protocolId).convertTagDefinitionObject(mapper, domainTag.toTagMap());
+        final ProtocolAdapterFactory<?> factory = getProtocolAdapterFactory(protocolId);
+        final TagDefinition definition =
+                factory.convertTagDefinitionObject(mapper, mapper.convertValue(domainTag.getDefinition(), Map.class));
+        final GenericTag tag = new GenericTag(domainTag.getTagName(), domainTag.getDescription(), definition);
         tag.setScope(domainTag.getAdapterId());
         //noinspection unchecked
         return (T) tag;

--- a/hivemq-edge/src/test/java/com/hivemq/protocols/ProtocolAdapterManagerTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/protocols/ProtocolAdapterManagerTest.java
@@ -37,7 +37,7 @@ import com.hivemq.adapter.sdk.api.model.ProtocolAdapterStartOutput;
 import com.hivemq.adapter.sdk.api.model.ProtocolAdapterStopInput;
 import com.hivemq.adapter.sdk.api.model.ProtocolAdapterStopOutput;
 import com.hivemq.adapter.sdk.api.state.ProtocolAdapterState;
-import com.hivemq.adapter.sdk.api.tag.Tag;
+import com.hivemq.adapter.sdk.api.tag.TagDefinition;
 import com.hivemq.adapter.sdk.api.writing.WritingInput;
 import com.hivemq.adapter.sdk.api.writing.WritingOutput;
 import com.hivemq.adapter.sdk.api.writing.WritingPayload;
@@ -321,8 +321,8 @@ class ProtocolAdapterManagerTest {
         }
 
         @Override
-        public @org.jetbrains.annotations.NotNull Class<? extends Tag> tagConfigurationClass() {
-            return null;
+        public @org.jetbrains.annotations.NotNull Class<? extends TagDefinition> tagDefinitionClass() {
+            return TagDefinition.class;
         }
 
         @Override

--- a/hivemq-edge/src/test/java/com/hivemq/protocols/ProtocolAdapterWrapperShutdownRaceConditionTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/protocols/ProtocolAdapterWrapperShutdownRaceConditionTest.java
@@ -33,7 +33,7 @@ import com.hivemq.adapter.sdk.api.model.ProtocolAdapterStopInput;
 import com.hivemq.adapter.sdk.api.model.ProtocolAdapterStopOutput;
 import com.hivemq.adapter.sdk.api.services.ModuleServices;
 import com.hivemq.adapter.sdk.api.state.ProtocolAdapterState;
-import com.hivemq.adapter.sdk.api.tag.Tag;
+import com.hivemq.adapter.sdk.api.tag.TagDefinition;
 import com.hivemq.adapter.sdk.api.writing.WritingInput;
 import com.hivemq.adapter.sdk.api.writing.WritingOutput;
 import com.hivemq.adapter.sdk.api.writing.WritingPayload;
@@ -348,8 +348,8 @@ class ProtocolAdapterWrapperShutdownRaceConditionTest {
         }
 
         @Override
-        public @NotNull Class<? extends Tag> tagConfigurationClass() {
-            return null;
+        public @NotNull Class<? extends TagDefinition> tagDefinitionClass() {
+            return TagDefinition.class;
         }
 
         @Override

--- a/modules/hivemq-edge-module-http/src/test/java/com/hivemq/edge/adapters/http/config/HttpProtocolAdapterConfigTest.java
+++ b/modules/hivemq-edge-module-http/src/test/java/com/hivemq/edge/adapters/http/config/HttpProtocolAdapterConfigTest.java
@@ -29,7 +29,6 @@ import static org.mockito.Mockito.when;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hivemq.adapter.sdk.api.factories.ProtocolAdapterFactoryInput;
 import com.hivemq.adapter.sdk.api.tag.GenericTag;
-import com.hivemq.adapter.sdk.api.tag.Tag;
 import com.hivemq.configuration.entity.HiveMQConfigEntity;
 import com.hivemq.configuration.entity.adapter.NorthboundMappingEntity;
 import com.hivemq.configuration.entity.adapter.ProtocolAdapterEntity;
@@ -92,9 +91,12 @@ public class HttpProtocolAdapterConfigTest {
         final HttpSpecificAdapterConfig config = (HttpSpecificAdapterConfig)
                 httpProtocolAdapterFactory.convertConfigObject(mapper, adapter.getConfig(), true);
 
-        final List<Map<String, Object>> tagMaps =
-                adapter.getTags().stream().map(tagEntity -> tagEntity.toMap()).collect(Collectors.toList());
-        final List<? extends Tag> tags = httpProtocolAdapterFactory.convertTagDefinitionObjects(mapper, tagMaps);
+        final List<GenericTag> tags = adapter.getTags().stream()
+                .map(tagEntity -> new GenericTag(
+                        tagEntity.getName(),
+                        tagEntity.getDescription() != null ? tagEntity.getDescription() : "",
+                        mapper.convertValue(tagEntity.getDefinition(), HttpTagDefinition.class)))
+                .collect(Collectors.toList());
 
         assertThat(adapter.getAdapterId()).isEqualTo("my-protocol-adapter");
         assertThat(adapter.getProtocolId()).isEqualTo("http");


### PR DESCRIPTION
## Motivation

A `Tag` is an Edge concept. It represents a named, described data point as Edge understands it — with a name, a description, and a lifecycle. A `TagDefinition` is the adapter's concern: it is the adapter-specific addressing information needed to locate that data point on a device (e.g. a Modbus register address, an OPC-UA node ID).

**Edge should have complete control over what a tag *is* and how it behaves.** Protocol adapters should only own what is necessary to address a tag on the device — i.e. the `TagDefinition`. Adapters receive `Tag` objects and pass them back to Edge, but they must not define or own the `Tag` implementation.

### Approach

The migration is done in phases. Phases 1 and 2 are **fully compatible** — no existing adapter needs to change. Phase 3 is **incompatible** and cleans up the SDK once all adapters have migrated. Phase 4 **seals** the interface to enforce the invariant permanently.

## Phase 1 — SDK and Edge changes (compatible, no adapter changes required)

## Phase 2 — Migrate adapters one at a time (compatible, per-adapter)

## Phase 3 — Clean up the SDK (incompatible)

Once all known adapters have migrated:
- Remove tagConfigurationClass() from ProtocolAdapterInformation entirely (or keep as deprecated)
- Remove the old-style dispatch path from ProtocolAdapterFactory.convertTagDefinitionObject
- Remove setScope() from the Tag interface — scope is set by Edge infrastructure, not by implementations. GenericTag retains its internal setScope as package-private or constructor parameter.
- Rename tagDefinitionClass() to tagConfigurationClass() for consistency (with updated return type Class<? extends TagDefinition>)