### PR TITLE
fix(telemetry): cache installation token to prevent per-event regeneration [EDG-280]

### DIFF
--- a/hivemq-edge/src/main/java/com/hivemq/edge/utils/HiveMQEdgeEnvironmentUtils.java
+++ b/hivemq-edge/src/main/java/com/hivemq/edge/utils/HiveMQEdgeEnvironmentUtils.java
@@ -27,22 +27,20 @@ import org.jetbrains.annotations.NotNull;
  */
 public class HiveMQEdgeEnvironmentUtils {
 
-    private static volatile UUID sessionToken;
-    private static Object lock = new Object();
+    private static class InstallationTokenHolder {
+        static final @NotNull String VALUE = getDefaultMachineId();
+    }
+
+    private static class SessionTokenHolder {
+        static final @NotNull String VALUE = UUID.randomUUID().toString();
+    }
 
     public static @NotNull String generateInstallationToken() {
-        return HiveMQEdgeEnvironmentUtils.getDefaultMachineId();
+        return InstallationTokenHolder.VALUE;
     }
 
     public static @NotNull String getSessionToken() {
-        if (sessionToken == null) {
-            synchronized (lock) {
-                if (sessionToken == null) {
-                    sessionToken = UUID.randomUUID();
-                }
-            }
-        }
-        return sessionToken.toString();
+        return SessionTokenHolder.VALUE;
     }
 
     public static @NotNull Map<String, String> generateEnvironmentMap() {

--- a/hivemq-edge/src/test/java/com/hivemq/edge/utils/HiveMQEdgeEnvironmentUtilsTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/edge/utils/HiveMQEdgeEnvironmentUtilsTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.edge.utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+
+class HiveMQEdgeEnvironmentUtilsTest {
+
+    @Test
+    void installationToken_returnsSameValueOnRepeatedCalls() {
+        final String first = HiveMQEdgeEnvironmentUtils.generateInstallationToken();
+        final String second = HiveMQEdgeEnvironmentUtils.generateInstallationToken();
+        final String third = HiveMQEdgeEnvironmentUtils.generateInstallationToken();
+
+        assertNotNull(first);
+        assertFalse(first.isBlank());
+        assertEquals(first, second, "Installation token must be stable across calls");
+        assertEquals(first, third, "Installation token must be stable across calls");
+    }
+
+    @Test
+    void installationToken_stableUnderConcurrentAccess() throws InterruptedException {
+        final int threadCount = 32;
+        final Set<String> tokens = ConcurrentHashMap.newKeySet();
+        final CountDownLatch ready = new CountDownLatch(threadCount);
+        final CountDownLatch go = new CountDownLatch(1);
+        final ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+
+        for (int i = 0; i < threadCount; i++) {
+            executor.submit(() -> {
+                ready.countDown();
+                try {
+                    go.await(5, TimeUnit.SECONDS);
+                } catch (final InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+                tokens.add(HiveMQEdgeEnvironmentUtils.generateInstallationToken());
+            });
+        }
+
+        ready.await(5, TimeUnit.SECONDS);
+        go.countDown();
+        executor.shutdown();
+        executor.awaitTermination(10, TimeUnit.SECONDS);
+
+        assertEquals(1, tokens.size(),
+                "All threads must observe the same installation token, but got " + tokens.size() + " distinct values");
+    }
+
+    @Test
+    void sessionToken_returnsSameValueOnRepeatedCalls() {
+        final String first = HiveMQEdgeEnvironmentUtils.getSessionToken();
+        final String second = HiveMQEdgeEnvironmentUtils.getSessionToken();
+
+        assertNotNull(first);
+        assertFalse(first.isBlank());
+        assertEquals(first, second, "Session token must be stable across calls");
+    }
+}


### PR DESCRIPTION
## Summary

- **Bug**: `generateInstallationToken()` called `MacAddressUtil.defaultMachineId()` on every phone-home event. In environments where Netty can't resolve a real MAC (Docker, cloud VMs), it falls back to random bytes — producing a unique token per event (~every 60s). BigQuery analysis showed 25 pathological sessions generating 97% of all 445K distinct installation tokens.
- **Fix**: Replace uncached call with initialization-on-demand holder pattern, guaranteeing a single computation per JVM lifetime. Apply the same pattern to `sessionToken` for consistency — removes volatile fields, synchronized blocks, and lock object.
- **Test**: New `HiveMQEdgeEnvironmentUtilsTest` with 3 tests: sequential stability, 32-thread concurrent stability, and session token regression.

## Test plan

- [x] `HiveMQEdgeEnvironmentUtilsTest` — 3 new unit tests pass
- [x] `HiveMQEdgeHttpServiceImplTest` — 8 existing phone-home tests pass
- [ ] CI green

EDG-280