### PR TITLE
chore: reduce trigger job build retention from 100 to 10

### DIFF
--- a/CompositeJenkinsfile
+++ b/CompositeJenkinsfile
@@ -4,7 +4,7 @@ pipeline {
     agent { label 'jenkins-worker' }
     options {
         skipDefaultCheckout() // no checkout needed
-        buildDiscarder(logRotator(numToKeepStr: '100'))
+        buildDiscarder(logRotator(numToKeepStr: '10'))
         timestamps()
     }
     stages {

--- a/modules/hivemq-edge-module-opcua/CompositeJenkinsfile
+++ b/modules/hivemq-edge-module-opcua/CompositeJenkinsfile
@@ -4,7 +4,7 @@ pipeline {
     agent { label 'jenkins-worker' }
     options {
         skipDefaultCheckout() // no checkout needed
-        buildDiscarder(logRotator(numToKeepStr: '100'))
+        buildDiscarder(logRotator(numToKeepStr: '10'))
         timestamps()
     }
     stages {


### PR DESCRIPTION
## Summary
- Reduce `numToKeepStr` from `100` to `10` in trigger job `CompositeJenkinsfile` and `modules/hivemq-edge-module-opcua/CompositeJenkinsfile`
- Trigger jobs are lightweight (just kick off the composite build) — 100 builds of history per branch is excessive
- Aligns with the platform standard of 10 builds for trigger jobs

Linear: EDG-285