### PR TITLE
fix: Enhance scope validation for TOPIC_FILTER in useValidateCombiner

### DIFF
--- a/hivemq-edge-frontend/src/modules/Mappings/hooks/useValidateCombiner.spec.ts
+++ b/hivemq-edge-frontend/src/modules/Mappings/hooks/useValidateCombiner.spec.ts
@@ -797,6 +797,45 @@ describe('useValidateCombiner', () => {
 
       expect(errors).toStrictEqual([])
     })
+
+    it('should validate when TOPIC_FILTER scope is undefined (backend omits null fields)', async () => {
+      const result = await loadingEntities(sources)
+
+      const errors = await renderValidateHook(
+        getFormData([
+          {
+            id: uuidv4(),
+            sources: {
+              topicFilters: ['a/topic/+/filter'],
+              primary: {
+                id: 'a/topic/+/filter',
+                type: DataIdentifierReference.type.TOPIC_FILTER,
+                // scope intentionally omitted (undefined) to simulate backend NON_NULL serialization
+              },
+            },
+            destination: {
+              topic: 'test/topic',
+              schema: MOCK_SIMPLE_SCHEMA_URI,
+            },
+            instructions: [
+              {
+                source: 'description',
+                destination: 'value',
+                sourceRef: {
+                  id: 'a/topic/+/filter',
+                  type: DataIdentifierReference.type.TOPIC_FILTER,
+                  // scope intentionally omitted (undefined)
+                },
+              },
+            ],
+          },
+        ]),
+        result.current,
+        sources
+      )
+
+      expect(errors).toStrictEqual([])
+    })
   })
 
   describe('validateInstructions', () => {

--- a/hivemq-edge-frontend/src/modules/Mappings/hooks/useValidateCombiner.ts
+++ b/hivemq-edge-frontend/src/modules/Mappings/hooks/useValidateCombiner.ts
@@ -207,7 +207,7 @@ export const useValidateCombiner = (
         primary.type === DataIdentifierReference.type.TOPIC_FILTER ||
         primary.type === DataIdentifierReference.type.PULSE_ASSET
       ) {
-        if (primary.scope !== null) {
+        if (primary.scope !== null && primary.scope !== undefined) {
           errors.sources?.primary?.addError(
             t('combiner.error.validation.unexpectedScopeForNonTag', {
               type: primary.type,
@@ -239,7 +239,7 @@ export const useValidateCombiner = (
           sourceRef.type === DataIdentifierReference.type.TOPIC_FILTER ||
           sourceRef.type === DataIdentifierReference.type.PULSE_ASSET
         ) {
-          if (sourceRef.scope !== null) {
+          if (sourceRef.scope !== null && sourceRef.scope !== undefined) {
             errors.instructions?.[index]?.addError(
               t('combiner.error.validation.unexpectedScopeForNonTag', {
                 type: sourceRef.type,


### PR DESCRIPTION
  The backend uses Jackson's NON_NULL serialization (CustomJsonProvider),
  which omits the `scope` field entirely when it is null. When the frontend
  deserializes this JSON, the scope property becomes `undefined` (not `null`).

  The combiner validation used strict equality (`scope !== null`) to check
  that TOPIC_FILTER/PULSE_ASSET references have no scope. Since
  `undefined !== null` evaluates to true in JavaScript, backend-loaded
  TOPIC_FILTER references incorrectly triggered the validation error:
  "The TOPIC_FILTER 'f1' should not have a scope field (must be null)"

  Frontend-created data was unaffected because it explicitly sets
  `scope: null`.

  Fix: add explicit `undefined` check alongside the `null` check at both
  validation sites (primary source and instruction sourceRef). Add a
  regression test with scope omitted to simulate backend-loaded data.