### PR TITLE
During shutdown the ProtocolAdapterWrapper could emit errors about data hub, setting the level to WARN fixes that

### DIFF
--- a/hivemq-edge/src/main/java/com/hivemq/protocols/ProtocolAdapterWrapper.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/ProtocolAdapterWrapper.java
@@ -249,7 +249,7 @@ public class ProtocolAdapterWrapper {
                                         .get()) {
                                     log.info("Successfully started adapter with id {}", adapter.getId());
                                 } else {
-                                    log.error(
+                                    log.warn(
                                             "Protocol adapter with id {} start writing failed as data hub is not available.",
                                             adapter.getId());
                                 }


### PR DESCRIPTION
**Motivation**

Reduce flakyness
