### PR TITLE
Use version placeholder in Redocly OpenAPI source

### DIFF
--- a/hivemq-edge-openapi/openapi/openapi.yaml
+++ b/hivemq-edge-openapi/openapi/openapi.yaml
@@ -30,7 +30,7 @@ info:
     imported into popular API tooling (e.g. Postman) or can be used to generate
     client-code for multiple programming languages.
   title: HiveMQ Edge REST API
-  version: 2026.5-SNAPSHOT
+  version: PLACEHOLDER_HIVEMQ_VERSION
   x-logo:
     url: https://www.hivemq.com/img/svg/hivemq-bee.svg
 tags:


### PR DESCRIPTION
## Summary

Change `info.version` in the Redocly OpenAPI source from a hardcoded `2026.5-SNAPSHOT` to `PLACEHOLDER_HIVEMQ_VERSION`.

This enables the composite build's `openApiSpec` task to stamp the correct version from `gradle.properties` during spec bundling. Without this, every version bump would require a manual edit to `openapi.yaml` — the same kind of manual step that has caused spec drift in previous releases.

This is the `hivemq-edge` counterpart of the Swagger-to-Redocly migration in hivemq/hivemq-edge-composite#139.

## Changes

- `hivemq-edge-openapi/openapi/openapi.yaml`: `version: 2026.5-SNAPSHOT` → `version: PLACEHOLDER_HIVEMQ_VERSION`

## Test plan

- [x] `./gradlew openApiSpecCopy` from composite produces spec with `version: 2026.6-SNAPSHOT` (stamped from `gradle.properties`)
- [x] No unresolved `PLACEHOLDER_HIVEMQ_VERSION` in the output spec or HTML docs
- [x] `genJaxRs` + `compileJava` succeed with the stamped spec