### PR TITLE
EDG-217: add frontend UI for Houston device tag browse/import

### DIFF
--- a/hivemq-edge-frontend/src/api/hooks/useHttpClient/useHttpClient.ts
+++ b/hivemq-edge-frontend/src/api/hooks/useHttpClient/useHttpClient.ts
@@ -11,7 +11,7 @@ import type { ApiRequestOptions } from '@/api/__generated__/core/ApiRequestOptio
 import { request as __request } from '@/api/__generated__/core/request.ts'
 import { useAuth } from '@/modules/Auth/hooks/useAuth.ts'
 
-const axiosInstance = axios.create()
+export const axiosInstance = axios.create()
 
 export class AxiosHttpRequestWithInterceptors extends BaseHttpRequest {
   constructor(config: OpenAPIConfig) {

--- a/hivemq-edge-frontend/src/api/hooks/useProtocolAdapters/useBrowseDeviceTags.ts
+++ b/hivemq-edge-frontend/src/api/hooks/useProtocolAdapters/useBrowseDeviceTags.ts
@@ -1,0 +1,36 @@
+import { useMutation } from '@tanstack/react-query'
+import type { ApiError } from '@/api/__generated__'
+import { axiosInstance } from '@/api/hooks/useHttpClient/useHttpClient.ts'
+import { useAuth } from '@/modules/Auth/hooks/useAuth.ts'
+import config from '@/config'
+
+export type BrowseFormat = 'text/csv' | 'application/json' | 'application/yaml'
+
+interface BrowseDeviceTagsProps {
+  adapterId: string
+  format?: BrowseFormat
+  rootId?: string
+  maxDepth?: number
+}
+
+export const useBrowseDeviceTags = () => {
+  const { credentials } = useAuth()
+
+  return useMutation<Blob, ApiError, BrowseDeviceTagsProps>({
+    mutationFn: async ({ adapterId, format = 'text/csv', rootId, maxDepth }) => {
+      const params = new URLSearchParams()
+      if (rootId) params.set('rootId', rootId)
+      if (maxDepth !== undefined) params.set('maxDepth', String(maxDepth))
+      const query = params.toString()
+      const url = `${config.apiBaseUrl}/api/v1/management/protocol-adapters/adapters/${adapterId}/device-tags/browse${query ? `?${query}` : ''}`
+      const response = await axiosInstance.post<Blob>(url, null, {
+        headers: {
+          Accept: format,
+          Authorization: `Bearer ${credentials?.token}`,
+        },
+        responseType: 'blob',
+      })
+      return response.data
+    },
+  })
+}

--- a/hivemq-edge-frontend/src/api/hooks/useProtocolAdapters/useImportDeviceTags.ts
+++ b/hivemq-edge-frontend/src/api/hooks/useProtocolAdapters/useImportDeviceTags.ts
@@ -1,0 +1,38 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import type { ApiError } from '@/api/__generated__'
+import { axiosInstance } from '@/api/hooks/useHttpClient/useHttpClient.ts'
+import { useAuth } from '@/modules/Auth/hooks/useAuth.ts'
+import { QUERY_KEYS } from '@/api/utils.ts'
+import config from '@/config'
+import type { BrowseFormat } from './useBrowseDeviceTags.ts'
+
+export type ImportMode = 'CREATE' | 'DELETE' | 'OVERWRITE' | 'MERGE_SAFE' | 'MERGE_OVERWRITE'
+
+interface ImportDeviceTagsProps {
+  adapterId: string
+  file: File
+  format: BrowseFormat
+  mode?: ImportMode
+}
+
+export const useImportDeviceTags = () => {
+  const { credentials } = useAuth()
+  const queryClient = useQueryClient()
+
+  return useMutation<unknown, ApiError, ImportDeviceTagsProps>({
+    mutationFn: async ({ adapterId, file, format, mode = 'MERGE_SAFE' }) => {
+      const params = new URLSearchParams({ mode })
+      const url = `${config.apiBaseUrl}/api/v1/management/protocol-adapters/adapters/${adapterId}/device-tags/import?${params}`
+      const body = await file.arrayBuffer()
+      return axiosInstance.post(url, body, {
+        headers: {
+          'Content-Type': format,
+          Authorization: `Bearer ${credentials?.token}`,
+        },
+      })
+    },
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.ADAPTERS, variables.adapterId, QUERY_KEYS.DISCOVERY_TAGS] })
+    },
+  })
+}

--- a/hivemq-edge-frontend/src/components/rjsf/ObjectFieldTemplate.tsx
+++ b/hivemq-edge-frontend/src/components/rjsf/ObjectFieldTemplate.tsx
@@ -18,7 +18,7 @@ export const ObjectFieldTemplate = <
 >(
   props: ObjectFieldTemplateProps<T, S, F>
 ) => {
-  const { registry, properties, title, description, uiSchema, required, schema, idSchema } = props
+  const { registry, properties, title, description, uiSchema, required, schema, idSchema, formContext } = props
   const uiOptions = getUiOptions(uiSchema, {})
   const TitleFieldTemplate = getTemplate<'TitleFieldTemplate', T, S, F>('TitleFieldTemplate', registry, uiOptions)
   const DescriptionFieldTemplate = getTemplate<'DescriptionFieldTemplate', T, S, F>(
@@ -27,6 +27,7 @@ export const ObjectFieldTemplate = <
     uiOptions
   )
   const { tabIndex, setTabIndex } = useFormControlStore()
+  const { extraTabs } = (formContext as { extraTabs?: import('@/modules/ProtocolAdapters/types.ts').ExtraTab[] } | undefined) ?? {}
 
   const { tabs } = uiOptions as UIOptionsType & { tabs?: UITab[] }
   if (!tabs) {
@@ -77,6 +78,9 @@ export const ObjectFieldTemplate = <
             </Tab>
           )
         })}
+        {extraTabs?.map((tab) => (
+          <Tab fontSize="md" key={tab.id}>{tab.title}</Tab>
+        ))}
       </TabList>
 
       <TabPanels>
@@ -95,6 +99,11 @@ export const ObjectFieldTemplate = <
             </TabPanel>
           )
         })}
+        {extraTabs?.map((tab) => (
+          <TabPanel key={tab.id} p={0} pt="1px" mb={6}>
+            {tab.content}
+          </TabPanel>
+        ))}
       </TabPanels>
       {properties
         .filter((property) => !allGrouped.includes(property.name))

--- a/hivemq-edge-frontend/src/locales/en/translation.json
+++ b/hivemq-edge-frontend/src/locales/en/translation.json
@@ -418,7 +418,10 @@
     "websocket": {
       "label": "Websockets",
       "description": "Websocket configuration associated with the bridge",
-      "enabled": { "label": "Enabled", "helper": "If Websockets are used" },
+      "enabled": {
+        "label": "Enabled",
+        "helper": "If Websockets are used"
+      },
       "serverPath": {
         "label": "Server Path",
         "helper": "The server path used by the bridge client. This must be setup as path at the remote broker."
@@ -752,18 +755,14 @@
     "capability": {
       "title_DISCOVER": "DISCOVER",
       "description_DISCOVER": "The device supports data point discoverability",
-
       "title_WRITE": "SOUTHBOUND",
       "description_WRITE": "The device supports Southbound mapping (WRITE)",
-
       "title_READ": "NORTHBOUND",
       "description_READ": "The device supports Northbound mapping (READ)",
-
       "title_COMBINE": "COMBINE",
       "description_COMBINE": "The device supports Data combining (COMBINE)"
     }
   },
-
   "articles": {
     "title": "Articles",
     "description": "Some reading for your understanding of HiveMQ Edge",
@@ -1378,7 +1377,6 @@
           "EDGE_NODE": "Edge Broker",
           "COMBINER_NODE": "Combiners",
           "ASSETS_NODE": "Assets",
-
           "CLUSTER_NODE": "Groups"
         }
       },
@@ -2058,13 +2056,37 @@
         }
       }
     },
-
     "workspace": {
       "nodeClient": {
         "status_ACTIVATED": "Activated",
         "status_DEACTIVATED": "Not Activated",
         "title": "Pulse Agent"
       }
+    }
+  },
+  "deviceTagBrowse": {
+    "section": {
+      "browse": "Browse Device Tags",
+      "import": "Import Device Tags"
+    },
+    "field": {
+      "rootId": "Root node ID",
+      "rootId.placeholder": "Optional — leave empty for full browse",
+      "maxDepth": "Max depth",
+      "format": "Format",
+      "file": "File",
+      "importMode": "Import mode"
+    },
+    "action": {
+      "browse": "Browse & Download",
+      "import": "Import"
+    },
+    "success": {
+      "import": "Tags imported successfully"
+    },
+    "error": {
+      "browse": "Failed to browse device tags",
+      "import": "Failed to import device tags"
     }
   }
 }

--- a/hivemq-edge-frontend/src/modules/ProtocolAdapters/components/drawers/AdapterInstanceDrawer.tsx
+++ b/hivemq-edge-frontend/src/modules/ProtocolAdapters/components/drawers/AdapterInstanceDrawer.tsx
@@ -25,9 +25,10 @@ import { useListProtocolAdapters } from '@/api/hooks/useProtocolAdapters/useList
 import LoaderSpinner from '@/components/Chakra/LoaderSpinner.tsx'
 import { customUniqueAdapterValidate } from '@/modules/ProtocolAdapters/utils/validation-utils.ts'
 import { getRequiredUiSchema } from '@/modules/ProtocolAdapters/utils/uiSchema.utils.ts'
-import type { AdapterContext } from '@/modules/ProtocolAdapters/types.ts'
+import type { AdapterContext, ExtraTab } from '@/modules/ProtocolAdapters/types.ts'
 
 import ChakraRJSForm from '@/components/rjsf/Form/ChakraRJSForm.tsx'
+import DeviceTagBrowsePanel from '@/modules/ProtocolAdapters/components/panels/DeviceTagBrowsePanel.tsx'
 import NodeNameCard from '@/modules/Workspace/components/parts/NodeNameCard.tsx'
 import { NodeTypes } from '@/modules/Workspace/types.ts'
 
@@ -54,12 +55,13 @@ const AdapterInstanceDrawer: FC<AdapterInstanceDrawerProps> = ({
   const { data: allAdapters } = useListProtocolAdapters()
   const { adapterId } = useParams()
 
-  const { schema, uiSchema, name, logo, isDiscoverable } = useMemo(() => {
+  const { schema, uiSchema, name, logo, isDiscoverable, isBrowsable } = useMemo(() => {
     const adapter: ProtocolAdapter | undefined = data?.items?.find((e) => e.id === adapterType)
     const { configSchema, uiSchema, capabilities } = adapter || {}
 
     return {
       isDiscoverable: Boolean(capabilities?.includes('DISCOVER')),
+      isBrowsable: adapterType === 'opcua',
       schema: configSchema,
       name: adapter?.name,
       logo: adapter?.logoUrl,
@@ -78,9 +80,15 @@ const AdapterInstanceDrawer: FC<AdapterInstanceDrawerProps> = ({
     if (data.formData) onSubmit(data.formData)
   }
 
+  const extraTabs: ExtraTab[] = isBrowsable && !isNewAdapter && adapterId
+    ? [{ id: 'device-tags', title: 'Device Tags', content: <DeviceTagBrowsePanel adapterId={adapterId} /> }]
+    : []
+
   const context: AdapterContext = {
     isEditAdapter: !isNewAdapter,
     isDiscoverable: isDiscoverable,
+    isBrowsable: isBrowsable,
+    extraTabs,
     adapterType: adapterType,
     adapterId: adapterId,
   }
@@ -113,6 +121,7 @@ const AdapterInstanceDrawer: FC<AdapterInstanceDrawerProps> = ({
                   customValidate={customUniqueAdapterValidate(schema, allAdapters)}
                 />
               )}
+
             </DrawerBody>
 
             <DrawerFooter borderTopWidth="1px">

--- a/hivemq-edge-frontend/src/modules/ProtocolAdapters/components/panels/DeviceTagBrowsePanel.tsx
+++ b/hivemq-edge-frontend/src/modules/ProtocolAdapters/components/panels/DeviceTagBrowsePanel.tsx
@@ -1,0 +1,193 @@
+import type { ChangeEvent, FC } from 'react'
+import { useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import {
+  Button,
+  Divider,
+  Flex,
+  FormControl,
+  FormLabel,
+  Input,
+  Select,
+  Spinner,
+  Text,
+} from '@chakra-ui/react'
+
+import { useEdgeToast } from '@/hooks/useEdgeToast/useEdgeToast.tsx'
+import type { BrowseFormat } from '@/api/hooks/useProtocolAdapters/useBrowseDeviceTags.ts'
+import { useBrowseDeviceTags } from '@/api/hooks/useProtocolAdapters/useBrowseDeviceTags.ts'
+import type { ImportMode } from '@/api/hooks/useProtocolAdapters/useImportDeviceTags.ts'
+import { useImportDeviceTags } from '@/api/hooks/useProtocolAdapters/useImportDeviceTags.ts'
+import { downloadTimeStamp } from '@/utils/download.utils.ts'
+
+interface DeviceTagBrowsePanelProps {
+  adapterId: string
+}
+
+const BROWSE_FORMATS: { value: BrowseFormat; label: string; ext: string }[] = [
+  { value: 'text/csv', label: 'CSV', ext: 'csv' },
+  { value: 'application/json', label: 'JSON', ext: 'json' },
+  { value: 'application/yaml', label: 'YAML', ext: 'yaml' },
+]
+
+const IMPORT_MODES: { value: ImportMode; label: string }[] = [
+  { value: 'MERGE_SAFE', label: 'Merge (safe)' },
+  { value: 'MERGE_OVERWRITE', label: 'Merge (overwrite)' },
+  { value: 'OVERWRITE', label: 'Overwrite' },
+  { value: 'CREATE', label: 'Create only' },
+  { value: 'DELETE', label: 'Delete' },
+]
+
+const DeviceTagBrowsePanel: FC<DeviceTagBrowsePanelProps> = ({ adapterId }) => {
+  const { t } = useTranslation()
+  const { successToast, errorToast } = useEdgeToast()
+
+  const [rootId, setRootId] = useState('')
+  const [maxDepth, setMaxDepth] = useState('')
+  const [browseFormat, setBrowseFormat] = useState<BrowseFormat>('text/csv')
+  const [importMode, setImportMode] = useState<ImportMode>('MERGE_SAFE')
+  const [importFile, setImportFile] = useState<File | null>(null)
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  const { mutate: browse, isPending: isBrowsing } = useBrowseDeviceTags()
+  const { mutate: importTags, isPending: isImporting } = useImportDeviceTags()
+
+  const handleBrowse = () => {
+    const ext = BROWSE_FORMATS.find((f) => f.value === browseFormat)?.ext ?? 'csv'
+    browse(
+      {
+        adapterId,
+        format: browseFormat,
+        rootId: rootId || undefined,
+        maxDepth: maxDepth !== '' ? Number(maxDepth) : undefined,
+      },
+      {
+        onSuccess: (blob) => {
+          const url = URL.createObjectURL(blob)
+          const a = document.createElement('a')
+          a.href = url
+          a.download = `tags-${adapterId}-${downloadTimeStamp()}.${ext}`
+          a.click()
+          URL.revokeObjectURL(url)
+        },
+        onError: (err) => {
+          errorToast({ title: t('deviceTagBrowse.error.browse') }, err)
+        },
+      }
+    )
+  }
+
+  const handleFileChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setImportFile(e.target.files?.[0] ?? null)
+  }
+
+  const handleImport = () => {
+    if (!importFile) return
+    const format = importFile.name.endsWith('.json')
+      ? 'application/json'
+      : importFile.name.endsWith('.yaml') || importFile.name.endsWith('.yml')
+        ? 'application/yaml'
+        : 'text/csv'
+    importTags(
+      { adapterId, file: importFile, format, mode: importMode },
+      {
+        onSuccess: () => {
+          successToast({ title: t('deviceTagBrowse.success.import') })
+          setImportFile(null)
+          if (fileInputRef.current) fileInputRef.current.value = ''
+        },
+        onError: (err) => {
+          errorToast({ title: t('deviceTagBrowse.error.import') }, err)
+        },
+      }
+    )
+  }
+
+  return (
+    <Flex direction="column" gap={4}>
+      <Text fontWeight="semibold">{t('deviceTagBrowse.section.browse')}</Text>
+
+      <Flex gap={3} wrap="wrap">
+        <FormControl flex="1" minW="160px">
+          <FormLabel fontSize="sm">{t('deviceTagBrowse.field.rootId')}</FormLabel>
+          <Input
+            size="sm"
+            placeholder={t('deviceTagBrowse.field.rootId.placeholder')}
+            value={rootId}
+            onChange={(e) => setRootId(e.target.value)}
+          />
+        </FormControl>
+
+        <FormControl w="110px">
+          <FormLabel fontSize="sm">{t('deviceTagBrowse.field.maxDepth')}</FormLabel>
+          <Input
+            size="sm"
+            type="number"
+            min={0}
+            placeholder="0"
+            value={maxDepth}
+            onChange={(e) => setMaxDepth(e.target.value)}
+          />
+        </FormControl>
+
+        <FormControl w="110px">
+          <FormLabel fontSize="sm">{t('deviceTagBrowse.field.format')}</FormLabel>
+          <Select size="sm" value={browseFormat} onChange={(e) => setBrowseFormat(e.target.value as BrowseFormat)}>
+            {BROWSE_FORMATS.map((f) => (
+              <option key={f.value} value={f.value}>
+                {f.label}
+              </option>
+            ))}
+          </Select>
+        </FormControl>
+      </Flex>
+
+      <Button variant="primary" size="sm" onClick={handleBrowse} isDisabled={isBrowsing} alignSelf="flex-start">
+        {isBrowsing ? <Spinner size="xs" mr={2} /> : null}
+        {t('deviceTagBrowse.action.browse')}
+      </Button>
+
+      <Divider />
+
+      <Text fontWeight="semibold">{t('deviceTagBrowse.section.import')}</Text>
+
+      <Flex gap={3} wrap="wrap" align="flex-end">
+        <FormControl flex="1" minW="200px">
+          <FormLabel fontSize="sm">{t('deviceTagBrowse.field.file')}</FormLabel>
+          <Input
+            ref={fileInputRef}
+            size="sm"
+            type="file"
+            accept=".csv,.json,.yaml,.yml"
+            onChange={handleFileChange}
+            sx={{ pt: '4px' }}
+          />
+        </FormControl>
+
+        <FormControl w="160px">
+          <FormLabel fontSize="sm">{t('deviceTagBrowse.field.importMode')}</FormLabel>
+          <Select size="sm" value={importMode} onChange={(e) => setImportMode(e.target.value as ImportMode)}>
+            {IMPORT_MODES.map((m) => (
+              <option key={m.value} value={m.value}>
+                {m.label}
+              </option>
+            ))}
+          </Select>
+        </FormControl>
+      </Flex>
+
+      <Button
+        variant="primary"
+        size="sm"
+        onClick={handleImport}
+        isDisabled={!importFile || isImporting}
+        alignSelf="flex-start"
+      >
+        {isImporting ? <Spinner size="xs" mr={2} /> : null}
+        {t('deviceTagBrowse.action.import')}
+      </Button>
+    </Flex>
+  )
+}
+
+export default DeviceTagBrowsePanel

--- a/hivemq-edge-frontend/src/modules/ProtocolAdapters/types.ts
+++ b/hivemq-edge-frontend/src/modules/ProtocolAdapters/types.ts
@@ -2,7 +2,7 @@ import type { UseFormReturn, FieldValues } from 'react-hook-form'
 import type { IdSchema } from '@rjsf/utils'
 import type { Adapter, ProtocolAdapter } from '@/api/__generated__'
 import type { FlatJSONSchema7 } from '@/components/rjsf/MqttTransformation/utils/json-schema.utils.ts'
-import type { Dispatch, SetStateAction } from 'react'
+import type { Dispatch, ReactNode, SetStateAction } from 'react'
 
 export type SubscriptionType = 'remoteSubscriptions' | 'localSubscriptions'
 
@@ -37,11 +37,19 @@ export interface AdapterNavigateState {
 
 export type AdapterConfig = NonNullable<Adapter['config']>
 
+export interface ExtraTab {
+  id: string
+  title: string
+  content: ReactNode
+}
+
 export interface AdapterContext {
   // TODO[NVL] Is that good enough for ANY form data?
   onBatchUpload?: (idSchema: IdSchema<unknown>, batch: Record<string, unknown>[]) => void
   isEditAdapter: boolean
   isDiscoverable: boolean
+  isBrowsable?: boolean
+  extraTabs?: ExtraTab[]
   adapterType?: string
   adapterId?: string
 }


### PR DESCRIPTION
Adds a "Device Tags" tab to the OPC-UA adapter configuration drawer. The tab contains two sections:
- Browse & Download: calls POST /device-tags/browse and saves the result as a CSV/JSON/YAML file
- Import: uploads a file to POST /device-tags/import with configurable conflict-resolution mode

The tab is shown only when editing an existing OPC-UA adapter (hardcoded adapter type check; can be replaced with a capability flag later).

ObjectFieldTemplate is extended to accept extraTabs from formContext, allowing arbitrary React content to be injected as additional tabs alongside the schema-driven ones.

**Motivation**

Resolves #<issue>

**Changes**
