### PR TITLE
INT-210 Migrate to OCI version catalog plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -200,7 +200,7 @@ oci {
         imageName.set("hivemq/hivemq-edge")
         allPlatforms {
             dependencies {
-                runtime("library:eclipse-temurin:sha256!caca81d76e77890ce54e175f1d121ce3bd70ae56051033c3204618d253c3c814") // 25-jre-noble
+                runtime(ociImages.eclipse.temurin.oci)
             }
             config {
                 user = "10000"

--- a/gradle/oci.versions.toml
+++ b/gradle/oci.versions.toml
@@ -1,0 +1,5 @@
+# https://hub.docker.com/_/eclipse-temurin/tags?name=25-jre-noble
+[[oci]]
+name = "eclipse-temurin"
+image = "library/eclipse-temurin"
+reference = "25-jre-noble@sha256:caca81d76e77890ce54e175f1d121ce3bd70ae56051033c3204618d253c3c814"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,10 +1,14 @@
-rootProject.name = "hivemq-edge-build"
-
 pluginManagement {
     plugins {
         includeBuild("./edge-plugins")
     }
 }
+
+plugins {
+    id("com.hivemq.tools.oci-version-catalog") version "0.2.0"
+}
+
+rootProject.name = "hivemq-edge-build"
 
 includeBuild("./hivemq-edge")
 includeBuild("./hivemq-edge-frontend")


### PR DESCRIPTION
## Summary
- Add `com.hivemq.tools.oci-version-catalog` plugin v0.2.0
- Create `gradle/oci.versions.toml` with Eclipse Temurin 25-jre-noble
- Replace hardcoded `sha256!` digest in `build.gradle.kts` with `ociImages.eclipse.temurin.oci` accessor