### PR TITLE
EDG-463 - fix validation of Edge Broker in Data Combiner creation

### DIFF
--- a/hivemq-edge-frontend/src/modules/Mappings/hooks/useValidateCombiner.spec.ts
+++ b/hivemq-edge-frontend/src/modules/Mappings/hooks/useValidateCombiner.spec.ts
@@ -155,25 +155,20 @@ describe('useValidateCombiner', () => {
 
     it('should fail to validate an adapter without combine but validate the Edge', async () => {
       server.use(...failCapabilityHandlers)
-      const errors = await renderValidateHook({
-        id: mockCombinerId,
-        name: 'my-combiner',
-        sources: {
-          items: [
-            {
-              id: 'the edge name',
-              type: EntityType.EDGE_BROKER,
-            },
-            {
-              id: 'my-adapter',
-              type: EntityType.ADAPTER,
-            },
-          ],
+      const edgeAndAdapter = [
+        { id: 'the edge name', type: EntityType.EDGE_BROKER },
+        { id: 'my-adapter', type: EntityType.ADAPTER },
+      ]
+      const errors = await renderValidateHook(
+        {
+          id: mockCombinerId,
+          name: 'my-combiner',
+          sources: { items: edgeAndAdapter },
+          mappings: { items: [] },
         },
-        mappings: {
-          items: [],
-        },
-      })
+        undefined,
+        edgeAndAdapter
+      )
       expect(errors).toStrictEqual([
         expect.objectContaining({
           message: 'The adapter does not support data combining and cannot be used as a source',
@@ -182,25 +177,20 @@ describe('useValidateCombiner', () => {
     })
 
     it('should validate properly', async () => {
-      const errors = await renderValidateHook({
-        id: mockCombinerId,
-        name: 'my-combiner',
-        sources: {
-          items: [
-            {
-              id: 'the edge name',
-              type: EntityType.EDGE_BROKER,
-            },
-            {
-              id: 'opcua-1',
-              type: EntityType.ADAPTER,
-            },
-          ],
+      const edgeAndAdapter = [
+        { id: 'the edge name', type: EntityType.EDGE_BROKER },
+        { id: 'opcua-1', type: EntityType.ADAPTER },
+      ]
+      const errors = await renderValidateHook(
+        {
+          id: mockCombinerId,
+          name: 'my-combiner',
+          sources: { items: edgeAndAdapter },
+          mappings: { items: [] },
         },
-        mappings: {
-          items: [],
-        },
-      })
+        undefined,
+        edgeAndAdapter
+      )
       expect(errors).toStrictEqual([])
     })
   })
@@ -228,7 +218,7 @@ describe('useValidateCombiner', () => {
     })
 
     it('should validate an empty list of mappings', async () => {
-      const errors = await renderValidateHook(getFormData([]))
+      const errors = await renderValidateHook(getFormData([]), undefined, sources)
       expect(errors).toStrictEqual([])
     })
 
@@ -246,7 +236,9 @@ describe('useValidateCombiner', () => {
             destination: {},
             instructions: [],
           },
-        ])
+        ]),
+        undefined,
+        sources
       )
       expect(errors).toStrictEqual([
         expect.objectContaining({

--- a/hivemq-edge-frontend/src/modules/Mappings/hooks/useValidateCombiner.ts
+++ b/hivemq-edge-frontend/src/modules/Mappings/hooks/useValidateCombiner.ts
@@ -133,14 +133,14 @@ export const useValidateCombiner = (
         }
       })
 
-      const hasEdge = formData?.sources.items?.filter((e) => e.type === EntityType.EDGE_BROKER)
+      const hasEdge = entities.filter((e) => e.type === EntityType.EDGE_BROKER)
       if (!hasEdge || hasEdge.length !== 1) {
         errors.sources?.items?.addError(t('combiner.error.validation.notEdgeSource'))
       }
 
       return errors
     },
-    [hasAdapterCapability, t]
+    [hasAdapterCapability, t, entities]
   )
 
   /**


### PR DESCRIPTION
## Summary

- Fixes a regression introduced by the tag scoping epic (PR #1434) that made it impossible to create a Data Combiner through the "Create New > Combiner" wizard
- The validation in `useValidateCombiner.ts` was checking `formData.sources.items` for the presence of EDGE_BROKER, which relied on a mutation side-effect that PR #1434 correctly removed
- Fix: check `entities` (the hook parameter) instead, which always contains EDGE_BROKER regardless of how the form was opened

## Root cause

Before PR #1434, `entities.push(EDGE_BROKER)` mutated `selectedNode.data.sources.items` in-place, so `formData.sources.items` accidentally contained EDGE_BROKER. After the fix (new array returned), the mutation was gone and validation broke.

## Test plan

- [ ] Open the frontend and click "Create New > Combiner" — select one OPC-UA adapter, proceed through the wizard, verify the form submits successfully (no "Edge broker must be connected" error)
- [ ] Verify the canvas multi-select flow (select adapter + Edge Broker node, click combiner icon) still works as before