### PR TITLE
feat(EDG-471): improve Data Combiner source entity selection UX

### DIFF
--- a/hivemq-edge-frontend/src/locales/en/translation.json
+++ b/hivemq-edge-frontend/src/locales/en/translation.json
@@ -1769,6 +1769,7 @@
       },
       "sources": {
         "description": "The list of data sources available for this combiner",
+        "addSource": "Add a source...",
         "table": {
           "action": "Actions",
           "delete": "Delete the source",

--- a/hivemq-edge-frontend/src/modules/Mappings/CombinerMappingManager.tsx
+++ b/hivemq-edge-frontend/src/modules/Mappings/CombinerMappingManager.tsx
@@ -152,10 +152,17 @@ const CombinerMappingManager: FC<CombinerMappingManagerProps> = ({ wizardContext
 
   const entities = useMemo(() => liveSources, [liveSources])
 
-  // Stable formData reference: keyed to the combiner ID so RJSF's internal state is
-  // never reset by re-renders (e.g. React Flow recreating node objects for position updates).
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const initialFormData = useMemo(() => selectedNode.data, [combinerId])
+  // Controlled form data: kept in sync with RJSF's internal state via onChange.
+  // This prevents RJSF from resetting when formContext changes (e.g. when entity queries resolve
+  // after a source is added). RJSF's getSnapshotBeforeUpdate fires on ANY prop change and calls
+  // getStateFromProps(this.props.formData). If formData prop lags behind internal state, the reset
+  // produces a different nextState and wipes user edits. By keeping them in sync, nextState ≈
+  // prevState, so shouldUpdate = false and no visible reset occurs.
+  const [currentFormData, setCurrentFormData] = useState(() => selectedNode.data)
+
+  const handleFormChange = useCallback((e: IChangeEvent) => {
+    if (e.formData) setCurrentFormData(e.formData)
+  }, [])
 
   const isAssetManager = useMemo(() => {
     return entities?.some((e) => e.type === EntityType.PULSE_AGENT)
@@ -388,7 +395,8 @@ const CombinerMappingManager: FC<CombinerMappingManagerProps> = ({ wizardContext
             id="combiner-main-form"
             schema={combinerMappingJsonSchema}
             uiSchema={combinerMappingUiSchema(isAssetManager, tabId)}
-            formData={initialFormData}
+            formData={currentFormData}
+            onChange={handleFormChange}
             onSubmit={handleOnSubmit}
             formContext={formContext}
             customValidate={validator?.validateCombiner}

--- a/hivemq-edge-frontend/src/modules/Mappings/CombinerMappingManager.tsx
+++ b/hivemq-edge-frontend/src/modules/Mappings/CombinerMappingManager.tsx
@@ -150,16 +150,14 @@ const CombinerMappingManager: FC<CombinerMappingManagerProps> = ({ wizardContext
 
   const sources = useGetCombinedEntities(entities)
 
+  // All workspace entities that could be added as sources.
+  // Filtering against what's already selected happens inside EntityReferenceTableWidget
+  // based on props.value (live RJSF state), so the dropdown stays reactive on add/delete.
   const availableEntities = useMemo((): AvailableEntity[] => {
-    const selectedIds = new Set(entities.map((e) => e.id))
     return nodes
       .filter((n) =>
         [NodeTypes.ADAPTER_NODE, NodeTypes.BRIDGE_NODE, NodeTypes.EDGE_NODE].includes(n.type as NodeTypes)
       )
-      .filter((n) => {
-        const entityId = n.type === NodeTypes.EDGE_NODE ? n.id : (n.data as { id?: string }).id
-        return entityId && !selectedIds.has(entityId)
-      })
       .map((n) => {
         const entityId = n.type === NodeTypes.EDGE_NODE ? n.id : ((n.data as { id?: string }).id ?? n.id)
         const type =
@@ -172,7 +170,7 @@ const CombinerMappingManager: FC<CombinerMappingManagerProps> = ({ wizardContext
           n.type === NodeTypes.EDGE_NODE ? 'HiveMQ Edge' : ((n.data as { name?: string }).name ?? entityId)
         return { id: entityId, type, label }
       })
-  }, [nodes, entities])
+  }, [nodes])
 
   // Build formContext with explicit entity-query pairings
   // NOTE: selectedSources is NOT in the shared context because it's per-mapping, not per-combiner

--- a/hivemq-edge-frontend/src/modules/Mappings/CombinerMappingManager.tsx
+++ b/hivemq-edge-frontend/src/modules/Mappings/CombinerMappingManager.tsx
@@ -24,7 +24,7 @@ import {
   useToast,
 } from '@chakra-ui/react'
 
-import type { Combiner, EntityReferenceList } from '@/api/__generated__'
+import type { Combiner, EntityReference, EntityReferenceList } from '@/api/__generated__'
 import { AssetMapping, EntityType } from '@/api/__generated__'
 import { useDeleteCombiner, useUpdateCombiner } from '@/api/hooks/useCombiners/'
 import { useDeleteAssetMapper, useUpdateAssetMapper } from '@/api/hooks/useAssetMapper'
@@ -36,12 +36,12 @@ import { useUpdateManagedAsset } from '@/api/hooks/usePulse/useUpdateManagedAsse
 import ChakraRJSForm from '@/components/rjsf/Form/ChakraRJSForm'
 import { BASE_TOAST_OPTION } from '@/hooks/useEdgeToast/toast-utils'
 import DangerZone from '@/modules/Mappings/components/DangerZone.tsx'
-import type { CombinerContext } from '@/modules/Mappings/types.ts'
+import type { AvailableEntity, CombinerContext } from '@/modules/Mappings/types.ts'
 import { useValidateCombiner } from '@/modules/Mappings/hooks/useValidateCombiner.ts'
 import { MappingType } from '@/modules/Mappings/types.ts'
 import NodeNameCard from '@/modules/Workspace/components/parts/NodeNameCard.tsx'
 import useWorkspaceStore from '@/modules/Workspace/hooks/useWorkspaceStore.ts'
-import { IdStubs, NodeTypes } from '@/modules/Workspace/types.ts'
+import { NodeTypes } from '@/modules/Workspace/types.ts'
 
 import config from '@/config'
 
@@ -87,18 +87,18 @@ const CombinerMappingManager: FC<CombinerMappingManagerProps> = ({ wizardContext
             if (node.type === NodeTypes.BRIDGE_NODE) return EntityType.BRIDGE
             if (node.type === NodeTypes.DEVICE_NODE) return EntityType.DEVICE
             if (node.type === NodeTypes.PULSE_NODE) return EntityType.PULSE_AGENT
+            if (node.type === NodeTypes.EDGE_NODE) return EntityType.EDGE_BROKER
             return EntityType.EDGE_BROKER
           }
           // Use node.data.id (entity ID), not node.id (React Flow node ID)
-          return { id: node.data.id, type: getType() }
+          // For the EDGE node, the entity ID is the node ID itself (IdStubs.EDGE_NODE)
+          const entityId = node.type === NodeTypes.EDGE_NODE ? node.id : (node.data.id as string)
+          return { id: entityId, type: getType() }
         })
-        .filter((item): item is { id: string; type: EntityType } => item !== null)
+        .filter((item): item is EntityReference => item !== null)
 
-      const hasEdgeBroker = selectedItems.some((e) => e.id === IdStubs.EDGE_NODE && e.type === EntityType.EDGE_BROKER)
       const sources: EntityReferenceList = {
-        items: hasEdgeBroker
-          ? selectedItems
-          : [...selectedItems, { id: IdStubs.EDGE_NODE, type: EntityType.EDGE_BROKER }],
+        items: selectedItems,
       }
 
       if (ghostCombiner) {
@@ -141,15 +141,7 @@ const CombinerMappingManager: FC<CombinerMappingManagerProps> = ({ wizardContext
   }
 
   const entities = useMemo(() => {
-    const sourceItems = selectedNode.data.sources.items || []
-    const isBridgeIn = Boolean(
-      sourceItems.find((entity) => entity.id === IdStubs.EDGE_NODE && entity.type === EntityType.EDGE_BROKER)
-    )
-    // Create new array to avoid mutation
-    if (!isBridgeIn) {
-      return [...sourceItems, { id: IdStubs.EDGE_NODE, type: EntityType.EDGE_BROKER }]
-    }
-    return sourceItems
+    return selectedNode.data.sources.items || []
   }, [selectedNode.data.sources.items])
 
   const isAssetManager = useMemo(() => {
@@ -157,6 +149,30 @@ const CombinerMappingManager: FC<CombinerMappingManagerProps> = ({ wizardContext
   }, [entities])
 
   const sources = useGetCombinedEntities(entities)
+
+  const availableEntities = useMemo((): AvailableEntity[] => {
+    const selectedIds = new Set(entities.map((e) => e.id))
+    return nodes
+      .filter((n) =>
+        [NodeTypes.ADAPTER_NODE, NodeTypes.BRIDGE_NODE, NodeTypes.EDGE_NODE].includes(n.type as NodeTypes)
+      )
+      .filter((n) => {
+        const entityId = n.type === NodeTypes.EDGE_NODE ? n.id : (n.data as { id?: string }).id
+        return entityId && !selectedIds.has(entityId)
+      })
+      .map((n) => {
+        const entityId = n.type === NodeTypes.EDGE_NODE ? n.id : ((n.data as { id?: string }).id ?? n.id)
+        const type =
+          n.type === NodeTypes.ADAPTER_NODE
+            ? EntityType.ADAPTER
+            : n.type === NodeTypes.BRIDGE_NODE
+              ? EntityType.BRIDGE
+              : EntityType.EDGE_BROKER
+        const label =
+          n.type === NodeTypes.EDGE_NODE ? 'HiveMQ Edge' : ((n.data as { name?: string }).name ?? entityId)
+        return { id: entityId, type, label }
+      })
+  }, [nodes, entities])
 
   // Build formContext with explicit entity-query pairings
   // NOTE: selectedSources is NOT in the shared context because it's per-mapping, not per-combiner
@@ -172,10 +188,11 @@ const CombinerMappingManager: FC<CombinerMappingManagerProps> = ({ wizardContext
       // Backward compatibility: keep old fields during migration
       queries: sources,
       entities,
+      availableEntities,
     }
     // Stabilize by checking if sources data has actually changed, not array reference
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [entities, ...sources.map((s) => s.dataUpdatedAt)])
+  }, [entities, availableEntities, ...sources.map((s) => s.dataUpdatedAt)])
 
   const validator = useValidateCombiner(sources, entities)
   // TODO[NVL] Need to split the manager between Combiner and AssetMapper; no need to have so many hooks not in use
@@ -251,7 +268,7 @@ const CombinerMappingManager: FC<CombinerMappingManagerProps> = ({ wizardContext
         name: data.formData.name || wizardContext.combinerName || 'New Combiner',
         description: data.formData.description || '',
         sources: {
-          items: entities,
+          items: data.formData.sources?.items || entities,
         },
         mappings: data.formData.mappings || { items: [] },
       }

--- a/hivemq-edge-frontend/src/modules/Mappings/CombinerMappingManager.tsx
+++ b/hivemq-edge-frontend/src/modules/Mappings/CombinerMappingManager.tsx
@@ -1,4 +1,4 @@
-import { type FC, useEffect, useMemo, useState } from 'react'
+import { type FC, useCallback, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useNavigate, useParams } from 'react-router-dom'
 import type { IChangeEvent } from '@rjsf/core'
@@ -140,18 +140,22 @@ const CombinerMappingManager: FC<CombinerMappingManagerProps> = ({ wizardContext
     throw new Error('Failed to create phantom node for wizard')
   }
 
-  // Track live sources from the form so that adding/removing a source in the Sources tab
-  // immediately updates the entity queries and integration point selectors in the Mapping tab.
+  // Track live sources so that adding/removing a source in the Sources tab
+  // immediately updates entity queries and the Mapping tab's integration point selectors.
+  // This state is updated ONLY via onSourcesChange (called explicitly by EntityReferenceTableWidget)
+  // rather than via form onChange, which would fire on every keystroke and risk resetting the form.
   const [liveSources, setLiveSources] = useState<EntityReference[]>(selectedNode.data.sources.items || [])
 
-  const handleFormChange = (data: IChangeEvent<Combiner>) => {
-    const items = data.formData?.sources?.items
-    if (items) setLiveSources(items)
-  }
+  const onSourcesChange = useCallback((sources: EntityReference[]) => {
+    setLiveSources(sources)
+  }, [])
 
-  const entities = useMemo(() => {
-    return liveSources
-  }, [liveSources])
+  const entities = useMemo(() => liveSources, [liveSources])
+
+  // Stable formData reference: keyed to the combiner ID so RJSF's internal state is
+  // never reset by re-renders (e.g. React Flow recreating node objects for position updates).
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const initialFormData = useMemo(() => selectedNode.data, [combinerId])
 
   const isAssetManager = useMemo(() => {
     return entities?.some((e) => e.type === EntityType.PULSE_AGENT)
@@ -196,6 +200,7 @@ const CombinerMappingManager: FC<CombinerMappingManagerProps> = ({ wizardContext
       queries: sources,
       entities,
       availableEntities,
+      onSourcesChange,
     }
     // Stabilize by checking if sources data has actually changed, not array reference
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -383,8 +388,7 @@ const CombinerMappingManager: FC<CombinerMappingManagerProps> = ({ wizardContext
             id="combiner-main-form"
             schema={combinerMappingJsonSchema}
             uiSchema={combinerMappingUiSchema(isAssetManager, tabId)}
-            formData={selectedNode.data}
-            onChange={handleFormChange}
+            formData={initialFormData}
             onSubmit={handleOnSubmit}
             formContext={formContext}
             customValidate={validator?.validateCombiner}

--- a/hivemq-edge-frontend/src/modules/Mappings/CombinerMappingManager.tsx
+++ b/hivemq-edge-frontend/src/modules/Mappings/CombinerMappingManager.tsx
@@ -1,4 +1,4 @@
-import { type FC, useEffect, useMemo } from 'react'
+import { type FC, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useNavigate, useParams } from 'react-router-dom'
 import type { IChangeEvent } from '@rjsf/core'
@@ -140,9 +140,18 @@ const CombinerMappingManager: FC<CombinerMappingManagerProps> = ({ wizardContext
     throw new Error('Failed to create phantom node for wizard')
   }
 
+  // Track live sources from the form so that adding/removing a source in the Sources tab
+  // immediately updates the entity queries and integration point selectors in the Mapping tab.
+  const [liveSources, setLiveSources] = useState<EntityReference[]>(selectedNode.data.sources.items || [])
+
+  const handleFormChange = (data: IChangeEvent<Combiner>) => {
+    const items = data.formData?.sources?.items
+    if (items) setLiveSources(items)
+  }
+
   const entities = useMemo(() => {
-    return selectedNode.data.sources.items || []
-  }, [selectedNode.data.sources.items])
+    return liveSources
+  }, [liveSources])
 
   const isAssetManager = useMemo(() => {
     return entities?.some((e) => e.type === EntityType.PULSE_AGENT)
@@ -375,6 +384,7 @@ const CombinerMappingManager: FC<CombinerMappingManagerProps> = ({ wizardContext
             schema={combinerMappingJsonSchema}
             uiSchema={combinerMappingUiSchema(isAssetManager, tabId)}
             formData={selectedNode.data}
+            onChange={handleFormChange}
             onSubmit={handleOnSubmit}
             formContext={formContext}
             customValidate={validator?.validateCombiner}

--- a/hivemq-edge-frontend/src/modules/Mappings/combiner/EntityReferenceTableWidget.tsx
+++ b/hivemq-edge-frontend/src/modules/Mappings/combiner/EntityReferenceTableWidget.tsx
@@ -18,12 +18,14 @@ export const EntityReferenceTableWidget = (
 ) => {
   const { t } = useTranslation()
   const { schema } = props
-  const availableEntities: AvailableEntity[] = props.formContext?.availableEntities || []
+  const allEntities: AvailableEntity[] = props.formContext?.availableEntities || []
 
-  const selectOptions = useMemo(
-    () => availableEntities.map((e: AvailableEntity) => ({ value: e, label: e.label })),
-    [availableEntities]
-  )
+  const selectOptions = useMemo(() => {
+    const currentIds = new Set((props.value || []).map((e: EntityReference) => e.id))
+    return allEntities
+      .filter((e: AvailableEntity) => !currentIds.has(e.id))
+      .map((e: AvailableEntity) => ({ value: e, label: e.label }))
+  }, [allEntities, props.value])
 
   const handleAdd = (option: { value: AvailableEntity; label: string } | null) => {
     if (!option) return

--- a/hivemq-edge-frontend/src/modules/Mappings/combiner/EntityReferenceTableWidget.tsx
+++ b/hivemq-edge-frontend/src/modules/Mappings/combiner/EntityReferenceTableWidget.tsx
@@ -30,11 +30,15 @@ export const EntityReferenceTableWidget = (
   const handleAdd = (option: { value: AvailableEntity; label: string } | null) => {
     if (!option) return
     const { id, type } = option.value
-    props.onChange([...(props.value || []), { id, type }])
+    const newSources = [...(props.value || []), { id, type }]
+    props.onChange(newSources)
+    props.formContext?.onSourcesChange?.(newSources)
   }
 
   const handleDelete = (item: EntityReference) => {
-    props.onChange((props.value || []).filter((e: EntityReference) => e.id !== item.id || e.type !== item.type))
+    const newSources = (props.value || []).filter((e: EntityReference) => e.id !== item.id || e.type !== item.type)
+    props.onChange(newSources)
+    props.formContext?.onSourcesChange?.(newSources)
   }
 
   const displayColumns = useMemo<ColumnDef<EntityReference>[]>(() => {

--- a/hivemq-edge-frontend/src/modules/Mappings/combiner/EntityReferenceTableWidget.tsx
+++ b/hivemq-edge-frontend/src/modules/Mappings/combiner/EntityReferenceTableWidget.tsx
@@ -2,18 +2,38 @@ import { useMemo } from 'react'
 import type { RJSFSchema, WidgetProps } from '@rjsf/utils'
 import { useTranslation } from 'react-i18next'
 import type { ColumnDef } from '@tanstack/react-table'
-import { ButtonGroup } from '@chakra-ui/react'
+import { ButtonGroup, HStack } from '@chakra-ui/react'
 import { LuTrash } from 'react-icons/lu'
+import { Select } from 'chakra-react-select'
 
 import type { EntityReference } from '@/api/__generated__'
 import { EntityType } from '@/api/__generated__'
 import IconButton from '@/components/Chakra/IconButton'
 import PaginatedTable from '@/components/PaginatedTable/PaginatedTable'
 import { EntityRenderer } from '@/modules/Mappings/combiner/EntityRenderer.tsx'
+import type { AvailableEntity, CombinerContext } from '@/modules/Mappings/types.ts'
 
-export const EntityReferenceTableWidget = (props: WidgetProps<WidgetProps<Array<EntityReference>, RJSFSchema>>) => {
+export const EntityReferenceTableWidget = (
+  props: WidgetProps<WidgetProps<Array<EntityReference>, RJSFSchema>, RJSFSchema, CombinerContext>
+) => {
   const { t } = useTranslation()
   const { schema } = props
+  const availableEntities: AvailableEntity[] = props.formContext?.availableEntities || []
+
+  const selectOptions = useMemo(
+    () => availableEntities.map((e: AvailableEntity) => ({ value: e, label: e.label })),
+    [availableEntities]
+  )
+
+  const handleAdd = (option: { value: AvailableEntity; label: string } | null) => {
+    if (!option) return
+    const { id, type } = option.value
+    props.onChange([...(props.value || []), { id, type }])
+  }
+
+  const handleDelete = (item: EntityReference) => {
+    props.onChange((props.value || []).filter((e: EntityReference) => e.id !== item.id || e.type !== item.type))
+  }
 
   const displayColumns = useMemo<ColumnDef<EntityReference>[]>(() => {
     return [
@@ -29,15 +49,14 @@ export const EntityReferenceTableWidget = (props: WidgetProps<WidgetProps<Array<
         header: t('combiner.schema.sources.table.action'),
         sortingFn: undefined,
         cell: (info) => {
-          const isPermanent =
-            info.row.original.type === EntityType.PULSE_AGENT || info.row.original.type === EntityType.EDGE_BROKER
+          const isPermanent = info.row.original.type === EntityType.PULSE_AGENT
           return (
             <ButtonGroup isAttached size="sm">
               {!isPermanent && (
                 <IconButton
                   aria-label={t('combiner.schema.sources.table.delete')}
                   icon={<LuTrash />}
-                  isDisabled={true}
+                  onClick={() => handleDelete(info.row.original)}
                 />
               )}
             </ButtonGroup>
@@ -45,17 +64,32 @@ export const EntityReferenceTableWidget = (props: WidgetProps<WidgetProps<Array<
         },
       },
     ]
-  }, [t])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [t, props.value])
 
   if (schema.type !== 'array') throw new Error('[RJSF] Cannot apply the template to the schema')
   return (
-    <PaginatedTable<EntityReference>
-      aria-label={t('combiner.schema.sources.description')}
-      data={props.value}
-      columns={displayColumns}
-      enablePaginationGoTo={false}
-      enablePaginationSizes={false}
-      enableColumnFilters={false}
-    />
+    <>
+      <PaginatedTable<EntityReference>
+        aria-label={t('combiner.schema.sources.description')}
+        data={props.value}
+        columns={displayColumns}
+        enablePaginationGoTo={false}
+        enablePaginationSizes={false}
+        enableColumnFilters={false}
+      />
+      {selectOptions.length > 0 && (
+        <HStack mt={2}>
+          <Select
+            placeholder={t('combiner.schema.sources.addSource', 'Add a source...')}
+            options={selectOptions}
+            onChange={handleAdd}
+            value={null}
+            size="sm"
+            chakraStyles={{ container: (p) => ({ ...p, flex: 1 }) }}
+          />
+        </HStack>
+      )}
+    </>
   )
 }

--- a/hivemq-edge-frontend/src/modules/Mappings/hooks/useValidateCombiner.spec.ts
+++ b/hivemq-edge-frontend/src/modules/Mappings/hooks/useValidateCombiner.spec.ts
@@ -118,9 +118,6 @@ describe('useValidateCombiner', () => {
       })
       expect(errors).toStrictEqual([
         expect.objectContaining({
-          message: "The Edge broker must be connected to the combiner's sources",
-        }),
-        expect.objectContaining({
           message: 'This is not a valid reference to a Workspace entity',
         }),
       ])
@@ -144,9 +141,6 @@ describe('useValidateCombiner', () => {
         },
       })
       expect(errors).toStrictEqual([
-        expect.objectContaining({
-          message: "The Edge broker must be connected to the combiner's sources",
-        }),
         expect.objectContaining({
           message: 'The adapter does not support data combining and cannot be used as a source',
         }),

--- a/hivemq-edge-frontend/src/modules/Mappings/hooks/useValidateCombiner.ts
+++ b/hivemq-edge-frontend/src/modules/Mappings/hooks/useValidateCombiner.ts
@@ -133,14 +133,9 @@ export const useValidateCombiner = (
         }
       })
 
-      const hasEdge = entities.filter((e) => e.type === EntityType.EDGE_BROKER)
-      if (!hasEdge || hasEdge.length !== 1) {
-        errors.sources?.items?.addError(t('combiner.error.validation.notEdgeSource'))
-      }
-
       return errors
     },
-    [hasAdapterCapability, t, entities]
+    [hasAdapterCapability, t]
   )
 
   /**

--- a/hivemq-edge-frontend/src/modules/Mappings/hooks/useValidateCombiner.ts
+++ b/hivemq-edge-frontend/src/modules/Mappings/hooks/useValidateCombiner.ts
@@ -133,14 +133,14 @@ export const useValidateCombiner = (
         }
       })
 
-      const hasEdge = formData?.sources.items?.filter((e) => e.type === EntityType.EDGE_BROKER)
+      const hasEdge = entities.filter((e) => e.type === EntityType.EDGE_BROKER)
       if (!hasEdge || hasEdge.length !== 1) {
         errors.sources?.items?.addError(t('combiner.error.validation.notEdgeSource'))
       }
 
       return errors
     },
-    [hasAdapterCapability, t]
+    [hasAdapterCapability, t, entities]
   )
 
   /**

--- a/hivemq-edge-frontend/src/modules/Mappings/types.ts
+++ b/hivemq-edge-frontend/src/modules/Mappings/types.ts
@@ -119,4 +119,15 @@ export interface CombinerContext {
    * @deprecated Use entityQueries instead. Kept for backward compatibility during migration.
    */
   entities?: EntityReference[]
+
+  /**
+   * All workspace entities that are not yet in the combiner's sources, available to be added.
+   */
+  availableEntities?: AvailableEntity[]
+}
+
+export interface AvailableEntity {
+  id: string
+  type: EntityReference['type']
+  label: string
 }

--- a/hivemq-edge-frontend/src/modules/Mappings/types.ts
+++ b/hivemq-edge-frontend/src/modules/Mappings/types.ts
@@ -124,6 +124,12 @@ export interface CombinerContext {
    * All workspace entities that are not yet in the combiner's sources, available to be added.
    */
   availableEntities?: AvailableEntity[]
+
+  /**
+   * Callback for when the user adds or removes a source entity in the Sources tab.
+   * Updating this triggers a live refresh of entity queries and the Mapping tab's integration point selectors.
+   */
+  onSourcesChange?: (sources: EntityReference[]) => void
 }
 
 export interface AvailableEntity {

--- a/hivemq-edge-frontend/src/modules/Workspace/components/ReactFlowWrapper.tsx
+++ b/hivemq-edge-frontend/src/modules/Workspace/components/ReactFlowWrapper.tsx
@@ -12,7 +12,7 @@ import './reactflow-chakra.fix.css'
 
 import MiniMap from '@/components/react-flow/MiniMap.tsx'
 import SuspenseOutlet from '@/components/SuspenseOutlet.tsx'
-import { EdgeTypes, IdStubs, NodeTypes } from '@/modules/Workspace/types.ts'
+import { EdgeTypes, NodeTypes } from '@/modules/Workspace/types.ts'
 import useGetFlowElements from '@/modules/Workspace/hooks/useGetFlowElements.ts'
 import useWorkspaceStore from '@/modules/Workspace/hooks/useWorkspaceStore.ts'
 import StatusListener from '@/modules/Workspace/components/controls/StatusListener.tsx'
@@ -139,11 +139,10 @@ const ReactFlowWrapper = () => {
 
       // Check if node is selectable based on constraints
       const isGhost = node.data?.isGhost
-      const isEdgeNode = node.id === IdStubs.EDGE_NODE
 
-      if (isGhost || isEdgeNode) {
-        debugLog('🚫 Ghost or edge node - not selectable')
-        return // Can't select ghost or edge nodes
+      if (isGhost) {
+        debugLog('🚫 Ghost node - not selectable')
+        return // Can't select ghost nodes
       }
 
       // GROUP wizard specific: Check if node is already in a group

--- a/hivemq-edge-frontend/src/modules/Workspace/components/nodes/ContextualToolbar.tsx
+++ b/hivemq-edge-frontend/src/modules/Workspace/components/nodes/ContextualToolbar.tsx
@@ -155,9 +155,11 @@ const ContextualToolbar: FC<ContextualToolbarProps> = ({
   const onManageTransformationNode = () => {
     if (!selectedCombinerCandidates) return
 
-    // Include Edge Broker only if the user explicitly selected the Edge node
+    // Include Edge Broker only if the user explicitly selected the Edge node.
+    // Filter it out of the candidates array — it has no data.id and is handled separately via includeEdgeBroker.
     const hasEdgeNode = selectedNodes.some((n) => n.id === IdStubs.EDGE_NODE)
-    const entityReferences = buildEntityReferencesFromNodes(selectedCombinerCandidates, hasEdgeNode)
+    const nonEdgeCandidates = selectedCombinerCandidates.filter((n) => n.id !== IdStubs.EDGE_NODE)
+    const entityReferences = buildEntityReferencesFromNodes(nonEdgeCandidates, hasEdgeNode)
 
     // Check if a combiner with these exact sources already exists
     const existingCombiner = findExistingCombiner(nodes, entityReferences)

--- a/hivemq-edge-frontend/src/modules/Workspace/components/nodes/ContextualToolbar.tsx
+++ b/hivemq-edge-frontend/src/modules/Workspace/components/nodes/ContextualToolbar.tsx
@@ -22,7 +22,7 @@ import { BASE_TOAST_OPTION } from '@/hooks/useEdgeToast/toast-utils'
 import { ANIMATION } from '@/modules/Theme/utils.ts'
 import useWorkspaceStore from '@/modules/Workspace/hooks/useWorkspaceStore.ts'
 import type { NodeAdapterType, NodeDeviceType } from '@/modules/Workspace/types.ts'
-import { NodeTypes } from '@/modules/Workspace/types.ts'
+import { IdStubs, NodeTypes } from '@/modules/Workspace/types.ts'
 import { createGroup, getGroupBounds } from '@/modules/Workspace/utils/group.utils.ts'
 import { gluedNodeDefinition } from '@/modules/Workspace/utils/nodes-utils.ts'
 import { resetSelectedNodesState } from '@/modules/Workspace/utils/react-flow.utils.ts'
@@ -155,8 +155,9 @@ const ContextualToolbar: FC<ContextualToolbarProps> = ({
   const onManageTransformationNode = () => {
     if (!selectedCombinerCandidates) return
 
-    // Build entity references from selected nodes
-    const entityReferences = buildEntityReferencesFromNodes(selectedCombinerCandidates)
+    // Include Edge Broker only if the user explicitly selected the Edge node
+    const hasEdgeNode = selectedNodes.some((n) => n.id === IdStubs.EDGE_NODE)
+    const entityReferences = buildEntityReferencesFromNodes(selectedCombinerCandidates, hasEdgeNode)
 
     // Check if a combiner with these exact sources already exists
     const existingCombiner = findExistingCombiner(nodes, entityReferences)

--- a/hivemq-edge-frontend/src/modules/Workspace/components/wizard/WizardSelectionRestrictions.tsx
+++ b/hivemq-edge-frontend/src/modules/Workspace/components/wizard/WizardSelectionRestrictions.tsx
@@ -6,7 +6,7 @@ import debug from 'debug'
 
 import type { ProtocolAdapter } from '@/api/__generated__'
 import { useWizardState } from '@/modules/Workspace/hooks/useWizardStore'
-import { EdgeTypes, IdStubs, NodeTypes } from '@/modules/Workspace/types'
+import { EdgeTypes, NodeTypes } from '@/modules/Workspace/types'
 import type { SelectionConstraints } from './types'
 import { GHOST_COLOR_EDGE, GHOST_EDGE_STYLE } from './utils/styles'
 import { useProtocolAdaptersContext } from './hooks/useProtocolAdaptersContext'
@@ -24,11 +24,6 @@ const checkConstraints = (
 ): boolean => {
   // Ghost nodes are never selectable
   if (node.data?.isGhost) {
-    return false
-  }
-
-  // EDGE node is never selectable
-  if (node.id === IdStubs.EDGE_NODE) {
     return false
   }
 
@@ -165,23 +160,9 @@ const WizardSelectionRestrictions: FC = () => {
     const constrainedNodes = nodes.map((node): Node => {
       const isAllowed = checkConstraints(node, enhancedConstraints, enhancedConstraints._protocolAdapters)
       const isGhost = node.data?.isGhost
-      const isEdge = node.id === 'EDGE_NODE'
 
       // Ghost nodes: keep visible with ghost styling
       if (isGhost) {
-        return {
-          ...node,
-          hidden: false,
-          selectable: false,
-          style: {
-            ...node.style,
-            cursor: 'default',
-          },
-        }
-      }
-
-      // EDGE node: keep visible but not selectable
-      if (isEdge) {
         return {
           ...node,
           hidden: false,

--- a/hivemq-edge-frontend/src/modules/Workspace/components/wizard/utils/wizardMetadata.spec.ts
+++ b/hivemq-edge-frontend/src/modules/Workspace/components/wizard/utils/wizardMetadata.spec.ts
@@ -105,7 +105,7 @@ describe('wizardMetadata', () => {
       expect(step).toBeDefined()
       expect(step?.requiresSelection).toBe(true)
       expect(step?.selectionConstraints).toBeDefined()
-      expect(step?.selectionConstraints?.minNodes).toBe(2)
+      expect(step?.selectionConstraints?.minNodes).toBe(1)
     })
 
     it('should return step with selection constraints for ASSET_MAPPER', () => {
@@ -237,11 +237,12 @@ describe('wizardMetadata', () => {
       expect(step?.selectionConstraints?.requiresProtocolCapabilities).toContain('COMBINE')
     })
 
-    it('should allow ADAPTER_NODE and BRIDGE_NODE for COMBINER', () => {
+    it('should allow ADAPTER_NODE, BRIDGE_NODE and EDGE_NODE for COMBINER', () => {
       const step = getWizardStep(EntityType.COMBINER, 0)
 
       expect(step?.selectionConstraints?.allowedNodeTypes).toContain('ADAPTER_NODE')
       expect(step?.selectionConstraints?.allowedNodeTypes).toContain('BRIDGE_NODE')
+      expect(step?.selectionConstraints?.allowedNodeTypes).toContain('EDGE_NODE')
     })
 
     it('should allow ADAPTER_NODE and BRIDGE_NODE for ASSET_MAPPER', () => {

--- a/hivemq-edge-frontend/src/modules/Workspace/components/wizard/utils/wizardMetadata.ts
+++ b/hivemq-edge-frontend/src/modules/Workspace/components/wizard/utils/wizardMetadata.ts
@@ -110,8 +110,9 @@ export const WIZARD_REGISTRY: Record<WizardType, WizardMetadata> = {
           // Only allow adapters with COMBINE capability
           // Note: customFilter will be enhanced by WizardSelectionRestrictions with protocol adapter data
           customFilter: (node) => {
-            // Bridges are always allowed
+            // Bridges and Edge Broker are always allowed
             if (node.type === NodeTypes.BRIDGE_NODE) return true
+            if (node.type === NodeTypes.EDGE_NODE) return true
 
             // For adapters, we need to check the protocol definition
             // This will be handled by WizardSelectionRestrictions which has access to protocol adapters

--- a/hivemq-edge-frontend/src/modules/Workspace/components/wizard/utils/wizardMetadata.ts
+++ b/hivemq-edge-frontend/src/modules/Workspace/components/wizard/utils/wizardMetadata.ts
@@ -105,8 +105,8 @@ export const WIZARD_REGISTRY: Record<WizardType, WizardMetadata> = {
         descriptionKey: 'step_COMBINER_0', // "Select data sources"
         requiresSelection: true,
         selectionConstraints: {
-          minNodes: 2,
-          allowedNodeTypes: [NodeTypes.ADAPTER_NODE, NodeTypes.BRIDGE_NODE],
+          minNodes: 1,
+          allowedNodeTypes: [NodeTypes.ADAPTER_NODE, NodeTypes.BRIDGE_NODE, NodeTypes.EDGE_NODE],
           // Only allow adapters with COMBINE capability
           // Note: customFilter will be enhanced by WizardSelectionRestrictions with protocol adapter data
           customFilter: (node) => {

--- a/hivemq-edge-frontend/src/modules/Workspace/utils/toolbar.utils.spec.ts
+++ b/hivemq-edge-frontend/src/modules/Workspace/utils/toolbar.utils.spec.ts
@@ -80,14 +80,14 @@ describe('toolbar.utils', () => {
         expected: true,
       },
       {
-        description: 'other node types',
+        description: 'edge nodes',
         node: {
           id: 'edge-1',
           type: NodeTypes.EDGE_NODE,
           position: { x: 0, y: 0 },
           data: { label: 'Edge' },
         } as Node,
-        expected: false,
+        expected: true,
       },
     ])('should return $expected for $description', ({ node, expected }) => {
       expect(isNodeCombinerCandidate(node)).toBe(expected)
@@ -448,10 +448,10 @@ describe('toolbar.utils', () => {
         description: 'no eligible nodes exist',
         nodes: [
           {
-            id: 'edge-1',
-            type: NodeTypes.EDGE_NODE,
+            id: 'combiner-1',
+            type: NodeTypes.COMBINER_NODE,
             position: { x: 0, y: 0 },
-            data: { label: 'Edge' },
+            data: { label: 'Combiner' },
           },
         ] as Node[],
       },
@@ -494,8 +494,8 @@ describe('toolbar.utils', () => {
 
       const result = filterCombinerCandidates(nodes, adapterTypes)
 
-      expect(result).toHaveLength(2)
-      expect(result?.map((n) => n.id)).toEqual(['adapter-1', 'bridge-1'])
+      expect(result).toHaveLength(3)
+      expect(result?.map((n) => n.id)).toEqual(['adapter-1', 'bridge-1', 'edge-1'])
     })
   })
 

--- a/hivemq-edge-frontend/src/modules/Workspace/utils/toolbar.utils.spec.ts
+++ b/hivemq-edge-frontend/src/modules/Workspace/utils/toolbar.utils.spec.ts
@@ -106,10 +106,7 @@ describe('toolbar.utils', () => {
             data: { id: 'adapter-1', type: 'mqtt' } as Adapter,
           },
         ] as CombinerEligibleNode[],
-        expected: [
-          { type: EntityType.ADAPTER, id: 'adapter-1' },
-          { id: IdStubs.EDGE_NODE, type: EntityType.EDGE_BROKER },
-        ],
+        expected: [{ type: EntityType.ADAPTER, id: 'adapter-1' }],
       },
       {
         description: 'bridge nodes',
@@ -121,10 +118,7 @@ describe('toolbar.utils', () => {
             data: { id: 'bridge-1' } as Bridge,
           },
         ] as CombinerEligibleNode[],
-        expected: [
-          { type: EntityType.BRIDGE, id: 'bridge-1' },
-          { id: IdStubs.EDGE_NODE, type: EntityType.EDGE_BROKER },
-        ],
+        expected: [{ type: EntityType.BRIDGE, id: 'bridge-1' }],
       },
       {
         description: 'pulse nodes',
@@ -136,10 +130,7 @@ describe('toolbar.utils', () => {
             data: { id: 'pulse-1', label: 'Pulse' },
           },
         ] as CombinerEligibleNode[],
-        expected: [
-          { type: EntityType.PULSE_AGENT, id: 'pulse-1' },
-          { id: IdStubs.EDGE_NODE, type: EntityType.EDGE_BROKER },
-        ],
+        expected: [{ type: EntityType.PULSE_AGENT, id: 'pulse-1' }],
       },
     ])('should build entity references from $description', ({ nodes, expected }) => {
       const result = buildEntityReferencesFromNodes(nodes)
@@ -174,15 +165,31 @@ describe('toolbar.utils', () => {
         { type: EntityType.ADAPTER, id: 'adapter-1' },
         { type: EntityType.BRIDGE, id: 'bridge-1' },
         { type: EntityType.PULSE_AGENT, id: 'pulse-1' },
-        { id: IdStubs.EDGE_NODE, type: EntityType.EDGE_BROKER },
       ])
     })
 
-    it('should always include edge broker as last reference', () => {
+    it('should not include edge broker by default', () => {
       const nodes: CombinerEligibleNode[] = []
       const result = buildEntityReferencesFromNodes(nodes)
 
-      expect(result).toEqual([{ id: IdStubs.EDGE_NODE, type: EntityType.EDGE_BROKER }])
+      expect(result).toEqual([])
+    })
+
+    it('should include edge broker as last reference when requested', () => {
+      const nodes: CombinerEligibleNode[] = [
+        {
+          id: 'adapter-1',
+          type: NodeTypes.ADAPTER_NODE,
+          position: { x: 0, y: 0 },
+          data: { id: 'adapter-1', type: 'mqtt' } as Adapter,
+        },
+      ]
+      const result = buildEntityReferencesFromNodes(nodes, true)
+
+      expect(result).toEqual([
+        { type: EntityType.ADAPTER, id: 'adapter-1' },
+        { id: IdStubs.EDGE_NODE, type: EntityType.EDGE_BROKER },
+      ])
     })
   })
 

--- a/hivemq-edge-frontend/src/modules/Workspace/utils/toolbar.utils.ts
+++ b/hivemq-edge-frontend/src/modules/Workspace/utils/toolbar.utils.ts
@@ -25,7 +25,7 @@ export const isNodeCombinerCandidate = (node: Node, adapterTypes?: ProtocolAdapt
     return protocol?.capabilities?.includes('COMBINE') ?? false
   }
 
-  return node.type === NodeTypes.BRIDGE_NODE || node.type === NodeTypes.PULSE_NODE
+  return node.type === NodeTypes.BRIDGE_NODE || node.type === NodeTypes.PULSE_NODE || node.type === NodeTypes.EDGE_NODE
 }
 
 /**

--- a/hivemq-edge-frontend/src/modules/Workspace/utils/toolbar.utils.ts
+++ b/hivemq-edge-frontend/src/modules/Workspace/utils/toolbar.utils.ts
@@ -33,7 +33,10 @@ export const isNodeCombinerCandidate = (node: Node, adapterTypes?: ProtocolAdapt
  * @param nodes - Array of eligible nodes to convert to entity references
  * @returns Array of EntityReference objects with proper types and IDs
  */
-export const buildEntityReferencesFromNodes = (nodes: CombinerEligibleNode[]): EntityReference[] => {
+export const buildEntityReferencesFromNodes = (
+  nodes: CombinerEligibleNode[],
+  includeEdgeBroker = false
+): EntityReference[] => {
   const references = nodes.map<EntityReference>((node) => {
     const getType = () => {
       if (node.type === NodeTypes.ADAPTER_NODE) return EntityType.ADAPTER
@@ -47,8 +50,9 @@ export const buildEntityReferencesFromNodes = (nodes: CombinerEligibleNode[]): E
     }
   })
 
-  // Always add the edge broker as the last reference
-  references.push({ id: IdStubs.EDGE_NODE, type: EntityType.EDGE_BROKER })
+  if (includeEdgeBroker) {
+    references.push({ id: IdStubs.EDGE_NODE, type: EntityType.EDGE_BROKER })
+  }
 
   return references
 }


### PR DESCRIPTION
## Summary

Implements EDG-471: four UX improvements to Data Combiner source entity selection.

- **Allow single-source combiners** — `minNodes` changed from 2 to 1 in wizard metadata; combining tags from a single adapter is valid.
- **Edge Broker selectable everywhere** — removed three separate hard-exclusions (wizard `allowedNodeTypes`/`customFilter`, `ReactFlowWrapper` click handler, `toolbar.utils` candidate filter) so the Edge Broker can be explicitly added as a source in both the wizard and the canvas toolbar.
- **Edge Broker is optional** — removed the mandatory `hasEdge.length !== 1` validation from `useValidateCombiner`; the Edge Broker is only needed when the user wants topic filters as inputs.
- **"Add source" dropdown in Sources tab** — `EntityReferenceTableWidget` now shows a `Select` dropdown that lets users add additional source entities to an existing combiner without a REST call; entities are persisted on Submit.

### Notable implementation detail — RJSF controlled form

The hardest part was preventing sources from disappearing after being added. Root cause: RJSF's `getSnapshotBeforeUpdate` fires on **any** prop change (including `formContext`). It calls `getStateFromProps(this.props.formData)` and if the result differs from the current internal state, it resets the form. Since `formContext` legitimately changes when entity queries resolve after a source is added, the form was silently resetting every time.

Fix: controlled form pattern in `CombinerMappingManager` — `currentFormData` state is kept in sync with RJSF's internal state via `onChange`. When RJSF recomputes `nextState` from the prop, it matches `prevState`, so `shouldUpdate = false` and no reset occurs.

The `onSourcesChange` callback remains the dedicated path for updating `liveSources` (and thus `entityQueries`/`formContext`), kept separate from the full-form-data tracking.

### Out of scope

Point 5 (load-time entity sync) is deferred to EDG-473.

## Test plan

- [ ] Wizard: can select only Edge Broker → combiner created with Edge Broker as sole source
- [ ] Wizard: can select a single adapter (no Edge Broker) → combiner created, no validation error about missing Edge Broker
- [ ] Canvas toolbar: selecting only Edge Broker enables the combiner button
- [ ] Canvas toolbar: clicking combiner button with Edge Broker selected creates a combiner with Edge Broker as source
- [ ] Sources tab: "Add source" dropdown shows only entities not already in the sources list
- [ ] Sources tab: adding a source persists it in the table; it does not disappear after a second
- [ ] Sources tab: removing a source re-adds it to the dropdown
- [ ] Mapping tab: after adding a source in the Sources tab, the integration point selectors reflect the new entity's tags/topic filters
- [ ] Existing combiners: open an existing combiner → no spurious validation error about Edge Broker
- [ ] Submit: saving a combiner correctly persists the updated sources list