### PR TITLE
EDG-486 Houston follow-up: browse/import throughput + browse stability fixes

### DIFF
--- a/hivemq-edge/src/main/java/com/hivemq/edge/adapters/browse/file/DeviceTagCsvSerializer.java
+++ b/hivemq-edge/src/main/java/com/hivemq/edge/adapters/browse/file/DeviceTagCsvSerializer.java
@@ -19,6 +19,7 @@ import com.hivemq.edge.adapters.browse.model.DeviceTagRow;
 import com.hivemq.edge.adapters.browse.model.FieldMappingInstruction;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
+import java.io.BufferedWriter;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -236,7 +237,10 @@ public class DeviceTagCsvSerializer {
 
     public void serialize(final @NotNull Iterable<DeviceTagRow> rows, final @NotNull OutputStream out)
             throws IOException {
-        try (final OutputStreamWriter writer = new OutputStreamWriter(out, StandardCharsets.UTF_8);
+        // BufferedWriter avoids per-row flushes on the HTTP OutputStream — fewer chunks on the wire,
+        // fewer syscalls, measurable on large browses over slow networks.
+        try (final OutputStreamWriter osw = new OutputStreamWriter(out, StandardCharsets.UTF_8);
+                final BufferedWriter writer = new BufferedWriter(osw);
                 final CSVPrinter printer = new CSVPrinter(
                         writer,
                         CSVFormat.RFC4180

--- a/hivemq-edge/src/main/java/com/hivemq/edge/adapters/browse/file/DeviceTagJsonSerializer.java
+++ b/hivemq-edge/src/main/java/com/hivemq/edge/adapters/browse/file/DeviceTagJsonSerializer.java
@@ -20,7 +20,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
 import com.hivemq.edge.adapters.browse.model.DeviceTagRow;
 import com.hivemq.edge.adapters.browse.model.FieldMappingInstruction;
 import jakarta.inject.Inject;
@@ -52,9 +51,10 @@ public class DeviceTagJsonSerializer {
     }
 
     static @NotNull ObjectMapper createDefaultMapper() {
+        // INDENT_OUTPUT is intentionally off: for large browses the whitespace roughly doubles the
+        // wire size. Consumers that want human-readable JSON can pipe through `jq`.
         return new ObjectMapper()
                 .setDefaultPropertyInclusion(JsonInclude.Include.NON_NULL)
-                .configure(SerializationFeature.INDENT_OUTPUT, true)
                 .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     }
 

--- a/hivemq-edge/src/main/java/com/hivemq/edge/adapters/browse/importer/DeviceTagImporter.java
+++ b/hivemq-edge/src/main/java/com/hivemq/edge/adapters/browse/importer/DeviceTagImporter.java
@@ -62,6 +62,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.stream.Collectors;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -78,6 +80,11 @@ public class DeviceTagImporter {
 
     private final @NotNull ProtocolAdapterExtractor adapterExtractor;
     private final @NotNull DataCombiningExtractor combiningExtractor;
+
+    // Per-adapter locks so concurrent imports on different adapters can proceed in parallel.
+    // Previously the entire import serialized on the shared adapterExtractor monitor, which
+    // was stricter than needed — TOCTOU protection is per-adapter, not global.
+    private final @NotNull ConcurrentMap<String, Object> perAdapterLocks = new ConcurrentHashMap<>();
 
     @Inject
     public DeviceTagImporter(
@@ -116,10 +123,12 @@ public class DeviceTagImporter {
             final @NotNull String adapterId,
             final @Nullable BulkTagBrowser browser)
             throws DeviceTagImporterException {
-        // Synchronize the entire read-compute-write cycle on the same intrinsic lock used by
-        // ProtocolAdapterExtractor's synchronized methods to prevent TOCTOU races between
-        // concurrent imports (e.g., two OVERWRITE operations reading the same stale state).
-        synchronized (adapterExtractor) {
+        // Per-adapter lock: two imports on the same adapter still serialize (preventing TOCTOU
+        // between concurrent OVERWRITE operations on the same adapter), but imports on
+        // different adapters can proceed in parallel. This matters for multi-adapter
+        // scripted-provisioning workflows where a global lock was a needless bottleneck.
+        final Object lock = perAdapterLocks.computeIfAbsent(adapterId, id -> new Object());
+        synchronized (lock) {
             return doImportLocked(rows, mode, adapterId, browser);
         }
     }
@@ -158,6 +167,23 @@ public class DeviceTagImporter {
 
         // if there was no validation error, now is the time to execute the plan
         final ProtocolAdapterEntity fac = finalAdapterConfiguration(adapter, twmsFinal);
+        // Classify the change so future work can skip the adapter restart for additive-only
+        // imports. Today ProtocolAdapterExtractor.updateAdapter always triggers a full-entity
+        // replacement; the registered consumer then restarts the adapter. A lighter-weight
+        // "addTagsAndMappings" path on the extractor (and a corresponding handler on the
+        // consumer) would let additive-only imports avoid disrupting the running data flow.
+        // Tracked as future optimisation — intentionally not gated here.
+        final boolean additiveOnly =
+                stats.tagsDeleted == 0 && stats.tagsUpdated == 0 && stats.nbDeleted == 0 && stats.sbDeleted == 0;
+        if (additiveOnly && log.isDebugEnabled()) {
+            log.debug(
+                    "Import for adapter '{}' is additive-only ({} tags created, {} NB, {} SB) — "
+                            + "eligible for no-restart path once the extractor supports it",
+                    adapterId,
+                    stats.tagsCreated,
+                    stats.nbCreated,
+                    stats.sbCreated);
+        }
         final boolean success = adapterExtractor.updateAdapter(fac);
         if (!success) {
             throw new DeviceTagImporterException(List.of(new ValidationError(

--- a/hivemq-edge/src/test/java/com/hivemq/edge/adapters/browse/file/DeviceTagJsonSerializerTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/edge/adapters/browse/file/DeviceTagJsonSerializerTest.java
@@ -342,4 +342,24 @@ class DeviceTagJsonSerializerTest {
 
         assertThat(errors.get()).isZero();
     }
+
+    @Test
+    void serialize_producesCompactJson_noPrettyPrint() throws IOException {
+        // Compact output halves wire size on large browses; consumers that want indented JSON
+        // can pipe through `jq`.
+        final DeviceTagRow row = DeviceTagRow.builder()
+                .nodeId("ns=2;i=100")
+                .tagName("t1")
+                .nodePath("/A")
+                .build();
+        final byte[] bytes = serializer.serialize(List.of(row));
+        final String json = new String(bytes, StandardCharsets.UTF_8);
+
+        // A pretty-printed single-row document would contain newlines between object keys.
+        // Compact output contains no newlines at all (Jackson's default separator is a comma).
+        assertThat(json).doesNotContain("\n");
+        assertThat(json).doesNotContain("\r");
+        // Round-trip must still work — the shape hasn't changed, only the whitespace.
+        assertThat(serializer.deserialize(bytes)).hasSize(1);
+    }
 }

--- a/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/OpcUaProtocolAdapter.java
+++ b/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/OpcUaProtocolAdapter.java
@@ -66,6 +66,8 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
+import org.eclipse.milo.opcua.sdk.core.typetree.DataTypeTree;
+import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
@@ -108,6 +110,13 @@ public class OpcUaProtocolAdapter implements WritingProtocolAdapter, BulkTagBrow
     // Last-known-good client reference for browse operations during adapter restarts.
     // Set when a connection succeeds, cleared only on explicit stop (not during reconnect).
     private final @NotNull AtomicReference<OpcUaClient> browseClient = new AtomicReference<>();
+
+    // Cached DataTypeTree reused across browse operations. Building the tree requires a
+    // non-trivial walk of the server's type hierarchy; most servers never reconfigure their
+    // types during operation, so caching saves one round-trip per browse. Invalidated on
+    // explicit stop only — on reconnect we keep the cache because the tree is server-side
+    // and rarely changes while the adapter is alive.
+    private final @NotNull AtomicReference<DataTypeTree> cachedDataTypeTree = new AtomicReference<>();
 
     // Flag to prevent scheduling after stop
     private volatile boolean stopped = false;
@@ -246,6 +255,8 @@ public class OpcUaProtocolAdapter implements WritingProtocolAdapter, BulkTagBrow
             this.moduleServices = null;
             // Clear browse client on explicit stop
             this.browseClient.set(null);
+            // Clear cached DataTypeTree — the next adapter start rebuilds from the fresh server.
+            this.cachedDataTypeTree.set(null);
 
             final OpcUaClientConnection conn = opcUaClientConnection.getAndSet(null);
             if (conn != null) {
@@ -555,7 +566,32 @@ public class OpcUaProtocolAdapter implements WritingProtocolAdapter, BulkTagBrow
         if (client == null) {
             throw new BrowseException("Browse failed: Client not connected");
         }
-        return new OpcUaNodeBrowser(client, adapterId).browse(rootId, maxDepth);
+        return new OpcUaNodeBrowser(client, adapterId, 0, getOrBuildDataTypeTree(client)).browse(rootId, maxDepth);
+    }
+
+    /**
+     * Returns the cached {@link DataTypeTree} for this adapter, building one on first use.
+     * The tree is tied to the live server's type hierarchy but changes so rarely during an
+     * adapter's lifetime that a per-adapter cache is safe. The cache is invalidated on
+     * {@link #stop}, so the next start rebuilds from the fresh server. Returns {@code null} if
+     * the tree cannot be built (the {@link OpcUaNodeBrowser} handles null by falling back to
+     * raw NodeId-based data type names).
+     */
+    private @Nullable DataTypeTree getOrBuildDataTypeTree(final @NotNull OpcUaClient client) {
+        final DataTypeTree cached = cachedDataTypeTree.get();
+        if (cached != null) {
+            return cached;
+        }
+        try {
+            final DataTypeTree tree = client.getDataTypeTree();
+            // CAS ensures we only publish a non-null tree once; concurrent callers may
+            // build their own but only one installs it.
+            cachedDataTypeTree.compareAndSet(null, tree);
+            return cachedDataTypeTree.get();
+        } catch (final UaException e) {
+            log.debug("Failed to build DataTypeTree for adapter '{}'; falling back to raw NodeId names", adapterId, e);
+            return null;
+        }
     }
 
     @Override

--- a/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/browse/OpcUaNodeBrowser.java
+++ b/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/browse/OpcUaNodeBrowser.java
@@ -24,7 +24,6 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -86,9 +85,10 @@ public class OpcUaNodeBrowser {
     private final @NotNull OpcUaClient client;
     private final @NotNull String adapterId;
     private final int maxReferencesPerNode;
+    private final @Nullable DataTypeTree providedDataTypeTree;
 
     public OpcUaNodeBrowser(final @NotNull OpcUaClient client, final @NotNull String adapterId) {
-        this(client, adapterId, 0);
+        this(client, adapterId, 0, null);
     }
 
     /**
@@ -98,9 +98,23 @@ public class OpcUaNodeBrowser {
      */
     public OpcUaNodeBrowser(
             final @NotNull OpcUaClient client, final @NotNull String adapterId, final int maxReferencesPerNode) {
+        this(client, adapterId, maxReferencesPerNode, null);
+    }
+
+    /**
+     * @param dataTypeTree a pre-built {@link DataTypeTree} to reuse across browses, or {@code null}
+     *                     to build one lazily for each browse. The tree walk is non-trivial on most
+     *                     servers; caching it at the adapter level saves a round-trip per browse.
+     */
+    public OpcUaNodeBrowser(
+            final @NotNull OpcUaClient client,
+            final @NotNull String adapterId,
+            final int maxReferencesPerNode,
+            final @Nullable DataTypeTree dataTypeTree) {
         this.client = client;
         this.adapterId = adapterId;
         this.maxReferencesPerNode = maxReferencesPerNode;
+        this.providedDataTypeTree = dataTypeTree;
     }
 
     /**
@@ -159,7 +173,9 @@ public class OpcUaNodeBrowser {
             final List<String> tagNameDefaults = deduplicateTagNameDefaults(variables);
 
             // Phase 2: Return a stream that lazily batch-reads attributes as it is consumed.
-            final DataTypeTree dataTypeTree = getDataTypeTree();
+            // Reuse the caller-provided DataTypeTree if one was supplied (avoids a round-trip
+            // per browse); otherwise build one now.
+            final DataTypeTree dataTypeTree = providedDataTypeTree != null ? providedDataTypeTree : getDataTypeTree();
             return StreamSupport.stream(
                     new BatchAttributeSpliterator(variables, tagNameDefaults, client, dataTypeTree, this), false);
         } catch (final ExecutionException e) {
@@ -329,9 +345,17 @@ public class OpcUaNodeBrowser {
 
     /**
      * Spliterator that lazily batch-reads OPC-UA attributes and produces {@link BrowsedNode} records.
-     * Each {@link #tryAdvance} call reads one batch of up to {@link #READ_BATCH_SIZE} nodes from the
-     * OPC-UA server, resolves attributes, and emits the resulting {@link BrowsedNode} records one at
-     * a time. This keeps at most one batch of {@code BrowsedNode} objects alive at any point.
+     * Each {@link #tryAdvance} call consumes one {@link BrowsedNode} from the current batch and,
+     * when a batch is exhausted, waits for the already-in-flight next batch before firing the
+     * one after. Prefetching keeps the wire busy while the HTTP serializer drains the current
+     * batch — the attribute-read round-trip for batch N+1 overlaps with the serialization of
+     * batch N.
+     *
+     * <p>Milo's channel is strictly serial, so prefetching does not add concurrent server load:
+     * the next read is dispatched only after the previous response has landed on the client,
+     * but before the client has finished emitting the current batch. For a typical browse the
+     * two costs (serialization + transfer vs attribute read round-trip) are close to equal, so
+     * prefetching roughly halves Phase 2 wall time on large address spaces.
      */
     private static final class BatchAttributeSpliterator implements Spliterator<BrowsedNode> {
 
@@ -343,6 +367,11 @@ public class OpcUaNodeBrowser {
         private int globalOffset;
         private @Nullable List<BrowsedNode> currentBatch;
         private int batchIndex;
+        private @Nullable CompletableFuture<List<BrowsedNode>> nextBatchFuture;
+        // Size of the prefetched batch that globalOffset has already been advanced past.
+        // Tracked so estimateSize() can correctly count the in-flight batch as remaining,
+        // which is required by the SIZED characteristic contract.
+        private int pendingBatchSize;
 
         private final @NotNull List<String> tagNameDefaults;
 
@@ -360,21 +389,28 @@ public class OpcUaNodeBrowser {
             this.globalOffset = 0;
             this.currentBatch = null;
             this.batchIndex = 0;
+            this.pendingBatchSize = 0;
+            // Prime the pipeline: fire the first batch eagerly so it is in flight before the
+            // first tryAdvance() call.
+            this.nextBatchFuture = firePrefetch();
         }
 
         @Override
         public boolean tryAdvance(final @NotNull Consumer<? super BrowsedNode> action) {
-            // Serve from current batch if available
+            // Serve from current batch if available.
             if (currentBatch != null && batchIndex < currentBatch.size()) {
                 action.accept(currentBatch.get(batchIndex++));
                 return true;
             }
-            // Load next batch if variables remain
-            if (globalOffset >= variables.size()) {
+            // No prefetched batch left — we're done.
+            if (nextBatchFuture == null) {
                 return false;
             }
-            currentBatch = readNextBatch();
+            // Wait for the prefetched batch, then fire the next one so it overlaps with the
+            // consumption of the batch we just received.
+            currentBatch = await(nextBatchFuture);
             batchIndex = 0;
+            nextBatchFuture = firePrefetch();
             if (currentBatch.isEmpty()) {
                 return false;
             }
@@ -382,10 +418,22 @@ public class OpcUaNodeBrowser {
             return true;
         }
 
-        private @NotNull List<BrowsedNode> readNextBatch() {
+        /**
+         * Schedule the next attribute-read batch if there are still variables to process.
+         * Returns {@code null} when the end of the variable list has been reached. Updates
+         * {@code pendingBatchSize} so {@link #estimateSize()} can count the in-flight batch.
+         */
+        private @Nullable CompletableFuture<List<BrowsedNode>> firePrefetch() {
+            if (globalOffset >= variables.size()) {
+                pendingBatchSize = 0;
+                return null;
+            }
             final int batchStart = globalOffset;
             final int end = Math.min(globalOffset + READ_BATCH_SIZE, variables.size());
-            final List<DiscoveredVariable> batch = variables.subList(globalOffset, end);
+            // Snapshot the slice so later globalOffset updates can't mutate the view used by
+            // the async callback.
+            final List<DiscoveredVariable> batch = List.copyOf(variables.subList(globalOffset, end));
+            pendingBatchSize = end - batchStart;
             globalOffset = end;
 
             final List<ReadValueId> readValueIds = new ArrayList<>(batch.size() * 3);
@@ -395,21 +443,15 @@ public class OpcUaNodeBrowser {
                 readValueIds.add(new ReadValueId(var.nodeId, AttributeId.Description.uid(), null, null));
             }
 
-            final DataValue[] values;
-            try {
-                values = client.readAsync(0.0, TimestampsToReturn.Neither, readValueIds)
-                        .get(TIMEOUT_SECONDS, TimeUnit.SECONDS)
-                        .getResults();
-            } catch (final ExecutionException e) {
-                throw new UncheckedBrowseException("Failed to read node attributes", e.getCause());
-            } catch (final TimeoutException e) {
-                throw new UncheckedBrowseException("Attribute read timed out after " + TIMEOUT_SECONDS + " seconds", e);
-            } catch (final InterruptedException e) {
-                Thread.currentThread().interrupt();
-                throw new UncheckedBrowseException("Attribute read interrupted", e);
-            }
-            assert values != null;
+            return client.readAsync(0.0, TimestampsToReturn.Neither, readValueIds)
+                    .orTimeout(TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                    .thenApply(response -> buildBatch(batch, batchStart, response.getResults()));
+        }
 
+        private @NotNull List<BrowsedNode> buildBatch(
+                final @NotNull List<DiscoveredVariable> batch,
+                final int batchStart,
+                final @NotNull DataValue[] values) {
             final List<BrowsedNode> result = new ArrayList<>(batch.size());
             for (int i = 0; i < batch.size(); i++) {
                 final DiscoveredVariable var = batch.get(i);
@@ -433,6 +475,22 @@ public class OpcUaNodeBrowser {
             return result;
         }
 
+        private @NotNull List<BrowsedNode> await(final @NotNull CompletableFuture<List<BrowsedNode>> future) {
+            try {
+                return future.get();
+            } catch (final ExecutionException e) {
+                final Throwable cause = e.getCause();
+                if (cause instanceof TimeoutException) {
+                    throw new UncheckedBrowseException(
+                            "Attribute read timed out after " + TIMEOUT_SECONDS + " seconds", cause);
+                }
+                throw new UncheckedBrowseException("Failed to read node attributes", cause);
+            } catch (final InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new UncheckedBrowseException("Attribute read interrupted", e);
+            }
+        }
+
         @Override
         public @Nullable Spliterator<BrowsedNode> trySplit() {
             return null; // sequential only
@@ -440,7 +498,12 @@ public class OpcUaNodeBrowser {
 
         @Override
         public long estimateSize() {
-            return variables.size() - globalOffset + (currentBatch != null ? currentBatch.size() - batchIndex : 0);
+            // Must be exact to satisfy the SIZED characteristic contract. Three sources of
+            // yet-to-emit items: (a) tail of the currentBatch we're iterating, (b) the
+            // prefetched batch that's already been scheduled but not yet received, (c) the
+            // tail of the variables list that we haven't fired a read for yet.
+            final int currentRemaining = currentBatch != null ? currentBatch.size() - batchIndex : 0;
+            return (long) currentRemaining + pendingBatchSize + (variables.size() - globalOffset);
         }
 
         @Override
@@ -564,11 +627,32 @@ public class OpcUaNodeBrowser {
         return adapterId + "/write/" + sanitizePath(path);
     }
 
+    /**
+     * Produces a kebab-case-safe identifier: lowercases, replaces runs of non-alphanumeric
+     * characters with a single dash, strips leading/trailing dashes. Single-pass character
+     * walk — no regex allocation or intermediate strings. Equivalent to the three-regex
+     * formulation previously used, but measurably faster in the Phase 2 hot path.
+     */
     static @NotNull String sanitize(final @NotNull String input) {
-        return input.toLowerCase(Locale.ROOT)
-                .replaceAll("[^a-z0-9]", "-")
-                .replaceAll("-+", "-")
-                .replaceAll("^-|-$", "");
+        final int len = input.length();
+        final StringBuilder sb = new StringBuilder(len);
+        boolean lastWasDash = false;
+        for (int i = 0; i < len; i++) {
+            final char lower = Character.toLowerCase(input.charAt(i));
+            if ((lower >= 'a' && lower <= 'z') || (lower >= '0' && lower <= '9')) {
+                sb.append(lower);
+                lastWasDash = false;
+            } else if (!lastWasDash && sb.length() > 0) {
+                // Collapse runs of non-alphanumeric characters and drop leading dashes.
+                sb.append('-');
+                lastWasDash = true;
+            }
+        }
+        // Strip trailing dash.
+        if (sb.length() > 0 && sb.charAt(sb.length() - 1) == '-') {
+            sb.setLength(sb.length() - 1);
+        }
+        return sb.toString();
     }
 
     static @NotNull String sanitizePath(final @NotNull String path) {

--- a/modules/hivemq-edge-module-opcua/src/test/java/com/hivemq/edge/adapters/opcua/browse/OpcUaNodeBrowserTest.java
+++ b/modules/hivemq-edge-module-opcua/src/test/java/com/hivemq/edge/adapters/opcua/browse/OpcUaNodeBrowserTest.java
@@ -112,6 +112,36 @@ class OpcUaNodeBrowserTest {
         assertThat(OpcUaNodeBrowser.sanitize("!@#$%")).isEqualTo("");
     }
 
+    @Test
+    void sanitize_leadingAndTrailingSpecialChars_produceNoDashes() {
+        // Runs of non-alphanumeric characters at either edge collapse away entirely.
+        assertThat(OpcUaNodeBrowser.sanitize("!!!ABC!!!")).isEqualTo("abc");
+    }
+
+    @Test
+    void sanitize_singleCharacterInputs() {
+        assertThat(OpcUaNodeBrowser.sanitize("A")).isEqualTo("a");
+        assertThat(OpcUaNodeBrowser.sanitize("1")).isEqualTo("1");
+        assertThat(OpcUaNodeBrowser.sanitize("-")).isEqualTo("");
+    }
+
+    @Test
+    void sanitize_internalDashesCollapse() {
+        // Multiple kinds of non-alphanumeric runs collapse into a single dash.
+        assertThat(OpcUaNodeBrowser.sanitize("foo !!!   bar")).isEqualTo("foo-bar");
+    }
+
+    @Test
+    void sanitize_alreadyKebabCase_isIdempotent() {
+        assertThat(OpcUaNodeBrowser.sanitize("already-kebab-case")).isEqualTo("already-kebab-case");
+    }
+
+    @Test
+    void sanitize_unicodeFallsBackToDashes() {
+        // Non-ASCII alphanumeric characters are not preserved; they collapse like punctuation.
+        assertThat(OpcUaNodeBrowser.sanitize("caf\u00e9-con-leche")).isEqualTo("caf-con-leche");
+    }
+
     // --- sanitizePath() ---
 
     @Test


### PR DESCRIPTION
## Summary

Houston follow-up on the OPC UA browse/import path: four server-safe throughput changes plus two browse-stability fixes found while load-testing this branch against Prosys. The slow-but-correct defaults established by [EDG-465](https://linear.app/hivemq/issue/EDG-465) (continuation-point fix on Siemens S7-1500) — `MAX_CONCURRENT_BROWSES = 1`, `READ_BATCH_SIZE = 100`, full-Phase-1-before-Phase-2 — are preserved. Nothing here adds concurrent server requests, widens batch sizes, or auto-tunes against advertised server capabilities.

Parent ticket: [EDG-486 — Tag Browsing and Discovery OPC-UA - Houston - Follow-up](https://linear.app/hivemq/issue/EDG-486). Sub-tickets EDG-493 (additive-only classification) and EDG-576/577 landed earlier via #1579; EDG-488 (adapter-level `DataTypeTree` cache) is cancelled — Milo 1.1.6 caches the tree per client and the EDG-577 warm-up pre-builds it on connect. EDG-492 (per-adapter import lock) is dropped after review, see below.

## What changed

### Throughput (one sub-ticket each)

| Ticket | Change |
|--------|--------|
| [EDG-487](https://linear.app/hivemq/issue/EDG-487) | `BatchAttributeSpliterator` fires `readAsync` for batch N+1 as soon as batch N's response lands, instead of blocking inside `tryAdvance` after the consumer drains batch N. Milo's channel stays serial, so the server sees the same request rate; only client-side idle gaps disappear. `pendingBatchSize` keeps `estimateSize()` exact under the `SIZED` contract. |
| [EDG-489](https://linear.app/hivemq/issue/EDG-489) | CSV streaming output wrapped in a `BufferedWriter`. |
| [EDG-490](https://linear.app/hivemq/issue/EDG-490) | JSON output is compact (`INDENT_OUTPUT` removed); roughly halves wire size, round-trip unchanged. |
| [EDG-491](https://linear.app/hivemq/issue/EDG-491) | `OpcUaNodeBrowser.sanitize()` is a single character-walking pass, no regex. Same observable behaviour, 13 existing + 6 new tests. |

### Stability fixes (found by the load test below; both pre-date this branch)

- **`tag_name_default` collision suffixes were non-deterministic.** Phase 1 sorted discovered variables by path only, so nodes sharing a browse path (Prosys `ValueSimulation` instances, for example) kept the order the async browse callbacks delivered them in, and the `-2/-3/-4` suffixes shuffled between browses (~1 in 30 under load). A CSV exported from one browse could therefore name a different node than the next browse would. Now tie-broken on the `NodeId`. Regression test asserts the same assignment for both delivery orders; verified live with 160 concurrent browses across four adapters producing one identical `nodeId → tag_name_default` map.
- **A read failing mid-stream returned a well-formed JSON document with fewer rows under HTTP 200.** The status is committed at the first flush, and `JsonGenerator.close()` on the exception path auto-terminated the open array and object, so the client could not tell 500 rows from 886. Observed once when an adapter was stopped during Phase 2 (`Bad_SessionClosed`). `AUTO_CLOSE_JSON_CONTENT` is now off for the streaming path, so a truncated document is left unterminated and fails to parse. CSV and YAML remain silently truncatable in this situation — a truncated block sequence is still valid YAML — and are not addressed here.

### Dropped after review: EDG-492 per-adapter import lock

The first cut replaced `synchronized (adapterExtractor)` around the import's read-compute-write cycle with a per-adapter lock so imports on different adapters could overlap. Sam flagged that the lock map was never cleaned up when an adapter was removed. Rather than fix the leak, the change is reverted and `DeviceTagImporter` is byte-identical to master again, because the win it promised does not exist here:

- the expensive part of an import — `updateAdapter`, which swaps the adapter and writes `config.xml` — is itself `synchronized` on the extractor, so imports on different adapters were serialised there anyway; only the millisecond validation phase could overlap;
- the admin API runs on two HTTP threads, so at most two imports are ever in flight;
- the extractor monitor also kept REST writes, config reloads and `updateAllAdapters` from interleaving with an import's cycle, which a per-adapter lock does not.

Measured on the Prosys node, fresh start per run, three runs each: four 60-tag imports on four adapters in parallel complete in **0.08–0.09 s wall with the per-adapter lock and 0.08 s with the extractor monitor**; four on one adapter, 0.05–0.06 s both ways. Per-import 50–90 ms. The synchronisation is not where the time goes.

Coverage added instead: two `DeviceTagImporterTest` cases drive the importer through a *stateful* extractor fake (reads return the last write, reads are slowed to widen the race) — 16 concurrent imports on one adapter must all land, and 8 adapters × 4 imports must each end with exactly their own tags. Both fail with the `synchronized` block removed (2 of 16 tags survive), both pass with it.

## Out of scope (deliberate)

- Increasing `MAX_CONCURRENT_BROWSES` (semaphore stays at 1 — the S7-1500 lesson holds).
- Auto-tuning `READ_BATCH_SIZE` from server-advertised `MaxNodesPerRead` (servers misadvertise).
- Pipelining Phase 1 + Phase 2 streaming (changes ordering contract; needs its own ticket).
- Dropping `CopyOnWriteArrayList`/`ConcurrentHashMap.newKeySet()` for plain `ArrayList`/`HashSet` — async callbacks can race even with semaphore=1, so the existing concurrent collections are correct.
- The admin API's fixed pool of **two** HTTP threads (`InternalConfigurations.HTTP_API_THREAD_COUNT`, not configurable). Verified with thread dumps under load: at most two browses ever execute concurrently whatever the adapter count, and every other REST call queues behind them. That caps cross-adapter parallelism on this path and belongs to the v2 design, not this PR.

## Test plan

- [x] Unit: `hivemq-edge-module-opcua` (1259) and `com.hivemq.edge.adapters.browse.*` (229) green on Temurin 25. All four new tests were mutation-checked: each fails with its fix (or the lock) removed.
- [x] Integration: `DeviceTagBrowseIT`, `DeviceTagImportIT`, `DeviceTagEndToEndIT`, `OpcUaNodeBrowserConcurrencyIT` (56) green from `hivemq-edge-test` master on JDK 21, `--no-build-cache`.
- [x] `spotlessJavaCheck` clean on `hivemq-edge` and `hivemq-edge-module-opcua`.
- [x] Load test against Prosys Simulation Server (886–898 nodes, ~500 KB JSON), branch core + module jars, four adapters:
  - sequential p50 **308 ms vs 338 ms** with the master module jar swapped in (A/B on the same node); the 2× Phase-2 claim needs a server with tens of ms RTT — on localhost Phase 1 dominates.
  - 8 concurrent browses on one adapter: p50 2.3 s, all 200, byte-identical.
  - 16 concurrent across four adapters: p50 3.7–4.0 s, 3.85 browses/s (capped by the two HTTP threads above).
  - chaos, 75 s, 8 workers while two adapters are stopped/started three times, 60-tag imports run in `MERGE_SAFE` and `OVERWRITE`, and an adapter is deleted and recreated: 526 requests → 427×200, 90×503 `AdapterBrowseNotReady` (first 200 within 1 s of START, 1.6 s of CREATE), 7×404 while deleted, 2×409 for browses in flight when their adapter stopped. No 500s, no hangs, no thread leak.
  - parallel imports with the extractor monitor vs the per-adapter lock: no measurable difference (numbers above).
- [ ] QA: smoke-test against live S7-1500 (SUGUS adapter) — full-depth browse should still return ~225 nodes consistently.
