### PR TITLE
Migrate oci-version-catalog plugin from settings to project plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,7 @@ group = "com.hivemq"
 plugins {
     id("com.hivemq.edge-version-updater")
     id("com.hivemq.repository-convention")
+    id("com.hivemq.tools.oci-version-catalog") version "0.3.0"
     id("io.github.sgtsilvio.gradle.oci") version "0.25.0"
     id("jacoco")
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,10 +4,6 @@ pluginManagement {
     }
 }
 
-plugins {
-    id("com.hivemq.tools.oci-version-catalog") version "0.2.0"
-}
-
 rootProject.name = "hivemq-edge-build"
 
 includeBuild("./hivemq-edge")


### PR DESCRIPTION
The plugin was converted from Plugin<Settings> to Plugin<Project> in v0.3.0. Apply it directly in build.gradle.kts instead of settings.gradle.kts.
