### PR TITLE
refactor(protocols): route wrapper start/stopAsync via lifecycle executor

### DIFF
--- a/hivemq-edge/src/main/java/com/hivemq/protocols/ProtocolAdapterManager.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/ProtocolAdapterManager.java
@@ -538,7 +538,8 @@ public class ProtocolAdapterManager {
                         perModule,
                         tagManager,
                         northboundConsumerFactory,
-                        protocolAdapterWritingService);
+                        protocolAdapterWritingService,
+                        adapterLifecycleExecutor);
                 protocolAdapterMetrics.increaseProtocolAdapterMetric(configProtocolId);
                 return wrapper;
             });

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/ProtocolAdapterManager.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/ProtocolAdapterManager.java
@@ -220,6 +220,17 @@ public class ProtocolAdapterManager {
                 }
             }
         });
+        // Release the manager-owned executor threads so embedded Edge instances (tests) don't
+        // leak parked threads across runs. The JVM-exit shutdown hook is kept as a fallback and
+        // is idempotent.
+        adapterLifecycleExecutor.shutdown();
+        executorService.shutdown();
+        try {
+            adapterLifecycleExecutor.awaitTermination(SHUTDOWN_STOP_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            executorService.awaitTermination(SHUTDOWN_STOP_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
     }
 
     // ===== Adapter Lookup =====

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/ProtocolAdapterWrapper.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/ProtocolAdapterWrapper.java
@@ -51,6 +51,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
 import java.util.stream.Collectors;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -107,6 +108,10 @@ public class ProtocolAdapterWrapper {
     private final @NotNull InternalProtocolAdapterWritingService protocolAdapterWritingService;
     private final @NotNull List<NorthboundTagConsumer> consumers = new ArrayList<>();
 
+    // Executor used by startAsync/stopAsync. Injected so the wrapper does not silently fall back to
+    // ForkJoinPool.commonPool() for blocking adapter lifecycle work — see fsm-patch-01.
+    private final @NotNull Executor lifecycleExecutor;
+
     /**
      * Full constructor with all context needed for production use.
      */
@@ -122,7 +127,8 @@ public class ProtocolAdapterWrapper {
             final @NotNull ModuleServices moduleServices,
             final @NotNull TagManager tagManager,
             final @NotNull NorthboundConsumerFactory northboundConsumerFactory,
-            final @NotNull InternalProtocolAdapterWritingService protocolAdapterWritingService) {
+            final @NotNull InternalProtocolAdapterWritingService protocolAdapterWritingService,
+            final @NotNull Executor lifecycleExecutor) {
         this.adapter = adapter;
         this.config = config;
         this.adapterFactory = adapterFactory;
@@ -135,6 +141,7 @@ public class ProtocolAdapterWrapper {
         this.tagManager = tagManager;
         this.northboundConsumerFactory = northboundConsumerFactory;
         this.protocolAdapterWritingService = protocolAdapterWritingService;
+        this.lifecycleExecutor = lifecycleExecutor;
         this.northboundConnectionState = ProtocolAdapterConnectionState.Disconnected;
         this.southboundConnectionState = ProtocolAdapterConnectionState.Disconnected;
         this.state = ProtocolAdapterRuntimeState.Idle;
@@ -275,10 +282,9 @@ public class ProtocolAdapterWrapper {
     /**
      * Maps the connection state to the old ConnectionStatus enum.
      * <p>
-     * Delegates to {@link ProtocolAdapterStateImpl} when available, since old adapters
+     * Delegates to {@link ProtocolAdapterStateImpl} unconditionally, since adapters
      * update their connection status internally (e.g., OPC UA health check detects
      * connection loss and sets DISCONNECTED) without going through the wrapper's FSM.
-     * Falls back to the FSM northbound connection state for test-only wrappers.
      *
      * @return the connection status compatible with the old API
      */
@@ -353,12 +359,14 @@ public class ProtocolAdapterWrapper {
      * @return a future that completes when the adapter is started
      */
     public @NotNull CompletableFuture<Void> startAsync() {
-        return CompletableFuture.runAsync(() -> {
-            final boolean success = start();
-            if (!success) {
-                throw new RuntimeException("Failed to start adapter: " + getAdapterId());
-            }
-        });
+        return CompletableFuture.runAsync(
+                () -> {
+                    final boolean success = start();
+                    if (!success) {
+                        throw new RuntimeException("Failed to start adapter: " + getAdapterId());
+                    }
+                },
+                lifecycleExecutor);
     }
 
     /**
@@ -368,12 +376,14 @@ public class ProtocolAdapterWrapper {
      * @return a future that completes when the adapter is stopped, or completes exceptionally if stop fails
      */
     public @NotNull CompletableFuture<Void> stopAsync(final boolean destroy) {
-        return CompletableFuture.runAsync(() -> {
-            final boolean success = stop(destroy);
-            if (!success) {
-                throw new RuntimeException("Failed to stop adapter: " + getAdapterId());
-            }
-        });
+        return CompletableFuture.runAsync(
+                () -> {
+                    final boolean success = stop(destroy);
+                    if (!success) {
+                        throw new RuntimeException("Failed to stop adapter: " + getAdapterId());
+                    }
+                },
+                lifecycleExecutor);
     }
 
     // ===== Listener Management =====

--- a/hivemq-edge/src/test/java/com/hivemq/protocols/ProtocolAdapterManagerTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/protocols/ProtocolAdapterManagerTest.java
@@ -215,7 +215,8 @@ class ProtocolAdapterManagerTest {
                 moduleServicesMock,
                 tagManager,
                 northboundConsumerFactory,
-                writingService);
+                writingService,
+                Runnable::run);
         try {
             final var field = ProtocolAdapterManager.class.getDeclaredField("protocolAdapterMap");
             field.setAccessible(true);

--- a/hivemq-edge/src/test/java/com/hivemq/protocols/ProtocolAdapterWrapperTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/protocols/ProtocolAdapterWrapperTest.java
@@ -145,7 +145,8 @@ class ProtocolAdapterWrapperTest {
                 moduleServices,
                 tagManager,
                 northboundConsumerFactory,
-                protocolAdapterWritingService);
+                protocolAdapterWritingService,
+                Runnable::run);
     }
 
     @Nested
@@ -581,7 +582,8 @@ class ProtocolAdapterWrapperTest {
                             moduleServices,
                             tagManager,
                             northboundConsumerFactory,
-                            protocolAdapterWritingService) {
+                            protocolAdapterWritingService,
+                            Runnable::run) {
                         @Override
                         protected void startPolling() {
                             pollingStarted = true;
@@ -670,7 +672,8 @@ class ProtocolAdapterWrapperTest {
                             moduleServices,
                             tagManager,
                             northboundConsumerFactory,
-                            protocolAdapterWritingService) {
+                            protocolAdapterWritingService,
+                            Runnable::run) {
                         @Override
                         protected void stopPolling() {
                             callOrder.add("stopPolling");
@@ -712,7 +715,8 @@ class ProtocolAdapterWrapperTest {
                             moduleServices,
                             tagManager,
                             northboundConsumerFactory,
-                            protocolAdapterWritingService) {
+                            protocolAdapterWritingService,
+                            Runnable::run) {
                         @Override
                         protected void startPolling() {
                             callOrder.add("startPolling");
@@ -904,7 +908,8 @@ class ProtocolAdapterWrapperTest {
                     moduleServices,
                     tagManager,
                     northboundConsumerFactory,
-                    protocolAdapterWritingService);
+                    protocolAdapterWritingService,
+                    Runnable::run);
 
             assertThat(writingWrapper.start()).isTrue();
             assertThat(writingWrapper.stop(false)).isTrue();
@@ -1010,7 +1015,8 @@ class ProtocolAdapterWrapperTest {
                         moduleServices,
                         tagManager,
                         northboundConsumerFactory,
-                        protocolAdapterWritingService);
+                        protocolAdapterWritingService,
+                        Runnable::run);
 
                 final CountDownLatch latch = new CountDownLatch(2);
 
@@ -1102,7 +1108,8 @@ class ProtocolAdapterWrapperTest {
                     moduleServices,
                     tagManager,
                     northboundConsumerFactory,
-                    protocolAdapterWritingService);
+                    protocolAdapterWritingService,
+                    Runnable::run);
         }
 
         @Test
@@ -1192,7 +1199,8 @@ class ProtocolAdapterWrapperTest {
                         moduleServices,
                         tagManager,
                         northboundConsumerFactory,
-                        protocolAdapterWritingService);
+                        protocolAdapterWritingService,
+                        Runnable::run);
 
                 iterationWrapper.start();
                 iterationState.setConnectionStatus(ProtocolAdapterState.ConnectionStatus.CONNECTED);


### PR DESCRIPTION
## Summary

- `ProtocolAdapterWrapper.startAsync` / `stopAsync` previously used `CompletableFuture.runAsync(Runnable)` without an explicit executor, silently dispatching blocking adapter-lifecycle work (precheck, OPC UA / PLC4X / BACnet/IP connect, RocksDB writing init, disconnect) onto `ForkJoinPool.commonPool()`. That pool is sized for short CPU-bound tasks, has no backpressure, no named threads, and is not shut down by Edge — so a slow adapter could starve unrelated `parallel()` streams elsewhere in the JVM, and `ProtocolAdapterManager.shutdown()` could time out behind queued common-pool tasks.
- Inject the existing `adapterLifecycleExecutor` (4–10 threads, queue 20, `CallerRunsPolicy`, `protocol-adapter-lifecycle-%d`) into `ProtocolAdapterWrapper` via its constructor, and pass it explicitly to both `runAsync` calls. The manager already used this executor for its own `startAsync` / `stopAsync`; the wrapper now shares it so direct callers (`AbstractSubscriptionSampler.onSamplerError` → `wrapper.stopAsync(false)`, and `ProtocolAdapterManager.shutdown` → `wrapper.stopAsync(true).get(...)`) get the same bounded, named, backpressured semantics.
- Tests pass `Runnable::run` as the executor for deterministic synchronous execution; no test in this repo exercises the async dispatch path through the wrapper, so a synchronous executor is the cleanest substitute.

Tracking: EDG-582

## Test plan

- [ ] `./gradlew :hivemq-edge-build:hivemq-edge:check` (Spotless + ErrorProne + NullAway + unit tests for the `hivemq-edge` core module)
- [ ] `./gradlew :hivemq-edge-build:hivemq-edge-test:test` (composite integration suite that exercises adapter lifecycle end-to-end)
- [ ] Manual smoke: start Edge with a slow OPC UA endpoint, observe `protocol-adapter-lifecycle-*` threads in a thread dump during start/stop (no `commonPool-worker-*` threads doing adapter work).
- [ ] Confirm `manager.shutdown()` completes within the 5-second timeout when adapters are mid-start.

## Out of scope (deliberately deferred)

- `AssetMapperManager.stopAll()` and `DataCombinerManager.stopAll()` — same `runAsync`-without-executor anti-pattern, separate domains. Tracked as follow-ups in `Documents/Diary/2026/202605/fsm-patch-01.md` §7.
- Migrate `Runtime.getRuntime().addShutdownHook(...)` for the manager's executors to the project's `ShutdownHooks` registry — pre-existing inconsistency, would couple this PR to a wider DI rewire.
- Per-protocol connect executors (OPC UA, PLC4X, BACnet/IP) — adapter-internal idioms, separate review.