### PR TITLE
fix(licenses): regenerate third-party license manifests (EDG-597)

### DIFF
--- a/hivemq-edge/src/distribution/third-party-licenses/licenses
+++ b/hivemq-edge/src/distribution/third-party-licenses/licenses
@@ -9,16 +9,16 @@ HiveMQ Edge uses the following third party libraries:
  ch.qos.logback:logback-core                                                | 1.5.32                                    | EPL-2.0       | https://spdx.org/licenses/EPL-2.0.html
  com.ethlo.time:itu                                                         | 1.14.0                                    | Apache-2.0    | https://spdx.org/licenses/Apache-2.0.html
  com.fasterxml.jackson.core:jackson-annotations                             | 2.21                                      | Apache-2.0    | https://spdx.org/licenses/Apache-2.0.html
- com.fasterxml.jackson.core:jackson-core                                    | 2.21.2                                    | Apache-2.0    | https://spdx.org/licenses/Apache-2.0.html
- com.fasterxml.jackson.core:jackson-databind                                | 2.21.2                                    | Apache-2.0    | https://spdx.org/licenses/Apache-2.0.html
- com.fasterxml.jackson.dataformat:jackson-dataformat-xml                    | 2.21.2                                    | Apache-2.0    | https://spdx.org/licenses/Apache-2.0.html
- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml                   | 2.21.2                                    | Apache-2.0    | https://spdx.org/licenses/Apache-2.0.html
- com.fasterxml.jackson.datatype:jackson-datatype-jdk8                       | 2.21.2                                    | Apache-2.0    | https://spdx.org/licenses/Apache-2.0.html
- com.fasterxml.jackson.datatype:jackson-datatype-jsr310                     | 2.21.2                                    | Apache-2.0    | https://spdx.org/licenses/Apache-2.0.html
- com.fasterxml.jackson.jakarta.rs:jackson-jakarta-rs-base                   | 2.21.2                                    | Apache-2.0    | https://spdx.org/licenses/Apache-2.0.html
- com.fasterxml.jackson.jakarta.rs:jackson-jakarta-rs-json-provider          | 2.21.2                                    | Apache-2.0    | https://spdx.org/licenses/Apache-2.0.html
- com.fasterxml.jackson.module:jackson-module-jakarta-xmlbind-annotations    | 2.21.2                                    | Apache-2.0    | https://spdx.org/licenses/Apache-2.0.html
- com.fasterxml.jackson:jackson-bom                                          | 2.21.2                                    | Apache-2.0    | https://spdx.org/licenses/Apache-2.0.html
+ com.fasterxml.jackson.core:jackson-core                                    | 2.21.3                                    | Apache-2.0    | https://spdx.org/licenses/Apache-2.0.html
+ com.fasterxml.jackson.core:jackson-databind                                | 2.21.3                                    | Apache-2.0    | https://spdx.org/licenses/Apache-2.0.html
+ com.fasterxml.jackson.dataformat:jackson-dataformat-xml                    | 2.21.3                                    | Apache-2.0    | https://spdx.org/licenses/Apache-2.0.html
+ com.fasterxml.jackson.dataformat:jackson-dataformat-yaml                   | 2.21.3                                    | Apache-2.0    | https://spdx.org/licenses/Apache-2.0.html
+ com.fasterxml.jackson.datatype:jackson-datatype-jdk8                       | 2.21.3                                    | Apache-2.0    | https://spdx.org/licenses/Apache-2.0.html
+ com.fasterxml.jackson.datatype:jackson-datatype-jsr310                     | 2.21.3                                    | Apache-2.0    | https://spdx.org/licenses/Apache-2.0.html
+ com.fasterxml.jackson.jakarta.rs:jackson-jakarta-rs-base                   | 2.21.3                                    | Apache-2.0    | https://spdx.org/licenses/Apache-2.0.html
+ com.fasterxml.jackson.jakarta.rs:jackson-jakarta-rs-json-provider          | 2.21.3                                    | Apache-2.0    | https://spdx.org/licenses/Apache-2.0.html
+ com.fasterxml.jackson.module:jackson-module-jakarta-xmlbind-annotations    | 2.21.3                                    | Apache-2.0    | https://spdx.org/licenses/Apache-2.0.html
+ com.fasterxml.jackson:jackson-bom                                          | 2.21.3                                    | Apache-2.0    | https://spdx.org/licenses/Apache-2.0.html
  com.fasterxml.woodstox:woodstox-core                                       | 7.1.1                                     | Apache-2.0    | https://spdx.org/licenses/Apache-2.0.html
  com.fasterxml:classmate                                                    | 1.7.0                                     | Apache-2.0    | https://spdx.org/licenses/Apache-2.0.html
  com.github.simon622.mqtt-sn:mqtt-sn-codec                                  | 838f51d691                                | Apache-2.0    | https://spdx.org/licenses/Apache-2.0.html
@@ -59,7 +59,7 @@ HiveMQ Edge uses the following third party libraries:
  io.netty:netty-transport                                                   | 4.2.12.Final                              | Apache-2.0    | https://spdx.org/licenses/Apache-2.0.html
  io.netty:netty-transport-native-unix-common                                | 4.2.12.Final                              | Apache-2.0    | https://spdx.org/licenses/Apache-2.0.html
  io.reactivex.rxjava2:rxjava                                                | 2.2.21                                    | Apache-2.0    | https://spdx.org/licenses/Apache-2.0.html
- io.swagger.core.v3:swagger-annotations                                     | 2.2.48                                    | Apache-2.0    | https://spdx.org/licenses/Apache-2.0.html
+ io.swagger.core.v3:swagger-annotations                                     | 2.2.49                                    | Apache-2.0    | https://spdx.org/licenses/Apache-2.0.html
  io.swagger:swagger-annotations                                             | 1.6.16                                    | Apache-2.0    | https://spdx.org/licenses/Apache-2.0.html
  io.swagger:swagger-core                                                    | 1.6.16                                    | Apache-2.0    | https://spdx.org/licenses/Apache-2.0.html
  io.swagger:swagger-jaxrs                                                   | 1.6.16                                    | Apache-2.0    | https://spdx.org/licenses/Apache-2.0.html

--- a/hivemq-edge/src/distribution/third-party-licenses/licenses.html
+++ b/hivemq-edge/src/distribution/third-party-licenses/licenses.html
@@ -60,7 +60,7 @@
     </tr>
     <tr>
         <td>com.fasterxml.jackson.core:jackson-core</td>
-        <td>2.21.2</td>
+        <td>2.21.3</td>
         <td>Apache-2.0</td>
         <td>
             <a href="https://spdx.org/licenses/Apache-2.0.html">https://spdx.org/licenses/Apache-2.0.html</a>
@@ -68,7 +68,7 @@
     </tr>
     <tr>
         <td>com.fasterxml.jackson.core:jackson-databind</td>
-        <td>2.21.2</td>
+        <td>2.21.3</td>
         <td>Apache-2.0</td>
         <td>
             <a href="https://spdx.org/licenses/Apache-2.0.html">https://spdx.org/licenses/Apache-2.0.html</a>
@@ -76,7 +76,7 @@
     </tr>
     <tr>
         <td>com.fasterxml.jackson.dataformat:jackson-dataformat-xml</td>
-        <td>2.21.2</td>
+        <td>2.21.3</td>
         <td>Apache-2.0</td>
         <td>
             <a href="https://spdx.org/licenses/Apache-2.0.html">https://spdx.org/licenses/Apache-2.0.html</a>
@@ -84,7 +84,7 @@
     </tr>
     <tr>
         <td>com.fasterxml.jackson.dataformat:jackson-dataformat-yaml</td>
-        <td>2.21.2</td>
+        <td>2.21.3</td>
         <td>Apache-2.0</td>
         <td>
             <a href="https://spdx.org/licenses/Apache-2.0.html">https://spdx.org/licenses/Apache-2.0.html</a>
@@ -92,7 +92,7 @@
     </tr>
     <tr>
         <td>com.fasterxml.jackson.datatype:jackson-datatype-jdk8</td>
-        <td>2.21.2</td>
+        <td>2.21.3</td>
         <td>Apache-2.0</td>
         <td>
             <a href="https://spdx.org/licenses/Apache-2.0.html">https://spdx.org/licenses/Apache-2.0.html</a>
@@ -100,7 +100,7 @@
     </tr>
     <tr>
         <td>com.fasterxml.jackson.datatype:jackson-datatype-jsr310</td>
-        <td>2.21.2</td>
+        <td>2.21.3</td>
         <td>Apache-2.0</td>
         <td>
             <a href="https://spdx.org/licenses/Apache-2.0.html">https://spdx.org/licenses/Apache-2.0.html</a>
@@ -108,7 +108,7 @@
     </tr>
     <tr>
         <td>com.fasterxml.jackson.jakarta.rs:jackson-jakarta-rs-base</td>
-        <td>2.21.2</td>
+        <td>2.21.3</td>
         <td>Apache-2.0</td>
         <td>
             <a href="https://spdx.org/licenses/Apache-2.0.html">https://spdx.org/licenses/Apache-2.0.html</a>
@@ -116,7 +116,7 @@
     </tr>
     <tr>
         <td>com.fasterxml.jackson.jakarta.rs:jackson-jakarta-rs-json-provider</td>
-        <td>2.21.2</td>
+        <td>2.21.3</td>
         <td>Apache-2.0</td>
         <td>
             <a href="https://spdx.org/licenses/Apache-2.0.html">https://spdx.org/licenses/Apache-2.0.html</a>
@@ -124,7 +124,7 @@
     </tr>
     <tr>
         <td>com.fasterxml.jackson.module:jackson-module-jakarta-xmlbind-annotations</td>
-        <td>2.21.2</td>
+        <td>2.21.3</td>
         <td>Apache-2.0</td>
         <td>
             <a href="https://spdx.org/licenses/Apache-2.0.html">https://spdx.org/licenses/Apache-2.0.html</a>
@@ -132,7 +132,7 @@
     </tr>
     <tr>
         <td>com.fasterxml.jackson:jackson-bom</td>
-        <td>2.21.2</td>
+        <td>2.21.3</td>
         <td>Apache-2.0</td>
         <td>
             <a href="https://spdx.org/licenses/Apache-2.0.html">https://spdx.org/licenses/Apache-2.0.html</a>
@@ -460,7 +460,7 @@
     </tr>
     <tr>
         <td>io.swagger.core.v3:swagger-annotations</td>
-        <td>2.2.48</td>
+        <td>2.2.49</td>
         <td>Apache-2.0</td>
         <td>
             <a href="https://spdx.org/licenses/Apache-2.0.html">https://spdx.org/licenses/Apache-2.0.html</a>

--- a/modules/hivemq-edge-module-databases/src/distribution/third-party-licenses/licenses
+++ b/modules/hivemq-edge-module-databases/src/distribution/third-party-licenses/licenses
@@ -7,8 +7,7 @@ hivemq-edge-module-databases uses the following third party libraries:
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  com.microsoft.sqlserver:mssql-jdbc                                         | 12.10.2.jre11                             | MIT           | https://spdx.org/licenses/MIT.html
  com.zaxxer:HikariCP                                                        | 6.3.3                                     | Apache-2.0    | https://spdx.org/licenses/Apache-2.0.html
- org.checkerframework:checker-qual                                          | 3.52.0                                    | MIT           | https://spdx.org/licenses/MIT.html
- org.postgresql:postgresql                                                  | 42.7.10                                   | BSD-2-Clause  | https://spdx.org/licenses/BSD-2-Clause.html
+ org.postgresql:postgresql                                                  | 42.7.11                                   | BSD-2-Clause  | https://spdx.org/licenses/BSD-2-Clause.html
  org.slf4j:slf4j-api                                                        | 2.0.17                                    | MIT           | https://spdx.org/licenses/MIT.html
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 

--- a/modules/hivemq-edge-module-databases/src/distribution/third-party-licenses/licenses.html
+++ b/modules/hivemq-edge-module-databases/src/distribution/third-party-licenses/licenses.html
@@ -43,16 +43,8 @@
         </td>
     </tr>
     <tr>
-        <td>org.checkerframework:checker-qual</td>
-        <td>3.52.0</td>
-        <td>MIT</td>
-        <td>
-            <a href="https://spdx.org/licenses/MIT.html">https://spdx.org/licenses/MIT.html</a>
-        </td>
-    </tr>
-    <tr>
         <td>org.postgresql:postgresql</td>
-        <td>42.7.10</td>
+        <td>42.7.11</td>
         <td>BSD-2-Clause</td>
         <td>
             <a href="https://spdx.org/licenses/BSD-2-Clause.html">https://spdx.org/licenses/BSD-2-Clause.html</a>

--- a/modules/hivemq-edge-module-etherip/src/distribution/third-party-licenses/licenses
+++ b/modules/hivemq-edge-module-etherip/src/distribution/third-party-licenses/licenses
@@ -6,9 +6,9 @@ hivemq-edge-module-etherip uses the following third party libraries:
  Module                                                                     | Version                                   | License ID    | License URL
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  com.fasterxml.jackson.core:jackson-annotations                             | 2.21                                      | Apache-2.0    | https://spdx.org/licenses/Apache-2.0.html
- com.fasterxml.jackson.core:jackson-core                                    | 2.21.2                                    | Apache-2.0    | https://spdx.org/licenses/Apache-2.0.html
- com.fasterxml.jackson.core:jackson-databind                                | 2.21.2                                    | Apache-2.0    | https://spdx.org/licenses/Apache-2.0.html
- com.fasterxml.jackson:jackson-bom                                          | 2.21.2                                    | Apache-2.0    | https://spdx.org/licenses/Apache-2.0.html
+ com.fasterxml.jackson.core:jackson-core                                    | 2.21.3                                    | Apache-2.0    | https://spdx.org/licenses/Apache-2.0.html
+ com.fasterxml.jackson.core:jackson-databind                                | 2.21.3                                    | Apache-2.0    | https://spdx.org/licenses/Apache-2.0.html
+ com.fasterxml.jackson:jackson-bom                                          | 2.21.3                                    | Apache-2.0    | https://spdx.org/licenses/Apache-2.0.html
  org.slf4j:slf4j-api                                                        | 2.0.17                                    | MIT           | https://spdx.org/licenses/MIT.html
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 

--- a/modules/hivemq-edge-module-etherip/src/distribution/third-party-licenses/licenses.html
+++ b/modules/hivemq-edge-module-etherip/src/distribution/third-party-licenses/licenses.html
@@ -36,7 +36,7 @@
     </tr>
     <tr>
         <td>com.fasterxml.jackson.core:jackson-core</td>
-        <td>2.21.2</td>
+        <td>2.21.3</td>
         <td>Apache-2.0</td>
         <td>
             <a href="https://spdx.org/licenses/Apache-2.0.html">https://spdx.org/licenses/Apache-2.0.html</a>
@@ -44,7 +44,7 @@
     </tr>
     <tr>
         <td>com.fasterxml.jackson.core:jackson-databind</td>
-        <td>2.21.2</td>
+        <td>2.21.3</td>
         <td>Apache-2.0</td>
         <td>
             <a href="https://spdx.org/licenses/Apache-2.0.html">https://spdx.org/licenses/Apache-2.0.html</a>
@@ -52,7 +52,7 @@
     </tr>
     <tr>
         <td>com.fasterxml.jackson:jackson-bom</td>
-        <td>2.21.2</td>
+        <td>2.21.3</td>
         <td>Apache-2.0</td>
         <td>
             <a href="https://spdx.org/licenses/Apache-2.0.html">https://spdx.org/licenses/Apache-2.0.html</a>


### PR DESCRIPTION
## Summary

- Regenerate the bundled OSS license report under `src/distribution/third-party-licenses/{licenses,licenses.html}` for the core edge module, the databases adapter, and the etherip adapter so the report matches the current artifact graph after upstream dependency bumps.
- Notable version changes: Jackson `2.21.2` → `2.21.3`, swagger-annotations `2.2.48` → `2.2.49`, plus minor adjustments in the databases and etherip module manifests.
- Pure regeneration of build artefacts. No source-code, configuration, or behavioural change.

Tracking: EDG-597

## Test plan

- [ ] CI passes (manifests are produced by the existing license plugin; no test changes required).
- [ ] Visual check of `licenses.html` rendering before publishing the next release artefacts.