### PR TITLE
fix(protocols): preserve ERROR ConnectionStatus on failed-start cleanup (EDG-603)

### DIFF
--- a/hivemq-edge/src/main/java/com/hivemq/protocols/ProtocolAdapterWrapper.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/ProtocolAdapterWrapper.java
@@ -644,6 +644,11 @@ public class ProtocolAdapterWrapper {
             return true;
         }
 
+        // Preserve ERROR on the legacy ConnectionStatus when draining the FSM out of Error
+        // (e.g. failed-start cleanup): the FSM must still walk Error → Disconnecting → Disconnected,
+        // but the user-visible status must keep reflecting the original failure.
+        final boolean wasError = northboundConnectionState.isError();
+
         LOGGER.info("Stopping northbound for protocol adapter '{}'.", getAdapterId());
 
         // current → Disconnecting
@@ -666,7 +671,7 @@ public class ProtocolAdapterWrapper {
         final boolean success = transitionNorthboundConnectionTo(ProtocolAdapterConnectionState.Disconnected)
                 .status()
                 .isSuccess();
-        if (success) {
+        if (success && !wasError) {
             protocolAdapterState.setConnectionStatus(ProtocolAdapterState.ConnectionStatus.DISCONNECTED);
         }
         return disconnectSuccess && success;

--- a/hivemq-edge/src/test/java/com/hivemq/protocols/ProtocolAdapterWrapperTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/protocols/ProtocolAdapterWrapperTest.java
@@ -425,6 +425,29 @@ class ProtocolAdapterWrapperTest {
             assertThat(wrapper.stop(false)).isTrue();
             assertThat(wrapper.getState()).isEqualTo(ProtocolAdapterRuntimeState.Idle);
         }
+
+        @Test
+        void failedNorthboundStart_cleanupPreservesErrorConnectionStatus() throws ProtocolAdapterException {
+            // Northbound start fails (matches Modbus invalid-host: adapter signals failStart).
+            doAnswer(invocation -> {
+                        final ProtocolAdapterStartOutput output = invocation.getArgument(2);
+                        output.failStart(new RuntimeException("invalid host"), "invalid host");
+                        return null;
+                    })
+                    .when(protocolAdapter)
+                    .start(eq(ProtocolAdapterConnectionDirection.Northbound), any(), any());
+
+            assertThat(wrapper.start()).isFalse();
+            assertThat(wrapper.getState()).isEqualTo(ProtocolAdapterRuntimeState.Error);
+            // FSM must still drain back to Disconnected so the adapter can be restarted later.
+            assertThat(wrapper.getNorthboundConnectionState()).isEqualTo(ProtocolAdapterConnectionState.Disconnected);
+
+            // ERROR must have been set on the legacy ConnectionStatus during the failure.
+            verify(protocolAdapterState).setErrorConnectionStatus(any(), eq("invalid host"));
+            // ...and the post-failure cleanup must NOT have overwritten it back to DISCONNECTED.
+            verify(protocolAdapterState, never())
+                    .setConnectionStatus(ProtocolAdapterState.ConnectionStatus.DISCONNECTED);
+        }
     }
 
     @Nested


### PR DESCRIPTION
## Summary
- After the FSM redesign (#1462), the failed-start cleanup in `ProtocolAdapterWrapper.start()` calls `stopNorthbound()` to drain the connection FSM out of `Error`. `stopNorthbound()` then unconditionally overwrote the legacy `ConnectionStatus` to `DISCONNECTED`, masking the `ERROR` set by the failed connect attempt.
- Misconfigured adapters (e.g. Modbus with an invalid host) therefore surfaced as `DISCONNECTED` via the REST API instead of `ERROR`, regressing `modbusAdapterCreationWithInvalidHostTest` in the broker-edge hardware test suite and hiding the real failure from operators.
- `stopNorthbound()` now records whether the FSM was in `Error` at entry and skips the `DISCONNECTED` overwrite in that case. The FSM itself still walks `Error → Disconnecting → Disconnected`, so subsequent start/stop cycles behave unchanged. Normal `stop()` from a healthy `Connected` adapter is unaffected.

## Test plan
- [x] New unit test `ProtocolAdapterWrapperTest.failedNorthboundStart_cleanupPreservesErrorConnectionStatus` asserts `setConnectionStatus(DISCONNECTED)` is never invoked when a northbound start fails via `failStart()`.
- [x] `./gradlew :hivemq-edge-build:hivemq-edge:check` is green locally.
- [ ] Re-run `modbusAdapterCreationWithInvalidHostTest` (hivemq-testsuite/hivemq-broker-edge-hardware-test) to confirm the test now sees `Status.ConnectionEnum.ERROR` again.
- [ ] Smoke-test a normal start/stop cycle on any adapter (e.g. simulation/HTTP) — should still report `DISCONNECTED` after `stop()`.