### PR TITLE
EDG-625: Show validation error details in tag import toast

### DIFF
--- a/hivemq-edge-frontend/src/modules/ProtocolAdapters/components/panels/DeviceTagBrowsePanel.tsx
+++ b/hivemq-edge-frontend/src/modules/ProtocolAdapters/components/panels/DeviceTagBrowsePanel.tsx
@@ -3,12 +3,21 @@ import { useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Button, Divider, Flex, FormControl, FormLabel, Input, Select, Spinner, Text } from '@chakra-ui/react'
 
+import type { AxiosError } from 'axios'
 import { useEdgeToast } from '@/hooks/useEdgeToast/useEdgeToast.tsx'
 import type { BrowseFormat } from '@/api/hooks/useProtocolAdapters/useBrowseDeviceTags.ts'
 import { useBrowseDeviceTags } from '@/api/hooks/useProtocolAdapters/useBrowseDeviceTags.ts'
 import type { ImportMode } from '@/api/hooks/useProtocolAdapters/useImportDeviceTags.ts'
 import { useImportDeviceTags } from '@/api/hooks/useProtocolAdapters/useImportDeviceTags.ts'
 import { downloadTimeStamp } from '@/utils/download.utils.ts'
+
+interface ValidationError {
+  row?: number
+  column?: string
+  value?: string
+  code?: string
+  message: string
+}
 
 interface DeviceTagBrowsePanelProps {
   adapterId: string
@@ -87,7 +96,33 @@ const DeviceTagBrowsePanel: FC<DeviceTagBrowsePanelProps> = ({ adapterId }) => {
           if (fileInputRef.current) fileInputRef.current.value = ''
         },
         onError: (err) => {
-          errorToast({ title: t('deviceTagBrowse.error.import') }, err)
+          const body = (err as unknown as AxiosError<{ errors?: ValidationError[] }>).response?.data
+          const validationErrors = body?.errors
+          if (validationErrors?.length) {
+            errorToast(
+              {
+                title: t('deviceTagBrowse.error.import'),
+                description: (
+                  <>
+                    <Text as="span" display="block" fontStyle="italic">
+                      {importFile.name} · {importMode}
+                    </Text>
+                    {validationErrors.map((e, i) => {
+                      const location = [e.row != null ? `Row ${e.row}` : null, e.column].filter(Boolean).join(', ')
+                      return (
+                        <Text as="span" display="block" key={i}>
+                          {location ? `${location}: ${e.message}` : e.message}
+                        </Text>
+                      )
+                    })}
+                  </>
+                ),
+              },
+              new Error()
+            )
+          } else {
+            errorToast({ title: t('deviceTagBrowse.error.import') }, err)
+          }
         },
       }
     )


### PR DESCRIPTION
**Linear Issue:** [EDG-625](https://linear.app/hivemq/issue/EDG-625/fix-tag-import-error-toast-showing-no-detail)

## Description

This PR fixes how users are informed when a tag import fails validation. Previously, a failed import (e.g. due to conflicting tag definitions) showed only a generic red bar saying "Failed to import device tags" — with no indication of what was wrong or which tags caused the problem. Now, each validation error is shown as its own line, together with the file name and import mode, giving users everything they need to understand and fix the problem themselves. Note that this was only a problem in the UI, the backend/REST API always exported the full failure description.

**What users gain:**

* **Actionable error messages**: Each conflicting tag is listed by name with the exact reason it was rejected (e.g. "tag_name: Tag 'csd' exists with different definitions — use OVERWRITE mode to update")
* **Import context**: The toast shows the file name and import mode so the error can be copy-pasted and sent to support with full context

## BEFORE

The error toast showed only the title and the raw HTTP error message ("Request failed with status code 400"), with no detail from the validation response.

**Why it was broken:** The import hook uses `axiosInstance.post()` directly (not the generated API client), so the error is a raw `AxiosError`. The previous code read `err.body` (the `ApiError` shape), which is always `undefined` for axios errors — causing the per-error rendering to silently produce nothing. The `ValidationError` fields from the backend (`row`, `column`, `message`, `code`) also never matched what the generic `errorToast` iterated (`fieldName`, `detail`, `title`). Broken since [EDG-217](https://linear.app/hivemq/issue/EDG-217/houston-implementation).

## AFTER

<img src="https://uploads.linear.app/82180129-a83f-414f-ba1c-81ea4b48a37d/6377a305-9e84-4dd9-b236-42f6f45aaf74/3717cc64-361d-4588-ad2c-e7b2cb366163?signature=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXRoIjoiLzgyMTgwMTI5LWE4M2YtNDE0Zi1iYTFjLTgxZWE0YjQ4YTM3ZC82Mzc3YTMwNS05ZTg0LTRkZDktYjIzNi00MmY2ZjQ1YWFmNzQvMzcxN2NjNjQtMzYxZC00NTg4LWFkMmMtZTdiMmNiMzY2MTYzIiwiaWF0IjoxNzc4ODgxMzM2LCJleHAiOjE4MTA0NTE4OTZ9._mWIKEspV1KVygP3lUzPvjyTY8U_vwhSoLFc5NrwSVk " alt="image.png" width="680" data-linear-height="631" />

The toast now shows the file name and import mode, followed by one line per validation error with the column and human-readable message.

## Changes

Single file changed: `hivemq-edge-frontend/src/modules/ProtocolAdapters/components/panels/DeviceTagBrowsePanel.tsx`

* Reads `err.response.data.errors` (the correct location for axios errors)
* Renders each `ValidationError` as its own line, formatted as `{column}: {message}` (with `Row N` prefix when `row` is present)
* Prepends file name and import mode to the toast description for support diagnostics
* Falls back to the existing generic `errorToast` behaviour for non-validation errors (parse failures, 404, etc.)

## Manual Testing

1. Open an OPC UA adapter → **Device Tags** tab
2. Import a CSV file where some tags already exist on the adapter with different definitions
3. Use **Merge (safe)** mode
4. Observe the toast — each conflicting tag should appear as a separate line with the conflict reason
5. Confirm the file name and import mode appear in italics below the title