### PR TITLE
EDG-688: Apply configured publishingInterval on OPC-UA subscription create

### DIFF
--- a/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/listeners/OpcUaSubscriptionLifecycleHandler.java
+++ b/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/listeners/OpcUaSubscriptionLifecycleHandler.java
@@ -101,32 +101,76 @@ public class OpcUaSubscriptionLifecycleHandler implements OpcUaSubscription.Subs
     }
 
     /**
-     * Creates a new OPC UA subscription.
-     * If the subscription is created successfully, it returns an Optional containing the subscription.
-     * If the subscription creation fails, it returns an empty Optional.
+     * Starts construction of a new OPC UA subscription. Configure with the builder's setters, then
+     * call {@link Builder#create()} to push the subscription to the server.
      *
      * @param client the OPC UA client
-     * @return an Optional containing the created subscription or empty if creation failed
+     * @return a builder
      */
-    public static @NotNull Optional<OpcUaSubscription> createNewSubscription(final @NotNull OpcUaClient client) {
-        log.debug("Creating new OPC UA subscription");
-        final OpcUaSubscription subscription = new OpcUaSubscription(client);
-        try {
-            subscription.create();
-            return subscription
-                    .getSubscriptionId()
-                    .map(subscriptionId -> {
-                        log.trace("New subscription ID: {}", subscriptionId);
-                        return subscription;
-                    })
-                    .or(() -> {
-                        log.error("Subscription not created on the server");
-                        return Optional.empty();
-                    });
-        } catch (final UaException e) {
-            log.error("Failed to create subscription", e);
+    public static @NotNull Builder newSubscription(final @NotNull OpcUaClient client) {
+        return new Builder(client);
+    }
+
+    /** Fluent builder for an {@link OpcUaSubscription}. */
+    public static final class Builder {
+
+        private final @NotNull OpcUaClient client;
+        private int publishingIntervalMs = 1000; // OPC UA / Milo default, kept here for documentation
+
+        private Builder(final @NotNull OpcUaClient client) {
+            this.client = client;
         }
-        return Optional.empty();
+
+        /**
+         * Set the requested publishing interval in milliseconds.
+         *
+         * @param publishingIntervalMs the requested publishing interval in milliseconds
+         * @return this builder, for chaining
+         */
+        public @NotNull Builder publishingInterval(final int publishingIntervalMs) {
+            this.publishingIntervalMs = publishingIntervalMs;
+            return this;
+        }
+
+        /**
+         * Create the subscription on the server with the configured parameters. If the server revises
+         * the requested publishing interval (e.g. to enforce a minimum), the revision is logged.
+         *
+         * @return the created subscription, or empty if the creation failed
+         */
+        public @NotNull Optional<OpcUaSubscription> create() {
+            log.debug("Creating new OPC UA subscription with publishingInterval={}ms", publishingIntervalMs);
+            final OpcUaSubscription subscription = new OpcUaSubscription(client);
+            subscription.setPublishingInterval((double) publishingIntervalMs);
+            try {
+                subscription.create();
+                final double revised = subscription.getPublishingInterval();
+                if (Math.abs(revised - publishingIntervalMs) > 1.0) {
+                    log.warn(
+                            "OPC UA server revised publishingInterval: requested={}ms, revised={}ms",
+                            publishingIntervalMs,
+                            revised);
+                } else {
+                    log.info(
+                            "OPC UA subscription created with publishingInterval={}ms (requested {}ms)",
+                            revised,
+                            publishingIntervalMs);
+                }
+                return subscription
+                        .getSubscriptionId()
+                        .map(subscriptionId -> {
+                            log.trace("New subscription ID: {}", subscriptionId);
+                            return subscription;
+                        })
+                        .or(() -> {
+                            log.error("Subscription not created on the server");
+                            return Optional.empty();
+                        });
+            } catch (final UaException e) {
+                log.error("Failed to create subscription", e);
+            }
+            return Optional.empty();
+        }
     }
 
     private static void extractPayload(
@@ -147,16 +191,17 @@ public class OpcUaSubscriptionLifecycleHandler implements OpcUaSubscription.Subs
      * @return an Optional containing the created or transferred subscription, or empty if failed
      */
     public @NotNull Optional<OpcUaSubscription> subscribe(final @NotNull OpcUaClient client) {
-        return createNewSubscription(client).map(subscription -> {
-            subscription.setPublishingInterval(
-                    (double) config.getOpcuaToMqttConfig().publishingInterval());
-            subscription.setSubscriptionListener(this);
-            if (syncTagsAndMonitoredItems(subscription, tags, config)) {
-                return subscription;
-            } else {
-                return null;
-            }
-        });
+        return newSubscription(client)
+                .publishingInterval(config.getOpcuaToMqttConfig().publishingInterval())
+                .create()
+                .map(subscription -> {
+                    subscription.setSubscriptionListener(this);
+                    if (syncTagsAndMonitoredItems(subscription, tags, config)) {
+                        return subscription;
+                    } else {
+                        return null;
+                    }
+                });
     }
 
     /**
@@ -323,7 +368,9 @@ public class OpcUaSubscriptionLifecycleHandler implements OpcUaSubscription.Subs
         protocolAdapterMetricsService.increment(Constants.METRIC_SUBSCRIPTION_TRANSFER_FAILED_COUNT);
 
         log.error("Subscription Transfer failed, recreating subscription for adapter '{}'", adapterId);
-        createNewSubscription(client)
+        newSubscription(client)
+                .publishingInterval(config.getOpcuaToMqttConfig().publishingInterval())
+                .create()
                 .ifPresentOrElse(
                         replacementSubscription -> {
                             // reconnect the listener with the new subscription

--- a/modules/hivemq-edge-module-opcua/src/test/java/com/hivemq/edge/adapters/opcua/OpcUaClientConnectionTest.java
+++ b/modules/hivemq-edge-module-opcua/src/test/java/com/hivemq/edge/adapters/opcua/OpcUaClientConnectionTest.java
@@ -16,6 +16,7 @@
 package com.hivemq.edge.adapters.opcua;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
 import static org.awaitility.Awaitility.await;
 import static org.mockito.Mockito.mock;
 
@@ -306,6 +307,85 @@ public class OpcUaClientConnectionTest {
             assertThat(opcUaClientConnection.isHealthy())
                     .as("Connection should not be healthy after being stopped")
                     .isFalse();
+        });
+    }
+
+    /**
+     * EDG-688 regression test: a non-default {@code publishingInterval} configured on the adapter
+     * must actually reach the OPC UA server. Before the fix, the adapter constructed the
+     * {@link org.eclipse.milo.opcua.sdk.client.subscriptions.OpcUaSubscription} with Milo's
+     * no-arg constructor (defaulting to 1000 ms) and only called {@code setPublishingInterval}
+     * <em>after</em> {@code create()} had already gone on the wire, queuing a
+     * {@code ModifySubscription} diff that was never flushed. The end effect was that every
+     * subscription ran at the Milo default of 1000 ms regardless of what was configured.
+     */
+    @Test
+    @Timeout(60)
+    void configuredPublishingInterval_isAppliedOnTheServer() throws Exception {
+        // Arrange — non-default, distinguishable-from-Milo-default value
+        final int requestedPublishingIntervalMs = 250;
+        final OpcUaSpecificAdapterConfig config = new OpcUaSpecificAdapterConfig(
+                opcUaServerExtension.getServerUri(),
+                false,
+                null,
+                null,
+                null,
+                new OpcUaToMqttConfig(1, requestedPublishingIntervalMs),
+                null,
+                null);
+
+        final OpcuaTag tag = new OpcuaTag(
+                "testTag",
+                "Test tag",
+                new OpcuaTagDefinition(
+                        "ns=" + opcUaServerExtension.getTestNamespace().getNamespaceIndex() + ";i=10"));
+
+        final ProtocolAdapterTagStreamingService streamingService = mock(ProtocolAdapterTagStreamingService.class);
+        final AtomicBoolean reconnectionCallbackInvoked = new AtomicBoolean(false);
+
+        opcUaClientConnection = new OpcUaClientConnection(
+                "test-adapter-id",
+                List.of(tag),
+                protocolAdapterState,
+                streamingService,
+                eventService,
+                metricsService,
+                config,
+                new OpcUaServiceFaultListener(
+                        metricsService,
+                        eventService,
+                        "test-adapter-id",
+                        () -> reconnectionCallbackInvoked.set(true),
+                        true));
+
+        final Result<ParsedConfig, String> result = ParsedConfig.fromConfig(config);
+        assertThat(result).isInstanceOf(Success.class);
+        final ParsedConfig parsedConfig = ((Success<ParsedConfig, String>) result).result();
+
+        // Act
+        final boolean started = opcUaClientConnection.start(parsedConfig);
+        assertThat(started).as("Connection should start successfully").isTrue();
+
+        await().untilAsserted(() -> assertThat(protocolAdapterState.getConnectionStatus())
+                .as("Connection should be established")
+                .isEqualTo(ProtocolAdapterState.ConnectionStatus.CONNECTED));
+
+        // Assert — the OPC UA server's subscription manager records the negotiated publishingInterval
+        // for every active subscription. With the fix, this is the value we requested; without the
+        // fix, the server would have received Milo's default of 1000 ms instead.
+        await().untilAsserted(() -> {
+            final var serverSubscriptions = java.util.Objects.requireNonNull(opcUaServerExtension.getOpcUaServer())
+                    .getSubscriptions()
+                    .values();
+            assertThat(serverSubscriptions)
+                    .as("server should see exactly one active subscription")
+                    .hasSize(1);
+            final double serverPublishingInterval =
+                    serverSubscriptions.iterator().next().getPublishingInterval();
+            assertThat(serverPublishingInterval)
+                    .as(
+                            "server-observed publishingInterval must equal the configured value, not Milo's 1000 ms default")
+                    .isCloseTo(requestedPublishingIntervalMs, within(1.0));
         });
     }
 }

--- a/modules/hivemq-edge-module-opcua/src/test/java/util/EmbeddedOpcUaServerExtension.java
+++ b/modules/hivemq-edge-module-opcua/src/test/java/util/EmbeddedOpcUaServerExtension.java
@@ -220,6 +220,10 @@ public class EmbeddedOpcUaServerExtension implements BeforeEachCallback, AfterEa
         return testNamespace;
     }
 
+    public @Nullable OpcUaServer getOpcUaServer() {
+        return opcUaServer;
+    }
+
     private @NotNull Set<EndpointConfig> createEndpointConfigs(final @NotNull X509Certificate certificate) {
         final EndpointConfig.Builder builder = EndpointConfig.newBuilder()
                 .setTransportProfile(TransportProfile.TCP_UASC_UABINARY)


### PR DESCRIPTION
**Motivation**

Resolves #EDG-688

The OPC-UA adapter's configured `publishingInterval` was silently ignored — every Subscription ran at Eclipse Milo's 1000 ms default regardless of configuration. The helper called `subscription.create()` *before* `setPublishingInterval(...)`; the post-create setter only queues a `ModifySubscription` diff that the adapter never flushed via `modify()`. Reported by Miele during a POC (100 ms requested, 1000 ms observed on the server-side subscription, despite another OPC-UA client honouring 100 ms against the same PLC).

The `onTransferFailed` recovery path additionally never called `setPublishingInterval` at all — same end state.

**Changes**

Replace the static `createNewSubscription` helper with a fluent builder:

```java
newSubscription(client)
    .publishingInterval(config.getOpcuaToMqttConfig().publishingInterval())
    .create()
```

The builder applies its setters between `new OpcUaSubscription(client)` and `subscription.create()`, so the configured value is sent in the initial `CreateSubscription` request rather than queued as a deferred modification. The staged lifecycle becomes structural — callers cannot configure after creating because there is no setter on the returned `Optional<OpcUaSubscription>`. Each future per-Subscription knob (lifetimeCount, maxKeepAliveCount, priority, …) becomes a new builder setter rather than another positional ordering hazard.

Both call sites (`subscribe` and `onTransferFailed`) now route through the builder. After `create()` returns, the requested-vs-revised publishingInterval is logged so future "interval not honoured" reports can be diagnosed without source-reading: WARN if the server revised by more than 1 ms, INFO otherwise.

`samplingInterval` stays coupled to `publishingInterval` — decoupling is in EDG-605's scope, not this fix.

**Tests**

New `OpcUaClientConnectionTest.configuredPublishingInterval_isAppliedOnTheServer()` drives a real `OpcUaClientConnection` against the embedded Milo test server with a non-default 250 ms config, then asserts the server-side `Subscription.getPublishingInterval()` reads 250 ms. Confirmed the test fails before the fix (sees Milo's 1000 ms default) and passes after.

Full OPC-UA module unit suite: 197/0/0/1.
OPC-UA integration suite (`com.hivemq.edge.modules.opcua.*` in `hivemq-edge-test`): 96/0/0/0, including `OpcUaAdapterLifecycleIT`, `SubscriptionResumeOpcUaIT`, and `OpcUaConnectionRetryIT` which exercise the lifecycle paths this change rewires.