### PR TITLE
EDG-718: Fix Snyk Frontend monitor by using --all-projects

### DIFF
--- a/.github/workflows/snyk-push.yml
+++ b/.github/workflows/snyk-push.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Run Snyk Frontend monitor
         shell: bash
         run: >
-          snyk monitor --file=pnpm-lock.yaml --target-reference=${{ steps.select_github_ref.outputs.selected_github_ref }} --org=hivemq-edge
+          snyk monitor --all-projects --target-reference=${{ steps.select_github_ref.outputs.selected_github_ref }} --org=hivemq-edge
           --project-name=hivemq-edge-frontend --remote-repo-url=hivemq-edge-frontend --project-lifecycle=development -d
           --project-tags="\"kanbanize_board_name=Edge,kanbanize_board_workflow_name=Development++Workflow,kanbanize_board_column_name=Requested++~~Selected~~,kanbanize_board_swimlane=Expedite,kanbanize_board_done_sections=4/5\""
           hivemq-edge/hivemq-edge-frontend

--- a/.github/workflows/snyk-release.yml
+++ b/.github/workflows/snyk-release.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Run Snyk Frontend monitor
         shell: bash
-        run: snyk monitor --file=pnpm-lock.yaml --target-reference=${{ github.ref_name }} --org=hivemq-releases --project-name=hivemq-edge-frontend --remote-repo-url=hivemq-edge-frontend --project-lifecycle=production -d hivemq-edge/hivemq-edge-frontend
+        run: snyk monitor --all-projects --target-reference=${{ github.ref_name }} --org=hivemq-releases --project-name=hivemq-edge-frontend --remote-repo-url=hivemq-edge-frontend --project-lifecycle=production -d hivemq-edge/hivemq-edge-frontend
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.JENKINS_GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

The **"Run Snyk monitor on push"** workflow fails on the **Run Snyk Frontend monitor** step with exit code 2 ([failing run](https://github.com/hivemq/hivemq-edge/actions/runs/27269783835/job/80535995818)).

## Root cause

The real error is buried under redacted HTTP debug output:

```
Both `pnpm-lock.yaml` and `pnpm-workspace.yaml` were found in .../hivemq-edge-frontend.
Please run your command again specifying `--all-projects` flag.
Exit Code: 2
```

`hivemq-edge-frontend/pnpm-workspace.yaml` was added by the pnpm 11 upgrade (#1534) to hold settings pnpm 11 no longer reads from `package.json` / `.npmrc` (`overrides`, `allowBuilds`, `minimumReleaseAge`). Snyk's pnpm plugin keys off the mere presence of `pnpm-workspace.yaml`, decides the directory is a workspace, and refuses the single-manifest `--file=pnpm-lock.yaml` mode — demanding `--all-projects`.

## Fix

Replace `--file=pnpm-lock.yaml` with `--all-projects` in the frontend Snyk step of both workflows (`--file` and `--all-projects` are mutually exclusive; `--all-projects` is exactly what the Snyk error instructs):

- `.github/workflows/snyk-push.yml` (the failing one)
- `.github/workflows/snyk-release.yml` (same step, same latent bug)

### Why this is safe / equivalent to before

- Only three manifests are git-tracked under `hivemq-edge-frontend/`, all at its root (`package.json`, `pnpm-lock.yaml`, `pnpm-workspace.yaml`) — no nested projects.
- The Snyk step runs right after checkout / `setup-node`, before any `pnpm install` or Gradle build, so `node_modules` / `.gradle` don't exist (and Snyk ignores `node_modules` anyway). `--all-projects` therefore detects exactly **one** pnpm project.
- `pnpm-workspace.yaml` has no `packages:` member globs, reinforcing single-project detection.
- The package's own `name` is already `hivemq-edge-frontend`, matching the retained `--project-name=hivemq-edge-frontend`, so the Snyk dashboard project mapping is preserved.

All other flags (`--project-name`, `--remote-repo-url`, `--project-lifecycle`, `--project-tags`) are left untouched.

## Caveat

Not validated with an actual `snyk monitor` run locally (requires `SNYK_TOKEN` and would push to the Snyk dashboard) — verified by reasoning against the Snyk docs and the repo's manifest layout.

Closes EDG-718