### PR TITLE
EDG-721: Add DataPointStamping and the reuse-wiring tests

### DIFF
--- a/hivemq-edge/src/main/java/com/hivemq/protocols2/runtime/DataPointStamping.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols2/runtime/DataPointStamping.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.protocols2.runtime;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.hivemq.adapter.sdk.api.data.DataPoint;
+import com.hivemq.adapter.sdk.api2.node.Node;
+import com.hivemq.adapter.sdk.api2.node.Tag2;
+import com.hivemq.datapoint.DataPointWithMetadata;
+import com.hivemq.edge.modules.adapters.data.DataPointImpl;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Stamps tag identity onto an adapter-produced {@link DataPoint}.
+ * <p>
+ * In the Nevsky framework, correlation across the adapter boundary is by {@link Node} reference — a protocol
+ * adapter reports values as {@code dataPoint(Node, DataPoint)} and is NOT required to set
+ * {@link DataPoint#getTagName()} or {@link DataPoint#getAdapterId()}. Before a value is handed to northbound
+ * consumers, the framework re-creates it with the owning tag's name and the adapter's id, preserving the
+ * payload:
+ * <ul>
+ * <li>a {@link DataPointWithMetadata} keeps its value, timestamp, metadata, and context — only the
+ * {@code tagName} inside the JSON envelope is rewritten (on a copy; the adapter's instance is never
+ * mutated);</li>
+ * <li>any other {@link DataPoint} is re-created with the same value reference and the same
+ * {@link DataPoint#treatTagValueAsJson()} flag.</li>
+ * </ul>
+ */
+public final class DataPointStamping {
+
+    private DataPointStamping() {}
+
+    /**
+     * @param dataPoint the adapter-produced data point; never mutated.
+     * @param tag       the owning tag of the node the adapter reported the value for.
+     * @param adapterId the id of the adapter instance that produced the value.
+     * @return a new data point carrying the tag's name and the adapter id, with the payload intact.
+     */
+    public static @NotNull DataPoint stamp(
+            final @NotNull DataPoint dataPoint, final @NotNull Tag2 tag, final @NotNull String adapterId) {
+        if (dataPoint instanceof final DataPointWithMetadata dataPointWithMetadata) {
+            final ObjectNode stampedEnvelope =
+                    dataPointWithMetadata.getJsonNode().deepCopy();
+            stampedEnvelope.put("tagName", tag.name());
+            return new DataPointWithMetadata(stampedEnvelope, adapterId);
+        }
+        return new DataPointImpl(tag.name(), dataPoint.getTagValue(), adapterId, dataPoint.treatTagValueAsJson());
+    }
+}

--- a/hivemq-edge/src/test/java/com/hivemq/protocols2/ReuseNoForkTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/protocols2/ReuseNoForkTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.protocols2;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The reuse boundary (decision D2) for the framework side: {@code protocols2} depends on the reused v1 SDK
+ * types and the new {@code api2} contracts — it never forks them into a parallel copy. The naming rules
+ * (N1/N2) govern every new {@code protocols2} identifier.
+ */
+class ReuseNoForkTest {
+
+    private static final Path PROTOCOLS2_SOURCE_DIRECTORY =
+            Path.of("src", "main", "java", "com", "hivemq", "protocols2");
+
+    /**
+     * Simple names of reused v1 SDK types and of the {@code api2} contracts — a same-named type under
+     * {@code protocols2} would be a fork.
+     */
+    private static final Set<String> NO_FORK_TYPE_SIMPLE_NAMES = Set.of(
+            // reused v1 SDK subset
+            "DataPoint",
+            "DataPointBuilder",
+            "DataPointFactory",
+            "Schema",
+            "ScalarSchema",
+            "ObjectSchema",
+            "ArraySchema",
+            "AnySchema",
+            "ScalarType",
+            "SchemaBuilder",
+            "SchemaJsonRepresentation",
+            "NodeType",
+            "ProtocolAdapterCategory",
+            "ProtocolAdapterTag",
+            // api2 contracts (SDK v2)
+            "Message",
+            "MessagePriority",
+            "MailboxSender",
+            "Mailbox",
+            "DefaultMailbox",
+            "Actor",
+            "Dispatcher",
+            "ActorHandle",
+            "Node",
+            "Tag2",
+            "NodeTagPair",
+            "NodeProperty",
+            "AccessTriState",
+            "AccessFlags",
+            "WriteEntry",
+            "BrowseFilter",
+            "BrowseResultEntry",
+            "ErrorScope",
+            "VerifyOutcome",
+            "ProtocolAdapter2",
+            "ProtocolAdapterCallbacks",
+            "ProtocolAdapterCapability2",
+            "ProtocolAdapterInformation2",
+            "ProtocolAdapterFactory2",
+            "ProtocolAdapterInput2",
+            "ProtocolAdapterServices2");
+
+    /**
+     * Architectural shorthands that must never appear in code identifiers (naming rule N2).
+     */
+    private static final Set<String> FORBIDDEN_ABBREVIATIONS =
+            Set.of("Paw", "Pam", "Paf", "Fsm", "Ctx", "Cfg", "Ack", "Mgr");
+
+    @Test
+    void protocols2_doesNotForkAnyReusedType() throws IOException {
+        for (final String typeName : protocols2TopLevelTypeNames()) {
+            assertThat(NO_FORK_TYPE_SIMPLE_NAMES)
+                    .as("protocols2 type %s must not fork a reused type", typeName)
+                    .doesNotContain(typeName);
+        }
+    }
+
+    @Test
+    void namingRuleN1_twoIsASuffixNeverAnInfix() throws IOException {
+        for (final String typeName : protocols2TopLevelTypeNames()) {
+            if (typeName.indexOf('2') >= 0) {
+                assertThat(typeName)
+                        .as("identifier %s must carry '2' only as a suffix (naming rule N1)", typeName)
+                        .matches("[A-Za-z]+2");
+            }
+        }
+    }
+
+    @Test
+    void namingRuleN2_noAbbreviationsInTypeNames() throws IOException {
+        for (final String typeName : protocols2TopLevelTypeNames()) {
+            for (final String abbreviation : FORBIDDEN_ABBREVIATIONS) {
+                assertThat(typeName)
+                        .as(
+                                "identifier %s must not contain the abbreviation '%s' (naming rule N2)",
+                                typeName, abbreviation)
+                        .doesNotContain(abbreviation);
+            }
+        }
+    }
+
+    private static List<String> protocols2TopLevelTypeNames() throws IOException {
+        assertThat(PROTOCOLS2_SOURCE_DIRECTORY)
+                .as("the test must run with the project directory as its working directory")
+                .exists();
+        try (final Stream<Path> paths = Files.walk(PROTOCOLS2_SOURCE_DIRECTORY)) {
+            return paths.filter(path -> path.getFileName().toString().endsWith(".java"))
+                    .map(path -> path.getFileName().toString().replace(".java", ""))
+                    .filter(typeName -> !typeName.equals("package-info"))
+                    .toList();
+        }
+    }
+}

--- a/hivemq-edge/src/test/java/com/hivemq/protocols2/runtime/DataPointStampingTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/protocols2/runtime/DataPointStampingTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.protocols2.runtime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.hivemq.adapter.sdk.api.data.DataPoint;
+import com.hivemq.adapter.sdk.api.schema.ScalarSchema;
+import com.hivemq.adapter.sdk.api.schema.ScalarType;
+import com.hivemq.adapter.sdk.api2.node.Node;
+import com.hivemq.adapter.sdk.api2.node.NodeProperty;
+import com.hivemq.adapter.sdk.api2.node.NodeTagPair;
+import com.hivemq.adapter.sdk.api2.node.Tag2;
+import com.hivemq.datapoint.DataPointWithMetadata;
+import java.util.EnumSet;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+
+/**
+ * S21 at unit level: the framework stamps the owning tag's name and the adapter id onto an adapter-produced
+ * {@link DataPoint}; the payload stays intact and the adapter's instance is never mutated.
+ */
+class DataPointStampingTest {
+
+    private static final class TestNode extends Node {
+        @Override
+        public @NotNull String nodeId() {
+            return "test-node";
+        }
+
+        @Override
+        public @NotNull String nodeString() {
+            return "{\"identifier\":\"test-node\"}";
+        }
+
+        @Override
+        public @NotNull EnumSet<NodeProperty> properties() {
+            return EnumSet.of(NodeProperty.UNIQUE, NodeProperty.TYPED, NodeProperty.VALID);
+        }
+    }
+
+    private record AdapterProducedDataPoint(@NotNull Object value, boolean treatAsJson) implements DataPoint {
+        @Override
+        public @NotNull Object getTagValue() {
+            return value;
+        }
+
+        @Override
+        public boolean treatTagValueAsJson() {
+            return treatAsJson;
+        }
+
+        @Override
+        public @NotNull String getTagName() {
+            return "";
+        }
+    }
+
+    private static @NotNull Tag2 temperatureTag() {
+        final NodeTagPair pair = NodeTagPair.create(
+                new TestNode(),
+                "temperature",
+                new ScalarSchema(ScalarType.DOUBLE, null, null, null, null, false, true, false),
+                true,
+                false);
+        return pair.tag();
+    }
+
+    @Test
+    void plainDataPoint_isRecreatedWithStampedTagNameAndAdapterId_payloadIntact() {
+        final Object payload = new Object();
+        final DataPoint produced = new AdapterProducedDataPoint(payload, false);
+
+        final DataPoint stamped = DataPointStamping.stamp(produced, temperatureTag(), "adapter-1");
+
+        assertThat(stamped.getTagName()).isEqualTo("temperature");
+        assertThat(stamped.getAdapterId()).isEqualTo("adapter-1");
+        assertThat(stamped.getTagValue()).isSameAs(payload);
+        assertThat(stamped.treatTagValueAsJson()).isFalse();
+    }
+
+    @Test
+    void treatTagValueAsJsonFlag_isPreserved() {
+        final DataPoint produced = new AdapterProducedDataPoint("{\"unit\":\"celsius\"}", true);
+
+        final DataPoint stamped = DataPointStamping.stamp(produced, temperatureTag(), "adapter-1");
+
+        assertThat(stamped.treatTagValueAsJson()).isTrue();
+        assertThat(stamped.getTagValue()).isEqualTo("{\"unit\":\"celsius\"}");
+    }
+
+    @Test
+    void dataPointWithMetadata_keepsValueTimestampMetadataAndContext() {
+        final ObjectNode envelope = JsonNodeFactory.instance.objectNode();
+        envelope.put("tagName", "adapter-side-name");
+        envelope.put("timestamp", 1234L);
+        envelope.put("value", 21.5d);
+        envelope.putObject("metadata").put("unit", "celsius");
+        envelope.putObject("context").put("source", "poll");
+        final DataPointWithMetadata produced = new DataPointWithMetadata(envelope, "");
+
+        final DataPoint stamped = DataPointStamping.stamp(produced, temperatureTag(), "adapter-1");
+
+        assertThat(stamped).isInstanceOf(DataPointWithMetadata.class);
+        final DataPointWithMetadata stampedWithMetadata = (DataPointWithMetadata) stamped;
+        assertThat(stampedWithMetadata.getTagName()).isEqualTo("temperature");
+        assertThat(stampedWithMetadata.getAdapterId()).isEqualTo("adapter-1");
+        assertThat(stampedWithMetadata.getTimestamp()).isEqualTo(1234L);
+        assertThat(stampedWithMetadata.getTagValue().doubleValue()).isEqualTo(21.5d);
+        assertThat(stampedWithMetadata.getMetadata())
+                .hasValueSatisfying(
+                        metadata -> assertThat(metadata.get("unit").asText()).isEqualTo("celsius"));
+        assertThat(stampedWithMetadata.getContext())
+                .hasValueSatisfying(
+                        context -> assertThat(context.get("source").asText()).isEqualTo("poll"));
+    }
+
+    @Test
+    void dataPointWithMetadata_originalEnvelopeIsNeverMutated() {
+        final ObjectNode envelope = JsonNodeFactory.instance.objectNode();
+        envelope.put("tagName", "adapter-side-name");
+        envelope.put("timestamp", 1234L);
+        envelope.put("value", 21.5d);
+        final DataPointWithMetadata produced = new DataPointWithMetadata(envelope, "");
+
+        DataPointStamping.stamp(produced, temperatureTag(), "adapter-1");
+
+        assertThat(produced.getTagName()).isEqualTo("adapter-side-name");
+        assertThat(produced.getAdapterId()).isEmpty();
+        assertThat(envelope.get("tagName").asText()).isEqualTo("adapter-side-name");
+    }
+}

--- a/hivemq-edge/src/test/java/com/hivemq/protocols2/view/SchemaJsonTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/protocols2/view/SchemaJsonTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.protocols2.view;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.hivemq.adapter.sdk.api.schema.AnySchema;
+import com.hivemq.adapter.sdk.api.schema.ArraySchema;
+import com.hivemq.adapter.sdk.api.schema.ObjectSchema;
+import com.hivemq.adapter.sdk.api.schema.ScalarSchema;
+import com.hivemq.adapter.sdk.api.schema.ScalarType;
+import com.hivemq.adapter.sdk.api.schema.Schema;
+import com.hivemq.adapter.sdk.api.schema.SchemaJsonRepresentation;
+import java.util.List;
+import java.util.Map;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.junit.jupiter.api.Test;
+
+/**
+ * S22 precursor: the v2 API serves the reused v1 {@link Schema} through the reused
+ * {@link SchemaJsonRepresentation} projection — no Nevsky-side copy exists (see {@code ReuseNoForkTest}).
+ * This locks the projection contract the v2 schema endpoints rely on: every reused {@link ScalarType} maps to
+ * the expected JSON-Schema {@code type}/{@code format}, and the constraints are projected.
+ */
+class SchemaJsonTest {
+
+    private static @NotNull ObjectNode toJsonSchema(final @NotNull Schema schema) {
+        return SchemaJsonRepresentation.INSTANCE.toJsonSchema(schema);
+    }
+
+    private static @NotNull ScalarSchema scalar(
+            final @NotNull ScalarType type, final @Nullable Number minimum, final @Nullable Number maximum) {
+        return new ScalarSchema(type, minimum, maximum, null, null, false, true, false);
+    }
+
+    /**
+     * Compiles WITHOUT a {@code default} branch — a new {@link ScalarType} constant breaks this test at
+     * compile time until its projection is locked in here.
+     */
+    private static @NotNull String expectedJsonType(final @NotNull ScalarType type) {
+        return switch (type) {
+            case BOOLEAN -> "boolean";
+            case LONG, ULONG -> "integer";
+            case DOUBLE -> "number";
+            case STRING, BINARY, INSTANT, LOCAL_DATE, LOCAL_TIME, LOCAL_DATE_TIME, DURATION -> "string";
+        };
+    }
+
+    private static @Nullable String expectedJsonFormat(final @NotNull ScalarType type) {
+        return switch (type) {
+            case BOOLEAN, LONG, ULONG, DOUBLE, STRING, BINARY -> null;
+            case INSTANT -> "date-time";
+            case LOCAL_DATE -> "date";
+            case LOCAL_TIME -> "local-time";
+            case LOCAL_DATE_TIME -> "local-date-time";
+            case DURATION -> "duration";
+        };
+    }
+
+    @Test
+    void everyScalarType_projectsTheExpectedJsonTypeAndFormat() {
+        for (final ScalarType scalarType : ScalarType.values()) {
+            final ObjectNode jsonSchema = toJsonSchema(scalar(scalarType, null, null));
+
+            assertThat(jsonSchema.get("type").asText())
+                    .as("JSON-Schema type for %s", scalarType)
+                    .isEqualTo(expectedJsonType(scalarType));
+
+            final String expectedFormat = expectedJsonFormat(scalarType);
+            if (expectedFormat == null) {
+                assertThat(jsonSchema.has("format"))
+                        .as("no format for %s", scalarType)
+                        .isFalse();
+            } else {
+                assertThat(jsonSchema.get("format").asText())
+                        .as("JSON-Schema format for %s", scalarType)
+                        .isEqualTo(expectedFormat);
+            }
+        }
+    }
+
+    @Test
+    void binary_projectsBase64ContentEncoding() {
+        final ObjectNode jsonSchema = toJsonSchema(scalar(ScalarType.BINARY, null, null));
+        assertThat(jsonSchema.get("contentEncoding").asText()).isEqualTo("base64");
+    }
+
+    @Test
+    void scalarRangeConstraints_areProjected() {
+        final ObjectNode integerSchema = toJsonSchema(scalar(ScalarType.LONG, 0L, 100L));
+        assertThat(integerSchema.get("minimum").asLong()).isEqualTo(0L);
+        assertThat(integerSchema.get("maximum").asLong()).isEqualTo(100L);
+
+        final ObjectNode numberSchema = toJsonSchema(scalar(ScalarType.DOUBLE, -1.5d, 1.5d));
+        assertThat(numberSchema.get("minimum").asDouble()).isEqualTo(-1.5d);
+        assertThat(numberSchema.get("maximum").asDouble()).isEqualTo(1.5d);
+    }
+
+    @Test
+    void objectConstraints_areProjected() {
+        final Schema objectSchema = new ObjectSchema(
+                Map.of("temperature", scalar(ScalarType.DOUBLE, null, null)),
+                List.of("temperature"),
+                false,
+                null,
+                null,
+                false,
+                true,
+                false);
+
+        final ObjectNode jsonSchema = toJsonSchema(objectSchema);
+
+        assertThat(jsonSchema.get("type").asText()).isEqualTo("object");
+        assertThat(jsonSchema.get("properties").get("temperature").get("type").asText())
+                .isEqualTo("number");
+        assertThat(jsonSchema.get("required")).hasSize(1);
+        assertThat(jsonSchema.get("required").get(0).asText()).isEqualTo("temperature");
+        assertThat(jsonSchema.get("additionalProperties").asBoolean()).isFalse();
+    }
+
+    @Test
+    void arrayConstraints_areProjected() {
+        final Schema arraySchema =
+                new ArraySchema(scalar(ScalarType.LONG, null, null), 1, 8, null, null, false, true, false);
+
+        final ObjectNode jsonSchema = toJsonSchema(arraySchema);
+
+        assertThat(jsonSchema.get("type").asText()).isEqualTo("array");
+        assertThat(jsonSchema.get("items").get("type").asText()).isEqualTo("integer");
+        assertThat(jsonSchema.get("minContains").asInt()).isEqualTo(1);
+        assertThat(jsonSchema.get("maxContains").asInt()).isEqualTo(8);
+    }
+
+    @Test
+    void anySchema_projectsNoTypeRestriction() {
+        final ObjectNode jsonSchema = toJsonSchema(new AnySchema(null, null, false, true, false));
+        assertThat(jsonSchema.has("type")).isFalse();
+    }
+}


### PR DESCRIPTION
## Summary

Nevsky Task 2 (EDG-721), framework half — reuse wiring (Schema + DataPoint) + node properties / strings / projection. First `com.hivemq.protocols2` sources in the core module.

- **`protocols2/runtime/DataPointStamping`**: the documented stamping helper. Correlation across the adapter boundary is by `Node` reference, so a protocol adapter is not required to set `getTagName()`/`getAdapterId()` — the framework re-creates the data point with the owning tag's name and the adapter id before handing it to northbound consumers, preserving the payload. A `DataPointWithMetadata` keeps its value, timestamp, metadata, and context (the `tagName` is rewritten on a copy of the JSON envelope; the adapter's instance is never mutated); any other `DataPoint` is re-created with the same value reference and `treatTagValueAsJson()` flag.
- **`protocols2/view/SchemaJsonTest`**: locks the JSON-Schema projection the v2 API serves through the reused `SchemaJsonRepresentation` (no Nevsky-side copy): an exhaustive every-`ScalarType` → type/format ladder (a new enum constant breaks it at compile time; includes the five temporal types the existing converter test does not cover), scalar minimum/maximum, object `required`/`additionalProperties`, array `minContains`/`maxContains`, `AnySchema`, and the BINARY base64 content encoding.
- **`protocols2/runtime/DataPointStampingTest`** (S21): tagName and adapterId stamped, payload intact for both `DataPoint` flavors, the original envelope never mutated.
- **`protocols2/ReuseNoForkTest`**: walks the `protocols2` main sources — no fork of any reused v1 SDK type or `api2` contract; naming rules N1 and N2 hold for every `protocols2` identifier.

The SDK half of Task 2 (Node contract Javadoc + `NodePropertiesTest`) lands in the hivemq-edge-adapter-sdk repository on the same feature branch.

## Test plan

- `./gradlew :hivemq-edge-build:hivemq-edge:test --tests "com.hivemq.protocols2.*"` — 13/13 green.
- Full `./gradlew :hivemq-edge-build:hivemq-edge:check` green (includes ErrorProne/NullAway and spotlessCheck).
- `./gradlew spotlessApply` run at the composite root.