### PR TITLE
EDG-722: Sync the protocols2 reuse no-fork guard with the api2 renames

### DIFF
--- a/hivemq-edge/src/test/java/com/hivemq/protocols2/ReuseNoForkTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/protocols2/ReuseNoForkTest.java
@@ -55,15 +55,16 @@ class ReuseNoForkTest {
             "NodeType",
             "ProtocolAdapterCategory",
             "ProtocolAdapterTag",
+            "ProtocolSpecificAdapterConfig",
             // api2 contracts (SDK v2)
-            "Message",
-            "MessagePriority",
+            "MailboxMessage",
+            "MailboxMessagePriority",
             "MailboxSender",
             "Mailbox",
             "DefaultMailbox",
-            "Actor",
-            "Dispatcher",
-            "ActorHandle",
+            "MessageHandler",
+            "MessageDispatcher",
+            "MessageDispatcherHandle",
             "Node",
             "Tag2",
             "NodeTagPair",
@@ -76,12 +77,13 @@ class ReuseNoForkTest {
             "ErrorScope",
             "VerifyOutcome",
             "ProtocolAdapter2",
-            "ProtocolAdapterCallbacks",
+            "ProtocolAdapterOutput2",
             "ProtocolAdapterCapability2",
             "ProtocolAdapterInformation2",
             "ProtocolAdapterFactory2",
             "ProtocolAdapterInput2",
-            "ProtocolAdapterServices2");
+            "ProtocolAdapterService",
+            "AdapterConfigSchema");
 
     /**
      * Architectural shorthands that must never appear in code identifiers (naming rule N2).


### PR DESCRIPTION
Updates ReuseNoForkTest's no-fork name set to the renamed SDK v2 api2 contracts
(MailboxMessage, MailboxMessagePriority, MessageHandler, MessageDispatcher,
MessageDispatcherHandle, ProtocolAdapterService, ProtocolAdapterOutput2,
AdapterConfigSchema, ProtocolSpecificAdapterConfig) so the guard keeps protocols2 from
forking the current api2 types.
