### PR TITLE
fix(simulation): make random INT/LONG upper bound exclusive (EDG-740)

### DIFF
--- a/hivemq-edge/src/main/java/com/hivemq/edge/modules/adapters/simulation/SimulationProtocolAdapter.java
+++ b/hivemq-edge/src/main/java/com/hivemq/edge/modules/adapters/simulation/SimulationProtocolAdapter.java
@@ -165,10 +165,10 @@ public class SimulationProtocolAdapter implements BatchPollingProtocolAdapter, W
                 switch (rv.getValueType()) {
                     case INT ->
                         b.value(ThreadLocalRandom.current()
-                                .nextInt((int) rv.getMinValue(), (int) rv.getMaxValue() + 1));
+                                .nextInt((int) rv.getMinValue(), (int) rv.getMaxValue()));
                     case LONG ->
                         b.value(ThreadLocalRandom.current()
-                                .nextLong((long) rv.getMinValue(), (long) rv.getMaxValue() + 1));
+                                .nextLong((long) rv.getMinValue(), (long) rv.getMaxValue()));
                     case DOUBLE -> b.value(ThreadLocalRandom.current().nextDouble(rv.getMinValue(), rv.getMaxValue()));
                     case STRING ->
                         throw new IllegalStateException(

--- a/hivemq-edge/src/main/java/com/hivemq/edge/modules/adapters/simulation/SimulationProtocolAdapter.java
+++ b/hivemq-edge/src/main/java/com/hivemq/edge/modules/adapters/simulation/SimulationProtocolAdapter.java
@@ -164,11 +164,9 @@ public class SimulationProtocolAdapter implements BatchPollingProtocolAdapter, W
                 final RandomValueConfig rv = Objects.requireNonNull(def.getRandomValue());
                 switch (rv.getValueType()) {
                     case INT ->
-                        b.value(ThreadLocalRandom.current()
-                                .nextInt((int) rv.getMinValue(), (int) rv.getMaxValue()));
+                        b.value(ThreadLocalRandom.current().nextInt((int) rv.getMinValue(), (int) rv.getMaxValue()));
                     case LONG ->
-                        b.value(ThreadLocalRandom.current()
-                                .nextLong((long) rv.getMinValue(), (long) rv.getMaxValue()));
+                        b.value(ThreadLocalRandom.current().nextLong((long) rv.getMinValue(), (long) rv.getMaxValue()));
                     case DOUBLE -> b.value(ThreadLocalRandom.current().nextDouble(rv.getMinValue(), rv.getMaxValue()));
                     case STRING ->
                         throw new IllegalStateException(

--- a/hivemq-edge/src/test/java/com/hivemq/edge/modules/adapters/simulation/SimulationProtocolAdapterTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/edge/modules/adapters/simulation/SimulationProtocolAdapterTest.java
@@ -166,7 +166,8 @@ class SimulationProtocolAdapterTest {
 
         final Object value = firstValue();
         assertThat(value).isInstanceOf(Integer.class);
-        assertThat((Integer) value).isBetween(5, 15);
+        // Upper bound is exclusive (nextInt(min, max)), so max=15 must never be emitted.
+        assertThat((Integer) value).isBetween(5, 14);
     }
 
     @Test


### PR DESCRIPTION
## What

`SimulationProtocolAdapter` generated random `INT`/`LONG` values with a `+ 1` on the bound:

```java
nextInt((int) min, (int) max + 1)
nextLong((long) min, (long) max + 1)
```

`ThreadLocalRandom.nextInt/nextLong(origin, bound)` is **bound-exclusive**, so the `+ 1` made `maxValue` reachable — e.g. configuring `max=1000` could emit `1000` instead of capping at `999`. The `DOUBLE` branch was already correct (`nextDouble(min, max)`).

## Fix

Remove the `+ 1` from both the `LONG` and `INT` branches so the range is `[min, max)` exclusive, consistent with `DOUBLE`.

- **LONG** — the bug reported in EDG-740 (caught in CI on #1565).
- **INT** — identical latent off-by-one. Its test never caught it because `assertThat(value).isBetween(5, 15)` is inclusive on both ends, so it passed whether the generator emitted `[5,14]` or `[5,15]`. Folded into this PR as same-root-cause; tightened the test to `isBetween(5, 14)` so the exclusive upper bound is actually pinned.

## Test

All 28 tests in `SimulationProtocolAdapterTest` pass, including the previously-failing `test_poll_randomNumberLong_emitsLongWithinRange`.

## Out of scope

The tag schema still advertises `maximum = max` (JSON-Schema inclusive) while the generator is now exclusive — pre-existing and identical to how `DOUBLE` already behaves (a harmless value superset). Not changed here.

Fixes EDG-740.