### PR TITLE
[LATEST] Remove outdated project tags from all Snyk workflows

### DIFF
--- a/.github/workflows/snyk-push.yml
+++ b/.github/workflows/snyk-push.yml
@@ -43,7 +43,6 @@ jobs:
         run: >
           snyk monitor --configuration-matching=^runtimeClasspath$ --target-reference=${{ steps.select_github_ref.outputs.selected_github_ref }} --org=hivemq-edge
           --project-name=hivemq-edge --remote-repo-url=hivemq-edge --project-lifecycle=development -d
-          --project-tags="\"kanbanize_board_name=Edge,kanbanize_board_workflow_name=Development++Workflow,kanbanize_board_column_name=Requested++~~Selected~~,kanbanize_board_swimlane=Expedite,kanbanize_board_done_sections=4/5\""
           hivemq-edge/hivemq-edge -- --stacktrace
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
@@ -58,7 +57,6 @@ jobs:
         run: >
           snyk monitor --all-projects --target-reference=${{ steps.select_github_ref.outputs.selected_github_ref }} --org=hivemq-edge
           --project-name=hivemq-edge-frontend --remote-repo-url=hivemq-edge-frontend --project-lifecycle=development -d
-          --project-tags="\"kanbanize_board_name=Edge,kanbanize_board_workflow_name=Development++Workflow,kanbanize_board_column_name=Requested++~~Selected~~,kanbanize_board_swimlane=Expedite,kanbanize_board_done_sections=4/5\""
           hivemq-edge/hivemq-edge-frontend
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}


### PR DESCRIPTION
## Summary

Remove the outdated Kanbanize `--project-tags` arguments from the Snyk workflows. These project tags were once used for a Kanbanize integration that is no longer in use.

INT-350
