### PR TITLE
EDG-723: Add the Nevsky runtime — dispatchers, clock/tick, timer queue, backoff, metrics

### DIFF
--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/runtime/Backoff.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/runtime/Backoff.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.protocols.v2.runtime;
+
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Stateful exponential backoff over a {@link RetryPolicy} (design §5.6). It is owned and stepped by a single
+ * actor on its dispatch thread; it does no scheduling itself — the caller schedules a timer for
+ * {@link #nextDelayMillis()} on the actor's {@link PriorityTimerQueue}.
+ * <p>
+ * With {@link RetryPolicy#defaults()} the delays are 1000, 1410, 1988, 2803, &hellip; each successive delay being
+ * the previous one times the policy factor, rounded to the nearest millisecond and capped at the policy ceiling.
+ */
+public final class Backoff {
+
+    private final @NotNull RetryPolicy policy;
+    private long nextDelayMillis;
+    private int retriesTaken;
+
+    public Backoff(final @NotNull RetryPolicy policy) {
+        this.policy = policy;
+        reset();
+    }
+
+    /**
+     * Hand out the next delay and advance the sequence. Counts as one retry against
+     * {@link RetryPolicy#maximumRetries()}.
+     *
+     * @return the delay to wait before the next attempt, in milliseconds.
+     */
+    public long nextDelayMillis() {
+        final long delay = nextDelayMillis;
+        retriesTaken++;
+        nextDelayMillis = Math.min(Math.round(delay * policy.factor()), policy.ceilingMillis());
+        return delay;
+    }
+
+    /**
+     * Return to the start of the sequence: the next {@link #nextDelayMillis()} yields
+     * {@link RetryPolicy#initialMillis()} again and the retry count is cleared. Called when an attempt succeeds.
+     */
+    public void reset() {
+        nextDelayMillis = policy.initialMillis();
+        retriesTaken = 0;
+    }
+
+    /**
+     * @return {@code true} once {@link RetryPolicy#maximumRetries()} delays have been handed out — the point at
+     *         which the caller stops retrying and escalates (for the adapter machine: to {@code ERROR}).
+     */
+    public boolean exhausted() {
+        return retriesTaken >= policy.maximumRetries();
+    }
+}

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/runtime/Clock.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/runtime/Clock.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.protocols.v2.runtime;
+
+import com.hivemq.adapter.sdk.api.v2.messaging.MailboxMessage;
+import com.hivemq.adapter.sdk.api.v2.messaging.MailboxSender;
+import java.util.function.Supplier;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Time, abstracted so the framework can be driven deterministically in tests (design §5.4).
+ * <p>
+ * Time enters an actor as a <b>message</b>, never as a callback that touches actor state: the clock's only job is
+ * to {@link MailboxSender#tell(MailboxMessage) tell} a tick to the actor's mailbox every period. The actor then
+ * fires its own {@link PriorityTimerQueue} on its own dispatch thread when it handles that tick — the clock never
+ * fires a timer itself.
+ * <p>
+ * The caller supplies how to build its own tick message, so the scheduler stays generic: production uses
+ * {@link SystemClock}; tests use {@link FakeClock}.
+ */
+public interface Clock {
+
+    /**
+     * @return the current time in milliseconds. In production this is wall-clock time; in tests it is the value
+     *         advanced explicitly via {@link FakeClock#advance(long)}.
+     */
+    long nowMillis();
+
+    /**
+     * Periodically tell the target a tick message (~50 ms in production).
+     *
+     * @param periodMillis  the interval between ticks, in milliseconds; must be positive.
+     * @param target        the send-only handle of the actor mailbox that receives the ticks.
+     * @param tickMessage   builds a fresh tick each period; invoked once per tick, on the scheduler's thread.
+     * @param <MessageType> the actor's tick message type.
+     * @return a handle that stops this periodic tick when closed; closing it never affects other schedules.
+     */
+    <MessageType extends MailboxMessage> @NotNull AutoCloseable scheduleTick(
+            long periodMillis, @NotNull MailboxSender<MessageType> target, @NotNull Supplier<MessageType> tickMessage);
+}

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/runtime/FakeClock.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/runtime/FakeClock.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.protocols.v2.runtime;
+
+import com.hivemq.adapter.sdk.api.v2.messaging.MailboxMessage;
+import com.hivemq.adapter.sdk.api.v2.messaging.MailboxSender;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Supplier;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Deterministic test {@link Clock}. {@link #advance(long)} moves {@link #nowMillis()} forward and tells the due
+ * tick messages, in fire-time order — <b>nothing else</b>.
+ * <p>
+ * The clock never fires a timer: a {@link PriorityTimerQueue} is drained exclusively inside the owning actor's
+ * tick handler, on the dispatch thread. Pairing a {@code FakeClock} with a {@link ManualDispatcher} gives a fully
+ * deterministic, sleep-free test: advancing the clock enqueues ticks, and draining the dispatcher delivers them.
+ * <p>
+ * Before each tick is told, {@link #nowMillis()} is set to that tick's fire time, so a supplier such as
+ * {@code () -> new Tick(clock.nowMillis())} stamps the correct logical time. Not thread-safe: drive it from one
+ * test thread.
+ */
+public final class FakeClock implements Clock {
+
+    private long nowMillis;
+    private final @NotNull List<TickRegistration<?>> registrations = new ArrayList<>();
+
+    public FakeClock() {
+        this(0L);
+    }
+
+    public FakeClock(final long initialMillis) {
+        this.nowMillis = initialMillis;
+    }
+
+    @Override
+    public long nowMillis() {
+        return nowMillis;
+    }
+
+    @Override
+    public <MessageType extends MailboxMessage> @NotNull AutoCloseable scheduleTick(
+            final long periodMillis,
+            final @NotNull MailboxSender<MessageType> target,
+            final @NotNull Supplier<MessageType> tickMessage) {
+        if (periodMillis <= 0) {
+            throw new IllegalArgumentException("tick period must be positive, but was " + periodMillis);
+        }
+        final TickRegistration<MessageType> registration =
+                new TickRegistration<>(periodMillis, target, tickMessage, nowMillis + periodMillis);
+        registrations.add(registration);
+        return () -> registration.active = false;
+    }
+
+    /**
+     * Move time forward by {@code millis}, telling every tick that becomes due along the way in fire-time order
+     * (ties broken by schedule order). {@link #nowMillis()} is advanced to each tick's fire time before that tick
+     * is told, then to the final target time once no tick remains due.
+     *
+     * @param millis the duration to advance by, in milliseconds; must not be negative.
+     */
+    public void advance(final long millis) {
+        if (millis < 0) {
+            throw new IllegalArgumentException("cannot advance by a negative duration: " + millis);
+        }
+        final long targetMillis = nowMillis + millis;
+        while (true) {
+            final TickRegistration<?> earliest = earliestDueRegistration(targetMillis);
+            if (earliest == null) {
+                break;
+            }
+            nowMillis = earliest.nextFireAtMillis;
+            earliest.fire();
+            earliest.nextFireAtMillis += earliest.periodMillis;
+        }
+        nowMillis = targetMillis;
+    }
+
+    private @Nullable TickRegistration<?> earliestDueRegistration(final long targetMillis) {
+        TickRegistration<?> earliest = null;
+        // index-based so a tick that re-schedules during fire() (appending) cannot throw a concurrent modification
+        for (int i = 0; i < registrations.size(); i++) {
+            final TickRegistration<?> registration = registrations.get(i);
+            if (!registration.active || registration.nextFireAtMillis > targetMillis) {
+                continue;
+            }
+            if (earliest == null || registration.nextFireAtMillis < earliest.nextFireAtMillis) {
+                earliest = registration;
+            }
+        }
+        return earliest;
+    }
+
+    private static final class TickRegistration<MessageType extends MailboxMessage> {
+
+        private final long periodMillis;
+        private final @NotNull MailboxSender<MessageType> target;
+        private final @NotNull Supplier<MessageType> tickMessage;
+        private long nextFireAtMillis;
+        private boolean active = true;
+
+        private TickRegistration(
+                final long periodMillis,
+                final @NotNull MailboxSender<MessageType> target,
+                final @NotNull Supplier<MessageType> tickMessage,
+                final long firstFireAtMillis) {
+            this.periodMillis = periodMillis;
+            this.target = target;
+            this.tickMessage = tickMessage;
+            this.nextFireAtMillis = firstFireAtMillis;
+        }
+
+        private void fire() {
+            target.tell(tickMessage.get());
+        }
+    }
+}

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/runtime/ManualDispatcher.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/runtime/ManualDispatcher.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.protocols.v2.runtime;
+
+import com.hivemq.adapter.sdk.api.v2.messaging.Mailbox;
+import com.hivemq.adapter.sdk.api.v2.messaging.MailboxMessage;
+import com.hivemq.adapter.sdk.api.v2.messaging.MessageDispatcher;
+import com.hivemq.adapter.sdk.api.v2.messaging.MessageDispatcherHandle;
+import com.hivemq.adapter.sdk.api.v2.messaging.MessageHandler;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Test {@link MessageDispatcher}: {@link #attach(Mailbox, MessageHandler)} records the binding and
+ * {@link #drainAll()} delivers every queued message on the <b>calling thread</b> — fully deterministic, pairs
+ * with {@link FakeClock}. No background threads; nothing happens until {@code drainAll()} is called.
+ */
+public final class ManualDispatcher implements MessageDispatcher {
+
+    private final @NotNull List<Binding<?>> bindings = new CopyOnWriteArrayList<>();
+
+    @Override
+    public <MessageType extends MailboxMessage> @NotNull MessageDispatcherHandle attach(
+            final @NotNull Mailbox<MessageType> mailbox, final @NotNull MessageHandler<MessageType> handler) {
+        final Binding<MessageType> binding = new Binding<>(mailbox, handler);
+        bindings.add(binding);
+        return () -> bindings.remove(binding);
+    }
+
+    /**
+     * Drain every attached mailbox until all are empty, delivering one message per mailbox per pass in
+     * priority-band order. Messages a {@code receive} tells back to any attached mailbox — including its own — are
+     * picked up by a later pass, so the drain reaches a fixed point before returning.
+     */
+    public void drainAll() {
+        boolean delivered = true;
+        while (delivered) {
+            delivered = false;
+            for (final Binding<?> binding : bindings) {
+                if (binding.deliverOne()) {
+                    delivered = true;
+                }
+            }
+        }
+    }
+
+    private static final class Binding<MessageType extends MailboxMessage> {
+
+        private final @NotNull Mailbox<MessageType> mailbox;
+        private final @NotNull MessageHandler<MessageType> handler;
+
+        private Binding(
+                final @NotNull Mailbox<MessageType> mailbox, final @NotNull MessageHandler<MessageType> handler) {
+            this.mailbox = mailbox;
+            this.handler = handler;
+        }
+
+        private boolean deliverOne() {
+            final MessageType message = mailbox.poll();
+            if (message == null) {
+                return false;
+            }
+            handler.receive(message);
+            return true;
+        }
+    }
+}

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/runtime/NevskyMetrics.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/runtime/NevskyMetrics.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.protocols.v2.runtime;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.MetricRegistry;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.IntSupplier;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * The minimal per-adapter metric set the risk model promises (design §5.8), registered on the shared
+ * {@link MetricRegistry}. One instance belongs to one adapter wrapper, created when the wrapper is and
+ * {@link #close() removed} when the wrapper is, so its metric names ({@code nevsky.adapter.<id>.*}) never outlive
+ * the adapter.
+ * <ul>
+ * <li>{@code nevsky.adapter.<id>.mailbox.depth} — gauge over the wrapper mailbox's {@code size()};</li>
+ * <li>{@code nevsky.adapter.<id>.state.transitions} — counter, one per adapter-machine transition;</li>
+ * <li>{@code nevsky.adapter.<id>.defensive.resets} — counter, one per defensive (unmatched) reset;</li>
+ * <li>{@code nevsky.adapter.<id>.tag.<name>.failures} — counter per tag (poll/write/subscription failures);</li>
+ * <li>{@code nevsky.adapter.<id>.tick.lag} — gauge of {@code now - tick.nowMillis} at processing time.</li>
+ * </ul>
+ * Counters and the tick-lag holder are updated from the owning actor's dispatch thread; the gauges are read from
+ * the metrics reporter's thread, which is why the mailbox-depth source is the thread-safe {@code Mailbox.size()}
+ * and the tick-lag source is an {@link AtomicLong}.
+ */
+public final class NevskyMetrics implements AutoCloseable {
+
+    public static final @NotNull String ADAPTER_PREFIX = "nevsky.adapter.";
+
+    private final @NotNull MetricRegistry metricRegistry;
+    private final @NotNull String adapterId;
+    private final @NotNull String mailboxDepthName;
+    private final @NotNull String stateTransitionsName;
+    private final @NotNull String defensiveResetsName;
+    private final @NotNull String tickLagName;
+    private final @NotNull Counter stateTransitions;
+    private final @NotNull Counter defensiveResets;
+    private final @NotNull AtomicLong tickLagMillis = new AtomicLong();
+    private final @NotNull Set<String> tagFailureNames = ConcurrentHashMap.newKeySet();
+
+    /**
+     * @param metricRegistry the shared registry to register on.
+     * @param adapterId      the adapter instance id; embedded in every metric name.
+     * @param mailboxDepth   the source of the mailbox-depth gauge — typically the wrapper mailbox's
+     *                       {@code size}, which is safe to read from any thread.
+     */
+    public NevskyMetrics(
+            final @NotNull MetricRegistry metricRegistry,
+            final @NotNull String adapterId,
+            final @NotNull IntSupplier mailboxDepth) {
+        this.metricRegistry = metricRegistry;
+        this.adapterId = adapterId;
+        this.mailboxDepthName = name("mailbox.depth");
+        this.stateTransitionsName = name("state.transitions");
+        this.defensiveResetsName = name("defensive.resets");
+        this.tickLagName = name("tick.lag");
+        metricRegistry.registerGauge(mailboxDepthName, mailboxDepth::getAsInt);
+        metricRegistry.registerGauge(tickLagName, tickLagMillis::get);
+        this.stateTransitions = metricRegistry.counter(stateTransitionsName);
+        this.defensiveResets = metricRegistry.counter(defensiveResetsName);
+    }
+
+    /**
+     * Record one adapter-machine state transition.
+     */
+    public void incrementStateTransition() {
+        stateTransitions.inc();
+    }
+
+    /**
+     * Record one defensive (unmatched) reset.
+     */
+    public void incrementDefensiveReset() {
+        defensiveResets.inc();
+    }
+
+    /**
+     * Record one failure (poll, write, or subscription) for the named tag, creating its counter on first use.
+     *
+     * @param tagName the tag the failure belongs to.
+     */
+    public void incrementTagFailure(final @NotNull String tagName) {
+        final String tagFailureName = name("tag." + tagName + ".failures");
+        tagFailureNames.add(tagFailureName);
+        metricRegistry.counter(tagFailureName).inc();
+    }
+
+    /**
+     * Publish the latest tick lag for the gauge to report.
+     *
+     * @param lagMillis {@code now - tick.nowMillis} measured when the tick was handled, in milliseconds.
+     */
+    public void recordTickLag(final long lagMillis) {
+        tickLagMillis.set(lagMillis);
+    }
+
+    /**
+     * Deregister every metric this instance registered, so a recreated adapter with the same id starts clean.
+     */
+    @Override
+    public void close() {
+        metricRegistry.remove(mailboxDepthName);
+        metricRegistry.remove(tickLagName);
+        metricRegistry.remove(stateTransitionsName);
+        metricRegistry.remove(defensiveResetsName);
+        for (final String tagFailureName : tagFailureNames) {
+            metricRegistry.remove(tagFailureName);
+        }
+    }
+
+    private @NotNull String name(final @NotNull String suffix) {
+        return ADAPTER_PREFIX + adapterId + "." + suffix;
+    }
+}

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/runtime/PriorityTimerQueue.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/runtime/PriorityTimerQueue.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.protocols.v2.runtime;
+
+import java.util.PriorityQueue;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * The single timer queue an actor owns (design §5.5): every time-based event — connection backoff, per-node poll
+ * schedule, subscription retry, verification retry, watchdog — is one entry sorted by fire time. On a tick the
+ * actor calls {@link #fireDue(long)} on its <b>own dispatch thread</b>; each due timer runs its callback, which
+ * feeds a typed event to the state machine.
+ * <p>
+ * This queue is unrelated to the mailbox's priority bands: timer expiries are not mailbox messages — they are
+ * generated inside the tick handler, on the dispatch thread, and never queue. Every method is owner-thread only;
+ * the queue does no locking.
+ * <p>
+ * Cancellation is lazy: {@link #cancel(TimerHandle)} flags the entry and {@link #size()} stops counting it
+ * immediately, but the entry is discarded only when it surfaces at the head during {@link #fireDue(long)}.
+ */
+public final class PriorityTimerQueue {
+
+    private final @NotNull PriorityQueue<ScheduledTimer> timers = new PriorityQueue<>();
+    private long sequenceCounter;
+    private int activeCount;
+
+    /**
+     * Schedule {@code onFire} to run the next time {@link #fireDue(long)} is called with a {@code nowMillis} at or
+     * past {@code fireAtMillis}.
+     *
+     * @param fireAtMillis the absolute time, in {@link Clock#nowMillis()} units, at or after which to fire.
+     * @param onFire       the callback; runs on the actor's dispatch thread inside {@link #fireDue(long)}.
+     * @return a handle for cancelling the timer.
+     */
+    public @NotNull TimerHandle schedule(final long fireAtMillis, final @NotNull Runnable onFire) {
+        final ScheduledTimer timer = new ScheduledTimer(fireAtMillis, sequenceCounter++, onFire);
+        timers.add(timer);
+        activeCount++;
+        return timer;
+    }
+
+    /**
+     * Cancel a pending timer. Cancelling an already-fired or already-cancelled handle, or a handle from another
+     * queue, is a no-op.
+     *
+     * @param handle the handle returned by {@link #schedule(long, Runnable)}.
+     */
+    public void cancel(final @NotNull TimerHandle handle) {
+        if (handle instanceof final ScheduledTimer timer && timer.active) {
+            timer.active = false;
+            activeCount--;
+        }
+    }
+
+    /**
+     * Pop and run every entry whose fire time is at or before {@code nowMillis}, in fire-time order (ties broken
+     * by schedule order). A callback may itself {@link #schedule(long, Runnable)} or {@link #cancel(TimerHandle)};
+     * a freshly scheduled timer that is already due fires within the same call.
+     *
+     * @param nowMillis the current time, in {@link Clock#nowMillis()} units.
+     */
+    public void fireDue(final long nowMillis) {
+        while (true) {
+            final ScheduledTimer next = timers.peek();
+            if (next == null || next.fireAtMillis > nowMillis) {
+                break;
+            }
+            timers.poll();
+            if (next.active) {
+                next.active = false;
+                activeCount--;
+                next.onFire.run();
+            }
+        }
+    }
+
+    /**
+     * @return the number of pending (scheduled, not yet fired or cancelled) timers.
+     */
+    public int size() {
+        return activeCount;
+    }
+
+    private static final class ScheduledTimer implements TimerHandle, Comparable<ScheduledTimer> {
+
+        private final long fireAtMillis;
+        private final long sequence;
+        private final @NotNull Runnable onFire;
+        private boolean active = true;
+
+        private ScheduledTimer(final long fireAtMillis, final long sequence, final @NotNull Runnable onFire) {
+            this.fireAtMillis = fireAtMillis;
+            this.sequence = sequence;
+            this.onFire = onFire;
+        }
+
+        @Override
+        public boolean isActive() {
+            return active;
+        }
+
+        @Override
+        public int compareTo(final @NotNull ScheduledTimer other) {
+            final int byFireTime = Long.compare(fireAtMillis, other.fireAtMillis);
+            return byFireTime != 0 ? byFireTime : Long.compare(sequence, other.sequence);
+        }
+    }
+}

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/runtime/RetryPolicy.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/runtime/RetryPolicy.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.protocols.v2.runtime;
+
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * The exponential-backoff retry policy for an adapter type (design §5.6). A {@link Backoff} turns this into a
+ * concrete delay sequence.
+ *
+ * @param initialMillis  the first retry delay, in milliseconds.
+ * @param factor         the multiplier applied to each successive delay; must be at least 1.
+ * @param ceilingMillis  the maximum retry delay, in milliseconds; delays never grow past it.
+ * @param maximumRetries the number of retries the policy permits before it is exhausted.
+ */
+public record RetryPolicy(long initialMillis, double factor, long ceilingMillis, int maximumRetries) {
+
+    public RetryPolicy {
+        if (initialMillis <= 0) {
+            throw new IllegalArgumentException("initialMillis must be positive, but was " + initialMillis);
+        }
+        if (factor < 1.0) {
+            throw new IllegalArgumentException("factor must be at least 1.0, but was " + factor);
+        }
+        if (ceilingMillis < initialMillis) {
+            throw new IllegalArgumentException(
+                    "ceilingMillis (" + ceilingMillis + ") must be at least initialMillis (" + initialMillis + ")");
+        }
+        if (maximumRetries < 0) {
+            throw new IllegalArgumentException("maximumRetries must not be negative, but was " + maximumRetries);
+        }
+    }
+
+    /**
+     * @return the default policy: 1 s, &times;1.41, capped at 32 s, unbounded retries — 1 s, 1.4 s, 2 s, 2.8 s,
+     *         4 s, 5.7 s, 8 s, 11 s, 16 s, 22 s, 32 s, 32 s&hellip;
+     */
+    public static @NotNull RetryPolicy defaults() {
+        return new RetryPolicy(1000, 1.41, 32000, Integer.MAX_VALUE);
+    }
+}

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/runtime/SystemClock.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/runtime/SystemClock.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.protocols.v2.runtime;
+
+import com.hivemq.adapter.sdk.api.v2.messaging.MailboxMessage;
+import com.hivemq.adapter.sdk.api.v2.messaging.MailboxSender;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Production {@link Clock}: wall-clock time plus a single {@link ScheduledExecutorService} that tells ticks.
+ * <p>
+ * The scheduler thread's only action is {@code target.tell(tickMessage.get())} — it never touches actor state,
+ * so the actor stays single-threaded. One daemon thread serves every schedule; closing a per-schedule handle
+ * cancels just that schedule, and {@link #close()} shuts the whole clock down.
+ */
+public final class SystemClock implements Clock, AutoCloseable {
+
+    private static final @NotNull AtomicLong THREAD_COUNTER = new AtomicLong();
+
+    private final @NotNull ScheduledExecutorService scheduler;
+
+    public SystemClock() {
+        this.scheduler = Executors.newSingleThreadScheduledExecutor(runnable -> {
+            final Thread thread = new Thread(runnable, "nevsky-clock-" + THREAD_COUNTER.incrementAndGet());
+            thread.setDaemon(true);
+            return thread;
+        });
+    }
+
+    @Override
+    public long nowMillis() {
+        return System.currentTimeMillis();
+    }
+
+    @Override
+    public <MessageType extends MailboxMessage> @NotNull AutoCloseable scheduleTick(
+            final long periodMillis,
+            final @NotNull MailboxSender<MessageType> target,
+            final @NotNull Supplier<MessageType> tickMessage) {
+        if (periodMillis <= 0) {
+            throw new IllegalArgumentException("tick period must be positive, but was " + periodMillis);
+        }
+        final ScheduledFuture<?> future = scheduler.scheduleAtFixedRate(
+                () -> target.tell(tickMessage.get()), periodMillis, periodMillis, TimeUnit.MILLISECONDS);
+        return () -> future.cancel(false);
+    }
+
+    @Override
+    public void close() {
+        scheduler.shutdownNow();
+    }
+}

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/runtime/SystemDispatcher.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/runtime/SystemDispatcher.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.protocols.v2.runtime;
+
+import com.hivemq.adapter.sdk.api.v2.messaging.Mailbox;
+import com.hivemq.adapter.sdk.api.v2.messaging.MailboxMessage;
+import com.hivemq.adapter.sdk.api.v2.messaging.MessageDispatcher;
+import com.hivemq.adapter.sdk.api.v2.messaging.MessageDispatcherHandle;
+import com.hivemq.adapter.sdk.api.v2.messaging.MessageHandler;
+import java.util.concurrent.atomic.AtomicLong;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Production {@link MessageDispatcher}: one dedicated daemon thread per handler that blocks in
+ * {@link Mailbox#awaitNextMessage(long)} and feeds {@link MessageHandler#receive(MailboxMessage)} one message at
+ * a time, in priority-band order. A parked thread consumes no CPU — it is woken by a {@code tell}, not by polling.
+ * <p>
+ * {@link MessageDispatcherHandle#close()} stops the loop and interrupts the thread; an in-flight {@code receive}
+ * always completes first (the interrupt is observed only at the next {@code awaitNextMessage}, or as a set flag
+ * the loop checks once {@code receive} returns).
+ */
+public final class SystemDispatcher implements MessageDispatcher {
+
+    private static final long POLL_TIMEOUT_MILLIS = 1_000L;
+    private static final @NotNull AtomicLong THREAD_COUNTER = new AtomicLong();
+
+    @Override
+    public <MessageType extends MailboxMessage> @NotNull MessageDispatcherHandle attach(
+            final @NotNull Mailbox<MessageType> mailbox, final @NotNull MessageHandler<MessageType> handler) {
+        final DispatchLoop<MessageType> loop = new DispatchLoop<>(mailbox, handler);
+        final Thread thread = new Thread(loop, "nevsky-dispatcher-" + THREAD_COUNTER.incrementAndGet());
+        thread.setDaemon(true);
+        loop.bind(thread);
+        thread.start();
+        return loop;
+    }
+
+    private static final class DispatchLoop<MessageType extends MailboxMessage>
+            implements Runnable, MessageDispatcherHandle {
+
+        private final @NotNull Mailbox<MessageType> mailbox;
+        private final @NotNull MessageHandler<MessageType> handler;
+        private volatile boolean running = true;
+        private volatile @Nullable Thread thread;
+
+        private DispatchLoop(
+                final @NotNull Mailbox<MessageType> mailbox, final @NotNull MessageHandler<MessageType> handler) {
+            this.mailbox = mailbox;
+            this.handler = handler;
+        }
+
+        private void bind(final @NotNull Thread thread) {
+            this.thread = thread;
+        }
+
+        @Override
+        public void run() {
+            while (running) {
+                final MessageType message;
+                try {
+                    message = mailbox.awaitNextMessage(POLL_TIMEOUT_MILLIS);
+                } catch (final InterruptedException interrupted) {
+                    // close() is the only interrupter; restore the flag and let the thread end.
+                    Thread.currentThread().interrupt();
+                    break;
+                }
+                if (message != null) {
+                    handler.receive(message);
+                }
+            }
+        }
+
+        @Override
+        public void close() {
+            running = false;
+            final Thread current = thread;
+            if (current != null) {
+                current.interrupt();
+            }
+        }
+    }
+}

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/runtime/Tick.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/runtime/Tick.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.protocols.v2.runtime;
+
+import com.hivemq.adapter.sdk.api.v2.messaging.MailboxMessage;
+import com.hivemq.adapter.sdk.api.v2.messaging.MailboxMessagePriority;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * A generic tick — time delivered as a message (D6 / design §5.4). The {@link Clock} tells one of these (or an
+ * actor-specific tick) to an actor's mailbox every period; the actor drains its {@link PriorityTimerQueue} from
+ * its own dispatch thread when it handles the tick.
+ * <p>
+ * The band is {@link MailboxMessagePriority#TICK}: time stays on time under data floods (above
+ * {@link MailboxMessagePriority#DATA}) but never overtakes an already-enqueued acknowledgment (below
+ * {@link MailboxMessagePriority#EVENT}), so a watchdog fires only when the awaited reply truly has not arrived.
+ * <p>
+ * Long-lived actors that carry extra context in their tick (the wrapper, the manager) declare their own tick
+ * record in their own package; this generic {@code Tick} is what the bare {@link Clock} schedules by default and
+ * what the runtime's own timing tests drive.
+ *
+ * @param nowMillis the clock time, in milliseconds, at which this tick was produced; the actor compares it to
+ *                  {@link Clock#nowMillis()} at processing time to measure tick lag.
+ */
+public record Tick(long nowMillis) implements MailboxMessage {
+
+    @Override
+    public @NotNull MailboxMessagePriority priority() {
+        return MailboxMessagePriority.TICK;
+    }
+}

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/runtime/TimerHandle.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/runtime/TimerHandle.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.protocols.v2.runtime;
+
+/**
+ * Opaque handle to a timer scheduled on a {@link PriorityTimerQueue}. Pass it back to
+ * {@link PriorityTimerQueue#cancel(TimerHandle)} to cancel the timer before it fires.
+ * <p>
+ * Like the rest of the queue, a handle is touched only on the owning actor's dispatch thread.
+ */
+public interface TimerHandle {
+
+    /**
+     * @return {@code true} while the timer is still pending; {@code false} once it has fired or been cancelled.
+     */
+    boolean isActive();
+}

--- a/hivemq-edge/src/test/java/com/hivemq/protocols/v2/runtime/BackoffTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/protocols/v2/runtime/BackoffTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.protocols.v2.runtime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class BackoffTest {
+
+    @Test
+    void defaults_startWithTheDocumentedSequence() {
+        final Backoff backoff = new Backoff(RetryPolicy.defaults());
+
+        assertThat(backoff.nextDelayMillis()).isEqualTo(1000);
+        assertThat(backoff.nextDelayMillis()).isEqualTo(1410);
+        assertThat(backoff.nextDelayMillis()).isEqualTo(1988);
+    }
+
+    @Test
+    void delays_areMonotonicAndConvergeOnTheCeiling() {
+        final Backoff backoff = new Backoff(RetryPolicy.defaults());
+
+        long previous = 0L;
+        long delay = 0L;
+        for (int i = 0; i < 50; i++) {
+            delay = backoff.nextDelayMillis();
+            assertThat(delay).isGreaterThanOrEqualTo(previous);
+            assertThat(delay).isLessThanOrEqualTo(32000);
+            previous = delay;
+        }
+        assertThat(delay).isEqualTo(32000);
+    }
+
+    @Test
+    void ceiling_capsAndHolds() {
+        final Backoff backoff = new Backoff(new RetryPolicy(1000, 2.0, 5000, Integer.MAX_VALUE));
+
+        assertThat(backoff.nextDelayMillis()).isEqualTo(1000);
+        assertThat(backoff.nextDelayMillis()).isEqualTo(2000);
+        assertThat(backoff.nextDelayMillis()).isEqualTo(4000);
+        assertThat(backoff.nextDelayMillis()).isEqualTo(5000);
+        assertThat(backoff.nextDelayMillis()).isEqualTo(5000);
+    }
+
+    @Test
+    void reset_returnsToTheStartOfTheSequence() {
+        final Backoff backoff = new Backoff(RetryPolicy.defaults());
+        backoff.nextDelayMillis();
+        backoff.nextDelayMillis();
+
+        backoff.reset();
+
+        assertThat(backoff.nextDelayMillis()).isEqualTo(1000);
+    }
+
+    @Test
+    void exhausted_flipsAfterMaximumRetriesAndClearsOnReset() {
+        final Backoff backoff = new Backoff(new RetryPolicy(1000, 2.0, 32000, 3));
+
+        assertThat(backoff.exhausted()).isFalse();
+        backoff.nextDelayMillis();
+        assertThat(backoff.exhausted()).isFalse();
+        backoff.nextDelayMillis();
+        assertThat(backoff.exhausted()).isFalse();
+        backoff.nextDelayMillis();
+        assertThat(backoff.exhausted()).isTrue();
+
+        backoff.reset();
+        assertThat(backoff.exhausted()).isFalse();
+    }
+
+    @Test
+    void retryPolicy_rejectsInvalidParameters() {
+        assertThatThrownBy(() -> new RetryPolicy(0, 1.41, 32000, 1)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new RetryPolicy(1000, 0.9, 32000, 1)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new RetryPolicy(1000, 1.41, 500, 1)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new RetryPolicy(1000, 1.41, 32000, -1)).isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/hivemq-edge/src/test/java/com/hivemq/protocols/v2/runtime/ClockQueueIntegrationTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/protocols/v2/runtime/ClockQueueIntegrationTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.protocols.v2.runtime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.hivemq.adapter.sdk.api.v2.messaging.DefaultMailbox;
+import com.hivemq.adapter.sdk.api.v2.messaging.MessageHandler;
+import java.util.ArrayList;
+import java.util.List;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+
+/**
+ * S24 precursor: timers scheduled on an actor's queue fire in order, inside that actor's tick handler, as the
+ * clock advances past them — proving the clock-never-fires / drain-on-tick contract end to end with a
+ * {@link FakeClock} + {@link ManualDispatcher} (no real threads, no sleeps).
+ */
+class ClockQueueIntegrationTest {
+
+    @Test
+    void timersFireInOrderInsideTheTickHandler_asTheClockAdvances() {
+        final FakeClock clock = new FakeClock();
+        final ManualDispatcher dispatcher = new ManualDispatcher();
+        final PriorityTimerQueue timers = new PriorityTimerQueue();
+        final DefaultMailbox<Tick> mailbox = new DefaultMailbox<>();
+        dispatcher.attach(mailbox, new TickHandlingActor(timers));
+
+        final List<Long> fired = new ArrayList<>();
+        timers.schedule(1000, () -> fired.add(1000L));
+        timers.schedule(1400, () -> fired.add(1400L));
+        timers.schedule(2000, () -> fired.add(2000L));
+
+        clock.scheduleTick(100, mailbox, () -> new Tick(clock.nowMillis()));
+        clock.advance(2000);
+        dispatcher.drainAll();
+
+        assertThat(fired).containsExactly(1000L, 1400L, 2000L);
+        assertThat(timers.size()).isZero();
+    }
+
+    /** A minimal actor that owns a timer queue and drains it from its own tick handler. */
+    private static final class TickHandlingActor implements MessageHandler<Tick> {
+
+        private final @NotNull PriorityTimerQueue timers;
+
+        private TickHandlingActor(final @NotNull PriorityTimerQueue timers) {
+            this.timers = timers;
+        }
+
+        @Override
+        public void receive(final @NotNull Tick tick) {
+            timers.fireDue(tick.nowMillis());
+        }
+    }
+}

--- a/hivemq-edge/src/test/java/com/hivemq/protocols/v2/runtime/FakeClockTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/protocols/v2/runtime/FakeClockTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.protocols.v2.runtime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.hivemq.adapter.sdk.api.v2.messaging.DefaultMailbox;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+
+class FakeClockTest {
+
+    @Test
+    void advance_tellsExactlyTheDueTicks_stampedWithTheirFireTime() {
+        final FakeClock clock = new FakeClock();
+        final DefaultMailbox<Tick> mailbox = new DefaultMailbox<>();
+        clock.scheduleTick(50, mailbox, () -> new Tick(clock.nowMillis()));
+
+        clock.advance(120);
+
+        assertThat(clock.nowMillis()).isEqualTo(120);
+        assertThat(drainTickTimes(mailbox)).containsExactly(50L, 100L);
+    }
+
+    @Test
+    void advance_belowTheFirstFireTime_tellsNothing() {
+        final FakeClock clock = new FakeClock();
+        final DefaultMailbox<Tick> mailbox = new DefaultMailbox<>();
+        clock.scheduleTick(50, mailbox, () -> new Tick(clock.nowMillis()));
+
+        clock.advance(30);
+        assertThat(clock.nowMillis()).isEqualTo(30);
+        assertThat(mailbox.isEmpty()).isTrue();
+
+        clock.advance(20);
+        assertThat(drainTickTimes(mailbox)).containsExactly(50L);
+    }
+
+    @Test
+    void advance_interleavesMultipleSchedulesInFireTimeOrder() {
+        final FakeClock clock = new FakeClock();
+        final DefaultMailbox<Tick> mailbox = new DefaultMailbox<>();
+        clock.scheduleTick(50, mailbox, () -> new Tick(clock.nowMillis()));
+        clock.scheduleTick(30, mailbox, () -> new Tick(clock.nowMillis()));
+
+        clock.advance(100);
+
+        assertThat(drainTickTimes(mailbox)).containsExactly(30L, 50L, 60L, 90L, 100L);
+    }
+
+    @Test
+    void closingAScheduleStopsItsTicks() throws Exception {
+        final FakeClock clock = new FakeClock();
+        final DefaultMailbox<Tick> mailbox = new DefaultMailbox<>();
+        final AutoCloseable handle = clock.scheduleTick(50, mailbox, () -> new Tick(clock.nowMillis()));
+
+        handle.close();
+        clock.advance(1000);
+
+        assertThat(mailbox.isEmpty()).isTrue();
+    }
+
+    @Test
+    void initialTime_offsetsTheFirstFire() {
+        final FakeClock clock = new FakeClock(1000);
+        final DefaultMailbox<Tick> mailbox = new DefaultMailbox<>();
+        clock.scheduleTick(50, mailbox, () -> new Tick(clock.nowMillis()));
+
+        clock.advance(60);
+
+        assertThat(drainTickTimes(mailbox)).containsExactly(1050L);
+    }
+
+    @Test
+    void advance_neverFiresAnActorTimerQueue() {
+        final FakeClock clock = new FakeClock();
+        final PriorityTimerQueue timers = new PriorityTimerQueue();
+        final AtomicBoolean fired = new AtomicBoolean();
+        timers.schedule(50, () -> fired.set(true));
+
+        // The clock is not wired to the queue: only an actor's tick handler drains timers.
+        clock.advance(1000);
+
+        assertThat(fired).isFalse();
+        assertThat(timers.size()).isEqualTo(1);
+    }
+
+    @Test
+    void rejectsNonPositivePeriodAndNegativeAdvance() {
+        final FakeClock clock = new FakeClock();
+        final DefaultMailbox<Tick> mailbox = new DefaultMailbox<>();
+
+        assertThatThrownBy(() -> clock.scheduleTick(0, mailbox, () -> new Tick(0)))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> clock.advance(-1)).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    private static @NotNull List<Long> drainTickTimes(final @NotNull DefaultMailbox<Tick> mailbox) {
+        final List<Long> times = new ArrayList<>();
+        Tick tick = mailbox.poll();
+        while (tick != null) {
+            times.add(tick.nowMillis());
+            tick = mailbox.poll();
+        }
+        return times;
+    }
+}

--- a/hivemq-edge/src/test/java/com/hivemq/protocols/v2/runtime/ManualDispatcherTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/protocols/v2/runtime/ManualDispatcherTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.protocols.v2.runtime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.hivemq.adapter.sdk.api.v2.messaging.DefaultMailbox;
+import com.hivemq.adapter.sdk.api.v2.messaging.MailboxMessage;
+import com.hivemq.adapter.sdk.api.v2.messaging.MailboxMessagePriority;
+import com.hivemq.adapter.sdk.api.v2.messaging.MessageDispatcherHandle;
+import com.hivemq.adapter.sdk.api.v2.messaging.MessageHandler;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+
+class ManualDispatcherTest {
+
+    @Test
+    void drainsOnTheCallingThreadInPriorityOrder() {
+        final ManualDispatcher dispatcher = new ManualDispatcher();
+        final DefaultMailbox<TestMessage> mailbox = new DefaultMailbox<>();
+        final RecordingHandler handler = new RecordingHandler();
+        dispatcher.attach(mailbox, handler);
+
+        mailbox.tell(new TestMessage("data-1", MailboxMessagePriority.DATA));
+        mailbox.tell(new TestMessage("data-2", MailboxMessagePriority.DATA));
+        mailbox.tell(new TestMessage("control", MailboxMessagePriority.CONTROL));
+
+        dispatcher.drainAll();
+
+        assertThat(handler.labels()).containsExactly("control", "data-1", "data-2");
+        assertThat(handler.threadNames()).containsExactly(Thread.currentThread().getName());
+    }
+
+    @Test
+    void deliversMessagesToldBackDuringReceive() {
+        final ManualDispatcher dispatcher = new ManualDispatcher();
+        final DefaultMailbox<TestMessage> mailbox = new DefaultMailbox<>();
+        final List<String> received = new ArrayList<>();
+        dispatcher.attach(mailbox, message -> {
+            received.add(message.label());
+            if ("first".equals(message.label())) {
+                mailbox.tell(new TestMessage("follow-up", MailboxMessagePriority.EVENT));
+            }
+        });
+
+        mailbox.tell(new TestMessage("first", MailboxMessagePriority.EVENT));
+        dispatcher.drainAll();
+
+        assertThat(received).containsExactly("first", "follow-up");
+    }
+
+    @Test
+    void drainsEveryAttachedMailbox() {
+        final ManualDispatcher dispatcher = new ManualDispatcher();
+        final DefaultMailbox<TestMessage> mailboxA = new DefaultMailbox<>();
+        final DefaultMailbox<TestMessage> mailboxB = new DefaultMailbox<>();
+        final RecordingHandler handlerA = new RecordingHandler();
+        final RecordingHandler handlerB = new RecordingHandler();
+        dispatcher.attach(mailboxA, handlerA);
+        dispatcher.attach(mailboxB, handlerB);
+
+        mailboxA.tell(new TestMessage("a", MailboxMessagePriority.EVENT));
+        mailboxB.tell(new TestMessage("b", MailboxMessagePriority.EVENT));
+        dispatcher.drainAll();
+
+        assertThat(handlerA.labels()).containsExactly("a");
+        assertThat(handlerB.labels()).containsExactly("b");
+    }
+
+    @Test
+    void closingAHandleStopsDeliveryToThatBinding() {
+        final ManualDispatcher dispatcher = new ManualDispatcher();
+        final DefaultMailbox<TestMessage> mailbox = new DefaultMailbox<>();
+        final RecordingHandler handler = new RecordingHandler();
+        final MessageDispatcherHandle handle = dispatcher.attach(mailbox, handler);
+
+        handle.close();
+        mailbox.tell(new TestMessage("ignored", MailboxMessagePriority.EVENT));
+        dispatcher.drainAll();
+
+        assertThat(handler.labels()).isEmpty();
+    }
+
+    private record TestMessage(
+            @NotNull String label, @NotNull MailboxMessagePriority band) implements MailboxMessage {
+        @Override
+        public @NotNull MailboxMessagePriority priority() {
+            return band;
+        }
+    }
+
+    private static final class RecordingHandler implements MessageHandler<TestMessage> {
+
+        private final @NotNull List<String> labels = new ArrayList<>();
+        private final @NotNull Set<String> threadNames = new LinkedHashSet<>();
+
+        @Override
+        public void receive(final @NotNull TestMessage message) {
+            threadNames.add(Thread.currentThread().getName());
+            labels.add(message.label());
+        }
+
+        private @NotNull List<String> labels() {
+            return labels;
+        }
+
+        private @NotNull Set<String> threadNames() {
+            return threadNames;
+        }
+    }
+}

--- a/hivemq-edge/src/test/java/com/hivemq/protocols/v2/runtime/NevskyMetricsTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/protocols/v2/runtime/NevskyMetricsTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.protocols.v2.runtime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.codahale.metrics.MetricRegistry;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+class NevskyMetricsTest {
+
+    @Test
+    void registersTheGaugesAndCounters() {
+        final MetricRegistry registry = new MetricRegistry();
+        try (NevskyMetrics metrics = new NevskyMetrics(registry, "adapter-1", () -> 0)) {
+            assertThat(registry.getGauges())
+                    .containsKeys("nevsky.adapter.adapter-1.mailbox.depth", "nevsky.adapter.adapter-1.tick.lag");
+            assertThat(registry.getCounters())
+                    .containsKeys(
+                            "nevsky.adapter.adapter-1.state.transitions", "nevsky.adapter.adapter-1.defensive.resets");
+        }
+    }
+
+    @Test
+    void mailboxDepthGaugeReflectsItsSource() {
+        final MetricRegistry registry = new MetricRegistry();
+        final AtomicInteger depth = new AtomicInteger(3);
+        try (NevskyMetrics metrics = new NevskyMetrics(registry, "adapter-1", depth::get)) {
+            assertThat(registry.getGauges()
+                            .get("nevsky.adapter.adapter-1.mailbox.depth")
+                            .getValue())
+                    .isEqualTo(3);
+            depth.set(7);
+            assertThat(registry.getGauges()
+                            .get("nevsky.adapter.adapter-1.mailbox.depth")
+                            .getValue())
+                    .isEqualTo(7);
+        }
+    }
+
+    @Test
+    void countersIncrement() {
+        final MetricRegistry registry = new MetricRegistry();
+        try (NevskyMetrics metrics = new NevskyMetrics(registry, "adapter-1", () -> 0)) {
+            metrics.incrementStateTransition();
+            metrics.incrementStateTransition();
+            metrics.incrementDefensiveReset();
+            metrics.incrementTagFailure("temperature");
+            metrics.incrementTagFailure("temperature");
+            metrics.incrementTagFailure("pressure");
+
+            assertThat(registry.counter("nevsky.adapter.adapter-1.state.transitions")
+                            .getCount())
+                    .isEqualTo(2);
+            assertThat(registry.counter("nevsky.adapter.adapter-1.defensive.resets")
+                            .getCount())
+                    .isEqualTo(1);
+            assertThat(registry.counter("nevsky.adapter.adapter-1.tag.temperature.failures")
+                            .getCount())
+                    .isEqualTo(2);
+            assertThat(registry.counter("nevsky.adapter.adapter-1.tag.pressure.failures")
+                            .getCount())
+                    .isEqualTo(1);
+        }
+    }
+
+    @Test
+    void tickLagGaugeReflectsTheRecordedValue() {
+        final MetricRegistry registry = new MetricRegistry();
+        try (NevskyMetrics metrics = new NevskyMetrics(registry, "adapter-1", () -> 0)) {
+            assertThat(registry.getGauges()
+                            .get("nevsky.adapter.adapter-1.tick.lag")
+                            .getValue())
+                    .isEqualTo(0L);
+            metrics.recordTickLag(42);
+            assertThat(registry.getGauges()
+                            .get("nevsky.adapter.adapter-1.tick.lag")
+                            .getValue())
+                    .isEqualTo(42L);
+        }
+    }
+
+    @Test
+    void closeDeregistersEveryMetric() {
+        final MetricRegistry registry = new MetricRegistry();
+        final NevskyMetrics metrics = new NevskyMetrics(registry, "adapter-1", () -> 0);
+        metrics.incrementTagFailure("temperature");
+
+        metrics.close();
+
+        assertThat(registry.getMetrics()).isEmpty();
+    }
+
+    @Test
+    void closeFreesTheNamesSoTheSameAdapterCanBeRecreated() {
+        final MetricRegistry registry = new MetricRegistry();
+        final NevskyMetrics first = new NevskyMetrics(registry, "adapter-1", () -> 0);
+        first.close();
+
+        // Re-registering the same names must not throw "duplicate metric".
+        final NevskyMetrics second = new NevskyMetrics(registry, "adapter-1", () -> 0);
+        second.close();
+
+        assertThat(registry.getMetrics()).isEmpty();
+    }
+}

--- a/hivemq-edge/src/test/java/com/hivemq/protocols/v2/runtime/PriorityTimerQueueTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/protocols/v2/runtime/PriorityTimerQueueTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.protocols.v2.runtime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+
+class PriorityTimerQueueTest {
+
+    @Test
+    void firesDueTimersInFireTimeOrder_tiesBrokenByScheduleOrder() {
+        final PriorityTimerQueue queue = new PriorityTimerQueue();
+        final List<String> fired = new ArrayList<>();
+        queue.schedule(100, () -> fired.add("a@100"));
+        queue.schedule(100, () -> fired.add("b@100"));
+        queue.schedule(50, () -> fired.add("c@50"));
+
+        queue.fireDue(100);
+
+        assertThat(fired).containsExactly("c@50", "a@100", "b@100");
+        assertThat(queue.size()).isZero();
+    }
+
+    @Test
+    void fireDue_boundaryIsInclusive() {
+        final PriorityTimerQueue queue = new PriorityTimerQueue();
+        final AtomicBoolean fired = new AtomicBoolean();
+        queue.schedule(100, () -> fired.set(true));
+
+        queue.fireDue(99);
+        assertThat(fired).isFalse();
+        assertThat(queue.size()).isEqualTo(1);
+
+        queue.fireDue(100);
+        assertThat(fired).isTrue();
+        assertThat(queue.size()).isZero();
+    }
+
+    @Test
+    void reentrantSchedule_firesWhenTheNewTimerIsAlreadyDue() {
+        final PriorityTimerQueue queue = new PriorityTimerQueue();
+        final List<String> fired = new ArrayList<>();
+        queue.schedule(50, () -> {
+            fired.add("first@50");
+            queue.schedule(40, () -> fired.add("reentrant@40"));
+        });
+
+        queue.fireDue(100);
+
+        assertThat(fired).containsExactly("first@50", "reentrant@40");
+        assertThat(queue.size()).isZero();
+    }
+
+    @Test
+    void cancel_preventsFiringAndUpdatesSizeAndIsActive() {
+        final PriorityTimerQueue queue = new PriorityTimerQueue();
+        final AtomicBoolean fired = new AtomicBoolean();
+        final TimerHandle handle = queue.schedule(50, () -> fired.set(true));
+        assertThat(handle.isActive()).isTrue();
+        assertThat(queue.size()).isEqualTo(1);
+
+        queue.cancel(handle);
+
+        assertThat(handle.isActive()).isFalse();
+        assertThat(queue.size()).isZero();
+        queue.fireDue(100);
+        assertThat(fired).isFalse();
+    }
+
+    @Test
+    void cancelDuringFireDue_skipsTheCancelledTimer() {
+        final PriorityTimerQueue queue = new PriorityTimerQueue();
+        final List<String> fired = new ArrayList<>();
+        final AtomicReference<TimerHandle> later = new AtomicReference<>();
+        queue.schedule(50, () -> {
+            fired.add("first@50");
+            queue.cancel(later.get());
+        });
+        later.set(queue.schedule(60, () -> fired.add("later@60")));
+
+        queue.fireDue(100);
+
+        assertThat(fired).containsExactly("first@50");
+        assertThat(queue.size()).isZero();
+    }
+
+    @Test
+    void handle_isInactiveAfterFiring() {
+        final PriorityTimerQueue queue = new PriorityTimerQueue();
+        final TimerHandle handle = queue.schedule(50, () -> {});
+
+        queue.fireDue(50);
+
+        assertThat(handle.isActive()).isFalse();
+    }
+
+    @Test
+    void cancellingAnAlreadyFiredOrForeignHandle_isANoOp() {
+        final PriorityTimerQueue queue = new PriorityTimerQueue();
+        final TimerHandle handle = queue.schedule(50, () -> {});
+        queue.fireDue(50);
+
+        queue.cancel(handle);
+        assertThat(queue.size()).isZero();
+
+        final TimerHandle foreign = () -> true;
+        queue.cancel(foreign);
+        assertThat(queue.size()).isZero();
+    }
+
+    @Test
+    void size_countsOnlyPendingTimers() {
+        final PriorityTimerQueue queue = new PriorityTimerQueue();
+        assertThat(queue.size()).isZero();
+        queue.schedule(10, () -> {});
+        queue.schedule(20, () -> {});
+        assertThat(queue.size()).isEqualTo(2);
+        queue.fireDue(10);
+        assertThat(queue.size()).isEqualTo(1);
+    }
+}

--- a/hivemq-edge/src/test/java/com/hivemq/protocols/v2/runtime/SystemDispatcherTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/protocols/v2/runtime/SystemDispatcherTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.protocols.v2.runtime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import com.hivemq.adapter.sdk.api.v2.messaging.DefaultMailbox;
+import com.hivemq.adapter.sdk.api.v2.messaging.MailboxMessage;
+import com.hivemq.adapter.sdk.api.v2.messaging.MailboxMessagePriority;
+import com.hivemq.adapter.sdk.api.v2.messaging.MessageDispatcherHandle;
+import com.hivemq.adapter.sdk.api.v2.messaging.MessageHandler;
+import java.time.Duration;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Real threads + Awaitility, never {@code Thread.sleep}: one dedicated dispatch thread processes messages
+ * sequentially and stays parked (no busy-poll) until told.
+ */
+class SystemDispatcherTest {
+
+    private static final @NotNull Duration TIMEOUT = Duration.ofSeconds(5);
+    private static final @NotNull Duration QUIET_WINDOW = Duration.ofMillis(300);
+
+    @Test
+    void processesMessagesSequentiallyInTellOrderOnOneThread() {
+        final SystemDispatcher dispatcher = new SystemDispatcher();
+        final DefaultMailbox<TestMessage> mailbox = new DefaultMailbox<>();
+        final RecordingHandler handler = new RecordingHandler();
+        try (MessageDispatcherHandle handle = dispatcher.attach(mailbox, handler)) {
+            for (int i = 0; i < 5; i++) {
+                mailbox.tell(new TestMessage("m" + i, MailboxMessagePriority.EVENT));
+            }
+
+            await().atMost(TIMEOUT).until(() -> handler.count() == 5);
+
+            assertThat(handler.labels()).containsExactly("m0", "m1", "m2", "m3", "m4");
+            assertThat(handler.threadNames()).hasSize(1);
+            assertThat(handler.threadNames().iterator().next()).startsWith("nevsky-dispatcher-");
+        }
+    }
+
+    @Test
+    void closeStopsTheLoop() {
+        final SystemDispatcher dispatcher = new SystemDispatcher();
+        final DefaultMailbox<TestMessage> mailbox = new DefaultMailbox<>();
+        final RecordingHandler handler = new RecordingHandler();
+        final MessageDispatcherHandle handle = dispatcher.attach(mailbox, handler);
+
+        mailbox.tell(new TestMessage("before-close", MailboxMessagePriority.EVENT));
+        await().atMost(TIMEOUT).until(() -> handler.count() == 1);
+
+        handle.close();
+        mailbox.tell(new TestMessage("after-close", MailboxMessagePriority.EVENT));
+
+        await().pollDelay(QUIET_WINDOW).atMost(TIMEOUT).untilAsserted(() -> assertThat(handler.count())
+                .isEqualTo(1));
+    }
+
+    @Test
+    void parkedDispatcherStaysQuietUntilTold() {
+        final SystemDispatcher dispatcher = new SystemDispatcher();
+        final DefaultMailbox<TestMessage> mailbox = new DefaultMailbox<>();
+        final RecordingHandler handler = new RecordingHandler();
+        try (MessageDispatcherHandle handle = dispatcher.attach(mailbox, handler)) {
+            // No tell yet: the handler must never be invoked while the mailbox is empty (no busy-poll).
+            await().pollDelay(QUIET_WINDOW).atMost(TIMEOUT).untilAsserted(() -> assertThat(handler.count())
+                    .isZero());
+
+            // A tell wakes the parked thread promptly.
+            mailbox.tell(new TestMessage("wake", MailboxMessagePriority.EVENT));
+            await().atMost(TIMEOUT).until(() -> handler.count() == 1);
+        }
+    }
+
+    private record TestMessage(
+            @NotNull String label, @NotNull MailboxMessagePriority band) implements MailboxMessage {
+        @Override
+        public @NotNull MailboxMessagePriority priority() {
+            return band;
+        }
+    }
+
+    private static final class RecordingHandler implements MessageHandler<TestMessage> {
+
+        private final @NotNull List<String> labels = new CopyOnWriteArrayList<>();
+        private final @NotNull Set<String> threadNames = ConcurrentHashMap.newKeySet();
+        private final @NotNull AtomicInteger count = new AtomicInteger();
+
+        @Override
+        public void receive(final @NotNull TestMessage message) {
+            threadNames.add(Thread.currentThread().getName());
+            labels.add(message.label());
+            count.incrementAndGet();
+        }
+
+        private int count() {
+            return count.get();
+        }
+
+        private @NotNull List<String> labels() {
+            return labels;
+        }
+
+        private @NotNull Set<String> threadNames() {
+            return threadNames;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Part of EDG-723 (Project Nevsky, Task 4). Adds `com.hivemq.protocols.v2.runtime`, the concrete actor runtime that drives the Nevsky framework (design §5). All new code is in the core module and consumes the existing SDK `api.v2.messaging` primitives read-only; nothing in the legacy framework is touched.

- **Dispatchers:** `SystemDispatcher` (one daemon thread per actor, blocks in `awaitNextMessage`, no busy-poll; `close()` interrupts after the in-flight `receive`) and `ManualDispatcher` (deterministic caller-thread `drainAll`).
- **Clock/tick:** `Clock`, `SystemClock` (owns a daemon scheduler, `AutoCloseable`), `FakeClock` (`advance()` tells due ticks in fire-time order — the clock never fires a timer queue), and the generic `Tick` (TICK band).
- **Timers:** `PriorityTimerQueue` (min-heap `schedule`/`cancel`/`fireDue`/`size`, owner-thread only, lazy cancellation, re-entrant-schedule safe) + `TimerHandle`.
- **Backoff:** `RetryPolicy` + `Backoff` (1 s, ×1.41, ceiling 32 s).
- **Metrics:** `NevskyMetrics` — per-adapter mailbox-depth and tick-lag gauges, plus state-transition, defensive-reset, and per-tag-failure counters on the shared `MetricRegistry`.

## Verification

`compileJava` + `compileTestJava` (ErrorProne + NullAway), `spotlessCheck`, and the `protocols.v2.runtime` unit tests are green — 35 tests across 7 classes. Deterministic tests run on `FakeClock` + `ManualDispatcher`; the dispatcher concurrency and no-busy-poll paths use real threads + Awaitility (no `Thread.sleep`). The full `hivemq-edge-test` suite is left to CI.

## Notes

Targets the `feat/nevsky-poc` branch. Implements Task 4 of `nevsky-plan-02.md`; consumes the SDK `api.v2` contracts from the merged EDG-720/721/722 work.
