### PR TITLE
EDG-724: Add the Nevsky state-machine engine and reconciling BatchCollector

### DIFF
--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/runtime/BatchCollector.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/runtime/BatchCollector.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.protocols.v2.runtime;
+
+import com.hivemq.adapter.sdk.api.v2.ProtocolAdapter;
+import com.hivemq.adapter.sdk.api.v2.model.WriteEntry;
+import com.hivemq.adapter.sdk.api.v2.node.Node;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * The per-tick batch collector (design §5.7). Tag aspects post requests during a tick by appending to one of
+ * four pending batches; after the timer drain the tick handler calls {@link #dispatch(ProtocolAdapter)}, which
+ * sends each non-empty batch as one command to the adapter in a fixed order and then clears.
+ * <p>
+ * Poll and write batches are append-only lists — duplicates are kept and the adapter executes them in order.
+ * Subscription requests are <b>reconciled per node, last request wins</b>: a node appears in at most one of
+ * the add/remove batches per dispatch. {@code addSubscription} then {@code removeSubscription} for one node in
+ * the same tick nets to a single remove; {@code removeSubscription} then {@code addSubscription} nets to a
+ * single add. Reconciliation is required because the typed batches are dispatched in a fixed cross-type order
+ * ({@code removeSubscriptionBatch}, {@code addSubscriptionBatch}, {@code pollBatch}, {@code writeBatch}), which
+ * cannot otherwise preserve same-tick interleavings — so the collector guarantees the net effect instead.
+ * <p>
+ * Owned by one actor and used only on its dispatch thread; it holds no locks.
+ */
+public final class BatchCollector {
+
+    private enum SubscriptionOperation {
+        ADD,
+        REMOVE
+    }
+
+    private final @NotNull List<Node> pollBatch = new ArrayList<>();
+    private final @NotNull List<WriteEntry> writeBatch = new ArrayList<>();
+    private final @NotNull Map<Node, SubscriptionOperation> subscriptionOperations = new LinkedHashMap<>();
+
+    /**
+     * Append a node to the poll batch. Duplicates are kept and polled in order.
+     *
+     * @param node the node to poll.
+     */
+    public void poll(final @NotNull Node node) {
+        pollBatch.add(node);
+    }
+
+    /**
+     * Append a write to the write batch. Duplicates are kept and written in order.
+     *
+     * @param entry the node/value pair to write.
+     */
+    public void write(final @NotNull WriteEntry entry) {
+        writeBatch.add(entry);
+    }
+
+    /**
+     * Request a subscription for a node. Reconciled per node: this supersedes any earlier add or remove for
+     * the same node in this tick.
+     *
+     * @param node the node to subscribe to.
+     */
+    public void addSubscription(final @NotNull Node node) {
+        subscriptionOperations.put(node, SubscriptionOperation.ADD);
+    }
+
+    /**
+     * Request a subscription removal for a node. Reconciled per node: this supersedes any earlier add or
+     * remove for the same node in this tick.
+     *
+     * @param node the node to unsubscribe from.
+     */
+    public void removeSubscription(final @NotNull Node node) {
+        subscriptionOperations.put(node, SubscriptionOperation.REMOVE);
+    }
+
+    /**
+     * Send each non-empty batch to the adapter in the fixed order remove, add, poll, write, then clear all
+     * four batches. Empty batches are not sent.
+     *
+     * @param protocolAdapter the adapter to dispatch the batches to.
+     */
+    public void dispatch(final @NotNull ProtocolAdapter protocolAdapter) {
+        final List<Node> toRemove = new ArrayList<>();
+        final List<Node> toAdd = new ArrayList<>();
+        for (final Map.Entry<Node, SubscriptionOperation> operation : subscriptionOperations.entrySet()) {
+            if (operation.getValue() == SubscriptionOperation.REMOVE) {
+                toRemove.add(operation.getKey());
+            } else {
+                toAdd.add(operation.getKey());
+            }
+        }
+        if (!toRemove.isEmpty()) {
+            protocolAdapter.removeSubscriptionBatch(toRemove);
+        }
+        if (!toAdd.isEmpty()) {
+            protocolAdapter.addSubscriptionBatch(toAdd);
+        }
+        if (!pollBatch.isEmpty()) {
+            protocolAdapter.pollBatch(new ArrayList<>(pollBatch));
+        }
+        if (!writeBatch.isEmpty()) {
+            protocolAdapter.writeBatch(new ArrayList<>(writeBatch));
+        }
+        subscriptionOperations.clear();
+        pollBatch.clear();
+        writeBatch.clear();
+    }
+}

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/statemachine/Action.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/statemachine/Action.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.protocols.v2.statemachine;
+
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * The behavior a matched transition runs (design §4). An action may issue commands and arm or cancel timers
+ * through the context, and returns the machine's next state. It runs on the actor's single dispatch thread.
+ *
+ * @param <StateType>   the machine's state type.
+ * @param <EventType>   the machine's event type.
+ * @param <ContextType> the machine's context — the bag of collaborators an action acts through.
+ */
+@FunctionalInterface
+public interface Action<StateType extends StateMachineState, EventType extends StateMachineEvent, ContextType> {
+
+    /**
+     * @param current the state the machine was in when the event arrived.
+     * @param event   the event that matched this transition.
+     * @param context the machine context.
+     * @return the next state.
+     */
+    @NotNull
+    StateType apply(@NotNull StateType current, @NotNull EventType event, @NotNull ContextType context);
+}

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/statemachine/Guard.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/statemachine/Guard.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.protocols.v2.statemachine;
+
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * The condition that gates a transition (design §4). Several guarded rows may share one
+ * {@code (state, eventType)} key; the table evaluates them in registration order and runs the first whose
+ * guard passes. A guard must be side-effect free — it runs on the actor's dispatch thread and may be tested
+ * without being chosen.
+ *
+ * @param <StateType>   the machine's state type.
+ * @param <EventType>   the machine's event type.
+ * @param <ContextType> the machine's context.
+ */
+@FunctionalInterface
+public interface Guard<StateType extends StateMachineState, EventType extends StateMachineEvent, ContextType> {
+
+    /**
+     * @param current the current machine state.
+     * @param event   the event being dispatched.
+     * @param context the machine context.
+     * @return whether this transition applies.
+     */
+    boolean test(@NotNull StateType current, @NotNull EventType event, @NotNull ContextType context);
+}

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/statemachine/StateMachine.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/statemachine/StateMachine.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.protocols.v2.statemachine;
+
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * The reusable state-machine engine (design §4). It owns the current state and drives it two ways:
+ * <ul>
+ * <li>{@link #onEvent(StateMachineEvent)} — table-driven. A protocol-adapter event or timer expiry runs
+ * through the {@link TransitionTable}; an event with no matching row runs the table's {@code unmatched} action
+ * (the defensive reset).</li>
+ * <li>{@link #onGoalChange(Runnable)} — the goal-command bypass. Activation, stop, tag-set updates, and retry
+ * are goal mutations, valid in <em>every</em> state; they run a caller-supplied mutation (mutate the goal,
+ * then {@code stepTowardGoal}) that never consults the table, so a goal command can never trigger a defensive
+ * reset (§4).</li>
+ * </ul>
+ * {@code stepTowardGoal} lives in the machine's context and advances the current state one step toward the
+ * goal through {@link #transitionTo(StateMachineState)}. All methods run on the actor's single dispatch
+ * thread; the machine holds no locks.
+ *
+ * @param <StateType>   the machine's state type.
+ * @param <EventType>   the machine's event type.
+ * @param <ContextType> the machine's context.
+ */
+public final class StateMachine<StateType extends StateMachineState, EventType extends StateMachineEvent, ContextType> {
+
+    private final @NotNull TransitionTable<StateType, EventType, ContextType> table;
+    private final @NotNull ContextType context;
+    private @NotNull StateType state;
+
+    /**
+     * @param initial the starting state.
+     * @param table   the transition table that drives {@link #onEvent(StateMachineEvent)}.
+     * @param context the context the table's guards and actions act through.
+     */
+    public StateMachine(
+            final @NotNull StateType initial,
+            final @NotNull TransitionTable<StateType, EventType, ContextType> table,
+            final @NotNull ContextType context) {
+        this.state = initial;
+        this.table = table;
+        this.context = context;
+    }
+
+    /**
+     * @return the current state.
+     */
+    public @NotNull StateType state() {
+        return state;
+    }
+
+    /**
+     * Feed a table event (a protocol-adapter event or timer expiry). The next state is the matched
+     * transition's result, or the {@code unmatched} action's result when no row matches.
+     *
+     * @param event the event to dispatch.
+     */
+    public void onEvent(final @NotNull EventType event) {
+        state = table.dispatch(state, event, context);
+    }
+
+    /**
+     * Run a goal mutation that bypasses the transition table. The runnable mutates the goal (and aspect
+     * goals) and then calls {@code stepTowardGoal}, which may advance the current state through
+     * {@link #transitionTo(StateMachineState)}. Because it never consults the table, a goal command is valid
+     * in every state and can never trigger the defensive reset.
+     *
+     * @param mutateGoalThenStep the goal mutation followed by {@code stepTowardGoal}.
+     */
+    public void onGoalChange(final @NotNull Runnable mutateGoalThenStep) {
+        mutateGoalThenStep.run();
+    }
+
+    /**
+     * Advance the current state directly — the primitive {@code stepTowardGoal} uses to take one step toward
+     * the goal (for example {@code STOPPED → WAITING_FOR_STARTED} when the goal becomes {@code CONNECTED}).
+     * Owner thread only.
+     *
+     * @param next the new current state.
+     */
+    public void transitionTo(final @NotNull StateType next) {
+        state = next;
+    }
+}

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/statemachine/StateMachineEvent.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/statemachine/StateMachineEvent.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.protocols.v2.statemachine;
+
+/**
+ * Marker for an event fed to a {@link StateMachine} through {@link StateMachine#onEvent(StateMachineEvent)}
+ * (design §4). Events — protocol-adapter acknowledgments, errors, and timer expiries — are the only inputs
+ * that flow through the {@link TransitionTable}; goal mutations bypass the table via
+ * {@link StateMachine#onGoalChange(Runnable)} and can never trigger the defensive reset.
+ */
+public interface StateMachineEvent {}

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/statemachine/StateMachineState.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/statemachine/StateMachineState.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.protocols.v2.statemachine;
+
+/**
+ * Marker for a state in a {@link StateMachine} (design §4). Implemented by the enum that enumerates a
+ * machine's states — for example the adapter machine's {@code ProtocolAdapterWrapperState} or a tag aspect's
+ * state enum. The engine treats states opaquely; the meaning lives entirely in the {@link TransitionTable}.
+ */
+public interface StateMachineState {}

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/statemachine/Transition.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/statemachine/Transition.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.protocols.v2.statemachine;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * One row of a {@link TransitionTable} (design §4): in state {@link #from()}, on an event of exactly type
+ * {@link #eventType()}, when the optional {@link #guard()} passes, run {@link #action()} to compute the next
+ * state. A {@code null} guard makes the row unconditional — the catch-all for its {@code (from, eventType)}
+ * key, evaluated only after every guarded row for that key has failed. Built through
+ * {@link TransitionTable.Builder}, never constructed directly by machine authors.
+ *
+ * @param <StateType>   the machine's state type.
+ * @param <EventType>   the machine's event type.
+ * @param <ContextType> the machine's context.
+ * @param from          the state this row applies in.
+ * @param eventType     the exact event type this row matches.
+ * @param guard         the optional gating condition; {@code null} for an unconditional row.
+ * @param action        the behavior that runs and returns the next state.
+ */
+public record Transition<StateType extends StateMachineState, EventType extends StateMachineEvent, ContextType>(
+        @NotNull StateType from,
+        @NotNull Class<? extends EventType> eventType,
+        @Nullable Guard<StateType, EventType, ContextType> guard,
+        @NotNull Action<StateType, EventType, ContextType> action) {
+
+    /**
+     * @return whether this row carries a guard; an unconditional (guardless) row is the catch-all for its
+     *         {@code (from, eventType)} key.
+     */
+    public boolean guarded() {
+        return guard != null;
+    }
+}

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/statemachine/TransitionTable.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/statemachine/TransitionTable.java
@@ -1,0 +1,276 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.protocols.v2.statemachine;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * The declarative transition table at the heart of the SOLID state-machine engine (design §4): a set of
+ * {@link Transition} rows plus a mandatory {@code unmatched} action (the defensive-reset slot). New machines
+ * are new tables, not new engine code.
+ * <p>
+ * {@link #dispatch(StateMachineState, StateMachineEvent, Object)} looks up the rows for the current state and
+ * the event's exact runtime type, evaluates their guards in registration order, and runs the first whose
+ * guard passes. A single guardless row for that key is the catch-all, tried only after every guarded row for
+ * the key has failed. When nothing matches — no row for the {@code (state, eventType)} key, or every guarded
+ * row failed and there is no guardless row — the {@code unmatched} action runs; for the adapter machine that
+ * is the defensive reset (§6.4). Goal mutations never reach this table: they go through
+ * {@link StateMachine#onGoalChange(Runnable)} and so can never trigger the defensive reset (§4).
+ * <p>
+ * A table is immutable once {@link Builder#build()} returns. The builder fails fast on an ambiguous table
+ * (more than one guardless row for the same {@code (state, eventType)} key) and on a missing {@code unmatched}
+ * action.
+ *
+ * @param <StateType>   the machine's state type.
+ * @param <EventType>   the machine's event type.
+ * @param <ContextType> the machine's context.
+ */
+public final class TransitionTable<
+        StateType extends StateMachineState, EventType extends StateMachineEvent, ContextType> {
+
+    private final @NotNull Map<StateType, List<Transition<StateType, EventType, ContextType>>> rowsByState;
+    private final @NotNull Action<StateType, EventType, ContextType> unmatched;
+
+    private TransitionTable(
+            final @NotNull Map<StateType, List<Transition<StateType, EventType, ContextType>>> rowsByState,
+            final @NotNull Action<StateType, EventType, ContextType> unmatched) {
+        this.rowsByState = rowsByState;
+        this.unmatched = unmatched;
+    }
+
+    /**
+     * @param <StateType>   the machine's state type.
+     * @param <EventType>   the machine's event type.
+     * @param <ContextType> the machine's context.
+     * @return a fresh builder for a table over the given state, event, and context types.
+     */
+    public static <StateType extends StateMachineState, EventType extends StateMachineEvent, ContextType> @NotNull
+            Builder<StateType, EventType, ContextType> builder() {
+        return new Builder<>();
+    }
+
+    /**
+     * Compute the next state for an event arriving in {@code current}. Runs on the actor's dispatch thread.
+     *
+     * @param current the current machine state.
+     * @param event   the event to dispatch.
+     * @param context the machine context the matched action acts through.
+     * @return the matched action's next state, or the {@code unmatched} action's next state when no row
+     *         matches.
+     */
+    public @NotNull StateType dispatch(
+            final @NotNull StateType current, final @NotNull EventType event, final @NotNull ContextType context) {
+        final List<Transition<StateType, EventType, ContextType>> rows = rowsByState.get(current);
+        if (rows != null) {
+            Transition<StateType, EventType, ContextType> guardless = null;
+            for (final Transition<StateType, EventType, ContextType> row : rows) {
+                if (!row.eventType().equals(event.getClass())) {
+                    continue;
+                }
+                final Guard<StateType, EventType, ContextType> guard = row.guard();
+                if (guard == null) {
+                    guardless = row;
+                } else if (guard.test(current, event, context)) {
+                    return row.action().apply(current, event, context);
+                }
+            }
+            if (guardless != null) {
+                return guardless.action().apply(current, event, context);
+            }
+        }
+        return unmatched.apply(current, event, context);
+    }
+
+    /**
+     * Fluent builder for a {@link TransitionTable}. Not thread-safe — build once at construction time.
+     *
+     * @param <StateType>   the machine's state type.
+     * @param <EventType>   the machine's event type.
+     * @param <ContextType> the machine's context.
+     */
+    public static final class Builder<
+            StateType extends StateMachineState, EventType extends StateMachineEvent, ContextType> {
+
+        private final @NotNull List<Transition<StateType, EventType, ContextType>> rows = new ArrayList<>();
+        private @Nullable Action<StateType, EventType, ContextType> unmatched;
+
+        private Builder() {}
+
+        /**
+         * Begin a row for {@code (state, eventType)}. Continue with {@link OnClause#when(Guard)} for a guarded
+         * row, or {@link OnClause#then(Action)} / {@link OnClause#otherwise(Action)} for the unconditional
+         * row.
+         *
+         * @param state     the state the row applies in.
+         * @param eventType the exact event type the row matches.
+         * @return the clause to complete the row.
+         */
+        public @NotNull OnClause<StateType, EventType, ContextType> on(
+                final @NotNull StateType state, final @NotNull Class<? extends EventType> eventType) {
+            return new OnClause<>(this, state, eventType);
+        }
+
+        /**
+         * Set the mandatory action run when no row matches — the defensive-reset slot.
+         *
+         * @param action the unmatched action.
+         * @return this builder.
+         */
+        public @NotNull Builder<StateType, EventType, ContextType> unmatched(
+                final @NotNull Action<StateType, EventType, ContextType> action) {
+            this.unmatched = action;
+            return this;
+        }
+
+        /**
+         * @return the immutable table.
+         * @throws IllegalStateException if no {@code unmatched} action was set, or the table is ambiguous —
+         *                               more than one guardless row for one {@code (state, eventType)} key.
+         */
+        public @NotNull TransitionTable<StateType, EventType, ContextType> build() {
+            final Action<StateType, EventType, ContextType> resolvedUnmatched = unmatched;
+            if (resolvedUnmatched == null) {
+                throw new IllegalStateException(
+                        "a TransitionTable requires an unmatched action (the defensive-reset slot)");
+            }
+            final Map<StateType, Set<Class<? extends EventType>>> guardlessSeen = new HashMap<>();
+            final Map<StateType, List<Transition<StateType, EventType, ContextType>>> byState = new HashMap<>();
+            for (final Transition<StateType, EventType, ContextType> row : rows) {
+                if (!row.guarded()
+                        && !guardlessSeen
+                                .computeIfAbsent(row.from(), key -> new HashSet<>())
+                                .add(row.eventType())) {
+                    throw new IllegalStateException(
+                            "ambiguous transition table: more than one unconditional transition for state "
+                                    + row.from()
+                                    + " on event "
+                                    + row.eventType().getSimpleName());
+                }
+                byState.computeIfAbsent(row.from(), key -> new ArrayList<>()).add(row);
+            }
+            return new TransitionTable<>(byState, resolvedUnmatched);
+        }
+
+        private void add(final @NotNull Transition<StateType, EventType, ContextType> row) {
+            rows.add(row);
+        }
+    }
+
+    /**
+     * The clause returned by {@link Builder#on}: gate the row with {@link #when(Guard)}, or register the
+     * unconditional row with {@link #then(Action)} / {@link #otherwise(Action)}.
+     *
+     * @param <StateType>   the machine's state type.
+     * @param <EventType>   the machine's event type.
+     * @param <ContextType> the machine's context.
+     */
+    public static final class OnClause<
+            StateType extends StateMachineState, EventType extends StateMachineEvent, ContextType> {
+
+        private final @NotNull Builder<StateType, EventType, ContextType> builder;
+        private final @NotNull StateType state;
+        private final @NotNull Class<? extends EventType> eventType;
+
+        private OnClause(
+                final @NotNull Builder<StateType, EventType, ContextType> builder,
+                final @NotNull StateType state,
+                final @NotNull Class<? extends EventType> eventType) {
+            this.builder = builder;
+            this.state = state;
+            this.eventType = eventType;
+        }
+
+        /**
+         * Gate this row; complete it with {@link GuardedClause#then(Action)}.
+         *
+         * @param guard the gating condition.
+         * @return the guarded clause.
+         */
+        public @NotNull GuardedClause<StateType, EventType, ContextType> when(
+                final @NotNull Guard<StateType, EventType, ContextType> guard) {
+            return new GuardedClause<>(builder, state, eventType, guard);
+        }
+
+        /**
+         * Register the unconditional row for this {@code (state, eventType)} and return to the builder.
+         *
+         * @param action the behavior that runs and returns the next state.
+         * @return the builder.
+         */
+        public @NotNull Builder<StateType, EventType, ContextType> then(
+                final @NotNull Action<StateType, EventType, ContextType> action) {
+            builder.add(new Transition<>(state, eventType, null, action));
+            return builder;
+        }
+
+        /**
+         * Alias of {@link #then(Action)} that reads as the explicit default when guarded rows precede it.
+         *
+         * @param action the behavior that runs and returns the next state.
+         * @return the builder.
+         */
+        public @NotNull Builder<StateType, EventType, ContextType> otherwise(
+                final @NotNull Action<StateType, EventType, ContextType> action) {
+            return then(action);
+        }
+    }
+
+    /**
+     * The clause returned by {@link OnClause#when}: complete the guarded row with {@link #then(Action)}.
+     *
+     * @param <StateType>   the machine's state type.
+     * @param <EventType>   the machine's event type.
+     * @param <ContextType> the machine's context.
+     */
+    public static final class GuardedClause<
+            StateType extends StateMachineState, EventType extends StateMachineEvent, ContextType> {
+
+        private final @NotNull Builder<StateType, EventType, ContextType> builder;
+        private final @NotNull StateType state;
+        private final @NotNull Class<? extends EventType> eventType;
+        private final @NotNull Guard<StateType, EventType, ContextType> guard;
+
+        private GuardedClause(
+                final @NotNull Builder<StateType, EventType, ContextType> builder,
+                final @NotNull StateType state,
+                final @NotNull Class<? extends EventType> eventType,
+                final @NotNull Guard<StateType, EventType, ContextType> guard) {
+            this.builder = builder;
+            this.state = state;
+            this.eventType = eventType;
+            this.guard = guard;
+        }
+
+        /**
+         * Register the guarded row and return to the builder.
+         *
+         * @param action the behavior that runs and returns the next state when the guard passes.
+         * @return the builder.
+         */
+        public @NotNull Builder<StateType, EventType, ContextType> then(
+                final @NotNull Action<StateType, EventType, ContextType> action) {
+            builder.add(new Transition<>(state, eventType, guard, action));
+            return builder;
+        }
+    }
+}

--- a/hivemq-edge/src/test/java/com/hivemq/protocols/v2/runtime/BatchCollectorReconciliationTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/protocols/v2/runtime/BatchCollectorReconciliationTest.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.protocols.v2.runtime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.hivemq.adapter.sdk.api.data.DataPoint;
+import com.hivemq.adapter.sdk.api.v2.ProtocolAdapter;
+import com.hivemq.adapter.sdk.api.v2.model.BrowseFilter;
+import com.hivemq.adapter.sdk.api.v2.model.WriteEntry;
+import com.hivemq.adapter.sdk.api.v2.node.Node;
+import com.hivemq.adapter.sdk.api.v2.node.NodeProperty;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+
+/**
+ * S26 at unit level: same-tick subscription requests are reconciled per node (last request wins) so a node
+ * appears in at most one of the add/remove batches; poll and write batches keep duplicates in order; and a
+ * dispatch sends the non-empty batches in the fixed order remove, add, poll, write, then clears them.
+ */
+class BatchCollectorReconciliationTest {
+
+    @Test
+    void subscribeThenCancelSameTick_netsToASingleRemove() {
+        final BatchCollector collector = new BatchCollector();
+        final RecordingProtocolAdapter adapter = new RecordingProtocolAdapter();
+        final Node node = new TestNode("n1");
+
+        collector.addSubscription(node);
+        collector.removeSubscription(node);
+        collector.dispatch(adapter);
+
+        assertThat(adapter.added).isEmpty();
+        assertThat(adapter.removed).containsExactly(List.of(node));
+    }
+
+    @Test
+    void cancelThenResubscribeSameTick_netsToASingleAdd() {
+        final BatchCollector collector = new BatchCollector();
+        final RecordingProtocolAdapter adapter = new RecordingProtocolAdapter();
+        final Node node = new TestNode("n1");
+
+        collector.removeSubscription(node);
+        collector.addSubscription(node);
+        collector.dispatch(adapter);
+
+        assertThat(adapter.removed).isEmpty();
+        assertThat(adapter.added).containsExactly(List.of(node));
+    }
+
+    @Test
+    void eachNodeAppearsInAtMostOneSubscriptionBatch() {
+        final BatchCollector collector = new BatchCollector();
+        final RecordingProtocolAdapter adapter = new RecordingProtocolAdapter();
+        final Node node1 = new TestNode("n1");
+        final Node node2 = new TestNode("n2");
+        final Node node3 = new TestNode("n3");
+
+        collector.addSubscription(node1);
+        collector.removeSubscription(node2);
+        collector.removeSubscription(node1); // node1's last request wins: remove
+        collector.addSubscription(node3);
+        collector.dispatch(adapter);
+
+        assertThat(adapter.removed).containsExactly(List.of(node1, node2));
+        assertThat(adapter.added).containsExactly(List.of(node3));
+    }
+
+    @Test
+    void pollAndWriteDuplicatesArePreservedInOrder() {
+        final BatchCollector collector = new BatchCollector();
+        final RecordingProtocolAdapter adapter = new RecordingProtocolAdapter();
+        final Node node1 = new TestNode("n1");
+        final Node node2 = new TestNode("n2");
+        final WriteEntry write1 = new WriteEntry(node1, new TestDataPoint("a"));
+        final WriteEntry write2 = new WriteEntry(node2, new TestDataPoint("b"));
+
+        collector.poll(node1);
+        collector.poll(node2);
+        collector.poll(node1); // duplicate kept
+        collector.write(write1);
+        collector.write(write2);
+        collector.write(write1); // duplicate kept
+        collector.dispatch(adapter);
+
+        assertThat(adapter.polled).containsExactly(List.of(node1, node2, node1));
+        assertThat(adapter.written).containsExactly(List.of(write1, write2, write1));
+    }
+
+    @Test
+    void dispatchSendsBatchesInTheFixedRemoveAddPollWriteOrder() {
+        final BatchCollector collector = new BatchCollector();
+        final RecordingProtocolAdapter adapter = new RecordingProtocolAdapter();
+
+        collector.poll(new TestNode("p"));
+        collector.write(new WriteEntry(new TestNode("w"), new TestDataPoint("v")));
+        collector.addSubscription(new TestNode("a"));
+        collector.removeSubscription(new TestNode("r"));
+        collector.dispatch(adapter);
+
+        assertThat(adapter.callOrder).containsExactly("remove", "add", "poll", "write");
+    }
+
+    @Test
+    void emptyBatchesAreNotSent_andStateIsClearedBetweenDispatches() {
+        final BatchCollector collector = new BatchCollector();
+        final RecordingProtocolAdapter adapter = new RecordingProtocolAdapter();
+        final Node node = new TestNode("n1");
+
+        collector.dispatch(adapter); // nothing posted
+        assertThat(adapter.callOrder).isEmpty();
+
+        collector.poll(node);
+        collector.dispatch(adapter);
+        collector.dispatch(adapter); // batches cleared by the first dispatch
+
+        assertThat(adapter.polled).containsExactly(List.of(node));
+    }
+
+    private static final class TestNode extends Node {
+
+        private final @NotNull String identifier;
+
+        private TestNode(final @NotNull String identifier) {
+            this.identifier = identifier;
+        }
+
+        @Override
+        public @NotNull String nodeId() {
+            return identifier;
+        }
+
+        @Override
+        public @NotNull String nodeString() {
+            return "{\"identifier\":\"" + identifier + "\"}";
+        }
+
+        @Override
+        public @NotNull EnumSet<NodeProperty> properties() {
+            return EnumSet.of(NodeProperty.UNIQUE);
+        }
+
+        @Override
+        public @NotNull String toString() {
+            return identifier;
+        }
+    }
+
+    private record TestDataPoint(@NotNull String value) implements DataPoint {
+        @Override
+        public @NotNull Object getTagValue() {
+            return value;
+        }
+
+        @Override
+        public boolean treatTagValueAsJson() {
+            return false;
+        }
+
+        @Override
+        public @NotNull String getTagName() {
+            return "tag";
+        }
+    }
+
+    private static final class RecordingProtocolAdapter implements ProtocolAdapter {
+
+        private final @NotNull List<String> callOrder = new ArrayList<>();
+        private final @NotNull List<List<Node>> removed = new ArrayList<>();
+        private final @NotNull List<List<Node>> added = new ArrayList<>();
+        private final @NotNull List<List<Node>> polled = new ArrayList<>();
+        private final @NotNull List<List<WriteEntry>> written = new ArrayList<>();
+
+        @Override
+        public @NotNull String adapterId() {
+            return "recording";
+        }
+
+        @Override
+        public void start() {}
+
+        @Override
+        public void stop() {}
+
+        @Override
+        public void connect() {}
+
+        @Override
+        public void disconnect() {}
+
+        @Override
+        public void verifyBatch(final @NotNull List<Node> nodes) {}
+
+        @Override
+        public void pollBatch(final @NotNull List<Node> nodes) {
+            callOrder.add("poll");
+            polled.add(nodes);
+        }
+
+        @Override
+        public void addSubscriptionBatch(final @NotNull List<Node> nodes) {
+            callOrder.add("add");
+            added.add(nodes);
+        }
+
+        @Override
+        public void removeSubscriptionBatch(final @NotNull List<Node> nodes) {
+            callOrder.add("remove");
+            removed.add(nodes);
+        }
+
+        @Override
+        public void writeBatch(final @NotNull List<WriteEntry> entries) {
+            callOrder.add("write");
+            written.add(entries);
+        }
+
+        @Override
+        public void browse(final @NotNull BrowseFilter filter) {}
+    }
+}

--- a/hivemq-edge/src/test/java/com/hivemq/protocols/v2/statemachine/StateMachineDemoTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/protocols/v2/statemachine/StateMachineDemoTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.protocols.v2.statemachine;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A small goal-seeking demo that mirrors the adapter machine's central principle (design §1, §6.5): an
+ * external actor sets a goal, the machine takes <em>one</em> step toward it per message — issuing exactly one
+ * command each step — and reaches the goal in N steps. The goal change drives the first step
+ * ({@code STOPPED → WAITING_FOR_STARTED} through {@code stepTowardGoal}); the acknowledgment event drives the
+ * next through the table. A goal flip mid-wait is absorbed when the acknowledgment lands (stop intent).
+ */
+class StateMachineDemoTest {
+
+    private enum DemoState implements StateMachineState {
+        STOPPED,
+        WAITING_FOR_STARTED,
+        RUNNING
+    }
+
+    private record Started() implements StateMachineEvent {}
+
+    private static final class Context {
+        private boolean wantRunning;
+        private final List<String> commands = new ArrayList<>();
+
+        private void stepTowardGoal(final @NotNull StateMachine<DemoState, StateMachineEvent, Context> machine) {
+            if (machine.state() == DemoState.STOPPED && wantRunning) {
+                commands.add("start");
+                machine.transitionTo(DemoState.WAITING_FOR_STARTED);
+            }
+        }
+    }
+
+    private static @NotNull TransitionTable<DemoState, StateMachineEvent, Context> demoTable() {
+        return TransitionTable.<DemoState, StateMachineEvent, Context>builder()
+                .on(DemoState.WAITING_FOR_STARTED, Started.class)
+                .when((current, event, context) -> context.wantRunning)
+                .then((current, event, context) -> {
+                    context.commands.add("run");
+                    return DemoState.RUNNING;
+                })
+                .on(DemoState.WAITING_FOR_STARTED, Started.class)
+                .otherwise((current, event, context) -> DemoState.STOPPED)
+                .unmatched((current, event, context) -> DemoState.STOPPED)
+                .build();
+    }
+
+    @Test
+    void reachesTheGoalInTwoSteps_oneCommandPerStep() {
+        final Context context = new Context();
+        final StateMachine<DemoState, StateMachineEvent, Context> machine =
+                new StateMachine<>(DemoState.STOPPED, demoTable(), context);
+
+        // Step 1: the goal becomes "running" — a goal command, bypassing the table; stepTowardGoal issues start().
+        machine.onGoalChange(() -> {
+            context.wantRunning = true;
+            context.stepTowardGoal(machine);
+        });
+        assertThat(machine.state()).isEqualTo(DemoState.WAITING_FOR_STARTED);
+        assertThat(context.commands).containsExactly("start");
+
+        // Step 2: the adapter acknowledges started() — a table event drives the final step to the goal.
+        machine.onEvent(new Started());
+        assertThat(machine.state()).isEqualTo(DemoState.RUNNING);
+        assertThat(context.commands).containsExactly("start", "run");
+    }
+
+    @Test
+    void goalFlipMidWait_isAbsorbedWhenTheAcknowledgmentLands() {
+        final Context context = new Context();
+        final StateMachine<DemoState, StateMachineEvent, Context> machine =
+                new StateMachine<>(DemoState.STOPPED, demoTable(), context);
+
+        machine.onGoalChange(() -> {
+            context.wantRunning = true;
+            context.stepTowardGoal(machine);
+        });
+        assertThat(machine.state()).isEqualTo(DemoState.WAITING_FOR_STARTED);
+
+        // The goal flips back to stopped while still waiting for the start acknowledgment.
+        machine.onGoalChange(() -> {
+            context.wantRunning = false;
+            context.stepTowardGoal(machine);
+        });
+        assertThat(machine.state()).isEqualTo(DemoState.WAITING_FOR_STARTED);
+
+        // started() now routes to STOPPED via the unconditional fallback — no "run" command is issued.
+        machine.onEvent(new Started());
+        assertThat(machine.state()).isEqualTo(DemoState.STOPPED);
+        assertThat(context.commands).containsExactly("start");
+    }
+}

--- a/hivemq-edge/src/test/java/com/hivemq/protocols/v2/statemachine/StateMachineGoalChangeTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/protocols/v2/statemachine/StateMachineGoalChangeTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.protocols.v2.statemachine;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * The goal-command bypass (design §4): {@link StateMachine#onGoalChange(Runnable)} mutations apply in
+ * <em>every</em> state without consulting the table, so a goal command never triggers the defensive reset —
+ * in contrast to an unhandled event, which does.
+ */
+class StateMachineGoalChangeTest {
+
+    private enum DemoState implements StateMachineState {
+        S1,
+        S2,
+        S3,
+        ERROR
+    }
+
+    private record SomeEvent() implements StateMachineEvent {}
+
+    private static final class Context {
+        private String goal = "stop";
+        private int defensiveResets;
+    }
+
+    @Test
+    void goalChangeAppliesInEveryStateAndNeverTriggersTheDefensiveReset() {
+        final Context context = new Context();
+        // A table with NO event rows: any event would hit the unmatched (defensive reset) slot.
+        final TransitionTable<DemoState, StateMachineEvent, Context> table =
+                TransitionTable.<DemoState, StateMachineEvent, Context>builder()
+                        .unmatched((current, event, ctx) -> {
+                            ctx.defensiveResets++;
+                            return DemoState.ERROR;
+                        })
+                        .build();
+        final StateMachine<DemoState, StateMachineEvent, Context> machine =
+                new StateMachine<>(DemoState.S1, table, context);
+
+        for (final DemoState start : DemoState.values()) {
+            machine.transitionTo(start);
+
+            machine.onGoalChange(() -> {
+                context.goal = "go";
+                machine.transitionTo(DemoState.S2);
+            });
+
+            assertThat(machine.state()).isEqualTo(DemoState.S2);
+            assertThat(context.goal).isEqualTo("go");
+        }
+        assertThat(context.defensiveResets).isZero();
+    }
+
+    @Test
+    void unhandledEvent_triggersTheDefensiveReset() {
+        final Context context = new Context();
+        final TransitionTable<DemoState, StateMachineEvent, Context> table =
+                TransitionTable.<DemoState, StateMachineEvent, Context>builder()
+                        .unmatched((current, event, ctx) -> {
+                            ctx.defensiveResets++;
+                            return DemoState.ERROR;
+                        })
+                        .build();
+        final StateMachine<DemoState, StateMachineEvent, Context> machine =
+                new StateMachine<>(DemoState.S1, table, context);
+
+        machine.onEvent(new SomeEvent());
+
+        assertThat(machine.state()).isEqualTo(DemoState.ERROR);
+        assertThat(context.defensiveResets).isEqualTo(1);
+    }
+}

--- a/hivemq-edge/src/test/java/com/hivemq/protocols/v2/statemachine/TransitionTableTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/protocols/v2/statemachine/TransitionTableTest.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.protocols.v2.statemachine;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+
+class TransitionTableTest {
+
+    private enum DemoState implements StateMachineState {
+        A,
+        B,
+        C,
+        RESET
+    }
+
+    private record Advance() implements StateMachineEvent {}
+
+    private record Other() implements StateMachineEvent {}
+
+    private static final class Recorder {
+        private final List<String> actions = new ArrayList<>();
+        private boolean flag;
+    }
+
+    @Test
+    void matchedTransition_runsActionAndReturnsNextState() {
+        final Recorder context = new Recorder();
+        final TransitionTable<DemoState, StateMachineEvent, Recorder> table =
+                TransitionTable.<DemoState, StateMachineEvent, Recorder>builder()
+                        .on(DemoState.A, Advance.class)
+                        .then((current, event, recorder) -> {
+                            recorder.actions.add("a->b");
+                            return DemoState.B;
+                        })
+                        .unmatched((current, event, recorder) -> {
+                            recorder.actions.add("reset");
+                            return DemoState.RESET;
+                        })
+                        .build();
+
+        final DemoState next = table.dispatch(DemoState.A, new Advance(), context);
+
+        assertThat(next).isEqualTo(DemoState.B);
+        assertThat(context.actions).containsExactly("a->b");
+    }
+
+    @Test
+    void passingGuard_isChosenOverTheUnconditionalFallback() {
+        final TransitionTable<DemoState, StateMachineEvent, Recorder> table = guardedTable();
+
+        final Recorder context = new Recorder();
+        context.flag = true;
+
+        final DemoState next = table.dispatch(DemoState.A, new Advance(), context);
+
+        assertThat(next).isEqualTo(DemoState.B);
+        assertThat(context.actions).containsExactly("guarded");
+    }
+
+    @Test
+    void failingGuard_fallsThroughToTheUnconditionalRow() {
+        final TransitionTable<DemoState, StateMachineEvent, Recorder> table = guardedTable();
+
+        final Recorder context = new Recorder();
+        context.flag = false;
+
+        final DemoState next = table.dispatch(DemoState.A, new Advance(), context);
+
+        assertThat(next).isEqualTo(DemoState.C);
+        assertThat(context.actions).containsExactly("default");
+    }
+
+    @Test
+    void guardedRowsAreEvaluatedInRegistrationOrder() {
+        final Recorder context = new Recorder();
+        final TransitionTable<DemoState, StateMachineEvent, Recorder> table =
+                TransitionTable.<DemoState, StateMachineEvent, Recorder>builder()
+                        .on(DemoState.A, Advance.class)
+                        .when((current, event, recorder) -> true)
+                        .then((current, event, recorder) -> {
+                            recorder.actions.add("first");
+                            return DemoState.B;
+                        })
+                        .on(DemoState.A, Advance.class)
+                        .when((current, event, recorder) -> true)
+                        .then((current, event, recorder) -> {
+                            recorder.actions.add("second");
+                            return DemoState.C;
+                        })
+                        .unmatched((current, event, recorder) -> DemoState.RESET)
+                        .build();
+
+        final DemoState next = table.dispatch(DemoState.A, new Advance(), context);
+
+        assertThat(next).isEqualTo(DemoState.B);
+        assertThat(context.actions).containsExactly("first");
+    }
+
+    @Test
+    void unknownEventForTheState_triggersTheUnmatchedAction() {
+        final Recorder context = new Recorder();
+        final TransitionTable<DemoState, StateMachineEvent, Recorder> table =
+                TransitionTable.<DemoState, StateMachineEvent, Recorder>builder()
+                        .on(DemoState.A, Advance.class)
+                        .then((current, event, recorder) -> DemoState.B)
+                        .unmatched((current, event, recorder) -> {
+                            recorder.actions.add("reset");
+                            return DemoState.RESET;
+                        })
+                        .build();
+
+        final DemoState next = table.dispatch(DemoState.A, new Other(), context);
+
+        assertThat(next).isEqualTo(DemoState.RESET);
+        assertThat(context.actions).containsExactly("reset");
+    }
+
+    @Test
+    void everyGuardFailsAndNoFallback_triggersTheUnmatchedAction() {
+        final Recorder context = new Recorder();
+        final TransitionTable<DemoState, StateMachineEvent, Recorder> table =
+                TransitionTable.<DemoState, StateMachineEvent, Recorder>builder()
+                        .on(DemoState.A, Advance.class)
+                        .when((current, event, recorder) -> false)
+                        .then((current, event, recorder) -> DemoState.B)
+                        .unmatched((current, event, recorder) -> {
+                            recorder.actions.add("reset");
+                            return DemoState.RESET;
+                        })
+                        .build();
+
+        final DemoState next = table.dispatch(DemoState.A, new Advance(), context);
+
+        assertThat(next).isEqualTo(DemoState.RESET);
+        assertThat(context.actions).containsExactly("reset");
+    }
+
+    @Test
+    void moreThanOneUnconditionalRowForOneKey_isRejectedAtBuild() {
+        assertThatThrownBy(() -> TransitionTable.<DemoState, StateMachineEvent, Recorder>builder()
+                        .on(DemoState.A, Advance.class)
+                        .then((current, event, recorder) -> DemoState.B)
+                        .on(DemoState.A, Advance.class)
+                        .otherwise((current, event, recorder) -> DemoState.C)
+                        .unmatched((current, event, recorder) -> DemoState.RESET)
+                        .build())
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("ambiguous");
+    }
+
+    @Test
+    void missingUnmatchedAction_isRejectedAtBuild() {
+        assertThatThrownBy(() -> TransitionTable.<DemoState, StateMachineEvent, Recorder>builder()
+                        .on(DemoState.A, Advance.class)
+                        .then((current, event, recorder) -> DemoState.B)
+                        .build())
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("unmatched");
+    }
+
+    private static @NotNull TransitionTable<DemoState, StateMachineEvent, Recorder> guardedTable() {
+        return TransitionTable.<DemoState, StateMachineEvent, Recorder>builder()
+                .on(DemoState.A, Advance.class)
+                .when((current, event, recorder) -> recorder.flag)
+                .then((current, event, recorder) -> {
+                    recorder.actions.add("guarded");
+                    return DemoState.B;
+                })
+                .on(DemoState.A, Advance.class)
+                .otherwise((current, event, recorder) -> {
+                    recorder.actions.add("default");
+                    return DemoState.C;
+                })
+                .unmatched((current, event, recorder) -> DemoState.RESET)
+                .build();
+    }
+}


### PR DESCRIPTION
## Summary

Part of EDG-724 (Project Nevsky, Task 5). Adds the reusable state-machine engine `com.hivemq.protocols.v2.statemachine` and the reconciling `runtime.BatchCollector` (design §4, §5.7) — the SOLID core the adapter machine (Task 6) and tag aspect machines (Tasks 7–8) will instantiate. All new code is in the core module and consumes the SDK `api.v2` types read-only; the legacy framework is untouched.

- **Engine:** `StateMachineState` / `StateMachineEvent` markers; `Guard` + `Action` over `(current, event, context)`; `Transition` rows; `TransitionTable` with a fluent builder — `.on(state, eventType).when(guard).then(action)` / `.otherwise` / `.unmatched`. `dispatch` matches by exact event class, runs the first passing guard, falls through to the single guardless row, else the mandatory `unmatched` (defensive-reset) slot. `build()` fails fast on a missing `unmatched` and on ambiguity (more than one guardless row per `(state, eventType)`).
- **StateMachine:** `onEvent` (table-driven), `onGoalChange` (the goal-command bypass — never consults the table, so a goal command can never trigger a defensive reset), and `transitionTo` (the `stepTowardGoal` current-mutation primitive that lets a goal change advance state, e.g. `STOPPED → WAITING_FOR_STARTED`).
- **BatchCollector:** poll/write append-only (duplicates preserved in order); add/remove subscriptions reconciled per node (last request wins); `dispatch` sends only non-empty batches in the fixed order remove, add, poll, write, then clears.

## Verification

`compileJava` + `compileTestJava` (ErrorProne + NullAway), `spotlessCheck`, and the unit tests are green — 18 tests across 4 classes (`TransitionTableTest`, `StateMachineGoalChangeTest`, `StateMachineDemoTest`, `BatchCollectorReconciliationTest` = S26), all deterministic with no threads or sleeps. The full `hivemq-edge-test` suite is left to CI.

## Notes

Targets the `feat/nevsky-2` branch. Implements Task 5 of `nevsky-plan-02.md`; consumes the SDK `api.v2` contracts and the runtime primitives from the merged EDG-720/721/722/723 work.

Design note for review: §4 lists only `state()` / `onEvent` / `onGoalChange`; I added `transitionTo(next)` as the documented current-mutation primitive `stepTowardGoal` calls from inside the `onGoalChange` runnable, so the goal path stays entirely off the transition table while still moving the machine. The PAW (Task 6) owns the machine field, so the runnable closes over it with no constructor circularity.
