### PR TITLE
EDG-726: Add Nevsky tag read aspects (polled + subscribed)

### DIFF
--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/runtime/SystemDispatcher.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/runtime/SystemDispatcher.java
@@ -30,8 +30,9 @@ import org.jetbrains.annotations.Nullable;
  * a time, in priority-band order. A parked thread consumes no CPU — it is woken by a {@code tell}, not by polling.
  * <p>
  * {@link MessageDispatcherHandle#close()} stops the loop and interrupts the thread; an in-flight {@code receive}
- * always completes first (the interrupt is observed only at the next {@code awaitNextMessage}, or as a set flag
- * the loop checks once {@code receive} returns).
+ * always completes first. The stop flag is observed either as the interrupt thrown by {@code awaitNextMessage}, or
+ * — when a {@code tell} races in and {@code awaitNextMessage} returns that message instead of throwing — by the
+ * re-check after the fetch, so a message arriving alongside {@code close()} is never delivered.
  */
 public final class SystemDispatcher implements MessageDispatcher {
 
@@ -76,6 +77,11 @@ public final class SystemDispatcher implements MessageDispatcher {
                 } catch (final InterruptedException interrupted) {
                     // close() is the only interrupter; restore the flag and let the thread end.
                     Thread.currentThread().interrupt();
+                    break;
+                }
+                if (!running) {
+                    // close() raced with an arriving message: awaitNextMessage returned it instead of throwing the
+                    // interrupt. The loop is stopping, so the post-close message is dropped, not delivered.
                     break;
                 }
                 if (message != null) {

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/tag/NodeVerifier.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/tag/NodeVerifier.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.protocols.v2.tag;
+
+import com.hivemq.adapter.sdk.api.v2.node.Node;
+import java.util.List;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * The narrow seam through which the {@link SharedNodeVerification} re-issues verification for a node — backed by
+ * the protocol adapter's {@code verifyBatch} in production. It exists so the coordinator depends on a single
+ * verb, not the whole adapter, and so tests can observe verification requests directly. Always invoked on the
+ * actor's single dispatch thread.
+ */
+@FunctionalInterface
+public interface NodeVerifier {
+
+    /**
+     * Verify the given nodes against the connected device.
+     *
+     * @param nodes the nodes to verify.
+     */
+    void verify(@NotNull List<Node> nodes);
+}

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/tag/SharedNodeVerification.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/tag/SharedNodeVerification.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.protocols.v2.tag;
+
+import com.hivemq.adapter.sdk.api.v2.model.VerifyOutcome;
+import com.hivemq.adapter.sdk.api.v2.node.Node;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Shared verification bookkeeping for a single adapter's tags (design §7.6). One node's verification serves all of
+ * that node's aspects: if both the read and write aspect of a tag need to verify, the coordinator issues
+ * <b>one</b> {@code verifyBatch} entry and fans the single {@link VerifyOutcome} out to every aspect of the node.
+ * <p>
+ * In this task only read aspects exist, so the fan-out reaches the read aspect; the write aspect joins in a later
+ * task with no change here. The coordinator owns the de-duplication: a node already in flight is not re-requested
+ * ({@link #needsVerify(Node)}), which is what keeps a read-and-write tag to a single verify.
+ * <p>
+ * The initial connect verification is issued by the wrapper's adapter gate (design §6.3), which also counts for
+ * the {@code CONNECTED} transition; those results flow through {@link #onVerifyResult(Node, VerifyOutcome)} for
+ * fan-out but are not tracked here. This coordinator issues only the post-connect re-verifications an aspect asks
+ * for — a verification retry or a tag retry (design §7.6). {@link #allReported()} reports whether the
+ * coordinator-issued requests have all come back; a later task wires it to the gate counting.
+ * <p>
+ * Owned by one adapter wrapper and used only on its single dispatch thread; it holds no locks.
+ */
+public final class SharedNodeVerification {
+
+    private final @NotNull NodeVerifier nodeVerifier;
+    private final @NotNull Function<Node, @Nullable TagRuntime> tagRuntimeByNode;
+    private final @NotNull Set<Node> inFlight = new HashSet<>();
+
+    /**
+     * @param nodeVerifier  the seam that verifies nodes against the device (the adapter's {@code verifyBatch}).
+     * @param tagRuntimeByNode the current node-to-tag-runtime lookup; consulted on every result so it always
+     *                         reflects the latest tag set after a tags-only transition.
+     */
+    public SharedNodeVerification(
+            final @NotNull NodeVerifier nodeVerifier,
+            final @NotNull Function<Node, @Nullable TagRuntime> tagRuntimeByNode) {
+        this.nodeVerifier = nodeVerifier;
+        this.tagRuntimeByNode = tagRuntimeByNode;
+    }
+
+    /**
+     * @param node the node an aspect wants to verify.
+     * @return {@code true} when the node is not already in flight — i.e. a fresh request is needed.
+     */
+    public boolean needsVerify(final @NotNull Node node) {
+        return !inFlight.contains(node);
+    }
+
+    /**
+     * Request a re-verification of the node, de-duplicated: if the node is already in flight (another aspect of
+     * the same tag asked first, or a request is outstanding) nothing is issued, so the single result serves all
+     * of the node's aspects (design §7.6).
+     *
+     * @param node the node to verify.
+     */
+    public void requestVerification(final @NotNull Node node) {
+        if (needsVerify(node)) {
+            inFlight.add(node);
+            nodeVerifier.verify(List.of(node));
+        }
+    }
+
+    /**
+     * Fan one node's verification outcome out to its aspects and clear it from the in-flight set (design §7.6). A
+     * result for a node this coordinator did not request — an initial connect verification issued by the adapter
+     * gate — is fanned out all the same; the in-flight removal is then a no-op.
+     *
+     * @param node    the verified node.
+     * @param outcome the verification outcome.
+     */
+    public void onVerifyResult(final @NotNull Node node, final @NotNull VerifyOutcome outcome) {
+        inFlight.remove(node);
+        final TagRuntime tagRuntime = tagRuntimeByNode.apply(node);
+        if (tagRuntime != null) {
+            tagRuntime.onVerifyResult(outcome);
+        }
+    }
+
+    /**
+     * @return {@code true} when every coordinator-issued verification has reported — the signal a later task
+     *         feeds into the adapter gate (design §6.3).
+     */
+    public boolean allReported() {
+        return inFlight.isEmpty();
+    }
+}

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/tag/TagAspectCoordinator.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/tag/TagAspectCoordinator.java
@@ -13,13 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.hivemq.protocols.v2.wrapper;
+package com.hivemq.protocols.v2.tag;
 
 import com.hivemq.adapter.sdk.api.data.DataPoint;
 import com.hivemq.adapter.sdk.api.v2.model.VerifyOutcome;
 import com.hivemq.adapter.sdk.api.v2.node.Node;
 import com.hivemq.adapter.sdk.api.v2.node.NodeTagPair;
 import com.hivemq.protocols.v2.view.TagStatusSnapshot;
+import com.hivemq.protocols.v2.wrapper.ProtocolAdapterGoalState;
+import com.hivemq.protocols.v2.wrapper.TagAspectActivationPreference;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -27,21 +29,29 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /**
- * The wrapper's view of all its tag aspect machines — the seam between the adapter machine (this task) and the
- * per-tag read/write aspect machines (later tasks). The wrapper invokes these hooks at the points where aspects
- * react: it never reaches into aspect internals.
+ * The wrapper's view of all of an adapter's tag aspect machines — the seam between the adapter machine (the
+ * {@code wrapper} package) and the per-tag read/write aspect machines (this {@code tag} package). The wrapper
+ * invokes these hooks at the points where aspects react; it never reaches into aspect internals.
  * <p>
- * This task ships {@link SnapshotOnlyTagAspectCoordinator}, a minimal implementation that holds the tag set and activation but runs
- * no aspect machines. A later task supplies a real {@code TagAspectCoordinator} backed by per-tag aspect runtimes; the
- * adapter machine and snapshot publication built here do not change. The hook set is therefore deliberately the
- * full wrapper-to-aspect contract, even though most hooks are no-ops for now.
+ * {@link TagAspectSnapshotOnlyCoordinator} is the minimal stand-in — tag set and activation only, no aspect
+ * machines — that the adapter-machine tests use; {@link TagAspectRuntimeCoordinator} is the running implementation
+ * backed by per-tag {@link TagRuntime}s. The hook set is the full wrapper-to-aspect contract.
  * <p>
  * Every method runs on the wrapper's single dispatch thread.
  */
 public interface TagAspectCoordinator {
 
     /**
-     * The adapter reached {@code CONNECTED}: aspects may begin verifying and operating (design §7.2).
+     * The adapter began verifying its nodes (design §6.3): active aspects waiting for the adapter move into
+     * verification so they consume the connect-time {@code verifyResult}s the wrapper routes to them — the single
+     * verify stream feeds both the adapter gate and the aspects (design §6.3).
+     */
+    void onAdapterVerifying();
+
+    /**
+     * The adapter reached {@code CONNECTED} (design §7.2). When verification was skipped, aspects still waiting for
+     * the adapter treat the connection as verified and begin operating; otherwise they have already advanced
+     * through verification on the routed results and this is a no-op for them.
      */
     void onAdapterReady();
 
@@ -85,14 +95,6 @@ public interface TagAspectCoordinator {
      * @param reason  the failure reason, or {@code null} on success.
      */
     void routeWriteResult(@NotNull Node node, boolean success, @Nullable String reason);
-
-    /**
-     * A tick elapsed: aspects post their due work (polls, subscription retries) to the batch collector before it
-     * is dispatched (design §5.7, §7.3).
-     *
-     * @param nowMillis the tick's logical time, in milliseconds.
-     */
-    void onTick(long nowMillis);
 
     /**
      * Apply changed activation flags atomically — the activation-only transition (design §8.2). Recomputes aspect

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/tag/TagAspectEvent.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/tag/TagAspectEvent.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.protocols.v2.tag;
+
+import com.hivemq.adapter.sdk.api.data.DataPoint;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * The table-driven inputs to a tag aspect machine (design §7). Each aspect is its own {@code FSM}; the wrapper
+ * routes the protocol-adapter events it receives to the owning tag's aspects, which feed them here, and the
+ * aspect's own timers (poll interval, verification retry, subscription retry) feed the timer-expiry events on the
+ * actor's single dispatch thread.
+ * <p>
+ * Aspect goal changes (the three-condition rule) and the adapter-readiness coupling are <b>not</b> events: like
+ * the adapter machine's goal-command bypass, they are applied directly by the aspect runtime and never run
+ * through the transition table.
+ */
+public sealed interface TagAspectEvent extends com.hivemq.protocols.v2.fsm.FSMEvent
+        permits TagAspectEvent.VerifySucceeded,
+                TagAspectEvent.VerifyTransientlyFailed,
+                TagAspectEvent.VerifyPermanentlyFailed,
+                TagAspectEvent.VerificationRetryElapsed,
+                TagAspectEvent.PollIntervalElapsed,
+                TagAspectEvent.ValueReceived,
+                TagAspectEvent.NodeFailed,
+                TagAspectEvent.SubscriptionRetryElapsed {
+
+    /**
+     * The node verified successfully (design §7.2).
+     */
+    record VerifySucceeded() implements TagAspectEvent {}
+
+    /**
+     * Verification failed transiently — retry after a delay (design §7.2).
+     *
+     * @param reason a human-readable description of the failure.
+     */
+    record VerifyTransientlyFailed(@NotNull String reason) implements TagAspectEvent {}
+
+    /**
+     * Verification failed permanently — suspend until a user-commanded retry (design §7.6).
+     *
+     * @param reason a human-readable description of the failure.
+     */
+    record VerifyPermanentlyFailed(@NotNull String reason) implements TagAspectEvent {}
+
+    /**
+     * The verification-retry timer elapsed — verify the node again (design §7.2). Generated in the tick handler.
+     */
+    record VerificationRetryElapsed() implements TagAspectEvent {}
+
+    /**
+     * The poll-interval timer elapsed — request the next poll (design §7.3). Generated in the tick handler.
+     */
+    record PollIntervalElapsed() implements TagAspectEvent {}
+
+    /**
+     * A value arrived for the node — a poll response or a subscription push (design §7.3, §7.4).
+     *
+     * @param value the reused v1 value.
+     */
+    record ValueReceived(@NotNull DataPoint value) implements TagAspectEvent {}
+
+    /**
+     * A per-node failure arrived — a failed poll, or a failed or lost subscription (design §7.3, §7.4).
+     *
+     * @param reason      a human-readable description of the failure.
+     * @param spontaneous {@code true} if the failure arrived outside a command-response exchange — selects the
+     *                    subscription recovery path.
+     */
+    record NodeFailed(@NotNull String reason, boolean spontaneous) implements TagAspectEvent {}
+
+    /**
+     * The subscription-retry backoff elapsed — re-add the subscription (design §7.4). Generated in the tick
+     * handler.
+     */
+    record SubscriptionRetryElapsed() implements TagAspectEvent {}
+}

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/tag/TagAspectGoal.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/tag/TagAspectGoal.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.protocols.v2.tag;
+
+/**
+ * The goal of a single tag aspect — the three-condition rule (design §7.1). An aspect is driven if and only if
+ * <b>all three</b> conditions hold:
+ * <ol>
+ * <li>the adapter direction is activated — northbound for a read aspect, southbound for a write aspect;</li>
+ * <li>the tag aspect is activated in the configuration ({@code read-activated} / {@code write-activated});</li>
+ * <li>the tag is used — a configured mapping consumes (read) or produces to (write) it.</li>
+ * </ol>
+ * The user never sets {@code used} directly; it is derived from the configuration's mapping graph (design §9.2)
+ * and flips as part of the tags-only gentlest transition. Deactivating an adapter direction returns that side's
+ * aspects to {@code DEACTIVATED} without touching the other side — the direction switch is a master switch.
+ *
+ * @param directionActivated whether the adapter direction this aspect belongs to is activated.
+ * @param aspectActivated    the persisted per-aspect activation preference for this tag.
+ * @param used               whether a configured mapping consumes or produces this tag.
+ */
+public record TagAspectGoal(boolean directionActivated, boolean aspectActivated, boolean used) {
+
+    /**
+     * @return the goal in which no condition holds — the aspect must be deactivated.
+     */
+    public static TagAspectGoal inactive() {
+        return new TagAspectGoal(false, false, false);
+    }
+
+    /**
+     * @return {@code true} when all three conditions hold and the aspect must be driven.
+     */
+    public boolean active() {
+        return directionActivated && aspectActivated && used;
+    }
+}

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/tag/TagAspectRead.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/tag/TagAspectRead.java
@@ -1,0 +1,489 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.protocols.v2.tag;
+
+import com.hivemq.adapter.sdk.api.data.DataPoint;
+import com.hivemq.adapter.sdk.api.v2.model.VerifyOutcome;
+import com.hivemq.adapter.sdk.api.v2.node.Node;
+import com.hivemq.adapter.sdk.api.v2.node.Tag;
+import com.hivemq.protocols.v2.fsm.FSM;
+import com.hivemq.protocols.v2.runtime.Backoff;
+import com.hivemq.protocols.v2.runtime.BatchCollector;
+import com.hivemq.protocols.v2.runtime.Clock;
+import com.hivemq.protocols.v2.runtime.NevskyMetrics;
+import com.hivemq.protocols.v2.runtime.PriorityTimerQueue;
+import com.hivemq.protocols.v2.runtime.RetryPolicy;
+import com.hivemq.protocols.v2.runtime.TimerHandle;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The read half of a tag's behavior (design §7.3, §7.4) — one of the two independent aspects every tag has. A
+ * read aspect is a {@link FSM} over an {@link TagAspectState} enum: <b>polled</b> (poll-interval cadence) when the
+ * tag is not subscribable, <b>subscribed</b> (push) when it is. Both share the five pre-operating states; their
+ * tables are built by {@link TagAspectReadTransitions}, the shared rows by one builder.
+ * <p>
+ * The aspect lives inside the wrapper actor and runs only on its single dispatch thread. It owns no thread: it
+ * requests work by appending to the shared {@link BatchCollector}, schedules its own poll / verification-retry /
+ * subscription-retry timers on the actor's single {@link PriorityTimerQueue} (design §5.5), observes the events
+ * the wrapper routes to it, and re-verifies through the shared {@link SharedNodeVerification}.
+ * <p>
+ * Two kinds of input drive it, mirroring the adapter machine:
+ * <ul>
+ * <li><b>events</b> ({@link TagAspectEvent}) run through the transition table — verification outcomes, values,
+ * per-node failures, and the aspect's own timer expiries;</li>
+ * <li><b>goal and adapter-readiness changes</b> bypass the table (like the adapter machine's goal commands): the
+ * three-condition goal ({@link TagAspectGoal}) and the {@code DEACTIVATED} ↔ operating coupling to the adapter's
+ * connection are applied directly, never through the table, so they can never trigger a defensive transition.</li>
+ * </ul>
+ */
+public final class TagAspectRead {
+
+    private static final @NotNull Logger log = LoggerFactory.getLogger(TagAspectRead.class);
+
+    /**
+     * The failure count past which a tag's failures are logged at {@code ERROR} rather than {@code WARN} — a few
+     * hiccups are routine, sustained failures are not (design §7.3).
+     */
+    private static final int SUSTAINED_FAILURE_THRESHOLD = 5;
+
+    /**
+     * The two read-aspect variants — which transition table and operating cycle the aspect runs.
+     */
+    private enum Variant {
+        POLLED,
+        SUBSCRIBED
+    }
+
+    /**
+     * The adapter's connection phase as the aspect last saw it — decides whether activating verifies now or waits.
+     */
+    private enum AdapterPhase {
+        DISCONNECTED,
+        VERIFYING,
+        READY
+    }
+
+    private final @NotNull String adapterId;
+    private final @NotNull Node node;
+    private final @NotNull Tag tag;
+    private final @NotNull Variant variant;
+
+    private final @NotNull Clock clock;
+    private final @NotNull PriorityTimerQueue timers;
+    private final @NotNull BatchCollector batches;
+    private final @NotNull NevskyMetrics metrics;
+    private final @NotNull SharedNodeVerification sharedNodeVerification;
+    private final long pollIntervalMillis;
+    private final @NotNull Backoff verificationRetryBackoff;
+    private final @NotNull Backoff subscriptionRetryBackoff;
+
+    // The variant's shared pre-operating constants and the state operation begins in (poll interval / subscribe).
+    private final @NotNull TagAspectState deactivated;
+    private final @NotNull TagAspectState waitingForAdapterReady;
+    private final @NotNull TagAspectState waitingForVerification;
+    private final @NotNull TagAspectState verifiedEntry;
+
+    private final @NotNull FSM<TagAspectState, TagAspectEvent, TagAspectRead> machine;
+
+    private @NotNull TagAspectGoal goal = TagAspectGoal.inactive();
+    private @NotNull AdapterPhase adapterPhase = AdapterPhase.DISCONNECTED;
+    private int failureCount;
+    private @Nullable String lastFailureReason;
+    private long lastTransitionAtMillis;
+    private @Nullable TimerHandle activeTimer;
+
+    /**
+     * @param adapterId               the owning adapter's id.
+     * @param node                    the protocol-specific node.
+     * @param tag                     Edge's half of the pair; its {@code subscribable} flag selects the variant.
+     * @param clock                   the actor clock the timers are scheduled against.
+     * @param timers                  the actor's single timer queue.
+     * @param batches                 the actor's batch collector — where poll / subscription requests are posted.
+     * @param metrics                 the per-adapter metrics (per-tag failure counters).
+     * @param sharedNodeVerification the shared verification authority for re-verifications.
+     * @param pollIntervalMillis      the poll cadence for a polled aspect, in milliseconds.
+     * @param retryPolicy             the backoff policy for verification and subscription retries.
+     */
+    public TagAspectRead(
+            final @NotNull String adapterId,
+            final @NotNull Node node,
+            final @NotNull Tag tag,
+            final @NotNull Clock clock,
+            final @NotNull PriorityTimerQueue timers,
+            final @NotNull BatchCollector batches,
+            final @NotNull NevskyMetrics metrics,
+            final @NotNull SharedNodeVerification sharedNodeVerification,
+            final long pollIntervalMillis,
+            final @NotNull RetryPolicy retryPolicy) {
+        this.adapterId = adapterId;
+        this.node = node;
+        this.tag = tag;
+        this.variant = tag.subscribable() ? Variant.SUBSCRIBED : Variant.POLLED;
+        this.clock = clock;
+        this.timers = timers;
+        this.batches = batches;
+        this.metrics = metrics;
+        this.sharedNodeVerification = sharedNodeVerification;
+        this.pollIntervalMillis = pollIntervalMillis;
+        this.verificationRetryBackoff = new Backoff(retryPolicy);
+        this.subscriptionRetryBackoff = new Backoff(retryPolicy);
+        if (variant == Variant.SUBSCRIBED) {
+            this.deactivated = TagAspectReadSubscribedState.DEACTIVATED;
+            this.waitingForAdapterReady = TagAspectReadSubscribedState.WAITING_FOR_ADAPTER_READY;
+            this.waitingForVerification = TagAspectReadSubscribedState.WAITING_FOR_VERIFICATION;
+            this.verifiedEntry = TagAspectReadSubscribedState.WAITING_FOR_SUBSCRIPTION;
+            this.machine = new FSM<>(deactivated, TagAspectReadTransitions.subscribedTable(), this);
+        } else {
+            this.deactivated = TagAspectReadPolledState.DEACTIVATED;
+            this.waitingForAdapterReady = TagAspectReadPolledState.WAITING_FOR_ADAPTER_READY;
+            this.waitingForVerification = TagAspectReadPolledState.WAITING_FOR_VERIFICATION;
+            this.verifiedEntry = TagAspectReadPolledState.WAITING_FOR_POLL_INTERVAL;
+            this.machine = new FSM<>(deactivated, TagAspectReadTransitions.polledTable(), this);
+        }
+    }
+
+    // ── goal and adapter-readiness coupling (bypass the table, design §7.1, §7.2) ───────────────────────────────
+
+    /**
+     * Apply a new aspect goal (the three-condition rule, design §7.1). When the goal becomes active the aspect
+     * leaves {@code DEACTIVATED}; when it becomes inactive the aspect returns to {@code DEACTIVATED}, tearing down
+     * any subscription and cancelling timers — never reconnecting the adapter (design §8.2).
+     *
+     * @param newGoal the recomputed goal.
+     */
+    public void applyGoal(final @NotNull TagAspectGoal newGoal) {
+        final boolean wasActive = goal.active();
+        goal = newGoal;
+        final boolean nowActive = goal.active();
+        if (wasActive == nowActive) {
+            return;
+        }
+        if (nowActive) {
+            activate();
+        } else {
+            deactivate();
+        }
+    }
+
+    private void activate() {
+        switch (adapterPhase) {
+            case DISCONNECTED -> moveTo(waitingForAdapterReady);
+            case VERIFYING, READY -> {
+                // Activated while the adapter is up: this node missed the connect-time gate verification, so ask
+                // for a fresh one of its own (design §7.6) — no reconnect.
+                moveTo(waitingForVerification);
+                requestVerification();
+            }
+        }
+    }
+
+    private void deactivate() {
+        if (machine.state().isDeactivated()) {
+            return;
+        }
+        if (variant == Variant.SUBSCRIBED && adapterPhase == AdapterPhase.READY && holdsSubscription()) {
+            batches.removeSubscription(node);
+        }
+        cancelActiveTimer();
+        moveTo(deactivated);
+    }
+
+    /**
+     * The adapter began verifying (design §6.3): an active aspect waiting for the adapter moves into verification
+     * and consumes the connect-time gate result the wrapper routes to it — it does not request its own.
+     */
+    public void onAdapterVerifying() {
+        adapterPhase = AdapterPhase.VERIFYING;
+        if (machine.state() == waitingForAdapterReady) {
+            moveTo(waitingForVerification);
+        }
+    }
+
+    /**
+     * The adapter reached {@code CONNECTED} (design §7.2). When verification was skipped the aspect is still
+     * waiting for the adapter — treat the connection as verified and begin operating; otherwise it has already
+     * advanced through verification and nothing happens here.
+     */
+    public void onAdapterReady() {
+        adapterPhase = AdapterPhase.READY;
+        if (machine.state() == waitingForAdapterReady) {
+            moveTo(enterVerified());
+        }
+    }
+
+    /**
+     * The adapter is no longer connected (design §7.2): every aspect except a deactivated or permanently-failed
+     * one returns to waiting for the adapter and re-verifies on the next connection. A permanent verification
+     * failure is sticky — only a user-commanded retry clears it (design §7.6).
+     */
+    public void onAdapterUnavailable() {
+        adapterPhase = AdapterPhase.DISCONNECTED;
+        final TagAspectState current = machine.state();
+        if (!current.isDeactivated() && !current.isPermanentVerificationFailure()) {
+            cancelActiveTimer();
+            verificationRetryBackoff.reset();
+            subscriptionRetryBackoff.reset();
+            moveTo(waitingForAdapterReady);
+        }
+    }
+
+    /**
+     * A user-commanded tag retry (design §7.6): if the aspect is in permanent verification failure, reset its
+     * counters and re-verify (or wait for the adapter). Any other state is left untouched — a no-op here, reported
+     * as a skip reason by the REST layer in a later task.
+     */
+    public void retry() {
+        if (!machine.state().isPermanentVerificationFailure()) {
+            return;
+        }
+        failureCount = 0;
+        lastFailureReason = null;
+        verificationRetryBackoff.reset();
+        if (adapterPhase == AdapterPhase.READY) {
+            moveTo(waitingForVerification);
+            requestVerification();
+        } else {
+            moveTo(waitingForAdapterReady);
+        }
+    }
+
+    // ── routed events (drive the table) ─────────────────────────────────────────────────────────────────────────
+
+    /**
+     * Feed the node's verification outcome to the machine (design §7.2).
+     *
+     * @param outcome the verification outcome.
+     */
+    public void onVerifyResult(final @NotNull VerifyOutcome outcome) {
+        switch (outcome) {
+            case VerifyOutcome.Success ignored -> dispatch(new TagAspectEvent.VerifySucceeded());
+            case VerifyOutcome.TransientFailure transientFailure ->
+                dispatch(new TagAspectEvent.VerifyTransientlyFailed(transientFailure.reason()));
+            case VerifyOutcome.PermanentFailure permanentFailure ->
+                dispatch(new TagAspectEvent.VerifyPermanentlyFailed(permanentFailure.reason()));
+        }
+    }
+
+    /**
+     * Feed a received value — a poll response or a subscription push (design §7.3, §7.4).
+     *
+     * @param value the reused v1 value.
+     */
+    public void onValue(final @NotNull DataPoint value) {
+        dispatch(new TagAspectEvent.ValueReceived(value));
+    }
+
+    /**
+     * Feed a per-node failure (design §7.3, §7.4).
+     *
+     * @param reason      a human-readable description.
+     * @param spontaneous whether the failure arrived outside a command-response exchange.
+     */
+    public void onNodeError(final @NotNull String reason, final boolean spontaneous) {
+        dispatch(new TagAspectEvent.NodeFailed(reason, spontaneous));
+    }
+
+    // ── actions the transition table runs (package-private) ─────────────────────────────────────────────────────
+
+    @NotNull
+    TagAspectState enterVerified() {
+        verificationRetryBackoff.reset();
+        if (variant == Variant.SUBSCRIBED) {
+            batches.addSubscription(node);
+        } else {
+            scheduleNextPoll();
+        }
+        return verifiedEntry;
+    }
+
+    void requestPoll() {
+        batches.poll(node);
+    }
+
+    void scheduleNextPoll() {
+        scheduleTimer(pollIntervalMillis, () -> dispatch(new TagAspectEvent.PollIntervalElapsed()));
+    }
+
+    void requestAddSubscription() {
+        batches.addSubscription(node);
+    }
+
+    void confirmSubscription() {
+        subscriptionRetryBackoff.reset();
+    }
+
+    void requestVerification() {
+        sharedNodeVerification.requestVerification(node);
+    }
+
+    void onTransientVerificationFailure(final @NotNull String reason) {
+        recordFailure(reason);
+        scheduleTimer(
+                verificationRetryBackoff.nextDelayMillis(),
+                () -> dispatch(new TagAspectEvent.VerificationRetryElapsed()));
+    }
+
+    void onPermanentVerificationFailure(final @NotNull String reason) {
+        recordFailure(reason);
+    }
+
+    void onPollFailure(final @NotNull String reason) {
+        recordFailure(reason);
+        scheduleNextPoll();
+    }
+
+    void onSubscriptionFailure(final @NotNull String reason) {
+        recordFailure(reason);
+        scheduleTimer(
+                subscriptionRetryBackoff.nextDelayMillis(),
+                () -> dispatch(new TagAspectEvent.SubscriptionRetryElapsed()));
+    }
+
+    void onSpontaneousSubscriptionLoss(final @NotNull String reason) {
+        recordFailure(reason);
+        requestVerification();
+    }
+
+    void logUnexpectedEvent(final @NotNull TagAspectEvent event) {
+        log.debug(
+                "Read aspect of tag '{}' on adapter '{}' ignored unexpected {} in {}",
+                tag.name(),
+                adapterId,
+                event.getClass().getSimpleName(),
+                machine.state());
+    }
+
+    // ── snapshot accessors (pure reads on the dispatch thread, design §6.6, §7.7) ───────────────────────────────
+
+    /**
+     * @return the current aspect state.
+     */
+    public @NotNull TagAspectState state() {
+        return machine.state();
+    }
+
+    /**
+     * @return the current aspect state name for the published snapshot.
+     */
+    public @NotNull String stateName() {
+        return machine.state().toString();
+    }
+
+    /**
+     * @return whether the aspect's goal is currently active (the three-condition rule holds).
+     */
+    public boolean goalActive() {
+        return goal.active();
+    }
+
+    /**
+     * @return whether the aspect is operating at its goal (producing values), per {@link TagAspectState#isOperating()}.
+     */
+    public boolean operating() {
+        return machine.state().isOperating();
+    }
+
+    /**
+     * @return whether the aspect is suspended after a permanent verification failure.
+     */
+    public boolean permanentFailure() {
+        return machine.state().isPermanentVerificationFailure();
+    }
+
+    /**
+     * @return the cumulative failure count (poll / subscription / verification).
+     */
+    public int failureCount() {
+        return failureCount;
+    }
+
+    /**
+     * @return the most recent failure reason, or {@code null} if none.
+     */
+    public @Nullable String lastFailureReason() {
+        return lastFailureReason;
+    }
+
+    /**
+     * @return the clock time of the last aspect transition, in milliseconds.
+     */
+    public long lastTransitionAtMillis() {
+        return lastTransitionAtMillis;
+    }
+
+    // ── internals ───────────────────────────────────────────────────────────────────────────────────────────────
+
+    private void dispatch(final @NotNull TagAspectEvent event) {
+        final TagAspectState before = machine.state();
+        machine.onEvent(event);
+        if (machine.state() != before) {
+            lastTransitionAtMillis = clock.nowMillis();
+        }
+    }
+
+    private void moveTo(final @NotNull TagAspectState next) {
+        if (machine.state() != next) {
+            machine.transitionTo(next);
+            lastTransitionAtMillis = clock.nowMillis();
+        }
+    }
+
+    private boolean holdsSubscription() {
+        final TagAspectState current = machine.state();
+        return current == TagAspectReadSubscribedState.SUBSCRIBED
+                || current == TagAspectReadSubscribedState.WAITING_FOR_SUBSCRIPTION
+                || current == TagAspectReadSubscribedState.WAITING_FOR_SUBSCRIPTION_RETRY;
+    }
+
+    private void scheduleTimer(final long delayMillis, final @NotNull Runnable onFire) {
+        cancelActiveTimer();
+        activeTimer = timers.schedule(clock.nowMillis() + delayMillis, onFire);
+    }
+
+    private void cancelActiveTimer() {
+        if (activeTimer != null) {
+            timers.cancel(activeTimer);
+            activeTimer = null;
+        }
+    }
+
+    private void recordFailure(final @NotNull String reason) {
+        failureCount++;
+        lastFailureReason = reason;
+        metrics.incrementTagFailure(tag.name());
+        // Escalating severity: a first hiccup is routine, sustained failures are not (design §7.3).
+        if (failureCount == 1) {
+            log.debug("Read aspect of tag '{}' on adapter '{}' failed: {}", tag.name(), adapterId, reason);
+        } else if (failureCount < SUSTAINED_FAILURE_THRESHOLD) {
+            log.warn(
+                    "Read aspect of tag '{}' on adapter '{}' failed ({} times): {}",
+                    tag.name(),
+                    adapterId,
+                    failureCount,
+                    reason);
+        } else {
+            log.error(
+                    "Read aspect of tag '{}' on adapter '{}' has failed {} times: {}",
+                    tag.name(),
+                    adapterId,
+                    failureCount,
+                    reason);
+        }
+    }
+}

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/tag/TagAspectReadPolledState.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/tag/TagAspectReadPolledState.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.protocols.v2.tag;
+
+/**
+ * The states of a <b>polled</b> read aspect (design §7.3): the five shared pre-operating states plus the two
+ * poll-cycle states. A poll failure introduces <b>no</b> new state — the aspect returns to
+ * {@link #WAITING_FOR_POLL_INTERVAL} and the next scheduled poll is the retry; the failure only increments a
+ * counter that drives escalating log severity.
+ */
+public enum TagAspectReadPolledState implements TagAspectState {
+
+    /**
+     * At rest: the aspect's goal is not active (the three-condition rule fails).
+     */
+    DEACTIVATED,
+
+    /**
+     * The goal is active but the adapter is not connected — waiting to verify on the next connection.
+     */
+    WAITING_FOR_ADAPTER_READY,
+
+    /**
+     * Verifying the node against the connected device.
+     */
+    WAITING_FOR_VERIFICATION,
+
+    /**
+     * A transient verification failure occurred; waiting for the retry timer before verifying again.
+     */
+    WAITING_FOR_VERIFICATION_RETRY,
+
+    /**
+     * Verification failed permanently; suspended until a user-commanded tag retry (design §7.6).
+     */
+    ERROR_PERMANENT_VERIFICATION_FAILURE,
+
+    /**
+     * Verified and operating: waiting for the poll interval timer before requesting the next poll.
+     */
+    WAITING_FOR_POLL_INTERVAL,
+
+    /**
+     * A poll was requested; waiting for the value (or a per-node error) to come back.
+     */
+    WAITING_FOR_POLL_DATAPOINT;
+
+    @Override
+    public boolean isDeactivated() {
+        return this == DEACTIVATED;
+    }
+
+    @Override
+    public boolean isPermanentVerificationFailure() {
+        return this == ERROR_PERMANENT_VERIFICATION_FAILURE;
+    }
+
+    @Override
+    public boolean isOperating() {
+        return this == WAITING_FOR_POLL_INTERVAL || this == WAITING_FOR_POLL_DATAPOINT;
+    }
+}

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/tag/TagAspectReadSubscribedState.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/tag/TagAspectReadSubscribedState.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.protocols.v2.tag;
+
+/**
+ * The states of a <b>subscribed</b> read aspect (design §7.4): the five shared pre-operating states plus the
+ * three subscription states. The {@code spontaneous} bit on a per-node error selects the recovery path — a
+ * command-response loss backs off and re-adds the subscription ({@link #WAITING_FOR_SUBSCRIPTION_RETRY}); a
+ * spontaneous loss power-cycles the aspect back through verification.
+ * <p>
+ * <b>Known limitation (design §7.4):</b> {@link #SUBSCRIBED} is confirmed only by the first {@code dataPoint}, so
+ * a protocol that does not push an initial value parks in {@link #WAITING_FOR_SUBSCRIPTION} (reported as not
+ * operating) until the first value arrives.
+ */
+public enum TagAspectReadSubscribedState implements TagAspectState {
+
+    /**
+     * At rest: the aspect's goal is not active (the three-condition rule fails).
+     */
+    DEACTIVATED,
+
+    /**
+     * The goal is active but the adapter is not connected — waiting to verify on the next connection.
+     */
+    WAITING_FOR_ADAPTER_READY,
+
+    /**
+     * Verifying the node against the connected device.
+     */
+    WAITING_FOR_VERIFICATION,
+
+    /**
+     * A transient verification failure occurred; waiting for the retry timer before verifying again.
+     */
+    WAITING_FOR_VERIFICATION_RETRY,
+
+    /**
+     * Verification failed permanently; suspended until a user-commanded tag retry (design §7.6).
+     */
+    ERROR_PERMANENT_VERIFICATION_FAILURE,
+
+    /**
+     * The subscription was requested; waiting for the first pushed value to confirm it.
+     */
+    WAITING_FOR_SUBSCRIPTION,
+
+    /**
+     * Subscribed and operating: receiving pushed values.
+     */
+    SUBSCRIBED,
+
+    /**
+     * A command-response subscription loss occurred; waiting for the backoff timer before re-adding.
+     */
+    WAITING_FOR_SUBSCRIPTION_RETRY;
+
+    @Override
+    public boolean isDeactivated() {
+        return this == DEACTIVATED;
+    }
+
+    @Override
+    public boolean isPermanentVerificationFailure() {
+        return this == ERROR_PERMANENT_VERIFICATION_FAILURE;
+    }
+
+    @Override
+    public boolean isOperating() {
+        return this == SUBSCRIBED;
+    }
+}

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/tag/TagAspectReadTransitions.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/tag/TagAspectReadTransitions.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.protocols.v2.tag;
+
+import com.hivemq.protocols.v2.fsm.FSMGuard;
+import com.hivemq.protocols.v2.fsm.FSMTransitionTable;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * The read-aspect transition tables (design §7.3, §7.4) — direct encodings of the polled and subscribed state
+ * diagrams. The five shared pre-operating rows (verification success / transient failure / permanent failure /
+ * verification retry) are built once by {@link #addPreOperatingRows} and parameterized by each variant's state
+ * constants, so engine reuse is achieved without a shared state enum (design §7.2). The role-specific rows — the
+ * poll cycle and the subscription cycle — are added per variant.
+ * <p>
+ * Each table is built once and shared by every aspect of that variant; an action acts through the
+ * {@link TagAspectRead} passed as the machine context. Goal and adapter-readiness changes never reach these tables —
+ * they are applied directly by {@link TagAspectRead} (design §7.1, §7.2). The mandatory {@code unmatched} slot is
+ * lenient: an unexpected event (a stale value, a late acknowledgment) is logged and ignored, never a reset — a
+ * stray data point must not kill a tag.
+ */
+public final class TagAspectReadTransitions {
+
+    private TagAspectReadTransitions() {}
+
+    private static final @NotNull FSMTransitionTable<TagAspectState, TagAspectEvent, TagAspectRead> POLLED =
+            buildPolledTable();
+    private static final @NotNull FSMTransitionTable<TagAspectState, TagAspectEvent, TagAspectRead> SUBSCRIBED =
+            buildSubscribedTable();
+
+    /**
+     * @return the polled read-aspect transition table (design §7.3).
+     */
+    public static @NotNull FSMTransitionTable<TagAspectState, TagAspectEvent, TagAspectRead> polledTable() {
+        return POLLED;
+    }
+
+    /**
+     * @return the subscribed read-aspect transition table (design §7.4).
+     */
+    public static @NotNull FSMTransitionTable<TagAspectState, TagAspectEvent, TagAspectRead> subscribedTable() {
+        return SUBSCRIBED;
+    }
+
+    private static @NotNull FSMTransitionTable<TagAspectState, TagAspectEvent, TagAspectRead> buildPolledTable() {
+        final FSMTransitionTable.Builder<TagAspectState, TagAspectEvent, TagAspectRead> builder =
+                FSMTransitionTable.builder();
+        addPreOperatingRows(
+                builder,
+                TagAspectReadPolledState.WAITING_FOR_VERIFICATION,
+                TagAspectReadPolledState.WAITING_FOR_VERIFICATION_RETRY,
+                TagAspectReadPolledState.ERROR_PERMANENT_VERIFICATION_FAILURE);
+        return builder
+                // The poll interval elapsed: request the next poll (design §7.3).
+                .on(TagAspectReadPolledState.WAITING_FOR_POLL_INTERVAL, TagAspectEvent.PollIntervalElapsed.class)
+                .then((current, event, aspect) -> {
+                    aspect.requestPoll();
+                    return TagAspectReadPolledState.WAITING_FOR_POLL_DATAPOINT;
+                })
+                // A value came back: schedule the next poll. No new state — the cadence simply continues.
+                .on(TagAspectReadPolledState.WAITING_FOR_POLL_DATAPOINT, TagAspectEvent.ValueReceived.class)
+                .then((current, event, aspect) -> {
+                    aspect.scheduleNextPoll();
+                    return TagAspectReadPolledState.WAITING_FOR_POLL_INTERVAL;
+                })
+                // A poll failed: count it, schedule the next poll. The next scheduled poll IS the retry (§7.3).
+                .on(TagAspectReadPolledState.WAITING_FOR_POLL_DATAPOINT, TagAspectEvent.NodeFailed.class)
+                .then((current, event, aspect) -> {
+                    aspect.onPollFailure(reasonOf(event));
+                    return TagAspectReadPolledState.WAITING_FOR_POLL_INTERVAL;
+                })
+                .unmatched((current, event, aspect) -> {
+                    aspect.logUnexpectedEvent(event);
+                    return current;
+                })
+                .build();
+    }
+
+    private static @NotNull FSMTransitionTable<TagAspectState, TagAspectEvent, TagAspectRead> buildSubscribedTable() {
+        final FSMGuard<TagAspectState, TagAspectEvent, TagAspectRead> spontaneous = (current, event, aspect) ->
+                event instanceof final TagAspectEvent.NodeFailed failed && failed.spontaneous();
+        final FSMTransitionTable.Builder<TagAspectState, TagAspectEvent, TagAspectRead> builder =
+                FSMTransitionTable.builder();
+        addPreOperatingRows(
+                builder,
+                TagAspectReadSubscribedState.WAITING_FOR_VERIFICATION,
+                TagAspectReadSubscribedState.WAITING_FOR_VERIFICATION_RETRY,
+                TagAspectReadSubscribedState.ERROR_PERMANENT_VERIFICATION_FAILURE);
+        return builder
+                // The first pushed value confirms the subscription (design §7.4).
+                .on(TagAspectReadSubscribedState.WAITING_FOR_SUBSCRIPTION, TagAspectEvent.ValueReceived.class)
+                .then((current, event, aspect) -> {
+                    aspect.confirmSubscription();
+                    return TagAspectReadSubscribedState.SUBSCRIBED;
+                })
+                // The add-subscription request failed: back off and re-add (command-response loss, §7.4).
+                .on(TagAspectReadSubscribedState.WAITING_FOR_SUBSCRIPTION, TagAspectEvent.NodeFailed.class)
+                .then((current, event, aspect) -> {
+                    aspect.onSubscriptionFailure(reasonOf(event));
+                    return TagAspectReadSubscribedState.WAITING_FOR_SUBSCRIPTION_RETRY;
+                })
+                // Subsequent pushed values keep the subscription operating.
+                .on(TagAspectReadSubscribedState.SUBSCRIBED, TagAspectEvent.ValueReceived.class)
+                .then((current, event, aspect) -> TagAspectReadSubscribedState.SUBSCRIBED)
+                // A spontaneous loss power-cycles through verification (design §7.4).
+                .on(TagAspectReadSubscribedState.SUBSCRIBED, TagAspectEvent.NodeFailed.class)
+                .when(spontaneous)
+                .then((current, event, aspect) -> {
+                    aspect.onSpontaneousSubscriptionLoss(reasonOf(event));
+                    return TagAspectReadSubscribedState.WAITING_FOR_VERIFICATION;
+                })
+                // A command-response loss backs off and re-adds (design §7.4).
+                .on(TagAspectReadSubscribedState.SUBSCRIBED, TagAspectEvent.NodeFailed.class)
+                .otherwise((current, event, aspect) -> {
+                    aspect.onSubscriptionFailure(reasonOf(event));
+                    return TagAspectReadSubscribedState.WAITING_FOR_SUBSCRIPTION_RETRY;
+                })
+                // The backoff elapsed: re-add the subscription (design §7.4).
+                .on(
+                        TagAspectReadSubscribedState.WAITING_FOR_SUBSCRIPTION_RETRY,
+                        TagAspectEvent.SubscriptionRetryElapsed.class)
+                .then((current, event, aspect) -> {
+                    aspect.requestAddSubscription();
+                    return TagAspectReadSubscribedState.WAITING_FOR_SUBSCRIPTION;
+                })
+                .unmatched((current, event, aspect) -> {
+                    aspect.logUnexpectedEvent(event);
+                    return current;
+                })
+                .build();
+    }
+
+    /**
+     * Add the five shared pre-operating rows (design §7.2), parameterized by the variant's "verified" target — the
+     * state the aspect begins operating in. Success enters that state through {@link TagAspectRead#enterVerified()},
+     * which performs the role-specific kickoff (schedule a poll or request a subscription).
+     */
+    private static void addPreOperatingRows(
+            final @NotNull FSMTransitionTable.Builder<TagAspectState, TagAspectEvent, TagAspectRead> builder,
+            final @NotNull TagAspectState waitingForVerification,
+            final @NotNull TagAspectState waitingForVerificationRetry,
+            final @NotNull TagAspectState errorPermanent) {
+        builder.on(waitingForVerification, TagAspectEvent.VerifySucceeded.class)
+                .then((current, event, aspect) -> aspect.enterVerified());
+        builder.on(waitingForVerification, TagAspectEvent.VerifyTransientlyFailed.class)
+                .then((current, event, aspect) -> {
+                    aspect.onTransientVerificationFailure(reasonOf(event));
+                    return waitingForVerificationRetry;
+                });
+        builder.on(waitingForVerification, TagAspectEvent.VerifyPermanentlyFailed.class)
+                .then((current, event, aspect) -> {
+                    aspect.onPermanentVerificationFailure(reasonOf(event));
+                    return errorPermanent;
+                });
+        builder.on(waitingForVerificationRetry, TagAspectEvent.VerificationRetryElapsed.class)
+                .then((current, event, aspect) -> {
+                    aspect.requestVerification();
+                    return waitingForVerification;
+                });
+    }
+
+    private static @NotNull String reasonOf(final @NotNull TagAspectEvent event) {
+        if (event instanceof final TagAspectEvent.VerifyTransientlyFailed transientlyFailed) {
+            return transientlyFailed.reason();
+        }
+        if (event instanceof final TagAspectEvent.VerifyPermanentlyFailed permanent) {
+            return permanent.reason();
+        }
+        if (event instanceof final TagAspectEvent.NodeFailed failed) {
+            return failed.reason();
+        }
+        return "failure";
+    }
+}

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/tag/TagAspectRuntimeCoordinator.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/tag/TagAspectRuntimeCoordinator.java
@@ -1,0 +1,277 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.protocols.v2.tag;
+
+import com.hivemq.adapter.sdk.api.data.DataPoint;
+import com.hivemq.adapter.sdk.api.v2.model.VerifyOutcome;
+import com.hivemq.adapter.sdk.api.v2.node.Node;
+import com.hivemq.adapter.sdk.api.v2.node.NodeTagPair;
+import com.hivemq.protocols.v2.runtime.BatchCollector;
+import com.hivemq.protocols.v2.runtime.Clock;
+import com.hivemq.protocols.v2.runtime.NevskyMetrics;
+import com.hivemq.protocols.v2.runtime.PriorityTimerQueue;
+import com.hivemq.protocols.v2.runtime.RetryPolicy;
+import com.hivemq.protocols.v2.view.TagStatusSnapshot;
+import com.hivemq.protocols.v2.wrapper.ProtocolAdapterGoalState;
+import com.hivemq.protocols.v2.wrapper.TagAspectActivationPreference;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * The running {@link TagAspectCoordinator} (design §7) — the wrapper's view of an adapter's tag aspect machines,
+ * backed by a live {@link TagRuntime} per tag. It replaces the snapshot-only stand-in once aspects come online:
+ * it routes the events the wrapper hands it to the owning tag, drives every aspect's three-condition goal, and
+ * publishes a per-tag snapshot reflecting the real aspect states.
+ * <p>
+ * It is constructed from configuration alone and then <b>bound</b> to the actor's runtime through
+ * {@link #bindRuntime} — the actor's clock, single timer queue, batch collector, metrics, and the verify seam —
+ * mirroring the wrapper context's own {@code bindMachine}. Binding builds the {@link SharedNodeVerification} and
+ * the per-tag runtimes and applies the initial goals. Everything runs on the wrapper's single dispatch thread.
+ */
+public final class TagAspectRuntimeCoordinator implements TagAspectCoordinator {
+
+    private record BoundRuntime(
+            @NotNull Clock clock,
+            @NotNull PriorityTimerQueue timers,
+            @NotNull BatchCollector batches,
+            @NotNull NevskyMetrics metrics,
+            @NotNull SharedNodeVerification sharedNodeVerification) {}
+
+    private final @NotNull String adapterId;
+    private final long pollIntervalMillis;
+    private final @NotNull RetryPolicy retryPolicy;
+
+    private @NotNull List<NodeTagPair> nodes;
+    private @NotNull Map<String, TagAspectActivationPreference> activation;
+    private @NotNull Set<String> readUsedTagNames;
+    private @NotNull Set<String> writeUsedTagNames;
+    private @NotNull ProtocolAdapterGoalState goal;
+
+    private @Nullable BoundRuntime runtime;
+    private @NotNull List<TagRuntime> tagRuntimes = new ArrayList<>();
+    private @NotNull Map<Node, TagRuntime> tagRuntimesByNode = new HashMap<>();
+
+    /**
+     * @param adapterId          the owning adapter's id.
+     * @param nodes              the configured node/tag pairs.
+     * @param activation         the per-tag activation preferences.
+     * @param readUsedTagNames   the tags consumed by a northbound mapping.
+     * @param writeUsedTagNames  the tags produced to by a southbound mapping.
+     * @param initialGoal        the initial adapter direction goal (from configuration).
+     * @param pollIntervalMillis the poll cadence for polled read aspects, in milliseconds.
+     * @param retryPolicy        the backoff policy for verification and subscription retries.
+     */
+    public TagAspectRuntimeCoordinator(
+            final @NotNull String adapterId,
+            final @NotNull List<NodeTagPair> nodes,
+            final @NotNull Map<String, TagAspectActivationPreference> activation,
+            final @NotNull Set<String> readUsedTagNames,
+            final @NotNull Set<String> writeUsedTagNames,
+            final @NotNull ProtocolAdapterGoalState initialGoal,
+            final long pollIntervalMillis,
+            final @NotNull RetryPolicy retryPolicy) {
+        this.adapterId = adapterId;
+        this.nodes = List.copyOf(nodes);
+        this.activation = new HashMap<>(activation);
+        this.readUsedTagNames = new HashSet<>(readUsedTagNames);
+        this.writeUsedTagNames = new HashSet<>(writeUsedTagNames);
+        this.goal = initialGoal;
+        this.pollIntervalMillis = pollIntervalMillis;
+        this.retryPolicy = retryPolicy;
+    }
+
+    /**
+     * Bind the actor's runtime — its clock, single timer queue, batch collector, metrics, and the verify seam —
+     * then build the verification coordinator and the per-tag runtimes and apply the initial goals. Called once,
+     * after the wrapper context exists and before any message is handled (the two-phase init mirrors the context's
+     * {@code bindMachine}).
+     *
+     * @param clock           the actor clock the aspect timers are scheduled against.
+     * @param timers          the actor's single timer queue (design §5.5).
+     * @param batches         the actor's batch collector (design §5.7).
+     * @param metrics         the per-adapter metrics.
+     * @param nodeVerifier the seam re-verifications are issued through — the adapter's {@code verifyBatch}.
+     */
+    public void bindRuntime(
+            final @NotNull Clock clock,
+            final @NotNull PriorityTimerQueue timers,
+            final @NotNull BatchCollector batches,
+            final @NotNull NevskyMetrics metrics,
+            final @NotNull NodeVerifier nodeVerifier) {
+        final SharedNodeVerification sharedNodeVerification =
+                new SharedNodeVerification(nodeVerifier, this::findTagRuntime);
+        this.runtime = new BoundRuntime(clock, timers, batches, metrics, sharedNodeVerification);
+        rebuildTagRuntimes();
+        applyGoalToAll();
+    }
+
+    // ── adapter-readiness coupling (design §6.3, §7.2) ──────────────────────────────────────────────────────────
+
+    @Override
+    public void onAdapterVerifying() {
+        for (final TagRuntime tagRuntime : tagRuntimes) {
+            tagRuntime.onAdapterVerifying();
+        }
+    }
+
+    @Override
+    public void onAdapterReady() {
+        for (final TagRuntime tagRuntime : tagRuntimes) {
+            tagRuntime.onAdapterReady();
+        }
+    }
+
+    @Override
+    public void onAdapterUnavailable() {
+        for (final TagRuntime tagRuntime : tagRuntimes) {
+            tagRuntime.onAdapterUnavailable();
+        }
+    }
+
+    // ── routed events (design §7) ───────────────────────────────────────────────────────────────────────────────
+
+    @Override
+    public void routeVerifyResult(final @NotNull Node node, final @NotNull VerifyOutcome outcome) {
+        runtime().sharedNodeVerification().onVerifyResult(node, outcome);
+    }
+
+    @Override
+    public void routeDataPoint(final @NotNull Node node, final @NotNull DataPoint value) {
+        final TagRuntime tagRuntime = findTagRuntime(node);
+        if (tagRuntime != null) {
+            tagRuntime.onValue(value);
+        }
+    }
+
+    @Override
+    public void routeNodeError(final @NotNull Node node, final @NotNull String reason, final boolean spontaneous) {
+        final TagRuntime tagRuntime = findTagRuntime(node);
+        if (tagRuntime != null) {
+            tagRuntime.onNodeError(reason, spontaneous);
+        }
+    }
+
+    @Override
+    public void routeWriteResult(final @NotNull Node node, final boolean success, final @Nullable String reason) {
+        // The write aspect joins in a later task; nothing consumes write acknowledgments yet.
+    }
+
+    // ── configuration transitions (design §8.2) ─────────────────────────────────────────────────────────────────
+
+    @Override
+    public void applyActivation(
+            final @NotNull ProtocolAdapterGoalState adapterDirections,
+            final @NotNull Map<String, TagAspectActivationPreference> tagActivation) {
+        this.goal = adapterDirections;
+        this.activation = new HashMap<>(tagActivation);
+        applyGoalToAll();
+    }
+
+    @Override
+    public void updateTagSet(
+            final @NotNull List<NodeTagPair> newNodes,
+            final @NotNull Map<String, TagAspectActivationPreference> newActivation,
+            final @NotNull Set<String> newReadUsedTagNames,
+            final @NotNull Set<String> newWriteUsedTagNames) {
+        // Tear down the current aspects (cancel their timers, drop subscriptions) before rebuilding, so no timer
+        // outlives its tag. Preserving surviving tags untouched is a gentlest-transition refinement for the PAM
+        // task; here a tags-only change re-verifies the new set without ever reconnecting the adapter (design §8.2).
+        deactivateAll();
+        this.nodes = List.copyOf(newNodes);
+        this.activation = new HashMap<>(newActivation);
+        this.readUsedTagNames = new HashSet<>(newReadUsedTagNames);
+        this.writeUsedTagNames = new HashSet<>(newWriteUsedTagNames);
+        rebuildTagRuntimes();
+        applyGoalToAll();
+    }
+
+    @Override
+    public void retryTag(final @NotNull String tagName) {
+        for (final TagRuntime tagRuntime : tagRuntimes) {
+            if (tagRuntime.tagName().equals(tagName)) {
+                tagRuntime.retry();
+            }
+        }
+    }
+
+    @Override
+    public @NotNull List<TagStatusSnapshot> tagSnapshots() {
+        final List<TagStatusSnapshot> snapshots = new ArrayList<>(tagRuntimes.size());
+        for (final TagRuntime tagRuntime : tagRuntimes) {
+            snapshots.add(tagRuntime.snapshot());
+        }
+        return snapshots;
+    }
+
+    // ── internals ───────────────────────────────────────────────────────────────────────────────────────────────
+
+    private @NotNull BoundRuntime runtime() {
+        return Objects.requireNonNull(runtime, "bindRuntime() must be called before the coordinator is used");
+    }
+
+    private @Nullable TagRuntime findTagRuntime(final @NotNull Node node) {
+        return tagRuntimesByNode.get(node);
+    }
+
+    private void rebuildTagRuntimes() {
+        final BoundRuntime bound = runtime();
+        final List<TagRuntime> rebuilt = new ArrayList<>(nodes.size());
+        final Map<Node, TagRuntime> byNode = new HashMap<>();
+        for (final NodeTagPair pair : nodes) {
+            final TagRuntime tagRuntime = new TagRuntime(
+                    adapterId,
+                    pair,
+                    bound.clock(),
+                    bound.timers(),
+                    bound.batches(),
+                    bound.metrics(),
+                    bound.sharedNodeVerification(),
+                    pollIntervalMillis,
+                    retryPolicy);
+            rebuilt.add(tagRuntime);
+            byNode.put(pair.node(), tagRuntime);
+        }
+        this.tagRuntimes = rebuilt;
+        this.tagRuntimesByNode = byNode;
+    }
+
+    private void deactivateAll() {
+        for (final TagRuntime tagRuntime : tagRuntimes) {
+            tagRuntime.deactivate();
+        }
+    }
+
+    private void applyGoalToAll() {
+        for (final TagRuntime tagRuntime : tagRuntimes) {
+            final String tagName = tagRuntime.tagName();
+            final TagAspectActivationPreference preference =
+                    activation.getOrDefault(tagName, TagAspectActivationPreference.defaults());
+            tagRuntime.applyActivation(
+                    goal.northboundActivated(),
+                    preference.readActivated(),
+                    preference.writeActivated(),
+                    readUsedTagNames.contains(tagName),
+                    writeUsedTagNames.contains(tagName));
+        }
+    }
+}

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/tag/TagAspectSnapshotOnlyCoordinator.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/tag/TagAspectSnapshotOnlyCoordinator.java
@@ -13,13 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.hivemq.protocols.v2.wrapper;
+package com.hivemq.protocols.v2.tag;
 
 import com.hivemq.adapter.sdk.api.data.DataPoint;
 import com.hivemq.adapter.sdk.api.v2.model.VerifyOutcome;
 import com.hivemq.adapter.sdk.api.v2.node.Node;
 import com.hivemq.adapter.sdk.api.v2.node.NodeTagPair;
 import com.hivemq.protocols.v2.view.TagStatusSnapshot;
+import com.hivemq.protocols.v2.wrapper.ProtocolAdapterGoalState;
+import com.hivemq.protocols.v2.wrapper.TagAspectActivationPreference;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -30,16 +32,16 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /**
- * The {@link TagAspectCoordinator} this task ships: it holds the tag set, activation preferences, and {@code used}
- * derivation, and publishes a minimal per-tag snapshot, but runs no aspect machines. Every routing and lifecycle
- * hook is a no-op — the read and write aspect machines that consume them are later tasks. The aspect state names
- * it reports are always {@code DEACTIVATED}, which is honest: with no aspect machines running, every aspect is at
- * rest.
+ * The minimal {@link TagAspectCoordinator} stand-in: it holds the tag set, activation preferences, and
+ * {@code used} derivation, and publishes a minimal per-tag snapshot, but runs no aspect machines. Every routing
+ * and lifecycle hook is a no-op. The aspect state names it reports are always {@code DEACTIVATED}, which is
+ * honest: with no aspect machines running, every aspect is at rest.
  * <p>
- * It exists so the adapter machine and snapshot publication can be built and tested in full now; a later task
- * replaces it with a real tag plane without changing the wrapper.
+ * It lets the adapter machine and snapshot publication be exercised on their own (the adapter-machine tests use
+ * it); {@link TagAspectRuntimeCoordinator} is the running implementation that drives real aspect machines, with no
+ * change to the wrapper.
  */
-public final class SnapshotOnlyTagAspectCoordinator implements TagAspectCoordinator {
+public final class TagAspectSnapshotOnlyCoordinator implements TagAspectCoordinator {
 
     private static final @NotNull String AT_REST_ASPECT_STATE = "DEACTIVATED";
 
@@ -54,7 +56,7 @@ public final class SnapshotOnlyTagAspectCoordinator implements TagAspectCoordina
      * @param readUsedTagNames  the tags consumed by a northbound mapping.
      * @param writeUsedTagNames the tags produced to by a southbound mapping.
      */
-    public SnapshotOnlyTagAspectCoordinator(
+    public TagAspectSnapshotOnlyCoordinator(
             final @NotNull List<NodeTagPair> nodes,
             final @NotNull Map<String, TagAspectActivationPreference> activation,
             final @NotNull Set<String> readUsedTagNames,
@@ -63,6 +65,11 @@ public final class SnapshotOnlyTagAspectCoordinator implements TagAspectCoordina
         this.activation = new HashMap<>(activation);
         this.readUsedTagNames = new HashSet<>(readUsedTagNames);
         this.writeUsedTagNames = new HashSet<>(writeUsedTagNames);
+    }
+
+    @Override
+    public void onAdapterVerifying() {
+        // No aspect machines yet; nothing to verify.
     }
 
     @Override
@@ -93,11 +100,6 @@ public final class SnapshotOnlyTagAspectCoordinator implements TagAspectCoordina
     @Override
     public void routeWriteResult(final @NotNull Node node, final boolean success, final @Nullable String reason) {
         // No write aspect yet; the acknowledgment is absorbed.
-    }
-
-    @Override
-    public void onTick(final long nowMillis) {
-        // No aspect machines yet; nothing to schedule.
     }
 
     @Override

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/tag/TagAspectState.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/tag/TagAspectState.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.protocols.v2.tag;
+
+import com.hivemq.protocols.v2.fsm.FSMState;
+
+/**
+ * The common query interface every aspect-machine state implements (design §7.2). A {@code FSM} needs exactly one
+ * state type, so each aspect variant has its own enum ({@code TagAspectReadPolledState},
+ * {@code TagAspectReadSubscribedState}, and the write enum in a later task), each containing the five shared
+ * pre-operating states plus its role-specific states. This interface lets the read-side view fold (design §7.7)
+ * and the snapshot builder reason about any aspect's state without knowing its variant.
+ */
+public interface TagAspectState extends FSMState {
+
+    /**
+     * @return {@code true} when the aspect is at rest because its goal is not active (the three-condition rule
+     *         fails) — it issues no work and reports no failure.
+     */
+    boolean isDeactivated();
+
+    /**
+     * @return {@code true} when the aspect is suspended after a permanent verification failure — it stays here
+     *         until a user-commanded tag retry (design §7.6).
+     */
+    boolean isPermanentVerificationFailure();
+
+    /**
+     * @return {@code true} when the aspect is operating at its role's goal: a read aspect polling or subscribed,
+     *         a write aspect ready for writes. In-flight work (awaiting a poll value or a write result) still
+     *         counts as operating, so a tag does not flap to {@code ERROR} during a normal round-trip (§7.7).
+     */
+    boolean isOperating();
+}

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/tag/TagRuntime.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/tag/TagRuntime.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.protocols.v2.tag;
+
+import com.hivemq.adapter.sdk.api.data.DataPoint;
+import com.hivemq.adapter.sdk.api.v2.model.VerifyOutcome;
+import com.hivemq.adapter.sdk.api.v2.node.NodeTagPair;
+import com.hivemq.protocols.v2.runtime.BatchCollector;
+import com.hivemq.protocols.v2.runtime.Clock;
+import com.hivemq.protocols.v2.runtime.NevskyMetrics;
+import com.hivemq.protocols.v2.runtime.PriorityTimerQueue;
+import com.hivemq.protocols.v2.runtime.RetryPolicy;
+import com.hivemq.protocols.v2.view.TagStatusSnapshot;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * One tag's runtime — both aspects of a tag plus their shared bookkeeping (design §7). A tag has an independent
+ * read aspect and write aspect sharing the Node/Tag pair; this task ships the {@link TagAspectRead}, and the write
+ * aspect joins in a later task with no change to the wrapper or the coordinator. The runtime forwards the events
+ * the wrapper routes to the right aspect, applies the three-condition goal to each, and folds the aspects into the
+ * published per-tag snapshot (design §6.6, §7.7).
+ * <p>
+ * Created and used only on the wrapper's single dispatch thread.
+ */
+public final class TagRuntime {
+
+    private static final @NotNull String INERT_ASPECT_STATE = "DEACTIVATED";
+
+    private final @NotNull NodeTagPair pair;
+    private final @NotNull TagAspectRead readAspect;
+
+    private boolean readActivated;
+    private boolean writeActivated;
+    private boolean readUsed;
+    private boolean writeUsed;
+
+    /**
+     * @param adapterId               the owning adapter's id.
+     * @param pair                    the node/tag pair this runtime drives.
+     * @param clock                   the actor clock.
+     * @param timers                  the actor's single timer queue.
+     * @param batches                 the actor's batch collector.
+     * @param metrics                 the per-adapter metrics.
+     * @param sharedNodeVerification the shared verification authority.
+     * @param pollIntervalMillis      the poll cadence for a polled read aspect, in milliseconds.
+     * @param retryPolicy             the backoff policy for verification and subscription retries.
+     */
+    public TagRuntime(
+            final @NotNull String adapterId,
+            final @NotNull NodeTagPair pair,
+            final @NotNull Clock clock,
+            final @NotNull PriorityTimerQueue timers,
+            final @NotNull BatchCollector batches,
+            final @NotNull NevskyMetrics metrics,
+            final @NotNull SharedNodeVerification sharedNodeVerification,
+            final long pollIntervalMillis,
+            final @NotNull RetryPolicy retryPolicy) {
+        this.pair = pair;
+        this.readAspect = new TagAspectRead(
+                adapterId,
+                pair.node(),
+                pair.tag(),
+                clock,
+                timers,
+                batches,
+                metrics,
+                sharedNodeVerification,
+                pollIntervalMillis,
+                retryPolicy);
+    }
+
+    /**
+     * @return the node/tag pair this runtime drives.
+     */
+    public @NotNull NodeTagPair pair() {
+        return pair;
+    }
+
+    /**
+     * @return the tag's name.
+     */
+    public @NotNull String tagName() {
+        return pair.tag().name();
+    }
+
+    // ── goal and lifecycle (design §7.1, §7.2) ──────────────────────────────────────────────────────────────────
+
+    /**
+     * Apply the tag's activation and usage to its aspects atomically — the activation-only transition (design
+     * §8.2). Recomputes each aspect's three-condition goal and applies it; never reconnects.
+     *
+     * @param northboundActivated the read direction (northbound) goal.
+     * @param readActivated       the persisted read-aspect activation preference.
+     * @param writeActivated      the persisted write-aspect activation preference.
+     * @param readUsed            whether a northbound mapping consumes the tag.
+     * @param writeUsed           whether a southbound mapping produces to the tag.
+     */
+    public void applyActivation(
+            final boolean northboundActivated,
+            final boolean readActivated,
+            final boolean writeActivated,
+            final boolean readUsed,
+            final boolean writeUsed) {
+        this.readActivated = readActivated;
+        this.writeActivated = writeActivated;
+        this.readUsed = readUsed;
+        this.writeUsed = writeUsed;
+        readAspect.applyGoal(new TagAspectGoal(northboundActivated, readActivated, readUsed));
+    }
+
+    /**
+     * Forward the adapter's entry into verification to the aspects (design §6.3).
+     */
+    public void onAdapterVerifying() {
+        readAspect.onAdapterVerifying();
+    }
+
+    /**
+     * Forward the adapter reaching {@code CONNECTED} to the aspects (design §7.2).
+     */
+    public void onAdapterReady() {
+        readAspect.onAdapterReady();
+    }
+
+    /**
+     * Forward the loss of the adapter connection to the aspects (design §7.2).
+     */
+    public void onAdapterUnavailable() {
+        readAspect.onAdapterUnavailable();
+    }
+
+    /**
+     * Retry the tag after a permanent verification failure (design §7.6).
+     */
+    public void retry() {
+        readAspect.retry();
+    }
+
+    /**
+     * Force every aspect to {@code DEACTIVATED}, cancelling timers and dropping subscriptions — used when the tag
+     * is being removed from the set (design §8.2). Never reconnects the adapter.
+     */
+    public void deactivate() {
+        readActivated = false;
+        writeActivated = false;
+        readUsed = false;
+        writeUsed = false;
+        readAspect.applyGoal(TagAspectGoal.inactive());
+    }
+
+    // ── routed events (design §7) ───────────────────────────────────────────────────────────────────────────────
+
+    /**
+     * Fan a verification outcome to the tag's aspects (design §7.6).
+     *
+     * @param outcome the verification outcome.
+     */
+    public void onVerifyResult(final @NotNull VerifyOutcome outcome) {
+        readAspect.onVerifyResult(outcome);
+    }
+
+    /**
+     * Route a received value to the read aspect (design §7.3, §7.4).
+     *
+     * @param value the reused v1 value.
+     */
+    public void onValue(final @NotNull DataPoint value) {
+        readAspect.onValue(value);
+    }
+
+    /**
+     * Route a per-node failure to the read aspect (design §7.3, §7.4).
+     *
+     * @param reason      a human-readable description.
+     * @param spontaneous whether the failure arrived outside a command-response exchange.
+     */
+    public void onNodeError(final @NotNull String reason, final boolean spontaneous) {
+        readAspect.onNodeError(reason, spontaneous);
+    }
+
+    // ── snapshot (design §6.6, §7.7) ────────────────────────────────────────────────────────────────────────────
+
+    /**
+     * @return the immutable per-tag status for publication. The write aspect is inert in this task and reported as
+     *         {@code DEACTIVATED}; the read aspect reports its live state, failure count, and last failure reason.
+     */
+    public @NotNull TagStatusSnapshot snapshot() {
+        return new TagStatusSnapshot(
+                tagName(),
+                readActivated,
+                writeActivated,
+                readUsed,
+                writeUsed,
+                readAspect.stateName(),
+                INERT_ASPECT_STATE,
+                readAspect.failureCount(),
+                readAspect.lastFailureReason(),
+                readAspect.lastTransitionAtMillis());
+    }
+
+    /**
+     * @return the read aspect — for direct assertions in tests.
+     */
+    public @NotNull TagAspectRead readAspect() {
+        return readAspect;
+    }
+}

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/wrapper/ProtocolAdapterWrapper.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/wrapper/ProtocolAdapterWrapper.java
@@ -89,8 +89,11 @@ public final class ProtocolAdapterWrapper implements MessageHandler<ProtocolAdap
     /**
      * Route one event (design §6.3). In {@code ERROR} every event is fed to the machine so the named absorb rows
      * can swallow it (design §6.4). Otherwise lifecycle events and the gate signal drive the machine, while
-     * verification, data, write, and browse events are routed to the tag plane; aspect-timer events are consumed by
-     * the aspect machines (a later task) and none are scheduled yet.
+     * verification, data, write, and browse events are routed to the tag plane. The wrapper-level aspect-timer
+     * events ({@code PollTimerFired} etc.) are never produced: each aspect schedules its own poll,
+     * verification-retry, and subscription-retry timers on the actor's single timer queue and feeds its own
+     * machine directly (design §5.5), so these remain only as part of the sealed hierarchy and its {@code ERROR}
+     * absorb rows.
      */
     private void handleEvent(final @NotNull ProtocolAdapterWrapperEvent event) {
         if (machine.state() == ProtocolAdapterWrapperState.ERROR) {
@@ -127,13 +130,13 @@ public final class ProtocolAdapterWrapper implements MessageHandler<ProtocolAdap
                 // The browse REST bridge is a later task; nothing consumes browse results yet.
             }
             case ProtocolAdapterWrapperEvent.PollTimerFired ignored -> {
-                // Consumed by the read aspect machines (a later task); none are scheduled yet.
+                // Unused: aspects schedule and fire their own timers on the actor's single timer queue (§5.5).
             }
             case ProtocolAdapterWrapperEvent.VerificationRetryTimerFired ignored -> {
-                // Consumed by the aspect machines (a later task); none are scheduled yet.
+                // Unused: aspects schedule and fire their own timers on the actor's single timer queue (§5.5).
             }
             case ProtocolAdapterWrapperEvent.SubscriptionRetryTimerFired ignored -> {
-                // Consumed by the read aspect machines (a later task); none are scheduled yet.
+                // Unused: aspects schedule and fire their own timers on the actor's single timer queue (§5.5).
             }
         }
     }

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/wrapper/ProtocolAdapterWrapperContext.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/wrapper/ProtocolAdapterWrapperContext.java
@@ -39,6 +39,7 @@ import com.hivemq.protocols.v2.runtime.NevskyMetrics;
 import com.hivemq.protocols.v2.runtime.PriorityTimerQueue;
 import com.hivemq.protocols.v2.runtime.RetryPolicy;
 import com.hivemq.protocols.v2.runtime.TimerHandle;
+import com.hivemq.protocols.v2.tag.TagAspectCoordinator;
 import com.hivemq.protocols.v2.view.AdapterStatusSnapshot;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
@@ -58,8 +59,8 @@ import org.slf4j.LoggerFactory;
  * the timers, and the tag plane only through here. Everything runs on the wrapper's single dispatch thread, so it
  * holds no locks.
  * <p>
- * Two pieces are seams for later tasks. The {@link TagAspectCoordinator} is the wrapper's view of the tag aspect machines
- * (this task ships {@link SnapshotOnlyTagAspectCoordinator}). The <b>verification gate</b> here is a node-counting precursor of the
+ * The {@link TagAspectCoordinator} (in the {@code tag} package) is the wrapper's view of the tag aspect machines.
+ * The <b>verification gate</b> here is a node-counting precursor of the
  * verification coordinator (design §7.6): on entry to {@code WAITING_FOR_VERIFICATION} it verifies every
  * configured node and synthesizes {@link ProtocolAdapterWrapperEvent.AllVerified} once each has reported any
  * outcome (failures do not block {@code CONNECTED}, design §6.3); a later task widens it to select nodes from the
@@ -260,6 +261,7 @@ public final class ProtocolAdapterWrapperContext {
     @NotNull
     ProtocolAdapterWrapperState verifyStep() {
         clearTimers();
+        tagPlane.onAdapterVerifying();
         beginVerification();
         return WAITING_FOR_VERIFICATION;
     }
@@ -527,8 +529,9 @@ public final class ProtocolAdapterWrapperContext {
     // ──────────────────────────────────────────────────────────────────────────────────────────────────────────
 
     /**
-     * Handle a tick on the dispatch thread (design §5.5, §6.1): record the tick lag, fire every due timer (each
-     * feeds an event straight to the machine), let the tag plane post its due work, then dispatch the pending
+     * Handle a tick on the dispatch thread (design §5.5, §6.1): record the tick lag, fire every due timer — the
+     * adapter machine's watchdog and backoff, and every aspect's poll, verification-retry, and subscription-retry
+     * timers, each feeding an event straight to its machine and posting any due work — then dispatch the pending
      * batches to the adapter.
      *
      * @param tickMillis the tick's logical time, in milliseconds.
@@ -536,7 +539,6 @@ public final class ProtocolAdapterWrapperContext {
     public void onTick(final long tickMillis) {
         metrics.recordTickLag(clock.nowMillis() - tickMillis);
         timers.fireDue(tickMillis);
-        tagPlane.onTick(tickMillis);
         batches.dispatch(protocolAdapter);
     }
 
@@ -578,5 +580,44 @@ public final class ProtocolAdapterWrapperContext {
      */
     public boolean skipVerification() {
         return skipVerification;
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────────────────────────────────────
+    //  Runtime accessors — the per-actor primitives shared with the tag plane (design §5.5, §5.7, §6.1)
+    // ──────────────────────────────────────────────────────────────────────────────────────────────────────────
+
+    /**
+     * @return the actor clock the timers are scheduled against.
+     */
+    public @NotNull Clock clock() {
+        return clock;
+    }
+
+    /**
+     * @return the actor's single timer queue — shared by the adapter machine and the tag aspects (design §5.5).
+     */
+    public @NotNull PriorityTimerQueue timers() {
+        return timers;
+    }
+
+    /**
+     * @return the actor's batch collector — where the tag aspects post poll and subscription requests (design §5.7).
+     */
+    public @NotNull BatchCollector batches() {
+        return batches;
+    }
+
+    /**
+     * @return the per-adapter metrics — the source of the per-tag failure counters.
+     */
+    public @NotNull NevskyMetrics metrics() {
+        return metrics;
+    }
+
+    /**
+     * @return the protocol adapter the machine commands — the verify seam the tag plane re-verifies through.
+     */
+    public @NotNull ProtocolAdapter protocolAdapter() {
+        return protocolAdapter;
     }
 }

--- a/hivemq-edge/src/test/java/com/hivemq/protocols/v2/tag/SharedNodeVerificationTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/protocols/v2/tag/SharedNodeVerificationTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.protocols.v2.tag;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.hivemq.adapter.sdk.api.v2.model.VerifyOutcome;
+import com.hivemq.adapter.sdk.api.v2.node.Node;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The shared verification bookkeeping (design §7.6): a node is verified at most once while in flight (so a
+ * read-and-write tag yields a single {@code verifyBatch} entry), a reported result clears it for the next time,
+ * and {@code allReported} tracks the outstanding requests the gate counting consumes.
+ */
+class SharedNodeVerificationTest {
+
+    private static final class CountingNode extends Node {
+        private final @NotNull String id;
+
+        private CountingNode(final @NotNull String id) {
+            this.id = id;
+        }
+
+        @Override
+        public @NotNull String nodeId() {
+            return id;
+        }
+
+        @Override
+        public @NotNull String nodeString() {
+            return "{}";
+        }
+
+        @Override
+        public @NotNull EnumSet<com.hivemq.adapter.sdk.api.v2.node.NodeProperty> properties() {
+            return EnumSet.noneOf(com.hivemq.adapter.sdk.api.v2.node.NodeProperty.class);
+        }
+    }
+
+    @Test
+    void requestVerification_deduplicatesWhileInFlight() {
+        final List<List<Node>> requests = new ArrayList<>();
+        final SharedNodeVerification coordinator = new SharedNodeVerification(requests::add, node -> null);
+        final Node node = new CountingNode("a");
+
+        coordinator.requestVerification(node);
+        coordinator.requestVerification(node); // already in flight — must not re-issue
+
+        assertThat(requests).hasSize(1);
+        assertThat(requests.get(0)).containsExactly(node);
+        assertThat(coordinator.needsVerify(node)).isFalse();
+        assertThat(coordinator.allReported()).isFalse();
+    }
+
+    @Test
+    void reportedResult_clearsTheNodeForTheNextRequest() {
+        final List<List<Node>> requests = new ArrayList<>();
+        final SharedNodeVerification coordinator = new SharedNodeVerification(requests::add, node -> null);
+        final Node node = new CountingNode("a");
+
+        coordinator.requestVerification(node);
+        coordinator.onVerifyResult(node, new VerifyOutcome.Success());
+
+        assertThat(coordinator.allReported()).isTrue();
+        assertThat(coordinator.needsVerify(node)).isTrue();
+
+        coordinator.requestVerification(node); // a fresh request issues again
+        assertThat(requests).hasSize(2);
+    }
+
+    @Test
+    void allReported_isFalseUntilEveryRequestedNodeReports() {
+        final List<List<Node>> requests = new ArrayList<>();
+        final SharedNodeVerification coordinator = new SharedNodeVerification(requests::add, node -> null);
+        final Node first = new CountingNode("a");
+        final Node second = new CountingNode("b");
+
+        coordinator.requestVerification(first);
+        coordinator.requestVerification(second);
+        assertThat(coordinator.allReported()).isFalse();
+
+        coordinator.onVerifyResult(first, new VerifyOutcome.Success());
+        assertThat(coordinator.allReported()).isFalse();
+
+        coordinator.onVerifyResult(second, new VerifyOutcome.TransientFailure("retry"));
+        assertThat(coordinator.allReported()).isTrue();
+    }
+}

--- a/hivemq-edge/src/test/java/com/hivemq/protocols/v2/tag/TagAspectGoalTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/protocols/v2/tag/TagAspectGoalTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.protocols.v2.tag;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * The three-condition rule (design §7.1): an aspect is driven only when its direction is activated, its
+ * preference is activated, and the tag is used. Any single condition failing keeps it inactive.
+ */
+class TagAspectGoalTest {
+
+    @Test
+    void active_requiresAllThreeConditions() {
+        assertThat(new TagAspectGoal(true, true, true).active()).isTrue();
+    }
+
+    @Test
+    void active_isFalseWhenAnySingleConditionFails() {
+        assertThat(new TagAspectGoal(false, true, true).active()).isFalse(); // direction off
+        assertThat(new TagAspectGoal(true, false, true).active()).isFalse(); // preference off
+        assertThat(new TagAspectGoal(true, true, false).active()).isFalse(); // not used
+    }
+
+    @Test
+    void inactive_isNeverActive() {
+        assertThat(TagAspectGoal.inactive().active()).isFalse();
+    }
+}

--- a/hivemq-edge/src/test/java/com/hivemq/protocols/v2/wrapper/TagAspectActivationTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/protocols/v2/wrapper/TagAspectActivationTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.protocols.v2.wrapper;
+
+import static com.hivemq.protocols.v2.wrapper.ProtocolAdapterWrapperState.CONNECTED;
+import static com.hivemq.protocols.v2.wrapper.ProtocolAdapterWrapperState.STOPPED;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The three-condition rule applied to the read aspect through the running coordinator (design §7.1; scenario S27
+ * at unit level — the read-side gate and the direction master switch; the write-side rows land in a later task).
+ * Deactivating the read aspect's preference keeps it off while the adapter runs; a config-origin
+ * {@code ApplyActivation} flips the preference atomically and the aspect verifies <b>without reconnecting</b>;
+ * deactivating the direction returns the aspect to {@code DEACTIVATED}.
+ */
+class TagAspectActivationTest {
+
+    private static long connectCount(final @NotNull WrapperTestFixture fixture) {
+        return fixture.commands().stream().filter("connect"::equals).count();
+    }
+
+    @Test
+    void readPreferenceOff_keepsTheAspectDeactivatedWhileTheAdapterRuns() {
+        final WrapperTestFixture fixture = WrapperTestFixture.builder()
+                .runningCoordinator()
+                .nodes(List.of(WrapperTestSupport.pair("temperature")))
+                .activation(Map.of("temperature", new TagAspectActivationPreference(false, true)))
+                .build();
+
+        fixture.activate(ProtocolAdapterDirection.NORTHBOUND);
+
+        assertThat(fixture.state()).isEqualTo(CONNECTED);
+        assertThat(fixture.readState("temperature")).isEqualTo("DEACTIVATED");
+    }
+
+    @Test
+    void applyActivation_activatesAndVerifiesWithoutReconnecting() {
+        final WrapperTestFixture fixture = WrapperTestFixture.builder()
+                .runningCoordinator()
+                .nodes(List.of(WrapperTestSupport.pair("temperature")))
+                .activation(Map.of("temperature", new TagAspectActivationPreference(false, true)))
+                .build();
+        fixture.activate(ProtocolAdapterDirection.NORTHBOUND);
+        assertThat(fixture.readState("temperature")).isEqualTo("DEACTIVATED");
+        assertThat(connectCount(fixture)).isEqualTo(1);
+
+        // Config reload flips read-activated on — an ACTIVATION_ONLY transition (design §8.2).
+        fixture.send(new ProtocolAdapterWrapperCommand.ApplyActivation(
+                new ProtocolAdapterGoalState(true, false),
+                Map.of("temperature", TagAspectActivationPreference.defaults())));
+
+        assertThat(fixture.state()).isEqualTo(CONNECTED); // still connected
+        assertThat(connectCount(fixture)).isEqualTo(1); // never reconnected
+        // The newly-activated aspect verifies itself against the live connection and begins polling.
+        assertThat(fixture.readState("temperature")).isEqualTo("WAITING_FOR_POLL_INTERVAL");
+    }
+
+    @Test
+    void deactivatingTheDirection_returnsTheAspectToDeactivated() {
+        final WrapperTestFixture fixture = WrapperTestFixture.builder()
+                .runningCoordinator()
+                .nodes(List.of(WrapperTestSupport.pair("temperature")))
+                .build();
+        fixture.activate(ProtocolAdapterDirection.NORTHBOUND);
+        assertThat(fixture.readState("temperature")).isEqualTo("WAITING_FOR_POLL_INTERVAL");
+
+        fixture.deactivate(ProtocolAdapterDirection.NORTHBOUND);
+
+        assertThat(fixture.state()).isEqualTo(STOPPED);
+        assertThat(fixture.readState("temperature")).isEqualTo("DEACTIVATED");
+    }
+}

--- a/hivemq-edge/src/test/java/com/hivemq/protocols/v2/wrapper/TagAspectReadPolledTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/protocols/v2/wrapper/TagAspectReadPolledTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.protocols.v2.wrapper;
+
+import static com.hivemq.protocols.v2.wrapper.ProtocolAdapterWrapperState.CONNECTED;
+import static com.hivemq.protocols.v2.wrapper.ProtocolAdapterWrapperState.WAITING_FOR_CONNECTION_RETRY;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.hivemq.adapter.sdk.api.v2.model.VerifyOutcome;
+import java.util.List;
+import java.util.Set;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The polled read aspect (design §7.3; scenarios S1, S3, S4, S5, S12 at unit level). The aspect verifies on
+ * connect, then polls on a cadence; a poll failure is its own retry; transient verification failures retry on a
+ * timer, permanent ones suspend; an adapter loss parks the aspect and re-verifies on reconnect. All driven on
+ * {@code FakeClock} + {@code ManualDispatcher} through the running coordinator, observed only through the
+ * published snapshot.
+ */
+class TagAspectReadPolledTest {
+
+    private static @NotNull WrapperTestFixture polledFixture() {
+        return WrapperTestFixture.builder()
+                .runningCoordinator()
+                .nodes(List.of(WrapperTestSupport.pair("temperature")))
+                .pollIntervalMillis(1000)
+                .build();
+    }
+
+    @Test
+    void verifyThenPollCadence_deliversValuesAndKeepsPolling() {
+        final WrapperTestFixture fixture = polledFixture();
+
+        fixture.activate(ProtocolAdapterDirection.NORTHBOUND);
+        assertThat(fixture.state()).isEqualTo(CONNECTED);
+        // Verified on connect via the gate's routed result, now resting at the poll interval.
+        assertThat(fixture.readState("temperature")).isEqualTo("WAITING_FOR_POLL_INTERVAL");
+
+        fixture.advance(1000); // the poll interval elapses: a poll is requested
+        assertThat(fixture.readState("temperature")).isEqualTo("WAITING_FOR_POLL_DATAPOINT");
+        assertThat(fixture.commands()).contains("pollBatch");
+
+        fixture.output.dataPoint(fixture.nodeFor("temperature"), WrapperTestSupport.dataPoint("temperature", "21"));
+        fixture.drain();
+        assertThat(fixture.readState("temperature")).isEqualTo("WAITING_FOR_POLL_INTERVAL");
+        assertThat(fixture.tag("temperature").failureCount()).isZero();
+    }
+
+    @Test
+    void pollFailure_returnsToPollIntervalAndCountsWithNoNewState() {
+        final WrapperTestFixture fixture = polledFixture();
+        fixture.activate(ProtocolAdapterDirection.NORTHBOUND);
+        fixture.advance(1000); // WAITING_FOR_POLL_DATAPOINT
+
+        fixture.output.nodeError(fixture.nodeFor("temperature"), "read timeout", false);
+        fixture.drain();
+
+        // The next scheduled poll is the retry — no new state (design §7.3), only the counter advances.
+        assertThat(fixture.readState("temperature")).isEqualTo("WAITING_FOR_POLL_INTERVAL");
+        assertThat(fixture.tag("temperature").failureCount()).isEqualTo(1);
+        assertThat(fixture.tag("temperature").lastFailureReason()).isEqualTo("read timeout");
+    }
+
+    @Test
+    void transientVerificationFailure_retriesOnTimerThenSucceeds() {
+        final WrapperTestFixture fixture = polledFixture();
+        fixture.adapter.verifyOutcome = new VerifyOutcome.TransientFailure("device busy");
+
+        fixture.activate(ProtocolAdapterDirection.NORTHBOUND);
+
+        // The gate still reaches CONNECTED (any outcome counts, §6.3); the aspect schedules a verification retry.
+        assertThat(fixture.state()).isEqualTo(CONNECTED);
+        assertThat(fixture.readState("temperature")).isEqualTo("WAITING_FOR_VERIFICATION_RETRY");
+
+        fixture.adapter.verifyOutcome = new VerifyOutcome.Success();
+        fixture.advance(1000); // the retry timer fires: re-verify, succeed, begin polling
+        assertThat(fixture.readState("temperature")).isEqualTo("WAITING_FOR_POLL_INTERVAL");
+    }
+
+    @Test
+    void permanentVerificationFailure_suspendsTheTagButLeavesTheAdapterConnected() {
+        final WrapperTestFixture fixture = polledFixture();
+        fixture.adapter.verifyOutcome = new VerifyOutcome.PermanentFailure("unknown address");
+
+        fixture.activate(ProtocolAdapterDirection.NORTHBOUND);
+
+        assertThat(fixture.state()).isEqualTo(CONNECTED); // the adapter does not reconnect (design §7.6, S4)
+        assertThat(fixture.readState("temperature")).isEqualTo("ERROR_PERMANENT_VERIFICATION_FAILURE");
+
+        fixture.advance(10_000); // no retry timer — a permanent failure stays put without a user-commanded retry
+        assertThat(fixture.readState("temperature")).isEqualTo("ERROR_PERMANENT_VERIFICATION_FAILURE");
+    }
+
+    @Test
+    void adapterLoss_parksTheAspectAndReVerifiesOnReconnect() {
+        final WrapperTestFixture fixture = polledFixture();
+        fixture.activate(ProtocolAdapterDirection.NORTHBOUND);
+        assertThat(fixture.readState("temperature")).isEqualTo("WAITING_FOR_POLL_INTERVAL");
+
+        fixture.output.disconnected(); // a spontaneous loss while CONNECTED (design §7.2, S5)
+        fixture.drain();
+        assertThat(fixture.state()).isEqualTo(WAITING_FOR_CONNECTION_RETRY);
+        assertThat(fixture.readState("temperature")).isEqualTo("WAITING_FOR_ADAPTER_READY");
+
+        fixture.advance(1000); // the connection backoff fires: reconnect, re-verify, resume polling
+        assertThat(fixture.state()).isEqualTo(CONNECTED);
+        assertThat(fixture.readState("temperature")).isEqualTo("WAITING_FOR_POLL_INTERVAL");
+    }
+
+    @Test
+    void unusedTag_staysDeactivatedEvenWhenActivated() {
+        final WrapperTestFixture fixture = WrapperTestFixture.builder()
+                .runningCoordinator()
+                .nodes(List.of(WrapperTestSupport.pair("temperature")))
+                .readUsed(Set.of()) // no mapping consumes the tag — the third condition fails
+                .build();
+
+        fixture.activate(ProtocolAdapterDirection.NORTHBOUND);
+
+        assertThat(fixture.state()).isEqualTo(CONNECTED);
+        assertThat(fixture.readState("temperature")).isEqualTo("DEACTIVATED");
+    }
+}

--- a/hivemq-edge/src/test/java/com/hivemq/protocols/v2/wrapper/TagAspectReadSubscribedTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/protocols/v2/wrapper/TagAspectReadSubscribedTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.protocols.v2.wrapper;
+
+import static com.hivemq.protocols.v2.wrapper.ProtocolAdapterWrapperState.CONNECTED;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The subscribed read aspect (design §7.4; scenarios S10, S11 at unit level). The aspect subscribes on
+ * verification, the first pushed value confirms it; a command-response loss backs off and re-adds, while a
+ * spontaneous loss power-cycles the aspect through verification. Driven on {@code FakeClock} +
+ * {@code ManualDispatcher} through the running coordinator, observed only through the published snapshot.
+ */
+class TagAspectReadSubscribedTest {
+
+    private static @NotNull WrapperTestFixture subscribedFixture() {
+        return WrapperTestFixture.builder()
+                .runningCoordinator()
+                .nodes(List.of(WrapperTestSupport.subscribablePair("temperature")))
+                .build();
+    }
+
+    private static long count(final @NotNull WrapperTestFixture fixture, final @NotNull String command) {
+        return fixture.commands().stream().filter(command::equals).count();
+    }
+
+    private static @NotNull WrapperTestFixture subscribedAndConfirmed() {
+        final WrapperTestFixture fixture = subscribedFixture();
+        fixture.activate(ProtocolAdapterDirection.NORTHBOUND);
+        fixture.advance(100); // a tick dispatches the queued add-subscription batch
+        fixture.output.dataPoint(fixture.nodeFor("temperature"), WrapperTestSupport.dataPoint("temperature", "21"));
+        fixture.drain();
+        return fixture;
+    }
+
+    @Test
+    void subscribeThenFirstValueConfirmsSubscribed() {
+        final WrapperTestFixture fixture = subscribedFixture();
+
+        fixture.activate(ProtocolAdapterDirection.NORTHBOUND);
+        assertThat(fixture.state()).isEqualTo(CONNECTED);
+        // Verified on connect: the add-subscription is requested; waiting for the first value to confirm it.
+        assertThat(fixture.readState("temperature")).isEqualTo("WAITING_FOR_SUBSCRIPTION");
+
+        fixture.advance(100); // a tick dispatches the queued add-subscription batch
+        assertThat(fixture.commands()).contains("addSubscriptionBatch");
+
+        fixture.output.dataPoint(fixture.nodeFor("temperature"), WrapperTestSupport.dataPoint("temperature", "21"));
+        fixture.drain();
+        assertThat(fixture.readState("temperature")).isEqualTo("SUBSCRIBED");
+
+        // Subsequent pushed values keep it operating.
+        fixture.output.dataPoint(fixture.nodeFor("temperature"), WrapperTestSupport.dataPoint("temperature", "22"));
+        fixture.drain();
+        assertThat(fixture.readState("temperature")).isEqualTo("SUBSCRIBED");
+    }
+
+    @Test
+    void commandResponseLoss_backsOffThenReAdds() {
+        final WrapperTestFixture fixture = subscribedAndConfirmed();
+        assertThat(fixture.readState("temperature")).isEqualTo("SUBSCRIBED");
+        final long verifyBatchesBefore = count(fixture, "verifyBatch");
+
+        fixture.output.nodeError(fixture.nodeFor("temperature"), "subscription dropped", false);
+        fixture.drain();
+        assertThat(fixture.readState("temperature")).isEqualTo("WAITING_FOR_SUBSCRIPTION_RETRY");
+
+        fixture.advance(1000); // the subscription backoff elapses: re-add, no re-verification
+        assertThat(fixture.readState("temperature")).isEqualTo("WAITING_FOR_SUBSCRIPTION");
+        assertThat(count(fixture, "addSubscriptionBatch")).isEqualTo(2);
+        assertThat(count(fixture, "verifyBatch")).isEqualTo(verifyBatchesBefore); // no re-verify on a command loss
+    }
+
+    @Test
+    void spontaneousLoss_powerCyclesThroughVerification() {
+        final WrapperTestFixture fixture = subscribedAndConfirmed();
+        assertThat(fixture.readState("temperature")).isEqualTo("SUBSCRIBED");
+        final long verifyBatchesBefore = count(fixture, "verifyBatch");
+        fixture.adapter.verifyDrop = true; // hold the power-cycle's re-verification so it is observable
+
+        fixture.output.nodeError(fixture.nodeFor("temperature"), "device reset", true);
+        fixture.drain();
+
+        // A spontaneous loss re-verifies (design §7.4) — the aspect parks in verification, not subscription retry.
+        assertThat(fixture.readState("temperature")).isEqualTo("WAITING_FOR_VERIFICATION");
+        assertThat(count(fixture, "verifyBatch")).isEqualTo(verifyBatchesBefore + 1);
+    }
+}

--- a/hivemq-edge/src/test/java/com/hivemq/protocols/v2/wrapper/WrapperTestFixture.java
+++ b/hivemq-edge/src/test/java/com/hivemq/protocols/v2/wrapper/WrapperTestFixture.java
@@ -18,12 +18,17 @@ package com.hivemq.protocols.v2.wrapper;
 import com.codahale.metrics.MetricRegistry;
 import com.hivemq.adapter.sdk.api.v2.messaging.DefaultMailbox;
 import com.hivemq.adapter.sdk.api.v2.messaging.Mailbox;
+import com.hivemq.adapter.sdk.api.v2.node.Node;
 import com.hivemq.adapter.sdk.api.v2.node.NodeTagPair;
 import com.hivemq.protocols.v2.runtime.FakeClock;
 import com.hivemq.protocols.v2.runtime.ManualDispatcher;
 import com.hivemq.protocols.v2.runtime.NevskyMetrics;
 import com.hivemq.protocols.v2.runtime.RetryPolicy;
+import com.hivemq.protocols.v2.tag.TagAspectCoordinator;
+import com.hivemq.protocols.v2.tag.TagAspectRuntimeCoordinator;
+import com.hivemq.protocols.v2.tag.TagAspectSnapshotOnlyCoordinator;
 import com.hivemq.protocols.v2.view.AdapterStatusSnapshot;
+import com.hivemq.protocols.v2.view.TagStatusSnapshot;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -52,6 +57,7 @@ final class WrapperTestFixture {
     final @NotNull RecordingProtocolAdapterWrapperEventListener health;
     final @NotNull AtomicReference<AdapterStatusSnapshot> snapshotReference;
     final @NotNull ProtocolAdapterWrapper wrapper;
+    final @NotNull List<NodeTagPair> nodes;
 
     private WrapperTestFixture(final @NotNull Builder builder) {
         this.adapterId = builder.adapterId;
@@ -62,6 +68,7 @@ final class WrapperTestFixture {
         this.output = new ProtocolAdapterOutputFacade(mailbox);
         this.adapter = new MockProtocolAdapter(adapterId, output);
         this.health = new RecordingProtocolAdapterWrapperEventListener();
+        this.nodes = builder.nodes;
 
         final Map<String, TagAspectActivationPreference> activation =
                 builder.activation != null ? builder.activation : defaultActivation(builder.nodes);
@@ -69,8 +76,25 @@ final class WrapperTestFixture {
         final Set<String> writeUsed = builder.writeUsed != null ? builder.writeUsed : new HashSet<>();
 
         final NevskyMetrics metrics = new NevskyMetrics(metricRegistry, adapterId, mailbox::size);
-        final SnapshotOnlyTagAspectCoordinator tagPlane =
-                new SnapshotOnlyTagAspectCoordinator(builder.nodes, activation, readUsed, writeUsed);
+        // The default tag plane is the snapshot-only stand-in (adapter-machine tests); opt in to the running
+        // coordinator to exercise the read aspect machines.
+        final TagAspectCoordinator tagPlane;
+        final TagAspectRuntimeCoordinator runningTagPlane;
+        if (builder.runningCoordinator) {
+            runningTagPlane = new TagAspectRuntimeCoordinator(
+                    adapterId,
+                    builder.nodes,
+                    activation,
+                    readUsed,
+                    writeUsed,
+                    builder.initialGoal,
+                    builder.pollIntervalMillis,
+                    builder.retryPolicy);
+            tagPlane = runningTagPlane;
+        } else {
+            tagPlane = new TagAspectSnapshotOnlyCoordinator(builder.nodes, activation, readUsed, writeUsed);
+            runningTagPlane = null;
+        }
         final ProtocolAdapterWrapperContext context = new ProtocolAdapterWrapperContext(
                 adapterId,
                 adapter,
@@ -85,6 +109,14 @@ final class WrapperTestFixture {
                 tagPlane,
                 health,
                 metrics);
+        if (runningTagPlane != null) {
+            runningTagPlane.bindRuntime(
+                    context.clock(),
+                    context.timers(),
+                    context.batches(),
+                    context.metrics(),
+                    context.protocolAdapter()::verifyBatch);
+        }
         this.snapshotReference = new AtomicReference<>();
         this.wrapper = new ProtocolAdapterWrapper(context, snapshotReference);
         dispatcher.attach(mailbox, wrapper);
@@ -159,6 +191,40 @@ final class WrapperTestFixture {
         return adapter.commands;
     }
 
+    /**
+     * @return the protocol node behind the given tag — for injecting per-node values and errors via {@link #output}.
+     */
+    @NotNull
+    Node nodeFor(final @NotNull String tagName) {
+        for (final NodeTagPair pair : nodes) {
+            if (pair.tag().name().equals(tagName)) {
+                return pair.node();
+            }
+        }
+        throw new IllegalArgumentException("no node for tag " + tagName);
+    }
+
+    /**
+     * @return the published per-tag status for the given tag.
+     */
+    @NotNull
+    TagStatusSnapshot tag(final @NotNull String tagName) {
+        for (final TagStatusSnapshot tag : snapshot().tags()) {
+            if (tag.tagName().equals(tagName)) {
+                return tag;
+            }
+        }
+        throw new IllegalArgumentException("no tag status for " + tagName);
+    }
+
+    /**
+     * @return the read aspect's current state name for the given tag, read from the published snapshot.
+     */
+    @NotNull
+    String readState(final @NotNull String tagName) {
+        return tag(tagName).readAspectStateName();
+    }
+
     long defensiveResets() {
         return metricRegistry
                 .counter(NevskyMetrics.ADAPTER_PREFIX + adapterId + ".defensive.resets")
@@ -197,6 +263,8 @@ final class WrapperTestFixture {
         private long watchdogTimeoutMillis = 1000;
         private boolean skipVerification;
         private long tickPeriodMillis = 100;
+        private boolean runningCoordinator;
+        private long pollIntervalMillis = 1000;
         private @Nullable Map<String, TagAspectActivationPreference> activation;
         private @Nullable Set<String> readUsed;
         private @Nullable Set<String> writeUsed;
@@ -240,6 +308,22 @@ final class WrapperTestFixture {
         @NotNull
         Builder tickPeriodMillis(final long tickPeriodMillis) {
             this.tickPeriodMillis = tickPeriodMillis;
+            return this;
+        }
+
+        /**
+         * Drive the real read-aspect machines through a {@link TagAspectRuntimeCoordinator} instead of the
+         * snapshot-only stand-in.
+         */
+        @NotNull
+        Builder runningCoordinator() {
+            this.runningCoordinator = true;
+            return this;
+        }
+
+        @NotNull
+        Builder pollIntervalMillis(final long pollIntervalMillis) {
+            this.pollIntervalMillis = pollIntervalMillis;
             return this;
         }
 

--- a/hivemq-edge/src/test/java/com/hivemq/protocols/v2/wrapper/WrapperTestSupport.java
+++ b/hivemq-edge/src/test/java/com/hivemq/protocols/v2/wrapper/WrapperTestSupport.java
@@ -43,6 +43,11 @@ final class WrapperTestSupport {
         return NodeTagPair.create(new TestNode(tagName), tagName, schema, true, false);
     }
 
+    static @NotNull NodeTagPair subscribablePair(final @NotNull String tagName) {
+        final Schema schema = new ScalarSchema(ScalarType.STRING, null, null, null, null, false, true, false);
+        return NodeTagPair.create(new TestNode(tagName), tagName, schema, false, true);
+    }
+
     static @NotNull DataPoint dataPoint(final @NotNull String tagName, final @NotNull Object value) {
         return new TestDataPoint(tagName, value);
     }


### PR DESCRIPTION
## Summary

Implements **Task 7 — tag read aspects (polled + subscribed)** of Project Nevsky (the v2 protocol-adapter framework), on top of the wrapper actor + adapter state machine from EDG-725.

Each tag gets a read-aspect FSM over a shared five-state pre-operating sequence, driven by the three-condition `TagAspectGoal` (direction activated ∧ aspect activated ∧ used) and coupled to the wrapper's verification phase (design §6.3, §7).

## What's included

- **`com.hivemq.protocols.v2.tag` package** — the wrapper↔aspect seam `TagAspectCoordinator` (relocated here from `wrapper/`) with two implementations: `TagAspectSnapshotOnlyCoordinator` (the snapshot-only stand-in the adapter-machine tests use) and `TagAspectRuntimeCoordinator` (the running coordinator, two-phase bound via `bindRuntime`), backed by per-tag `TagRuntime` + `TagAspectRead`.
- **Read-aspect FSMs** — `TagAspectReadPolledState` / `TagAspectReadSubscribedState` enums + transition tables (shared pre-operating rows from one builder); polled poll-interval scheduling and subscribed subscription retry/backoff, with escalating-severity failure handling.
- **`SharedNodeVerification`** — de-dups and fans out verify results across aspects and drives the adapter gate via `allReported()`; re-verification is issued through the `NodeVerifier` seam (the adapter's `verifyBatch`). Aspect timers run on the actor's single `PriorityTimerQueue`.

## Testing

- `./gradlew :hivemq-edge-build:hivemq-edge:check` → green (Spotless + ErrorProne + NullAway + the v2 unit suite).
- Comprehensive `hivemq-edge-test` coverage is left to CI.
