### PR TITLE
EDG-727: Add Nevsky tag write aspect, verification model, and tag retry

### DIFF
--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/tag/SharedNodeVerification.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/tag/SharedNodeVerification.java
@@ -17,6 +17,7 @@ package com.hivemq.protocols.v2.tag;
 
 import com.hivemq.adapter.sdk.api.v2.model.VerifyOutcome;
 import com.hivemq.adapter.sdk.api.v2.node.Node;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -25,19 +26,22 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /**
- * Shared verification bookkeeping for a single adapter's tags (design §7.6). One node's verification serves all of
- * that node's aspects: if both the read and write aspect of a tag need to verify, the coordinator issues
- * <b>one</b> {@code verifyBatch} entry and fans the single {@link VerifyOutcome} out to every aspect of the node.
+ * Shared verification bookkeeping for a single adapter's tags (design §7.6) — <b>the single verification
+ * authority</b> that both the connect-time adapter gate (design §6.3) and the per-aspect re-verifications run
+ * through. One node's verification serves all of that node's aspects: if both the read and write aspect of a tag
+ * need to verify, exactly <b>one</b> {@code verifyBatch} entry is issued and the single {@link VerifyOutcome} is
+ * fanned out to every aspect of the node.
  * <p>
- * In this task only read aspects exist, so the fan-out reaches the read aspect; the write aspect joins in a later
- * task with no change here. The coordinator owns the de-duplication: a node already in flight is not re-requested
- * ({@link #needsVerify(Node)}), which is what keeps a read-and-write tag to a single verify.
+ * It owns the de-duplication and the counting: a node already in flight is not re-requested
+ * ({@link #needsVerify(Node)}), which is what keeps a read-and-write tag to a single verify, and
+ * {@link #allReported()} is the signal the wrapper uses to leave {@code WAITING_FOR_VERIFICATION} for
+ * {@code CONNECTED} once every node in the connect batch has reported some outcome (design §6.3).
  * <p>
- * The initial connect verification is issued by the wrapper's adapter gate (design §6.3), which also counts for
- * the {@code CONNECTED} transition; those results flow through {@link #onVerifyResult(Node, VerifyOutcome)} for
- * fan-out but are not tracked here. This coordinator issues only the post-connect re-verifications an aspect asks
- * for — a verification retry or a tag retry (design §7.6). {@link #allReported()} reports whether the
- * coordinator-issued requests have all come back; a later task wires it to the gate counting.
+ * Two entry points feed it: {@link #beginConnectVerification(List)} — the connect gate issues the aspects' nodes
+ * as <b>one</b> batch — and {@link #requestVerification(Node)} — a single post-connect re-verification an aspect
+ * asks for after a verification-retry or a tag retry (design §7.6). {@link #reset()} drops any outstanding
+ * in-flight nodes when verification is abandoned (a disconnect or stop). Every reported outcome flows through
+ * {@link #onVerifyResult(Node, VerifyOutcome)}, which both clears the count and fans out to the aspects.
  * <p>
  * Owned by one adapter wrapper and used only on its single dispatch thread; it holds no locks.
  */
@@ -82,6 +86,34 @@ public final class SharedNodeVerification {
     }
 
     /**
+     * Begin the connect-time verification (design §6.3): register every given node as in flight (de-duplicated)
+     * and issue them as <b>one</b> {@code verifyBatch} — a read-and-write tag therefore yields a single entry.
+     * {@link #allReported()} then gates the {@code CONNECTED} transition. An empty list issues nothing and leaves
+     * {@link #allReported()} {@code true}, so an adapter with no aspect needing verification connects immediately.
+     *
+     * @param nodes the nodes whose aspects need verifying on connect.
+     */
+    public void beginConnectVerification(final @NotNull List<Node> nodes) {
+        final List<Node> toVerify = new ArrayList<>(nodes.size());
+        for (final Node node : nodes) {
+            if (inFlight.add(node)) {
+                toVerify.add(node);
+            }
+        }
+        if (!toVerify.isEmpty()) {
+            nodeVerifier.verify(toVerify);
+        }
+    }
+
+    /**
+     * Drop every outstanding in-flight node — called when verification is abandoned (the adapter disconnected,
+     * errored, or stopped), so a stale request can never linger into the next connect gate (design §6.3).
+     */
+    public void reset() {
+        inFlight.clear();
+    }
+
+    /**
      * Fan one node's verification outcome out to its aspects and clear it from the in-flight set (design §7.6). A
      * result for a node this coordinator did not request — an initial connect verification issued by the adapter
      * gate — is fanned out all the same; the in-flight removal is then a no-op.
@@ -98,8 +130,8 @@ public final class SharedNodeVerification {
     }
 
     /**
-     * @return {@code true} when every coordinator-issued verification has reported — the signal a later task
-     *         feeds into the adapter gate (design §6.3).
+     * @return {@code true} when no verification is outstanding — the signal the wrapper uses to leave
+     *         {@code WAITING_FOR_VERIFICATION} for {@code CONNECTED} (the adapter gate, design §6.3).
      */
     public boolean allReported() {
         return inFlight.isEmpty();

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/tag/TagAspectCoordinator.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/tag/TagAspectCoordinator.java
@@ -43,10 +43,24 @@ public interface TagAspectCoordinator {
 
     /**
      * The adapter began verifying its nodes (design §6.3): active aspects waiting for the adapter move into
-     * verification so they consume the connect-time {@code verifyResult}s the wrapper routes to them — the single
-     * verify stream feeds both the adapter gate and the aspects (design §6.3).
+     * verification, and the coordinator issues the nodes those aspects need verified as <b>one</b>
+     * {@code verifyBatch} through the shared verification authority. The single verify stream then feeds both the
+     * adapter gate (via {@link #allReported()}) and the aspects (via {@link #routeVerifyResult}).
      */
     void onAdapterVerifying();
+
+    /**
+     * @return {@code true} when no connect-time verification is outstanding — the signal the wrapper uses to leave
+     *         {@code WAITING_FOR_VERIFICATION} for {@code CONNECTED} (the adapter gate, design §6.3).
+     */
+    boolean allReported();
+
+    /**
+     * Drop any outstanding connect-time verification — called when verification is abandoned (the adapter
+     * disconnected, errored, or stopped), so a stale request never lingers into the next connect gate (design
+     * §6.3).
+     */
+    void resetVerificationGate();
 
     /**
      * The adapter reached {@code CONNECTED} (design §7.2). When verification was skipped, aspects still waiting for
@@ -86,6 +100,14 @@ public interface TagAspectCoordinator {
      * @param spontaneous whether the failure arrived outside a command-response exchange.
      */
     void routeNodeError(@NotNull Node node, @NotNull String reason, boolean spontaneous);
+
+    /**
+     * Submit a southbound write to the node's write aspect (design §7.5) — the "write arrives" trigger.
+     *
+     * @param node  the node to write to.
+     * @param value the reused v1 value to write.
+     */
+    void submitWrite(@NotNull Node node, @NotNull DataPoint value);
 
     /**
      * Route a write acknowledgment to the node's write aspect (design §7.5).

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/tag/TagAspectEvent.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/tag/TagAspectEvent.java
@@ -36,7 +36,10 @@ public sealed interface TagAspectEvent extends com.hivemq.protocols.v2.fsm.FSMEv
                 TagAspectEvent.PollIntervalElapsed,
                 TagAspectEvent.ValueReceived,
                 TagAspectEvent.NodeFailed,
-                TagAspectEvent.SubscriptionRetryElapsed {
+                TagAspectEvent.SubscriptionRetryElapsed,
+                TagAspectEvent.WriteRequested,
+                TagAspectEvent.WriteSucceeded,
+                TagAspectEvent.WriteFailed {
 
     /**
      * The node verified successfully (design §7.2).
@@ -88,4 +91,27 @@ public sealed interface TagAspectEvent extends com.hivemq.protocols.v2.fsm.FSMEv
      * handler.
      */
     record SubscriptionRetryElapsed() implements TagAspectEvent {}
+
+    /**
+     * A southbound write arrived for the tag — request the write (design §7.5). Consumed only by the write
+     * aspect; the read aspect's table ignores it. The carried value is the reused v1 value to write.
+     *
+     * @param value the reused v1 value to write.
+     */
+    record WriteRequested(@NotNull DataPoint value) implements TagAspectEvent {}
+
+    /**
+     * The protocol adapter acknowledged the in-flight write successfully (design §7.5). Consumed only by the
+     * write aspect.
+     */
+    record WriteSucceeded() implements TagAspectEvent {}
+
+    /**
+     * The protocol adapter reported the in-flight write as failed (design §7.5) — logged and counted, the
+     * aspect returns to {@code WAITING_FOR_WRITE_REQUEST} without flapping to {@code ERROR}. Consumed only by the
+     * write aspect.
+     *
+     * @param reason a human-readable description of the failure.
+     */
+    record WriteFailed(@NotNull String reason) implements TagAspectEvent {}
 }

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/tag/TagAspectPreOperatingTransitions.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/tag/TagAspectPreOperatingTransitions.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.protocols.v2.tag;
+
+import com.hivemq.protocols.v2.fsm.FSMTransitionTable;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * The five shared pre-operating transition rows (design §7.2), built <b>once</b> and reused by every aspect
+ * variant — the polled and subscribed read tables ({@link TagAspectReadTransitions}) and the write table
+ * ({@link TagAspectWriteTransitions}). The rows are parameterized by the variant's pre-operating state constants
+ * and by the role-specific "verified" entry reached through {@link TagAspectVerifying#enterVerified()}, so engine
+ * reuse is achieved without a shared state enum (the {@code FSM} still has exactly one state type per variant).
+ * <p>
+ * The rows act through the {@link TagAspectVerifying} context — the small contract both aspect classes implement —
+ * so a {@code ContextType} of {@link TagAspectRead} or {@link TagAspectWrite} both satisfy it. Goal and
+ * adapter-readiness changes never reach these rows; they are applied directly by the aspect (design §7.1, §7.2).
+ */
+final class TagAspectPreOperatingTransitions {
+
+    private TagAspectPreOperatingTransitions() {}
+
+    /**
+     * Add the five shared pre-operating rows to {@code builder}, parameterized by the variant's "verified" target —
+     * the state the aspect begins operating in. Success enters that state through
+     * {@link TagAspectVerifying#enterVerified()}, which performs the role-specific kickoff.
+     *
+     * @param builder                     the table builder to add the rows to.
+     * @param waitingForVerification       the variant's verifying state.
+     * @param waitingForVerificationRetry  the variant's verification-retry state.
+     * @param errorPermanent               the variant's permanent-verification-failure state.
+     * @param <ContextType>               the aspect context the rows act through.
+     */
+    static <ContextType extends TagAspectVerifying> void addPreOperatingRows(
+            final @NotNull FSMTransitionTable.Builder<TagAspectState, TagAspectEvent, ContextType> builder,
+            final @NotNull TagAspectState waitingForVerification,
+            final @NotNull TagAspectState waitingForVerificationRetry,
+            final @NotNull TagAspectState errorPermanent) {
+        builder.on(waitingForVerification, TagAspectEvent.VerifySucceeded.class)
+                .then((current, event, aspect) -> aspect.enterVerified());
+        builder.on(waitingForVerification, TagAspectEvent.VerifyTransientlyFailed.class)
+                .then((current, event, aspect) -> {
+                    aspect.onTransientVerificationFailure(reasonOf(event));
+                    return waitingForVerificationRetry;
+                });
+        builder.on(waitingForVerification, TagAspectEvent.VerifyPermanentlyFailed.class)
+                .then((current, event, aspect) -> {
+                    aspect.onPermanentVerificationFailure(reasonOf(event));
+                    return errorPermanent;
+                });
+        builder.on(waitingForVerificationRetry, TagAspectEvent.VerificationRetryElapsed.class)
+                .then((current, event, aspect) -> {
+                    aspect.requestVerification();
+                    return waitingForVerification;
+                });
+    }
+
+    /**
+     * @param event a failure-carrying event.
+     * @return the event's failure reason, or a generic fallback for an event that carries none.
+     */
+    static @NotNull String reasonOf(final @NotNull TagAspectEvent event) {
+        if (event instanceof final TagAspectEvent.VerifyTransientlyFailed transientlyFailed) {
+            return transientlyFailed.reason();
+        }
+        if (event instanceof final TagAspectEvent.VerifyPermanentlyFailed permanent) {
+            return permanent.reason();
+        }
+        if (event instanceof final TagAspectEvent.NodeFailed failed) {
+            return failed.reason();
+        }
+        if (event instanceof final TagAspectEvent.WriteFailed writeFailed) {
+            return writeFailed.reason();
+        }
+        return "failure";
+    }
+}

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/tag/TagAspectReadTransitions.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/tag/TagAspectReadTransitions.java
@@ -22,9 +22,10 @@ import org.jetbrains.annotations.NotNull;
 /**
  * The read-aspect transition tables (design §7.3, §7.4) — direct encodings of the polled and subscribed state
  * diagrams. The five shared pre-operating rows (verification success / transient failure / permanent failure /
- * verification retry) are built once by {@link #addPreOperatingRows} and parameterized by each variant's state
- * constants, so engine reuse is achieved without a shared state enum (design §7.2). The role-specific rows — the
- * poll cycle and the subscription cycle — are added per variant.
+ * verification retry) are built once by {@link TagAspectPreOperatingTransitions} — the same builder the write
+ * table uses — parameterized by each variant's state constants, so engine reuse is achieved without a shared
+ * state enum (design §7.2). The role-specific rows — the poll cycle and the subscription cycle — are added per
+ * variant.
  * <p>
  * Each table is built once and shared by every aspect of that variant; an action acts through the
  * {@link TagAspectRead} passed as the machine context. Goal and adapter-readiness changes never reach these tables —
@@ -58,7 +59,7 @@ public final class TagAspectReadTransitions {
     private static @NotNull FSMTransitionTable<TagAspectState, TagAspectEvent, TagAspectRead> buildPolledTable() {
         final FSMTransitionTable.Builder<TagAspectState, TagAspectEvent, TagAspectRead> builder =
                 FSMTransitionTable.builder();
-        addPreOperatingRows(
+        TagAspectPreOperatingTransitions.addPreOperatingRows(
                 builder,
                 TagAspectReadPolledState.WAITING_FOR_VERIFICATION,
                 TagAspectReadPolledState.WAITING_FOR_VERIFICATION_RETRY,
@@ -79,7 +80,7 @@ public final class TagAspectReadTransitions {
                 // A poll failed: count it, schedule the next poll. The next scheduled poll IS the retry (§7.3).
                 .on(TagAspectReadPolledState.WAITING_FOR_POLL_DATAPOINT, TagAspectEvent.NodeFailed.class)
                 .then((current, event, aspect) -> {
-                    aspect.onPollFailure(reasonOf(event));
+                    aspect.onPollFailure(TagAspectPreOperatingTransitions.reasonOf(event));
                     return TagAspectReadPolledState.WAITING_FOR_POLL_INTERVAL;
                 })
                 .unmatched((current, event, aspect) -> {
@@ -94,7 +95,7 @@ public final class TagAspectReadTransitions {
                 event instanceof final TagAspectEvent.NodeFailed failed && failed.spontaneous();
         final FSMTransitionTable.Builder<TagAspectState, TagAspectEvent, TagAspectRead> builder =
                 FSMTransitionTable.builder();
-        addPreOperatingRows(
+        TagAspectPreOperatingTransitions.addPreOperatingRows(
                 builder,
                 TagAspectReadSubscribedState.WAITING_FOR_VERIFICATION,
                 TagAspectReadSubscribedState.WAITING_FOR_VERIFICATION_RETRY,
@@ -109,7 +110,7 @@ public final class TagAspectReadTransitions {
                 // The add-subscription request failed: back off and re-add (command-response loss, §7.4).
                 .on(TagAspectReadSubscribedState.WAITING_FOR_SUBSCRIPTION, TagAspectEvent.NodeFailed.class)
                 .then((current, event, aspect) -> {
-                    aspect.onSubscriptionFailure(reasonOf(event));
+                    aspect.onSubscriptionFailure(TagAspectPreOperatingTransitions.reasonOf(event));
                     return TagAspectReadSubscribedState.WAITING_FOR_SUBSCRIPTION_RETRY;
                 })
                 // Subsequent pushed values keep the subscription operating.
@@ -119,13 +120,13 @@ public final class TagAspectReadTransitions {
                 .on(TagAspectReadSubscribedState.SUBSCRIBED, TagAspectEvent.NodeFailed.class)
                 .when(spontaneous)
                 .then((current, event, aspect) -> {
-                    aspect.onSpontaneousSubscriptionLoss(reasonOf(event));
+                    aspect.onSpontaneousSubscriptionLoss(TagAspectPreOperatingTransitions.reasonOf(event));
                     return TagAspectReadSubscribedState.WAITING_FOR_VERIFICATION;
                 })
                 // A command-response loss backs off and re-adds (design §7.4).
                 .on(TagAspectReadSubscribedState.SUBSCRIBED, TagAspectEvent.NodeFailed.class)
                 .otherwise((current, event, aspect) -> {
-                    aspect.onSubscriptionFailure(reasonOf(event));
+                    aspect.onSubscriptionFailure(TagAspectPreOperatingTransitions.reasonOf(event));
                     return TagAspectReadSubscribedState.WAITING_FOR_SUBSCRIPTION_RETRY;
                 })
                 // The backoff elapsed: re-add the subscription (design §7.4).
@@ -141,47 +142,5 @@ public final class TagAspectReadTransitions {
                     return current;
                 })
                 .build();
-    }
-
-    /**
-     * Add the five shared pre-operating rows (design §7.2), parameterized by the variant's "verified" target — the
-     * state the aspect begins operating in. Success enters that state through {@link TagAspectRead#enterVerified()},
-     * which performs the role-specific kickoff (schedule a poll or request a subscription).
-     */
-    private static void addPreOperatingRows(
-            final @NotNull FSMTransitionTable.Builder<TagAspectState, TagAspectEvent, TagAspectRead> builder,
-            final @NotNull TagAspectState waitingForVerification,
-            final @NotNull TagAspectState waitingForVerificationRetry,
-            final @NotNull TagAspectState errorPermanent) {
-        builder.on(waitingForVerification, TagAspectEvent.VerifySucceeded.class)
-                .then((current, event, aspect) -> aspect.enterVerified());
-        builder.on(waitingForVerification, TagAspectEvent.VerifyTransientlyFailed.class)
-                .then((current, event, aspect) -> {
-                    aspect.onTransientVerificationFailure(reasonOf(event));
-                    return waitingForVerificationRetry;
-                });
-        builder.on(waitingForVerification, TagAspectEvent.VerifyPermanentlyFailed.class)
-                .then((current, event, aspect) -> {
-                    aspect.onPermanentVerificationFailure(reasonOf(event));
-                    return errorPermanent;
-                });
-        builder.on(waitingForVerificationRetry, TagAspectEvent.VerificationRetryElapsed.class)
-                .then((current, event, aspect) -> {
-                    aspect.requestVerification();
-                    return waitingForVerification;
-                });
-    }
-
-    private static @NotNull String reasonOf(final @NotNull TagAspectEvent event) {
-        if (event instanceof final TagAspectEvent.VerifyTransientlyFailed transientlyFailed) {
-            return transientlyFailed.reason();
-        }
-        if (event instanceof final TagAspectEvent.VerifyPermanentlyFailed permanent) {
-            return permanent.reason();
-        }
-        if (event instanceof final TagAspectEvent.NodeFailed failed) {
-            return failed.reason();
-        }
-        return "failure";
     }
 }

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/tag/TagAspectRuntimeCoordinator.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/tag/TagAspectRuntimeCoordinator.java
@@ -129,9 +129,26 @@ public final class TagAspectRuntimeCoordinator implements TagAspectCoordinator {
 
     @Override
     public void onAdapterVerifying() {
+        // Move active aspects into verification, then issue the nodes they need as ONE connect-verification batch
+        // through the shared authority — a read-and-write tag therefore yields a single verifyBatch entry (§6.3).
+        final List<Node> toVerify = new ArrayList<>();
         for (final TagRuntime tagRuntime : tagRuntimes) {
             tagRuntime.onAdapterVerifying();
+            if (tagRuntime.needsConnectVerification()) {
+                toVerify.add(tagRuntime.node());
+            }
         }
+        runtime().sharedNodeVerification().beginConnectVerification(toVerify);
+    }
+
+    @Override
+    public boolean allReported() {
+        return runtime().sharedNodeVerification().allReported();
+    }
+
+    @Override
+    public void resetVerificationGate() {
+        runtime().sharedNodeVerification().reset();
     }
 
     @Override
@@ -143,6 +160,7 @@ public final class TagAspectRuntimeCoordinator implements TagAspectCoordinator {
 
     @Override
     public void onAdapterUnavailable() {
+        runtime().sharedNodeVerification().reset();
         for (final TagRuntime tagRuntime : tagRuntimes) {
             tagRuntime.onAdapterUnavailable();
         }
@@ -172,8 +190,19 @@ public final class TagAspectRuntimeCoordinator implements TagAspectCoordinator {
     }
 
     @Override
+    public void submitWrite(final @NotNull Node node, final @NotNull DataPoint value) {
+        final TagRuntime tagRuntime = findTagRuntime(node);
+        if (tagRuntime != null) {
+            tagRuntime.submitWrite(value);
+        }
+    }
+
+    @Override
     public void routeWriteResult(final @NotNull Node node, final boolean success, final @Nullable String reason) {
-        // The write aspect joins in a later task; nothing consumes write acknowledgments yet.
+        final TagRuntime tagRuntime = findTagRuntime(node);
+        if (tagRuntime != null) {
+            tagRuntime.onWriteResult(success, reason);
+        }
     }
 
     // ── configuration transitions (design §8.2) ─────────────────────────────────────────────────────────────────
@@ -268,6 +297,7 @@ public final class TagAspectRuntimeCoordinator implements TagAspectCoordinator {
                     activation.getOrDefault(tagName, TagAspectActivationPreference.defaults());
             tagRuntime.applyActivation(
                     goal.northboundActivated(),
+                    goal.southboundActivated(),
                     preference.readActivated(),
                     preference.writeActivated(),
                     readUsedTagNames.contains(tagName),

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/tag/TagAspectSnapshotOnlyCoordinator.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/tag/TagAspectSnapshotOnlyCoordinator.java
@@ -27,19 +27,23 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /**
  * The minimal {@link TagAspectCoordinator} stand-in: it holds the tag set, activation preferences, and
- * {@code used} derivation, and publishes a minimal per-tag snapshot, but runs no aspect machines. Every routing
- * and lifecycle hook is a no-op. The aspect state names it reports are always {@code DEACTIVATED}, which is
- * honest: with no aspect machines running, every aspect is at rest.
+ * {@code used} derivation, and publishes a minimal per-tag snapshot, but runs <b>no</b> aspect machines. The
+ * aspect state names it reports are always {@code DEACTIVATED} and every per-aspect flag is {@code false}, which
+ * is honest: with no aspect machines running, every aspect is at rest.
  * <p>
- * It lets the adapter machine and snapshot publication be exercised on their own (the adapter-machine tests use
- * it); {@link TagAspectRuntimeCoordinator} is the running implementation that drives real aspect machines, with no
- * change to the wrapper.
+ * It does still drive the adapter's connect-time verification gate (design §6.3) so the adapter machine and
+ * snapshot publication can be exercised on their own (the adapter-machine tests use it): on connect it verifies
+ * <b>all</b> configured nodes through a {@link SharedNodeVerification} with a no-op fan-out (there are no aspects
+ * to route results to), and {@link #allReported()} gates {@code CONNECTED}. It must be bound to the adapter's
+ * verify seam through {@link #bindVerifier(NodeVerifier)} before the first connect. {@link TagAspectRuntimeCoordinator}
+ * is the running implementation that drives real aspect machines, with no change to the wrapper.
  */
 public final class TagAspectSnapshotOnlyCoordinator implements TagAspectCoordinator {
 
@@ -49,6 +53,7 @@ public final class TagAspectSnapshotOnlyCoordinator implements TagAspectCoordina
     private @NotNull Map<String, TagAspectActivationPreference> activation;
     private @NotNull Set<String> readUsedTagNames;
     private @NotNull Set<String> writeUsedTagNames;
+    private @Nullable SharedNodeVerification verification;
 
     /**
      * @param nodes             the initial node/tag pairs.
@@ -67,24 +72,51 @@ public final class TagAspectSnapshotOnlyCoordinator implements TagAspectCoordina
         this.writeUsedTagNames = new HashSet<>(writeUsedTagNames);
     }
 
+    /**
+     * Bind the adapter's verify seam so the connect gate can issue {@code verifyBatch} (design §6.3). Called once,
+     * before the first connect — mirroring {@link TagAspectRuntimeCoordinator#bindRuntime}. The fan-out is a no-op
+     * because there are no aspect machines; the verification authority is used purely for the gate count.
+     *
+     * @param nodeVerifier the adapter's {@code verifyBatch} seam.
+     */
+    public void bindVerifier(final @NotNull NodeVerifier nodeVerifier) {
+        this.verification = new SharedNodeVerification(nodeVerifier, node -> null);
+    }
+
     @Override
     public void onAdapterVerifying() {
-        // No aspect machines yet; nothing to verify.
+        // No aspect machines: verify every configured node so the adapter machine's verification flow is exercised.
+        final List<Node> toVerify = new ArrayList<>(nodes.size());
+        for (final NodeTagPair pair : nodes) {
+            toVerify.add(pair.node());
+        }
+        verification().beginConnectVerification(toVerify);
+    }
+
+    @Override
+    public boolean allReported() {
+        return verification().allReported();
+    }
+
+    @Override
+    public void resetVerificationGate() {
+        verification().reset();
     }
 
     @Override
     public void onAdapterReady() {
-        // No aspect machines yet; nothing to start.
+        // No aspect machines; nothing to start.
     }
 
     @Override
     public void onAdapterUnavailable() {
-        // No aspect machines yet; nothing to suspend.
+        verification().reset();
     }
 
     @Override
     public void routeVerifyResult(final @NotNull Node node, final @NotNull VerifyOutcome outcome) {
-        // No aspect machines yet; the adapter gate's counting is handled by the wrapper.
+        // No aspects to fan out to; decrement the connect gate so allReported() advances the adapter to CONNECTED.
+        verification().onVerifyResult(node, outcome);
     }
 
     @Override
@@ -98,8 +130,13 @@ public final class TagAspectSnapshotOnlyCoordinator implements TagAspectCoordina
     }
 
     @Override
+    public void submitWrite(final @NotNull Node node, final @NotNull DataPoint value) {
+        // No write aspect; the write is absorbed.
+    }
+
+    @Override
     public void routeWriteResult(final @NotNull Node node, final boolean success, final @Nullable String reason) {
-        // No write aspect yet; the acknowledgment is absorbed.
+        // No write aspect; the acknowledgment is absorbed.
     }
 
     @Override
@@ -141,10 +178,21 @@ public final class TagAspectSnapshotOnlyCoordinator implements TagAspectCoordina
                     writeUsedTagNames.contains(tagName),
                     AT_REST_ASPECT_STATE,
                     AT_REST_ASPECT_STATE,
+                    false, // readAspectGoalActive — no aspect machine, so never active
+                    false, // writeAspectGoalActive
+                    false, // readAspectOperating
+                    false, // writeAspectOperating
+                    false, // readAspectPermanentFailure
+                    false, // writeAspectPermanentFailure
                     0,
                     null,
                     0L));
         }
         return snapshots;
+    }
+
+    private @NotNull SharedNodeVerification verification() {
+        return Objects.requireNonNull(
+                verification, "bindVerifier() must be called before the snapshot-only coordinator is used");
     }
 }

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/tag/TagAspectVerifying.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/tag/TagAspectVerifying.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.protocols.v2.tag;
+
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * The verification-lifecycle actions every tag aspect exposes (design §7.2) — the seam the <b>shared pre-operating
+ * transition rows</b> act through. Because both the read aspect ({@link TagAspectRead}) and the write aspect
+ * ({@link TagAspectWrite}) move through the same five pre-operating states (verifying, retrying, permanently
+ * failed), those rows are built <b>once</b> by {@link TagAspectPreOperatingTransitions} and parameterized by each
+ * variant's state constants and its role-specific "verified" entry — engine reuse without a shared state enum.
+ * <p>
+ * Every method runs on the wrapper's single dispatch thread.
+ */
+interface TagAspectVerifying {
+
+    /**
+     * Verification succeeded: perform the role-specific kickoff (a read aspect schedules its first poll or
+     * requests its subscription; a write aspect simply rests ready for writes) and return the state in which the
+     * aspect begins operating.
+     *
+     * @return the operating-entry state for this aspect variant.
+     */
+    @NotNull
+    TagAspectState enterVerified();
+
+    /**
+     * (Re-)verify the node through the shared verification authority — the action the verification-retry row runs.
+     */
+    void requestVerification();
+
+    /**
+     * A transient verification failure: count it and schedule a verification retry on the actor's timer queue.
+     *
+     * @param reason a human-readable description of the failure.
+     */
+    void onTransientVerificationFailure(@NotNull String reason);
+
+    /**
+     * A permanent verification failure: count it; the aspect is suspended until a user-commanded tag retry
+     * (design §7.6).
+     *
+     * @param reason a human-readable description of the failure.
+     */
+    void onPermanentVerificationFailure(@NotNull String reason);
+}

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/tag/TagAspectWrite.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/tag/TagAspectWrite.java
@@ -17,6 +17,7 @@ package com.hivemq.protocols.v2.tag;
 
 import com.hivemq.adapter.sdk.api.data.DataPoint;
 import com.hivemq.adapter.sdk.api.v2.model.VerifyOutcome;
+import com.hivemq.adapter.sdk.api.v2.model.WriteEntry;
 import com.hivemq.adapter.sdk.api.v2.node.Node;
 import com.hivemq.adapter.sdk.api.v2.node.Tag;
 import com.hivemq.protocols.v2.fsm.FSM;
@@ -33,42 +34,36 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * The read half of a tag's behavior (design §7.3, §7.4) — one of the two independent aspects every tag has. A
- * read aspect is a {@link FSM} over an {@link TagAspectState} enum: <b>polled</b> (poll-interval cadence) when the
- * tag is not subscribable, <b>subscribed</b> (push) when it is. Both share the five pre-operating states; their
- * tables are built by {@link TagAspectReadTransitions}, the shared rows by one builder.
+ * The write half of a tag's behavior (design §7.5) — one of the two independent aspects every tag has. A write
+ * aspect is a {@link FSM} over {@link TagAspectWriteState}: it shares the five pre-operating states with the read
+ * aspect (built by {@link TagAspectPreOperatingTransitions}, the same shared rows) and adds the
+ * {@code WAITING_FOR_WRITE_REQUEST} ⇄ {@code WAITING_FOR_WRITE_RESULT} write cycle.
  * <p>
- * The aspect lives inside the wrapper actor and runs only on its single dispatch thread. It owns no thread: it
- * requests work by appending to the shared {@link BatchCollector}, schedules its own poll / verification-retry /
- * subscription-retry timers on the actor's single {@link PriorityTimerQueue} (design §5.5), observes the events
- * the wrapper routes to it, and re-verifies through the shared {@link SharedNodeVerification}.
+ * Like the read aspect it lives inside the wrapper actor and runs only on its single dispatch thread; it owns no
+ * thread. It requests writes by appending to the shared {@link BatchCollector}, schedules its verification-retry
+ * timer on the actor's single {@link PriorityTimerQueue}, observes the events the wrapper routes to it, and
+ * re-verifies through the shared {@link SharedNodeVerification}.
  * <p>
- * Two kinds of input drive it, mirroring the adapter machine:
+ * Two kinds of input drive it, mirroring the read aspect:
  * <ul>
- * <li><b>events</b> ({@link TagAspectEvent}) run through the transition table — verification outcomes, values,
- * per-node failures, and the aspect's own timer expiries;</li>
- * <li><b>goal and adapter-readiness changes</b> bypass the table (like the adapter machine's goal commands): the
- * three-condition goal ({@link TagAspectGoal}) and the {@code DEACTIVATED} ↔ operating coupling to the adapter's
- * connection are applied directly, never through the table, so they can never trigger a defensive transition.</li>
+ * <li><b>events</b> ({@link TagAspectEvent}) run through the transition table — verification outcomes, the
+ * verification-retry timer expiry, and the southbound write request and its acknowledgment;</li>
+ * <li><b>goal and adapter-readiness changes</b> bypass the table: the three-condition goal ({@link TagAspectGoal})
+ * and the {@code DEACTIVATED} ↔ operating coupling to the adapter's connection are applied directly.</li>
  * </ul>
+ * <b>One write is in flight at a time</b> (design §7.5): a write arriving while the aspect is not resting at
+ * {@code WAITING_FOR_WRITE_REQUEST} is dropped by the table's lenient {@code unmatched} slot — multi-write
+ * ordering and back-pressure are a reserved extension point (design §14).
  */
-public final class TagAspectRead implements TagAspectVerifying {
+public final class TagAspectWrite implements TagAspectVerifying {
 
-    private static final @NotNull Logger log = LoggerFactory.getLogger(TagAspectRead.class);
+    private static final @NotNull Logger log = LoggerFactory.getLogger(TagAspectWrite.class);
 
     /**
      * The failure count past which a tag's failures are logged at {@code ERROR} rather than {@code WARN} — a few
-     * hiccups are routine, sustained failures are not (design §7.3).
+     * hiccups are routine, sustained failures are not (mirrors the read aspect, design §7.3).
      */
     private static final int SUSTAINED_FAILURE_THRESHOLD = 5;
-
-    /**
-     * The two read-aspect variants — which transition table and operating cycle the aspect runs.
-     */
-    private enum Variant {
-        POLLED,
-        SUBSCRIBED
-    }
 
     /**
      * The adapter's connection phase as the aspect last saw it — decides whether activating verifies now or waits.
@@ -82,24 +77,15 @@ public final class TagAspectRead implements TagAspectVerifying {
     private final @NotNull String adapterId;
     private final @NotNull Node node;
     private final @NotNull Tag tag;
-    private final @NotNull Variant variant;
 
     private final @NotNull Clock clock;
     private final @NotNull PriorityTimerQueue timers;
     private final @NotNull BatchCollector batches;
     private final @NotNull NevskyMetrics metrics;
     private final @NotNull SharedNodeVerification sharedNodeVerification;
-    private final long pollIntervalMillis;
     private final @NotNull Backoff verificationRetryBackoff;
-    private final @NotNull Backoff subscriptionRetryBackoff;
 
-    // The variant's shared pre-operating constants and the state operation begins in (poll interval / subscribe).
-    private final @NotNull TagAspectState deactivated;
-    private final @NotNull TagAspectState waitingForAdapterReady;
-    private final @NotNull TagAspectState waitingForVerification;
-    private final @NotNull TagAspectState verifiedEntry;
-
-    private final @NotNull FSM<TagAspectState, TagAspectEvent, TagAspectRead> machine;
+    private final @NotNull FSM<TagAspectState, TagAspectEvent, TagAspectWrite> machine;
 
     private @NotNull TagAspectGoal goal = TagAspectGoal.inactive();
     private @NotNull AdapterPhase adapterPhase = AdapterPhase.DISCONNECTED;
@@ -109,18 +95,17 @@ public final class TagAspectRead implements TagAspectVerifying {
     private @Nullable TimerHandle activeTimer;
 
     /**
-     * @param adapterId               the owning adapter's id.
-     * @param node                    the protocol-specific node.
-     * @param tag                     Edge's half of the pair; its {@code subscribable} flag selects the variant.
-     * @param clock                   the actor clock the timers are scheduled against.
-     * @param timers                  the actor's single timer queue.
-     * @param batches                 the actor's batch collector — where poll / subscription requests are posted.
-     * @param metrics                 the per-adapter metrics (per-tag failure counters).
+     * @param adapterId              the owning adapter's id.
+     * @param node                   the protocol-specific node.
+     * @param tag                    Edge's half of the pair.
+     * @param clock                  the actor clock the timers are scheduled against.
+     * @param timers                 the actor's single timer queue.
+     * @param batches                the actor's batch collector — where write requests are posted.
+     * @param metrics                the per-adapter metrics (per-tag failure counters).
      * @param sharedNodeVerification the shared verification authority for re-verifications.
-     * @param pollIntervalMillis      the poll cadence for a polled aspect, in milliseconds.
-     * @param retryPolicy             the backoff policy for verification and subscription retries.
+     * @param retryPolicy            the backoff policy for verification retries.
      */
-    public TagAspectRead(
+    public TagAspectWrite(
             final @NotNull String adapterId,
             final @NotNull Node node,
             final @NotNull Tag tag,
@@ -129,41 +114,25 @@ public final class TagAspectRead implements TagAspectVerifying {
             final @NotNull BatchCollector batches,
             final @NotNull NevskyMetrics metrics,
             final @NotNull SharedNodeVerification sharedNodeVerification,
-            final long pollIntervalMillis,
             final @NotNull RetryPolicy retryPolicy) {
         this.adapterId = adapterId;
         this.node = node;
         this.tag = tag;
-        this.variant = tag.subscribable() ? Variant.SUBSCRIBED : Variant.POLLED;
         this.clock = clock;
         this.timers = timers;
         this.batches = batches;
         this.metrics = metrics;
         this.sharedNodeVerification = sharedNodeVerification;
-        this.pollIntervalMillis = pollIntervalMillis;
         this.verificationRetryBackoff = new Backoff(retryPolicy);
-        this.subscriptionRetryBackoff = new Backoff(retryPolicy);
-        if (variant == Variant.SUBSCRIBED) {
-            this.deactivated = TagAspectReadSubscribedState.DEACTIVATED;
-            this.waitingForAdapterReady = TagAspectReadSubscribedState.WAITING_FOR_ADAPTER_READY;
-            this.waitingForVerification = TagAspectReadSubscribedState.WAITING_FOR_VERIFICATION;
-            this.verifiedEntry = TagAspectReadSubscribedState.WAITING_FOR_SUBSCRIPTION;
-            this.machine = new FSM<>(deactivated, TagAspectReadTransitions.subscribedTable(), this);
-        } else {
-            this.deactivated = TagAspectReadPolledState.DEACTIVATED;
-            this.waitingForAdapterReady = TagAspectReadPolledState.WAITING_FOR_ADAPTER_READY;
-            this.waitingForVerification = TagAspectReadPolledState.WAITING_FOR_VERIFICATION;
-            this.verifiedEntry = TagAspectReadPolledState.WAITING_FOR_POLL_INTERVAL;
-            this.machine = new FSM<>(deactivated, TagAspectReadTransitions.polledTable(), this);
-        }
+        this.machine = new FSM<>(TagAspectWriteState.DEACTIVATED, TagAspectWriteTransitions.table(), this);
     }
 
     // ── goal and adapter-readiness coupling (bypass the table, design §7.1, §7.2) ───────────────────────────────
 
     /**
-     * Apply a new aspect goal (the three-condition rule, design §7.1). When the goal becomes active the aspect
-     * leaves {@code DEACTIVATED}; when it becomes inactive the aspect returns to {@code DEACTIVATED}, tearing down
-     * any subscription and cancelling timers — never reconnecting the adapter (design §8.2).
+     * Apply a new aspect goal (the three-condition rule, design §7.1; for a write aspect the direction is
+     * southbound). When the goal becomes active the aspect leaves {@code DEACTIVATED}; when it becomes inactive it
+     * returns to {@code DEACTIVATED}, cancelling any timer — never reconnecting the adapter (design §8.2).
      *
      * @param newGoal the recomputed goal.
      */
@@ -183,11 +152,11 @@ public final class TagAspectRead implements TagAspectVerifying {
 
     private void activate() {
         switch (adapterPhase) {
-            case DISCONNECTED -> moveTo(waitingForAdapterReady);
+            case DISCONNECTED -> moveTo(TagAspectWriteState.WAITING_FOR_ADAPTER_READY);
             case VERIFYING, READY -> {
                 // Activated while the adapter is up: this node missed the connect-time gate verification, so ask
                 // for a fresh one of its own (design §7.6) — no reconnect.
-                moveTo(waitingForVerification);
+                moveTo(TagAspectWriteState.WAITING_FOR_VERIFICATION);
                 requestVerification();
             }
         }
@@ -197,11 +166,8 @@ public final class TagAspectRead implements TagAspectVerifying {
         if (machine.state().isDeactivated()) {
             return;
         }
-        if (variant == Variant.SUBSCRIBED && adapterPhase == AdapterPhase.READY && holdsSubscription()) {
-            batches.removeSubscription(node);
-        }
         cancelActiveTimer();
-        moveTo(deactivated);
+        moveTo(TagAspectWriteState.DEACTIVATED);
     }
 
     /**
@@ -210,19 +176,19 @@ public final class TagAspectRead implements TagAspectVerifying {
      */
     public void onAdapterVerifying() {
         adapterPhase = AdapterPhase.VERIFYING;
-        if (machine.state() == waitingForAdapterReady) {
-            moveTo(waitingForVerification);
+        if (machine.state() == TagAspectWriteState.WAITING_FOR_ADAPTER_READY) {
+            moveTo(TagAspectWriteState.WAITING_FOR_VERIFICATION);
         }
     }
 
     /**
      * The adapter reached {@code CONNECTED} (design §7.2). When verification was skipped the aspect is still
-     * waiting for the adapter — treat the connection as verified and begin operating; otherwise it has already
-     * advanced through verification and nothing happens here.
+     * waiting for the adapter — treat the connection as verified and rest ready for writes; otherwise it has
+     * already advanced through verification and nothing happens here.
      */
     public void onAdapterReady() {
         adapterPhase = AdapterPhase.READY;
-        if (machine.state() == waitingForAdapterReady) {
+        if (machine.state() == TagAspectWriteState.WAITING_FOR_ADAPTER_READY) {
             moveTo(enterVerified());
         }
     }
@@ -238,8 +204,7 @@ public final class TagAspectRead implements TagAspectVerifying {
         if (!current.isDeactivated() && !current.isPermanentVerificationFailure()) {
             cancelActiveTimer();
             verificationRetryBackoff.reset();
-            subscriptionRetryBackoff.reset();
-            moveTo(waitingForAdapterReady);
+            moveTo(TagAspectWriteState.WAITING_FOR_ADAPTER_READY);
         }
     }
 
@@ -256,10 +221,10 @@ public final class TagAspectRead implements TagAspectVerifying {
         lastFailureReason = null;
         verificationRetryBackoff.reset();
         if (adapterPhase == AdapterPhase.READY) {
-            moveTo(waitingForVerification);
+            moveTo(TagAspectWriteState.WAITING_FOR_VERIFICATION);
             requestVerification();
         } else {
-            moveTo(waitingForAdapterReady);
+            moveTo(TagAspectWriteState.WAITING_FOR_ADAPTER_READY);
         }
     }
 
@@ -281,51 +246,38 @@ public final class TagAspectRead implements TagAspectVerifying {
     }
 
     /**
-     * Feed a received value — a poll response or a subscription push (design §7.3, §7.4).
+     * A southbound write arrived for the tag (design §7.5). Drives the write cycle when the aspect is resting at
+     * {@code WAITING_FOR_WRITE_REQUEST}; in any other state the table's {@code unmatched} slot drops it (one write
+     * in flight at a time).
      *
-     * @param value the reused v1 value.
+     * @param value the reused v1 value to write.
      */
-    public void onValue(final @NotNull DataPoint value) {
-        dispatch(new TagAspectEvent.ValueReceived(value));
+    public void onWriteRequested(final @NotNull DataPoint value) {
+        dispatch(new TagAspectEvent.WriteRequested(value));
     }
 
     /**
-     * Feed a per-node failure (design §7.3, §7.4).
+     * The adapter acknowledged the in-flight write (design §7.5).
      *
-     * @param reason      a human-readable description.
-     * @param spontaneous whether the failure arrived outside a command-response exchange.
+     * @param success whether the write succeeded.
+     * @param reason  the failure reason, or {@code null} on success.
      */
-    public void onNodeError(final @NotNull String reason, final boolean spontaneous) {
-        dispatch(new TagAspectEvent.NodeFailed(reason, spontaneous));
+    public void onWriteResult(final boolean success, final @Nullable String reason) {
+        if (success) {
+            dispatch(new TagAspectEvent.WriteSucceeded());
+        } else {
+            dispatch(new TagAspectEvent.WriteFailed(reason != null ? reason : "write failed"));
+        }
     }
 
-    // ── actions the transition table runs (package-private) ─────────────────────────────────────────────────────
+    // ── actions the transition table runs ───────────────────────────────────────────────────────────────────────
 
     @Override
     public @NotNull TagAspectState enterVerified() {
         verificationRetryBackoff.reset();
-        if (variant == Variant.SUBSCRIBED) {
-            batches.addSubscription(node);
-        } else {
-            scheduleNextPoll();
-        }
-        return verifiedEntry;
-    }
-
-    void requestPoll() {
-        batches.poll(node);
-    }
-
-    void scheduleNextPoll() {
-        scheduleTimer(pollIntervalMillis, () -> dispatch(new TagAspectEvent.PollIntervalElapsed()));
-    }
-
-    void requestAddSubscription() {
-        batches.addSubscription(node);
-    }
-
-    void confirmSubscription() {
-        subscriptionRetryBackoff.reset();
+        // The healthy resting goal state: ready to accept southbound writes. No kickoff work — unlike the read
+        // aspect there is no poll to schedule or subscription to request.
+        return TagAspectWriteState.WAITING_FOR_WRITE_REQUEST;
     }
 
     @Override
@@ -346,26 +298,17 @@ public final class TagAspectRead implements TagAspectVerifying {
         recordFailure(reason);
     }
 
-    void onPollFailure(final @NotNull String reason) {
-        recordFailure(reason);
-        scheduleNextPoll();
+    void requestWrite(final @NotNull DataPoint value) {
+        batches.write(new WriteEntry(node, value));
     }
 
-    void onSubscriptionFailure(final @NotNull String reason) {
+    void onWriteFailure(final @NotNull String reason) {
         recordFailure(reason);
-        scheduleTimer(
-                subscriptionRetryBackoff.nextDelayMillis(),
-                () -> dispatch(new TagAspectEvent.SubscriptionRetryElapsed()));
-    }
-
-    void onSpontaneousSubscriptionLoss(final @NotNull String reason) {
-        recordFailure(reason);
-        requestVerification();
     }
 
     void logUnexpectedEvent(final @NotNull TagAspectEvent event) {
         log.debug(
-                "Read aspect of tag '{}' on adapter '{}' ignored unexpected {} in {}",
+                "Write aspect of tag '{}' on adapter '{}' ignored unexpected {} in {}",
                 tag.name(),
                 adapterId,
                 event.getClass().getSimpleName(),
@@ -396,7 +339,8 @@ public final class TagAspectRead implements TagAspectVerifying {
     }
 
     /**
-     * @return whether the aspect is operating at its goal (producing values), per {@link TagAspectState#isOperating()}.
+     * @return whether the aspect is operating at its goal (ready for or performing a write), per
+     *         {@link TagAspectState#isOperating()}.
      */
     public boolean operating() {
         return machine.state().isOperating();
@@ -414,11 +358,11 @@ public final class TagAspectRead implements TagAspectVerifying {
      *         coordinator uses to select this node for the single connect verification batch.
      */
     public boolean awaitingVerification() {
-        return machine.state() == waitingForVerification;
+        return machine.state() == TagAspectWriteState.WAITING_FOR_VERIFICATION;
     }
 
     /**
-     * @return the cumulative failure count (poll / subscription / verification).
+     * @return the cumulative failure count (verification / write).
      */
     public int failureCount() {
         return failureCount;
@@ -455,13 +399,6 @@ public final class TagAspectRead implements TagAspectVerifying {
         }
     }
 
-    private boolean holdsSubscription() {
-        final TagAspectState current = machine.state();
-        return current == TagAspectReadSubscribedState.SUBSCRIBED
-                || current == TagAspectReadSubscribedState.WAITING_FOR_SUBSCRIPTION
-                || current == TagAspectReadSubscribedState.WAITING_FOR_SUBSCRIPTION_RETRY;
-    }
-
     private void scheduleTimer(final long delayMillis, final @NotNull Runnable onFire) {
         cancelActiveTimer();
         activeTimer = timers.schedule(clock.nowMillis() + delayMillis, onFire);
@@ -480,17 +417,17 @@ public final class TagAspectRead implements TagAspectVerifying {
         metrics.incrementTagFailure(tag.name());
         // Escalating severity: a first hiccup is routine, sustained failures are not (design §7.3).
         if (failureCount == 1) {
-            log.debug("Read aspect of tag '{}' on adapter '{}' failed: {}", tag.name(), adapterId, reason);
+            log.debug("Write aspect of tag '{}' on adapter '{}' failed: {}", tag.name(), adapterId, reason);
         } else if (failureCount < SUSTAINED_FAILURE_THRESHOLD) {
             log.warn(
-                    "Read aspect of tag '{}' on adapter '{}' failed ({} times): {}",
+                    "Write aspect of tag '{}' on adapter '{}' failed ({} times): {}",
                     tag.name(),
                     adapterId,
                     failureCount,
                     reason);
         } else {
             log.error(
-                    "Read aspect of tag '{}' on adapter '{}' has failed {} times: {}",
+                    "Write aspect of tag '{}' on adapter '{}' has failed {} times: {}",
                     tag.name(),
                     adapterId,
                     failureCount,

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/tag/TagAspectWriteState.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/tag/TagAspectWriteState.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.protocols.v2.tag;
+
+/**
+ * The states of a tag's <b>write</b> aspect (design §7.5): the five shared pre-operating states plus the two
+ * write-cycle states. {@link #WAITING_FOR_WRITE_REQUEST} is the healthy <b>goal</b> state — verified and ready to
+ * accept southbound writes; a write arriving there requests the write and moves to
+ * {@link #WAITING_FOR_WRITE_RESULT}, which returns to the request state on the acknowledgment (success or failure;
+ * a failure is logged and counted but does <b>not</b> flap the aspect to {@code ERROR}). One write is in flight at
+ * a time; multi-write ordering and back-pressure are a reserved extension point (design §7.5, §14).
+ */
+public enum TagAspectWriteState implements TagAspectState {
+
+    /**
+     * At rest: the aspect's goal is not active (the three-condition rule fails).
+     */
+    DEACTIVATED,
+
+    /**
+     * The goal is active but the adapter is not connected — waiting to verify on the next connection.
+     */
+    WAITING_FOR_ADAPTER_READY,
+
+    /**
+     * Verifying the node against the connected device.
+     */
+    WAITING_FOR_VERIFICATION,
+
+    /**
+     * A transient verification failure occurred; waiting for the retry timer before verifying again.
+     */
+    WAITING_FOR_VERIFICATION_RETRY,
+
+    /**
+     * Verification failed permanently; suspended until a user-commanded tag retry (design §7.6).
+     */
+    ERROR_PERMANENT_VERIFICATION_FAILURE,
+
+    /**
+     * Verified and operating: the resting goal state, ready to accept a southbound write.
+     */
+    WAITING_FOR_WRITE_REQUEST,
+
+    /**
+     * A write was requested; waiting for the adapter's write acknowledgment (still operating — a normal write
+     * round-trip does not flap the tag to {@code ERROR}, design §7.7).
+     */
+    WAITING_FOR_WRITE_RESULT;
+
+    @Override
+    public boolean isDeactivated() {
+        return this == DEACTIVATED;
+    }
+
+    @Override
+    public boolean isPermanentVerificationFailure() {
+        return this == ERROR_PERMANENT_VERIFICATION_FAILURE;
+    }
+
+    @Override
+    public boolean isOperating() {
+        return this == WAITING_FOR_WRITE_REQUEST || this == WAITING_FOR_WRITE_RESULT;
+    }
+}

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/tag/TagAspectWriteTransitions.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/tag/TagAspectWriteTransitions.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.protocols.v2.tag;
+
+import com.hivemq.protocols.v2.fsm.FSMTransitionTable;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * The write-aspect transition table (design §7.5) — a direct encoding of the write state diagram. The five shared
+ * pre-operating rows are built by {@link TagAspectPreOperatingTransitions} (the same builder the read tables use);
+ * the role-specific rows are the write cycle: a write arriving while the aspect rests at
+ * {@code WAITING_FOR_WRITE_REQUEST} requests it and moves to {@code WAITING_FOR_WRITE_RESULT}; the acknowledgment
+ * returns it to the request state (a failure is logged and counted but does <b>not</b> flap to {@code ERROR},
+ * design §7.7).
+ * <p>
+ * The table is built once and shared by every write aspect; an action acts through the {@link TagAspectWrite}
+ * passed as the machine context. Goal and adapter-readiness changes never reach it — they are applied directly by
+ * {@link TagAspectWrite} (design §7.1, §7.2). The mandatory {@code unmatched} slot is lenient: an unexpected event
+ * (a stale acknowledgment, or a second write while one is in flight) is logged and ignored, never a reset — this
+ * is what enforces the single-in-flight-write rule (design §7.5, §14).
+ */
+public final class TagAspectWriteTransitions {
+
+    private TagAspectWriteTransitions() {}
+
+    private static final @NotNull FSMTransitionTable<TagAspectState, TagAspectEvent, TagAspectWrite> TABLE =
+            buildTable();
+
+    /**
+     * @return the write-aspect transition table (design §7.5).
+     */
+    public static @NotNull FSMTransitionTable<TagAspectState, TagAspectEvent, TagAspectWrite> table() {
+        return TABLE;
+    }
+
+    private static @NotNull FSMTransitionTable<TagAspectState, TagAspectEvent, TagAspectWrite> buildTable() {
+        final FSMTransitionTable.Builder<TagAspectState, TagAspectEvent, TagAspectWrite> builder =
+                FSMTransitionTable.builder();
+        TagAspectPreOperatingTransitions.addPreOperatingRows(
+                builder,
+                TagAspectWriteState.WAITING_FOR_VERIFICATION,
+                TagAspectWriteState.WAITING_FOR_VERIFICATION_RETRY,
+                TagAspectWriteState.ERROR_PERMANENT_VERIFICATION_FAILURE);
+        return builder
+                // A southbound write arrived while resting ready: request it and wait for the acknowledgment (§7.5).
+                .on(TagAspectWriteState.WAITING_FOR_WRITE_REQUEST, TagAspectEvent.WriteRequested.class)
+                .then((current, event, aspect) -> {
+                    aspect.requestWrite(((TagAspectEvent.WriteRequested) event).value());
+                    return TagAspectWriteState.WAITING_FOR_WRITE_RESULT;
+                })
+                // The write was acknowledged successfully: return to the resting goal state (§7.5).
+                .on(TagAspectWriteState.WAITING_FOR_WRITE_RESULT, TagAspectEvent.WriteSucceeded.class)
+                .then((current, event, aspect) -> TagAspectWriteState.WAITING_FOR_WRITE_REQUEST)
+                // The write failed: log and count, return to the resting goal state — no flap to ERROR (§7.7).
+                .on(TagAspectWriteState.WAITING_FOR_WRITE_RESULT, TagAspectEvent.WriteFailed.class)
+                .then((current, event, aspect) -> {
+                    aspect.onWriteFailure(TagAspectPreOperatingTransitions.reasonOf(event));
+                    return TagAspectWriteState.WAITING_FOR_WRITE_REQUEST;
+                })
+                .unmatched((current, event, aspect) -> {
+                    aspect.logUnexpectedEvent(event);
+                    return current;
+                })
+                .build();
+    }
+}

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/tag/TagRuntime.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/tag/TagRuntime.java
@@ -17,6 +17,7 @@ package com.hivemq.protocols.v2.tag;
 
 import com.hivemq.adapter.sdk.api.data.DataPoint;
 import com.hivemq.adapter.sdk.api.v2.model.VerifyOutcome;
+import com.hivemq.adapter.sdk.api.v2.node.Node;
 import com.hivemq.adapter.sdk.api.v2.node.NodeTagPair;
 import com.hivemq.protocols.v2.runtime.BatchCollector;
 import com.hivemq.protocols.v2.runtime.Clock;
@@ -25,22 +26,21 @@ import com.hivemq.protocols.v2.runtime.PriorityTimerQueue;
 import com.hivemq.protocols.v2.runtime.RetryPolicy;
 import com.hivemq.protocols.v2.view.TagStatusSnapshot;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * One tag's runtime — both aspects of a tag plus their shared bookkeeping (design §7). A tag has an independent
- * read aspect and write aspect sharing the Node/Tag pair; this task ships the {@link TagAspectRead}, and the write
- * aspect joins in a later task with no change to the wrapper or the coordinator. The runtime forwards the events
- * the wrapper routes to the right aspect, applies the three-condition goal to each, and folds the aspects into the
- * published per-tag snapshot (design §6.6, §7.7).
+ * {@link TagAspectRead read aspect} and {@link TagAspectWrite write aspect} sharing the Node/Tag pair but otherwise
+ * orthogonal. The runtime forwards the events the wrapper routes to the right aspect, applies each aspect's
+ * three-condition goal, and folds the two aspects into the published per-tag snapshot (design §6.6, §7.7).
  * <p>
  * Created and used only on the wrapper's single dispatch thread.
  */
 public final class TagRuntime {
 
-    private static final @NotNull String INERT_ASPECT_STATE = "DEACTIVATED";
-
     private final @NotNull NodeTagPair pair;
     private final @NotNull TagAspectRead readAspect;
+    private final @NotNull TagAspectWrite writeAspect;
 
     private boolean readActivated;
     private boolean writeActivated;
@@ -48,15 +48,15 @@ public final class TagRuntime {
     private boolean writeUsed;
 
     /**
-     * @param adapterId               the owning adapter's id.
-     * @param pair                    the node/tag pair this runtime drives.
-     * @param clock                   the actor clock.
-     * @param timers                  the actor's single timer queue.
-     * @param batches                 the actor's batch collector.
-     * @param metrics                 the per-adapter metrics.
+     * @param adapterId              the owning adapter's id.
+     * @param pair                   the node/tag pair this runtime drives.
+     * @param clock                  the actor clock.
+     * @param timers                 the actor's single timer queue.
+     * @param batches                the actor's batch collector.
+     * @param metrics                the per-adapter metrics.
      * @param sharedNodeVerification the shared verification authority.
-     * @param pollIntervalMillis      the poll cadence for a polled read aspect, in milliseconds.
-     * @param retryPolicy             the backoff policy for verification and subscription retries.
+     * @param pollIntervalMillis     the poll cadence for a polled read aspect, in milliseconds.
+     * @param retryPolicy            the backoff policy for verification and subscription retries.
      */
     public TagRuntime(
             final @NotNull String adapterId,
@@ -80,6 +80,16 @@ public final class TagRuntime {
                 sharedNodeVerification,
                 pollIntervalMillis,
                 retryPolicy);
+        this.writeAspect = new TagAspectWrite(
+                adapterId,
+                pair.node(),
+                pair.tag(),
+                clock,
+                timers,
+                batches,
+                metrics,
+                sharedNodeVerification,
+                retryPolicy);
     }
 
     /**
@@ -90,19 +100,36 @@ public final class TagRuntime {
     }
 
     /**
+     * @return the protocol node this runtime's aspects share.
+     */
+    public @NotNull Node node() {
+        return pair.node();
+    }
+
+    /**
      * @return the tag's name.
      */
     public @NotNull String tagName() {
         return pair.tag().name();
     }
 
+    /**
+     * @return whether either aspect is awaiting the connect-time verification (design §6.3) — used by the
+     *         coordinator to select this node for the single connect verification batch.
+     */
+    public boolean needsConnectVerification() {
+        return readAspect.awaitingVerification() || writeAspect.awaitingVerification();
+    }
+
     // ── goal and lifecycle (design §7.1, §7.2) ──────────────────────────────────────────────────────────────────
 
     /**
      * Apply the tag's activation and usage to its aspects atomically — the activation-only transition (design
-     * §8.2). Recomputes each aspect's three-condition goal and applies it; never reconnects.
+     * §8.2). Recomputes each aspect's three-condition goal (read on northbound, write on southbound) and applies
+     * it; never reconnects.
      *
      * @param northboundActivated the read direction (northbound) goal.
+     * @param southboundActivated the write direction (southbound) goal.
      * @param readActivated       the persisted read-aspect activation preference.
      * @param writeActivated      the persisted write-aspect activation preference.
      * @param readUsed            whether a northbound mapping consumes the tag.
@@ -110,6 +137,7 @@ public final class TagRuntime {
      */
     public void applyActivation(
             final boolean northboundActivated,
+            final boolean southboundActivated,
             final boolean readActivated,
             final boolean writeActivated,
             final boolean readUsed,
@@ -119,38 +147,44 @@ public final class TagRuntime {
         this.readUsed = readUsed;
         this.writeUsed = writeUsed;
         readAspect.applyGoal(new TagAspectGoal(northboundActivated, readActivated, readUsed));
+        writeAspect.applyGoal(new TagAspectGoal(southboundActivated, writeActivated, writeUsed));
     }
 
     /**
-     * Forward the adapter's entry into verification to the aspects (design §6.3).
+     * Forward the adapter's entry into verification to both aspects (design §6.3).
      */
     public void onAdapterVerifying() {
         readAspect.onAdapterVerifying();
+        writeAspect.onAdapterVerifying();
     }
 
     /**
-     * Forward the adapter reaching {@code CONNECTED} to the aspects (design §7.2).
+     * Forward the adapter reaching {@code CONNECTED} to both aspects (design §7.2).
      */
     public void onAdapterReady() {
         readAspect.onAdapterReady();
+        writeAspect.onAdapterReady();
     }
 
     /**
-     * Forward the loss of the adapter connection to the aspects (design §7.2).
+     * Forward the loss of the adapter connection to both aspects (design §7.2).
      */
     public void onAdapterUnavailable() {
         readAspect.onAdapterUnavailable();
+        writeAspect.onAdapterUnavailable();
     }
 
     /**
-     * Retry the tag after a permanent verification failure (design §7.6).
+     * Retry the tag after a permanent verification failure (design §7.6): each aspect in permanent verification
+     * failure resets and re-verifies; an aspect in any other state is left untouched.
      */
     public void retry() {
         readAspect.retry();
+        writeAspect.retry();
     }
 
     /**
-     * Force every aspect to {@code DEACTIVATED}, cancelling timers and dropping subscriptions — used when the tag
+     * Force both aspects to {@code DEACTIVATED}, cancelling timers and dropping subscriptions — used when the tag
      * is being removed from the set (design §8.2). Never reconnects the adapter.
      */
     public void deactivate() {
@@ -159,17 +193,20 @@ public final class TagRuntime {
         readUsed = false;
         writeUsed = false;
         readAspect.applyGoal(TagAspectGoal.inactive());
+        writeAspect.applyGoal(TagAspectGoal.inactive());
     }
 
     // ── routed events (design §7) ───────────────────────────────────────────────────────────────────────────────
 
     /**
-     * Fan a verification outcome to the tag's aspects (design §7.6).
+     * Fan a verification outcome to both of the tag's aspects (design §7.6) — the single result serves the read
+     * and write aspect alike.
      *
      * @param outcome the verification outcome.
      */
     public void onVerifyResult(final @NotNull VerifyOutcome outcome) {
         readAspect.onVerifyResult(outcome);
+        writeAspect.onVerifyResult(outcome);
     }
 
     /**
@@ -191,13 +228,41 @@ public final class TagRuntime {
         readAspect.onNodeError(reason, spontaneous);
     }
 
+    /**
+     * Route a southbound write request to the write aspect (design §7.5).
+     *
+     * @param value the reused v1 value to write.
+     */
+    public void submitWrite(final @NotNull DataPoint value) {
+        writeAspect.onWriteRequested(value);
+    }
+
+    /**
+     * Route a write acknowledgment to the write aspect (design §7.5).
+     *
+     * @param success whether the write succeeded.
+     * @param reason  the failure reason, or {@code null} on success.
+     */
+    public void onWriteResult(final boolean success, final @Nullable String reason) {
+        writeAspect.onWriteResult(success, reason);
+    }
+
     // ── snapshot (design §6.6, §7.7) ────────────────────────────────────────────────────────────────────────────
 
     /**
-     * @return the immutable per-tag status for publication. The write aspect is inert in this task and reported as
-     *         {@code DEACTIVATED}; the read aspect reports its live state, failure count, and last failure reason.
+     * @return the immutable per-tag status for publication, folding both aspects' live state, goal activation,
+     *         operating status, permanent-failure flag, and failure counters (design §6.6, §7.7).
      */
     public @NotNull TagStatusSnapshot snapshot() {
+        final int totalFailureCount = readAspect.failureCount() + writeAspect.failureCount();
+        final long lastTransition = Math.max(readAspect.lastTransitionAtMillis(), writeAspect.lastTransitionAtMillis());
+        // The single reported reason is the more recent of the two aspects' last failures.
+        @Nullable String lastFailureReason = readAspect.lastFailureReason();
+        if (writeAspect.lastFailureReason() != null
+                && (lastFailureReason == null
+                        || writeAspect.lastTransitionAtMillis() >= readAspect.lastTransitionAtMillis())) {
+            lastFailureReason = writeAspect.lastFailureReason();
+        }
         return new TagStatusSnapshot(
                 tagName(),
                 readActivated,
@@ -205,10 +270,16 @@ public final class TagRuntime {
                 readUsed,
                 writeUsed,
                 readAspect.stateName(),
-                INERT_ASPECT_STATE,
-                readAspect.failureCount(),
-                readAspect.lastFailureReason(),
-                readAspect.lastTransitionAtMillis());
+                writeAspect.stateName(),
+                readAspect.goalActive(),
+                writeAspect.goalActive(),
+                readAspect.operating(),
+                writeAspect.operating(),
+                readAspect.permanentFailure(),
+                writeAspect.permanentFailure(),
+                totalFailureCount,
+                lastFailureReason,
+                lastTransition);
     }
 
     /**
@@ -216,5 +287,12 @@ public final class TagRuntime {
      */
     public @NotNull TagAspectRead readAspect() {
         return readAspect;
+    }
+
+    /**
+     * @return the write aspect — for direct assertions in tests.
+     */
+    public @NotNull TagAspectWrite writeAspect() {
+        return writeAspect;
     }
 }

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/view/TagStatus.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/view/TagStatus.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.protocols.v2.view;
+
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * The externally visible status of a tag (design §7.7): a distinct value per direction-activation combination,
+ * plus deactivated and error. It is a <b>pure function of the {@link TagStatusSnapshot}</b> computed by
+ * {@link #of(TagStatusSnapshot)} — no tag owns this state.
+ * <p>
+ * "Operating" includes in-flight work ({@code WAITING_FOR_POLL_DATAPOINT}, {@code WAITING_FOR_WRITE_RESULT}), so a
+ * tag does not flap to {@link #ERROR} during a normal poll or write round-trip; a healthy write-only tag folds to
+ * {@link #SOUTHBOUND_ONLY}, not {@link #ERROR}.
+ */
+public enum TagStatus {
+
+    /**
+     * Both sides active and healthy: the read aspect is producing (poll cycle or subscription) and the write
+     * aspect is ready.
+     */
+    NORTHBOUND_AND_SOUTHBOUND,
+
+    /**
+     * The read side is active and producing; the write side is deactivated (by direction, aspect switch, or
+     * unused).
+     */
+    NORTHBOUND_ONLY,
+
+    /**
+     * The write side is active and ready (verified, accepting writes); the read side is deactivated.
+     */
+    SOUTHBOUND_ONLY,
+
+    /**
+     * Every aspect is deactivated.
+     */
+    DEACTIVATED,
+
+    /**
+     * Any aspect is permanently failed, or any active aspect is not operating yet (verifying, waiting for the
+     * adapter, retrying).
+     */
+    ERROR;
+
+    /**
+     * Fold a tag's snapshot into its externally visible status (design §7.7).
+     *
+     * @param tag the per-tag snapshot.
+     * @return the tag status.
+     */
+    public static @NotNull TagStatus of(final @NotNull TagStatusSnapshot tag) {
+        final boolean anyPermanent = tag.readAspectPermanentFailure() || tag.writeAspectPermanentFailure();
+        final boolean readActive = tag.readAspectGoalActive();
+        final boolean writeActive = tag.writeAspectGoalActive();
+        final boolean readOperating = tag.readAspectOperating();
+        final boolean writeOperating = tag.writeAspectOperating();
+        if (anyPermanent) {
+            return ERROR;
+        }
+        if (readActive && !readOperating) {
+            return ERROR; // active but not yet operating (verifying, waiting for the adapter, retrying)
+        }
+        if (writeActive && !writeOperating) {
+            return ERROR;
+        }
+        if (readActive && writeActive) {
+            return NORTHBOUND_AND_SOUTHBOUND;
+        }
+        if (readActive) {
+            return NORTHBOUND_ONLY;
+        }
+        if (writeActive) {
+            return SOUTHBOUND_ONLY;
+        }
+        return DEACTIVATED;
+    }
+}

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/view/TagStatusSnapshot.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/view/TagStatusSnapshot.java
@@ -21,18 +21,26 @@ import org.jetbrains.annotations.Nullable;
 /**
  * The immutable per-tag status the wrapper publishes for readers (design §6.6). Part of an
  * {@link AdapterStatusSnapshot}; produced by the actor on its own dispatch thread, read by REST threads. All
- * read-side views ({@link TagStatus}, mapping status — a later task) are pure functions of these fields.
+ * read-side views ({@link TagStatus} fold, mapping status — a later task) are pure functions of these fields; the
+ * per-aspect booleans carry exactly what the five-value {@link TagStatus} fold needs (design §7.7), so the fold
+ * stays a pure function of one snapshot.
  *
- * @param tagName               the tag name.
- * @param readActivated         the persisted read-aspect activation preference.
- * @param writeActivated        the persisted write-aspect activation preference.
- * @param readUsed              whether a northbound mapping consumes the tag.
- * @param writeUsed             whether a southbound mapping produces to the tag.
- * @param readAspectStateName   the read aspect's current state name.
- * @param writeAspectStateName  the write aspect's current state name.
- * @param failureCount          the cumulative failure count (poll / write / subscription).
- * @param lastFailureReason     the most recent failure reason, or {@code null} if none.
- * @param lastTransitionAtMillis the clock time of the last aspect transition, in milliseconds.
+ * @param tagName                     the tag name.
+ * @param readActivated               the persisted read-aspect activation preference.
+ * @param writeActivated              the persisted write-aspect activation preference.
+ * @param readUsed                    whether a northbound mapping consumes the tag.
+ * @param writeUsed                   whether a southbound mapping produces to the tag.
+ * @param readAspectStateName         the read aspect's current state name.
+ * @param writeAspectStateName        the write aspect's current state name.
+ * @param readAspectGoalActive        whether the read aspect's three-condition goal is active.
+ * @param writeAspectGoalActive       whether the write aspect's three-condition goal is active.
+ * @param readAspectOperating         whether the read aspect is operating (polling, subscribed, or mid round-trip).
+ * @param writeAspectOperating        whether the write aspect is operating (ready for or performing a write).
+ * @param readAspectPermanentFailure  whether the read aspect is permanently failed.
+ * @param writeAspectPermanentFailure whether the write aspect is permanently failed.
+ * @param failureCount                the cumulative failure count across both aspects.
+ * @param lastFailureReason           the most recent failure reason, or {@code null} if none.
+ * @param lastTransitionAtMillis      the clock time of the last aspect transition, in milliseconds.
  */
 public record TagStatusSnapshot(
         @NotNull String tagName,
@@ -42,6 +50,12 @@ public record TagStatusSnapshot(
         boolean writeUsed,
         @NotNull String readAspectStateName,
         @NotNull String writeAspectStateName,
+        boolean readAspectGoalActive,
+        boolean writeAspectGoalActive,
+        boolean readAspectOperating,
+        boolean writeAspectOperating,
+        boolean readAspectPermanentFailure,
+        boolean writeAspectPermanentFailure,
         int failureCount,
         @Nullable String lastFailureReason,
         long lastTransitionAtMillis) {}

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/wrapper/ProtocolAdapterWrapper.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/wrapper/ProtocolAdapterWrapper.java
@@ -34,7 +34,9 @@ import org.jetbrains.annotations.NotNull;
  * <li>a {@link ProtocolAdapterWrapperEvent} is routed: protocol-adapter lifecycle events and the synthesized
  * {@code AllVerified} drive the transition table, while verification, data, write, and browse events are routed
  * to the tag plane (design §6.3). In {@code ERROR} every event is fed to the machine so the absorb rows can swallow
- * it (design §6.4).</li>
+ * it (design §6.4);</li>
+ * <li>a {@link ProtocolAdapterWrapperWriteRequest} routes a southbound write to the node's write aspect (design
+ * §7.5) — it changes no adapter goal or machine state.</li>
  * </ul>
  * After every message it publishes an immutable {@link AdapterStatusSnapshot} (design §6.6) — the only state that
  * crosses the actor boundary outward. {@code receive} runs on the actor's single dispatch thread; the wrapper
@@ -79,6 +81,10 @@ public final class ProtocolAdapterWrapper implements MessageHandler<ProtocolAdap
                 handleEvent(event);
                 context.stepTowardGoal();
             }
+            case ProtocolAdapterWrapperWriteRequest write ->
+                // A southbound write: route it to the node's write aspect (design §7.5). It changes no adapter
+                // goal or machine state, so no stepTowardGoal — only the write aspect (and the snapshot) move.
+                context.routeWriteRequestToTags(write.node(), write.value());
         }
         if (machine.state() != before) {
             context.recordTransition();
@@ -114,12 +120,8 @@ public final class ProtocolAdapterWrapper implements MessageHandler<ProtocolAdap
                 }
                 // Otherwise the gate result is stale (verification was abandoned); ignore it.
             }
-            case ProtocolAdapterWrapperEvent.VerifyResultReceived verify -> {
-                context.routeVerifyResultToTags(verify.node(), verify.outcome());
-                if (machine.state() == WAITING_FOR_VERIFICATION) {
-                    context.recordVerifyResult(verify.node());
-                }
-            }
+            case ProtocolAdapterWrapperEvent.VerifyResultReceived verify ->
+                context.onVerifyResultReceived(verify.node(), verify.outcome());
             case ProtocolAdapterWrapperEvent.DataPointReceived data ->
                 context.routeDataPointToTags(data.node(), data.value());
             case ProtocolAdapterWrapperEvent.NodeErrorReceived nodeError ->

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/wrapper/ProtocolAdapterWrapperContext.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/wrapper/ProtocolAdapterWrapperContext.java
@@ -30,7 +30,6 @@ import com.hivemq.adapter.sdk.api.v2.ProtocolAdapter;
 import com.hivemq.adapter.sdk.api.v2.messaging.MailboxSender;
 import com.hivemq.adapter.sdk.api.v2.model.VerifyOutcome;
 import com.hivemq.adapter.sdk.api.v2.node.Node;
-import com.hivemq.adapter.sdk.api.v2.node.NodeTagPair;
 import com.hivemq.protocols.v2.fsm.FSM;
 import com.hivemq.protocols.v2.runtime.Backoff;
 import com.hivemq.protocols.v2.runtime.BatchCollector;
@@ -41,12 +40,8 @@ import com.hivemq.protocols.v2.runtime.RetryPolicy;
 import com.hivemq.protocols.v2.runtime.TimerHandle;
 import com.hivemq.protocols.v2.tag.TagAspectCoordinator;
 import com.hivemq.protocols.v2.view.AdapterStatusSnapshot;
-import java.util.ArrayList;
-import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
@@ -60,11 +55,11 @@ import org.slf4j.LoggerFactory;
  * holds no locks.
  * <p>
  * The {@link TagAspectCoordinator} (in the {@code tag} package) is the wrapper's view of the tag aspect machines.
- * The <b>verification gate</b> here is a node-counting precursor of the
- * verification coordinator (design §7.6): on entry to {@code WAITING_FOR_VERIFICATION} it verifies every
- * configured node and synthesizes {@link ProtocolAdapterWrapperEvent.AllVerified} once each has reported any
- * outcome (failures do not block {@code CONNECTED}, design §6.3); a later task widens it to select nodes from the
- * aspects that need verification and to fan each result out to those aspects.
+ * The <b>verification gate</b> is owned by the shared verification authority behind that coordinator (design §7.6):
+ * on entry to {@code WAITING_FOR_VERIFICATION} the coordinator verifies the nodes its active aspects need as one
+ * batch, and the wrapper synthesizes {@link ProtocolAdapterWrapperEvent.AllVerified} once the coordinator reports
+ * {@code allReported()} — every node in the batch has reported some outcome (failures do not block
+ * {@code CONNECTED}, design §6.3). The single verify stream feeds both this gate and the per-tag aspects.
  * <p>
  * The machine is bound after construction through {@link #bindMachine(FSM)} because the machine's
  * constructor needs this context — the cycle is closed once, before any message is handled. {@code stepTowardGoal}
@@ -87,10 +82,7 @@ public final class ProtocolAdapterWrapperContext {
     private final @NotNull ProtocolAdapterWrapperEventListener healthListener;
     private final @NotNull NevskyMetrics metrics;
 
-    private final @NotNull Set<Node> pendingVerification = new LinkedHashSet<>();
-
     private @NotNull ProtocolAdapterGoalState goal;
-    private @NotNull List<NodeTagPair> nodes;
     private @NotNull Map<String, TagAspectActivationPreference> activation;
     private long lastTransitionAtMillis;
     private @Nullable String lastErrorReason;
@@ -111,7 +103,6 @@ public final class ProtocolAdapterWrapperContext {
      * @param skipVerification      whether to skip verification and reach {@code CONNECTED} straight from
      *                              {@code WAITING_FOR_CONNECTED}.
      * @param initialGoal           the initial direction goal (from the configuration).
-     * @param nodes                 the configured node/tag pairs.
      * @param activation            the per-tag activation preferences.
      * @param tagPlane              the wrapper's view of the tag aspect machines.
      * @param healthListener        the supervisor notification seam.
@@ -126,7 +117,6 @@ public final class ProtocolAdapterWrapperContext {
             final long watchdogTimeoutMillis,
             final boolean skipVerification,
             final @NotNull ProtocolAdapterGoalState initialGoal,
-            final @NotNull List<NodeTagPair> nodes,
             final @NotNull Map<String, TagAspectActivationPreference> activation,
             final @NotNull TagAspectCoordinator tagPlane,
             final @NotNull ProtocolAdapterWrapperEventListener healthListener,
@@ -139,7 +129,6 @@ public final class ProtocolAdapterWrapperContext {
         this.watchdogTimeoutMillis = watchdogTimeoutMillis;
         this.skipVerification = skipVerification;
         this.goal = initialGoal;
-        this.nodes = List.copyOf(nodes);
         this.activation = Map.copyOf(activation);
         this.tagPlane = tagPlane;
         this.healthListener = healthListener;
@@ -224,7 +213,6 @@ public final class ProtocolAdapterWrapperContext {
                 tagPlane.applyActivation(goal, activation);
             }
             case ProtocolAdapterWrapperCommand.UpdateTagSet update -> {
-                nodes = List.copyOf(update.nodes());
                 activation = Map.copyOf(update.activation());
                 tagPlane.updateTagSet(
                         update.nodes(), update.activation(), update.readUsedTagNames(), update.writeUsedTagNames());
@@ -261,8 +249,15 @@ public final class ProtocolAdapterWrapperContext {
     @NotNull
     ProtocolAdapterWrapperState verifyStep() {
         clearTimers();
+        // Move active aspects into verification and issue the nodes they need as one verifyBatch through the
+        // shared verification authority (design §6.3, §7.6).
         tagPlane.onAdapterVerifying();
-        beginVerification();
+        if (tagPlane.allReported()) {
+            // No aspect needs verification — connect straight away.
+            synthesizeAllVerified();
+        } else {
+            armWatchdog();
+        }
         return WAITING_FOR_VERIFICATION;
     }
 
@@ -407,47 +402,28 @@ public final class ProtocolAdapterWrapperContext {
     }
 
     // ──────────────────────────────────────────────────────────────────────────────────────────────────────────
-    //  Verification gate (precursor of the verification coordinator, design §6.3, §7.6)
+    //  Verification gate (owned by the shared verification authority, design §6.3, §7.6)
     // ──────────────────────────────────────────────────────────────────────────────────────────────────────────
 
-    private void beginVerification() {
-        pendingVerification.clear();
-        final List<Node> nodesToVerify = distinctNodes();
-        if (nodesToVerify.isEmpty()) {
-            synthesizeAllVerified();
-            return;
-        }
-        pendingVerification.addAll(nodesToVerify);
-        protocolAdapter.verifyBatch(nodesToVerify);
-        armWatchdog();
-    }
-
-    /**
-     * Record one node's verification outcome against the adapter gate (design §6.3). When every node in the batch
-     * has reported any outcome, synthesize {@link ProtocolAdapterWrapperEvent.AllVerified}. Routing the outcome to
-     * the node's aspects is the tag plane's job and happens separately.
-     *
-     * @param node the node that reported.
-     */
-    public void recordVerifyResult(final @NotNull Node node) {
-        if (pendingVerification.remove(node) && pendingVerification.isEmpty()) {
-            synthesizeAllVerified();
-        }
-    }
-
     private void clearVerification() {
-        pendingVerification.clear();
+        tagPlane.resetVerificationGate();
     }
 
     /**
-     * Route one node's verification outcome to its tag aspects (design §6.3) — the fan-out the wrapper performs
-     * for every {@code verifyResult}, independent of the adapter gate's counting.
+     * Handle one node's verification outcome (design §6.3): fan it out to the node's aspects through the shared
+     * verification authority — which also clears the connect-gate count — then, while the machine is still gating
+     * in {@code WAITING_FOR_VERIFICATION}, synthesize {@link ProtocolAdapterWrapperEvent.AllVerified} once every
+     * node in the batch has reported some outcome. The single verify stream feeds both consumers (the adapter gate
+     * and the per-tag aspects), on the one dispatch thread.
      *
      * @param node    the verified node.
      * @param outcome the verification outcome.
      */
-    public void routeVerifyResultToTags(final @NotNull Node node, final @NotNull VerifyOutcome outcome) {
+    public void onVerifyResultReceived(final @NotNull Node node, final @NotNull VerifyOutcome outcome) {
         tagPlane.routeVerifyResult(node, outcome);
+        if (machine().state() == WAITING_FOR_VERIFICATION && tagPlane.allReported()) {
+            synthesizeAllVerified();
+        }
     }
 
     /**
@@ -483,16 +459,18 @@ public final class ProtocolAdapterWrapperContext {
         tagPlane.routeWriteResult(node, success, reason);
     }
 
-    private void synthesizeAllVerified() {
-        selfSender.tell(new ProtocolAdapterWrapperEvent.AllVerified());
+    /**
+     * Route a southbound write request to its write aspect (design §7.5) — the "write arrives" trigger.
+     *
+     * @param node  the node to write to.
+     * @param value the reused v1 value to write.
+     */
+    public void routeWriteRequestToTags(final @NotNull Node node, final @NotNull DataPoint value) {
+        tagPlane.submitWrite(node, value);
     }
 
-    private @NotNull List<Node> distinctNodes() {
-        final Set<Node> distinct = new LinkedHashSet<>();
-        for (final NodeTagPair pair : nodes) {
-            distinct.add(pair.node());
-        }
-        return new ArrayList<>(distinct);
+    private void synthesizeAllVerified() {
+        selfSender.tell(new ProtocolAdapterWrapperEvent.AllVerified());
     }
 
     // ──────────────────────────────────────────────────────────────────────────────────────────────────────────

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/wrapper/ProtocolAdapterWrapperMessage.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/wrapper/ProtocolAdapterWrapperMessage.java
@@ -19,17 +19,22 @@ import com.hivemq.adapter.sdk.api.v2.messaging.MailboxMessage;
 
 /**
  * The single mailbox message type of the {@link ProtocolAdapterWrapper} actor (design §6.1). Everything the
- * wrapper consumes arrives as one of these three:
+ * wrapper consumes arrives as one of these four:
  * <ul>
  * <li>{@link ProtocolAdapterWrapperCommand} — goal and lifecycle commands ({@code CONTROL} band) handled via the
  * goal-command bypass, valid in every state;</li>
  * <li>{@link ProtocolAdapterWrapperEvent} — protocol-adapter events and timer expiries, the only messages that
  * flow through the transition table;</li>
- * <li>{@link ProtocolAdapterWrapperTick} — time, delivered as a message ({@code TICK} band).</li>
+ * <li>{@link ProtocolAdapterWrapperTick} — time, delivered as a message ({@code TICK} band);</li>
+ * <li>{@link ProtocolAdapterWrapperWriteRequest} — a southbound write to route to a tag's write aspect
+ * ({@code DATA} band, design §7.5), neither a goal command nor a transition-table event.</li>
  * </ul>
- * Sealed because all three permitted subtypes live in this package (a sealed interface and its {@code permits}
- * must share a package); the generic {@link MailboxMessage} marker is the non-sealed bridge that lets each
- * extend it across packages.
+ * Sealed because all permitted subtypes live in this package (a sealed interface and its {@code permits} must
+ * share a package); the generic {@link MailboxMessage} marker is the non-sealed bridge that lets each extend it
+ * across packages.
  */
 public sealed interface ProtocolAdapterWrapperMessage extends MailboxMessage
-        permits ProtocolAdapterWrapperCommand, ProtocolAdapterWrapperEvent, ProtocolAdapterWrapperTick {}
+        permits ProtocolAdapterWrapperCommand,
+                ProtocolAdapterWrapperEvent,
+                ProtocolAdapterWrapperTick,
+                ProtocolAdapterWrapperWriteRequest {}

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/wrapper/ProtocolAdapterWrapperWriteRequest.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/wrapper/ProtocolAdapterWrapperWriteRequest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.protocols.v2.wrapper;
+
+import com.hivemq.adapter.sdk.api.data.DataPoint;
+import com.hivemq.adapter.sdk.api.v2.messaging.MailboxMessagePriority;
+import com.hivemq.adapter.sdk.api.v2.node.Node;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * A southbound write to deliver to a tag's write aspect (design §7.5) — the "write arrives" trigger, told to the
+ * wrapper mailbox by an external producer (a future southbound mapping; tests drive it directly). The {@link Node}
+ * is the correlation key; the wrapper routes the value to that node's write aspect, which requests the write when
+ * it is resting at {@code WAITING_FOR_WRITE_REQUEST} and drops it otherwise (one write in flight at a time).
+ * <p>
+ * Band: {@link MailboxMessagePriority#DATA} — like data points, southbound payload yields to control,
+ * acknowledgments, and time (design §5.1). It is its own kind of {@link ProtocolAdapterWrapperMessage}: it is not
+ * a goal command, not a protocol-adapter event (it never flows through the adapter transition table), and not a
+ * tick.
+ *
+ * @param node  the node to write to.
+ * @param value the reused v1 value to write.
+ */
+public record ProtocolAdapterWrapperWriteRequest(
+        @NotNull Node node, @NotNull DataPoint value) implements ProtocolAdapterWrapperMessage {
+
+    @Override
+    public @NotNull MailboxMessagePriority priority() {
+        return MailboxMessagePriority.DATA;
+    }
+}

--- a/hivemq-edge/src/test/java/com/hivemq/protocols/v2/tag/SharedNodeVerificationTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/protocols/v2/tag/SharedNodeVerificationTest.java
@@ -103,4 +103,47 @@ class SharedNodeVerificationTest {
         coordinator.onVerifyResult(second, new VerifyOutcome.TransientFailure("retry"));
         assertThat(coordinator.allReported()).isTrue();
     }
+
+    @Test
+    void beginConnectVerification_issuesOneBatchForAllNodes_andGatesUntilEachReports() {
+        final List<List<Node>> requests = new ArrayList<>();
+        final SharedNodeVerification coordinator = new SharedNodeVerification(requests::add, node -> null);
+        final Node first = new CountingNode("a");
+        final Node second = new CountingNode("b");
+
+        coordinator.beginConnectVerification(List.of(first, second));
+
+        // The connect gate issues a single verifyBatch carrying every node (design §6.3, §7.6).
+        assertThat(requests).hasSize(1);
+        assertThat(requests.get(0)).containsExactly(first, second);
+        assertThat(coordinator.allReported()).isFalse();
+
+        coordinator.onVerifyResult(first, new VerifyOutcome.Success());
+        assertThat(coordinator.allReported()).isFalse();
+        coordinator.onVerifyResult(second, new VerifyOutcome.PermanentFailure("unknown"));
+        assertThat(coordinator.allReported()).isTrue(); // any outcome counts toward the gate
+    }
+
+    @Test
+    void beginConnectVerification_withNoNodes_issuesNothing_andReportsAllReported() {
+        final List<List<Node>> requests = new ArrayList<>();
+        final SharedNodeVerification coordinator = new SharedNodeVerification(requests::add, node -> null);
+
+        coordinator.beginConnectVerification(List.of());
+
+        assertThat(requests).isEmpty();
+        assertThat(coordinator.allReported()).isTrue();
+    }
+
+    @Test
+    void reset_dropsOutstandingInFlightSoTheGateDoesNotLinger() {
+        final List<List<Node>> requests = new ArrayList<>();
+        final SharedNodeVerification coordinator = new SharedNodeVerification(requests::add, node -> null);
+        coordinator.requestVerification(new CountingNode("a"));
+        assertThat(coordinator.allReported()).isFalse();
+
+        coordinator.reset();
+
+        assertThat(coordinator.allReported()).isTrue();
+    }
 }

--- a/hivemq-edge/src/test/java/com/hivemq/protocols/v2/view/TagStatusTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/protocols/v2/view/TagStatusTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.protocols.v2.view;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The five-value tag-status fold (design §7.7) — a pure function of the {@link TagStatusSnapshot}. Each
+ * direction-activation combination maps to its own value; an active-but-not-operating aspect or a permanent
+ * failure is {@code ERROR}; and a healthy write-only tag folds to {@code SOUTHBOUND_ONLY}, not {@code ERROR} (the
+ * S30 regression the v01 fold got wrong).
+ */
+class TagStatusTest {
+
+    private static @NotNull TagStatusSnapshot snapshot(
+            final boolean readActive,
+            final boolean writeActive,
+            final boolean readOperating,
+            final boolean writeOperating,
+            final boolean readPermanentFailure,
+            final boolean writePermanentFailure) {
+        return new TagStatusSnapshot(
+                "tag",
+                true,
+                true,
+                true,
+                true,
+                "readState",
+                "writeState",
+                readActive,
+                writeActive,
+                readOperating,
+                writeOperating,
+                readPermanentFailure,
+                writePermanentFailure,
+                0,
+                null,
+                0L);
+    }
+
+    @Test
+    void everyAspectDeactivated_isDeactivated() {
+        assertThat(TagStatus.of(snapshot(false, false, false, false, false, false)))
+                .isEqualTo(TagStatus.DEACTIVATED);
+    }
+
+    @Test
+    void readActiveAndOperating_isNorthboundOnly() {
+        assertThat(TagStatus.of(snapshot(true, false, true, false, false, false)))
+                .isEqualTo(TagStatus.NORTHBOUND_ONLY);
+    }
+
+    @Test
+    void writeActiveAndOperating_isSouthboundOnly() {
+        assertThat(TagStatus.of(snapshot(false, true, false, true, false, false)))
+                .isEqualTo(TagStatus.SOUTHBOUND_ONLY);
+    }
+
+    @Test
+    void bothActiveAndOperating_isNorthboundAndSouthbound() {
+        assertThat(TagStatus.of(snapshot(true, true, true, true, false, false)))
+                .isEqualTo(TagStatus.NORTHBOUND_AND_SOUTHBOUND);
+    }
+
+    @Test
+    void aPermanentFailure_isError() {
+        assertThat(TagStatus.of(snapshot(true, false, true, false, true, false)))
+                .isEqualTo(TagStatus.ERROR);
+    }
+
+    @Test
+    void readActiveButNotOperating_isError() {
+        assertThat(TagStatus.of(snapshot(true, false, false, false, false, false)))
+                .isEqualTo(TagStatus.ERROR);
+    }
+
+    @Test
+    void writeActiveButNotOperating_isError() {
+        assertThat(TagStatus.of(snapshot(false, true, false, false, false, false)))
+                .isEqualTo(TagStatus.ERROR);
+    }
+
+    @Test
+    void healthyWriteOnlyTag_isSouthboundOnly_notError() {
+        // S30: a write-only tag (read deactivated, write resting at WAITING_FOR_WRITE_REQUEST) is operating, so it
+        // is SOUTHBOUND_ONLY — the v01 fold wrongly reported ERROR.
+        assertThat(TagStatus.of(snapshot(false, true, false, true, false, false)))
+                .isEqualTo(TagStatus.SOUTHBOUND_ONLY);
+    }
+}

--- a/hivemq-edge/src/test/java/com/hivemq/protocols/v2/wrapper/TagAspectWriteTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/protocols/v2/wrapper/TagAspectWriteTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.protocols.v2.wrapper;
+
+import static com.hivemq.protocols.v2.wrapper.ProtocolAdapterWrapperState.CONNECTED;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.hivemq.adapter.sdk.api.v2.model.VerifyOutcome;
+import com.hivemq.protocols.v2.view.TagStatus;
+import java.util.List;
+import java.util.Set;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The write aspect (design §7.5; scenario S4 and the S30 write-only fold at unit level). The aspect verifies on
+ * connect, then rests ready for writes; a write arriving requests it and waits for the acknowledgment; a write
+ * failure is logged and counted but never flaps the tag to {@code ERROR}; one write is in flight at a time; an
+ * unused or permanently-failed write aspect is off. All driven on {@code FakeClock} + {@code ManualDispatcher}
+ * through the running coordinator, observed only through the published snapshot.
+ */
+class TagAspectWriteTest {
+
+    private static @NotNull WrapperTestFixture writeOnlyFixture() {
+        return WrapperTestFixture.builder()
+                .runningCoordinator()
+                .nodes(List.of(WrapperTestSupport.pair("setpoint")))
+                .readUsed(Set.of()) // no northbound mapping — the read aspect stays deactivated
+                .writeUsed(Set.of("setpoint"))
+                .build();
+    }
+
+    @Test
+    void verifyOnConnect_thenRestsReadyForWrites() {
+        final WrapperTestFixture fixture = writeOnlyFixture();
+
+        fixture.activate(ProtocolAdapterDirection.SOUTHBOUND);
+
+        assertThat(fixture.state()).isEqualTo(CONNECTED);
+        assertThat(fixture.writeState("setpoint")).isEqualTo("WAITING_FOR_WRITE_REQUEST");
+        assertThat(fixture.readState("setpoint")).isEqualTo("DEACTIVATED");
+        assertThat(fixture.tagStatus("setpoint")).isEqualTo(TagStatus.SOUTHBOUND_ONLY);
+    }
+
+    @Test
+    void writeHappyPath_requestsWriteThenReturnsToRequestOnSuccess() {
+        final WrapperTestFixture fixture = writeOnlyFixture();
+        fixture.activate(ProtocolAdapterDirection.SOUTHBOUND);
+
+        fixture.submitWrite("setpoint", WrapperTestSupport.dataPoint("setpoint", "42"));
+        assertThat(fixture.writeState("setpoint")).isEqualTo("WAITING_FOR_WRITE_RESULT");
+
+        fixture.advance(100); // a tick dispatches the pending write batch to the adapter
+        assertThat(fixture.commands()).contains("writeBatch");
+
+        fixture.output.writeResult(fixture.nodeFor("setpoint"), true, null);
+        fixture.drain();
+        assertThat(fixture.writeState("setpoint")).isEqualTo("WAITING_FOR_WRITE_REQUEST");
+        assertThat(fixture.tag("setpoint").failureCount()).isZero();
+        assertThat(fixture.tagStatus("setpoint")).isEqualTo(TagStatus.SOUTHBOUND_ONLY);
+    }
+
+    @Test
+    void writeFailure_countsAndReturnsToRequestWithoutFlappingToError() {
+        final WrapperTestFixture fixture = writeOnlyFixture();
+        fixture.activate(ProtocolAdapterDirection.SOUTHBOUND);
+        fixture.submitWrite("setpoint", WrapperTestSupport.dataPoint("setpoint", "42"));
+
+        fixture.output.writeResult(fixture.nodeFor("setpoint"), false, "device rejected the value");
+        fixture.drain();
+
+        assertThat(fixture.writeState("setpoint")).isEqualTo("WAITING_FOR_WRITE_REQUEST");
+        assertThat(fixture.tag("setpoint").failureCount()).isEqualTo(1);
+        assertThat(fixture.tag("setpoint").lastFailureReason()).isEqualTo("device rejected the value");
+        // A normal write round-trip — even a failed one — never flaps the tag to ERROR (design §7.7).
+        assertThat(fixture.tagStatus("setpoint")).isEqualTo(TagStatus.SOUTHBOUND_ONLY);
+    }
+
+    @Test
+    void secondWriteWhileOneIsInFlight_isDropped() {
+        final WrapperTestFixture fixture = writeOnlyFixture();
+        fixture.activate(ProtocolAdapterDirection.SOUTHBOUND);
+
+        fixture.submitWrite("setpoint", WrapperTestSupport.dataPoint("setpoint", "1"));
+        assertThat(fixture.writeState("setpoint")).isEqualTo("WAITING_FOR_WRITE_RESULT");
+
+        // One write in flight at a time (design §7.5): a second write while waiting is dropped, not queued.
+        fixture.submitWrite("setpoint", WrapperTestSupport.dataPoint("setpoint", "2"));
+        assertThat(fixture.writeState("setpoint")).isEqualTo("WAITING_FOR_WRITE_RESULT");
+    }
+
+    @Test
+    void unusedWriteTag_staysDeactivatedEvenWhenActivated() {
+        final WrapperTestFixture fixture = WrapperTestFixture.builder()
+                .runningCoordinator()
+                .nodes(List.of(WrapperTestSupport.pair("setpoint")))
+                .readUsed(Set.of())
+                .writeUsed(Set.of()) // no southbound mapping consumes the tag — the third condition fails
+                .build();
+
+        fixture.activate(ProtocolAdapterDirection.SOUTHBOUND);
+
+        assertThat(fixture.state()).isEqualTo(CONNECTED);
+        assertThat(fixture.writeState("setpoint")).isEqualTo("DEACTIVATED");
+        assertThat(fixture.tagStatus("setpoint")).isEqualTo(TagStatus.DEACTIVATED);
+    }
+
+    @Test
+    void permanentVerificationFailure_suspendsTheWriteAspectButLeavesTheAdapterConnected() {
+        final WrapperTestFixture fixture = writeOnlyFixture();
+        fixture.adapter.verifyOutcome = new VerifyOutcome.PermanentFailure("unknown address");
+
+        fixture.activate(ProtocolAdapterDirection.SOUTHBOUND);
+
+        assertThat(fixture.state()).isEqualTo(CONNECTED); // failures do not block CONNECTED (design §6.3)
+        assertThat(fixture.writeState("setpoint")).isEqualTo("ERROR_PERMANENT_VERIFICATION_FAILURE");
+        assertThat(fixture.tagStatus("setpoint")).isEqualTo(TagStatus.ERROR);
+    }
+}

--- a/hivemq-edge/src/test/java/com/hivemq/protocols/v2/wrapper/TagVerificationAndRetryTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/protocols/v2/wrapper/TagVerificationAndRetryTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.protocols.v2.wrapper;
+
+import static com.hivemq.protocols.v2.wrapper.ProtocolAdapterWrapperState.CONNECTED;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.hivemq.adapter.sdk.api.v2.model.VerifyOutcome;
+import com.hivemq.protocols.v2.view.TagStatus;
+import java.util.List;
+import java.util.Set;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The shared verification model and tag retry for a read-and-write tag (design §7.6; scenarios S29 and the
+ * verification optimization at unit level). One {@code verifyBatch} entry serves both aspects; one {@code Success}
+ * advances both, one {@code PermanentFailure} suspends both; and a runtime tag retry re-verifies a permanently
+ * failed tag and resets its counters without touching configuration.
+ */
+class TagVerificationAndRetryTest {
+
+    private static @NotNull WrapperTestFixture readAndWriteFixture() {
+        return WrapperTestFixture.builder()
+                .runningCoordinator()
+                .nodes(List.of(WrapperTestSupport.pair("temperature")))
+                .readUsed(Set.of("temperature"))
+                .writeUsed(Set.of("temperature"))
+                .pollIntervalMillis(1000)
+                .build();
+    }
+
+    private static long verifyBatchCount(final @NotNull WrapperTestFixture fixture) {
+        return fixture.commands().stream().filter("verifyBatch"::equals).count();
+    }
+
+    @Test
+    void readAndWriteTag_verifiesOnce_andOneSuccessAdvancesBothAspects() {
+        final WrapperTestFixture fixture = readAndWriteFixture();
+
+        fixture.activate(ProtocolAdapterDirection.BOTH);
+
+        assertThat(fixture.state()).isEqualTo(CONNECTED);
+        // Exactly one verifyBatch for the connect gate — the single result served both aspects (design §7.6).
+        assertThat(verifyBatchCount(fixture)).isEqualTo(1);
+        assertThat(fixture.readState("temperature")).isEqualTo("WAITING_FOR_POLL_INTERVAL");
+        assertThat(fixture.writeState("temperature")).isEqualTo("WAITING_FOR_WRITE_REQUEST");
+        assertThat(fixture.tagStatus("temperature")).isEqualTo(TagStatus.NORTHBOUND_AND_SOUTHBOUND);
+    }
+
+    @Test
+    void onePermanentFailure_suspendsBothAspects() {
+        final WrapperTestFixture fixture = readAndWriteFixture();
+        fixture.adapter.verifyOutcome = new VerifyOutcome.PermanentFailure("unknown address");
+
+        fixture.activate(ProtocolAdapterDirection.BOTH);
+
+        assertThat(fixture.state()).isEqualTo(CONNECTED);
+        assertThat(verifyBatchCount(fixture)).isEqualTo(1);
+        assertThat(fixture.readState("temperature")).isEqualTo("ERROR_PERMANENT_VERIFICATION_FAILURE");
+        assertThat(fixture.writeState("temperature")).isEqualTo("ERROR_PERMANENT_VERIFICATION_FAILURE");
+        assertThat(fixture.tagStatus("temperature")).isEqualTo(TagStatus.ERROR);
+    }
+
+    @Test
+    void retry_reVerifiesAPermanentlyFailedTag_resetsCounters_andRestoresBothAspects() {
+        final WrapperTestFixture fixture = readAndWriteFixture();
+        fixture.adapter.verifyOutcome = new VerifyOutcome.PermanentFailure("unknown address");
+        fixture.activate(ProtocolAdapterDirection.BOTH);
+        assertThat(fixture.readState("temperature")).isEqualTo("ERROR_PERMANENT_VERIFICATION_FAILURE");
+        assertThat(fixture.writeState("temperature")).isEqualTo("ERROR_PERMANENT_VERIFICATION_FAILURE");
+        assertThat(fixture.tag("temperature").failureCount()).isEqualTo(2); // read + write each counted once
+
+        // The device is fixed; a runtime tag retry re-verifies the tag (design §7.6, EDG-462).
+        fixture.adapter.verifyOutcome = new VerifyOutcome.Success();
+        fixture.retryTag("temperature");
+
+        assertThat(fixture.readState("temperature")).isEqualTo("WAITING_FOR_POLL_INTERVAL");
+        assertThat(fixture.writeState("temperature")).isEqualTo("WAITING_FOR_WRITE_REQUEST");
+        assertThat(fixture.tag("temperature").failureCount()).isZero(); // counters reset
+        assertThat(fixture.tagStatus("temperature")).isEqualTo(TagStatus.NORTHBOUND_AND_SOUTHBOUND);
+    }
+
+    @Test
+    void retry_onAHealthyTag_isANoOp() {
+        final WrapperTestFixture fixture = readAndWriteFixture();
+        fixture.activate(ProtocolAdapterDirection.BOTH);
+        final long verifyBatchesBeforeRetry = verifyBatchCount(fixture);
+
+        fixture.retryTag("temperature"); // neither aspect is permanently failed — nothing to retry
+
+        assertThat(fixture.readState("temperature")).isEqualTo("WAITING_FOR_POLL_INTERVAL");
+        assertThat(fixture.writeState("temperature")).isEqualTo("WAITING_FOR_WRITE_REQUEST");
+        assertThat(verifyBatchCount(fixture)).isEqualTo(verifyBatchesBeforeRetry); // no re-verification issued
+    }
+}

--- a/hivemq-edge/src/test/java/com/hivemq/protocols/v2/wrapper/WrapperTestFixture.java
+++ b/hivemq-edge/src/test/java/com/hivemq/protocols/v2/wrapper/WrapperTestFixture.java
@@ -16,6 +16,7 @@
 package com.hivemq.protocols.v2.wrapper;
 
 import com.codahale.metrics.MetricRegistry;
+import com.hivemq.adapter.sdk.api.data.DataPoint;
 import com.hivemq.adapter.sdk.api.v2.messaging.DefaultMailbox;
 import com.hivemq.adapter.sdk.api.v2.messaging.Mailbox;
 import com.hivemq.adapter.sdk.api.v2.node.Node;
@@ -28,6 +29,7 @@ import com.hivemq.protocols.v2.tag.TagAspectCoordinator;
 import com.hivemq.protocols.v2.tag.TagAspectRuntimeCoordinator;
 import com.hivemq.protocols.v2.tag.TagAspectSnapshotOnlyCoordinator;
 import com.hivemq.protocols.v2.view.AdapterStatusSnapshot;
+import com.hivemq.protocols.v2.view.TagStatus;
 import com.hivemq.protocols.v2.view.TagStatusSnapshot;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -77,9 +79,10 @@ final class WrapperTestFixture {
 
         final NevskyMetrics metrics = new NevskyMetrics(metricRegistry, adapterId, mailbox::size);
         // The default tag plane is the snapshot-only stand-in (adapter-machine tests); opt in to the running
-        // coordinator to exercise the read aspect machines.
+        // coordinator to exercise the read and write aspect machines.
         final TagAspectCoordinator tagPlane;
         final TagAspectRuntimeCoordinator runningTagPlane;
+        final TagAspectSnapshotOnlyCoordinator snapshotOnlyTagPlane;
         if (builder.runningCoordinator) {
             runningTagPlane = new TagAspectRuntimeCoordinator(
                     adapterId,
@@ -90,10 +93,12 @@ final class WrapperTestFixture {
                     builder.initialGoal,
                     builder.pollIntervalMillis,
                     builder.retryPolicy);
+            snapshotOnlyTagPlane = null;
             tagPlane = runningTagPlane;
         } else {
-            tagPlane = new TagAspectSnapshotOnlyCoordinator(builder.nodes, activation, readUsed, writeUsed);
+            snapshotOnlyTagPlane = new TagAspectSnapshotOnlyCoordinator(builder.nodes, activation, readUsed, writeUsed);
             runningTagPlane = null;
+            tagPlane = snapshotOnlyTagPlane;
         }
         final ProtocolAdapterWrapperContext context = new ProtocolAdapterWrapperContext(
                 adapterId,
@@ -104,7 +109,6 @@ final class WrapperTestFixture {
                 builder.watchdogTimeoutMillis,
                 builder.skipVerification,
                 builder.initialGoal,
-                builder.nodes,
                 activation,
                 tagPlane,
                 health,
@@ -116,6 +120,11 @@ final class WrapperTestFixture {
                     context.batches(),
                     context.metrics(),
                     context.protocolAdapter()::verifyBatch);
+        }
+        if (snapshotOnlyTagPlane != null) {
+            // The connect gate runs through the shared verification authority even with no aspect machines; bind
+            // it to the adapter's verify seam so the adapter-machine tests still exercise the verification flow.
+            snapshotOnlyTagPlane.bindVerifier(context.protocolAdapter()::verifyBatch);
         }
         this.snapshotReference = new AtomicReference<>();
         this.wrapper = new ProtocolAdapterWrapper(context, snapshotReference);
@@ -174,6 +183,17 @@ final class WrapperTestFixture {
         send(new ProtocolAdapterWrapperCommand.StopAdapter());
     }
 
+    void retryTag(final @NotNull String tagName) {
+        send(new ProtocolAdapterWrapperCommand.RetryTag(tagName));
+    }
+
+    /**
+     * Submit a southbound write to a tag's write aspect — the "write arrives" trigger (design §7.5).
+     */
+    void submitWrite(final @NotNull String tagName, final @NotNull DataPoint value) {
+        send(new ProtocolAdapterWrapperWriteRequest(nodeFor(tagName), value));
+    }
+
     // ── observation (snapshot-only, per the actor model) ─────────────────────────────────────────────────────
 
     @NotNull
@@ -223,6 +243,22 @@ final class WrapperTestFixture {
     @NotNull
     String readState(final @NotNull String tagName) {
         return tag(tagName).readAspectStateName();
+    }
+
+    /**
+     * @return the write aspect's current state name for the given tag, read from the published snapshot.
+     */
+    @NotNull
+    String writeState(final @NotNull String tagName) {
+        return tag(tagName).writeAspectStateName();
+    }
+
+    /**
+     * @return the externally visible {@link TagStatus} folded from the given tag's published snapshot.
+     */
+    @NotNull
+    TagStatus tagStatus(final @NotNull String tagName) {
+        return TagStatus.of(tag(tagName));
     }
 
     long defensiveResets() {


### PR DESCRIPTION
## Summary

Implements **Task 8 — tag write aspect + verification model + tag retry** of Project Nevsky (the v2 protocol-adapter framework), on top of the read aspects from EDG-726.

## What's included

- **Write aspect** — `TagAspectWriteState` / `TagAspectWrite` / `TagAspectWriteTransitions`: the `WAITING_FOR_WRITE_REQUEST` ⇄ `WAITING_FOR_WRITE_RESULT` cycle over the shared five-state pre-operating sequence. One write in flight at a time; a write failure is logged and counted but never flaps the tag to `ERROR` (design §7.5, §7.7).
- **Shared pre-operating rows, built once** — extracted `TagAspectPreOperatingTransitions` + the `TagAspectVerifying` seam, now reused by both the read and write aspect tables (design §7.2).
- **Unified verification model** — `SharedNodeVerification` is the single verification authority: it drives the connect-time adapter gate (`beginConnectVerification` + `allReported()`, which synthesizes `AllVerified`) as well as the per-aspect re-verifications, replacing the wrapper context's ad-hoc node-counting gate (design §6.3, §7.6). A read-and-write tag yields exactly one `verifyBatch` entry, fanned out to both aspects.
- **Southbound write trigger** — a new `ProtocolAdapterWrapperWriteRequest` mailbox message (DATA band) routes a write to the node's write aspect.
- **`TagStatus` fold** — the five-value external status (`NORTHBOUND_AND_SOUTHBOUND` / `NORTHBOUND_ONLY` / `SOUTHBOUND_ONLY` / `DEACTIVATED` / `ERROR`) as a pure function of an enriched `TagStatusSnapshot` (design §7.7); a healthy write-only tag folds to `SOUTHBOUND_ONLY`, not `ERROR`.
- **Tag retry (D7, EDG-462)** — `RetryTag` drives both aspects of the named tag: a permanently-failed aspect re-verifies and resets its counters; a healthy aspect is a no-op. Runtime-only — never touches configuration.

## Design notes

Two refinements that extend the design doc, agreed during implementation:
- The write trigger is modeled as a new `ProtocolAdapterWrapperMessage` (it is neither a goal command nor a transition-table event; not in the §5.1 band table).
- The connect-time verification gate is unified onto `SharedNodeVerification`, fulfilling §6.3 ("`SharedNodeVerification` does the counting and synthesizes the `AllVerified` event") and the Task 6 "a later task widens it to select nodes from the aspects that need verification" note.

## Testing

- `./gradlew :hivemq-edge-build:hivemq-edge:check` → green (Spotless + ErrorProne + NullAway + the v2 unit suite).
- New unit tests: the write aspect, the verification optimization + tag retry (S29), the `TagStatus` fold (S30), and the connect-gate batch / reset on `SharedNodeVerification`.
- Comprehensive `hivemq-edge-test` coverage is left to CI.
