### PR TITLE
Houston follow-up: atomic adapter swap + browse serialisation/readiness (EDG-602, 493, 576, 577)

### DIFF
--- a/ext/hivemq-edge-openapi.yaml
+++ b/ext/hivemq-edge-openapi.yaml
@@ -4108,6 +4108,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/ProblemDetails'
           description: Adapter does not support bulk tag browsing or browse failed
+        '503':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Adapter is connected but its device address-space metadata is still loading; retry after the indicated delay.
+          headers:
+            Retry-After:
+              description: Seconds to wait before retrying the browse.
+              schema:
+                type: integer
+              example: 2
         '504':
           content:
             application/json:

--- a/hivemq-edge-openapi/openapi/paths/api_v1_management_protocol-adapters_adapters_{adapterId}_device-tags_browse.yaml
+++ b/hivemq-edge-openapi/openapi/paths/api_v1_management_protocol-adapters_adapters_{adapterId}_device-tags_browse.yaml
@@ -55,6 +55,20 @@ post:
           schema:
             $ref: ../components/schemas/ProblemDetails.yaml
       description: Adapter does not support bulk tag browsing or browse failed
+    '503':
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/ProblemDetails.yaml
+      description: >-
+        Adapter is connected but its device address-space metadata is still
+        loading; retry after the indicated delay.
+      headers:
+        Retry-After:
+          description: Seconds to wait before retrying the browse.
+          schema:
+            type: integer
+          example: 2
     '504':
       content:
         application/json:

--- a/hivemq-edge/src/main/java/com/hivemq/api/errors/adapters/AdapterBrowseNotReadyError.java
+++ b/hivemq-edge/src/main/java/com/hivemq/api/errors/adapters/AdapterBrowseNotReadyError.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.api.errors.adapters;
+
+import com.hivemq.http.HttpStatus;
+import com.hivemq.http.error.ProblemDetails;
+import java.util.List;
+
+/**
+ * The adapter is connected but its device address-space metadata is still being loaded, so a browse would be
+ * non-deterministic. Returned as {@code 503 Service Unavailable} with a {@code Retry-After} hint so the caller
+ * retries once the adapter is browse-ready (EDG-577).
+ */
+public class AdapterBrowseNotReadyError extends ProblemDetails {
+    public AdapterBrowseNotReadyError(final String adapterId) {
+        super(
+                "AdapterBrowseNotReady",
+                "Adapter not ready for browsing",
+                "Adapter '" + adapterId
+                        + "' is connected but still loading its device metadata; retry after the indicated delay.",
+                HttpStatus.SERVICE_UNAVAILABLE_503,
+                List.of());
+    }
+}

--- a/hivemq-edge/src/main/java/com/hivemq/edge/adapters/browse/BulkTagBrowser.java
+++ b/hivemq-edge/src/main/java/com/hivemq/edge/adapters/browse/BulkTagBrowser.java
@@ -39,6 +39,19 @@ public interface BulkTagBrowser {
     Stream<BrowsedNode> browse(@Nullable String rootId, int maxDepth) throws BrowseException;
 
     /**
+     * Whether the adapter has hydrated the metadata a deterministic browse needs. Adapters without a warm-up
+     * phase are always ready. OPC UA reports {@code false} after a (re)connect until its namespace table and
+     * data-type tree are loaded — the Milo session reports CONNECTED before that metadata is available — so the
+     * REST layer can answer {@code 503 Service Unavailable} with {@code Retry-After} instead of serving a
+     * degraded browse (EDG-577).
+     *
+     * @return {@code true} once the device address-space metadata is loaded and a browse will be deterministic
+     */
+    default boolean isBrowseReady() {
+        return true;
+    }
+
+    /**
      * Resolve a node ID against the device's current namespace table using the stable namespace URI.
      * If the device's namespace index for the given URI has changed since the file was exported,
      * the returned node ID will contain the updated index.

--- a/hivemq-edge/src/main/java/com/hivemq/edge/adapters/browse/importer/DeviceTagImporter.java
+++ b/hivemq-edge/src/main/java/com/hivemq/edge/adapters/browse/importer/DeviceTagImporter.java
@@ -158,6 +158,20 @@ public class DeviceTagImporter {
 
         // if there was no validation error, now is the time to execute the plan
         final ProtocolAdapterEntity fac = finalAdapterConfiguration(adapter, twmsFinal);
+
+        // EDG-493: classify the import as additive-only — nothing deleted, nothing updated, only creations. Such
+        // an import does not need the full adapter restart that updateAdapter triggers; for now we only surface
+        // how often the condition holds so the skip-restart follow-up can be prioritised on real workloads.
+        if (stats.isAdditiveOnly() && log.isDebugEnabled()) {
+            log.debug(
+                    "Import for adapter '{}' is additive-only ({} tags, {} northbound, {} southbound created; "
+                            + "no updates or deletions) — eligible for the future skip-restart optimisation (EDG-493)",
+                    adapterId,
+                    stats.tagsCreated,
+                    stats.nbCreated,
+                    stats.sbCreated);
+        }
+
         final boolean success = adapterExtractor.updateAdapter(fac);
         if (!success) {
             throw new DeviceTagImporterException(List.of(new ValidationError(
@@ -950,6 +964,15 @@ public class DeviceTagImporter {
             tagsCreated = tagsUpdated = tagsDeleted = 0;
             nbCreated = nbDeleted = 0;
             sbCreated = sbDeleted = 0;
+        }
+
+        /**
+         * An import is additive-only when it neither updates nor deletes anything — no tag updated or deleted and
+         * no north-/southbound mapping deleted. Pure creations leave every existing tag and subscription intact,
+         * which is what makes the adapter restart skippable (EDG-493).
+         */
+        boolean isAdditiveOnly() {
+            return tagsUpdated == 0 && tagsDeleted == 0 && nbDeleted == 0 && sbDeleted == 0;
         }
     }
 

--- a/hivemq-edge/src/main/java/com/hivemq/edge/adapters/browse/rest/DeviceTagBrowsingResourceImpl.java
+++ b/hivemq-edge/src/main/java/com/hivemq/edge/adapters/browse/rest/DeviceTagBrowsingResourceImpl.java
@@ -126,6 +126,19 @@ public class DeviceTagBrowsingResourceImpl extends AbstractApi implements Device
                     Response.Status.CONFLICT, "Adapter '" + adapterId + "' does not support bulk tag browsing");
         }
 
+        // EDG-577: the adapter may be CONNECTED but still loading its address-space metadata, during which a
+        // browse would be non-deterministic. Answer 503 with Retry-After so the caller retries once it is ready.
+        if (!browser.isBrowseReady()) {
+            return Response.status(Response.Status.SERVICE_UNAVAILABLE)
+                    .header("Retry-After", "2")
+                    .entity(errorBody(
+                            Response.Status.SERVICE_UNAVAILABLE.getReasonPhrase(),
+                            "Adapter '" + adapterId
+                                    + "' is connected but still loading device metadata; retry shortly"))
+                    .type(APPLICATION_JSON)
+                    .build();
+        }
+
         // Browse
         if (maxDepth != null && maxDepth < 0) {
             return errorResponse(Response.Status.BAD_REQUEST, "maxDepth must be >= 0 (0 = unlimited)");

--- a/hivemq-edge/src/main/java/com/hivemq/edge/adapters/browse/rest/DeviceTagBrowsingResourceImpl.java
+++ b/hivemq-edge/src/main/java/com/hivemq/edge/adapters/browse/rest/DeviceTagBrowsingResourceImpl.java
@@ -20,6 +20,7 @@ import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hivemq.adapter.sdk.api.ProtocolAdapter;
 import com.hivemq.api.AbstractApi;
+import com.hivemq.api.errors.adapters.AdapterBrowseNotReadyError;
 import com.hivemq.edge.adapters.browse.BrowseException;
 import com.hivemq.edge.adapters.browse.BrowsedNode;
 import com.hivemq.edge.adapters.browse.BulkTagBrowser;
@@ -35,6 +36,7 @@ import com.hivemq.edge.adapters.browse.validate.ValidationError;
 import com.hivemq.edge.api.DeviceTagBrowsingApi;
 import com.hivemq.protocols.ProtocolAdapterManager;
 import com.hivemq.protocols.ProtocolAdapterWrapper;
+import com.hivemq.util.ErrorResponseUtil;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import jakarta.ws.rs.core.Response;
@@ -127,15 +129,11 @@ public class DeviceTagBrowsingResourceImpl extends AbstractApi implements Device
         }
 
         // EDG-577: the adapter may be CONNECTED but still loading its address-space metadata, during which a
-        // browse would be non-deterministic. Answer 503 with Retry-After so the caller retries once it is ready.
+        // browse would be non-deterministic. Answer 503 (ProblemDetails) with Retry-After so the caller retries
+        // once it is ready.
         if (!browser.isBrowseReady()) {
-            return Response.status(Response.Status.SERVICE_UNAVAILABLE)
+            return Response.fromResponse(ErrorResponseUtil.errorResponse(new AdapterBrowseNotReadyError(adapterId)))
                     .header("Retry-After", "2")
-                    .entity(errorBody(
-                            Response.Status.SERVICE_UNAVAILABLE.getReasonPhrase(),
-                            "Adapter '" + adapterId
-                                    + "' is connected but still loading device metadata; retry shortly"))
-                    .type(APPLICATION_JSON)
                     .build();
         }
 

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/ProtocolAdapterManager.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/ProtocolAdapterManager.java
@@ -588,9 +588,7 @@ public class ProtocolAdapterManager {
      * protocol exist.
      */
     private void updateProtocolAdapterAtomically(
-            final @NotNull String adapterId,
-            final @NotNull ProtocolAdapterConfig config,
-            final @NotNull String version)
+            final @NotNull String adapterId, final @NotNull ProtocolAdapterConfig config, final @NotNull String version)
             throws ProtocolAdapterException {
         final ProtocolAdapterWrapper newWrapper = buildProtocolAdapterWrapper(config, version);
         final ProtocolAdapterWrapper previous = protocolAdapterMap.put(adapterId, newWrapper);

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/ProtocolAdapterManager.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/ProtocolAdapterManager.java
@@ -349,10 +349,8 @@ public class ProtocolAdapterManager {
     }
 
     private void updateAdapter(final @NotNull ProtocolAdapterConfig config) {
-        deleteProtocolAdapterByAdapterId(config.getAdapterId());
-        createProtocolAdapter(config, versionProvider.getVersion());
         try {
-            start(config.getAdapterId());
+            updateProtocolAdapterAtomically(config.getAdapterId(), config, versionProvider.getVersion());
         } catch (final ProtocolAdapterException e) {
             final Throwable cause = e.getCause();
             if (cause instanceof InterruptedException) {
@@ -421,14 +419,24 @@ public class ProtocolAdapterManager {
      * @throws ProtocolAdapterException if the adapter is not found
      */
     public void stop(final @NotNull String adapterId, final boolean destroy) throws ProtocolAdapterException {
-        LOGGER.info("Stopping protocol-adapter '{}'.", adapterId);
         final var optionalWrapper = getProtocolAdapterWrapperByAdapterId(adapterId);
         if (optionalWrapper.isEmpty()) {
             throw new ProtocolAdapterException(
                     I18nProtocolAdapterMessage.PROTOCOL_ADAPTER_MANAGER_PROTOCOL_ADAPTER_NOT_FOUND.get(
                             Map.of(ADAPTER_ID, adapterId)));
         }
-        final ProtocolAdapterWrapper wrapper = optionalWrapper.get();
+        stopWrapper(optionalWrapper.get(), adapterId, destroy);
+    }
+
+    /**
+     * Stop (and optionally destroy) a specific wrapper instance and fire the corresponding adapter event. Unlike
+     * {@link #stop(String, boolean)} this acts on the given instance rather than re-resolving it from the map,
+     * which {@link #updateProtocolAdapterAtomically} relies on: by the time the displaced wrapper is stopped the
+     * map already points at its replacement.
+     */
+    private void stopWrapper(
+            final @NotNull ProtocolAdapterWrapper wrapper, final @NotNull String adapterId, final boolean destroy) {
+        LOGGER.info("Stopping protocol-adapter '{}'.", adapterId);
         final String protocolId = wrapper.getProtocolAdapterInformation().getProtocolId();
         final boolean success = wrapper.stop(destroy);
 
@@ -493,68 +501,105 @@ public class ProtocolAdapterManager {
         Preconditions.checkNotNull(config);
         final String adapterId = config.getAdapterId();
         protocolAdapterMap.computeIfAbsent(adapterId, ignored -> {
-            final String configProtocolId = config.getProtocolId();
-            // legacy handling, hardcoded here, to not add legacy stuff into the adapter-sdk
-            final String adapterType =
-                    switch (configProtocolId) {
-                        case "ethernet-ip" -> "eip";
-                        case "opc-ua-client" -> "opcua";
-                        case "file_input" -> "file";
-                        default -> configProtocolId;
-                    };
-
-            final Optional<ProtocolAdapterFactory<?>> maybeFactory = protocolAdapterFactoryManager.get(adapterType);
-            if (maybeFactory.isEmpty()) {
-                throw new IllegalArgumentException("Protocol adapter for config " + adapterType + " not found.");
-            }
-            final ProtocolAdapterFactory<?> factory = maybeFactory.get();
-
-            LOGGER.info("Found configuration for adapter {} / {}", config.getAdapterId(), adapterType);
-            config.missingTags().ifPresent(missingTag -> {
-                throw new IllegalArgumentException(
-                        "Tags used in mappings but not configured in adapter " + adapterType + ": " + missingTag);
-            });
-
-            return runWithContextLoader(factory.getClass().getClassLoader(), () -> {
-                final ProtocolAdapterMetricsService metricsService =
-                        new ProtocolAdapterMetricsServiceImpl(configProtocolId, config.getAdapterId(), metricRegistry);
-                final ProtocolAdapterStateImpl state =
-                        new ProtocolAdapterStateImpl(eventService, config.getAdapterId(), configProtocolId);
-                final var streamingService = new ProtocolAdapterTagStreamingServiceImpl(
-                        config.getAdapterId(), tagManager, dataPointBuilder -> {});
-                final ModuleServicesPerModuleImpl perModule = new ModuleServicesPerModuleImpl(
-                        adapterPublishService, eventService, protocolAdapterWritingService, streamingService);
-                final ProtocolAdapter protocolAdapter = factory.createAdapter(
-                        factory.getInformation(),
-                        new ProtocolAdapterInputImpl(
-                                config.getAdapterId(),
-                                config.getAdapterConfig(),
-                                config.getTags(),
-                                config.getNorthboundMappings(),
-                                version,
-                                state,
-                                perModule,
-                                metricsService));
-                // hen-egg problem. Rather solve this here as have not final fields in the adapter.
-                perModule.setAdapter(protocolAdapter);
-                final ProtocolAdapterWrapper wrapper = new ProtocolAdapterWrapper(
-                        protocolAdapter,
-                        config,
-                        factory,
-                        factory.getInformation(),
-                        metricsService,
-                        state,
-                        protocolAdapterPollingService,
-                        eventService,
-                        perModule,
-                        tagManager,
-                        northboundConsumerFactory,
-                        protocolAdapterWritingService,
-                        adapterLifecycleExecutor);
-                protocolAdapterMetrics.increaseProtocolAdapterMetric(configProtocolId);
-                return wrapper;
-            });
+            final ProtocolAdapterWrapper wrapper = buildProtocolAdapterWrapper(config, version);
+            protocolAdapterMetrics.increaseProtocolAdapterMetric(config.getProtocolId());
+            return wrapper;
         });
+    }
+
+    /**
+     * Build a fully-wired {@link ProtocolAdapterWrapper} for {@code config} without inserting it into
+     * {@link #protocolAdapterMap} or mutating adapter metrics. Keeping construction side-effect free is what
+     * lets an update build the replacement <i>before</i> evicting the old instance, so the adapter id is never
+     * momentarily absent from the map — see {@link #updateProtocolAdapterAtomically} (EDG-602).
+     */
+    private @NotNull ProtocolAdapterWrapper buildProtocolAdapterWrapper(
+            final @NotNull ProtocolAdapterConfig config, final @NotNull String version) {
+        final String configProtocolId = config.getProtocolId();
+        // legacy handling, hardcoded here, to not add legacy stuff into the adapter-sdk
+        final String adapterType =
+                switch (configProtocolId) {
+                    case "ethernet-ip" -> "eip";
+                    case "opc-ua-client" -> "opcua";
+                    case "file_input" -> "file";
+                    default -> configProtocolId;
+                };
+
+        final Optional<ProtocolAdapterFactory<?>> maybeFactory = protocolAdapterFactoryManager.get(adapterType);
+        if (maybeFactory.isEmpty()) {
+            throw new IllegalArgumentException("Protocol adapter for config " + adapterType + " not found.");
+        }
+        final ProtocolAdapterFactory<?> factory = maybeFactory.get();
+
+        LOGGER.info("Found configuration for adapter {} / {}", config.getAdapterId(), adapterType);
+        config.missingTags().ifPresent(missingTag -> {
+            throw new IllegalArgumentException(
+                    "Tags used in mappings but not configured in adapter " + adapterType + ": " + missingTag);
+        });
+
+        return runWithContextLoader(factory.getClass().getClassLoader(), () -> {
+            final ProtocolAdapterMetricsService metricsService =
+                    new ProtocolAdapterMetricsServiceImpl(configProtocolId, config.getAdapterId(), metricRegistry);
+            final ProtocolAdapterStateImpl state =
+                    new ProtocolAdapterStateImpl(eventService, config.getAdapterId(), configProtocolId);
+            final var streamingService = new ProtocolAdapterTagStreamingServiceImpl(
+                    config.getAdapterId(), tagManager, dataPointBuilder -> {});
+            final ModuleServicesPerModuleImpl perModule = new ModuleServicesPerModuleImpl(
+                    adapterPublishService, eventService, protocolAdapterWritingService, streamingService);
+            final ProtocolAdapter protocolAdapter = factory.createAdapter(
+                    factory.getInformation(),
+                    new ProtocolAdapterInputImpl(
+                            config.getAdapterId(),
+                            config.getAdapterConfig(),
+                            config.getTags(),
+                            config.getNorthboundMappings(),
+                            version,
+                            state,
+                            perModule,
+                            metricsService));
+            // hen-egg problem. Rather solve this here as have not final fields in the adapter.
+            perModule.setAdapter(protocolAdapter);
+            return new ProtocolAdapterWrapper(
+                    protocolAdapter,
+                    config,
+                    factory,
+                    factory.getInformation(),
+                    metricsService,
+                    state,
+                    protocolAdapterPollingService,
+                    eventService,
+                    perModule,
+                    tagManager,
+                    northboundConsumerFactory,
+                    protocolAdapterWritingService,
+                    adapterLifecycleExecutor);
+        });
+    }
+
+    /**
+     * Replace a running adapter's wrapper with one built from {@code config} without ever removing the adapter
+     * id from {@link #protocolAdapterMap}. The replacement is constructed first, then swapped in with a single
+     * {@code put}; only afterwards is the displaced instance stopped and destroyed. A concurrent REST read
+     * therefore always resolves a wrapper — the old tags before the swap, the new tags after — and never the
+     * 404 that the previous delete-then-recreate sequence exposed (EDG-602). If construction fails the old
+     * wrapper is left untouched and running, and the throw is surfaced to the caller as an update failure.
+     * <p>
+     * The adapter metric is intentionally left untouched: an update does not change how many adapters of this
+     * protocol exist.
+     */
+    private void updateProtocolAdapterAtomically(
+            final @NotNull String adapterId,
+            final @NotNull ProtocolAdapterConfig config,
+            final @NotNull String version)
+            throws ProtocolAdapterException {
+        final ProtocolAdapterWrapper newWrapper = buildProtocolAdapterWrapper(config, version);
+        final ProtocolAdapterWrapper previous = protocolAdapterMap.put(adapterId, newWrapper);
+        if (previous != null) {
+            // The displaced instance is no longer reachable through the map; stop and destroy it by reference so
+            // stop(adapterId, ...) cannot act on the freshly-installed wrapper instead.
+            stopWrapper(previous, adapterId, true);
+        }
+        start(adapterId);
     }
 
     protected @NotNull Optional<ProtocolAdapterWrapper> deleteProtocolAdapterWrapperByAdapterId(
@@ -734,10 +779,10 @@ public class ProtocolAdapterManager {
                 if (LOGGER.isDebugEnabled()) {
                     LOGGER.debug("Updating adapter '{}'", adapterId);
                 }
-                stop(adapterId, true);
-                deleteProtocolAdapterByAdapterId(adapterId);
-                createProtocolAdapter(protocolAdapterConfig, versionProvider.getVersion());
-                start(adapterId);
+                // Swap the wrapper in place: build the replacement, atomically replace the map entry, then stop
+                // the displaced instance. The adapter id stays resolvable throughout, so a concurrent REST read
+                // never observes the transient 404 the old delete-then-recreate sequence could expose (EDG-602).
+                updateProtocolAdapterAtomically(adapterId, protocolAdapterConfig, versionProvider.getVersion());
             } catch (final Exception e) {
                 failedAdapterSet.add(adapterId);
                 if (e.getCause() instanceof InterruptedException) {

--- a/hivemq-edge/src/test/java/com/hivemq/edge/adapters/browse/rest/DeviceTagBrowsingResourceImplTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/edge/adapters/browse/rest/DeviceTagBrowsingResourceImplTest.java
@@ -85,6 +85,7 @@ class DeviceTagBrowsingResourceImplTest {
         when(adapterManager.getProtocolAdapterWrapperByAdapterId(ADAPTER_ID)).thenReturn(Optional.of(wrapper));
         when(wrapper.getAdapter()).thenReturn(adapter);
         when(adapter.browse(any(), anyInt())).thenReturn(Stream.of(testNode()));
+        when(adapter.isBrowseReady()).thenReturn(true);
 
         importer = mock(DeviceTagImporter.class);
         resource = new DeviceTagBrowsingResourceImpl(
@@ -248,11 +249,31 @@ class DeviceTagBrowsingResourceImplTest {
     }
 
     @Test
+    void browse_adapterConnectedButNotBrowseReady_returns503WithRetryAfter() throws BrowseException {
+        // EDG-577: a browsable adapter that is connected but still loading its metadata must answer 503 with a
+        // Retry-After hint, not serve a degraded browse.
+        final ProtocolAdapterWrapper wrapper = mock(ProtocolAdapterWrapper.class);
+        final BrowsableAdapter warmingUpAdapter = mock(BrowsableAdapter.class);
+        when(adapterManager.getProtocolAdapterWrapperByAdapterId("warming-up")).thenReturn(Optional.of(wrapper));
+        when(wrapper.getAdapter()).thenReturn(warmingUpAdapter);
+        when(warmingUpAdapter.isBrowseReady()).thenReturn(false);
+
+        when(httpHeaders.getHeaderString("Accept")).thenReturn("application/json");
+        final Response response = resource.browseDeviceTags("warming-up", null, null);
+
+        assertThat(response.getStatus()).isEqualTo(503);
+        assertThat(response.getHeaderString("Retry-After")).isEqualTo("2");
+        // the browse itself must never be attempted while not ready
+        verify(warmingUpAdapter, org.mockito.Mockito.never()).browse(any(), anyInt());
+    }
+
+    @Test
     void browse_browseException_returns409() throws BrowseException {
         final ProtocolAdapterWrapper wrapper = mock(ProtocolAdapterWrapper.class);
         final BrowsableAdapter failingAdapter = mock(BrowsableAdapter.class);
         when(adapterManager.getProtocolAdapterWrapperByAdapterId("failing")).thenReturn(Optional.of(wrapper));
         when(wrapper.getAdapter()).thenReturn(failingAdapter);
+        when(failingAdapter.isBrowseReady()).thenReturn(true);
         when(failingAdapter.browse(any(), anyInt())).thenThrow(new BrowseException("Server error"));
 
         when(httpHeaders.getHeaderString("Accept")).thenReturn("application/json");
@@ -266,6 +287,7 @@ class DeviceTagBrowsingResourceImplTest {
         final BrowsableAdapter failingAdapter = mock(BrowsableAdapter.class);
         when(adapterManager.getProtocolAdapterWrapperByAdapterId("timeout")).thenReturn(Optional.of(wrapper));
         when(wrapper.getAdapter()).thenReturn(failingAdapter);
+        when(failingAdapter.isBrowseReady()).thenReturn(true);
         when(failingAdapter.browse(any(), anyInt())).thenThrow(new BrowseException("Operation timed out after 30s"));
 
         when(httpHeaders.getHeaderString("Accept")).thenReturn("application/json");
@@ -279,6 +301,7 @@ class DeviceTagBrowsingResourceImplTest {
         final BrowsableAdapter failingAdapter = mock(BrowsableAdapter.class);
         when(adapterManager.getProtocolAdapterWrapperByAdapterId("null-msg")).thenReturn(Optional.of(wrapper));
         when(wrapper.getAdapter()).thenReturn(failingAdapter);
+        when(failingAdapter.isBrowseReady()).thenReturn(true);
         when(failingAdapter.browse(any(), anyInt())).thenThrow(new BrowseException("Browse failed", null));
 
         when(httpHeaders.getHeaderString("Accept")).thenReturn("application/json");

--- a/hivemq-edge/src/test/java/com/hivemq/edge/adapters/browse/rest/DeviceTagBrowsingResourceImplTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/edge/adapters/browse/rest/DeviceTagBrowsingResourceImplTest.java
@@ -263,6 +263,8 @@ class DeviceTagBrowsingResourceImplTest {
 
         assertThat(response.getStatus()).isEqualTo(503);
         assertThat(response.getHeaderString("Retry-After")).isEqualTo("2");
+        // the error is returned as a ProblemDetails entity (application/problem+json), not an ad-hoc body
+        assertThat(response.getMediaType().toString()).contains("application/problem+json");
         // the browse itself must never be attempted while not ready
         verify(warmingUpAdapter, org.mockito.Mockito.never()).browse(any(), anyInt());
     }

--- a/hivemq-edge/src/test/java/com/hivemq/protocols/ProtocolAdapterManagerTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/protocols/ProtocolAdapterManagerTest.java
@@ -689,5 +689,55 @@ class ProtocolAdapterManagerTest {
             continueStart.countDown();
             waitUntilNotBusy(spyManager);
         }
+
+        @Test
+        void refresh_changedConfig_swapsInPlaceWithoutDeletingTheAdapter() throws Exception {
+            // EDG-602: an update must never remove the adapter id from the map. The previous delete-then-recreate
+            // sequence left a window where getAdapterDomainTags resolved no wrapper and returned 404. The new
+            // config is now swapped in place — the old wrapper is stopped, the new one started, and the adapter
+            // stays resolvable throughout.
+            final ProtocolAdapter oldAdapter = createSuccessAdapter("adapter-1");
+            final ProtocolAdapterConfig oldConfig = mock(ProtocolAdapterConfig.class);
+            addAdapterToManager("adapter-1", oldAdapter, oldConfig);
+            manager.start("adapter-1");
+
+            final ProtocolAdapterEntity entity = mock(ProtocolAdapterEntity.class);
+            final ProtocolAdapterConfig newConfig = mock(ProtocolAdapterConfig.class);
+            final ProtocolSpecificAdapterConfig newAdapterConfig = mock(ProtocolSpecificAdapterConfig.class);
+            final ProtocolAdapterFactory<?> factory = mock(ProtocolAdapterFactory.class);
+            final ProtocolAdapterInformation info = mock(ProtocolAdapterInformation.class);
+            final ProtocolAdapter newAdapter = createSuccessAdapter("adapter-1");
+
+            when(configConverter.fromEntity(entity)).thenReturn(newConfig);
+            when(versionProvider.getVersion()).thenReturn("1.0.0");
+            when(newConfig.getAdapterId()).thenReturn("adapter-1");
+            when(newConfig.getProtocolId()).thenReturn("test-protocol");
+            when(newConfig.getAdapterConfig()).thenReturn(newAdapterConfig);
+            org.mockito.Mockito.doReturn(List.of()).when(newConfig).getTags();
+            when(newConfig.getNorthboundMappings()).thenReturn(List.<NorthboundMapping>of());
+            when(newConfig.getSouthboundMappings()).thenReturn(List.<SouthboundMapping>of());
+            when(newConfig.missingTags()).thenReturn(Optional.empty());
+            when(factoryManager.get("test-protocol")).thenReturn(Optional.of(factory));
+            when(factory.getInformation()).thenReturn(info);
+            when(info.getProtocolId()).thenReturn("test-protocol");
+            when(factory.createAdapter(any(), any())).thenReturn(newAdapter);
+
+            manager.refresh(List.of(entity));
+            waitUntilNotBusy(manager);
+
+            // the adapter id never disappeared: it resolves, and to the NEW wrapper (new config swapped in)
+            assertThat(manager.getProtocolAdapterWrapperByAdapterId("adapter-1"))
+                    .isPresent()
+                    .get()
+                    .extracting(ProtocolAdapterWrapper::getConfig)
+                    .isSameAs(newConfig);
+            // the displaced instance was stopped and destroyed; the replacement was started
+            verify(oldAdapter).stop(any(), any(), any());
+            verify(oldAdapter).destroy();
+            verify(newAdapter).start(any(), any(), any());
+            // an update is metric-neutral and must never run the delete path that caused the 404
+            verify(protocolAdapterMetrics, org.mockito.Mockito.never()).decreaseProtocolAdapterMetric(anyString());
+            verify(protocolAdapterMetrics, org.mockito.Mockito.never()).increaseProtocolAdapterMetric(anyString());
+        }
     }
 }

--- a/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/OpcUaProtocolAdapter.java
+++ b/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/OpcUaProtocolAdapter.java
@@ -118,6 +118,18 @@ public class OpcUaProtocolAdapter implements WritingProtocolAdapter, BulkTagBrow
     static final int MAX_CONCURRENT_BROWSES = 1;
     private final @NotNull Semaphore browseConcurrency = new Semaphore(MAX_CONCURRENT_BROWSES);
 
+    // EDG-577: browse-readiness is tracked separately from CONNECTED. The Milo session reports CONNECTED the
+    // moment it activates, before the namespace table and data-type tree are hydrated; a browse in that window
+    // is non-deterministic. Kept OPC-UA-local (not on the shared SDK ConnectionStatus enum). Reset to WARMING_UP
+    // on every (re)connect attempt and flipped to BROWSE_READY once the warm-up has loaded the metadata.
+    private enum ReadinessStatus {
+        WARMING_UP,
+        BROWSE_READY
+    }
+
+    private final @NotNull AtomicReference<ReadinessStatus> browseReadiness =
+            new AtomicReference<>(ReadinessStatus.WARMING_UP);
+
     // Flag to prevent scheduling after stop
     private volatile boolean stopped = false;
 
@@ -588,6 +600,12 @@ public class OpcUaProtocolAdapter implements WritingProtocolAdapter, BulkTagBrow
     }
 
     @Override
+    public boolean isBrowseReady() {
+        // Connected AND the address-space metadata has been hydrated by the post-connect warm-up (EDG-577).
+        return !stopped && browseReadiness.get() == ReadinessStatus.BROWSE_READY;
+    }
+
+    @Override
     public @NotNull String resolveNodeId(final @NotNull String nodeId, final @Nullable String namespaceUri) {
         if (namespaceUri == null || namespaceUri.isEmpty()) {
             return nodeId;
@@ -743,6 +761,9 @@ public class OpcUaProtocolAdapter implements WritingProtocolAdapter, BulkTagBrow
             final @NotNull ParsedConfig parsedConfig,
             final @NotNull ProtocolAdapterStartInput input) {
 
+        // EDG-577: a fresh (re)connect is not browse-ready until its warm-up completes.
+        browseReadiness.set(ReadinessStatus.WARMING_UP);
+
         @SuppressWarnings("unused")
         final var unused = CompletableFuture.supplyAsync(() -> conn.start(parsedConfig))
                 .whenComplete((success, throwable) -> {
@@ -757,6 +778,9 @@ public class OpcUaProtocolAdapter implements WritingProtocolAdapter, BulkTagBrow
                         reconnectAttempts.set(0);
                         // Update browse client snapshot so browse works during future restarts
                         conn.client().ifPresent(browseClient::set);
+                        // EDG-577: CONNECTED has fired, but the address-space metadata still needs hydrating
+                        // before a deterministic browse — warm it up, then flip to BROWSE_READY.
+                        conn.client().ifPresent(this::warmUpBrowseReadiness);
                         // Connection succeeded - cancel any pending retries and start health check
                         cancelRetry();
                         scheduleHealthCheck();
@@ -782,6 +806,34 @@ public class OpcUaProtocolAdapter implements WritingProtocolAdapter, BulkTagBrow
                         scheduleRetry(input);
                     }
                 });
+    }
+
+    /**
+     * EDG-577: one-shot async warm-up run after a successful (re)connect. The Milo session reports CONNECTED as
+     * soon as it activates, but the namespace table and data-type tree a deterministic browse depends on may not
+     * be populated yet. Force-load them off the connection thread, then flip the adapter to BROWSE_READY so the
+     * REST browse endpoint stops answering 503. A failure leaves the adapter not-ready; the next reconnect (or a
+     * later browse) re-warms.
+     */
+    private void warmUpBrowseReadiness(final @NotNull OpcUaClient client) {
+        @SuppressWarnings("unused")
+        final var unused = CompletableFuture.runAsync(() -> {
+            try {
+                client.getNamespaceTable(); // ensure the namespace table is read from the server
+                client.getDataTypeTree(); // build the data-type tree (feeds the EDG-488 cache when that lands)
+                if (!stopped) {
+                    browseReadiness.set(ReadinessStatus.BROWSE_READY);
+                    log.info(
+                            "OPC UA adapter '{}' is browse-ready (namespace table and data-type tree hydrated)",
+                            adapterId);
+                }
+            } catch (final @NotNull Exception e) {
+                log.warn(
+                        "OPC UA adapter '{}' browse warm-up failed; adapter stays not browse-ready until the next reconnect",
+                        adapterId,
+                        e);
+            }
+        });
     }
 
     /**

--- a/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/OpcUaProtocolAdapter.java
+++ b/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/OpcUaProtocolAdapter.java
@@ -57,6 +57,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.Semaphore;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -109,6 +110,13 @@ public class OpcUaProtocolAdapter implements WritingProtocolAdapter, BulkTagBrow
     // Last-known-good client reference for browse operations during adapter restarts.
     // Set when a connection succeeds, cleared only on explicit stop (not during reconnect).
     private final @NotNull AtomicReference<OpcUaClient> browseClient = new AtomicReference<>();
+
+    // Serialise all browse operations against this adapter to one at a time. Every REST browse call shares a
+    // single Milo OpcUaClient against one physical device; resource-constrained PLCs (e.g. S7-1500) return
+    // non-deterministic node counts when browseAsync/browseNext requests overlap. Owning the permit here makes
+    // the serialisation effective across concurrent calls, not just within a single browse (EDG-576).
+    static final int MAX_CONCURRENT_BROWSES = 1;
+    private final @NotNull Semaphore browseConcurrency = new Semaphore(MAX_CONCURRENT_BROWSES);
 
     // Flag to prevent scheduling after stop
     private volatile boolean stopped = false;
@@ -576,7 +584,7 @@ public class OpcUaProtocolAdapter implements WritingProtocolAdapter, BulkTagBrow
         if (client == null) {
             throw new BrowseException("Browse failed: Client not connected");
         }
-        return new OpcUaNodeBrowser(client, adapterId).browse(rootId, maxDepth);
+        return new OpcUaNodeBrowser(client, adapterId, 0, browseConcurrency).browse(rootId, maxDepth);
     }
 
     @Override

--- a/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/browse/OpcUaNodeBrowser.java
+++ b/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/browse/OpcUaNodeBrowser.java
@@ -77,15 +77,14 @@ public class OpcUaNodeBrowser {
 
     private static final long TIMEOUT_SECONDS = 120;
     private static final int READ_BATCH_SIZE = 100;
-    // Serialise all browse operations (including continuation-point requests) to avoid
-    // server-side throttling on resource-constrained PLCs (e.g. S7-1500). Even at
-    // concurrency 4 the S7-1500 produced non-deterministic results because browseNext
-    // requests bypassed the semaphore and overlapped with new browseAsync calls.
-    private static final int MAX_CONCURRENT_BROWSES = 1;
 
     private final @NotNull OpcUaClient client;
     private final @NotNull String adapterId;
     private final int maxReferencesPerNode;
+    // Serialise all browse operations (including continuation-point requests) so they never overlap on the
+    // shared client. In production this permit is owned by the OpcUaProtocolAdapter and shared across every
+    // browse call against the device (EDG-576); standalone/test callers get their own single permit.
+    private final @NotNull Semaphore concurrency;
 
     public OpcUaNodeBrowser(final @NotNull OpcUaClient client, final @NotNull String adapterId) {
         this(client, adapterId, 0);
@@ -98,9 +97,26 @@ public class OpcUaNodeBrowser {
      */
     public OpcUaNodeBrowser(
             final @NotNull OpcUaClient client, final @NotNull String adapterId, final int maxReferencesPerNode) {
+        // Standalone default: one permit private to this browser. Production uses the constructor below to share
+        // the adapter-scoped permit so concurrent browses against the same device are serialised too (EDG-576).
+        this(client, adapterId, maxReferencesPerNode, new Semaphore(1));
+    }
+
+    /**
+     * @param maxReferencesPerNode maximum references the server should return per browse request (0 =
+     *                             server-decides).
+     * @param concurrency          permit that serialises browse operations; pass the adapter-owned semaphore to
+     *                             serialise across concurrent browse calls sharing one client (EDG-576).
+     */
+    public OpcUaNodeBrowser(
+            final @NotNull OpcUaClient client,
+            final @NotNull String adapterId,
+            final int maxReferencesPerNode,
+            final @NotNull Semaphore concurrency) {
         this.client = client;
         this.adapterId = adapterId;
         this.maxReferencesPerNode = maxReferencesPerNode;
+        this.concurrency = concurrency;
     }
 
     /**
@@ -136,7 +152,6 @@ public class OpcUaNodeBrowser {
             // The visited set deduplicates nodes reachable via multiple paths in the OPC UA graph.
             final List<DiscoveredVariable> variables = new CopyOnWriteArrayList<>();
             final Set<NodeId> visited = ConcurrentHashMap.newKeySet();
-            final Semaphore concurrency = new Semaphore(MAX_CONCURRENT_BROWSES);
             browseRecursive(
                             browseRoot,
                             "",

--- a/modules/hivemq-edge-module-opcua/src/test/java/com/hivemq/edge/adapters/opcua/browse/OpcUaNodeBrowserTest.java
+++ b/modules/hivemq-edge-module-opcua/src/test/java/com/hivemq/edge/adapters/opcua/browse/OpcUaNodeBrowserTest.java
@@ -24,6 +24,11 @@ import static org.mockito.Mockito.when;
 import com.hivemq.edge.adapters.browse.BrowseException;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
@@ -68,6 +73,46 @@ class OpcUaNodeBrowserTest {
         final OpcUaNodeBrowser browser = new OpcUaNodeBrowser(client, "test-adapter");
 
         assertThat(browser.browse(null, 0).count()).isEqualTo(0);
+    }
+
+    // --- adapter-scoped browse serialisation (EDG-576) ---
+
+    @Test
+    void browse_sharedSemaphore_serialisesBrowseAsyncAcrossBrowsers() throws Exception {
+        // EDG-576: two distinct browsers sharing the adapter-owned permit must never have their browseAsync
+        // calls overlap on the shared client. The peak in-flight count therefore stays at 1.
+        final OpcUaClient client = mock(OpcUaClient.class);
+        final AtomicInteger inFlight = new AtomicInteger();
+        final AtomicInteger peak = new AtomicInteger();
+        final BrowseResult empty =
+                new BrowseResult(StatusCode.GOOD, ByteString.NULL_VALUE, new ReferenceDescription[0]);
+        when(client.browseAsync(any(BrowseDescription.class))).thenAnswer(invocation -> {
+            peak.accumulateAndGet(inFlight.incrementAndGet(), Math::max);
+            try {
+                Thread.sleep(100); // hold the permit long enough that an overlap would be observable
+            } finally {
+                inFlight.decrementAndGet();
+            }
+            return CompletableFuture.completedFuture(empty);
+        });
+
+        final Semaphore shared = new Semaphore(1);
+        final OpcUaNodeBrowser first = new OpcUaNodeBrowser(client, "adapter", 0, shared);
+        final OpcUaNodeBrowser second = new OpcUaNodeBrowser(client, "adapter", 0, shared);
+
+        final ExecutorService pool = Executors.newFixedThreadPool(2);
+        try {
+            final var f1 = pool.submit(() -> first.browse(null, 0).count());
+            final var f2 = pool.submit(() -> second.browse(null, 0).count());
+            f1.get(10, TimeUnit.SECONDS);
+            f2.get(10, TimeUnit.SECONDS);
+        } finally {
+            pool.shutdownNow();
+        }
+
+        assertThat(peak.get())
+                .as("the shared adapter-scoped permit serialises browseAsync across concurrent browsers")
+                .isEqualTo(1);
     }
 
     // --- sanitize() ---


### PR DESCRIPTION
Bundled Houston follow-up (one PR for economy). Four cohesive lifecycle/browse fixes, one commit per ticket.

## Tickets
- **EDG-602** — https://linear.app/hivemq/issue/EDG-602 — adapter update ran delete-then-recreate on `protocolAdapterMap`, leaving a window where `getAdapterDomainTags` returned **404** (flaky `DeviceTagBrowseStressTest`; "adapter unknown state"). Now an **atomic swap**: build replacement → single `put` → stop displaced instance → start new. Adapter id never absent. Both update paths routed through it.
- **EDG-576** — https://linear.app/hivemq/issue/EDG-576 — the browse `Semaphore` was created per `browse()` call, serialising only within one browse. Moved to **one permit per `OpcUaProtocolAdapter`**, so concurrent REST browses sharing one Milo client are serialised (fixes non-deterministic S7-1500 counts).
- **EDG-577** — https://linear.app/hivemq/issue/EDG-577 — `CONNECTED` fires before the namespace table / data-type tree are hydrated, so an early browse is non-deterministic. Adds an **OPC-UA-local readiness signal** (kept off the shared SDK `ConnectionStatus` enum): post-connect async warm-up → `BROWSE_READY`; browse REST answers **503 + Retry-After** until ready.
- **EDG-493** — https://linear.app/hivemq/issue/EDG-493 — classify **additive-only imports** (+ debug log) before `updateAdapter`; groundwork for the deferred skip-restart path.
- **EDG-579** — duplicate of EDG-576 (closed).

## Verification
- Unit-verified: `ProtocolAdapterManagerTest` (28), `DeviceTagBrowsingResourceImplTest` (42), `OpcUaNodeBrowserTest` (38), `OpcUaProtocolAdapterTest` (29), `DeviceTagImporterTest` (47) — all green; both modules compile. New regression tests for the swap invariant, shared-semaphore serialisation, and the 503 gate.
- **Not** hardware-verified: EDG-576's S7-1500 consistency and EDG-577's warm-up against a real Milo server need the physical PLC.

## Design notes for review
- EDG-577 readiness is **OPC-UA-scoped**, not on the shared SDK `ConnectionStatus` enum (deliberate, lower blast radius). Consequence: it's surfaced via the browse 503→200 transition, not a status-API field.

## Follow-up (separate, testsuite repo)
Replace the two `Thread.sleep` workarounds in `DeviceTagBrowseImportHardwareTest` with a wait on the browse 503→200 transition.