### PR TITLE
EDG-730: Add the Nevsky protocol adapter manager (PAM)

### DIFF
--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/manager/DefaultProtocolAdapterWrapperFactory.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/manager/DefaultProtocolAdapterWrapperFactory.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.protocols.v2.manager;
+
+import com.codahale.metrics.MetricRegistry;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hivemq.adapter.sdk.api.data.DataPoint;
+import com.hivemq.adapter.sdk.api.factories.DataPointFactory;
+import com.hivemq.adapter.sdk.api.v2.ProtocolAdapter;
+import com.hivemq.adapter.sdk.api.v2.factories.ProtocolAdapterFactory;
+import com.hivemq.adapter.sdk.api.v2.messaging.DefaultMailbox;
+import com.hivemq.adapter.sdk.api.v2.messaging.Mailbox;
+import com.hivemq.adapter.sdk.api.v2.messaging.MessageDispatcher;
+import com.hivemq.adapter.sdk.api.v2.messaging.MessageDispatcherHandle;
+import com.hivemq.adapter.sdk.api.v2.model.ProtocolAdapterInput;
+import com.hivemq.adapter.sdk.api.v2.model.ProtocolAdapterOutput;
+import com.hivemq.adapter.sdk.api.v2.node.Node;
+import com.hivemq.adapter.sdk.api.v2.node.NodeTagPair;
+import com.hivemq.adapter.sdk.api.v2.services.ProtocolAdapterService;
+import com.hivemq.protocols.v2.config.ProtocolAdapterEntity;
+import com.hivemq.protocols.v2.config.TagEntity;
+import com.hivemq.protocols.v2.manager.ProtocolAdapterHandleRegistry.ProtocolAdapterHandle;
+import com.hivemq.protocols.v2.runtime.Clock;
+import com.hivemq.protocols.v2.runtime.NevskyMetrics;
+import com.hivemq.protocols.v2.runtime.RetryPolicy;
+import com.hivemq.protocols.v2.tag.TagAspectRuntimeCoordinator;
+import com.hivemq.protocols.v2.view.AdapterStatusSnapshot;
+import com.hivemq.protocols.v2.wrapper.ProtocolAdapterGoalState;
+import com.hivemq.protocols.v2.wrapper.ProtocolAdapterOutputFacade;
+import com.hivemq.protocols.v2.wrapper.ProtocolAdapterWrapper;
+import com.hivemq.protocols.v2.wrapper.ProtocolAdapterWrapperContext;
+import com.hivemq.protocols.v2.wrapper.ProtocolAdapterWrapperEventListener;
+import com.hivemq.protocols.v2.wrapper.ProtocolAdapterWrapperMessage;
+import com.hivemq.protocols.v2.wrapper.ProtocolAdapterWrapperTick;
+import com.hivemq.protocols.v2.wrapper.TagAspectActivationPreference;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Production {@link ProtocolAdapterWrapperFactory}: assembles the full wrapper/adapter actor for one configuration
+ * (design §6, §8.2), exactly as the wrapper test rig does but driven from the read-only configuration and the
+ * injected runtime. For each adapter it
+ * <ol>
+ * <li>creates the wrapper mailbox and the tell-façade the protocol adapter reports through;</li>
+ * <li>translates the configuration's tags into runtime {@link NodeTagPair}s (deserializing each {@code node-string}
+ * into the type's node class) and the adapter configuration into a reused v1 {@link DataPoint};</li>
+ * <li>asks the type's {@link ProtocolAdapterFactory} to construct the pure-mechanism adapter;</li>
+ * <li>builds the running tag coordinator and the wrapper context with the config-declared goal, activation,
+ * {@code used} derivation, retry policy, and watchdog timeout, then binds the coordinator to the actor runtime;</li>
+ * <li>publishes the wrapper into a fresh snapshot reference, attaches it to the dispatcher, and schedules its
+ * periodic tick.</li>
+ * </ol>
+ * The runtime collaborators ({@link Clock}, {@link MessageDispatcher}, {@link MetricRegistry},
+ * {@link DataPointFactory}, the JSON {@link ObjectMapper}, and the tick period) are injected, so the same factory
+ * serves production (a {@code SystemClock} / {@code SystemDispatcher}) and tests (a {@code FakeClock} /
+ * {@code ManualDispatcher}).
+ */
+public final class DefaultProtocolAdapterWrapperFactory implements ProtocolAdapterWrapperFactory {
+
+    private final @NotNull Clock clock;
+    private final @NotNull MessageDispatcher dispatcher;
+    private final @NotNull MetricRegistry metricRegistry;
+    private final @NotNull DataPointFactory dataPointFactory;
+    private final @NotNull ObjectMapper objectMapper;
+    private final long tickPeriodMillis;
+
+    /**
+     * @param clock            the clock the wrapper timers and tick are scheduled against.
+     * @param dispatcher       the dispatcher each wrapper mailbox is attached to.
+     * @param metricRegistry   the shared registry per-adapter metrics are registered on.
+     * @param dataPointFactory the reused v1 factory the protocol adapter builds its values with.
+     * @param objectMapper     the JSON mapper that deserializes a {@code node-string} into the type's node class.
+     * @param tickPeriodMillis the wrapper tick period, in milliseconds (~50 ms in production).
+     */
+    public DefaultProtocolAdapterWrapperFactory(
+            final @NotNull Clock clock,
+            final @NotNull MessageDispatcher dispatcher,
+            final @NotNull MetricRegistry metricRegistry,
+            final @NotNull DataPointFactory dataPointFactory,
+            final @NotNull ObjectMapper objectMapper,
+            final long tickPeriodMillis) {
+        this.clock = clock;
+        this.dispatcher = dispatcher;
+        this.metricRegistry = metricRegistry;
+        this.dataPointFactory = dataPointFactory;
+        this.objectMapper = objectMapper;
+        this.tickPeriodMillis = tickPeriodMillis;
+    }
+
+    @Override
+    public @NotNull ProtocolAdapterContainer create(
+            final @NotNull ProtocolAdapterEntity entity,
+            final @NotNull ProtocolAdapterFactory factory,
+            final @NotNull ProtocolAdapterWrapperEventListener healthListener) {
+        final String adapterId = entity.getAdapterId();
+
+        final Mailbox<ProtocolAdapterWrapperMessage> mailbox = new DefaultMailbox<>();
+        final ProtocolAdapterOutput output = new ProtocolAdapterOutputFacade(mailbox);
+
+        final List<NodeTagPair> nodes = translateNodes(entity, factory);
+        final DataPoint adapterConfig =
+                dataPointFactory.createJsonDataPoint(adapterId, entity.getAdapterConfiguration());
+        final ProtocolAdapterService services = new WrapperServices(dataPointFactory, dispatcher);
+        final ProtocolAdapterInput input = new WrapperInput(adapterId, adapterConfig, nodes, services);
+        final ProtocolAdapter protocolAdapter = factory.createAdapter(input, output);
+
+        final NevskyMetrics metrics = new NevskyMetrics(metricRegistry, adapterId, mailbox::size);
+        final ProtocolAdapterGoalState goal = ProtocolAdapterConfigSupport.goalOf(entity);
+        final Map<String, TagAspectActivationPreference> activation = ProtocolAdapterConfigSupport.activationOf(entity);
+        final Set<String> readUsed = entity.getReadUsedTagNames();
+        final Set<String> writeUsed = entity.getWriteUsedTagNames();
+        final RetryPolicy retryPolicy = entity.getRetryPolicy().toRetryPolicy();
+
+        final TagAspectRuntimeCoordinator tagPlane = new TagAspectRuntimeCoordinator(
+                adapterId,
+                nodes,
+                activation,
+                readUsed,
+                writeUsed,
+                goal,
+                ProtocolAdapterConfigSupport.pollIntervalMillisOf(entity),
+                retryPolicy);
+        final ProtocolAdapterWrapperContext context = new ProtocolAdapterWrapperContext(
+                adapterId,
+                protocolAdapter,
+                mailbox,
+                clock,
+                retryPolicy,
+                entity.getWatchdogTimeoutMillis(),
+                entity.isSkipVerification(),
+                goal,
+                activation,
+                tagPlane,
+                healthListener,
+                metrics);
+        tagPlane.bindRuntime(
+                context.clock(),
+                context.timers(),
+                context.batches(),
+                context.metrics(),
+                context.protocolAdapter()::verifyBatch);
+
+        final AtomicReference<AdapterStatusSnapshot> snapshot = new AtomicReference<>();
+        final ProtocolAdapterWrapper wrapper = new ProtocolAdapterWrapper(context, snapshot);
+        final MessageDispatcherHandle dispatcherHandle = dispatcher.attach(mailbox, wrapper);
+        final AutoCloseable tickHandle =
+                clock.scheduleTick(tickPeriodMillis, mailbox, () -> new ProtocolAdapterWrapperTick(clock.nowMillis()));
+
+        final ProtocolAdapterHandle handle = new ProtocolAdapterHandle(adapterId, mailbox, snapshot);
+        return new ProtocolAdapterContainer(handle, dispatcherHandle, tickHandle, metrics, entity);
+    }
+
+    @Override
+    public @NotNull List<NodeTagPair> translateNodes(
+            final @NotNull ProtocolAdapterEntity entity, final @NotNull ProtocolAdapterFactory factory) {
+        final Class<? extends Node> nodeClass = factory.information().nodeClass();
+        final List<NodeTagPair> nodes = new ArrayList<>(entity.getTags().size());
+        for (final TagEntity tag : entity.getTags()) {
+            final Node node;
+            try {
+                node = objectMapper.readValue(tag.getNodeString(), nodeClass);
+            } catch (final JsonProcessingException exception) {
+                throw new ProtocolAdapterConfigException(
+                        "adapter ["
+                                + entity.getAdapterId()
+                                + "] tag ["
+                                + tag.getName()
+                                + "] node-string is not a valid "
+                                + nodeClass.getSimpleName(),
+                        exception);
+            }
+            nodes.add(NodeTagPair.create(
+                    node, tag.getName(), factory.nodeDefinitionSchema(), tag.isPollable(), tag.isSubscribable()));
+        }
+        return nodes;
+    }
+
+    /**
+     * The framework services handed to a constructed adapter (design §3.8): the reused v1 value factory and the
+     * dispatcher its mailbox attaches to.
+     */
+    private record WrapperServices(
+            @NotNull DataPointFactory dataPointFactory,
+            @NotNull MessageDispatcher dispatcher) implements ProtocolAdapterService {}
+
+    /**
+     * Everything one adapter instance is constructed from (design §3.8): its id, the reused v1 configuration value,
+     * the node/tag pairs it serves, and the framework services.
+     */
+    private record WrapperInput(
+            @NotNull String adapterId,
+            @NotNull DataPoint adapterConfig,
+            @NotNull List<NodeTagPair> nodes,
+            @NotNull ProtocolAdapterService services)
+            implements ProtocolAdapterInput {}
+}

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/manager/ProtocolAdapterConfigDiffUtils.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/manager/ProtocolAdapterConfigDiffUtils.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.protocols.v2.manager;
+
+import com.hivemq.protocols.v2.config.AccessFlagsEntity;
+import com.hivemq.protocols.v2.config.NorthboundMappingEntity;
+import com.hivemq.protocols.v2.config.ProtocolAdapterEntity;
+import com.hivemq.protocols.v2.config.RetryPolicyEntity;
+import com.hivemq.protocols.v2.config.SouthboundMappingEntity;
+import com.hivemq.protocols.v2.config.TagEntity;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Classifies the difference between an adapter's running configuration and a freshly-loaded one into the gentlest
+ * correct {@link ProtocolAdapterConfigStateTransition} (design §8.2). A pure function of the two entities — it touches no runtime state,
+ * so it is exhaustively unit-testable on its own.
+ * <p>
+ * The classification is layered, gentlest last to win only when nothing more disruptive changed:
+ * <ol>
+ * <li>any <b>connection-critical</b> field differs (protocol id, config version, skip-verification, adapter
+ * configuration, retry policy, watchdog / command timeouts) &rarr; {@link ProtocolAdapterConfigStateTransition#FULL_RECREATE};</li>
+ * <li>otherwise, if the <b>tag set</b> (a tag's identity beyond its activation flags) or the <b>mappings</b> (which
+ * drive {@code used}) differ &rarr; {@link ProtocolAdapterConfigStateTransition#TAGS_ONLY};</li>
+ * <li>otherwise, if any <b>activation flag</b> differs (adapter {@code northbound-activated} /
+ * {@code southbound-activated} or a tag's {@code read-activated} / {@code write-activated}) &rarr;
+ * {@link ProtocolAdapterConfigStateTransition#ACTIVATION_ONLY};</li>
+ * <li>otherwise &rarr; {@link ProtocolAdapterConfigStateTransition#NO_CHANGE}.</li>
+ * </ol>
+ * A {@code TAGS_ONLY} difference may carry activation changes too; the manager applies the tag-set update and, only
+ * when the adapter-level direction goal also changed, follows it with an activation command (the REST live goal is
+ * otherwise preserved — design §8.2).
+ */
+public final class ProtocolAdapterConfigDiffUtils {
+
+    private ProtocolAdapterConfigDiffUtils() {}
+
+    /**
+     * Classify the difference between two configurations of the same adapter (same {@code adapter-id}).
+     *
+     * @param running the configuration currently applied to the running adapter.
+     * @param updated the freshly-loaded configuration.
+     * @return the gentlest transition that brings the running adapter in line with {@code updated}.
+     */
+    public static @NotNull ProtocolAdapterConfigStateTransition classify(
+            final @NotNull ProtocolAdapterEntity running, final @NotNull ProtocolAdapterEntity updated) {
+        if (!connectionCritical(running).equals(connectionCritical(updated))) {
+            return ProtocolAdapterConfigStateTransition.FULL_RECREATE;
+        }
+        if (!tagSetIdentity(running).equals(tagSetIdentity(updated)) || mappingsChanged(running, updated)) {
+            return ProtocolAdapterConfigStateTransition.TAGS_ONLY;
+        }
+        if (activationChanged(running, updated)) {
+            return ProtocolAdapterConfigStateTransition.ACTIVATION_ONLY;
+        }
+        return ProtocolAdapterConfigStateTransition.NO_CHANGE;
+    }
+
+    /**
+     * @param running the running configuration.
+     * @param updated the freshly-loaded configuration.
+     * @return whether the adapter-level direction activation (the {@code northbound-activated} /
+     *         {@code southbound-activated} goal) differs between the two — the case in which a
+     *         {@link ProtocolAdapterConfigStateTransition#TAGS_ONLY} transition must also re-assert the config-declared direction goal.
+     */
+    public static boolean adapterDirectionChanged(
+            final @NotNull ProtocolAdapterEntity running, final @NotNull ProtocolAdapterEntity updated) {
+        return running.isNorthboundActivated() != updated.isNorthboundActivated()
+                || running.isSouthboundActivated() != updated.isSouthboundActivated();
+    }
+
+    // ── comparison projections ──────────────────────────────────────────────────────────────────────────────────
+
+    /**
+     * The fields whose change forces a full recreate — everything baked into the adapter instance or its connection
+     * policy, independent of tags, mappings, and activation.
+     */
+    private record ConnectionCritical(
+            @NotNull String protocolId,
+            int configVersion,
+            boolean skipVerification,
+            @NotNull Map<String, Object> adapterConfiguration,
+            @NotNull RetryPolicyEntity retryPolicy,
+            long watchdogTimeoutMillis,
+            long commandTimeoutMillis) {}
+
+    private static @NotNull ConnectionCritical connectionCritical(final @NotNull ProtocolAdapterEntity entity) {
+        return new ConnectionCritical(
+                entity.getProtocolId(),
+                entity.getConfigVersion(),
+                entity.isSkipVerification(),
+                entity.getAdapterConfiguration(),
+                entity.getRetryPolicy(),
+                entity.getWatchdogTimeoutMillis(),
+                entity.getCommandTimeoutMillis());
+    }
+
+    /**
+     * A tag's identity excluding its activation flags — what makes it a different tag rather than the same tag with
+     * a flipped preference. Comparing the per-name identity map detects tags added, removed, or edited.
+     */
+    private record TagIdentity(
+            @NotNull String nodeString,
+            boolean pollable,
+            boolean subscribable,
+            long pollIntervalMillis,
+            @NotNull AccessFlagsEntity access) {}
+
+    private static @NotNull Map<String, TagIdentity> tagSetIdentity(final @NotNull ProtocolAdapterEntity entity) {
+        final Map<String, TagIdentity> byName = new LinkedHashMap<>();
+        for (final TagEntity tag : entity.getTags()) {
+            byName.put(
+                    tag.getName(),
+                    new TagIdentity(
+                            tag.getNodeString(),
+                            tag.isPollable(),
+                            tag.isSubscribable(),
+                            tag.getPollIntervalMillis(),
+                            tag.getAccess()));
+        }
+        return byName;
+    }
+
+    private static boolean mappingsChanged(
+            final @NotNull ProtocolAdapterEntity running, final @NotNull ProtocolAdapterEntity updated) {
+        final List<NorthboundMappingEntity> runningNorth = running.getNorthboundMappings();
+        final List<NorthboundMappingEntity> updatedNorth = updated.getNorthboundMappings();
+        final List<SouthboundMappingEntity> runningSouth = running.getSouthboundMappings();
+        final List<SouthboundMappingEntity> updatedSouth = updated.getSouthboundMappings();
+        return !runningNorth.equals(updatedNorth) || !runningSouth.equals(updatedSouth);
+    }
+
+    private static boolean activationChanged(
+            final @NotNull ProtocolAdapterEntity running, final @NotNull ProtocolAdapterEntity updated) {
+        if (adapterDirectionChanged(running, updated)) {
+            return true;
+        }
+        return !tagActivation(running).equals(tagActivation(updated));
+    }
+
+    private static @NotNull Map<String, List<Boolean>> tagActivation(final @NotNull ProtocolAdapterEntity entity) {
+        final Map<String, List<Boolean>> byName = new LinkedHashMap<>();
+        for (final TagEntity tag : entity.getTags()) {
+            byName.put(tag.getName(), List.of(tag.isReadActivated(), tag.isWriteActivated()));
+        }
+        return byName;
+    }
+}

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/manager/ProtocolAdapterConfigException.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/manager/ProtocolAdapterConfigException.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.protocols.v2.manager;
+
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Thrown by the wrapper factory when an otherwise well-formed adapter configuration cannot be turned into a running
+ * wrapper — for example a {@code node-string} that does not deserialize into the adapter type's node class (design
+ * §9.1). The manager catches it and surfaces the adapter as an {@code ERROR} registry handle with the message,
+ * rather than failing the whole reload (design §8.2).
+ */
+public class ProtocolAdapterConfigException extends RuntimeException {
+
+    /**
+     * @param message a human-readable description of why the configuration could not be instantiated.
+     * @param cause   the underlying failure.
+     */
+    public ProtocolAdapterConfigException(final @NotNull String message, final @NotNull Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/manager/ProtocolAdapterConfigState.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/manager/ProtocolAdapterConfigState.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.protocols.v2.manager;
+
+/**
+ * How disruptively one piece of adapter configuration must be applied — the layer that would refine a
+ * {@link ProtocolAdapterConfigStateTransition#FULL_RECREATE} into a gentler reconnect window where the protocol allows it (design §8.2).
+ * <p>
+ * This enum is the documented seam the primary design reserves; the manager treats every {@code FULL_RECREATE} as a
+ * stop / discard / recreate today (the credential-rotation-via-disconnect-window optimization and the full
+ * per-field dependency handling stay a documented stub, design §8.2). It is defined here so that refinement can be
+ * added later without touching the transition classification or the manager's reconcile loop.
+ */
+public enum ProtocolAdapterConfigState {
+
+    /**
+     * Baked into the adapter instance at construction (for example the protocol id or the adapter configuration) —
+     * a change requires a full recreate.
+     */
+    FACTORY_BAKED_IN,
+
+    /**
+     * Changeable while connected by cycling the connection (for example a credential rotation) — applicable in a
+     * disconnect/reconnect window rather than a full recreate. Reserved; not yet exploited.
+     */
+    HOT_AT_DISCONNECT_WINDOW,
+
+    /**
+     * Changeable only while the adapter is stopped. Reserved; not yet exploited.
+     */
+    HOT_WHILE_STOPPED,
+
+    /**
+     * Changeable at runtime with no connection impact (for example activation flags or the tag set) — already
+     * handled by {@link ProtocolAdapterConfigStateTransition#ACTIVATION_ONLY} / {@link ProtocolAdapterConfigStateTransition#TAGS_ONLY}.
+     */
+    TRULY_LIVE
+}

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/manager/ProtocolAdapterConfigStateTransition.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/manager/ProtocolAdapterConfigStateTransition.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.protocols.v2.manager;
+
+/**
+ * The class of difference between an adapter's running configuration and a freshly-loaded one — the
+ * <b>gentlest correct transition</b> the manager applies on reload (design §8.2). The classes are ordered from
+ * gentlest to most disruptive; {@link ProtocolAdapterConfigDiffUtils} chooses the gentlest one that still brings the running
+ * adapter fully in line with the new configuration.
+ */
+public enum ProtocolAdapterConfigStateTransition {
+
+    /**
+     * The new configuration is identical to the running one — nothing to do.
+     */
+    NO_CHANGE,
+
+    /**
+     * Only activation flags changed — the adapter {@code northbound-activated} / {@code southbound-activated}
+     * and/or a tag's {@code read-activated} / {@code write-activated}. Applied as one atomic
+     * {@link com.hivemq.protocols.v2.wrapper.ProtocolAdapterWrapperCommand.ApplyActivation} to the running
+     * wrapper: no reconnect, no re-verification of unaffected aspects (design §8.2, EDG-462).
+     */
+    ACTIVATION_ONLY,
+
+    /**
+     * The tag set changed (tags added, removed, or edited beyond their activation flags) or the mappings changed
+     * (so {@code used} is recomputed). Applied as one atomic
+     * {@link com.hivemq.protocols.v2.wrapper.ProtocolAdapterWrapperCommand.UpdateTagSet} to the running wrapper,
+     * which diffs in place — never reconnects (design §8.2).
+     */
+    TAGS_ONLY,
+
+    /**
+     * Anything else — a change to the protocol id, the adapter configuration, the retry / watchdog / command
+     * timeouts, the skip-verification flag, or the config version. The wrapper is stopped, the protocol adapter is
+     * discarded, and a fresh pair is created and started (design §8.2). The
+     * {@link ProtocolAdapterConfigState} refinement (a credential rotation handled in a disconnect/reconnect
+     * window rather than a full recreate) is a documented stub in this project.
+     */
+    FULL_RECREATE
+}

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/manager/ProtocolAdapterConfigSupport.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/manager/ProtocolAdapterConfigSupport.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.protocols.v2.manager;
+
+import com.hivemq.protocols.v2.config.ProtocolAdapterEntity;
+import com.hivemq.protocols.v2.config.TagEntity;
+import com.hivemq.protocols.v2.wrapper.ProtocolAdapterGoalState;
+import com.hivemq.protocols.v2.wrapper.TagAspectActivationPreference;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Pure translations from the read-only {@code <v2-protocol-adapters>} configuration entities (design §9) into the
+ * runtime value types the wrapper consumes — the parts that need no protocol-specific deserialization (node-string
+ * &rarr; {@code Node} translation needs the adapter type's {@code nodeClass} and lives in the wrapper factory).
+ * Shared by the manager and the wrapper factory so the config-declared goal and per-tag activation are derived in
+ * exactly one place.
+ */
+public final class ProtocolAdapterConfigSupport {
+
+    private ProtocolAdapterConfigSupport() {}
+
+    /**
+     * The config-declared adapter direction goal — the initial goal at startup and the authoritative goal again
+     * after a reload that touches the activation flags (design §8.2, §9.3).
+     *
+     * @param entity the adapter configuration.
+     * @return the goal carrying the entity's {@code northbound-activated} / {@code southbound-activated} flags.
+     */
+    public static @NotNull ProtocolAdapterGoalState goalOf(final @NotNull ProtocolAdapterEntity entity) {
+        return new ProtocolAdapterGoalState(entity.isNorthboundActivated(), entity.isSouthboundActivated());
+    }
+
+    /**
+     * The persisted per-aspect activation preferences keyed by tag name (design §7.1, EDG-462).
+     *
+     * @param entity the adapter configuration.
+     * @return a map of tag name to its {@code read-activated} / {@code write-activated} preference, in declaration
+     *         order.
+     */
+    public static @NotNull Map<String, TagAspectActivationPreference> activationOf(
+            final @NotNull ProtocolAdapterEntity entity) {
+        final Map<String, TagAspectActivationPreference> activation = new LinkedHashMap<>();
+        for (final TagEntity tag : entity.getTags()) {
+            activation.put(
+                    tag.getName(), new TagAspectActivationPreference(tag.isReadActivated(), tag.isWriteActivated()));
+        }
+        return activation;
+    }
+
+    /**
+     * The single poll cadence the running tag coordinator applies to every polled aspect (design §7.3). The
+     * coordinator currently takes one interval per adapter; the configuration carries one per tag, so this reduces
+     * them conservatively to the <b>shortest</b> declared interval — no tag then polls slower than its configuration
+     * asks, though tags with a longer configured interval poll faster than declared. A per-tag poll cadence is a
+     * follow-up tied to the coordinator's single-interval support.
+     *
+     * @param entity the adapter configuration.
+     * @return the shortest declared poll interval, or {@link TagEntity}'s default when the adapter declares no tags.
+     */
+    public static long pollIntervalMillisOf(final @NotNull ProtocolAdapterEntity entity) {
+        long shortest = Long.MAX_VALUE;
+        for (final TagEntity tag : entity.getTags()) {
+            shortest = Math.min(shortest, tag.getPollIntervalMillis());
+        }
+        return shortest == Long.MAX_VALUE ? new TagEntity().getPollIntervalMillis() : shortest;
+    }
+}

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/manager/ProtocolAdapterContainer.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/manager/ProtocolAdapterContainer.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.protocols.v2.manager;
+
+import com.hivemq.adapter.sdk.api.v2.messaging.MessageDispatcherHandle;
+import com.hivemq.protocols.v2.config.ProtocolAdapterEntity;
+import com.hivemq.protocols.v2.manager.ProtocolAdapterHandleRegistry.ProtocolAdapterHandle;
+import com.hivemq.protocols.v2.runtime.NevskyMetrics;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * One adapter the manager owns: its REST-readable {@link ProtocolAdapterHandle} plus the teardown resources the
+ * manager must close when the adapter is discarded or recreated — the dispatcher binding, the periodic tick, and
+ * the per-adapter metrics. The last-applied configuration is held here too, so the manager can diff a reload
+ * against the configuration actually running rather than against the live (REST-mutated) goal (design §8.2).
+ * <p>
+ * An adapter whose {@code protocol-id} has no registered factory, or whose configuration cannot be instantiated, is
+ * represented as an {@link #unknown(ProtocolAdapterHandle, ProtocolAdapterEntity) unknown} managed adapter: it
+ * carries the {@code ERROR} handle and the applied entity but no runtime resources, so {@link #close()} is a no-op.
+ * <p>
+ * Mutated only on the manager's single dispatch thread; it holds no locks.
+ */
+public final class ProtocolAdapterContainer implements AutoCloseable {
+
+    private static final @NotNull Logger log = LoggerFactory.getLogger(ProtocolAdapterContainer.class);
+
+    private final @NotNull ProtocolAdapterHandle handle;
+    private final @Nullable MessageDispatcherHandle dispatcherHandle;
+    private final @Nullable AutoCloseable tickHandle;
+    private final @Nullable NevskyMetrics metrics;
+    private @NotNull ProtocolAdapterEntity appliedEntity;
+
+    /**
+     * Create a running managed adapter with its teardown resources.
+     *
+     * @param handle           the REST-readable handle.
+     * @param dispatcherHandle the binding of the wrapper mailbox to the dispatcher.
+     * @param tickHandle       the periodic wrapper tick schedule.
+     * @param metrics          the per-adapter metrics.
+     * @param appliedEntity    the configuration this adapter is running.
+     */
+    public ProtocolAdapterContainer(
+            final @NotNull ProtocolAdapterHandle handle,
+            final @NotNull MessageDispatcherHandle dispatcherHandle,
+            final @NotNull AutoCloseable tickHandle,
+            final @NotNull NevskyMetrics metrics,
+            final @NotNull ProtocolAdapterEntity appliedEntity) {
+        this.handle = handle;
+        this.dispatcherHandle = dispatcherHandle;
+        this.tickHandle = tickHandle;
+        this.metrics = metrics;
+        this.appliedEntity = appliedEntity;
+    }
+
+    private ProtocolAdapterContainer(
+            final @NotNull ProtocolAdapterHandle handle, final @NotNull ProtocolAdapterEntity entity) {
+        this.handle = handle;
+        this.dispatcherHandle = null;
+        this.tickHandle = null;
+        this.metrics = null;
+        this.appliedEntity = entity;
+    }
+
+    /**
+     * Create a managed adapter with no running wrapper — the representation of an unknown adapter type or an
+     * un-instantiable configuration (design §8.2).
+     *
+     * @param handle the {@code ERROR} handle.
+     * @param entity the configuration that could not be run.
+     * @return the unknown managed adapter; {@link #close()} on it is a no-op.
+     */
+    public static @NotNull ProtocolAdapterContainer unknown(
+            final @NotNull ProtocolAdapterHandle handle, final @NotNull ProtocolAdapterEntity entity) {
+        return new ProtocolAdapterContainer(handle, entity);
+    }
+
+    /**
+     * @return the REST-readable handle.
+     */
+    public @NotNull ProtocolAdapterHandle handle() {
+        return handle;
+    }
+
+    /**
+     * @return {@code true} when this adapter has a running wrapper (a registered factory built it); {@code false}
+     *         for an unknown / un-instantiable adapter.
+     */
+    public boolean isReal() {
+        return dispatcherHandle != null;
+    }
+
+    /**
+     * @return the configuration this adapter is currently running — the basis for diffing the next reload.
+     */
+    public @NotNull ProtocolAdapterEntity appliedEntity() {
+        return appliedEntity;
+    }
+
+    /**
+     * Record the configuration now applied to this adapter (after a gentlest in-place transition).
+     *
+     * @param appliedEntity the configuration now running.
+     */
+    public void appliedEntity(final @NotNull ProtocolAdapterEntity appliedEntity) {
+        this.appliedEntity = appliedEntity;
+    }
+
+    /**
+     * Release the adapter's runtime resources: stop the periodic tick, detach the wrapper from the dispatcher, and
+     * deregister the per-adapter metrics so a recreated adapter with the same id starts clean. Each step is best
+     * effort; a failure in one never prevents the others. A no-op for an unknown adapter.
+     */
+    @Override
+    public void close() {
+        closeQuietly(tickHandle, "tick schedule");
+        closeQuietly(dispatcherHandle, "dispatcher binding");
+        closeQuietly(metrics, "metrics");
+    }
+
+    private void closeQuietly(final @Nullable AutoCloseable closeable, final @NotNull String what) {
+        if (closeable == null) {
+            return;
+        }
+        try {
+            closeable.close();
+        } catch (final Exception exception) {
+            log.warn("Failed to close the {} of adapter '{}'", what, handle.adapterId(), exception);
+        }
+    }
+}

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/manager/ProtocolAdapterFactoryRegistry.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/manager/ProtocolAdapterFactoryRegistry.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.protocols.v2.manager;
+
+import com.hivemq.adapter.sdk.api.v2.factories.ProtocolAdapterFactory;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * The set of protocol-adapter type factories the manager can instantiate, keyed by {@code protocol-id} (design §8,
+ * D8). The factory set is <b>constructor-injected</b> and is <b>empty in production wiring</b> — no real adapter is
+ * ported in this project; the core-module tests inject the {@code ChaosProtocolAdapterFactory} (a later task), and
+ * the manager tests inject a minimal test factory. An adapter whose {@code protocol-id} has no factory here is
+ * surfaced as an {@code ERROR} registry handle with no wrapper created (design §8.2).
+ */
+public final class ProtocolAdapterFactoryRegistry {
+
+    private final @NotNull Map<String, ProtocolAdapterFactory> factoryMap;
+
+    /**
+     * @param factorySet the protocol-adapter factories available to this Edge instance; empty in production.
+     * @throws IllegalArgumentException if two factories declare the same {@code protocol-id}.
+     */
+    public ProtocolAdapterFactoryRegistry(final @NotNull Set<ProtocolAdapterFactory> factorySet) {
+        final Map<String, ProtocolAdapterFactory> map = new LinkedHashMap<>();
+        for (final ProtocolAdapterFactory factory : factorySet) {
+            final String protocolId = factory.information().protocolId();
+            final ProtocolAdapterFactory duplicatedFactory = map.put(protocolId, factory);
+            if (duplicatedFactory != null) {
+                throw new IllegalArgumentException(
+                        "two protocol adapter factories declare protocol-id [" + protocolId + "]");
+            }
+        }
+        this.factoryMap = Map.copyOf(map);
+    }
+
+    /**
+     * @param protocolId the protocol id to look up.
+     * @return the factory for the type, or empty if no factory declares that {@code protocol-id}.
+     */
+    public @NotNull Optional<ProtocolAdapterFactory> findByProtocolId(final @NotNull String protocolId) {
+        return Optional.ofNullable(factoryMap.get(protocolId));
+    }
+}

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/manager/ProtocolAdapterHandleRegistry.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/manager/ProtocolAdapterHandleRegistry.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.protocols.v2.manager;
+
+import com.hivemq.adapter.sdk.api.v2.messaging.MailboxSender;
+import com.hivemq.protocols.v2.view.AdapterStatusSnapshot;
+import com.hivemq.protocols.v2.wrapper.ProtocolAdapterWrapperMessage;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicReference;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * The concurrent, REST-readable directory of an Edge instance's Nevsky adapters (design §6.6, §8). Each entry is a
+ * {@link ProtocolAdapterHandle} that exposes <b>only</b> the immutable status snapshot reference and the wrapper's
+ * send-only mailbox handle — never the wrapper, its state, or its mailbox's receive side. REST threads and the
+ * manager's own tick read snapshots and {@code tell} commands; nothing else crosses the boundary (the actor model,
+ * design §5.2).
+ * <p>
+ * The map is mutated only by the manager actor (register on create, remove on discard) but read from foreign
+ * threads, so it is backed by a {@link ConcurrentHashMap}; the per-handle snapshot is an {@link AtomicReference}
+ * published by the owning wrapper on its own dispatch thread.
+ */
+public final class ProtocolAdapterHandleRegistry {
+
+    private final @NotNull ConcurrentMap<String, ProtocolAdapterHandle> handles = new ConcurrentHashMap<>();
+
+    /**
+     * @param adapterId the adapter instance id.
+     * @return the handle for the adapter, or {@code null} if no adapter with that id is registered.
+     */
+    public @Nullable ProtocolAdapterHandle find(final @NotNull String adapterId) {
+        return handles.get(adapterId);
+    }
+
+    /**
+     * @return an immutable snapshot of all registered handles, safe to iterate from any thread.
+     */
+    public @NotNull Collection<ProtocolAdapterHandle> all() {
+        return List.copyOf(handles.values());
+    }
+
+    /**
+     * Register (or replace) the handle for its adapter id. Called only by the manager actor.
+     *
+     * @param handle the handle to register.
+     */
+    public void register(final @NotNull ProtocolAdapterHandle handle) {
+        handles.put(handle.adapterId(), handle);
+    }
+
+    /**
+     * Unregister the handle for the given adapter id, if any. Called only by the manager actor.
+     *
+     * @param adapterId the adapter instance id.
+     */
+    public void unregister(final @NotNull String adapterId) {
+        handles.remove(adapterId);
+    }
+
+    /**
+     * A REST-readable handle to one adapter: its id, the send-only handle of its wrapper mailbox, and the reference
+     * the wrapper publishes its immutable status snapshot into (design §6.6). For an adapter whose type has no
+     * registered factory the wrapper sender is a no-op and the snapshot is a fixed {@code ERROR} (design §8.2).
+     *
+     * @param adapterId     the adapter instance id.
+     * @param wrapperSender the send-only handle of the wrapper mailbox — {@code tell}-only, callable from any thread.
+     * @param snapshot      the reference holding the wrapper's latest immutable status snapshot.
+     */
+    public record ProtocolAdapterHandle(
+            @NotNull String adapterId,
+            @NotNull MailboxSender<ProtocolAdapterWrapperMessage> wrapperSender,
+            @NotNull AtomicReference<AdapterStatusSnapshot> snapshot) {}
+}

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/manager/ProtocolAdapterManager.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/manager/ProtocolAdapterManager.java
@@ -1,0 +1,445 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.protocols.v2.manager;
+
+import com.hivemq.adapter.sdk.api.v2.factories.ProtocolAdapterFactory;
+import com.hivemq.adapter.sdk.api.v2.messaging.MailboxSender;
+import com.hivemq.adapter.sdk.api.v2.messaging.MessageHandler;
+import com.hivemq.adapter.sdk.api.v2.node.NodeTagPair;
+import com.hivemq.protocols.v2.config.ProtocolAdapterEntity;
+import com.hivemq.protocols.v2.manager.ProtocolAdapterHandleRegistry.ProtocolAdapterHandle;
+import com.hivemq.protocols.v2.manager.ProtocolAdapterManagerMessage.ActivateAdapter;
+import com.hivemq.protocols.v2.manager.ProtocolAdapterManagerMessage.BrowseRequested;
+import com.hivemq.protocols.v2.manager.ProtocolAdapterManagerMessage.ConfigurationChanged;
+import com.hivemq.protocols.v2.manager.ProtocolAdapterManagerMessage.DeactivateAdapter;
+import com.hivemq.protocols.v2.manager.ProtocolAdapterManagerMessage.ProtocolAdapterManagerTick;
+import com.hivemq.protocols.v2.manager.ProtocolAdapterManagerMessage.RetryTag;
+import com.hivemq.protocols.v2.manager.ProtocolAdapterManagerMessage.WrapperError;
+import com.hivemq.protocols.v2.manager.ProtocolAdapterManagerMessage.WrapperStarted;
+import com.hivemq.protocols.v2.manager.ProtocolAdapterManagerMessage.WrapperStopped;
+import com.hivemq.protocols.v2.runtime.Clock;
+import com.hivemq.protocols.v2.view.AdapterStatusSnapshot;
+import com.hivemq.protocols.v2.wrapper.ProtocolAdapterWrapperCommand;
+import com.hivemq.protocols.v2.wrapper.ProtocolAdapterWrapperMessage;
+import com.hivemq.protocols.v2.wrapper.ProtocolAdapterWrapperState;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The Protocol Adapter Manager — the supervisor {@link MessageHandler} of the Nevsky subsystem (design §8). It owns
+ * the wrapper/adapter pairs, applies the gentlest correct transition on configuration change, routes the
+ * runtime-state commands from REST, and reacts to wrapper health. It reads <b>only</b> the
+ * {@code <v2-protocol-adapters>} section (through the {@link ConfigurationChanged} message the extractor's consumer
+ * tells it) and it never writes configuration.
+ * <p>
+ * Like every Nevsky component it is an actor: {@link #receive(ProtocolAdapterManagerMessage)} runs on the manager's
+ * single dispatch thread, so its maps need no locks. The only state that crosses the boundary outward is the
+ * immutable {@link ProtocolAdapterManagerSnapshot} health summary it publishes on each tick, and each wrapper's own
+ * snapshot in the {@link ProtocolAdapterHandleRegistry} — read by REST threads without locking (the actor model,
+ * design §5.2).
+ * <p>
+ * The manager is bound to its own mailbox through {@link #bindSelf(MailboxSender)} once, before any message is
+ * handled (the two-phase init mirrors the wrapper context's {@code bindMachine}): the manager needs its own
+ * send-only handle to give each wrapper a health-notification seam and to schedule its tick (a later wiring task).
+ */
+public final class ProtocolAdapterManager implements MessageHandler<ProtocolAdapterManagerMessage> {
+
+    private static final @NotNull Logger log = LoggerFactory.getLogger(ProtocolAdapterManager.class);
+
+    /**
+     * The wrapper sender of an {@code ERROR} handle for an unknown / un-instantiable adapter: there is no wrapper,
+     * so a {@code tell} is dropped. REST commands to such an adapter are therefore harmless no-ops (design §8.2).
+     */
+    private static final @NotNull MailboxSender<ProtocolAdapterWrapperMessage> NO_OP_WRAPPER_SENDER = message -> {};
+
+    private final @NotNull ProtocolAdapterFactoryRegistry factoryRegistry;
+    private final @NotNull ProtocolAdapterHandleRegistry registry;
+    private final @NotNull ProtocolAdapterWrapperFactory wrapperFactory;
+    private final @NotNull Clock clock;
+
+    /** adapterId &rarr; the adapter the manager currently owns. Mutated only on the dispatch thread. */
+    private final @NotNull Map<String, ProtocolAdapterContainer> containerMap = new LinkedHashMap<>();
+
+    /** adapterId &rarr; an adapter told to stop, awaiting its {@code stopped()} before teardown / recreate. */
+    private final @NotNull Map<String, PendingRemoval> pendingRemovalMap = new LinkedHashMap<>();
+
+    private final @NotNull AtomicReference<ProtocolAdapterManagerSnapshot> healthSummary =
+            new AtomicReference<>(ProtocolAdapterManagerSnapshot.empty());
+
+    private @Nullable ProtocolAdapterManagerHealthListener healthListener;
+
+    /**
+     * @param factoryRegistry the protocol-adapter type factories (empty in production, D8).
+     * @param registry       the REST-readable adapter registry the manager populates.
+     * @param wrapperFactory the seam that builds and attaches a wrapper/adapter pair from one configuration.
+     * @param clock          the clock used to stamp the {@code ERROR} snapshots and the health summary.
+     */
+    public ProtocolAdapterManager(
+            final @NotNull ProtocolAdapterFactoryRegistry factoryRegistry,
+            final @NotNull ProtocolAdapterHandleRegistry registry,
+            final @NotNull ProtocolAdapterWrapperFactory wrapperFactory,
+            final @NotNull Clock clock) {
+        this.factoryRegistry = factoryRegistry;
+        this.registry = registry;
+        this.wrapperFactory = wrapperFactory;
+        this.clock = clock;
+    }
+
+    /**
+     * Close the construction cycle: the manager needs its own send-only handle to wire each wrapper's health
+     * notifications back to itself. Called once, before the first message is handled.
+     *
+     * @param selfSender the manager's own mailbox sender.
+     */
+    public void bindSelf(final @NotNull MailboxSender<ProtocolAdapterManagerMessage> selfSender) {
+        this.healthListener = new ProtocolAdapterManagerHealthListener(selfSender);
+    }
+
+    /**
+     * @return the latest health summary the manager has published (design §8.3).
+     */
+    public @NotNull ProtocolAdapterManagerSnapshot healthSummary() {
+        return Objects.requireNonNullElse(healthSummary.get(), ProtocolAdapterManagerSnapshot.empty());
+    }
+
+    @Override
+    public void receive(final @NotNull ProtocolAdapterManagerMessage message) {
+        switch (message) {
+            case ConfigurationChanged configuration -> reconcile(configuration.adapters());
+            case ActivateAdapter activate ->
+                forwardCommand(
+                        activate.adapterId(),
+                        new ProtocolAdapterWrapperCommand.ActivateDirection(activate.direction()));
+            case DeactivateAdapter deactivate ->
+                forwardCommand(
+                        deactivate.adapterId(),
+                        new ProtocolAdapterWrapperCommand.DeactivateDirection(deactivate.direction()));
+            case RetryTag retry ->
+                forwardCommand(retry.adapterId(), new ProtocolAdapterWrapperCommand.RetryTag(retry.tagName()));
+            case BrowseRequested browse -> handleBrowse(browse);
+            case WrapperStarted started -> onWrapperStarted(started.adapterId());
+            case WrapperStopped stopped -> onWrapperStopped(stopped.adapterId());
+            case WrapperError error -> onWrapperError(error.adapterId(), error.reason());
+            case ProtocolAdapterManagerTick tick -> publishHealthSummary(tick.nowMillis());
+        }
+    }
+
+    // ── configuration difference → gentlest transition (design §8.2) ────────────────────────────────────────────
+
+    private void reconcile(final @NotNull List<ProtocolAdapterEntity> newConfigs) {
+        final Map<String, ProtocolAdapterEntity> updatedById = new LinkedHashMap<>();
+        for (final ProtocolAdapterEntity entity : newConfigs) {
+            updatedById.put(entity.getAdapterId(), entity);
+        }
+
+        // Removals first: adapters no longer in the configuration are stopped and discarded.
+        final List<String> toRemove = new ArrayList<>();
+        for (final String adapterId : containerMap.keySet()) {
+            if (!updatedById.containsKey(adapterId)) {
+                toRemove.add(adapterId);
+            }
+        }
+        for (final String adapterId : toRemove) {
+            stopAndDiscard(adapterId, null);
+        }
+
+        // Adds and updates.
+        for (final ProtocolAdapterEntity entity : newConfigs) {
+            final String adapterId = entity.getAdapterId();
+            final ProtocolAdapterContainer existing = containerMap.get(adapterId);
+            if (existing != null) {
+                applyDifference(existing, entity);
+            } else if (pendingRemovalMap.containsKey(adapterId)) {
+                // The previous instance is still stopping; recreate with this configuration once it reports stopped.
+                final PendingRemoval pending = pendingRemovalMap.get(adapterId);
+                pendingRemovalMap.put(adapterId, new PendingRemoval(pending.stopping(), entity));
+            } else {
+                createAdapter(entity);
+            }
+        }
+    }
+
+    private void applyDifference(
+            final @NotNull ProtocolAdapterContainer existing, final @NotNull ProtocolAdapterEntity updated) {
+        final String adapterId = updated.getAdapterId();
+        final ProtocolAdapterEntity running = existing.appliedEntity();
+
+        if (!existing.isReal()) {
+            // An unknown / un-instantiable adapter. If its protocol-id changed it may now resolve (or fail
+            // differently), so re-evaluate by discarding and recreating; otherwise just record the new config.
+            if (running.getProtocolId().equals(updated.getProtocolId())) {
+                existing.appliedEntity(updated);
+            } else {
+                stopAndDiscard(adapterId, updated);
+            }
+            return;
+        }
+
+        switch (ProtocolAdapterConfigDiffUtils.classify(running, updated)) {
+            case NO_CHANGE -> {
+                // Nothing changed in the configuration; a REST live goal (if any) is deliberately preserved.
+            }
+            case ACTIVATION_ONLY -> {
+                tellWrapper(existing, activationCommand(updated));
+                existing.appliedEntity(updated);
+            }
+            case TAGS_ONLY -> applyTagsOnly(existing, running, updated);
+            case FULL_RECREATE -> stopAndDiscard(adapterId, updated);
+        }
+    }
+
+    private void applyTagsOnly(
+            final @NotNull ProtocolAdapterContainer existing,
+            final @NotNull ProtocolAdapterEntity running,
+            final @NotNull ProtocolAdapterEntity updated) {
+        final Optional<ProtocolAdapterFactory> factory = factoryRegistry.findByProtocolId(updated.getProtocolId());
+        if (factory.isEmpty()) {
+            // Connection-critical fields are equal for TAGS_ONLY, so the factory that built the running adapter
+            // must still be present; fall back to a recreate if that invariant is ever broken.
+            stopAndDiscard(updated.getAdapterId(), updated);
+            return;
+        }
+        final List<NodeTagPair> nodes;
+        try {
+            nodes = wrapperFactory.translateNodes(updated, factory.get());
+        } catch (final ProtocolAdapterConfigException exception) {
+            log.error(
+                    "Cannot apply the tag set of v2 adapter '{}' in place: {}",
+                    updated.getAdapterId(),
+                    exception.getMessage());
+            stopAndDiscard(updated.getAdapterId(), updated);
+            return;
+        }
+        tellWrapper(
+                existing,
+                new ProtocolAdapterWrapperCommand.UpdateTagSet(
+                        nodes,
+                        ProtocolAdapterConfigSupport.activationOf(updated),
+                        updated.getReadUsedTagNames(),
+                        updated.getWriteUsedTagNames()));
+        if (ProtocolAdapterConfigDiffUtils.adapterDirectionChanged(running, updated)) {
+            // The tag-set update does not carry the adapter direction goal; re-assert the config-declared goal when
+            // it changed too (design §8.2). Still never reconnects.
+            tellWrapper(existing, activationCommand(updated));
+        }
+        existing.appliedEntity(updated);
+    }
+
+    // ── instance lifecycle (design §8.2) ────────────────────────────────────────────────────────────────────────
+
+    private void createAdapter(final @NotNull ProtocolAdapterEntity entity) {
+        final String adapterId = entity.getAdapterId();
+        final Optional<ProtocolAdapterFactory> factory = factoryRegistry.findByProtocolId(entity.getProtocolId());
+        if (factory.isEmpty()) {
+            registerErrorAdapter(entity, "no registered adapter type for protocol-id [" + entity.getProtocolId() + "]");
+            return;
+        }
+        final ProtocolAdapterContainer adapter;
+        try {
+            adapter = wrapperFactory.create(entity, factory.get(), requireHealthListener());
+        } catch (final ProtocolAdapterConfigException exception) {
+            final String reason = Objects.requireNonNullElse(exception.getMessage(), "invalid adapter configuration");
+            log.error("Cannot create v2 adapter '{}': {}", adapterId, reason);
+            registerErrorAdapter(entity, reason);
+            return;
+        }
+        containerMap.put(adapterId, adapter);
+        registry.register(adapter.handle());
+        // Apply the config-declared activation to bring the freshly-created wrapper to its initial goal (design
+        // §9.3). The wrapper starts in STOPPED; this is the command that steps it toward CONNECTED when a direction
+        // is activated, and leaves it STOPPED when neither is.
+        tellWrapper(adapter, activationCommand(entity));
+    }
+
+    private void registerErrorAdapter(final @NotNull ProtocolAdapterEntity entity, final @NotNull String reason) {
+        final String adapterId = entity.getAdapterId();
+        final AdapterStatusSnapshot errorSnapshot = new AdapterStatusSnapshot(
+                adapterId,
+                ProtocolAdapterWrapperState.ERROR,
+                entity.isNorthboundActivated(),
+                entity.isSouthboundActivated(),
+                List.of(),
+                clock.nowMillis(),
+                reason);
+        final ProtocolAdapterHandle handle =
+                new ProtocolAdapterHandle(adapterId, NO_OP_WRAPPER_SENDER, new AtomicReference<>(errorSnapshot));
+        containerMap.put(adapterId, ProtocolAdapterContainer.unknown(handle, entity));
+        registry.register(handle);
+        log.warn("v2 adapter '{}' is unavailable: {}", adapterId, reason);
+    }
+
+    /**
+     * Begin discarding an adapter: stop the wrapper, then close its resources once it reports {@code stopped()}, and
+     * optionally recreate it from a new configuration (a full recreate). An already-stopped or unknown adapter is
+     * torn down immediately.
+     *
+     * @param adapterId  the adapter to discard.
+     * @param recreateAs the configuration to recreate the adapter from once stopped, or {@code null} for a pure
+     *                   removal.
+     */
+    private void stopAndDiscard(final @NotNull String adapterId, final @Nullable ProtocolAdapterEntity recreateAs) {
+        final ProtocolAdapterContainer adapter = containerMap.remove(adapterId);
+        if (adapter == null) {
+            // Already stopping: fold the (possibly new) recreate target into the pending removal.
+            final PendingRemoval pending = pendingRemovalMap.get(adapterId);
+            if (pending != null) {
+                pendingRemovalMap.put(adapterId, new PendingRemoval(pending.stopping(), recreateAs));
+            } else if (recreateAs != null) {
+                createAdapter(recreateAs);
+            }
+            return;
+        }
+        if (!adapter.isReal() || isStopped(adapter)) {
+            // No wrapper to wind down, or it is already at rest — tear down now.
+            registry.unregister(adapterId);
+            adapter.close();
+            if (recreateAs != null) {
+                createAdapter(recreateAs);
+            }
+            return;
+        }
+        // Running: ask it to stop and tear it down when it reports stopped. Remove the handle now so REST no longer
+        // sees an adapter that is going away.
+        tellWrapper(adapter, new ProtocolAdapterWrapperCommand.StopAdapter());
+        registry.unregister(adapterId);
+        pendingRemovalMap.put(adapterId, new PendingRemoval(adapter, recreateAs));
+    }
+
+    // ── wrapper health (design §6.1, §8.3) ──────────────────────────────────────────────────────────────────────
+
+    private void onWrapperStarted(final @NotNull String adapterId) {
+        // Health is read from the wrapper's own snapshot; the event is logged for visibility. No action needed.
+        log.debug("v2 adapter '{}' started", adapterId);
+    }
+
+    private void onWrapperStopped(final @NotNull String adapterId) {
+        final PendingRemoval pending = pendingRemovalMap.remove(adapterId);
+        if (pending == null) {
+            // A normal stop (for example the user deactivated both directions). The adapter stays managed and
+            // registered, its snapshot now showing STOPPED.
+            return;
+        }
+        pending.stopping().close();
+        if (pending.recreateAs() != null) {
+            createAdapter(pending.recreateAs());
+        }
+    }
+
+    private void onWrapperError(final @NotNull String adapterId, final @NotNull String reason) {
+        // The wrapper's snapshot already shows ERROR (design §6.4). The manager performs NO automatic recreate
+        // (manual recovery in this project, design §8.3): the user deactivates and re-activates, or replaces the
+        // configuration.
+        log.warn("v2 adapter '{}' entered ERROR: {}", adapterId, reason);
+    }
+
+    // ── browse bridge (design §11.4 — completed in the OpenAPI/resource task) ────────────────────────────────────
+
+    private void handleBrowse(final @NotNull BrowseRequested browse) {
+        final ProtocolAdapterHandle handle = registry.find(browse.adapterId());
+        if (handle == null) {
+            browse.completion()
+                    .completeExceptionally(new IllegalArgumentException("no v2 adapter [" + browse.adapterId() + "]"));
+            return;
+        }
+        // The wrapper→adapter browse bridge (capability and connection checks, the forward, and the request
+        // timeout) is wired in the OpenAPI/resource task; the message and its completion future are part of the
+        // sealed hierarchy now so that task only adds the forward.
+        browse.completion()
+                .completeExceptionally(new UnsupportedOperationException(
+                        "the v2 browse bridge for adapter [" + browse.adapterId() + "] is not wired yet"));
+    }
+
+    // ── health summary (design §8.3) ────────────────────────────────────────────────────────────────────────────
+
+    private void publishHealthSummary(final long nowMillis) {
+        int total = 0;
+        int connected = 0;
+        int error = 0;
+        int stopped = 0;
+        int transitioning = 0;
+        for (final ProtocolAdapterHandle handle : registry.all()) {
+            total++;
+            final AdapterStatusSnapshot snapshot = handle.snapshot().get();
+            if (snapshot == null) {
+                transitioning++;
+                continue;
+            }
+            switch (snapshot.machineState()) {
+                case CONNECTED -> connected++;
+                case ERROR -> error++;
+                case STOPPED -> stopped++;
+                default -> transitioning++;
+            }
+        }
+        healthSummary.set(
+                new ProtocolAdapterManagerSnapshot(total, connected, error, stopped, transitioning, nowMillis));
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────────────────────────────────────────────────
+
+    private void forwardCommand(final @NotNull String adapterId, final @NotNull ProtocolAdapterWrapperCommand command) {
+        final ProtocolAdapterHandle handle = registry.find(adapterId);
+        if (handle == null) {
+            log.warn(
+                    "Dropping {} for unknown v2 adapter '{}'",
+                    command.getClass().getSimpleName(),
+                    adapterId);
+            return;
+        }
+        handle.wrapperSender().tell(command);
+    }
+
+    private static void tellWrapper(
+            final @NotNull ProtocolAdapterContainer adapter, final @NotNull ProtocolAdapterWrapperCommand command) {
+        adapter.handle().wrapperSender().tell(command);
+    }
+
+    private static @NotNull ProtocolAdapterWrapperCommand.ApplyActivation activationCommand(
+            final @NotNull ProtocolAdapterEntity entity) {
+        return new ProtocolAdapterWrapperCommand.ApplyActivation(
+                ProtocolAdapterConfigSupport.goalOf(entity), ProtocolAdapterConfigSupport.activationOf(entity));
+    }
+
+    private static boolean isStopped(final @NotNull ProtocolAdapterContainer adapter) {
+        final AdapterStatusSnapshot snapshot = adapter.handle().snapshot().get();
+        return snapshot != null && snapshot.machineState() == ProtocolAdapterWrapperState.STOPPED;
+    }
+
+    private @NotNull ProtocolAdapterManagerHealthListener requireHealthListener() {
+        return Objects.requireNonNull(
+                healthListener, "bindSelf must be called before the manager handles a configuration");
+    }
+
+    /**
+     * An adapter told to stop, awaiting its {@code stopped()} acknowledgment before its resources are released and
+     * (for a full recreate) a fresh instance is created.
+     *
+     * @param stopping   the stopping adapter, whose resources are closed once it reports stopped.
+     * @param recreateAs the configuration to recreate from after teardown, or {@code null} for a pure removal.
+     */
+    private record PendingRemoval(
+            @NotNull ProtocolAdapterContainer stopping,
+            @Nullable ProtocolAdapterEntity recreateAs) {}
+}

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/manager/ProtocolAdapterManagerHealthListener.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/manager/ProtocolAdapterManagerHealthListener.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.protocols.v2.manager;
+
+import com.hivemq.adapter.sdk.api.v2.messaging.MailboxSender;
+import com.hivemq.protocols.v2.wrapper.ProtocolAdapterWrapperEventListener;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * The wrapper&rarr;manager health seam (design §6.1, §8.3): turns each {@link ProtocolAdapterWrapperEventListener}
+ * callback a managed wrapper makes into one immutable {@link ProtocolAdapterManagerMessage} told onto the manager's
+ * own mailbox. A wrapper runs on its own dispatch thread and tells the manager from there; the manager then handles
+ * the health event on its single thread (the actor model — no shared state crosses the boundary, design §5.2).
+ * <p>
+ * One instance is shared by every wrapper the manager owns: each callback already carries the adapter id, so the
+ * listener only needs the manager's send-only handle.
+ */
+public final class ProtocolAdapterManagerHealthListener implements ProtocolAdapterWrapperEventListener {
+
+    private final @NotNull MailboxSender<ProtocolAdapterManagerMessage> managerSender;
+
+    /**
+     * @param managerSender the send-only handle of the manager's own mailbox.
+     */
+    public ProtocolAdapterManagerHealthListener(
+            final @NotNull MailboxSender<ProtocolAdapterManagerMessage> managerSender) {
+        this.managerSender = managerSender;
+    }
+
+    @Override
+    public void wrapperStarted(final @NotNull String adapterId) {
+        managerSender.tell(new ProtocolAdapterManagerMessage.WrapperStarted(adapterId));
+    }
+
+    @Override
+    public void wrapperStopped(final @NotNull String adapterId) {
+        managerSender.tell(new ProtocolAdapterManagerMessage.WrapperStopped(adapterId));
+    }
+
+    @Override
+    public void wrapperError(final @NotNull String adapterId, final @NotNull String reason) {
+        managerSender.tell(new ProtocolAdapterManagerMessage.WrapperError(adapterId, reason));
+    }
+}

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/manager/ProtocolAdapterManagerMessage.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/manager/ProtocolAdapterManagerMessage.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.protocols.v2.manager;
+
+import com.hivemq.adapter.sdk.api.v2.messaging.MailboxMessage;
+import com.hivemq.adapter.sdk.api.v2.messaging.MailboxMessagePriority;
+import com.hivemq.adapter.sdk.api.v2.model.BrowseFilter;
+import com.hivemq.adapter.sdk.api.v2.model.BrowseResultEntry;
+import com.hivemq.protocols.v2.config.ProtocolAdapterEntity;
+import com.hivemq.protocols.v2.wrapper.ProtocolAdapterDirection;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * The single mailbox message type of the {@link ProtocolAdapterManager} supervisor actor (design §8.1). Everything
+ * the manager consumes arrives as one of these, in priority-band order (design §5.1):
+ * <ul>
+ * <li>{@code CONTROL} — externally-driven intent: a freshly-loaded configuration, REST direction activation, REST
+ * tag retry, and a REST browse request;</li>
+ * <li>{@code EVENT} — wrapper health notifications a managed wrapper tells back ({@code started} / {@code stopped} /
+ * {@code error});</li>
+ * <li>{@code TICK} — periodic housekeeping (the health summary).</li>
+ * </ul>
+ * Sealed because all permitted subtypes live in this package; the generic {@link MailboxMessage} marker is the
+ * non-sealed bridge they extend.
+ */
+public sealed interface ProtocolAdapterManagerMessage extends MailboxMessage {
+
+    /**
+     * A freshly-loaded {@code <v2-protocol-adapters>} section from the extractor (design §8.2, §9.3) — the same
+     * path at startup and on every reload. The manager diffs it against the running set and applies the gentlest
+     * correct transition per adapter.
+     *
+     * @param adapters the complete new set of adapter configurations.
+     */
+    record ConfigurationChanged(@NotNull List<ProtocolAdapterEntity> adapters)
+            implements ProtocolAdapterManagerMessage {
+        @Override
+        public @NotNull MailboxMessagePriority priority() {
+            return MailboxMessagePriority.CONTROL;
+        }
+    }
+
+    /**
+     * Activate a direction of an adapter (REST origin) — a <b>live-goal command, never persisted</b> (design §8.2,
+     * D7). Forwarded to the running wrapper as
+     * {@link com.hivemq.protocols.v2.wrapper.ProtocolAdapterWrapperCommand.ActivateDirection}.
+     *
+     * @param adapterId the adapter instance id.
+     * @param direction the direction to activate.
+     */
+    record ActivateAdapter(
+            @NotNull String adapterId, @NotNull ProtocolAdapterDirection direction)
+            implements ProtocolAdapterManagerMessage {
+        @Override
+        public @NotNull MailboxMessagePriority priority() {
+            return MailboxMessagePriority.CONTROL;
+        }
+    }
+
+    /**
+     * Deactivate a direction of an adapter (REST origin) — a <b>live-goal command, never persisted</b> (design
+     * §8.2, D7). Forwarded to the running wrapper as
+     * {@link com.hivemq.protocols.v2.wrapper.ProtocolAdapterWrapperCommand.DeactivateDirection}.
+     *
+     * @param adapterId the adapter instance id.
+     * @param direction the direction to deactivate.
+     */
+    record DeactivateAdapter(
+            @NotNull String adapterId, @NotNull ProtocolAdapterDirection direction)
+            implements ProtocolAdapterManagerMessage {
+        @Override
+        public @NotNull MailboxMessagePriority priority() {
+            return MailboxMessagePriority.CONTROL;
+        }
+    }
+
+    /**
+     * Retry a permanently-failed tag of an adapter (REST origin, EDG-462) — a runtime-only command, forwarded to
+     * the running wrapper as {@link com.hivemq.protocols.v2.wrapper.ProtocolAdapterWrapperCommand.RetryTag}; never
+     * touches configuration (design §7.6).
+     *
+     * @param adapterId the adapter instance id.
+     * @param tagName   the tag to retry.
+     */
+    record RetryTag(@NotNull String adapterId, @NotNull String tagName) implements ProtocolAdapterManagerMessage {
+        @Override
+        public @NotNull MailboxMessagePriority priority() {
+            return MailboxMessagePriority.CONTROL;
+        }
+    }
+
+    /**
+     * Browse an adapter's device address space (REST origin, design §11.4). Carries the completion future the REST
+     * thread blocks on; the manager forwards the request toward the wrapper and the result is relayed back by
+     * completing the future. The full browse bridge (capability and connection checks, the wrapper&rarr;adapter
+     * forward, the timeout) is completed in the OpenAPI/resource task; here the message is part of the sealed
+     * hierarchy and the manager fails the future for a missing or not-yet-bridged adapter.
+     *
+     * @param adapterId  the adapter instance id.
+     * @param filter     the browse filter selecting where to browse.
+     * @param completion the future the REST thread awaits; completed with the results or completed exceptionally.
+     */
+    record BrowseRequested(
+            @NotNull String adapterId,
+            @NotNull BrowseFilter filter,
+            @NotNull CompletableFuture<List<BrowseResultEntry>> completion)
+            implements ProtocolAdapterManagerMessage {
+        @Override
+        public @NotNull MailboxMessagePriority priority() {
+            return MailboxMessagePriority.CONTROL;
+        }
+    }
+
+    /**
+     * A managed wrapper reached {@code CONNECTED} (design §6.1, §8.3). The {@code EVENT} band (the default).
+     *
+     * @param adapterId the adapter instance id.
+     */
+    record WrapperStarted(@NotNull String adapterId) implements ProtocolAdapterManagerMessage {}
+
+    /**
+     * A managed wrapper reached {@code STOPPED} (design §6.1, §8.3) — the signal that a stop-and-discard or full
+     * recreate may now tear the wrapper down. The {@code EVENT} band.
+     *
+     * @param adapterId the adapter instance id.
+     */
+    record WrapperStopped(@NotNull String adapterId) implements ProtocolAdapterManagerMessage {}
+
+    /**
+     * A managed wrapper entered {@code ERROR} (design §6.4, §8.3). The manager records it and performs <b>no</b>
+     * automatic recreate (manual recovery in this project, §8.3). The {@code EVENT} band.
+     *
+     * @param adapterId the adapter instance id.
+     * @param reason    a human-readable description of why.
+     */
+    record WrapperError(@NotNull String adapterId, @NotNull String reason) implements ProtocolAdapterManagerMessage {}
+
+    /**
+     * Periodic housekeeping (design §8.3): the manager folds the registry's snapshots into a health summary it
+     * publishes for readers. The {@code TICK} band.
+     *
+     * @param nowMillis the tick's logical time, in milliseconds.
+     */
+    record ProtocolAdapterManagerTick(long nowMillis) implements ProtocolAdapterManagerMessage {
+        @Override
+        public @NotNull MailboxMessagePriority priority() {
+            return MailboxMessagePriority.TICK;
+        }
+    }
+}

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/manager/ProtocolAdapterManagerSnapshot.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/manager/ProtocolAdapterManagerSnapshot.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.protocols.v2.manager;
+
+/**
+ * The manager's own immutable health summary (design §8.3): adapter counts folded from the registry's snapshots on
+ * each {@link ProtocolAdapterManagerMessage.ProtocolAdapterManagerTick}, published into an
+ * {@code AtomicReference} the manager exposes. A pure function of the registry's snapshots — readers (the REST
+ * surface, a later task) read it without locking.
+ *
+ * @param totalAdapters         the number of registered adapters.
+ * @param connectedAdapters     adapters whose machine is {@code CONNECTED} (healthy and serving).
+ * @param errorAdapters         adapters whose machine is {@code ERROR}.
+ * @param stoppedAdapters       adapters whose machine is {@code STOPPED}.
+ * @param transitioningAdapters adapters in any waiting state (connecting, retrying, or stopping).
+ * @param lastUpdatedAtMillis   the tick time this summary was folded, in milliseconds.
+ */
+public record ProtocolAdapterManagerSnapshot(
+        int totalAdapters,
+        int connectedAdapters,
+        int errorAdapters,
+        int stoppedAdapters,
+        int transitioningAdapters,
+        long lastUpdatedAtMillis) {
+
+    /**
+     * @return an empty summary — no adapters registered yet.
+     */
+    public static ProtocolAdapterManagerSnapshot empty() {
+        return new ProtocolAdapterManagerSnapshot(0, 0, 0, 0, 0, 0L);
+    }
+}

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/manager/ProtocolAdapterWrapperFactory.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/manager/ProtocolAdapterWrapperFactory.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.protocols.v2.manager;
+
+import com.hivemq.adapter.sdk.api.v2.factories.ProtocolAdapterFactory;
+import com.hivemq.adapter.sdk.api.v2.node.NodeTagPair;
+import com.hivemq.protocols.v2.config.ProtocolAdapterEntity;
+import com.hivemq.protocols.v2.wrapper.ProtocolAdapterWrapperEventListener;
+import java.util.List;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Builds a fully-wired, dispatcher-attached {@link com.hivemq.protocols.v2.wrapper.ProtocolAdapterWrapper} from one
+ * read-only {@link ProtocolAdapterEntity} and its type's {@link ProtocolAdapterFactory} (design §8.2). The seam the
+ * manager depends on so its supervision logic is testable without the full actor stack: production wiring uses
+ * {@link DefaultProtocolAdapterWrapperFactory}; the manager tests inject a recording double.
+ */
+public interface ProtocolAdapterWrapperFactory {
+
+    /**
+     * Construct, wire, and attach a wrapper/adapter pair for the given configuration. The returned adapter is
+     * <b>not yet started</b> — the manager brings it to its config-declared goal with an explicit activation
+     * command (design §9.3). Implementations must not perform I/O or connect.
+     *
+     * @param entity         the adapter configuration to instantiate.
+     * @param factory        the factory of the configuration's protocol-adapter type.
+     * @param healthListener the seam the new wrapper tells its {@code started} / {@code stopped} / {@code error}
+     *                       transitions through.
+     * @return the managed adapter (handle plus teardown resources), ready to be registered and started.
+     * @throws ProtocolAdapterConfigException if the configuration cannot be turned into a wrapper (for
+     *                                               example a {@code node-string} that does not deserialize into
+     *                                               the type's node class).
+     */
+    @NotNull
+    ProtocolAdapterContainer create(
+            @NotNull ProtocolAdapterEntity entity,
+            @NotNull ProtocolAdapterFactory factory,
+            @NotNull ProtocolAdapterWrapperEventListener healthListener);
+
+    /**
+     * Translate the configuration's tags into the runtime node/tag pairs — the payload of an in-place
+     * {@link com.hivemq.protocols.v2.wrapper.ProtocolAdapterWrapperCommand.UpdateTagSet} (design §8.2). Shares the
+     * exact node-string deserialization {@link #create} uses, so a tags-only reload builds the same pairs the
+     * adapter was created with.
+     *
+     * @param entity  the adapter configuration whose tags to translate.
+     * @param factory the factory of the configuration's protocol-adapter type.
+     * @return the node/tag pairs in declaration order.
+     * @throws ProtocolAdapterConfigException if a {@code node-string} does not deserialize into the type's
+     *                                               node class.
+     */
+    @NotNull
+    List<NodeTagPair> translateNodes(@NotNull ProtocolAdapterEntity entity, @NotNull ProtocolAdapterFactory factory);
+}

--- a/hivemq-edge/src/test/java/com/hivemq/protocols/v2/manager/DefaultProtocolAdapterWrapperFactoryTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/protocols/v2/manager/DefaultProtocolAdapterWrapperFactoryTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.protocols.v2.manager;
+
+import static com.hivemq.protocols.v2.manager.ProtocolAdapterManagerTestSupport.adapter;
+import static com.hivemq.protocols.v2.manager.ProtocolAdapterManagerTestSupport.tag;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.codahale.metrics.MetricRegistry;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hivemq.adapter.sdk.api.v2.node.NodeTagPair;
+import com.hivemq.protocols.v2.config.ProtocolAdapterEntity;
+import com.hivemq.protocols.v2.manager.ProtocolAdapterManagerTestSupport.TestDataPointFactory;
+import com.hivemq.protocols.v2.manager.ProtocolAdapterManagerTestSupport.TestProtocolAdapterFactory;
+import com.hivemq.protocols.v2.runtime.FakeClock;
+import com.hivemq.protocols.v2.runtime.ManualDispatcher;
+import com.hivemq.protocols.v2.view.AdapterStatusSnapshot;
+import com.hivemq.protocols.v2.view.TagStatusSnapshot;
+import com.hivemq.protocols.v2.wrapper.ProtocolAdapterWrapperCommand;
+import com.hivemq.protocols.v2.wrapper.ProtocolAdapterWrapperEventListener;
+import com.hivemq.protocols.v2.wrapper.ProtocolAdapterWrapperState;
+import java.util.ArrayList;
+import java.util.List;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The production wrapper factory (design §8.2): it turns a read-only configuration entity into a fully-wired,
+ * dispatcher-attached wrapper that — driven by the same activation kick the manager sends — reaches
+ * {@code CONNECTED}, including the {@code node-string} deserialization and the config-to-{@code DataPoint}
+ * translation. Run on a {@link FakeClock} + {@link ManualDispatcher} with a synchronous protocol-adapter double.
+ */
+class DefaultProtocolAdapterWrapperFactoryTest {
+
+    private FakeClock clock;
+    private ManualDispatcher dispatcher;
+    private DefaultProtocolAdapterWrapperFactory factory;
+    private TestProtocolAdapterFactory sdkFactory;
+
+    @BeforeEach
+    void setUp() {
+        clock = new FakeClock();
+        dispatcher = new ManualDispatcher();
+        factory = new DefaultProtocolAdapterWrapperFactory(
+                clock, dispatcher, new MetricRegistry(), new TestDataPointFactory(), new ObjectMapper(), 100);
+        sdkFactory = new TestProtocolAdapterFactory(ProtocolAdapterManagerTestSupport.TEST_PROTOCOL_ID);
+    }
+
+    @Test
+    void buildsAndStartsARealWrapperToConnected() {
+        final ProtocolAdapterEntity entity = adapter("a")
+                .northboundActivated(true)
+                .northboundMapping("temperature", "plant/a/temperature")
+                .build();
+        final RecordingHealth health = new RecordingHealth();
+
+        final ProtocolAdapterContainer managed = factory.create(entity, sdkFactory, health);
+        assertThat(managed.isReal()).isTrue();
+
+        // The manager would send exactly this to bring the freshly-created wrapper to its config-declared goal.
+        managed.handle()
+                .wrapperSender()
+                .tell(new ProtocolAdapterWrapperCommand.ApplyActivation(
+                        ProtocolAdapterConfigSupport.goalOf(entity),
+                        ProtocolAdapterConfigSupport.activationOf(entity)));
+        dispatcher.drainAll();
+
+        final AdapterStatusSnapshot snapshot = managed.handle().snapshot().get();
+        assertThat(snapshot).isNotNull();
+        assertThat(snapshot.machineState()).isEqualTo(ProtocolAdapterWrapperState.CONNECTED);
+        assertThat(snapshot.tags()).extracting(TagStatusSnapshot::tagName).contains("temperature");
+        assertThat(health.started).containsExactly("a");
+
+        managed.close();
+    }
+
+    @Test
+    void translateNodes_deserializesNodeStringsIntoTheTypesNodeClass() {
+        final ProtocolAdapterEntity entity = adapter("a")
+                .tags(tag("temperature")
+                        .nodeString("{\"identifier\":\"node-1\"}")
+                        .build())
+                .build();
+
+        final List<NodeTagPair> nodes = factory.translateNodes(entity, sdkFactory);
+
+        assertThat(nodes).hasSize(1);
+        assertThat(nodes.get(0).tag().name()).isEqualTo("temperature");
+        assertThat(nodes.get(0).node().nodeId()).isEqualTo("node-1");
+    }
+
+    @Test
+    void invalidNodeString_isReportedAsAConfigurationException() {
+        final ProtocolAdapterEntity entity = adapter("a")
+                .tags(tag("temperature").nodeString("}{ not json").build())
+                .build();
+
+        assertThatThrownBy(() -> factory.create(entity, sdkFactory, ProtocolAdapterWrapperEventListener.NONE))
+                .isInstanceOf(ProtocolAdapterConfigException.class)
+                .hasMessageContaining("temperature");
+    }
+
+    @Test
+    void staysStoppedWhenNeitherDirectionIsActivated() {
+        final ProtocolAdapterEntity entity = adapter("a")
+                .northboundActivated(false)
+                .southboundActivated(false)
+                .build();
+
+        final ProtocolAdapterContainer managed =
+                factory.create(entity, sdkFactory, ProtocolAdapterWrapperEventListener.NONE);
+        managed.handle()
+                .wrapperSender()
+                .tell(new ProtocolAdapterWrapperCommand.ApplyActivation(
+                        ProtocolAdapterConfigSupport.goalOf(entity),
+                        ProtocolAdapterConfigSupport.activationOf(entity)));
+        dispatcher.drainAll();
+
+        final AdapterStatusSnapshot snapshot = managed.handle().snapshot().get();
+        assertThat(snapshot).isNotNull();
+        assertThat(snapshot.machineState()).isEqualTo(ProtocolAdapterWrapperState.STOPPED);
+
+        managed.close();
+    }
+
+    private static final class RecordingHealth implements ProtocolAdapterWrapperEventListener {
+
+        private final @NotNull List<String> started = new ArrayList<>();
+        private final @NotNull List<String> stopped = new ArrayList<>();
+        private final @NotNull List<String> errored = new ArrayList<>();
+
+        @Override
+        public void wrapperStarted(final @NotNull String adapterId) {
+            started.add(adapterId);
+        }
+
+        @Override
+        public void wrapperStopped(final @NotNull String adapterId) {
+            stopped.add(adapterId);
+        }
+
+        @Override
+        public void wrapperError(final @NotNull String adapterId, final @NotNull String reason) {
+            errored.add(adapterId);
+        }
+    }
+}

--- a/hivemq-edge/src/test/java/com/hivemq/protocols/v2/manager/ProtocolAdapterConfigDiffUtilsTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/protocols/v2/manager/ProtocolAdapterConfigDiffUtilsTest.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.protocols.v2.manager;
+
+import static com.hivemq.protocols.v2.manager.ProtocolAdapterManagerTestSupport.adapter;
+import static com.hivemq.protocols.v2.manager.ProtocolAdapterManagerTestSupport.tag;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.hivemq.protocols.v2.config.ProtocolAdapterEntity;
+import com.hivemq.protocols.v2.config.RetryPolicyEntity;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The config-difference classifier (design §8.2): every transition class, the layering that lets the more
+ * disruptive change win, and the adapter-direction predicate the manager uses to compose a tags-only transition.
+ */
+class ProtocolAdapterConfigDiffUtilsTest {
+
+    @Test
+    void identicalConfigurations_areNoChange() {
+        final ProtocolAdapterEntity running =
+                adapter("a").northboundMapping("temperature", "t/a").build();
+        final ProtocolAdapterEntity updated =
+                adapter("a").northboundMapping("temperature", "t/a").build();
+
+        assertThat(ProtocolAdapterConfigDiffUtils.classify(running, updated))
+                .isEqualTo(ProtocolAdapterConfigStateTransition.NO_CHANGE);
+    }
+
+    @Test
+    void flippedAdapterDirection_isActivationOnly() {
+        final ProtocolAdapterEntity running =
+                adapter("a").southboundActivated(false).build();
+        final ProtocolAdapterEntity updated =
+                adapter("a").southboundActivated(true).build();
+
+        assertThat(ProtocolAdapterConfigDiffUtils.classify(running, updated))
+                .isEqualTo(ProtocolAdapterConfigStateTransition.ACTIVATION_ONLY);
+    }
+
+    @Test
+    void flippedTagAspectActivation_isActivationOnly() {
+        final ProtocolAdapterEntity running = adapter("a")
+                .tags(tag("temperature").readActivated(true).build())
+                .build();
+        final ProtocolAdapterEntity updated = adapter("a")
+                .tags(tag("temperature").readActivated(false).build())
+                .build();
+
+        assertThat(ProtocolAdapterConfigDiffUtils.classify(running, updated))
+                .isEqualTo(ProtocolAdapterConfigStateTransition.ACTIVATION_ONLY);
+    }
+
+    @Test
+    void addedTag_isTagsOnly() {
+        final ProtocolAdapterEntity running =
+                adapter("a").tags(tag("temperature").build()).build();
+        final ProtocolAdapterEntity updated = adapter("a")
+                .tags(tag("temperature").build(), tag("pressure").build())
+                .build();
+
+        assertThat(ProtocolAdapterConfigDiffUtils.classify(running, updated))
+                .isEqualTo(ProtocolAdapterConfigStateTransition.TAGS_ONLY);
+    }
+
+    @Test
+    void changedNodeString_isTagsOnly() {
+        final ProtocolAdapterEntity running = adapter("a")
+                .tags(tag("temperature").nodeString("{\"identifier\":\"x\"}").build())
+                .build();
+        final ProtocolAdapterEntity updated = adapter("a")
+                .tags(tag("temperature").nodeString("{\"identifier\":\"y\"}").build())
+                .build();
+
+        assertThat(ProtocolAdapterConfigDiffUtils.classify(running, updated))
+                .isEqualTo(ProtocolAdapterConfigStateTransition.TAGS_ONLY);
+    }
+
+    @Test
+    void addedMappingThatFlipsUsed_isTagsOnly() {
+        // S16: a northbound mapping added in config flips the tag's readUsed — a tags-only transition (UpdateTagSet
+        // recomputes used), never a reconnect.
+        final ProtocolAdapterEntity running = adapter("a").build();
+        final ProtocolAdapterEntity updated =
+                adapter("a").northboundMapping("temperature", "t/a").build();
+
+        assertThat(ProtocolAdapterConfigDiffUtils.classify(running, updated))
+                .isEqualTo(ProtocolAdapterConfigStateTransition.TAGS_ONLY);
+    }
+
+    @Test
+    void changedProtocolId_isFullRecreate() {
+        final ProtocolAdapterEntity running = adapter("a").protocolId("test").build();
+        final ProtocolAdapterEntity updated = adapter("a").protocolId("other").build();
+
+        assertThat(ProtocolAdapterConfigDiffUtils.classify(running, updated))
+                .isEqualTo(ProtocolAdapterConfigStateTransition.FULL_RECREATE);
+    }
+
+    @Test
+    void changedAdapterConfiguration_isFullRecreate() {
+        final ProtocolAdapterEntity running =
+                adapter("a").adapterConfiguration(Map.of("host", "a")).build();
+        final ProtocolAdapterEntity updated =
+                adapter("a").adapterConfiguration(Map.of("host", "b")).build();
+
+        assertThat(ProtocolAdapterConfigDiffUtils.classify(running, updated))
+                .isEqualTo(ProtocolAdapterConfigStateTransition.FULL_RECREATE);
+    }
+
+    @Test
+    void changedRetryPolicy_isFullRecreate() {
+        final ProtocolAdapterEntity running = adapter("a")
+                .retryPolicy(new RetryPolicyEntity(1000, 1.41, 32000, 3))
+                .build();
+        final ProtocolAdapterEntity updated = adapter("a")
+                .retryPolicy(new RetryPolicyEntity(2000, 1.41, 32000, 3))
+                .build();
+
+        assertThat(ProtocolAdapterConfigDiffUtils.classify(running, updated))
+                .isEqualTo(ProtocolAdapterConfigStateTransition.FULL_RECREATE);
+    }
+
+    @Test
+    void changedWatchdogTimeout_isFullRecreate() {
+        final ProtocolAdapterEntity running =
+                adapter("a").watchdogTimeoutMillis(30000).build();
+        final ProtocolAdapterEntity updated =
+                adapter("a").watchdogTimeoutMillis(20000).build();
+
+        assertThat(ProtocolAdapterConfigDiffUtils.classify(running, updated))
+                .isEqualTo(ProtocolAdapterConfigStateTransition.FULL_RECREATE);
+    }
+
+    @Test
+    void changedCommandTimeout_isFullRecreate() {
+        final ProtocolAdapterEntity running =
+                adapter("a").commandTimeoutMillis(10000).build();
+        final ProtocolAdapterEntity updated =
+                adapter("a").commandTimeoutMillis(5000).build();
+
+        assertThat(ProtocolAdapterConfigDiffUtils.classify(running, updated))
+                .isEqualTo(ProtocolAdapterConfigStateTransition.FULL_RECREATE);
+    }
+
+    @Test
+    void changedSkipVerification_isFullRecreate() {
+        final ProtocolAdapterEntity running =
+                adapter("a").skipVerification(false).build();
+        final ProtocolAdapterEntity updated =
+                adapter("a").skipVerification(true).build();
+
+        assertThat(ProtocolAdapterConfigDiffUtils.classify(running, updated))
+                .isEqualTo(ProtocolAdapterConfigStateTransition.FULL_RECREATE);
+    }
+
+    @Test
+    void changedConfigVersion_isFullRecreate() {
+        final ProtocolAdapterEntity running = adapter("a").configVersion(2).build();
+        final ProtocolAdapterEntity updated = adapter("a").configVersion(3).build();
+
+        assertThat(ProtocolAdapterConfigDiffUtils.classify(running, updated))
+                .isEqualTo(ProtocolAdapterConfigStateTransition.FULL_RECREATE);
+    }
+
+    @Test
+    void connectionCriticalChange_winsOverActivationChange() {
+        final ProtocolAdapterEntity running =
+                adapter("a").protocolId("test").southboundActivated(false).build();
+        final ProtocolAdapterEntity updated =
+                adapter("a").protocolId("other").southboundActivated(true).build();
+
+        assertThat(ProtocolAdapterConfigDiffUtils.classify(running, updated))
+                .isEqualTo(ProtocolAdapterConfigStateTransition.FULL_RECREATE);
+    }
+
+    @Test
+    void tagSetChange_winsOverActivationChange() {
+        final ProtocolAdapterEntity running = adapter("a")
+                .southboundActivated(false)
+                .tags(tag("temperature").build())
+                .build();
+        final ProtocolAdapterEntity updated = adapter("a")
+                .southboundActivated(true)
+                .tags(tag("temperature").build(), tag("pressure").build())
+                .build();
+
+        assertThat(ProtocolAdapterConfigDiffUtils.classify(running, updated))
+                .isEqualTo(ProtocolAdapterConfigStateTransition.TAGS_ONLY);
+    }
+
+    @Test
+    void adapterDirectionChanged_tracksTheDirectionFlags() {
+        final ProtocolAdapterEntity running = adapter("a")
+                .northboundActivated(true)
+                .southboundActivated(false)
+                .build();
+        final ProtocolAdapterEntity sameDirections = adapter("a")
+                .northboundActivated(true)
+                .southboundActivated(false)
+                .build();
+        final ProtocolAdapterEntity flipped =
+                adapter("a").northboundActivated(true).southboundActivated(true).build();
+
+        assertThat(ProtocolAdapterConfigDiffUtils.adapterDirectionChanged(running, sameDirections))
+                .isFalse();
+        assertThat(ProtocolAdapterConfigDiffUtils.adapterDirectionChanged(running, flipped))
+                .isTrue();
+    }
+}

--- a/hivemq-edge/src/test/java/com/hivemq/protocols/v2/manager/ProtocolAdapterHandleRegistryTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/protocols/v2/manager/ProtocolAdapterHandleRegistryTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.protocols.v2.manager;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import com.hivemq.adapter.sdk.api.v2.messaging.MailboxSender;
+import com.hivemq.protocols.v2.manager.ProtocolAdapterHandleRegistry.ProtocolAdapterHandle;
+import com.hivemq.protocols.v2.view.AdapterStatusSnapshot;
+import com.hivemq.protocols.v2.wrapper.ProtocolAdapterWrapperMessage;
+import com.hivemq.protocols.v2.wrapper.ProtocolAdapterWrapperState;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The REST-readable registry (design §6.6, §8): basic lifecycle, and — with real threads and Awaitility, never
+ * {@code Thread.sleep} — that handles and their published snapshots are safely readable from a foreign thread while
+ * the (single) writer mutates the registry, honoring the actor model's snapshot-only read path.
+ */
+class ProtocolAdapterHandleRegistryTest {
+
+    private static final @NotNull Duration TIMEOUT = Duration.ofSeconds(5);
+    private static final @NotNull MailboxSender<ProtocolAdapterWrapperMessage> NO_OP_SENDER = message -> {};
+
+    @Test
+    void registerFindAndUnregister() {
+        final ProtocolAdapterHandleRegistry registry = new ProtocolAdapterHandleRegistry();
+        final ProtocolAdapterHandle handle = handle("a", ProtocolAdapterWrapperState.STOPPED);
+
+        registry.register(handle);
+
+        assertThat(registry.find("a")).isSameAs(handle);
+        assertThat(registry.all()).containsExactly(handle);
+
+        registry.unregister("a");
+
+        assertThat(registry.find("a")).isNull();
+        assertThat(registry.all()).isEmpty();
+    }
+
+    @Test
+    void publishedSnapshotIsVisibleFromAForeignThread() throws InterruptedException {
+        final ProtocolAdapterHandleRegistry registry = new ProtocolAdapterHandleRegistry();
+        final AtomicReference<AdapterStatusSnapshot> snapshot =
+                new AtomicReference<>(snapshot("a", ProtocolAdapterWrapperState.WAITING_FOR_CONNECTED));
+        registry.register(new ProtocolAdapterHandle("a", NO_OP_SENDER, snapshot));
+
+        final CountDownLatch reading = new CountDownLatch(1);
+        final AtomicReference<ProtocolAdapterWrapperState> seen = new AtomicReference<>();
+        final Thread reader = new Thread(() -> {
+            reading.countDown();
+            await().atMost(TIMEOUT).until(() -> {
+                final ProtocolAdapterHandle found = registry.find("a");
+                return found != null && found.snapshot().get().machineState() == ProtocolAdapterWrapperState.CONNECTED;
+            });
+            final ProtocolAdapterHandle found = registry.find("a");
+            seen.set(found == null ? null : found.snapshot().get().machineState());
+        });
+        reader.start();
+
+        reading.await();
+        // The owning thread publishes a new snapshot; the foreign reader must observe it (AtomicReference).
+        snapshot.set(snapshot("a", ProtocolAdapterWrapperState.CONNECTED));
+        reader.join(TIMEOUT.toMillis());
+
+        assertThat(seen.get()).isEqualTo(ProtocolAdapterWrapperState.CONNECTED);
+    }
+
+    @Test
+    void concurrentRegistrationsAreAllVisible() {
+        final ProtocolAdapterHandleRegistry registry = new ProtocolAdapterHandleRegistry();
+        final int writers = 8;
+        final int perWriter = 50;
+        final List<Thread> threads = new java.util.ArrayList<>(writers);
+        for (int writer = 0; writer < writers; writer++) {
+            final int base = writer * perWriter;
+            threads.add(new Thread(() -> {
+                for (int i = 0; i < perWriter; i++) {
+                    registry.register(handle("adapter-" + (base + i), ProtocolAdapterWrapperState.STOPPED));
+                }
+            }));
+        }
+        threads.forEach(Thread::start);
+
+        await().atMost(TIMEOUT).until(() -> registry.all().size() == writers * perWriter);
+
+        assertThat(registry.all()).hasSize(writers * perWriter);
+    }
+
+    private static @NotNull ProtocolAdapterHandle handle(
+            final @NotNull String adapterId, final @NotNull ProtocolAdapterWrapperState state) {
+        return new ProtocolAdapterHandle(adapterId, NO_OP_SENDER, new AtomicReference<>(snapshot(adapterId, state)));
+    }
+
+    private static @NotNull AdapterStatusSnapshot snapshot(
+            final @NotNull String adapterId, final @NotNull ProtocolAdapterWrapperState state) {
+        return new AdapterStatusSnapshot(adapterId, state, false, false, List.of(), 0L, null);
+    }
+}

--- a/hivemq-edge/src/test/java/com/hivemq/protocols/v2/manager/ProtocolAdapterManagerTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/protocols/v2/manager/ProtocolAdapterManagerTest.java
@@ -1,0 +1,272 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.protocols.v2.manager;
+
+import static com.hivemq.protocols.v2.manager.ProtocolAdapterManagerTestSupport.adapter;
+import static com.hivemq.protocols.v2.manager.ProtocolAdapterManagerTestSupport.tag;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.hivemq.adapter.sdk.api.v2.messaging.DefaultMailbox;
+import com.hivemq.adapter.sdk.api.v2.messaging.Mailbox;
+import com.hivemq.protocols.v2.config.ProtocolAdapterEntity;
+import com.hivemq.protocols.v2.manager.ProtocolAdapterHandleRegistry.ProtocolAdapterHandle;
+import com.hivemq.protocols.v2.manager.ProtocolAdapterManagerMessage.ActivateAdapter;
+import com.hivemq.protocols.v2.manager.ProtocolAdapterManagerMessage.ConfigurationChanged;
+import com.hivemq.protocols.v2.manager.ProtocolAdapterManagerMessage.DeactivateAdapter;
+import com.hivemq.protocols.v2.manager.ProtocolAdapterManagerMessage.ProtocolAdapterManagerTick;
+import com.hivemq.protocols.v2.runtime.FakeClock;
+import com.hivemq.protocols.v2.runtime.ManualDispatcher;
+import com.hivemq.protocols.v2.view.AdapterStatusSnapshot;
+import com.hivemq.protocols.v2.wrapper.ProtocolAdapterDirection;
+import com.hivemq.protocols.v2.wrapper.ProtocolAdapterWrapperCommand;
+import com.hivemq.protocols.v2.wrapper.ProtocolAdapterWrapperState;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The supervisor actor (design §8) driven through its mailbox on a {@link ManualDispatcher}: configuration
+ * add/remove, the four gentlest transitions, REST live-goal and retry routing, unknown-type handling, manual-only
+ * recovery, and the health summary. The wrapper is the {@link RecordingWrapperFactory} double so these tests prove
+ * the manager's own logic; the real wrapper wiring has its own test.
+ */
+class ProtocolAdapterManagerTest {
+
+    private FakeClock clock;
+    private ManualDispatcher dispatcher;
+    private Mailbox<ProtocolAdapterManagerMessage> mailbox;
+    private ProtocolAdapterHandleRegistry registry;
+    private RecordingWrapperFactory wrapperFactory;
+    private ProtocolAdapterManager manager;
+
+    @BeforeEach
+    void setUp() {
+        clock = new FakeClock();
+        dispatcher = new ManualDispatcher();
+        mailbox = new DefaultMailbox<>();
+        registry = new ProtocolAdapterHandleRegistry();
+        wrapperFactory = new RecordingWrapperFactory();
+        final ProtocolAdapterFactoryRegistry factories = new ProtocolAdapterFactoryRegistry(
+                Set.of(new ProtocolAdapterManagerTestSupport.TestProtocolAdapterFactory(
+                        ProtocolAdapterManagerTestSupport.TEST_PROTOCOL_ID)));
+        manager = new ProtocolAdapterManager(factories, registry, wrapperFactory, clock);
+        dispatcher.attach(mailbox, manager);
+        manager.bindSelf(mailbox);
+    }
+
+    @Test
+    void configurationAdd_createsRegistersAndStartsTheAdapter() {
+        send(new ConfigurationChanged(List.of(adapter("a").build())));
+
+        assertThat(wrapperFactory.createdAdapterIds()).containsExactly("a");
+        assertThat(registry.find("a")).isNotNull();
+        // The config-declared activation is applied to bring the freshly-created wrapper to its goal (design §9.3).
+        assertThat(wrapperFactory.commands("a"))
+                .last()
+                .isInstanceOf(ProtocolAdapterWrapperCommand.ApplyActivation.class);
+    }
+
+    @Test
+    void configurationRemove_stopsAndDiscardsARunningAdapter() {
+        send(new ConfigurationChanged(List.of(adapter("a").build())));
+        wrapperFactory.setMachineState("a", ProtocolAdapterWrapperState.CONNECTED);
+
+        send(new ConfigurationChanged(List.of()));
+
+        assertThat(wrapperFactory.commands("a"))
+                .hasAtLeastOneElementOfType(ProtocolAdapterWrapperCommand.StopAdapter.class);
+        assertThat(registry.find("a")).isNull();
+
+        // The wrapper reports stopped; teardown completes and there is no recreate.
+        fireWrapperStopped("a");
+        assertThat(registry.find("a")).isNull();
+        assertThat(wrapperFactory.createdAdapterIds()).containsExactly("a");
+    }
+
+    @Test
+    void configurationRemove_tearsDownImmediatelyWhenAlreadyStopped() {
+        send(new ConfigurationChanged(List.of(adapter("a").build()))); // snapshot starts STOPPED
+
+        send(new ConfigurationChanged(List.of()));
+
+        assertThat(registry.find("a")).isNull();
+        assertThat(wrapperFactory.commands("a")).noneMatch(ProtocolAdapterWrapperCommand.StopAdapter.class::isInstance);
+    }
+
+    @Test
+    void restActivationAndDeactivation_forwardLiveGoalCommands() {
+        send(new ConfigurationChanged(List.of(adapter("a").build())));
+
+        send(new ActivateAdapter("a", ProtocolAdapterDirection.SOUTHBOUND));
+        send(new DeactivateAdapter("a", ProtocolAdapterDirection.NORTHBOUND));
+
+        assertThat(wrapperFactory.commands("a"))
+                .anyMatch(command -> command instanceof ProtocolAdapterWrapperCommand.ActivateDirection activate
+                        && activate.direction() == ProtocolAdapterDirection.SOUTHBOUND)
+                .anyMatch(command -> command instanceof ProtocolAdapterWrapperCommand.DeactivateDirection deactivate
+                        && deactivate.direction() == ProtocolAdapterDirection.NORTHBOUND);
+    }
+
+    @Test
+    void reloadWithUnchangedFlags_isNoChange_andPreservesTheRestLiveGoal() {
+        final ProtocolAdapterEntity config = adapter("a").build();
+        send(new ConfigurationChanged(List.of(config)));
+        send(new DeactivateAdapter("a", ProtocolAdapterDirection.NORTHBOUND));
+        final int commandsBefore = wrapperFactory.commands("a").size();
+
+        send(new ConfigurationChanged(List.of(adapter("a").build())));
+
+        // NO_CHANGE sends nothing, so the REST live goal (deactivated northbound) is not clobbered.
+        assertThat(wrapperFactory.commands("a")).hasSize(commandsBefore);
+    }
+
+    @Test
+    void reloadActivationOnly_appliesAnActivationCommand() {
+        send(new ConfigurationChanged(
+                List.of(adapter("a").southboundActivated(false).build())));
+        final int commandsBefore = wrapperFactory.commands("a").size();
+
+        send(new ConfigurationChanged(
+                List.of(adapter("a").southboundActivated(true).build())));
+
+        assertThat(wrapperFactory.commands("a")).hasSizeGreaterThan(commandsBefore);
+        assertThat(wrapperFactory.commands("a"))
+                .last()
+                .isInstanceOf(ProtocolAdapterWrapperCommand.ApplyActivation.class);
+    }
+
+    @Test
+    void reloadTagsOnly_appliesAnUpdateTagSetCommand() {
+        send(new ConfigurationChanged(
+                List.of(adapter("a").tags(tag("temperature").build()).build())));
+
+        send(new ConfigurationChanged(List.of(adapter("a")
+                .tags(tag("temperature").build(), tag("pressure").build())
+                .build())));
+
+        assertThat(wrapperFactory.commands("a"))
+                .hasAtLeastOneElementOfType(ProtocolAdapterWrapperCommand.UpdateTagSet.class);
+        assertThat(wrapperFactory.translateNodesAdapterIds()).contains("a");
+    }
+
+    @Test
+    void reloadFullRecreate_stopsThenRecreates() {
+        send(new ConfigurationChanged(
+                List.of(adapter("a").adapterConfiguration(Map.of("host", "a")).build())));
+        wrapperFactory.setMachineState("a", ProtocolAdapterWrapperState.CONNECTED);
+
+        send(new ConfigurationChanged(
+                List.of(adapter("a").adapterConfiguration(Map.of("host", "b")).build())));
+
+        assertThat(wrapperFactory.commands("a"))
+                .hasAtLeastOneElementOfType(ProtocolAdapterWrapperCommand.StopAdapter.class);
+        assertThat(registry.find("a")).isNull();
+
+        fireWrapperStopped("a");
+
+        assertThat(wrapperFactory.createdAdapterIds()).containsExactly("a", "a");
+        assertThat(registry.find("a")).isNotNull();
+    }
+
+    @Test
+    void wrapperError_isRecordedWithoutAutomaticRecreate() {
+        send(new ConfigurationChanged(List.of(adapter("a").build())));
+        final int createdBefore = wrapperFactory.createdAdapterIds().size();
+
+        fireWrapperError("a", "boom");
+
+        assertThat(wrapperFactory.createdAdapterIds()).hasSize(createdBefore);
+        assertThat(registry.find("a")).isNotNull();
+    }
+
+    @Test
+    void recovery_deactivateThenActivate_areForwardedAsLiveGoalCommands() {
+        send(new ConfigurationChanged(List.of(adapter("a").build())));
+
+        send(new DeactivateAdapter("a", ProtocolAdapterDirection.BOTH));
+        send(new ActivateAdapter("a", ProtocolAdapterDirection.BOTH));
+
+        assertThat(wrapperFactory.commands("a"))
+                .anyMatch(command -> command instanceof ProtocolAdapterWrapperCommand.DeactivateDirection deactivate
+                        && deactivate.direction() == ProtocolAdapterDirection.BOTH)
+                .anyMatch(command -> command instanceof ProtocolAdapterWrapperCommand.ActivateDirection activate
+                        && activate.direction() == ProtocolAdapterDirection.BOTH);
+    }
+
+    @Test
+    void retryTag_isForwardedToTheWrapper() {
+        send(new ConfigurationChanged(List.of(adapter("a").build())));
+
+        send(new ProtocolAdapterManagerMessage.RetryTag("a", "temperature"));
+
+        assertThat(wrapperFactory.commands("a"))
+                .anyMatch(command -> command instanceof ProtocolAdapterWrapperCommand.RetryTag retry
+                        && retry.tagName().equals("temperature"));
+    }
+
+    @Test
+    void unknownProtocolId_isSurfacedAsAnErrorHandleWithNoWrapper() {
+        send(new ConfigurationChanged(
+                List.of(adapter("ghost").protocolId("nope").build())));
+
+        final ProtocolAdapterHandle handle = registry.find("ghost");
+        assertThat(handle).isNotNull();
+        final AdapterStatusSnapshot snapshot = handle.snapshot().get();
+        assertThat(snapshot).isNotNull();
+        assertThat(snapshot.machineState()).isEqualTo(ProtocolAdapterWrapperState.ERROR);
+        assertThat(snapshot.lastErrorReason()).contains("no registered adapter type");
+        assertThat(wrapperFactory.createdAdapterIds()).doesNotContain("ghost");
+    }
+
+    @Test
+    void restCommandToUnknownAdapter_isDroppedSafely() {
+        send(new ActivateAdapter("ghost", ProtocolAdapterDirection.BOTH));
+
+        assertThat(registry.find("ghost")).isNull();
+    }
+
+    @Test
+    void managerTick_publishesAHealthSummaryFoldedFromTheRegistry() {
+        send(new ConfigurationChanged(List.of(adapter("a").build(), adapter("b").build())));
+        wrapperFactory.setMachineState("a", ProtocolAdapterWrapperState.CONNECTED);
+
+        send(new ProtocolAdapterManagerTick(123L));
+
+        final ProtocolAdapterManagerSnapshot summary = manager.healthSummary();
+        assertThat(summary.totalAdapters()).isEqualTo(2);
+        assertThat(summary.connectedAdapters()).isEqualTo(1);
+        assertThat(summary.stoppedAdapters()).isEqualTo(1);
+        assertThat(summary.lastUpdatedAtMillis()).isEqualTo(123L);
+    }
+
+    private void send(final @NotNull ProtocolAdapterManagerMessage message) {
+        mailbox.tell(message);
+        dispatcher.drainAll();
+    }
+
+    private void fireWrapperStopped(final @NotNull String adapterId) {
+        wrapperFactory.healthListener().wrapperStopped(adapterId);
+        dispatcher.drainAll();
+    }
+
+    private void fireWrapperError(final @NotNull String adapterId, final @NotNull String reason) {
+        wrapperFactory.healthListener().wrapperError(adapterId, reason);
+        dispatcher.drainAll();
+    }
+}

--- a/hivemq-edge/src/test/java/com/hivemq/protocols/v2/manager/ProtocolAdapterManagerTestSupport.java
+++ b/hivemq-edge/src/test/java/com/hivemq/protocols/v2/manager/ProtocolAdapterManagerTestSupport.java
@@ -1,0 +1,485 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.protocols.v2.manager;
+
+import com.hivemq.adapter.sdk.api.ProtocolAdapterCategory;
+import com.hivemq.adapter.sdk.api.ProtocolAdapterTag;
+import com.hivemq.adapter.sdk.api.data.DataPoint;
+import com.hivemq.adapter.sdk.api.factories.DataPointFactory;
+import com.hivemq.adapter.sdk.api.schema.ScalarSchema;
+import com.hivemq.adapter.sdk.api.schema.ScalarType;
+import com.hivemq.adapter.sdk.api.schema.Schema;
+import com.hivemq.adapter.sdk.api.v2.ProtocolAdapter;
+import com.hivemq.adapter.sdk.api.v2.ProtocolAdapterCapability;
+import com.hivemq.adapter.sdk.api.v2.ProtocolAdapterInformation;
+import com.hivemq.adapter.sdk.api.v2.factories.ProtocolAdapterFactory;
+import com.hivemq.adapter.sdk.api.v2.model.BrowseFilter;
+import com.hivemq.adapter.sdk.api.v2.model.ProtocolAdapterInput;
+import com.hivemq.adapter.sdk.api.v2.model.ProtocolAdapterOutput;
+import com.hivemq.adapter.sdk.api.v2.model.VerifyOutcome;
+import com.hivemq.adapter.sdk.api.v2.model.WriteEntry;
+import com.hivemq.adapter.sdk.api.v2.node.Node;
+import com.hivemq.adapter.sdk.api.v2.node.NodeProperty;
+import com.hivemq.protocols.v2.config.AccessFlagsEntity;
+import com.hivemq.protocols.v2.config.NorthboundMappingEntity;
+import com.hivemq.protocols.v2.config.ProtocolAdapterEntity;
+import com.hivemq.protocols.v2.config.RetryPolicyEntity;
+import com.hivemq.protocols.v2.config.SouthboundMappingEntity;
+import com.hivemq.protocols.v2.config.TagEntity;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Shared fixtures for the manager tests: fluent builders for the read-only {@code <v2-protocol-adapters>} entities,
+ * and the minimal SDK-v2 doubles (a Jackson-friendly {@link Node}, a synchronous protocol adapter, its information,
+ * and a factory) the real wiring is exercised against. The doubles are deliberately tiny — the manager and the
+ * wrapper factory are what these tests prove, not a real protocol.
+ */
+final class ProtocolAdapterManagerTestSupport {
+
+    static final @NotNull String TEST_PROTOCOL_ID = "test";
+
+    private ProtocolAdapterManagerTestSupport() {}
+
+    static @NotNull EntityBuilder adapter(final @NotNull String adapterId) {
+        return new EntityBuilder(adapterId);
+    }
+
+    static @NotNull TagBuilder tag(final @NotNull String name) {
+        return new TagBuilder(name);
+    }
+
+    /**
+     * A fluent builder for a {@link ProtocolAdapterEntity}, defaulting to a northbound-activated single-tag adapter
+     * of the {@link #TEST_PROTOCOL_ID test} type.
+     */
+    static final class EntityBuilder {
+
+        private final @NotNull String adapterId;
+        private @NotNull String protocolId = TEST_PROTOCOL_ID;
+        private int configVersion = ProtocolAdapterEntity.DEFAULT_CONFIG_VERSION;
+        private boolean northboundActivated = true;
+        private boolean southboundActivated = false;
+        private boolean skipVerification = false;
+        private @NotNull Map<String, Object> adapterConfiguration = new HashMap<>();
+        private @NotNull RetryPolicyEntity retryPolicy = new RetryPolicyEntity();
+        private long watchdogTimeoutMillis = ProtocolAdapterEntity.DEFAULT_WATCHDOG_TIMEOUT_MILLIS;
+        private long commandTimeoutMillis = ProtocolAdapterEntity.DEFAULT_COMMAND_TIMEOUT_MILLIS;
+        private @NotNull List<TagEntity> tags =
+                new ArrayList<>(List.of(tag("temperature").build()));
+        private @NotNull List<NorthboundMappingEntity> northboundMappings = new ArrayList<>();
+        private @NotNull List<SouthboundMappingEntity> southboundMappings = new ArrayList<>();
+
+        private EntityBuilder(final @NotNull String adapterId) {
+            this.adapterId = adapterId;
+        }
+
+        @NotNull
+        EntityBuilder protocolId(final @NotNull String protocolId) {
+            this.protocolId = protocolId;
+            return this;
+        }
+
+        @NotNull
+        EntityBuilder configVersion(final int configVersion) {
+            this.configVersion = configVersion;
+            return this;
+        }
+
+        @NotNull
+        EntityBuilder northboundActivated(final boolean northboundActivated) {
+            this.northboundActivated = northboundActivated;
+            return this;
+        }
+
+        @NotNull
+        EntityBuilder southboundActivated(final boolean southboundActivated) {
+            this.southboundActivated = southboundActivated;
+            return this;
+        }
+
+        @NotNull
+        EntityBuilder skipVerification(final boolean skipVerification) {
+            this.skipVerification = skipVerification;
+            return this;
+        }
+
+        @NotNull
+        EntityBuilder adapterConfiguration(final @NotNull Map<String, Object> adapterConfiguration) {
+            this.adapterConfiguration = adapterConfiguration;
+            return this;
+        }
+
+        @NotNull
+        EntityBuilder retryPolicy(final @NotNull RetryPolicyEntity retryPolicy) {
+            this.retryPolicy = retryPolicy;
+            return this;
+        }
+
+        @NotNull
+        EntityBuilder watchdogTimeoutMillis(final long watchdogTimeoutMillis) {
+            this.watchdogTimeoutMillis = watchdogTimeoutMillis;
+            return this;
+        }
+
+        @NotNull
+        EntityBuilder commandTimeoutMillis(final long commandTimeoutMillis) {
+            this.commandTimeoutMillis = commandTimeoutMillis;
+            return this;
+        }
+
+        @NotNull
+        EntityBuilder tags(final @NotNull TagEntity... tags) {
+            this.tags = new ArrayList<>(List.of(tags));
+            return this;
+        }
+
+        @NotNull
+        EntityBuilder northboundMapping(final @NotNull String tagName, final @NotNull String topic) {
+            this.northboundMappings.add(new NorthboundMappingEntity(tagName, topic));
+            return this;
+        }
+
+        @NotNull
+        EntityBuilder southboundMapping(final @NotNull String topic, final @NotNull String tagName) {
+            this.southboundMappings.add(new SouthboundMappingEntity(topic, tagName));
+            return this;
+        }
+
+        @NotNull
+        ProtocolAdapterEntity build() {
+            return new ProtocolAdapterEntity(
+                    adapterId,
+                    protocolId,
+                    configVersion,
+                    northboundActivated,
+                    southboundActivated,
+                    skipVerification,
+                    adapterConfiguration,
+                    retryPolicy,
+                    watchdogTimeoutMillis,
+                    commandTimeoutMillis,
+                    tags,
+                    northboundMappings,
+                    southboundMappings);
+        }
+    }
+
+    /**
+     * A fluent builder for a {@link TagEntity}, defaulting to a pollable, both-aspect-activated tag whose
+     * {@code node-string} deserializes into {@link TestNode}.
+     */
+    static final class TagBuilder {
+
+        private final @NotNull String name;
+        private @NotNull String nodeString;
+        private boolean readActivated = true;
+        private boolean writeActivated = true;
+        private boolean pollable = true;
+        private boolean subscribable = false;
+        private long pollIntervalMillis = 5000;
+        private @NotNull AccessFlagsEntity access = new AccessFlagsEntity();
+
+        private TagBuilder(final @NotNull String name) {
+            this.name = name;
+            this.nodeString = "{\"identifier\":\"" + name + "\"}";
+        }
+
+        @NotNull
+        TagBuilder nodeString(final @NotNull String nodeString) {
+            this.nodeString = nodeString;
+            return this;
+        }
+
+        @NotNull
+        TagBuilder readActivated(final boolean readActivated) {
+            this.readActivated = readActivated;
+            return this;
+        }
+
+        @NotNull
+        TagBuilder writeActivated(final boolean writeActivated) {
+            this.writeActivated = writeActivated;
+            return this;
+        }
+
+        @NotNull
+        TagBuilder pollable(final boolean pollable) {
+            this.pollable = pollable;
+            return this;
+        }
+
+        @NotNull
+        TagBuilder pollIntervalMillis(final long pollIntervalMillis) {
+            this.pollIntervalMillis = pollIntervalMillis;
+            return this;
+        }
+
+        @NotNull
+        TagEntity build() {
+            return new TagEntity(
+                    name,
+                    nodeString,
+                    readActivated,
+                    writeActivated,
+                    pollable,
+                    subscribable,
+                    pollIntervalMillis,
+                    access);
+        }
+    }
+
+    static @NotNull Schema scalarSchema() {
+        return new ScalarSchema(ScalarType.STRING, null, null, null, null, false, true, false);
+    }
+
+    /**
+     * A reused-{@link DataPoint} double — the wrapper never inspects it, so the simplest carrier suffices.
+     */
+    record TestDataPoint(@NotNull String tagName, @NotNull Object value, boolean json) implements DataPoint {
+
+        @Override
+        public @NotNull Object getTagValue() {
+            return value;
+        }
+
+        @Override
+        public boolean treatTagValueAsJson() {
+            return json;
+        }
+
+        @Override
+        public @NotNull String getTagName() {
+            return tagName;
+        }
+    }
+
+    /**
+     * A {@link DataPointFactory} double building {@link TestDataPoint}s.
+     */
+    static final class TestDataPointFactory implements DataPointFactory {
+
+        @Override
+        public @NotNull DataPoint create(final @NotNull String tagName, final @NotNull Object tagValue) {
+            return new TestDataPoint(tagName, tagValue, false);
+        }
+
+        @Override
+        public @NotNull DataPoint createJsonDataPoint(final @NotNull String tagName, final @NotNull Object tagValue) {
+            return new TestDataPoint(tagName, tagValue, true);
+        }
+    }
+
+    /**
+     * A Jackson-friendly {@link Node}: a public {@code identifier} field a {@code node-string} deserializes into.
+     */
+    static final class TestNode extends Node {
+
+        public @NotNull String identifier = "";
+
+        @Override
+        public @NotNull String nodeId() {
+            return identifier;
+        }
+
+        @Override
+        public @NotNull String nodeString() {
+            return "{\"identifier\":\"" + identifier + "\"}";
+        }
+
+        @Override
+        public @NotNull EnumSet<NodeProperty> properties() {
+            return EnumSet.of(NodeProperty.UNIQUE);
+        }
+    }
+
+    /**
+     * A synchronous protocol-adapter double: every command acknowledges immediately through the tell-façade, so a
+     * real wrapper reaches {@code CONNECTED} deterministically under a {@link com.hivemq.protocols.v2.runtime.ManualDispatcher}.
+     */
+    static final class TestProtocolAdapter implements ProtocolAdapter {
+
+        private final @NotNull String adapterId;
+        private final @NotNull ProtocolAdapterOutput output;
+        private final @NotNull DataPointFactory dataPointFactory;
+
+        TestProtocolAdapter(
+                final @NotNull String adapterId,
+                final @NotNull ProtocolAdapterOutput output,
+                final @NotNull DataPointFactory dataPointFactory) {
+            this.adapterId = adapterId;
+            this.output = output;
+            this.dataPointFactory = dataPointFactory;
+        }
+
+        @Override
+        public @NotNull String adapterId() {
+            return adapterId;
+        }
+
+        @Override
+        public void start() {
+            output.started();
+        }
+
+        @Override
+        public void stop() {
+            output.stopped();
+        }
+
+        @Override
+        public void connect() {
+            output.connected();
+        }
+
+        @Override
+        public void disconnect() {
+            output.disconnected();
+        }
+
+        @Override
+        public void verifyBatch(final @NotNull List<Node> nodes) {
+            nodes.forEach(node -> output.verifyResult(node, new VerifyOutcome.Success()));
+        }
+
+        @Override
+        public void pollBatch(final @NotNull List<Node> nodes) {
+            nodes.forEach(node -> output.dataPoint(node, dataPointFactory.create(node.nodeId(), "value")));
+        }
+
+        @Override
+        public void addSubscriptionBatch(final @NotNull List<Node> nodes) {}
+
+        @Override
+        public void removeSubscriptionBatch(final @NotNull List<Node> nodes) {}
+
+        @Override
+        public void writeBatch(final @NotNull List<WriteEntry> entries) {
+            entries.forEach(entry -> output.writeResult(entry.node(), true, null));
+        }
+
+        @Override
+        public void browse(final @NotNull BrowseFilter filter) {
+            output.browseResult(List.of());
+        }
+    }
+
+    /**
+     * The {@link ProtocolAdapterInformation} of {@link TestProtocolAdapter}: only {@code protocolId} and
+     * {@code nodeClass} matter to the manager and the wrapper factory.
+     */
+    static final class TestProtocolAdapterInformation implements ProtocolAdapterInformation {
+
+        private final @NotNull String protocolId;
+
+        TestProtocolAdapterInformation(final @NotNull String protocolId) {
+            this.protocolId = protocolId;
+        }
+
+        @Override
+        public @NotNull String protocolId() {
+            return protocolId;
+        }
+
+        @Override
+        public @NotNull String displayName() {
+            return "Test Adapter";
+        }
+
+        @Override
+        public @NotNull String description() {
+            return "A synchronous protocol-adapter double for the manager tests.";
+        }
+
+        @Override
+        public @NotNull String version() {
+            return "1";
+        }
+
+        @Override
+        public @NotNull String logoUrl() {
+            return "";
+        }
+
+        @Override
+        public @NotNull String author() {
+            return "HiveMQ";
+        }
+
+        @Override
+        public @NotNull ProtocolAdapterCategory category() {
+            return ProtocolAdapterCategory.SIMULATION;
+        }
+
+        @Override
+        public @NotNull List<ProtocolAdapterTag> tags() {
+            return List.of();
+        }
+
+        @Override
+        public @NotNull EnumSet<ProtocolAdapterCapability> capabilities() {
+            return EnumSet.of(ProtocolAdapterCapability.SUBSCRIPTIONS, ProtocolAdapterCapability.WRITE);
+        }
+
+        @Override
+        public @NotNull Class<? extends Node> nodeClass() {
+            return TestNode.class;
+        }
+
+        @Override
+        public int currentConfigVersion() {
+            return 2;
+        }
+    }
+
+    /**
+     * The factory of the {@link #TEST_PROTOCOL_ID test} adapter type, building {@link TestProtocolAdapter}s.
+     */
+    static final class TestProtocolAdapterFactory implements ProtocolAdapterFactory {
+
+        private final @NotNull ProtocolAdapterInformation information;
+
+        TestProtocolAdapterFactory(final @NotNull String protocolId) {
+            this.information = new TestProtocolAdapterInformation(protocolId);
+        }
+
+        @Override
+        public @NotNull ProtocolAdapterInformation information() {
+            return information;
+        }
+
+        @Override
+        public @NotNull ProtocolAdapter createAdapter(
+                final @NotNull ProtocolAdapterInput input, final @NotNull ProtocolAdapterOutput output) {
+            return new TestProtocolAdapter(
+                    input.adapterId(), output, input.services().dataPointFactory());
+        }
+
+        @Override
+        public @NotNull Schema adapterConfigSchema() {
+            return scalarSchema();
+        }
+
+        @Override
+        public @NotNull Schema nodeDefinitionSchema() {
+            return scalarSchema();
+        }
+    }
+}

--- a/hivemq-edge/src/test/java/com/hivemq/protocols/v2/manager/RecordingWrapperFactory.java
+++ b/hivemq-edge/src/test/java/com/hivemq/protocols/v2/manager/RecordingWrapperFactory.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.protocols.v2.manager;
+
+import com.codahale.metrics.MetricRegistry;
+import com.hivemq.adapter.sdk.api.v2.factories.ProtocolAdapterFactory;
+import com.hivemq.adapter.sdk.api.v2.messaging.MailboxSender;
+import com.hivemq.adapter.sdk.api.v2.node.NodeTagPair;
+import com.hivemq.protocols.v2.config.ProtocolAdapterEntity;
+import com.hivemq.protocols.v2.manager.ProtocolAdapterHandleRegistry.ProtocolAdapterHandle;
+import com.hivemq.protocols.v2.runtime.NevskyMetrics;
+import com.hivemq.protocols.v2.view.AdapterStatusSnapshot;
+import com.hivemq.protocols.v2.wrapper.ProtocolAdapterWrapperEventListener;
+import com.hivemq.protocols.v2.wrapper.ProtocolAdapterWrapperMessage;
+import com.hivemq.protocols.v2.wrapper.ProtocolAdapterWrapperState;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * A {@link ProtocolAdapterWrapperFactory} double that builds a {@link ProtocolAdapterContainer} whose wrapper sender simply
+ * records the commands told to it and whose published snapshot is settable by the test. It lets the manager tests
+ * drive supervision, routing, and the gentlest-transition logic without the full actor stack — the real wrapper
+ * factory has its own test.
+ * <p>
+ * A freshly-created adapter starts with a {@code STOPPED} snapshot (as a real wrapper does); a test moves it to
+ * {@code CONNECTED} or {@code ERROR} with {@link #setMachineState} to exercise the stop-and-discard paths, and
+ * fires the captured {@link #healthListener()} to simulate wrapper health events.
+ */
+final class RecordingWrapperFactory implements ProtocolAdapterWrapperFactory {
+
+    private final @NotNull List<String> createdAdapterIds = new ArrayList<>();
+    private final @NotNull Map<String, Recorded> recordedByAdapterId = new LinkedHashMap<>();
+    private final @NotNull List<String> translateNodesAdapterIds = new ArrayList<>();
+    private @Nullable ProtocolAdapterWrapperEventListener healthListener;
+
+    @Override
+    public @NotNull ProtocolAdapterContainer create(
+            final @NotNull ProtocolAdapterEntity entity,
+            final @NotNull ProtocolAdapterFactory factory,
+            final @NotNull ProtocolAdapterWrapperEventListener healthListener) {
+        this.healthListener = healthListener;
+        final String adapterId = entity.getAdapterId();
+        createdAdapterIds.add(adapterId);
+
+        final List<ProtocolAdapterWrapperMessage> commands = new ArrayList<>();
+        final AtomicReference<AdapterStatusSnapshot> snapshot =
+                new AtomicReference<>(snapshotOf(entity, ProtocolAdapterWrapperState.STOPPED));
+        recordedByAdapterId.put(adapterId, new Recorded(commands, snapshot, entity));
+
+        final MailboxSender<ProtocolAdapterWrapperMessage> sender = commands::add;
+        final ProtocolAdapterHandle handle = new ProtocolAdapterHandle(adapterId, sender, snapshot);
+        final NevskyMetrics metrics = new NevskyMetrics(new MetricRegistry(), adapterId, () -> 0);
+        return new ProtocolAdapterContainer(handle, () -> {}, () -> {}, metrics, entity);
+    }
+
+    @Override
+    public @NotNull List<NodeTagPair> translateNodes(
+            final @NotNull ProtocolAdapterEntity entity, final @NotNull ProtocolAdapterFactory factory) {
+        translateNodesAdapterIds.add(entity.getAdapterId());
+        return List.of();
+    }
+
+    // ── test helpers ────────────────────────────────────────────────────────────────────────────────────────────
+
+    @NotNull
+    List<String> createdAdapterIds() {
+        return createdAdapterIds;
+    }
+
+    @NotNull
+    List<String> translateNodesAdapterIds() {
+        return translateNodesAdapterIds;
+    }
+
+    @NotNull
+    ProtocolAdapterWrapperEventListener healthListener() {
+        if (healthListener == null) {
+            throw new IllegalStateException("no wrapper has been created yet");
+        }
+        return healthListener;
+    }
+
+    @NotNull
+    List<ProtocolAdapterWrapperMessage> commands(final @NotNull String adapterId) {
+        final Recorded recorded = recordedByAdapterId.get(adapterId);
+        return recorded == null ? List.of() : recorded.commands();
+    }
+
+    void setMachineState(final @NotNull String adapterId, final @NotNull ProtocolAdapterWrapperState state) {
+        final Recorded recorded = recordedByAdapterId.get(adapterId);
+        if (recorded != null) {
+            recorded.snapshot().set(snapshotOf(recorded.entity(), state));
+        }
+    }
+
+    private static @NotNull AdapterStatusSnapshot snapshotOf(
+            final @NotNull ProtocolAdapterEntity entity, final @NotNull ProtocolAdapterWrapperState state) {
+        return new AdapterStatusSnapshot(
+                entity.getAdapterId(),
+                state,
+                entity.isNorthboundActivated(),
+                entity.isSouthboundActivated(),
+                List.of(),
+                0L,
+                null);
+    }
+
+    private record Recorded(
+            @NotNull List<ProtocolAdapterWrapperMessage> commands,
+            @NotNull AtomicReference<AdapterStatusSnapshot> snapshot,
+            @NotNull ProtocolAdapterEntity entity) {}
+}


### PR DESCRIPTION
## Summary

Implements **Task 11 — the protocol adapter manager (PAM)** of Project Nevsky (the v2 protocol-adapter framework). The PAM is the supervisor actor (design §8): it owns the wrapper/adapter pairs, applies the **gentlest correct transition** on configuration change, routes the runtime-state commands from REST, and reacts to wrapper health. It reads **only** the `<v2-protocol-adapters>` section and **never writes** configuration.

Runs side by side with the legacy framework; not yet wired into Edge (the five additive touchpoints land in T13).

## What's included

- **`ProtocolAdapterManager`** — a `MessageHandler` supervisor with the sealed `ProtocolAdapterManagerMessage` set (`ConfigurationChanged`, `ActivateAdapter`/`DeactivateAdapter`, `RetryTag`, `BrowseRequested`, `WrapperStarted`/`WrapperStopped`/`WrapperError`, `ProtocolAdapterManagerTick`), banded per the priority ladder. Single dispatch thread, no locks; two-phase `bindSelf` gives each wrapper a health-notification seam back to the manager.
- **`ProtocolAdapterConfigDiffUtils`** + **`ProtocolAdapterConfigStateTransition`** — the pure, layered classifier: connection-critical change → `FULL_RECREATE`; else tag-set/mapping change → `TAGS_ONLY`; else activation-flag change → `ACTIVATION_ONLY`; else `NO_CHANGE`. **`ProtocolAdapterConfigState`** is the documented stub for the credential-rotation refinement.
- **`ProtocolAdapterHandleRegistry`** (+ `ProtocolAdapterHandle` = id, `MailboxSender`, snapshot `AtomicReference`) — the concurrent, REST-readable directory. **`ProtocolAdapterFactoryRegistry`** — the constructor-injected factory set, **empty in production** (D8).
- **`ProtocolAdapterWrapperFactory`** seam + **`DefaultProtocolAdapterWrapperFactory`** — turns one read-only config entity into a fully-wired, dispatcher-attached wrapper (node-string → `Node`, config → reused v1 `DataPoint`, tag coordinator, context, tick). **`ProtocolAdapterContainer`** bundles a wrapper with its teardown resources; an unknown `protocol-id` or un-instantiable config surfaces as an `ERROR` handle (`ProtocolAdapterConfigException`).
- **Supervision** — `WrapperError` marks the adapter unhealthy and performs **no** automatic recreate (manual recovery, §8.3); `ProtocolAdapterManagerTick` folds the registry's snapshots into a health summary.

## Design notes (extends the design doc)

- **Wrapper-factory seam** so the PAM's supervision logic is unit-testable without the full actor stack (a recording double); the production wiring + config→runtime translation has its own focused test. T13 injects the real `Clock`/`Dispatcher`/`MetricRegistry`/`DataPointFactory`/`ObjectMapper`.
- **Startup kick** = the manager sends `ApplyActivation(configGoal, configActivation)` to a freshly-created wrapper to bring it to its config-declared goal (§9.3) — explicit and deterministic.
- **Combined tags + direction reload:** `TAGS_ONLY` sends `UpdateTagSet`, plus `ApplyActivation` only when the adapter direction also changed (still no reconnect).
- **Poll-interval reduction:** the coordinator takes one interval; config carries one per tag — reduced to the shortest declared (documented; per-tag cadence is a follow-up).
- **`BrowseRequested`** is in the sealed set and routed, but its future is completed exceptionally — the full PA browse bridge lands in T12 (§11.4).

## Testing

- `./gradlew :hivemq-edge-build:hivemq-edge:check` → green (Spotless + ErrorProne + NullAway + the v2 manager unit suite).
- New unit tests: `ProtocolAdapterConfigDiffUtilsTest` (every transition class incl. the used-flip S16, layering precedence), `ProtocolAdapterManagerTest` (add/remove, the four transitions, REST live-goal routing, `NO_CHANGE` preserves the live goal, retry forwarding, unknown-type `ERROR` handle, no auto-recreate, health summary), `ProtocolAdapterHandleRegistryTest` (foreign-thread snapshot reads — real threads + Awaitility), `DefaultProtocolAdapterWrapperFactoryTest` (a real wrapper reaches `CONNECTED`, node-string deserialization, bad-config rejection).
- Comprehensive `hivemq-edge-test` coverage is left to CI.
