### PR TITLE
EDG-762: Redesign InternalTopicFilterSubscriber with factory + builder

### DIFF
--- a/hivemq-edge/src/main/java/com/hivemq/mqtt/services/InternalPublishServiceImpl.java
+++ b/hivemq-edge/src/main/java/com/hivemq/mqtt/services/InternalPublishServiceImpl.java
@@ -29,6 +29,8 @@ import com.hivemq.mqtt.topic.SubscriberWithIdentifiers;
 import com.hivemq.mqtt.topic.tree.LocalTopicTree;
 import com.hivemq.mqtt.topic.tree.TopicSubscribers;
 import com.hivemq.persistence.RetainedMessage;
+import com.hivemq.persistence.clientqueue.InternalTopicFilterSubscriber;
+import com.hivemq.persistence.clientqueue.InternalTopicFilterSubscriberFactory;
 import com.hivemq.persistence.retained.RetainedMessagePersistence;
 import com.hivemq.util.Exceptions;
 import jakarta.inject.Inject;
@@ -51,6 +53,7 @@ public class InternalPublishServiceImpl implements InternalPublishService {
     private final @NotNull RetainedMessagePersistence retainedMessagePersistence;
     private final @NotNull LocalTopicTree topicTree;
     private final @NotNull PublishDistributor publishDistributor;
+    private final @NotNull InternalTopicFilterSubscriberFactory internalTopicFilterSubscriberFactory;
 
     private final boolean acknowledgeAfterPersist;
 
@@ -58,10 +61,12 @@ public class InternalPublishServiceImpl implements InternalPublishService {
     public InternalPublishServiceImpl(
             final @NotNull RetainedMessagePersistence retainedMessagePersistence,
             final @NotNull LocalTopicTree topicTree,
-            final @NotNull PublishDistributor publishDistributor) {
+            final @NotNull PublishDistributor publishDistributor,
+            final @NotNull InternalTopicFilterSubscriberFactory internalTopicFilterSubscriberFactory) {
         this.retainedMessagePersistence = retainedMessagePersistence;
         this.topicTree = topicTree;
         this.publishDistributor = publishDistributor;
+        this.internalTopicFilterSubscriberFactory = internalTopicFilterSubscriberFactory;
         this.acknowledgeAfterPersist = ACKNOWLEDGE_INCOMING_PUBLISH_AFTER_PERSISTING_ENABLED.get();
     }
 
@@ -184,6 +189,20 @@ public class InternalPublishServiceImpl implements InternalPublishService {
                 if (subscriber.isNoLocal() && sender != null && sender.equals(subscriber.getSubscriber())) {
                     // do not send to this subscriber, because NoLocal Option is set and subscriber == sender
                     continue;
+                }
+
+                // Ingress-exclusion (generalized No Local) for internal topic-filter subscribers: if this
+                // subscriber is one of ours and was configured to exclude the ingress client, skip it —
+                // before queueing, so an excluded message never enters the subscriber's queue. The cheap
+                // prefix check gates the registry lookup so ordinary MQTT subscribers (the vast majority
+                // on this hot path) pay nothing. getSubscriber(...) is null for an internal subscriber
+                // that is not currently attached, in which case we do not skip.
+                if (subscriber.getSubscriber().startsWith(InternalTopicFilterSubscriber.INTERNAL_SUBSCRIBER_PREFIX)) {
+                    final InternalTopicFilterSubscriber internalSubscriber =
+                            internalTopicFilterSubscriberFactory.getSubscriber(subscriber.getSubscriber());
+                    if (internalSubscriber != null && internalSubscriber.isExcludedIngressClientId(sender)) {
+                        continue;
+                    }
                 }
 
                 notSharedSubscribers.put(subscriber.getSubscriber(), subscriber);

--- a/hivemq-edge/src/main/java/com/hivemq/persistence/clientqueue/InternalTopicFilterSubscriber.java
+++ b/hivemq-edge/src/main/java/com/hivemq/persistence/clientqueue/InternalTopicFilterSubscriber.java
@@ -109,6 +109,18 @@ public final class InternalTopicFilterSubscriber {
     // The per-message handler. Set once at construction (Builder requires it).
     private final @NotNull Processor processor;
 
+    // The factory that built this subscriber, kept as a back-reference so that attach()/detach() can
+    // (de)register this subscriber in the factory's registry — see isExcludedIngressClientId() below.
+    private final @NotNull InternalTopicFilterSubscriberFactory factory;
+
+    // excludedIngressClientId — ingress-exclusion (generalized No Local). If set, a message whose
+    //            INGRESS client id (the publishing client, i.e. the distributor's `sender`) equals this
+    //            value must NOT be delivered to us. Set once via the builder, immutable after build();
+    //            null means "no exclusion — accept from everyone". The check happens at distribution
+    //            time (PublishDistributorImpl), BEFORE the message is queued, so an excluded message
+    //            never enters our queue. See isExcludedIngressClientId().
+    private final @Nullable String excludedIngressClientId;
+
     // ── mutable lifecycle state, all touched only via the verbs below ────────────────────────────
     // topicFilters — the CURRENT desired filter set. When detached this is just a remembered set
     //                (replayed by the next attach()); when attached the topic tree is kept reconciled
@@ -123,6 +135,12 @@ public final class InternalTopicFilterSubscriber {
     //             drained and handed to the processor).
     private boolean consuming = false;
 
+    // deallocated — true once deallocate() has cleared the queue. TERMINAL: once deallocated the
+    //               subscriber is dead and cannot be resurrected; every verb is a no-op (or, for
+    //               attach/consume, rejected) from then on. This flag makes deallocate()/stop() safely
+    //               idempotent and guards the other verbs against use-after-deallocate.
+    private boolean deallocated = false;
+
     // endregion
 
     // region constructor — package-private, only the factory/builder construct this
@@ -135,18 +153,24 @@ public final class InternalTopicFilterSubscriber {
     //                   configuration ID of the owning instance.
     // processor       — the per-message handler (runs on the SingleWriter thread).
     // initialFilters  — the topic filter set assembled in the builder (may be empty; that is valid).
+    // excludedIngressClientId — ingress-exclusion id, or null for none (see the field above).
+    // factory         — the factory that built us, used as the registry for ingress-exclusion lookups.
     //
     InternalTopicFilterSubscriber(
             final @NotNull String componentPrefix,
             final @NotNull String instanceId,
             final @NotNull Processor processor,
             final @NotNull Set<String> initialFilters,
+            final @Nullable String excludedIngressClientId,
+            final @NotNull InternalTopicFilterSubscriberFactory factory,
             final @NotNull LocalTopicTree topicTree,
             final @NotNull ClientQueuePersistence clientQueuePersistence,
             final @NotNull SingleWriterService singleWriterService) {
         this.clientId = INTERNAL_SUBSCRIBER_PREFIX + componentPrefix + "::" + instanceId;
         this.processor = processor;
         this.topicFilters.addAll(initialFilters);
+        this.excludedIngressClientId = excludedIngressClientId;
+        this.factory = factory;
         this.topicTree = topicTree;
         this.clientQueuePersistence = clientQueuePersistence;
         this.singleWriterService = singleWriterService;
@@ -185,22 +209,27 @@ public final class InternalTopicFilterSubscriber {
 
         private final @NotNull String componentPrefix;
         private final @NotNull String instanceId;
+        private final @NotNull InternalTopicFilterSubscriberFactory factory;
         private final @NotNull LocalTopicTree topicTree;
         private final @NotNull ClientQueuePersistence clientQueuePersistence;
         private final @NotNull SingleWriterService singleWriterService;
 
         private @Nullable Processor processor = null; // required; checked in build()
         private final @NotNull Set<String> topicFilters = new LinkedHashSet<>();
+        private @Nullable String excludedIngressClientId = null; // optional; ingress-exclusion
 
-        // Package-private — only the factory creates builders (it supplies the injected singletons).
+        // Package-private — only the factory creates builders (it supplies the injected singletons and
+        // itself, as the registry the built subscriber registers with on attach()).
         Builder(
                 final @NotNull String componentPrefix,
                 final @NotNull String instanceId,
+                final @NotNull InternalTopicFilterSubscriberFactory factory,
                 final @NotNull LocalTopicTree topicTree,
                 final @NotNull ClientQueuePersistence clientQueuePersistence,
                 final @NotNull SingleWriterService singleWriterService) {
             this.componentPrefix = componentPrefix;
             this.instanceId = instanceId;
+            this.factory = factory;
             this.topicTree = topicTree;
             this.clientQueuePersistence = clientQueuePersistence;
             this.singleWriterService = singleWriterService;
@@ -209,6 +238,15 @@ public final class InternalTopicFilterSubscriber {
         // Required: the per-message work.
         public @NotNull Builder withProcessor(final @NotNull Processor processor) {
             this.processor = processor;
+            return this;
+        }
+
+        // Optional: ingress-exclusion (generalized No Local). A message whose ingress (publishing)
+        // client id equals this value will not be delivered to the built subscriber. Build-time only;
+        // immutable after build(). For a bridge, this is the peer it forwards to — so a message it sent
+        // us is not sent straight back. The plain No Local case is excludedIngressClientId == our own id.
+        public @NotNull Builder withExcludedIngressClientId(final @NotNull String excludedIngressClientId) {
+            this.excludedIngressClientId = excludedIngressClientId;
             return this;
         }
 
@@ -259,6 +297,8 @@ public final class InternalTopicFilterSubscriber {
                     instanceId,
                     processor,
                     topicFilters,
+                    excludedIngressClientId,
+                    factory,
                     topicTree,
                     clientQueuePersistence,
                     singleWriterService);
@@ -280,6 +320,7 @@ public final class InternalTopicFilterSubscriber {
     }
 
     public synchronized @NotNull InternalTopicFilterSubscriber withTopicFilter(final @NotNull List<String> newFilters) {
+        throwIfDeallocated();
         final Set<String> target = new LinkedHashSet<>(newFilters);
         if (attached) {
             // Reconcile the tree with the new target: remove what is no longer wanted, add what is new.
@@ -305,6 +346,7 @@ public final class InternalTopicFilterSubscriber {
 
     public synchronized @NotNull InternalTopicFilterSubscriber addTopicFilter(
             final @NotNull List<String> topicFiltersToAdd) {
+        throwIfDeallocated();
         for (final String topicFilter : topicFiltersToAdd) {
             if (topicFilters.add(topicFilter) && attached) {
                 addToTree(topicFilter);
@@ -319,6 +361,7 @@ public final class InternalTopicFilterSubscriber {
 
     public synchronized @NotNull InternalTopicFilterSubscriber removeTopicFilter(
             final @NotNull List<String> topicFiltersToRemove) {
+        throwIfDeallocated();
         for (final String topicFilter : topicFiltersToRemove) {
             if (topicFilters.remove(topicFilter) && attached) {
                 removeFromTree(topicFilter);
@@ -349,17 +392,22 @@ public final class InternalTopicFilterSubscriber {
     // verbs so state transitions and tree reconciliation never interleave.
     //
     public synchronized @NotNull InternalTopicFilterSubscriber attach() {
+        throwIfDeallocated();
         if (attached) {
             return this;
         }
         for (final String topicFilter : topicFilters) {
             addToTree(topicFilter);
         }
+        // Register with the factory's registry so the distributor can find us by clientId and ask
+        // isExcludedIngressClientId(...) before queueing a message to us. Symmetric with detach().
+        factory.register(this);
         attached = true;
         return this;
     }
 
     public synchronized @NotNull InternalTopicFilterSubscriber consume() {
+        throwIfDeallocated();
         if (consuming) {
             return this;
         }
@@ -373,6 +421,7 @@ public final class InternalTopicFilterSubscriber {
     }
 
     public synchronized @NotNull InternalTopicFilterSubscriber pause() {
+        throwIfDeallocated();
         if (!consuming) {
             return this;
         }
@@ -382,25 +431,45 @@ public final class InternalTopicFilterSubscriber {
     }
 
     public synchronized @NotNull InternalTopicFilterSubscriber detach() {
+        throwIfDeallocated();
         if (!attached) {
             return this;
         }
         for (final String topicFilter : topicFilters) {
             removeFromTree(topicFilter);
         }
+        factory.deregister(this); // symmetric with attach()
         attached = false;
         return this;
     }
 
+    // deallocate() is the one terminal verb — and the one exception to throwIfDeallocated(): calling it
+    // on an already-dead subscriber is a no-op (idempotent), not an error.
     public synchronized void deallocate() {
+        if (deallocated) {
+            return; // idempotent — already dead, nothing to clear
+        }
         if (attached || consuming) {
             throw new IllegalStateException("InternalTopicFilterSubscriber '" + clientId
                     + "' must be detached and paused before deallocate() (attached="
                     + attached + ", consuming="
                     + consuming + ")");
         }
-        // Remove the queue entry from persistence entirely. false == do not keep a tombstone.
+        // Remove the queue entry from persistence entirely. false == do not keep a tombstone. This
+        // also DROPS any messages that were collected but not yet processed — which is exactly why a
+        // long-lived subscriber must eventually stop()/deallocate() rather than just detach(), or the
+        // queue (and its memory) would linger.
         clientQueuePersistence.clear(clientId, false);
+        deallocated = true;
+    }
+
+    // Guard for every verb except deallocate(): a deallocated subscriber is dead and cannot be
+    // resurrected or operated on. Throws on any use-after-deallocate.
+    private void throwIfDeallocated() {
+        if (deallocated) {
+            throw new IllegalStateException(
+                    "InternalTopicFilterSubscriber '" + clientId + "' has been deallocated and cannot be used");
+        }
     }
 
     // endregion
@@ -415,6 +484,10 @@ public final class InternalTopicFilterSubscriber {
     // They exist only to spare callers the common two-/three-call sequences; a caller that wants finer
     // control (e.g. attach without consuming, or pause without deallocating) calls the verbs directly.
     //
+    // start() throws on a deallocated subscriber (you cannot resurrect a dead one — that goes through
+    // attach()). stop() is idempotent: it is the only composition you can safely call on a dead
+    // subscriber, returning quietly (it just deallocates, which is itself a no-op when already dead).
+    //
     public synchronized @NotNull InternalTopicFilterSubscriber start() {
         attach();
         consume();
@@ -422,9 +495,33 @@ public final class InternalTopicFilterSubscriber {
     }
 
     public synchronized void stop() {
+        if (deallocated) {
+            return; // already dead — stop() is idempotent
+        }
         detach();
         pause();
         deallocate();
+    }
+
+    // endregion
+
+    // region ingress-exclusion — identity and the accept decision
+    // =================================================================================================================
+    // clientId() — this subscriber's reserved-prefix id, used by the factory as the registry key.
+    //
+    // isExcludedIngressClientId(senderClientId) — the ingress-exclusion decision, called by the publish
+    //   path at distribution time (BEFORE queueing) with the ingress/publishing client id (its
+    //   `sender`). Returns true iff an excluded id is configured and equals senderClientId — in which
+    //   case the message must NOT be queued to us. With no excluded id (the common case) it always
+    //   returns false. The excluded id is immutable after build(), so this is a lock-free read and safe
+    //   to call from the publish path concurrently with the lifecycle verbs.
+    //
+    public @NotNull String clientId() {
+        return clientId;
+    }
+
+    public boolean isExcludedIngressClientId(final @Nullable String senderClientId) {
+        return excludedIngressClientId != null && excludedIngressClientId.equals(senderClientId);
     }
 
     // endregion

--- a/hivemq-edge/src/main/java/com/hivemq/persistence/clientqueue/InternalTopicFilterSubscriber.java
+++ b/hivemq-edge/src/main/java/com/hivemq/persistence/clientqueue/InternalTopicFilterSubscriber.java
@@ -29,25 +29,49 @@ import com.hivemq.mqtt.topic.SubscriptionFlag;
 import com.hivemq.mqtt.topic.tree.LocalTopicTree;
 import com.hivemq.persistence.SingleWriterService;
 import com.hivemq.persistence.util.FutureUtils;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-// region InternalTopicFilterSubscriber — base class for internal topic-tree subscribers
+// region InternalTopicFilterSubscriber — concrete topic-tree subscriber for internal Edge components
 // =====================================================================================================================
-// Base class for internal Edge components that need to receive messages from the topic tree without
-// being an MQTT client. Extend this class, supply a COMPONENT_PREFIX constant and a unique
-// instanceId, and implement process().
+// Lets an internal Edge component (a bridge, a combiner, a sampler, ...) receive messages from the
+// local topic tree without being an MQTT client.
 //
-// Call start() once to subscribe and stop() to unsubscribe. Both methods are safe to call on any
-// thread.
+// This is a CONCRETE, FINAL class — there is nothing to subclass and nothing to override. You do not
+// extend it; you obtain one from InternalTopicFilterSubscriberFactory, configure it through a fluent
+// Builder, and drive it with explicit lifecycle verbs. The single piece of behaviour the component
+// supplies — what to do with each message — is a Processor lambda passed to the builder.
+//
+//   subscriber = factory.create("tynebridge", bridgeId)
+//                       .withProcessor(message -> { ... })   // runs on the SingleWriter thread
+//                       .withTopicFilter("sensors/#")
+//                       .build();
+//   subscriber.start();                       // attach(); consume();
+//   subscriber.addTopicFilter("actuators/#"); // runtime mutation, no teardown
+//   subscriber.stop();                        // detach(); pause(); deallocate();
+//
+// Lifecycle. The lifecycle is decomposed into independent verbs. attach()/detach() control the
+// SUBSCRIPTION (topics in the topic tree, i.e. whether messages are COLLECTED); consume()/pause()
+// control the CALLBACK (whether collected messages are PROCESSED). They are orthogonal — a subscriber
+// can be attached-but-paused (collecting into the queue without draining) or detached-but-consuming
+// (callback armed, ready for when topics are attached later). start() and stop() are just convenience
+// compositions of the verbs.
+//
+// Threading. The whole message pipeline runs on the SingleWriter thread keyed by clientId. The verbs
+// themselves are safe to call from any thread; the queue/topic-tree operations they perform are the
+// same ones the previous design performed, just split apart so each is independently callable.
 //
 // @see <a href="https://hivemq.github.io/hivemq-edge-lore/2-implementation/internal-topic-filter-subscriber/">Edge Lore
 // — Internal Topic Filter Subscriber</a>
 //
-@SuppressWarnings({"FutureReturnValueIgnored", "CheckReturnValue"})
-public abstract class InternalTopicFilterSubscriber {
+@SuppressWarnings({"FutureReturnValueIgnored", "CheckReturnValue", "UnusedReturnValue"})
+public final class InternalTopicFilterSubscriber {
 
     private static final @NotNull Logger log = LoggerFactory.getLogger(InternalTopicFilterSubscriber.class);
 
@@ -59,44 +83,70 @@ public abstract class InternalTopicFilterSubscriber {
     private static final @NotNull ImmutableIntArray POLL_PACKET_IDS =
             ImmutableIntArray.of(ClientQueuePersistenceImpl.SHARED_IN_FLIGHT_MARKER);
 
+    // clientId — built once as the reserved-prefix triple "$INTERNAL::<componentPrefix>::<instanceId>"
+    //            (see the constructor for what each segment means). PublishDistributorImpl
+    //            .isReservedClientId() recognises the "$INTERNAL::" prefix and rejects any external
+    //            MQTT client that tries to connect with it, so this namespace cannot collide with real
+    //            clients.
+    //
+    //            ONE id, used as the identity in TWO different subsystems — and deliberately so:
+    //              - in the TOPIC TREE  it is the subscriber id (addTopic / removeSubscriber), i.e.
+    //                "who is subscribed to this filter".
+    //              - in the CLIENT-QUEUE persistence it is the queue id (the bucket key for
+    //                addPublishAvailableCallback / submit / readNew / removeShared / clear), i.e.
+    //                "whose queue do the matched messages land in".
+    //            Using the same string for both is what wires the two together: the topic tree routes
+    //            a matching message into the queue named by this id, and we drain that same-named
+    //            queue. They are the same id on purpose; there is no separate topic-tree id vs queue id.
     private final @NotNull String clientId;
-    private final @NotNull List<String> topicFilters;
+
+    // The three Edge singletons this subscriber operates against. Supplied by the factory (which has
+    // them injected), so callers never see or thread them. Final — set once at construction.
     private final @NotNull LocalTopicTree topicTree;
     private final @NotNull ClientQueuePersistence clientQueuePersistence;
     private final @NotNull SingleWriterService singleWriterService;
 
+    // The per-message handler. Set once at construction (Builder requires it).
+    private final @NotNull Processor processor;
+
+    // ── mutable lifecycle state, all touched only via the verbs below ────────────────────────────
+    // topicFilters — the CURRENT desired filter set. When detached this is just a remembered set
+    //                (replayed by the next attach()); when attached the topic tree is kept reconciled
+    //                with it. A LinkedHashSet so order is stable and duplicates are ignored.
+    private final @NotNull Set<String> topicFilters = new LinkedHashSet<>();
+
+    // attached — true iff the current topicFilters are registered in the topic tree (messages are
+    //            being collected into the client queue).
+    private boolean attached = false;
+
+    // consuming — true iff the publish-available callback is registered (collected messages are being
+    //             drained and handed to the processor).
+    private boolean consuming = false;
+
     // endregion
 
-    // region InternalTopicFilterSubscriber() constructor
+    // region constructor — package-private, only the factory/builder construct this
     // =================================================================================================================
-    // componentPrefix — identifies the Edge component type (e.g. "combiner", "sampler"). Must be
-    //                   unique across all components in Edge. Becomes the middle segment of the
-    //                   internal client ID.
+    // componentPrefix — identifies the Edge component type (e.g. "tynebridge", "combiner", "sampler").
+    //                   Must be unique across all components in Edge. Becomes the middle segment of
+    //                   the internal client ID.
     // instanceId      — identifies this specific subscriber instance within the component. Must be
     //                   unique within the componentPrefix namespace. Typically derived from the
     //                   configuration ID of the owning instance.
-    // topicFilter(s)  — the MQTT topic filter(s) to subscribe to. All filters share the same
-    //                   client queue; messages matching any of them are delivered to process().
+    // processor       — the per-message handler (runs on the SingleWriter thread).
+    // initialFilters  — the topic filter set assembled in the builder (may be empty; that is valid).
     //
-    protected InternalTopicFilterSubscriber(
+    InternalTopicFilterSubscriber(
             final @NotNull String componentPrefix,
             final @NotNull String instanceId,
-            final @NotNull String topicFilter,
-            final @NotNull LocalTopicTree topicTree,
-            final @NotNull ClientQueuePersistence clientQueuePersistence,
-            final @NotNull SingleWriterService singleWriterService) {
-        this(componentPrefix, instanceId, List.of(topicFilter), topicTree, clientQueuePersistence, singleWriterService);
-    }
-
-    protected InternalTopicFilterSubscriber(
-            final @NotNull String componentPrefix,
-            final @NotNull String instanceId,
-            final @NotNull List<String> topicFilters,
+            final @NotNull Processor processor,
+            final @NotNull Set<String> initialFilters,
             final @NotNull LocalTopicTree topicTree,
             final @NotNull ClientQueuePersistence clientQueuePersistence,
             final @NotNull SingleWriterService singleWriterService) {
         this.clientId = INTERNAL_SUBSCRIBER_PREFIX + componentPrefix + "::" + instanceId;
-        this.topicFilters = topicFilters;
+        this.processor = processor;
+        this.topicFilters.addAll(initialFilters);
         this.topicTree = topicTree;
         this.clientQueuePersistence = clientQueuePersistence;
         this.singleWriterService = singleWriterService;
@@ -104,78 +154,322 @@ public abstract class InternalTopicFilterSubscriber {
 
     // endregion
 
-    // region process(message) - handler that must be defined by the user of this mechanism
+    // region Processor — the per-message handler supplied by the user (a lambda)
     // =================================================================================================================
-    // Called once per message, on the SingleWriter thread. Implementations must not block.
-    // Any exception thrown is caught, logged, and the message is dropped.
+    // Called once per message, on the SingleWriter thread. Implementations must not block. Any
+    // exception thrown is caught, logged, and the message is dropped.
     //
-    public abstract void process(final @NotNull PUBLISH message);
+    // Deliberately NOT named MessageProcessor / MessageTransformer — those names belong to the
+    // MessageFabric design, the long-term home. This is the interim ITFS-local type; its signature is
+    // exactly the old abstract process(PUBLISH), so an old override body ports into a lambda verbatim.
+    //
+    @FunctionalInterface
+    public interface Processor {
+        void process(final @NotNull PUBLISH message);
+    }
 
     // endregion
 
-    // region start() / doStart() - starts the subscription for the topic filters
+    // region Builder — fluent build-time configuration, obtained from the factory
     // =================================================================================================================
-    // start() is the public entry point; override it to add logic before or after the subscription
-    // is established. doStart() contains the core wiring — call super.start() or doStart()
-    // explicitly if you override start(). Safe to call on any thread.
+    // The Processor is required; build() throws without it. Topic filters are optional — the set
+    // starts empty, and an empty set is perfectly valid (a subscriber that subscribes to nothing on
+    // attach(), to which filters can be added later).
     //
-    public void start() {
-        doStart();
+    // The three topic-filter verbs are the SAME as on the subscriber (see the topic-filter region
+    // there): withTopicFilter is ABSOLUTE (replace the whole set, last call wins); addTopicFilter and
+    // removeTopicFilter are RELATIVE. On the builder add/remove are not strictly necessary (with could
+    // express any set) but are convenient for assembling a set incrementally.
+    //
+    public static final class Builder {
+
+        private final @NotNull String componentPrefix;
+        private final @NotNull String instanceId;
+        private final @NotNull LocalTopicTree topicTree;
+        private final @NotNull ClientQueuePersistence clientQueuePersistence;
+        private final @NotNull SingleWriterService singleWriterService;
+
+        private @Nullable Processor processor = null; // required; checked in build()
+        private final @NotNull Set<String> topicFilters = new LinkedHashSet<>();
+
+        // Package-private — only the factory creates builders (it supplies the injected singletons).
+        Builder(
+                final @NotNull String componentPrefix,
+                final @NotNull String instanceId,
+                final @NotNull LocalTopicTree topicTree,
+                final @NotNull ClientQueuePersistence clientQueuePersistence,
+                final @NotNull SingleWriterService singleWriterService) {
+            this.componentPrefix = componentPrefix;
+            this.instanceId = instanceId;
+            this.topicTree = topicTree;
+            this.clientQueuePersistence = clientQueuePersistence;
+            this.singleWriterService = singleWriterService;
+        }
+
+        // Required: the per-message work.
+        public @NotNull Builder withProcessor(final @NotNull Processor processor) {
+            this.processor = processor;
+            return this;
+        }
+
+        // Absolute: replace the whole set with this filter / these filters. Last call wins.
+        public @NotNull Builder withTopicFilter(final @NotNull String topicFilter) {
+            topicFilters.clear();
+            topicFilters.add(topicFilter);
+            return this;
+        }
+
+        public @NotNull Builder withTopicFilter(final @NotNull List<String> topicFilters) {
+            this.topicFilters.clear();
+            this.topicFilters.addAll(topicFilters);
+            return this;
+        }
+
+        // Relative: add to the current set.
+        public @NotNull Builder addTopicFilter(final @NotNull String topicFilter) {
+            topicFilters.add(topicFilter);
+            return this;
+        }
+
+        public @NotNull Builder addTopicFilter(final @NotNull List<String> topicFilters) {
+            this.topicFilters.addAll(topicFilters);
+            return this;
+        }
+
+        // Relative: remove from the current set.
+        public @NotNull Builder removeTopicFilter(final @NotNull String topicFilter) {
+            topicFilters.remove(topicFilter);
+            return this;
+        }
+
+        public @NotNull Builder removeTopicFilter(final @NotNull List<String> topicFilters) {
+            this.topicFilters.removeAll(topicFilters);
+            return this;
+        }
+
+        // Produce the live subscriber. The subscriber is constructed in the IDLE state — detached and
+        // paused — i.e. nothing happens until start() (or attach()/consume()) is called.
+        public @NotNull InternalTopicFilterSubscriber build() {
+            if (processor == null) {
+                throw new IllegalStateException(
+                        "InternalTopicFilterSubscriber requires a processor; call withProcessor(...) before build()");
+            }
+            return new InternalTopicFilterSubscriber(
+                    componentPrefix,
+                    instanceId,
+                    processor,
+                    topicFilters,
+                    topicTree,
+                    clientQueuePersistence,
+                    singleWriterService);
+        }
     }
 
-    protected void doStart() {
-        // Register the callback first so any message arriving during topic registration wakes the
-        // poller. The explicit submitPoll() drains messages already in the queue from a previous run.
+    // endregion
+
+    // region topic-filter verbs — the same three on builder and subscriber
+    // =================================================================================================================
+    // withTopicFilter — ABSOLUTE: replace the whole set. addTopicFilter / removeTopicFilter — RELATIVE.
+    // Each is overloaded for one filter or a list. When DETACHED these only update the remembered set
+    // (replayed by the next attach()); when ATTACHED the topic tree is reconciled immediately — only
+    // the genuine additions/removals are pushed to the tree, so a withTopicFilter(wholeNewSet) becomes
+    // exactly the diff against what is currently registered.
+    //
+    public synchronized @NotNull InternalTopicFilterSubscriber withTopicFilter(final @NotNull String topicFilter) {
+        return withTopicFilter(List.of(topicFilter));
+    }
+
+    public synchronized @NotNull InternalTopicFilterSubscriber withTopicFilter(final @NotNull List<String> newFilters) {
+        final Set<String> target = new LinkedHashSet<>(newFilters);
+        if (attached) {
+            // Reconcile the tree with the new target: remove what is no longer wanted, add what is new.
+            for (final String existing : new ArrayList<>(topicFilters)) {
+                if (!target.contains(existing)) {
+                    removeFromTree(existing);
+                }
+            }
+            for (final String wanted : target) {
+                if (!topicFilters.contains(wanted)) {
+                    addToTree(wanted);
+                }
+            }
+        }
+        topicFilters.clear();
+        topicFilters.addAll(target);
+        return this;
+    }
+
+    public synchronized @NotNull InternalTopicFilterSubscriber addTopicFilter(final @NotNull String topicFilter) {
+        return addTopicFilter(List.of(topicFilter));
+    }
+
+    public synchronized @NotNull InternalTopicFilterSubscriber addTopicFilter(
+            final @NotNull List<String> topicFiltersToAdd) {
+        for (final String topicFilter : topicFiltersToAdd) {
+            if (topicFilters.add(topicFilter) && attached) {
+                addToTree(topicFilter);
+            }
+        }
+        return this;
+    }
+
+    public synchronized @NotNull InternalTopicFilterSubscriber removeTopicFilter(final @NotNull String topicFilter) {
+        return removeTopicFilter(List.of(topicFilter));
+    }
+
+    public synchronized @NotNull InternalTopicFilterSubscriber removeTopicFilter(
+            final @NotNull List<String> topicFiltersToRemove) {
+        for (final String topicFilter : topicFiltersToRemove) {
+            if (topicFilters.remove(topicFilter) && attached) {
+                removeFromTree(topicFilter);
+            }
+        }
+        return this;
+    }
+
+    // endregion
+
+    // region lifecycle verbs — attach / consume / pause / detach / deallocate
+    // =================================================================================================================
+    // attach()    — register the current topic filters in the topic tree. Messages now COLLECTED into
+    //               the client queue. Idempotent.
+    // consume()   — register the publish-available callback and drain anything already queued. Messages
+    //               now PROCESSED (if attached). Legal while detached — the callback is simply armed for
+    //               when topics attach later. Idempotent.
+    // pause()     — deregister the callback. Messages keep being COLLECTED (if attached) but are no
+    //               longer PROCESSED. Idempotent.
+    // detach()    — remove the current topic filters from the topic tree. Messages no longer COLLECTED.
+    //               The remembered filter set survives, so a later attach() restores the same
+    //               subscription. Idempotent.
+    // deallocate()— clear the client queue entry from persistence. Precondition: detached AND paused
+    //               (throws otherwise) — clearing the queue while still collecting or draining would
+    //               race the SingleWriter.
+    //
+    // All return `this` (except deallocate) so they chain. All are synchronized with the topic-filter
+    // verbs so state transitions and tree reconciliation never interleave.
+    //
+    public synchronized @NotNull InternalTopicFilterSubscriber attach() {
+        if (attached) {
+            return this;
+        }
+        for (final String topicFilter : topicFilters) {
+            addToTree(topicFilter);
+        }
+        attached = true;
+        return this;
+    }
+
+    public synchronized @NotNull InternalTopicFilterSubscriber consume() {
+        if (consuming) {
+            return this;
+        }
+        // Register the callback first so any message arriving from now on wakes the poller; the
+        // explicit submitPoll() then drains messages already in the queue (e.g. from a previous run,
+        // or collected while attached-but-paused).
         clientQueuePersistence.addPublishAvailableCallback(id -> submitPoll(), clientId);
         submitPoll();
-        for (final String topicFilter : topicFilters) {
-            topicTree.addTopic(
-                    clientId,
-                    new Topic(topicFilter, QoS.AT_LEAST_ONCE, false, true),
-                    SubscriptionFlag.getDefaultFlags(false, true, false),
-                    null);
-        }
+        consuming = true;
+        return this;
     }
 
-    // endregion
-
-    // region stop() / doStop() - stops the subscription
-    // =================================================================================================================
-    // stop() is the public entry point; override it to add logic before or after the subscription
-    // is torn down. doStop() contains the core wiring — call super.stop() or doStop() explicitly
-    // if you override stop(). Safe to call on any thread.
-    //
-    public void stop() {
-        doStop();
-    }
-
-    protected void doStop() {
-        // Unsubscribe from the topic tree first so no new messages are routed here,
-        // then deregister the callback.
-        for (final String topicFilter : topicFilters) {
-            topicTree.removeSubscriber(clientId, topicFilter, null);
+    public synchronized @NotNull InternalTopicFilterSubscriber pause() {
+        if (!consuming) {
+            return this;
         }
         clientQueuePersistence.removePublishAvailableCallback(clientId);
+        consuming = false;
+        return this;
+    }
+
+    public synchronized @NotNull InternalTopicFilterSubscriber detach() {
+        if (!attached) {
+            return this;
+        }
+        for (final String topicFilter : topicFilters) {
+            removeFromTree(topicFilter);
+        }
+        attached = false;
+        return this;
+    }
+
+    public synchronized void deallocate() {
+        if (attached || consuming) {
+            throw new IllegalStateException("InternalTopicFilterSubscriber '" + clientId
+                    + "' must be detached and paused before deallocate() (attached="
+                    + attached + ", consuming="
+                    + consuming + ")");
+        }
+        // Remove the queue entry from persistence entirely. false == do not keep a tombstone.
+        clientQueuePersistence.clear(clientId, false);
     }
 
     // endregion
 
-    // region internal wiring
+    // region start() / stop() — convenience compositions of the verbs
     // =================================================================================================================
-    // The four methods below form a simple pipeline that runs entirely on the SingleWriter thread:
+    // start() = attach(); consume();  — order does not matter operationally; whichever runs second
+    //           activates the flow.
+    // stop()  = detach(); pause(); deallocate();  — order DOES matter: detach first (stop the inflow),
+    //           pause second (stop the processing), deallocate last (clear the now-quiet queue).
+    //
+    // They exist only to spare callers the common two-/three-call sequences; a caller that wants finer
+    // control (e.g. attach without consuming, or pause without deallocating) calls the verbs directly.
+    //
+    public synchronized @NotNull InternalTopicFilterSubscriber start() {
+        attach();
+        consume();
+        return this;
+    }
+
+    public synchronized void stop() {
+        detach();
+        pause();
+        deallocate();
+    }
+
+    // endregion
+
+    // region internal wiring — topic-tree add/remove and the SingleWriter poll pipeline
+    // =================================================================================================================
+    // addToTree() / removeFromTree() — the two topic-tree operations, factored out so the verbs and
+    //                     the reconciliation logic share one definition of "register a filter" and
+    //                     "deregister a filter" under this clientId.
+    //
+    // The four methods after them form a simple pipeline that runs entirely on the SingleWriter thread:
     //
     // submitPoll()      — schedules pollAndForward() on the SingleWriter queue. Called from the
-    //                     publish-available callback (new message arrived), from doStart() (drain
+    //                     publish-available callback (new message arrived), from consume() (drain
     //                     pre-existing messages), and at the end of each processed message (to
     //                     continue draining).
     // pollAndForward()  — reads one message from the client queue. On success hands it to
     //                     processPublish(); on failure logs and reschedules via submitPoll().
-    // processPublish()  — calls process() (the user-supplied handler), then removeMessage(), then
+    // processPublish()  — calls the processor (the user-supplied handler), then removeMessage(), then
     //                     submitPoll() to pick up the next message. Errors are caught, logged, and
     //                     the message is dropped — processing continues regardless.
     // removeMessage()   — acknowledges the message to the queue persistence. QoS 0 messages are
     //                     not persisted and need no acknowledgement.
     //
+    // The trailing `null` in both calls is the topic tree's `sharedName` — and it is null ON PURPOSE.
+    // The topic tree distinguishes shared from non-shared subscriptions: a non-null sharedName makes
+    // the subscription part of a shared group (load-balanced across the group's members). Some other
+    // internal subscribers ARE shared and pass one (the bridge forwarder's sharedName is
+    // "forwarder#{id}"; the combiner's is its uuid, with the subscriber id differing by a trailing
+    // "#"). An InternalTopicFilterSubscriber is deliberately NON-shared: that is the whole point of
+    // EDG-504 — a non-shared internal subscriber so the topic tree deduplicates by client id and a
+    // message matching several of our filters is delivered to our queue exactly once. So sharedName
+    // stays null, and our `clientId` is the sole identity (no separate shared-group name).
+    private void addToTree(final @NotNull String topicFilter) {
+        topicTree.addTopic(
+                clientId,
+                new Topic(topicFilter, QoS.AT_LEAST_ONCE, false, true),
+                SubscriptionFlag.getDefaultFlags(false, true, false),
+                null); // sharedName — null: non-shared (see note above)
+    }
+
+    private void removeFromTree(final @NotNull String topicFilter) {
+        topicTree.removeSubscriber(clientId, topicFilter, null); // sharedName — null: non-shared
+    }
+
     private void submitPoll() {
         singleWriterService.getQueuedMessagesQueue().submit(clientId, bucketIndex -> {
             pollAndForward();
@@ -205,7 +499,7 @@ public abstract class InternalTopicFilterSubscriber {
 
     private void processPublish(final @NotNull PUBLISH message) {
         try {
-            process(message);
+            processor.process(message);
             removeMessage(message);
             submitPoll();
         } catch (final Exception e) {

--- a/hivemq-edge/src/main/java/com/hivemq/persistence/clientqueue/InternalTopicFilterSubscriber.java
+++ b/hivemq-edge/src/main/java/com/hivemq/persistence/clientqueue/InternalTopicFilterSubscriber.java
@@ -48,13 +48,15 @@ import org.slf4j.LoggerFactory;
 // Builder, and drive it with explicit lifecycle verbs. The single piece of behaviour the component
 // supplies — what to do with each message — is a Processor lambda passed to the builder.
 //
-//   subscriber = factory.create("tynebridge", bridgeId)
-//                       .withProcessor(message -> { ... })   // runs on the SingleWriter thread
-//                       .withTopicFilter("sensors/#")
+//   // a combiner keeping the latest value of one topic in an atomic reference:
+//   final AtomicReference<byte[]> latest = new AtomicReference<>();
+//   subscriber = factory.builder("combiner", combinerId)
+//                       .withProcessor(message -> latest.set(message.getPayload())) // SingleWriter thread
+//                       .withTopicFilter("sensors/temperature")
 //                       .build();
-//   subscriber.start();                       // attach(); consume();
-//   subscriber.addTopicFilter("actuators/#"); // runtime mutation, no teardown
-//   subscriber.stop();                        // detach(); pause(); deallocate();
+//   subscriber.start();                          // attach(); consume();
+//   subscriber.addTopicFilter("sensors/humidity"); // runtime mutation, no teardown
+//   subscriber.stop();                           // detach(); pause(); deallocate();
 //
 // Lifecycle. The lifecycle is decomposed into independent verbs. attach()/detach() control the
 // SUBSCRIPTION (topics in the topic tree, i.e. whether messages are COLLECTED); consume()/pause()

--- a/hivemq-edge/src/main/java/com/hivemq/persistence/clientqueue/InternalTopicFilterSubscriber.java
+++ b/hivemq-edge/src/main/java/com/hivemq/persistence/clientqueue/InternalTopicFilterSubscriber.java
@@ -109,7 +109,7 @@ public final class InternalTopicFilterSubscriber {
     // The per-message handler. Set once at construction (Builder requires it).
     private final @NotNull Processor processor;
 
-    // The factory that built this subscriber, kept as a back-reference so that attach()/detach() can
+    // The factory that built this subscriber, kept as a back-reference so that build()/deallocate() can
     // (de)register this subscriber in the factory's registry — see isExcludedIngressClientId() below.
     private final @NotNull InternalTopicFilterSubscriberFactory factory;
 
@@ -286,13 +286,16 @@ public final class InternalTopicFilterSubscriber {
         }
 
         // Produce the live subscriber. The subscriber is constructed in the IDLE state — detached and
-        // paused — i.e. nothing happens until start() (or attach()/consume()) is called.
+        // paused — i.e. no messages flow until start() (or attach()/consume()) is called. It is, however,
+        // already REGISTERED with the factory: the subscriber owns its clientId ("$INTERNAL::<prefix>::
+        // <instanceId>") from build() until deallocate(). register() throws if that identity is already in
+        // use, so a duplicate componentPrefix::instanceId is rejected here rather than silently colliding.
         public @NotNull InternalTopicFilterSubscriber build() {
             if (processor == null) {
                 throw new IllegalStateException(
                         "InternalTopicFilterSubscriber requires a processor; call withProcessor(...) before build()");
             }
-            return new InternalTopicFilterSubscriber(
+            final InternalTopicFilterSubscriber subscriber = new InternalTopicFilterSubscriber(
                     componentPrefix,
                     instanceId,
                     processor,
@@ -302,6 +305,8 @@ public final class InternalTopicFilterSubscriber {
                     topicTree,
                     clientQueuePersistence,
                     singleWriterService);
+            factory.register(subscriber); // throws if clientId already in use — deregistered by deallocate()
+            return subscriber;
         }
     }
 
@@ -399,9 +404,6 @@ public final class InternalTopicFilterSubscriber {
         for (final String topicFilter : topicFilters) {
             addToTree(topicFilter);
         }
-        // Register with the factory's registry so the distributor can find us by clientId and ask
-        // isExcludedIngressClientId(...) before queueing a message to us. Symmetric with detach().
-        factory.register(this);
         attached = true;
         return this;
     }
@@ -438,7 +440,6 @@ public final class InternalTopicFilterSubscriber {
         for (final String topicFilter : topicFilters) {
             removeFromTree(topicFilter);
         }
-        factory.deregister(this); // symmetric with attach()
         attached = false;
         return this;
     }
@@ -460,6 +461,9 @@ public final class InternalTopicFilterSubscriber {
         // long-lived subscriber must eventually stop()/deallocate() rather than just detach(), or the
         // queue (and its memory) would linger.
         clientQueuePersistence.clear(clientId, false);
+        // Free the clientId in the factory's registry — symmetric with build(). The queue is now
+        // destroyed, so the componentPrefix::instanceId identity becomes available for reuse.
+        factory.deregister(this);
         deallocated = true;
     }
 

--- a/hivemq-edge/src/main/java/com/hivemq/persistence/clientqueue/InternalTopicFilterSubscriberFactory.java
+++ b/hivemq-edge/src/main/java/com/hivemq/persistence/clientqueue/InternalTopicFilterSubscriberFactory.java
@@ -29,13 +29,15 @@ import org.jetbrains.annotations.Nullable;
 // It holds the three Edge singletons a subscriber operates against — LocalTopicTree, the client-queue
 // persistence, and the SingleWriterService — so that callers never have to know about, hold, or thread
 // those singletons through their own constructors. A component just injects this factory and calls
-// create(...).
+// builder(...).
 //
 //   @Inject MyComponent(final InternalTopicFilterSubscriberFactory subscriberFactory) { ... }
 //   ...
-//   subscriber = subscriberFactory.create("tynebridge", bridgeId)
-//                                 .withProcessor(message -> { ... })
-//                                 .withTopicFilter("sensors/#")
+//   // a combiner that keeps the latest value of one topic in an atomic reference:
+//   final AtomicReference<byte[]> latest = new AtomicReference<>();
+//   subscriber = subscriberFactory.builder("combiner", combinerId)
+//                                 .withProcessor(message -> latest.set(message.getPayload()))
+//                                 .withTopicFilter("sensors/temperature")
 //                                 .build();
 //
 @Singleton
@@ -87,14 +89,15 @@ public class InternalTopicFilterSubscriberFactory {
         return registry.get(clientId);
     }
 
-    // Begin building a subscriber for the given component identity.
+    // A builder for a subscriber with the given component identity. Named for what it returns (a Builder),
+    // not for its effect — it has none until build() is called on the returned builder.
     //
-    // componentPrefix — the Edge component type, unique across Edge (e.g. "tynebridge"). Becomes the
-    //                   middle segment of the reserved internal client ID "$INTERNAL::<prefix>::<id>".
+    // componentPrefix — the Edge component type, unique across Edge (e.g. "combiner"). Becomes the middle
+    //                   segment of the reserved internal client ID "$INTERNAL::<prefix>::<id>".
     // instanceId      — unique within the componentPrefix namespace; typically the config ID of the
     //                   owning instance.
     //
-    public @NotNull InternalTopicFilterSubscriber.Builder create(
+    public @NotNull InternalTopicFilterSubscriber.Builder builder(
             final @NotNull String componentPrefix, final @NotNull String instanceId) {
         return new InternalTopicFilterSubscriber.Builder(
                 componentPrefix, instanceId, this, topicTree, clientQueuePersistence, singleWriterService);

--- a/hivemq-edge/src/main/java/com/hivemq/persistence/clientqueue/InternalTopicFilterSubscriberFactory.java
+++ b/hivemq-edge/src/main/java/com/hivemq/persistence/clientqueue/InternalTopicFilterSubscriberFactory.java
@@ -19,7 +19,9 @@ import com.hivemq.mqtt.topic.tree.LocalTopicTree;
 import com.hivemq.persistence.SingleWriterService;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
+import java.util.concurrent.ConcurrentHashMap;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 // region InternalTopicFilterSubscriberFactory — the injected entry point for building subscribers
 // =====================================================================================================================
@@ -43,6 +45,13 @@ public class InternalTopicFilterSubscriberFactory {
     private final @NotNull ClientQueuePersistence clientQueuePersistence;
     private final @NotNull SingleWriterService singleWriterService;
 
+    // Registry of currently-attached subscribers, keyed by their reserved-prefix clientId. Populated
+    // by attach(), cleared by detach(). The PublishDistributor consults it (getSubscriber) to ask a
+    // subscriber's isExcludedIngressClientId(...) before queueing a publish — i.e. ingress-exclusion.
+    // Concurrent because the publish path reads it while lifecycle verbs (any thread) mutate it.
+    private final @NotNull ConcurrentHashMap<String, InternalTopicFilterSubscriber> registry =
+            new ConcurrentHashMap<>();
+
     @Inject
     InternalTopicFilterSubscriberFactory(
             final @NotNull LocalTopicTree topicTree,
@@ -51,6 +60,24 @@ public class InternalTopicFilterSubscriberFactory {
         this.topicTree = topicTree;
         this.clientQueuePersistence = clientQueuePersistence;
         this.singleWriterService = singleWriterService;
+    }
+
+    // ── registry — called by the subscriber's attach()/detach(), read by the distributor ────────────
+
+    void register(final @NotNull InternalTopicFilterSubscriber subscriber) {
+        registry.put(subscriber.clientId(), subscriber);
+    }
+
+    void deregister(final @NotNull InternalTopicFilterSubscriber subscriber) {
+        registry.remove(subscriber.clientId(), subscriber);
+    }
+
+    /**
+     * The attached subscriber with this reserved-prefix clientId, or null if none is attached. Used by
+     * the PublishDistributor to ask isExcludedIngressClientId(...) before queueing a publish.
+     */
+    public @Nullable InternalTopicFilterSubscriber getSubscriber(final @NotNull String clientId) {
+        return registry.get(clientId);
     }
 
     // Begin building a subscriber for the given component identity.
@@ -63,7 +90,7 @@ public class InternalTopicFilterSubscriberFactory {
     public @NotNull InternalTopicFilterSubscriber.Builder create(
             final @NotNull String componentPrefix, final @NotNull String instanceId) {
         return new InternalTopicFilterSubscriber.Builder(
-                componentPrefix, instanceId, topicTree, clientQueuePersistence, singleWriterService);
+                componentPrefix, instanceId, this, topicTree, clientQueuePersistence, singleWriterService);
     }
 }
 

--- a/hivemq-edge/src/main/java/com/hivemq/persistence/clientqueue/InternalTopicFilterSubscriberFactory.java
+++ b/hivemq-edge/src/main/java/com/hivemq/persistence/clientqueue/InternalTopicFilterSubscriberFactory.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.persistence.clientqueue;
+
+import com.hivemq.mqtt.topic.tree.LocalTopicTree;
+import com.hivemq.persistence.SingleWriterService;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import org.jetbrains.annotations.NotNull;
+
+// region InternalTopicFilterSubscriberFactory — the injected entry point for building subscribers
+// =====================================================================================================================
+// This factory is the ONE thing a component injects in order to obtain an InternalTopicFilterSubscriber.
+// It holds the three Edge singletons a subscriber operates against — LocalTopicTree, the client-queue
+// persistence, and the SingleWriterService — so that callers never have to know about, hold, or thread
+// those singletons through their own constructors. A component just injects this factory and calls
+// create(...).
+//
+//   @Inject MyComponent(final InternalTopicFilterSubscriberFactory subscriberFactory) { ... }
+//   ...
+//   subscriber = subscriberFactory.create("tynebridge", bridgeId)
+//                                 .withProcessor(message -> { ... })
+//                                 .withTopicFilter("sensors/#")
+//                                 .build();
+//
+@Singleton
+public class InternalTopicFilterSubscriberFactory {
+
+    private final @NotNull LocalTopicTree topicTree;
+    private final @NotNull ClientQueuePersistence clientQueuePersistence;
+    private final @NotNull SingleWriterService singleWriterService;
+
+    @Inject
+    InternalTopicFilterSubscriberFactory(
+            final @NotNull LocalTopicTree topicTree,
+            final @NotNull ClientQueuePersistence clientQueuePersistence,
+            final @NotNull SingleWriterService singleWriterService) {
+        this.topicTree = topicTree;
+        this.clientQueuePersistence = clientQueuePersistence;
+        this.singleWriterService = singleWriterService;
+    }
+
+    // Begin building a subscriber for the given component identity.
+    //
+    // componentPrefix — the Edge component type, unique across Edge (e.g. "tynebridge"). Becomes the
+    //                   middle segment of the reserved internal client ID "$INTERNAL::<prefix>::<id>".
+    // instanceId      — unique within the componentPrefix namespace; typically the config ID of the
+    //                   owning instance.
+    //
+    public @NotNull InternalTopicFilterSubscriber.Builder create(
+            final @NotNull String componentPrefix, final @NotNull String instanceId) {
+        return new InternalTopicFilterSubscriber.Builder(
+                componentPrefix, instanceId, topicTree, clientQueuePersistence, singleWriterService);
+    }
+}
+
+// endregion

--- a/hivemq-edge/src/main/java/com/hivemq/persistence/clientqueue/InternalTopicFilterSubscriberFactory.java
+++ b/hivemq-edge/src/main/java/com/hivemq/persistence/clientqueue/InternalTopicFilterSubscriberFactory.java
@@ -45,9 +45,11 @@ public class InternalTopicFilterSubscriberFactory {
     private final @NotNull ClientQueuePersistence clientQueuePersistence;
     private final @NotNull SingleWriterService singleWriterService;
 
-    // Registry of currently-attached subscribers, keyed by their reserved-prefix clientId. Populated
-    // by attach(), cleared by detach(). The PublishDistributor consults it (getSubscriber) to ask a
-    // subscriber's isExcludedIngressClientId(...) before queueing a publish — i.e. ingress-exclusion.
+    // Registry of currently-allocated subscribers, keyed by their reserved-prefix clientId. Populated
+    // by build(), cleared by deallocate() — a subscriber owns its identity for its whole live span, not
+    // just while attached. The PublishDistributor consults it (getSubscriber) to ask a subscriber's
+    // isExcludedIngressClientId(...) before queueing a publish — i.e. ingress-exclusion. It is also the
+    // uniqueness guard: register() rejects a duplicate componentPrefix::instanceId.
     // Concurrent because the publish path reads it while lifecycle verbs (any thread) mutate it.
     private final @NotNull ConcurrentHashMap<String, InternalTopicFilterSubscriber> registry =
             new ConcurrentHashMap<>();
@@ -62,10 +64,15 @@ public class InternalTopicFilterSubscriberFactory {
         this.singleWriterService = singleWriterService;
     }
 
-    // ── registry — called by the subscriber's attach()/detach(), read by the distributor ────────────
+    // ── registry — called by the subscriber's build()/deallocate(), read by the distributor ──────────
 
     void register(final @NotNull InternalTopicFilterSubscriber subscriber) {
-        registry.put(subscriber.clientId(), subscriber);
+        final InternalTopicFilterSubscriber existing = registry.putIfAbsent(subscriber.clientId(), subscriber);
+        if (existing != null) {
+            throw new IllegalStateException("InternalTopicFilterSubscriber '" + subscriber.clientId()
+                    + "' is already in use; componentPrefix::instanceId must be unique within Edge"
+                    + " (the existing subscriber must deallocate() before this identity can be reused)");
+        }
     }
 
     void deregister(final @NotNull InternalTopicFilterSubscriber subscriber) {
@@ -73,7 +80,7 @@ public class InternalTopicFilterSubscriberFactory {
     }
 
     /**
-     * The attached subscriber with this reserved-prefix clientId, or null if none is attached. Used by
+     * The allocated subscriber with this reserved-prefix clientId, or null if none is allocated. Used by
      * the PublishDistributor to ask isExcludedIngressClientId(...) before queueing a publish.
      */
     public @Nullable InternalTopicFilterSubscriber getSubscriber(final @NotNull String clientId) {

--- a/hivemq-edge/src/test/java/com/hivemq/mqtt/InternalPublishServiceImplTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/mqtt/InternalPublishServiceImplTest.java
@@ -45,6 +45,8 @@ import com.hivemq.mqtt.topic.SubscriberWithIdentifiers;
 import com.hivemq.mqtt.topic.SubscriptionFlag;
 import com.hivemq.mqtt.topic.tree.LocalTopicTree;
 import com.hivemq.mqtt.topic.tree.TopicSubscribers;
+import com.hivemq.persistence.clientqueue.InternalTopicFilterSubscriber;
+import com.hivemq.persistence.clientqueue.InternalTopicFilterSubscriberFactory;
 import com.hivemq.persistence.retained.RetainedMessagePersistence;
 import java.util.Map;
 import java.util.Set;
@@ -64,6 +66,7 @@ public class InternalPublishServiceImplTest {
     private final @NotNull RetainedMessagePersistence retainedMessagePersistence = mock();
     private final @NotNull LocalTopicTree topicTree = mock();
     private final @NotNull PublishDistributor publishDistributor = mock();
+    private final @NotNull InternalTopicFilterSubscriberFactory internalTopicFilterSubscriberFactory = mock();
     private final @NotNull ExecutorService executorService = MoreExecutors.newDirectExecutorService();
 
     private @NotNull InternalPublishServiceImpl publishService;
@@ -76,7 +79,8 @@ public class InternalPublishServiceImplTest {
         when(publishDistributor.distributeToSharedSubscribers(anySet(), any(PUBLISH.class), eq(executorService)))
                 .thenReturn(Futures.immediateFuture(null));
 
-        publishService = new InternalPublishServiceImpl(retainedMessagePersistence, topicTree, publishDistributor);
+        publishService = new InternalPublishServiceImpl(
+                retainedMessagePersistence, topicTree, publishDistributor, internalTopicFilterSubscriberFactory);
     }
 
     @Test
@@ -85,7 +89,8 @@ public class InternalPublishServiceImplTest {
 
         when(topicTree.findTopicSubscribers(anyString()))
                 .thenReturn(new TopicSubscribers(ImmutableSet.of(), ImmutableSet.of()));
-        publishService = new InternalPublishServiceImpl(retainedMessagePersistence, topicTree, publishDistributor);
+        publishService = new InternalPublishServiceImpl(
+                retainedMessagePersistence, topicTree, publishDistributor, internalTopicFilterSubscriberFactory);
 
         final PUBLISH publish =
                 TestMessageUtil.createMqtt3Publish("hivemqId", "subonly", QoS.AT_LEAST_ONCE, new byte[0], true);
@@ -103,7 +108,8 @@ public class InternalPublishServiceImplTest {
 
         when(topicTree.findTopicSubscribers(anyString()))
                 .thenReturn(new TopicSubscribers(ImmutableSet.of(), ImmutableSet.of()));
-        publishService = new InternalPublishServiceImpl(retainedMessagePersistence, topicTree, publishDistributor);
+        publishService = new InternalPublishServiceImpl(
+                retainedMessagePersistence, topicTree, publishDistributor, internalTopicFilterSubscriberFactory);
 
         final PUBLISH publish =
                 TestMessageUtil.createMqtt3Publish("hivemqId", "subonly", QoS.AT_LEAST_ONCE, new byte[0], true);
@@ -157,6 +163,65 @@ public class InternalPublishServiceImplTest {
         assertEquals(1, map.size());
         assertNull(map.get("sub1"));
         assertNotNull(map.get("sub2"));
+    }
+
+    @Test
+    @Timeout(20)
+    public void test_ingress_exclusion() {
+        // Two non-shared subscribers; the internal one ($INTERNAL::...) is registered with the factory
+        // and configured to exclude ingress from "sender". A publish from "sender" must NOT be queued to
+        // the internal subscriber, but must still go to the ordinary subscriber.
+        final String internalId = "$INTERNAL::tynebridge::b1";
+        final SubscriberWithIdentifiers internalSub = new SubscriberWithIdentifiers(internalId, 1, (byte) 0, null);
+        final SubscriberWithIdentifiers ordinarySub = new SubscriberWithIdentifiers("sub2", 1, (byte) 0, null);
+
+        when(topicTree.findTopicSubscribers("topic"))
+                .thenReturn(new TopicSubscribers(ImmutableSet.of(internalSub, ordinarySub), ImmutableSet.of()));
+
+        final InternalTopicFilterSubscriber subscriber = mock();
+        when(subscriber.isExcludedIngressClientId("sender")).thenReturn(true);
+        when(internalTopicFilterSubscriberFactory.getSubscriber(internalId)).thenReturn(subscriber);
+
+        final PUBLISH publish = TestMessageUtil.createMqtt5Publish("topic");
+
+        publishService.publish(publish, executorService, "sender");
+
+        final ArgumentCaptor<Map> mapArgumentCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(publishDistributor, atLeastOnce())
+                .distributeToNonSharedSubscribers(mapArgumentCaptor.capture(), any(), any());
+
+        final Map map = mapArgumentCaptor.getAllValues().get(0);
+
+        assertEquals(1, map.size());
+        assertNull(map.get(internalId)); // excluded — the ingress client equals the configured exclusion
+        assertNotNull(map.get("sub2")); // ordinary subscriber unaffected
+    }
+
+    @Test
+    @Timeout(20)
+    public void test_ingress_exclusion_acceptsWhenSenderDiffers() {
+        // Same internal subscriber, but the publish ingresses from a DIFFERENT client — it must be queued.
+        final String internalId = "$INTERNAL::tynebridge::b1";
+        final SubscriberWithIdentifiers internalSub = new SubscriberWithIdentifiers(internalId, 1, (byte) 0, null);
+
+        when(topicTree.findTopicSubscribers("topic"))
+                .thenReturn(new TopicSubscribers(ImmutableSet.of(internalSub), ImmutableSet.of()));
+
+        final InternalTopicFilterSubscriber subscriber = mock();
+        when(subscriber.isExcludedIngressClientId("someoneElse")).thenReturn(false);
+        when(internalTopicFilterSubscriberFactory.getSubscriber(internalId)).thenReturn(subscriber);
+
+        final PUBLISH publish = TestMessageUtil.createMqtt5Publish("topic");
+
+        publishService.publish(publish, executorService, "someoneElse");
+
+        final ArgumentCaptor<Map> mapArgumentCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(publishDistributor, atLeastOnce())
+                .distributeToNonSharedSubscribers(mapArgumentCaptor.capture(), any(), any());
+
+        final Map map = mapArgumentCaptor.getAllValues().get(0);
+        assertEquals(1, map.size());
+        assertNotNull(map.get(internalId)); // accepted — sender differs from the exclusion
     }
 
     @Test

--- a/hivemq-edge/src/test/java/com/hivemq/persistence/clientqueue/InternalTopicFilterSubscriberTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/persistence/clientqueue/InternalTopicFilterSubscriberTest.java
@@ -246,22 +246,49 @@ class InternalTopicFilterSubscriberTest {
     }
 
     @Test
-    void attach_registersInFactory_detachDeregisters() {
+    void build_registersInFactory_deallocateDeregisters() {
+        // Registration brackets the subscriber's whole live span: it owns its clientId from build()
+        // until deallocate(), NOT just while attached. attach()/detach() leave the registration alone.
         final InternalTopicFilterSubscriber s = build("sensors/#");
 
         assertThat(factory.getSubscriber(clientId()))
-                .as("not registered before attach")
-                .isNull();
+                .as("registered at build()")
+                .isSameAs(s);
 
         s.attach();
         assertThat(factory.getSubscriber(clientId()))
-                .as("registered after attach")
+                .as("still registered after attach()")
                 .isSameAs(s);
 
         s.detach();
         assertThat(factory.getSubscriber(clientId()))
-                .as("deregistered after detach")
+                .as("still registered after detach() — detach does not free the identity")
+                .isSameAs(s);
+
+        s.deallocate();
+        assertThat(factory.getSubscriber(clientId()))
+                .as("deregistered only at deallocate()")
                 .isNull();
+    }
+
+    @Test
+    void build_duplicateIdentity_throws_andDeallocateFreesItForReuse() {
+        // Two subscribers with the same componentPrefix::instanceId cannot coexist: the second build()
+        // is rejected. This is the uniqueness guard — the identity is the subscriber, 1:1.
+        final InternalTopicFilterSubscriber first = build("sensors/#");
+
+        assertThatThrownBy(() -> build("other/#"))
+                .as("a second subscriber with the same identity is rejected at build()")
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("already in use");
+
+        // Once the first deallocates, the queue is destroyed and the identity is free to reuse.
+        first.deallocate();
+
+        final InternalTopicFilterSubscriber second = build("other/#");
+        assertThat(factory.getSubscriber(clientId()))
+                .as("the same identity is reusable after the first subscriber deallocated")
+                .isSameAs(second);
     }
 
     // ── helpers ─────────────────────────────────────────────────────────────────────────────────────

--- a/hivemq-edge/src/test/java/com/hivemq/persistence/clientqueue/InternalTopicFilterSubscriberTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/persistence/clientqueue/InternalTopicFilterSubscriberTest.java
@@ -189,6 +189,81 @@ class InternalTopicFilterSubscriberTest {
         assertThat(treeIdsFor("anything")).isEmpty();
     }
 
+    // ── ingress-exclusion ───────────────────────────────────────────────────────────────────────────
+
+    @Test
+    void isExcludedIngressClientId_excludesOnlyTheConfiguredId() {
+        final InternalTopicFilterSubscriber s = factory.create("tynebridge", "my-bridge")
+                .withProcessor(m -> {})
+                .withExcludedIngressClientId("peer-broker")
+                .build();
+
+        assertThat(s.isExcludedIngressClientId("peer-broker"))
+                .as("the configured id is excluded")
+                .isTrue();
+        assertThat(s.isExcludedIngressClientId("someone-else"))
+                .as("any other id is not excluded")
+                .isFalse();
+        assertThat(s.isExcludedIngressClientId(null))
+                .as("a null sender is not excluded")
+                .isFalse();
+    }
+
+    @Test
+    void isExcludedIngressClientId_excludesNoOneWhenNoExclusionConfigured() {
+        final InternalTopicFilterSubscriber s = build("sensors/#"); // no withExcludedIngressClientId
+
+        assertThat(s.isExcludedIngressClientId("anyone")).isFalse();
+        assertThat(s.isExcludedIngressClientId(null)).isFalse();
+    }
+
+    // ── terminal state: dead after deallocate ───────────────────────────────────────────────────────
+
+    @Test
+    void afterDeallocate_everyVerbThrows_exceptDeallocateAndStop() {
+        final InternalTopicFilterSubscriber s = build("sensors/#");
+        s.stop(); // attach was never called; stop() = detach (no-op) + pause (no-op) + deallocate
+
+        // deallocate() and stop() are idempotent no-ops on a dead subscriber.
+        s.deallocate();
+        s.stop();
+
+        // every other verb throws use-after-deallocate.
+        assertThatThrownBy(s::attach).isInstanceOf(IllegalStateException.class).hasMessageContaining("deallocated");
+        assertThatThrownBy(s::consume).isInstanceOf(IllegalStateException.class).hasMessageContaining("deallocated");
+        assertThatThrownBy(s::pause).isInstanceOf(IllegalStateException.class).hasMessageContaining("deallocated");
+        assertThatThrownBy(s::detach).isInstanceOf(IllegalStateException.class).hasMessageContaining("deallocated");
+        assertThatThrownBy(s::start).isInstanceOf(IllegalStateException.class).hasMessageContaining("deallocated");
+        assertThatThrownBy(() -> s.addTopicFilter("x/#"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("deallocated");
+        assertThatThrownBy(() -> s.removeTopicFilter("x/#"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("deallocated");
+        assertThatThrownBy(() -> s.withTopicFilter("x/#"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("deallocated");
+    }
+
+    @Test
+    void attach_registersInFactory_detachDeregisters() {
+        final InternalTopicFilterSubscriber s = build("sensors/#");
+
+        assertThat(factory.getSubscriber(clientId()))
+                .as("not registered before attach")
+                .isNull();
+
+        s.attach();
+        assertThat(factory.getSubscriber(clientId()))
+                .as("registered after attach")
+                .isSameAs(s);
+
+        s.detach();
+        assertThat(factory.getSubscriber(clientId()))
+                .as("deregistered after detach")
+                .isNull();
+    }
+
     // ── helpers ─────────────────────────────────────────────────────────────────────────────────────
 
     private @NotNull InternalTopicFilterSubscriber build(final @NotNull String... filters) {

--- a/hivemq-edge/src/test/java/com/hivemq/persistence/clientqueue/InternalTopicFilterSubscriberTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/persistence/clientqueue/InternalTopicFilterSubscriberTest.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.persistence.clientqueue;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.util.concurrent.Futures;
+import com.hivemq.metrics.MetricsHolder;
+import com.hivemq.mqtt.topic.SubscriberWithIdentifiers;
+import com.hivemq.mqtt.topic.tree.LocalTopicTree;
+import com.hivemq.mqtt.topic.tree.TopicSubscribers;
+import com.hivemq.persistence.ProducerQueues;
+import com.hivemq.persistence.SingleWriterService;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+@SuppressWarnings({"unchecked", "rawtypes"})
+class InternalTopicFilterSubscriberTest {
+
+    private LocalTopicTree topicTree; // REAL — the seam under test
+    private ClientQueuePersistence clientQueuePersistence; // mock — used to capture the queue id
+    private SingleWriterService singleWriterService; // mock
+    private InternalTopicFilterSubscriberFactory factory;
+
+    @BeforeEach
+    void setUp() {
+        // The real topic tree — this is what makes the id-coupling test meaningful.
+        topicTree = new LocalTopicTree(new MetricsHolder(new MetricRegistry()));
+
+        clientQueuePersistence = mock(ClientQueuePersistence.class);
+        singleWriterService = mock(SingleWriterService.class);
+
+        // consume() calls submitPoll(), which submits a task onto the SingleWriter queue. We do NOT run
+        // the task here: in production each submit() is asynchronous, and the poll pipeline reschedules
+        // itself via submitPoll() — running it synchronously in the test thread would recurse without
+        // bound. These tests exercise the wiring and state machine, not the poll loop, so submit() just
+        // returns an immediate future. (Mockito still records the queueId argument, which is what the
+        // id-coupling test captures.)
+        final ProducerQueues producerQueues = mock(ProducerQueues.class);
+        when(singleWriterService.getQueuedMessagesQueue()).thenReturn(producerQueues);
+        when(producerQueues.submit(any(), any(SingleWriterService.Task.class)))
+                .thenReturn(Futures.immediateFuture(null));
+
+        factory = new InternalTopicFilterSubscriberFactory(topicTree, clientQueuePersistence, singleWriterService);
+    }
+
+    // ── Tier 3 (the requested one): real-topic-tree contract — subscribe-id == poll-id ──────────────
+    //
+    // The implicit contract between the topic tree and the client-queue persistence is that the
+    // SAME id is used on both sides: the id we subscribe with in the tree must equal the id we poll
+    // the queue with, otherwise a message the tree routes to us would land in a queue we never drain.
+    //
+    // This test pins that contract using the REAL topic tree. It (a) subscribes via attach(), (b) asks
+    // the real tree who matches a topic our filter covers, and (c) asserts the id the tree reports is
+    // exactly the id our subscriber uses on EVERY queue-persistence call. A regression that made the
+    // tree id and the queue id diverge — the classic "subscribed as X, polled as Y" bug — turns this
+    // red, where mock-only tests (Tier 1/2) would stay green because each mock accepts its own id.
+    @Test
+    void realTree_subscribeIdEqualsPollId() {
+        final InternalTopicFilterSubscriber subscriber = factory.create("tynebridge", "my-bridge")
+                .withProcessor(message -> {})
+                .withTopicFilter("sensors/#")
+                .build();
+
+        subscriber.start(); // attach() registers in the real tree; consume() exercises the poll path
+
+        // (b) the real tree's view: who is subscribed to a topic our filter matches?
+        final TopicSubscribers matched = topicTree.findTopicSubscribers("sensors/temperature");
+        final Set<String> idsFromTree = matched.getSubscribers().stream()
+                .map(SubscriberWithIdentifiers::getSubscriber)
+                .collect(Collectors.toSet());
+
+        assertThat(idsFromTree)
+                .as("the real topic tree must report exactly our reserved-prefix client id")
+                .containsExactly("$INTERNAL::tynebridge::my-bridge");
+        final String idFromTree = idsFromTree.iterator().next();
+
+        // (c) the id our subscriber actually uses against the queue persistence, captured from the
+        // publish-available-callback registration (consume() registers it under the poll id directly).
+        final ArgumentCaptor<String> callbackQueueId = ArgumentCaptor.forClass(String.class);
+        verify(clientQueuePersistence).addPublishAvailableCallback(any(), callbackQueueId.capture());
+
+        // The contract: the id the tree reports for our subscription == the id we use against the queue.
+        assertThat(callbackQueueId.getValue())
+                .as("the id we register the publish-available callback under must equal the tree id")
+                .isEqualTo(idFromTree);
+    }
+
+    // ── Tier 1: lifecycle state machine ─────────────────────────────────────────────────────────────
+
+    @Test
+    void attach_isIdempotent_andDetachReversesIt() {
+        final InternalTopicFilterSubscriber s = build("sensors/#");
+
+        s.attach();
+        s.attach(); // second attach must NOT double-subscribe in the tree
+        assertThat(treeIdsFor("sensors/x")).containsExactly(clientId());
+
+        s.detach();
+        assertThat(treeIdsFor("sensors/x")).isEmpty();
+    }
+
+    @Test
+    void deallocate_throws_whenNotDetachedAndPaused() {
+        final InternalTopicFilterSubscriber s = build("sensors/#").start(); // attached + consuming
+
+        assertThatThrownBy(s::deallocate)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("must be detached and paused");
+    }
+
+    @Test
+    void stop_ordersDetachThenPauseThenDeallocate() {
+        final InternalTopicFilterSubscriber s = build("sensors/#").start();
+
+        s.stop();
+
+        // detached: no longer in the tree; deallocated: queue cleared.
+        assertThat(treeIdsFor("sensors/x")).isEmpty();
+        verify(clientQueuePersistence).removePublishAvailableCallback(clientId()); // pause()
+        verify(clientQueuePersistence).clear(clientId(), false); // deallocate()
+    }
+
+    // ── Tier 1: runtime topic-filter reconciliation ─────────────────────────────────────────────────
+
+    @Test
+    void addTopicFilter_whileDetached_doesNotTouchTree_butReplaysOnAttach() {
+        final InternalTopicFilterSubscriber s = build(); // no filters, detached
+
+        s.addTopicFilter("sensors/#"); // detached: internal set only
+        assertThat(treeIdsFor("sensors/x")).isEmpty(); // nothing in the tree yet
+
+        s.attach(); // now the remembered set is replayed
+        assertThat(treeIdsFor("sensors/x")).containsExactly(clientId());
+    }
+
+    @Test
+    void withTopicFilter_whileAttached_appliesOnlyTheDiff() {
+        final InternalTopicFilterSubscriber s = build("a/#", "b/#").attach();
+        assertThat(treeIdsFor("a/x")).containsExactly(clientId());
+        assertThat(treeIdsFor("b/x")).containsExactly(clientId());
+
+        s.withTopicFilter(List.of("b/#", "c/#")); // absolute: drop a, keep b, add c
+
+        assertThat(treeIdsFor("a/x")).as("a was removed").isEmpty();
+        assertThat(treeIdsFor("b/x")).as("b was kept").containsExactly(clientId());
+        assertThat(treeIdsFor("c/x")).as("c was added").containsExactly(clientId());
+    }
+
+    // ── Tier 1: builder validation ──────────────────────────────────────────────────────────────────
+
+    @Test
+    void build_withoutProcessor_throws() {
+        assertThatThrownBy(() -> factory.create("tynebridge", "x").build())
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("requires a processor");
+    }
+
+    @Test
+    void build_withEmptyFilterSet_isValid_andAttachIsANoOp() {
+        final InternalTopicFilterSubscriber s =
+                factory.create("tynebridge", "x").withProcessor(m -> {}).build();
+
+        s.attach(); // empty set: subscribes to nothing, must not error
+        assertThat(treeIdsFor("anything")).isEmpty();
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────────────────────────────────────
+
+    private @NotNull InternalTopicFilterSubscriber build(final @NotNull String... filters) {
+        return factory.create("tynebridge", "my-bridge")
+                .withProcessor(m -> {})
+                .withTopicFilter(List.of(filters))
+                .build();
+    }
+
+    private @NotNull String clientId() {
+        return "$INTERNAL::tynebridge::my-bridge";
+    }
+
+    private @NotNull Set<String> treeIdsFor(final @NotNull String topic) {
+        return topicTree.findTopicSubscribers(topic).getSubscribers().stream()
+                .map(SubscriberWithIdentifiers::getSubscriber)
+                .collect(Collectors.toSet());
+    }
+}

--- a/hivemq-edge/src/test/java/com/hivemq/persistence/clientqueue/InternalTopicFilterSubscriberTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/persistence/clientqueue/InternalTopicFilterSubscriberTest.java
@@ -81,7 +81,7 @@ class InternalTopicFilterSubscriberTest {
     // red, where mock-only tests (Tier 1/2) would stay green because each mock accepts its own id.
     @Test
     void realTree_subscribeIdEqualsPollId() {
-        final InternalTopicFilterSubscriber subscriber = factory.create("tynebridge", "my-bridge")
+        final InternalTopicFilterSubscriber subscriber = factory.builder("tynebridge", "my-bridge")
                 .withProcessor(message -> {})
                 .withTopicFilter("sensors/#")
                 .build();
@@ -175,7 +175,7 @@ class InternalTopicFilterSubscriberTest {
 
     @Test
     void build_withoutProcessor_throws() {
-        assertThatThrownBy(() -> factory.create("tynebridge", "x").build())
+        assertThatThrownBy(() -> factory.builder("tynebridge", "x").build())
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("requires a processor");
     }
@@ -183,7 +183,7 @@ class InternalTopicFilterSubscriberTest {
     @Test
     void build_withEmptyFilterSet_isValid_andAttachIsANoOp() {
         final InternalTopicFilterSubscriber s =
-                factory.create("tynebridge", "x").withProcessor(m -> {}).build();
+                factory.builder("tynebridge", "x").withProcessor(m -> {}).build();
 
         s.attach(); // empty set: subscribes to nothing, must not error
         assertThat(treeIdsFor("anything")).isEmpty();
@@ -193,7 +193,7 @@ class InternalTopicFilterSubscriberTest {
 
     @Test
     void isExcludedIngressClientId_excludesOnlyTheConfiguredId() {
-        final InternalTopicFilterSubscriber s = factory.create("tynebridge", "my-bridge")
+        final InternalTopicFilterSubscriber s = factory.builder("tynebridge", "my-bridge")
                 .withProcessor(m -> {})
                 .withExcludedIngressClientId("peer-broker")
                 .build();
@@ -294,7 +294,7 @@ class InternalTopicFilterSubscriberTest {
     // ── helpers ─────────────────────────────────────────────────────────────────────────────────────
 
     private @NotNull InternalTopicFilterSubscriber build(final @NotNull String... filters) {
-        return factory.create("tynebridge", "my-bridge")
+        return factory.builder("tynebridge", "my-bridge")
                 .withProcessor(m -> {})
                 .withTopicFilter(List.of(filters))
                 .build();


### PR DESCRIPTION
Replace the abstract-class-and-subclass design with a concrete, final class obtained from an injected InternalTopicFilterSubscriberFactory via a fluent builder. The class had zero users, so the redesign carries no migration cost.

Why: dynamic bridging needs runtime mutability of topic filters — change what a live subscription carries without tearing down and re-establishing it. The v1 lifecycle was monolithic (filter set fixed at construction).

- Processor lambda (withProcessor) replaces the overridden process().
- Factory holds the three Edge singletons; callers no longer thread them.
- Lifecycle decomposed into verbs: attach / consume / pause / detach / deallocate; start/stop are convenience compositions.
- Runtime filter mutation: withTopicFilter (absolute, diffed against the tree when attached), addTopicFilter / removeTopicFilter (relative); same three verbs on builder and subscriber. Empty filter set is valid.

The underlying mechanism (topic-tree add/remove, publish-available callback, SingleWriter poll loop, queue clear) is unchanged; the v1 explanatory comments are preserved.

Tests: a real-LocalTopicTree test pins the subscribe-id == poll-id contract, plus state-machine, filter-reconciliation, and builder validation. Full hivemq-edge suite green; Spotless clean.

**Motivation**

Resolves #<issue>

**Changes**
