### PR TITLE
EDG-759: Send hmq-bridge user property on bridge CONNECT

### DIFF
--- a/hivemq-edge/src/main/java/com/hivemq/bridge/mqtt/BridgeMqttClient.java
+++ b/hivemq-edge/src/main/java/com/hivemq/bridge/mqtt/BridgeMqttClient.java
@@ -15,6 +15,8 @@
  */
 package com.hivemq.bridge.mqtt;
 
+import static com.hivemq.edge.HiveMQEdgeConstants.BRIDGE_MARKER_PROPERTY;
+import static com.hivemq.edge.HiveMQEdgeConstants.BRIDGE_MARKER_PROPERTY_VALUE;
 import static com.hivemq.edge.HiveMQEdgeConstants.CLIENT_AGENT_PROPERTY;
 import static com.hivemq.edge.HiveMQEdgeConstants.CLIENT_AGENT_PROPERTY_VALUE;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -148,6 +150,7 @@ public class BridgeMqttClient {
                             .add(
                                     CLIENT_AGENT_PROPERTY,
                                     String.format(CLIENT_AGENT_PROPERTY_VALUE, systemInformation.getHiveMQVersion()))
+                            .add(BRIDGE_MARKER_PROPERTY, BRIDGE_MARKER_PROPERTY_VALUE)
                             .build())
                     .sessionExpiryInterval(bridge.getSessionExpiry())
                     .send()

--- a/hivemq-edge/src/main/java/com/hivemq/edge/HiveMQEdgeConstants.java
+++ b/hivemq-edge/src/main/java/com/hivemq/edge/HiveMQEdgeConstants.java
@@ -30,6 +30,14 @@ public interface HiveMQEdgeConstants {
     String VERSION_PROPERTY = "version";
     String CLIENT_AGENT_PROPERTY = "client-agent";
 
+    // -- CONNECT user property marking a bridge client to the broker;
+    // the enterprise broker assigns a larger receive buffer to connections with this user property
+    // and will not shrink this receive buffer when entering overload protection
+    // currently the broker only checks whether the property exists, it doesn't read the value
+    // See BCD-515 and EDG-759
+    String BRIDGE_MARKER_PROPERTY = "hmq-bridge";
+    String BRIDGE_MARKER_PROPERTY_VALUE = "edge";
+
     int MAX_ID_LEN = 500;
     int MAX_NAME_LEN = 256;
     String NAME_REGEX =


### PR DESCRIPTION
## Description (the why)
Edge bridge clients now send the `hmq-bridge=edge` MQTT 5 user property on CONNECT. A HiveMQ broker keys off the property name to assign a larger receive buffer to these connections and to skip shrinking it under overload protection — the differentiated receive buffer from [BCD-515](https://linear.app/hivemq/issue/BCD-515). This is the Edge-side counterpart, [EDG-759](https://linear.app/hivemq/issue/EDG-759). Always-on; no config field, schema, or frontend.

## Acceptance Criteria (the what)
- [ ] Edge sends `hmq-bridge` = `edge` as a CONNECT user property on every bridge client.
- [ ] The marker is present on the initial connect and on every reconnect.
- [ ] No new configuration surface (field/XML schema/frontend).

## Non-Goals
- Edge does not read or act on the property; only the broker consumes it.
- No change to `hmq-bridge-token` (the broker does not consume it).
- The broker-side pin-vs-autotune buffer design is out of scope.