### PR TITLE
fix(EDG-784,EDG-785): browse RESOLVE completeness + abort resilient to a throwing browseCancel

### DIFF
--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/browse/ProtocolAdapterBrowseEngine.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/browse/ProtocolAdapterBrowseEngine.java
@@ -32,6 +32,8 @@ import java.util.Map;
 import java.util.Set;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The single browse traversal engine — the policy the framework's PAW drives in production <b>and</b> the
@@ -68,6 +70,8 @@ import org.jetbrains.annotations.Nullable;
  */
 public final class ProtocolAdapterBrowseEngine {
 
+    private static final @NotNull Logger log = LoggerFactory.getLogger(ProtocolAdapterBrowseEngine.class);
+
     /** Discovered variables are attribute-read in batches of this size. */
     public static final int RESOLVE_BATCH = 100;
 
@@ -102,6 +106,7 @@ public final class ProtocolAdapterBrowseEngine {
     private final @NotNull Map<String, String> pathByNode = new HashMap<>();
     private final @NotNull Map<String, String> tagNameByNode = new HashMap<>();
     private final @NotNull Map<String, ResolvedAttributes> resolvedByNode = new HashMap<>();
+    private final @NotNull List<String> pendingResolveIds = new ArrayList<>();
     private int resolveOffset;
 
     /**
@@ -165,6 +170,7 @@ public final class ProtocolAdapterBrowseEngine {
         pathByNode.clear();
         tagNameByNode.clear();
         resolvedByNode.clear();
+        pendingResolveIds.clear();
         resolveOffset = 0;
         activePath = "";
         activeContinuation = null;
@@ -255,8 +261,10 @@ public final class ProtocolAdapterBrowseEngine {
         }
         final int end = Math.min(resolveOffset + RESOLVE_BATCH, sorted.size());
         final List<Node> batch = new ArrayList<>(end - resolveOffset);
+        pendingResolveIds.clear();
         for (final DiscoveredVariable variable : sorted.subList(resolveOffset, end)) {
             batch.add(variable.node());
+            pendingResolveIds.add(variable.node().nodeId());
         }
         resolveOffset = end;
         resolveBatches++;
@@ -274,10 +282,40 @@ public final class ProtocolAdapterBrowseEngine {
         if (phase != Phase.RESOLVING || requestId != this.requestId) {
             return;
         }
+        // The SDK contract is exactly one ResolvedAttributes per requested node. Validate the batch before trusting
+        // it: an unrequested, duplicate, or missing node id means the adapter broke that contract, and quietly
+        // dropping the affected variables would return an incomplete browse as a success (they are filtered out in
+        // finish()). Fail the whole browse instead, so the caller sees an error rather than a silently short result.
+        final Set<String> expected = new HashSet<>(pendingResolveIds);
+        final Set<String> seen = new HashSet<>();
+        for (final ResolvedAttributes attribute : attributes) {
+            final String nodeId = attribute.node().nodeId();
+            if (!expected.contains(nodeId)) {
+                failResolve("attributes returned for an unrequested node '" + nodeId + "'");
+                return;
+            }
+            if (!seen.add(nodeId)) {
+                failResolve("duplicate attributes returned for node '" + nodeId + "'");
+                return;
+            }
+        }
+        if (seen.size() != expected.size()) {
+            final Set<String> missing = new HashSet<>(expected);
+            missing.removeAll(seen);
+            failResolve("missing attributes for " + missing.size() + " requested node(s): " + missing);
+            return;
+        }
         for (final ResolvedAttributes attribute : attributes) {
             resolvedByNode.put(attribute.node().nodeId(), attribute);
         }
         readNextBatch();
+    }
+
+    /** Fail the in-flight browse from the RESOLVE phase (contract violation in the returned attributes) and reset. */
+    private void failResolve(final @NotNull String reason) {
+        final BrowseSink target = requireSink();
+        reset();
+        target.fail(Phase.RESOLVING + ": " + reason);
     }
 
     // ── termination ───────────────────────────────────────────────────────────────────────────────────────
@@ -307,8 +345,16 @@ public final class ProtocolAdapterBrowseEngine {
         if (!isActive()) {
             return;
         }
-        requireAdapter().browseCancel(requestId);
-        reset();
+        // browseCancel is a courtesy to the device (release its open continuation point). A direct adapter runs it
+        // synchronously on this thread and may throw; that must never stop the engine resetting and releasing the
+        // in-flight slot, or the caller (a deadline or a lost connection) could never browse this adapter again.
+        try {
+            requireAdapter().browseCancel(requestId);
+        } catch (final RuntimeException e) {
+            log.debug("browseCancel threw during abort; ignoring (best-effort)", e);
+        } finally {
+            reset();
+        }
     }
 
     private void finish() {

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/wrapper/ProtocolAdapterWrapperContext.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/wrapper/ProtocolAdapterWrapperContext.java
@@ -574,11 +574,16 @@ public final class ProtocolAdapterWrapperContext {
             return;
         }
         pendingBrowse = null;
-        browseEngine.abort();
-        pending.completion()
-                .completeExceptionally(new BrowseRejectedException(
-                        BrowseRejectedException.Reason.TIMED_OUT,
-                        "browse on adapter '" + adapterId + "' did not complete before the deadline"));
+        // Complete the REST future in a finally: the caller is waiting on the deadline rejection and must get it
+        // even if abort() were ever to fail. (abort() is itself best-effort, so this is defence in depth.)
+        try {
+            browseEngine.abort();
+        } finally {
+            pending.completion()
+                    .completeExceptionally(new BrowseRejectedException(
+                            BrowseRejectedException.Reason.TIMED_OUT,
+                            "browse on adapter '" + adapterId + "' did not complete before the deadline"));
+        }
     }
 
     /**
@@ -623,11 +628,16 @@ public final class ProtocolAdapterWrapperContext {
         }
         pendingBrowse = null;
         timers.cancel(pending.deadline());
-        browseEngine.abort();
-        pending.completion()
-                .completeExceptionally(new BrowseRejectedException(
-                        BrowseRejectedException.Reason.NOT_CONNECTED,
-                        "adapter '" + adapterId + "' lost its connection before the browse completed"));
+        // Complete the REST future in a finally so a connection-loss rejection is never skipped, and so a throwing
+        // abort() can never propagate out of the state-transition action that calls this.
+        try {
+            browseEngine.abort();
+        } finally {
+            pending.completion()
+                    .completeExceptionally(new BrowseRejectedException(
+                            BrowseRejectedException.Reason.NOT_CONNECTED,
+                            "adapter '" + adapterId + "' lost its connection before the browse completed"));
+        }
     }
 
     // ──────────────────────────────────────────────────────────────────────────────────────────────────────────

--- a/hivemq-edge/src/test/java/com/hivemq/protocols/v2/wrapper/MockProtocolAdapter.java
+++ b/hivemq-edge/src/test/java/com/hivemq/protocols/v2/wrapper/MockProtocolAdapter.java
@@ -71,6 +71,8 @@ final class MockProtocolAdapter implements ProtocolAdapter {
 
     boolean verifyDrop;
 
+    boolean browseCancelThrows;
+
     MockProtocolAdapter(final @NotNull String adapterId, final @NotNull ProtocolAdapterOutput output) {
         this.adapterId = adapterId;
         this.output = output;
@@ -167,5 +169,13 @@ final class MockProtocolAdapter implements ProtocolAdapter {
     @Override
     public void readNodeAttributes(final int requestId, final @NotNull List<Node> nodes) {
         commands.add("readNodeAttributes");
+    }
+
+    @Override
+    public void browseCancel(final int requestId) {
+        commands.add("browseCancel");
+        if (browseCancelThrows) {
+            throw new RuntimeException("browseCancel failed");
+        }
     }
 }

--- a/hivemq-edge/src/test/java/com/hivemq/protocols/v2/wrapper/ProtocolAdapterWrapperBrowseTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/protocols/v2/wrapper/ProtocolAdapterWrapperBrowseTest.java
@@ -126,6 +126,46 @@ class ProtocolAdapterWrapperBrowseTest {
         assertThat(fixture.state()).isEqualTo(ProtocolAdapterWrapperState.WAITING_FOR_CONNECTION_RETRY);
     }
 
+    @Test
+    void browseDeadlineWhenBrowseCancelThrows_stillTimesOutAndReleasesTheSlot() {
+        final WrapperTestFixture fixture = connectedFixture();
+        fixture.adapter.browseCancelThrows = true;
+        final CompletableFuture<List<BrowseNode>> future = new CompletableFuture<>();
+
+        fixture.send(new ProtocolAdapterWrapperBrowseRequest(new BrowseFilter(fixture.nodeFor("temperature")), future));
+        assertThat(future).isNotDone();
+
+        // The deadline fires abort(), which runs the throwing browseCancel; the future must still time out and the
+        // engine must still release the slot — a throwing cancel must not wedge it as permanently ALREADY_IN_FLIGHT.
+        fixture.advance(60_000);
+        assertThat(reasonOf(future)).isEqualTo(BrowseRejectedException.Reason.TIMED_OUT);
+
+        final CompletableFuture<List<BrowseNode>> second = new CompletableFuture<>();
+        fixture.send(new ProtocolAdapterWrapperBrowseRequest(new BrowseFilter(fixture.nodeFor("temperature")), second));
+        assertThat(second)
+                .as("the slot was released, so a fresh browse is accepted")
+                .isNotDone();
+        assertThat(fixture.state()).isEqualTo(ProtocolAdapterWrapperState.CONNECTED);
+    }
+
+    @Test
+    void browseWhenConnectionLostAndBrowseCancelThrows_isFailedCleanly() {
+        final WrapperTestFixture fixture = connectedFixture();
+        fixture.adapter.browseCancelThrows = true;
+        final CompletableFuture<List<BrowseNode>> future = new CompletableFuture<>();
+
+        fixture.send(new ProtocolAdapterWrapperBrowseRequest(new BrowseFilter(fixture.nodeFor("temperature")), future));
+        assertThat(future).isNotDone();
+
+        // Losing the connection aborts the pending browse from inside a state-transition action; a throwing
+        // browseCancel must neither strand the future nor derail the transition to the retry state.
+        fixture.output.disconnected();
+        fixture.drain();
+
+        assertThat(reasonOf(future)).isEqualTo(BrowseRejectedException.Reason.NOT_CONNECTED);
+        assertThat(fixture.state()).isEqualTo(ProtocolAdapterWrapperState.WAITING_FOR_CONNECTION_RETRY);
+    }
+
     private static @NotNull WrapperTestFixture connectedFixture() {
         // skip-verification so the adapter reaches CONNECTED straight away; a wide tick period so the browse
         // deadline test fires exactly one tick.

--- a/modules/hivemq-edge-module-opcua/src/test/java/com/hivemq/edge/adapters/opcua/conformance/ProtocolAdapterBrowseEngineTest.java
+++ b/modules/hivemq-edge-module-opcua/src/test/java/com/hivemq/edge/adapters/opcua/conformance/ProtocolAdapterBrowseEngineTest.java
@@ -16,13 +16,17 @@
 package com.hivemq.edge.adapters.opcua.conformance;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 import com.hivemq.adapter.sdk.api.discovery.NodeType;
 import com.hivemq.adapter.sdk.api.v2.ProtocolAdapter;
 import com.hivemq.adapter.sdk.api.v2.model.BrowseContinuation;
 import com.hivemq.adapter.sdk.api.v2.model.BrowseFilter;
 import com.hivemq.adapter.sdk.api.v2.model.BrowseNode;
+import com.hivemq.adapter.sdk.api.v2.model.ResolvedAttributes;
 import com.hivemq.adapter.sdk.api.v2.model.WriteEntry;
+import com.hivemq.adapter.sdk.api.v2.node.AccessFlags;
+import com.hivemq.adapter.sdk.api.v2.node.AccessTriState;
 import com.hivemq.adapter.sdk.api.v2.node.Node;
 import com.hivemq.protocols.v2.browse.BrowseOutcome;
 import com.hivemq.protocols.v2.browse.ProtocolAdapterBrowseEngine;
@@ -100,10 +104,91 @@ class ProtocolAdapterBrowseEngineTest {
         assertThat(engine.isActive()).isTrue();
     }
 
+    @Test
+    void resolveMissingARequestedNode_failsTheBrowseInsteadOfDroppingIt() {
+        final RecordingAdapter adapter = new RecordingAdapter();
+        final ProtocolAdapterBrowseEngine engine = new ProtocolAdapterBrowseEngine();
+        final BrowseOutcome outcome = new BrowseOutcome();
+        engine.start(adapter, new ConformanceNode("ns=0;i=85"), 0, 0, outcome);
+
+        // Discover one selectable variable; the engine moves to RESOLVE and requests its attributes.
+        final ConformanceNode temperature = new ConformanceNode("ns=1;i=1");
+        engine.onBrowsePage(1, List.of(new BrowseNode(temperature, NodeType.VALUE, true, "temperature")), null);
+        assertThat(adapter.readAttrsCalls).isEqualTo(1);
+
+        // The adapter returns nothing for the requested node. Historically this silently dropped the variable and
+        // completed the browse short; it must now fail the browse instead.
+        engine.onAttributesResolved(1, List.of());
+        assertThat(outcome.isDone()).isTrue();
+        assertThat(outcome.isOk()).isFalse();
+        assertThat(outcome.failure()).contains("missing");
+        assertThat(engine.isActive()).isFalse();
+    }
+
+    @Test
+    void resolveWithAttributesForAnUnrequestedNode_failsTheBrowse() {
+        final RecordingAdapter adapter = new RecordingAdapter();
+        final ProtocolAdapterBrowseEngine engine = new ProtocolAdapterBrowseEngine();
+        final BrowseOutcome outcome = new BrowseOutcome();
+        engine.start(adapter, new ConformanceNode("ns=0;i=85"), 0, 0, outcome);
+
+        engine.onBrowsePage(
+                1, List.of(new BrowseNode(new ConformanceNode("ns=1;i=1"), NodeType.VALUE, true, "temperature")), null);
+
+        engine.onAttributesResolved(1, List.of(attributesFor(new ConformanceNode("ns=9;i=9"))));
+        assertThat(outcome.isOk()).isFalse();
+        assertThat(outcome.failure()).contains("unrequested");
+        assertThat(engine.isActive()).isFalse();
+    }
+
+    @Test
+    void resolveComplete_completesWithTheResolvedVariable() {
+        final RecordingAdapter adapter = new RecordingAdapter();
+        final ProtocolAdapterBrowseEngine engine = new ProtocolAdapterBrowseEngine();
+        final BrowseOutcome outcome = new BrowseOutcome();
+        engine.start(adapter, new ConformanceNode("ns=0;i=85"), 0, 0, outcome);
+
+        final ConformanceNode temperature = new ConformanceNode("ns=1;i=1");
+        engine.onBrowsePage(1, List.of(new BrowseNode(temperature, NodeType.VALUE, true, "temperature")), null);
+        engine.onAttributesResolved(1, List.of(attributesFor(temperature)));
+
+        assertThat(outcome.isOk()).isTrue();
+        assertThat(outcome.result()).hasSize(1);
+        assertThat(engine.isActive()).isFalse();
+    }
+
+    @Test
+    void abort_whenBrowseCancelThrows_stillResetsAndDoesNotPropagate() {
+        final RecordingAdapter adapter = new RecordingAdapter();
+        adapter.browseCancelThrows = true;
+        final ProtocolAdapterBrowseEngine engine = new ProtocolAdapterBrowseEngine();
+        engine.start(adapter, new ConformanceNode("ns=0;i=85"), 0, 0, new BrowseOutcome());
+        assertThat(engine.isActive()).isTrue();
+
+        assertThatCode(engine::abort).doesNotThrowAnyException();
+        assertThat(adapter.browseCancelCalls).isEqualTo(1);
+        assertThat(engine.isActive())
+                .as("the in-flight slot is released even when browseCancel throws")
+                .isFalse();
+    }
+
+    private static @NotNull ResolvedAttributes attributesFor(final @NotNull Node node) {
+        return new ResolvedAttributes(
+                node,
+                "double",
+                AccessFlags.builder()
+                        .readable(AccessTriState.YES)
+                        .pollable(AccessTriState.YES)
+                        .build(),
+                "");
+    }
+
     /** Counts the commands the engine issues; all callbacks are no-ops (the test drives events directly). */
     private static final class RecordingAdapter implements ProtocolAdapter {
         private int browseCalls;
         private int readAttrsCalls;
+        private int browseCancelCalls;
+        private boolean browseCancelThrows;
 
         @Override
         public @NotNull String adapterId() {
@@ -148,6 +233,14 @@ class ProtocolAdapterBrowseEngineTest {
         @Override
         public void readNodeAttributes(final int requestId, final @NotNull List<Node> nodes) {
             readAttrsCalls++;
+        }
+
+        @Override
+        public void browseCancel(final int requestId) {
+            browseCancelCalls++;
+            if (browseCancelThrows) {
+                throw new RuntimeException("browseCancel failed");
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes EDG-784 and EDG-785 from the round-2 review (EDG-779). `hivemq-edge` only.

## EDG-784 — RESOLVE completeness
The browse engine accepted any `readNodeAttributes` result and dropped discovered selectable nodes that had no resolved attributes in `finish()`, returning an incomplete browse as `200 OK` (short, silent). It now tracks the requested node ids per resolve batch and **fails the browse** on a missing, duplicate, or unrequested attribute instead of dropping.

## EDG-785 — abort resilient to a throwing `browseCancel`
`ProtocolAdapterBrowseEngine.abort()` called `browseCancel()` unguarded before `reset()`. A direct adapter throwing from `browseCancel` skipped the reset — wedging the in-flight slot into a permanent `409 ALREADY_IN_FLIGHT` — and skipped the caller's rejection. `browseCancel` is now best-effort with `reset()` in a `finally`; the wrapper completes the REST future in a `finally` on the deadline and connection-loss paths (defence in depth).

## Tests
- Engine: missing / unrequested resolve → browse fails; a complete resolve still succeeds; a throwing `browseCancel` no longer propagates from `abort()` and the slot is released.
- Wrapper: deadline and connection-loss with a throwing `browseCancel` still resolve `TIMED_OUT` / `NOT_CONNECTED`, leave the engine reusable, and keep the transition intact.

Verified locally: compile clean, `ProtocolAdapterWrapperBrowseTest` 7/7, `ProtocolAdapterBrowseEngineTest` 10/10, no regressions in `v2.wrapper.*` (56) or opcua `conformance.*` (18).
