### PR TITLE
EDG-791: Prevent errorprone log listener from wedging the build

### DIFF
--- a/edge-plugins/src/main/kotlin/com/hivemq/errorprone/ErrorProneConventionPlugin.kt
+++ b/edge-plugins/src/main/kotlin/com/hivemq/errorprone/ErrorProneConventionPlugin.kt
@@ -45,7 +45,17 @@ class ErrorProneConventionPlugin : Plugin<Project> {
             }
             logging.addStandardErrorListener { msg ->
                 val reportFile = reportFileProvider.get().asFile
-                reportFile.appendText(msg.toString())
+                // The listener can fire before doFirst runs (or when the task is
+                // UP-TO-DATE / FROM-CACHE and doFirst is skipped), so ensure the
+                // parent directory exists here rather than relying on doFirst. An
+                // I/O failure in a logging listener runs on a Gradle worker thread
+                // and would otherwise wedge the whole build, so it must never escape.
+                try {
+                    reportFile.parentFile.mkdirs()
+                    reportFile.appendText(msg.toString())
+                } catch (_: Exception) {
+                    // Best-effort logging; never fail the build from here.
+                }
             }
         }
     }


### PR DESCRIPTION
The addStandardErrorListener callback appended to the errorprone report file assuming its parent directory existed. When the listener fires while doFirst is skipped (UP-TO-DATE / FROM-CACHE), the directory is absent and appendText throws FileNotFoundException on a Gradle worker thread, which wedges the whole build. Create the parent dir at append time and swallow I/O errors so logging can never fail the build.

**Motivation**

Resolves #<issue>

**Changes**
