### PR TITLE
EDG-803: Validate tag byte-offset layout in the EtherNet/IP – Logical Addressing adapter

### DIFF
--- a/modules/hivemq-edge-module-etherip-cip-odva/src/main/java/com/hivemq/edge/adapters/etherip_cip_odva/config/CipDataType.java
+++ b/modules/hivemq-edge-module-etherip-cip-odva/src/main/java/com/hivemq/edge/adapters/etherip_cip_odva/config/CipDataType.java
@@ -15,6 +15,8 @@
  */
 package com.hivemq.edge.adapters.etherip_cip_odva.config;
 
+import org.jetbrains.annotations.NotNull;
+
 public enum CipDataType {
     BOOL,
     SINT, // 8 bit signed
@@ -34,5 +36,21 @@ public enum CipDataType {
     // DWORD // 32 bit string
     // LWORD // 64 bit string
 
-    COMPOSITE // artificial type to indicate creation of a composite of all tags at given tag address
+    COMPOSITE; // artificial type to indicate creation of a composite of all tags at given tag address
+
+    /**
+     * The fixed number of bytes one element of this type occupies on the wire, or empty if the width is not
+     * statically known. Strings ({@link #SSTRING}/{@link #STRING}) are variable-length (a length prefix plus the
+     * character bytes), and {@link #COMPOSITE} is not a wire type at all, so those return empty. The widths mirror
+     * the encoders (see {@code CipTagEncoders}); this is the single source of truth for byte-layout validation.
+     */
+    public @NotNull java.util.OptionalInt staticByteWidth() {
+        return switch (this) {
+            case BOOL, SINT, USINT -> java.util.OptionalInt.of(1);
+            case INT, UINT -> java.util.OptionalInt.of(2);
+            case DINT, UDINT, REAL -> java.util.OptionalInt.of(4);
+            case LINT, LREAL -> java.util.OptionalInt.of(8);
+            case SSTRING, STRING, COMPOSITE -> java.util.OptionalInt.empty();
+        };
+    }
 }

--- a/modules/hivemq-edge-module-etherip-cip-odva/src/main/java/com/hivemq/edge/adapters/etherip_cip_odva/config/CipDataType.java
+++ b/modules/hivemq-edge-module-etherip-cip-odva/src/main/java/com/hivemq/edge/adapters/etherip_cip_odva/config/CipDataType.java
@@ -15,6 +15,7 @@
  */
 package com.hivemq.edge.adapters.etherip_cip_odva.config;
 
+import java.util.OptionalInt;
 import org.jetbrains.annotations.NotNull;
 
 public enum CipDataType {
@@ -44,13 +45,13 @@ public enum CipDataType {
      * character bytes), and {@link #COMPOSITE} is not a wire type at all, so those return empty. The widths mirror
      * the encoders (see {@code CipTagEncoders}); this is the single source of truth for byte-layout validation.
      */
-    public @NotNull java.util.OptionalInt staticByteWidth() {
+    public @NotNull OptionalInt staticByteWidth() {
         return switch (this) {
-            case BOOL, SINT, USINT -> java.util.OptionalInt.of(1);
-            case INT, UINT -> java.util.OptionalInt.of(2);
-            case DINT, UDINT, REAL -> java.util.OptionalInt.of(4);
-            case LINT, LREAL -> java.util.OptionalInt.of(8);
-            case SSTRING, STRING, COMPOSITE -> java.util.OptionalInt.empty();
+            case BOOL, SINT, USINT -> OptionalInt.of(1);
+            case INT, UINT -> OptionalInt.of(2);
+            case DINT, UDINT, REAL -> OptionalInt.of(4);
+            case LINT, LREAL -> OptionalInt.of(8);
+            case SSTRING, STRING, COMPOSITE -> OptionalInt.empty();
         };
     }
 }

--- a/modules/hivemq-edge-module-etherip-cip-odva/src/main/java/com/hivemq/edge/adapters/etherip_cip_odva/tag/TagGroups.java
+++ b/modules/hivemq-edge-module-etherip-cip-odva/src/main/java/com/hivemq/edge/adapters/etherip_cip_odva/tag/TagGroups.java
@@ -17,12 +17,14 @@ package com.hivemq.edge.adapters.etherip_cip_odva.tag;
 
 import static java.util.Objects.requireNonNull;
 
+import com.hivemq.edge.adapters.etherip_cip_odva.config.CipDataType;
 import com.hivemq.edge.adapters.etherip_cip_odva.config.CipReadWrite;
 import com.hivemq.edge.adapters.etherip_cip_odva.config.tag.CipTag;
 import com.hivemq.edge.adapters.etherip_cip_odva.config.tag.CipTagDefinition;
 import com.hivemq.edge.adapters.etherip_cip_odva.exception.OdvaException;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -65,10 +67,12 @@ public class TagGroups {
         // registration from scratch instead of continuing on stale or half-built groups.
         try {
             for (CipTag cipTag : cipTags) {
+                validateTagDefinition(cipTag);
                 registerTag(cipTag);
             }
             validateDirectionConsistency();
             validateCompositesHaveSiblings();
+            validateNoByteRangeOverlap();
         } catch (final OdvaException e) {
             clear();
             throw e;
@@ -122,6 +126,102 @@ public class TagGroups {
                                 + ") has no scalar siblings to aggregate. A composite needs at least one scalar tag at the same address and direction.");
             }
         }
+    }
+
+    /**
+     * Per-tag sanity checks on the byte-layout fields. These are cheap, device-independent, and reject configs
+     * that cannot describe a valid field: a {@code batchByteIndex} must be non-negative, {@code numberOfElements}
+     * at least one, and a {@code batchBitIndex} (when set) must be a real bit position 0–7. The JSON schema
+     * declares these bounds too, but that is only a UI/schema hint and is not enforced on the config/REST parse
+     * path, so a config with e.g. {@code batchBitIndex=8} reaches here unchecked; reject it explicitly.
+     */
+    private void validateTagDefinition(final @NotNull CipTag cipTag) throws OdvaException {
+        final CipTagDefinition definition = cipTag.getDefinition();
+        if (definition.getBatchByteIndex() < 0) {
+            throw new OdvaException("Tag '"
+                    + cipTag.getName()
+                    + "' has a negative batchByteIndex "
+                    + definition.getBatchByteIndex()
+                    + ". The byte index of a tag within its attribute must be 0 or greater.");
+        }
+        if (definition.getNumberOfElements() < 1) {
+            throw new OdvaException("Tag '"
+                    + cipTag.getName()
+                    + "' has numberOfElements "
+                    + definition.getNumberOfElements()
+                    + ". A tag must hold at least one element.");
+        }
+        final Integer bitIndex = definition.getBatchBitIndex();
+        if (bitIndex != null && (bitIndex < 0 || bitIndex > 7)) {
+            throw new OdvaException("Tag '"
+                    + cipTag.getName()
+                    + "' has batchBitIndex "
+                    + bitIndex
+                    + ". A bit index must be between 0 and 7 (a byte has 8 bits).");
+        }
+    }
+
+    /**
+     * Within a {@code (address, readWrite)} group, no two tags may claim overlapping bytes of the attribute. Two
+     * tags whose byte ranges overlap decode from the same bytes (silently wrong data) and, for a writable group,
+     * <em>corrupt each other on write</em> — a {@code PARTIAL_WRITE} read-modify-write or a {@code COMPLETE_WRITE}
+     * lays their bytes down over the same region, last-writer-wins, with no warning. Reject that at registration.
+     * <p>
+     * A tag's range is {@code [batchByteIndex, batchByteIndex + width * numberOfElements)}, where {@code width}
+     * is the type's {@link CipDataType#staticByteWidth() static byte width}. Two cases are deliberately excluded:
+     * <ul>
+     *   <li><b>Strings</b> ({@code SSTRING}/{@code STRING}) have no static width — their length is only known at
+     *       write/read time — so their span cannot be checked up front and they are skipped here.</li>
+     *   <li><b>Bit-addressed {@code BOOL}s</b> (a {@code BOOL} with a {@code batchBitIndex}) occupy a single bit,
+     *       so several may legitimately share one byte at different bit positions; they are not byte-overlaps.</li>
+     * </ul>
+     * The composite tag itself carries no bytes (it aggregates its siblings), so it is not considered here.
+     */
+    private void validateNoByteRangeOverlap() throws OdvaException {
+        for (final TagGroup tagGroup : tagAddressToTagGroup.values()) {
+            final List<CipTag> byteRangedTags = tagGroup.getTags().stream()
+                    .filter(TagGroups::occupiesAStaticByteRange)
+                    .toList();
+            for (int i = 0; i < byteRangedTags.size(); i++) {
+                for (int j = i + 1; j < byteRangedTags.size(); j++) {
+                    final CipTag a = byteRangedTags.get(i);
+                    final CipTag b = byteRangedTags.get(j);
+                    if (byteRangesOverlap(a, b)) {
+                        throw new OdvaException("Tags '"
+                                + a.getName()
+                                + "' and '"
+                                + b.getName()
+                                + "' at address "
+                                + tagGroup.getTagAddress()
+                                + " ("
+                                + tagGroup.getReadWrite()
+                                + ") claim overlapping bytes of the attribute. Each field of an attribute must occupy a"
+                                + " distinct byte range; overlapping tags read the same bytes and corrupt each other on"
+                                + " write.");
+                    }
+                }
+            }
+        }
+    }
+
+    /** A tag occupies a checkable byte range if its type has a static width and it is not a bit-addressed BOOL. */
+    private static boolean occupiesAStaticByteRange(final @NotNull CipTag cipTag) {
+        final CipTagDefinition definition = cipTag.getDefinition();
+        final boolean bitAddressedBool =
+                definition.getDataType() == CipDataType.BOOL && definition.getBatchBitIndex() != null;
+        return definition.getDataType().staticByteWidth().isPresent() && !bitAddressedBool;
+    }
+
+    private static boolean byteRangesOverlap(final @NotNull CipTag a, final @NotNull CipTag b) {
+        final int aStart = a.getDefinition().getBatchByteIndex();
+        final int aEnd = aStart
+                + a.getDefinition().getDataType().staticByteWidth().getAsInt()
+                        * a.getDefinition().getNumberOfElements();
+        final int bStart = b.getDefinition().getBatchByteIndex();
+        final int bEnd = bStart
+                + b.getDefinition().getDataType().staticByteWidth().getAsInt()
+                        * b.getDefinition().getNumberOfElements();
+        return aStart < bEnd && bStart < aEnd;
     }
 
     private @NotNull TagGroup getOrCreateTagGroup(final @NotNull CipTagDefinition definition) throws OdvaException {

--- a/modules/hivemq-edge-module-etherip-cip-odva/src/test/java/com/hivemq/edge/adapters/etherip_cip_odva/tag/TagGroupsTest.java
+++ b/modules/hivemq-edge-module-etherip-cip-odva/src/test/java/com/hivemq/edge/adapters/etherip_cip_odva/tag/TagGroupsTest.java
@@ -37,8 +37,9 @@ class TagGroupsTest {
 
         CipTag batch1 =
                 new CipTag("batch1", "batch1", new CipTagDefinition("@1/2/3", 1, CipDataType.INT, 1d, null, 0, null));
+        // batch2 starts at byte 2, just past batch1's INT (bytes 0-1), so the two do not overlap.
         CipTag batch2 =
-                new CipTag("batch2", "batch2", new CipTagDefinition("@1/2/3", 1, CipDataType.SINT, 1d, null, 1, null));
+                new CipTag("batch2", "batch2", new CipTagDefinition("@1/2/3", 1, CipDataType.SINT, 1d, null, 2, null));
         CipTag single =
                 new CipTag("single", "single", new CipTagDefinition("@1/2/4", 1, CipDataType.INT, 1d, null, 0, null));
 
@@ -207,6 +208,96 @@ class TagGroupsTest {
         Assertions.assertThat(tagGroups.getTagGroups()).hasSize(1);
         Assertions.assertThat(tagGroups.getTagGroups().iterator().next().getTags())
                 .containsExactly(valid);
+    }
+
+    @Test
+    void shouldRejectNegativeBatchByteIndex() {
+        final TagGroups tagGroups = new TagGroups();
+        final CipTag bad = layoutTag("bad", "@1/2/3", CipDataType.INT, 1, -1, null);
+        Assertions.assertThatThrownBy(() -> tagGroups.registerTagsIfEmpty(List.of(bad)))
+                .isInstanceOf(OdvaException.class)
+                .hasMessageContaining("negative batchByteIndex");
+    }
+
+    @Test
+    void shouldRejectZeroNumberOfElements() {
+        final TagGroups tagGroups = new TagGroups();
+        final CipTag bad = layoutTag("bad", "@1/2/3", CipDataType.INT, 0, 0, null);
+        Assertions.assertThatThrownBy(() -> tagGroups.registerTagsIfEmpty(List.of(bad)))
+                .isInstanceOf(OdvaException.class)
+                .hasMessageContaining("at least one element");
+    }
+
+    @Test
+    void shouldRejectBitIndexAboveSeven() {
+        final TagGroups tagGroups = new TagGroups();
+        final CipTag bad = layoutTag("bad", "@1/2/3", CipDataType.BOOL, 1, 0, 8);
+        Assertions.assertThatThrownBy(() -> tagGroups.registerTagsIfEmpty(List.of(bad)))
+                .isInstanceOf(OdvaException.class)
+                .hasMessageContaining("bit index must be between 0 and 7");
+    }
+
+    @Test
+    void shouldRejectTwoTagsClaimingTheSameByte() {
+        final TagGroups tagGroups = new TagGroups();
+        final CipTag a = layoutTag("a", "@1/2/3", CipDataType.SINT, 1, 0, null);
+        final CipTag b = layoutTag("b", "@1/2/3", CipDataType.SINT, 1, 0, null);
+        Assertions.assertThatThrownBy(() -> tagGroups.registerTagsIfEmpty(List.of(a, b)))
+                .isInstanceOf(OdvaException.class)
+                .hasMessageContaining("overlapping bytes");
+    }
+
+    @Test
+    void shouldRejectTwoTagsWithOverlappingRanges() {
+        final TagGroups tagGroups = new TagGroups();
+        // INT covers bytes 0-1; the SINT at byte 1 lands inside it.
+        final CipTag wide = layoutTag("wide", "@1/2/3", CipDataType.INT, 1, 0, null);
+        final CipTag inside = layoutTag("inside", "@1/2/3", CipDataType.SINT, 1, 1, null);
+        Assertions.assertThatThrownBy(() -> tagGroups.registerTagsIfEmpty(List.of(wide, inside)))
+                .isInstanceOf(OdvaException.class)
+                .hasMessageContaining("overlapping bytes");
+    }
+
+    @Test
+    void shouldAcceptAdjacentNonOverlappingTags() throws OdvaException {
+        final TagGroups tagGroups = new TagGroups();
+        final CipTag first = layoutTag("first", "@1/2/3", CipDataType.INT, 1, 0, null); // bytes 0-1
+        final CipTag second = layoutTag("second", "@1/2/3", CipDataType.SINT, 1, 2, null); // byte 2
+        Assertions.assertThat(tagGroups.registerTagsIfEmpty(List.of(first, second)))
+                .isTrue();
+    }
+
+    @Test
+    void shouldAcceptSeveralBoolsSharingAByteAtDifferentBits() throws OdvaException {
+        final TagGroups tagGroups = new TagGroups();
+        final CipTag bit0 = layoutTag("bit0", "@1/2/3", CipDataType.BOOL, 1, 0, 0);
+        final CipTag bit1 = layoutTag("bit1", "@1/2/3", CipDataType.BOOL, 1, 0, 1);
+        final CipTag bit7 = layoutTag("bit7", "@1/2/3", CipDataType.BOOL, 1, 0, 7);
+        Assertions.assertThat(tagGroups.registerTagsIfEmpty(List.of(bit0, bit1, bit7)))
+                .isTrue();
+    }
+
+    @Test
+    void shouldNotOverlapCheckStringsWithoutStaticWidth() throws OdvaException {
+        // Strings have no static width, so their span cannot be checked and they must not be rejected as overlaps.
+        final TagGroups tagGroups = new TagGroups();
+        final CipTag stringA = layoutTag("stringA", "@1/2/3", CipDataType.STRING, 1, 0, null);
+        final CipTag stringB = layoutTag("stringB", "@1/2/3", CipDataType.SSTRING, 1, 0, null);
+        Assertions.assertThat(tagGroups.registerTagsIfEmpty(List.of(stringA, stringB)))
+                .isTrue();
+    }
+
+    private static CipTag layoutTag(
+            final String name,
+            final String address,
+            final CipDataType dataType,
+            final int numberOfElements,
+            final int batchByteIndex,
+            final Integer batchBitIndex) {
+        return new CipTag(
+                name,
+                name,
+                new CipTagDefinition(address, numberOfElements, dataType, 0d, null, batchByteIndex, batchBitIndex));
     }
 
     private static CipTag tag(final String name, final String address, final CipReadWrite rw, final CipWriteMode wm) {


### PR DESCRIPTION
## Description (the why)
Tag byte offsets in the EtherNet/IP – Logical Addressing adapter were accepted without any validation, so nonsensical layouts passed silently. The dangerous case is two tags at the **same attribute and direction** claiming **overlapping bytes**: on write they corrupt each other (last-writer-wins, no warning); on read they decode the same bytes into different fields. Found in QA by Estefania Amundaray (finding 2 on EDG-777).

Linear: EDG-803.

## Acceptance Criteria (the what)
- [x] Per-tag validation at registration: `batchByteIndex >= 0`, `numberOfElements >= 1`, `batchBitIndex` in 0–7.
- [x] Per `(address, direction)` group: reject tags whose byte ranges `[batchByteIndex, batchByteIndex + width * numberOfElements)` overlap.
- [x] Byte width from a single source of truth (`CipDataType.staticByteWidth()`, mirroring the encoders).
- [x] Strings (no static width) and bit-addressed BOOLs (share a byte at different bits) are correctly **not** treated as overlaps.
- [x] Tags at different attributes or different directions are never compared (they are independent operations).
- [x] Unit tests for each reject case and the legitimate non-overlap cases; all EIP integration tests stay green.

## Non-Goals
- Validating a byte offset **past the end of the attribute**: a generic CIP device does not expose an attribute's size, so this is only detectable at read/write time (handled there), not at config time.
- Findings 1 and 3 from the QA pass (separate issues: EDG-791 packaging, and runtime-vs-startup validation consistency).