### PR TITLE
fix(EDG-784,EDG-785): browse RESOLVE completeness + abort resilient to a throwing browseCancel

### DIFF
--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/browse/ProtocolAdapterBrowseEngine.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/browse/ProtocolAdapterBrowseEngine.java
@@ -106,6 +106,7 @@ public final class ProtocolAdapterBrowseEngine {
     private final @NotNull Map<String, String> pathByNode = new HashMap<>();
     private final @NotNull Map<String, String> tagNameByNode = new HashMap<>();
     private final @NotNull Map<String, ResolvedAttributes> resolvedByNode = new HashMap<>();
+    private final @NotNull List<String> pendingResolveBatch = new ArrayList<>();
     private int resolveOffset;
 
     /**
@@ -169,6 +170,7 @@ public final class ProtocolAdapterBrowseEngine {
         pathByNode.clear();
         tagNameByNode.clear();
         resolvedByNode.clear();
+        pendingResolveBatch.clear();
         resolveOffset = 0;
         activePath = "";
         activeContinuation = null;
@@ -259,8 +261,10 @@ public final class ProtocolAdapterBrowseEngine {
         }
         final int end = Math.min(resolveOffset + RESOLVE_BATCH, sorted.size());
         final List<Node> batch = new ArrayList<>(end - resolveOffset);
+        pendingResolveBatch.clear();
         for (final DiscoveredVariable variable : sorted.subList(resolveOffset, end)) {
             batch.add(variable.node());
+            pendingResolveBatch.add(variable.node().nodeId());
         }
         resolveOffset = end;
         resolveBatches++;
@@ -270,6 +274,11 @@ public final class ProtocolAdapterBrowseEngine {
     /**
      * Consume one RESOLVE batch result. Ignored when not resolving or the result carries a superseded
      * {@code requestId}.
+     * <p>
+     * The batch must resolve <b>exactly and completely</b>: one attribute per requested node, with no missing,
+     * duplicate, or unrequested node. A short, padded, or foreign result would otherwise silently drop a discovered
+     * <i>selectable</i> node from an apparently-successful browse (the operator would see a {@code 200 OK} with fewer
+     * tags than exist on the device). Any such mismatch fails the whole browse through the sink instead of dropping.
      *
      * @param requestId  the browse this batch belongs to.
      * @param attributes the resolved attributes, one per requested node.
@@ -278,10 +287,36 @@ public final class ProtocolAdapterBrowseEngine {
         if (phase != Phase.RESOLVING || requestId != this.requestId) {
             return;
         }
+        final Set<String> requested = new HashSet<>(pendingResolveBatch);
+        final Set<String> outstanding = new HashSet<>(requested);
         for (final ResolvedAttributes attribute : attributes) {
-            resolvedByNode.put(attribute.node().nodeId(), attribute);
+            final String nodeId = attribute.node().nodeId();
+            if (!requested.contains(nodeId)) {
+                failBrowse("attribute for unrequested node '" + nodeId + "'");
+                return;
+            }
+            if (!outstanding.remove(nodeId)) {
+                failBrowse("duplicate attribute for node '" + nodeId + "'");
+                return;
+            }
+            resolvedByNode.put(nodeId, attribute);
+        }
+        if (!outstanding.isEmpty()) {
+            failBrowse("missing attributes for requested node(s) " + missingInRequestOrder(outstanding));
+            return;
         }
         readNextBatch();
+    }
+
+    /** The still-unresolved node ids of the active batch, in the order they were requested (a stable error message). */
+    private @NotNull List<String> missingInRequestOrder(final @NotNull Set<String> outstanding) {
+        final List<String> missing = new ArrayList<>(outstanding.size());
+        for (final String nodeId : pendingResolveBatch) {
+            if (outstanding.contains(nodeId)) {
+                missing.add(nodeId);
+            }
+        }
+        return missing;
     }
 
     // ── termination ───────────────────────────────────────────────────────────────────────────────────────
@@ -297,6 +332,11 @@ public final class ProtocolAdapterBrowseEngine {
         if (!isActive() || requestId != this.requestId) {
             return;
         }
+        failBrowse(reason);
+    }
+
+    /** Terminate the in-flight browse as failed — tag the reason with the phase it failed in, then go idle. */
+    private void failBrowse(final @NotNull String reason) {
         final Phase failedIn = phase;
         phase = Phase.IDLE;
         requireSink().fail(failedIn + ": " + reason);

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/browse/ProtocolAdapterBrowseEngine.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/browse/ProtocolAdapterBrowseEngine.java
@@ -32,6 +32,8 @@ import java.util.Map;
 import java.util.Set;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The single browse traversal engine — the policy the framework's PAW drives in production <b>and</b> the
@@ -67,6 +69,8 @@ import org.jetbrains.annotations.Nullable;
  * surface it.
  */
 public final class ProtocolAdapterBrowseEngine {
+
+    private static final @NotNull Logger log = LoggerFactory.getLogger(ProtocolAdapterBrowseEngine.class);
 
     /** Discovered variables are attribute-read in batches of this size. */
     public static final int RESOLVE_BATCH = 100;
@@ -302,13 +306,26 @@ public final class ProtocolAdapterBrowseEngine {
      * Abort an in-flight browse on an external interruption (a caller deadline or a lost connection): issue
      * {@link ProtocolAdapter#browseCancel(int)} so the device releases any open continuation point, then reset.
      * Does not call the sink — the caller surfaces the interruption. A no-op when no browse is in flight.
+     * <p>
+     * {@code browseCancel} is a best-effort courtesy to the device: a raw adapter that does real synchronous work
+     * there may throw, but the framework must not trust an adapter callback. The throw is caught and logged, and the
+     * engine is reset in a {@code finally} so the in-flight slot is always released — otherwise a throwing cancel
+     * would strand the engine {@link #isActive() active} forever and every later browse on that adapter would be
+     * rejected as already in flight.
      */
     public void abort() {
         if (!isActive()) {
             return;
         }
-        requireAdapter().browseCancel(requestId);
-        reset();
+        try {
+            requireAdapter().browseCancel(requestId);
+        } catch (final Exception cancelFailure) {
+            log.warn(
+                    "browseCancel while aborting a browse threw; releasing the in-flight slot regardless",
+                    cancelFailure);
+        } finally {
+            reset();
+        }
     }
 
     private void finish() {

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/wrapper/ProtocolAdapterWrapperContext.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/wrapper/ProtocolAdapterWrapperContext.java
@@ -574,11 +574,16 @@ public final class ProtocolAdapterWrapperContext {
             return;
         }
         pendingBrowse = null;
-        browseEngine.abort();
-        pending.completion()
-                .completeExceptionally(new BrowseRejectedException(
-                        BrowseRejectedException.Reason.TIMED_OUT,
-                        "browse on adapter '" + adapterId + "' did not complete before the deadline"));
+        // abort() is best-effort and self-resetting; complete the REST future in a finally so the caller is always
+        // released with the intended rejection even if the engine's abort ever throws.
+        try {
+            browseEngine.abort();
+        } finally {
+            pending.completion()
+                    .completeExceptionally(new BrowseRejectedException(
+                            BrowseRejectedException.Reason.TIMED_OUT,
+                            "browse on adapter '" + adapterId + "' did not complete before the deadline"));
+        }
     }
 
     /**
@@ -623,11 +628,17 @@ public final class ProtocolAdapterWrapperContext {
         }
         pendingBrowse = null;
         timers.cancel(pending.deadline());
-        browseEngine.abort();
-        pending.completion()
-                .completeExceptionally(new BrowseRejectedException(
-                        BrowseRejectedException.Reason.NOT_CONNECTED,
-                        "adapter '" + adapterId + "' lost its connection before the browse completed"));
+        // Called from an FSM transition action: abort() must never let an adapter's throwing browseCancel escape into
+        // the tick loop, and the future must still be completed. abort() swallows the throw; the finally guarantees
+        // the completion regardless.
+        try {
+            browseEngine.abort();
+        } finally {
+            pending.completion()
+                    .completeExceptionally(new BrowseRejectedException(
+                            BrowseRejectedException.Reason.NOT_CONNECTED,
+                            "adapter '" + adapterId + "' lost its connection before the browse completed"));
+        }
     }
 
     // ──────────────────────────────────────────────────────────────────────────────────────────────────────────

--- a/hivemq-edge/src/test/java/com/hivemq/protocols/v2/wrapper/MockProtocolAdapter.java
+++ b/hivemq-edge/src/test/java/com/hivemq/protocols/v2/wrapper/MockProtocolAdapter.java
@@ -71,6 +71,9 @@ final class MockProtocolAdapter implements ProtocolAdapter {
 
     boolean verifyDrop;
 
+    /** When set, {@link #browseCancel(int)} does real synchronous work that throws — the raw-adapter case EDG-785. */
+    boolean browseCancelThrows;
+
     MockProtocolAdapter(final @NotNull String adapterId, final @NotNull ProtocolAdapterOutput output) {
         this.adapterId = adapterId;
         this.output = output;
@@ -162,6 +165,14 @@ final class MockProtocolAdapter implements ProtocolAdapter {
     @Override
     public void browseNext(final int requestId, final @NotNull BrowseContinuation continuation) {
         commands.add("browseNext");
+    }
+
+    @Override
+    public void browseCancel(final int requestId) {
+        commands.add("browseCancel");
+        if (browseCancelThrows) {
+            throw new IllegalStateException("browseCancel failed");
+        }
     }
 
     @Override

--- a/hivemq-edge/src/test/java/com/hivemq/protocols/v2/wrapper/ProtocolAdapterWrapperBrowseTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/protocols/v2/wrapper/ProtocolAdapterWrapperBrowseTest.java
@@ -170,6 +170,47 @@ class ProtocolAdapterWrapperBrowseTest {
         assertThat(fixture.defensiveResets()).isZero();
     }
 
+    @Test
+    void browseWithAnIncompleteResolveResult_failsInsteadOfReturningAShort200() {
+        // EDG-784: two selectable variables are discovered but the adapter resolves only one; the browse must fail
+        // (the REST layer maps it to an error) rather than complete 200 OK with the second variable silently dropped.
+        final WrapperTestFixture fixture = connectedFixture();
+        final CompletableFuture<List<BrowseNode>> future = new CompletableFuture<>();
+
+        fixture.send(
+                new ProtocolAdapterWrapperBrowseRequest(new BrowseFilter(WrapperTestSupport.node("root")), future));
+
+        fixture.output.browsePage(
+                1,
+                List.of(
+                        new BrowseNode(WrapperTestSupport.node("temperature"), NodeType.VALUE, true, "temperature"),
+                        new BrowseNode(WrapperTestSupport.node("pressure"), NodeType.VALUE, true, "pressure")),
+                null);
+        fixture.drain();
+        assertThat(fixture.commands()).contains("readNodeAttributes");
+        assertThat(future).isNotDone();
+
+        // resolve only "temperature", omitting "pressure".
+        fixture.output.readAttributesResult(
+                1,
+                List.of(new ResolvedAttributes(
+                        WrapperTestSupport.node("temperature"),
+                        "double",
+                        AccessFlags.builder()
+                                .readable(AccessTriState.YES)
+                                .pollable(AccessTriState.YES)
+                                .build(),
+                        "")));
+        fixture.drain();
+
+        assertThat(reasonOf(future)).isEqualTo(BrowseRejectedException.Reason.FAILED);
+        // the slot is released: the adapter stays CONNECTED and a fresh browse is accepted.
+        assertThat(fixture.state()).isEqualTo(ProtocolAdapterWrapperState.CONNECTED);
+        final CompletableFuture<List<BrowseNode>> next = new CompletableFuture<>();
+        fixture.send(new ProtocolAdapterWrapperBrowseRequest(new BrowseFilter(fixture.nodeFor("temperature")), next));
+        assertThat(next).isNotDone();
+    }
+
     private static @NotNull WrapperTestFixture connectedFixture() {
         // skip-verification so the adapter reaches CONNECTED straight away; a wide tick period so the browse
         // deadline test fires exactly one tick.

--- a/hivemq-edge/src/test/java/com/hivemq/protocols/v2/wrapper/ProtocolAdapterWrapperBrowseTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/protocols/v2/wrapper/ProtocolAdapterWrapperBrowseTest.java
@@ -126,6 +126,50 @@ class ProtocolAdapterWrapperBrowseTest {
         assertThat(fixture.state()).isEqualTo(ProtocolAdapterWrapperState.WAITING_FOR_CONNECTION_RETRY);
     }
 
+    @Test
+    void browseDeadlineWithAThrowingBrowseCancel_stillTimesOutAndReleasesTheSlot() {
+        // EDG-785: the deadline aborts the engine, which issues browseCancel; a raw adapter that throws there must
+        // not skip the caller's TIMED_OUT rejection nor wedge the in-flight slot on a permanent 409.
+        final WrapperTestFixture fixture = connectedFixture();
+        fixture.adapter.browseCancelThrows = true;
+        final CompletableFuture<List<BrowseNode>> future = new CompletableFuture<>();
+
+        fixture.send(new ProtocolAdapterWrapperBrowseRequest(new BrowseFilter(fixture.nodeFor("temperature")), future));
+        assertThat(future).isNotDone();
+
+        fixture.advance(60_000);
+
+        assertThat(fixture.commands()).contains("browseCancel");
+        assertThat(reasonOf(future)).isEqualTo(BrowseRejectedException.Reason.TIMED_OUT);
+        assertThat(fixture.state()).isEqualTo(ProtocolAdapterWrapperState.CONNECTED);
+
+        // the slot was genuinely released: the next browse is accepted, not rejected as already in flight.
+        final CompletableFuture<List<BrowseNode>> next = new CompletableFuture<>();
+        fixture.send(new ProtocolAdapterWrapperBrowseRequest(new BrowseFilter(fixture.nodeFor("temperature")), next));
+        assertThat(next).isNotDone();
+    }
+
+    @Test
+    void connectionLossWithAThrowingBrowseCancel_stillFailsNotConnectedAndDoesNotWedgeTheFsm() {
+        // EDG-785: connection loss aborts the pending browse from an FSM transition action; a throwing browseCancel
+        // must be swallowed (never escaping into the tick/FSM loop) and the caller still rejected NOT_CONNECTED.
+        final WrapperTestFixture fixture = connectedFixture();
+        fixture.adapter.browseCancelThrows = true;
+        final CompletableFuture<List<BrowseNode>> future = new CompletableFuture<>();
+
+        fixture.send(new ProtocolAdapterWrapperBrowseRequest(new BrowseFilter(fixture.nodeFor("temperature")), future));
+        assertThat(future).isNotDone();
+
+        fixture.output.disconnected();
+        fixture.drain();
+
+        assertThat(fixture.commands()).contains("browseCancel");
+        assertThat(reasonOf(future)).isEqualTo(BrowseRejectedException.Reason.NOT_CONNECTED);
+        // the FSM advanced normally rather than tripping a defensive reset from an escaped exception.
+        assertThat(fixture.state()).isEqualTo(ProtocolAdapterWrapperState.WAITING_FOR_CONNECTION_RETRY);
+        assertThat(fixture.defensiveResets()).isZero();
+    }
+
     private static @NotNull WrapperTestFixture connectedFixture() {
         // skip-verification so the adapter reaches CONNECTED straight away; a wide tick period so the browse
         // deadline test fires exactly one tick.

--- a/modules/hivemq-edge-module-opcua/src/test/java/com/hivemq/edge/adapters/opcua/conformance/ProtocolAdapterBrowseEngineTest.java
+++ b/modules/hivemq-edge-module-opcua/src/test/java/com/hivemq/edge/adapters/opcua/conformance/ProtocolAdapterBrowseEngineTest.java
@@ -23,7 +23,10 @@ import com.hivemq.adapter.sdk.api.v2.ProtocolAdapter;
 import com.hivemq.adapter.sdk.api.v2.model.BrowseContinuation;
 import com.hivemq.adapter.sdk.api.v2.model.BrowseFilter;
 import com.hivemq.adapter.sdk.api.v2.model.BrowseNode;
+import com.hivemq.adapter.sdk.api.v2.model.ResolvedAttributes;
 import com.hivemq.adapter.sdk.api.v2.model.WriteEntry;
+import com.hivemq.adapter.sdk.api.v2.node.AccessFlags;
+import com.hivemq.adapter.sdk.api.v2.node.AccessTriState;
 import com.hivemq.adapter.sdk.api.v2.node.Node;
 import com.hivemq.protocols.v2.browse.BrowseOutcome;
 import com.hivemq.protocols.v2.browse.ProtocolAdapterBrowseEngine;
@@ -123,6 +126,88 @@ class ProtocolAdapterBrowseEngineTest {
         assertThatCode(() -> engine.start(adapter, new ConformanceNode("ns=0;i=85"), 0, 0, outcome))
                 .doesNotThrowAnyException();
         assertThat(engine.isActive()).isTrue();
+    }
+
+    @Test
+    void onAttributesResolved_completeBatch_completesTheBrowseWithEveryDiscoveredVariable() {
+        // EDG-784 happy path: every requested node resolved exactly once ⇒ the browse completes with both variables.
+        final RecordingAdapter adapter = new RecordingAdapter();
+        final ProtocolAdapterBrowseEngine engine = new ProtocolAdapterBrowseEngine();
+        final BrowseOutcome outcome = new BrowseOutcome();
+        engine.start(adapter, new ConformanceNode("ns=0;i=85"), 0, 0, outcome);
+        discoverTwoVariables(engine);
+
+        engine.onAttributesResolved(1, List.of(attributes("ns=1;i=1"), attributes("ns=1;i=2")));
+
+        assertThat(outcome.isDone()).isTrue();
+        assertThat(outcome.isOk()).isTrue();
+        assertThat(outcome.result()).hasSize(2);
+        assertThat(engine.isActive()).isFalse();
+    }
+
+    @Test
+    void onAttributesResolved_withAMissingAttribute_failsTheBrowseInsteadOfDroppingTheNode() {
+        // EDG-784: a well-behaved adapter that browses a node as selectable but returns no attribute for it (e.g. a
+        // denied attribute read) must not vanish from an apparently-successful browse — the whole browse fails.
+        final RecordingAdapter adapter = new RecordingAdapter();
+        final ProtocolAdapterBrowseEngine engine = new ProtocolAdapterBrowseEngine();
+        final BrowseOutcome outcome = new BrowseOutcome();
+        engine.start(adapter, new ConformanceNode("ns=0;i=85"), 0, 0, outcome);
+        discoverTwoVariables(engine);
+
+        engine.onAttributesResolved(1, List.of(attributes("ns=1;i=1")));
+
+        assertThat(outcome.isOk()).isFalse();
+        assertThat(outcome.failure()).contains("missing").contains("ns=1;i=2");
+        assertThat(engine.isActive()).isFalse();
+    }
+
+    @Test
+    void onAttributesResolved_withADuplicateAttribute_failsTheBrowse() {
+        final RecordingAdapter adapter = new RecordingAdapter();
+        final ProtocolAdapterBrowseEngine engine = new ProtocolAdapterBrowseEngine();
+        final BrowseOutcome outcome = new BrowseOutcome();
+        engine.start(adapter, new ConformanceNode("ns=0;i=85"), 0, 0, outcome);
+        discoverTwoVariables(engine);
+
+        engine.onAttributesResolved(1, List.of(attributes("ns=1;i=1"), attributes("ns=1;i=1")));
+
+        assertThat(outcome.isOk()).isFalse();
+        assertThat(outcome.failure()).contains("duplicate").contains("ns=1;i=1");
+        assertThat(engine.isActive()).isFalse();
+    }
+
+    @Test
+    void onAttributesResolved_withAnUnrequestedAttribute_failsTheBrowse() {
+        final RecordingAdapter adapter = new RecordingAdapter();
+        final ProtocolAdapterBrowseEngine engine = new ProtocolAdapterBrowseEngine();
+        final BrowseOutcome outcome = new BrowseOutcome();
+        engine.start(adapter, new ConformanceNode("ns=0;i=85"), 0, 0, outcome);
+        discoverTwoVariables(engine);
+
+        engine.onAttributesResolved(1, List.of(attributes("ns=1;i=1"), attributes("ns=9;i=99")));
+
+        assertThat(outcome.isOk()).isFalse();
+        assertThat(outcome.failure()).contains("unrequested").contains("ns=9;i=99");
+        assertThat(engine.isActive()).isFalse();
+    }
+
+    /** Drive one DISCOVER page carrying two selectable variables (ns=1;i=1, ns=1;i=2) into a single RESOLVE batch. */
+    private static void discoverTwoVariables(final @NotNull ProtocolAdapterBrowseEngine engine) {
+        engine.onBrowsePage(
+                1,
+                List.of(
+                        new BrowseNode(new ConformanceNode("ns=1;i=1"), NodeType.VALUE, true, "a"),
+                        new BrowseNode(new ConformanceNode("ns=1;i=2"), NodeType.VALUE, true, "b")),
+                null);
+    }
+
+    private static @NotNull ResolvedAttributes attributes(final @NotNull String nodeId) {
+        return new ResolvedAttributes(
+                new ConformanceNode(nodeId),
+                "double",
+                AccessFlags.builder().readable(AccessTriState.YES).build(),
+                "");
     }
 
     /** Counts the commands the engine issues; all callbacks are no-ops (the test drives events directly). */

--- a/modules/hivemq-edge-module-opcua/src/test/java/com/hivemq/edge/adapters/opcua/conformance/ProtocolAdapterBrowseEngineTest.java
+++ b/modules/hivemq-edge-module-opcua/src/test/java/com/hivemq/edge/adapters/opcua/conformance/ProtocolAdapterBrowseEngineTest.java
@@ -16,6 +16,7 @@
 package com.hivemq.edge.adapters.opcua.conformance;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 import com.hivemq.adapter.sdk.api.discovery.NodeType;
 import com.hivemq.adapter.sdk.api.v2.ProtocolAdapter;
@@ -100,10 +101,36 @@ class ProtocolAdapterBrowseEngineTest {
         assertThat(engine.isActive()).isTrue();
     }
 
+    @Test
+    void abort_withAThrowingBrowseCancel_swallowsTheThrowAndStillReleasesTheSlot() {
+        // EDG-785: a raw adapter that does real synchronous work in browseCancel and throws must not strand the
+        // engine active — otherwise every later browse on that adapter is rejected as already in flight.
+        final RecordingAdapter adapter = new RecordingAdapter();
+        adapter.browseCancelThrows = true;
+        final ProtocolAdapterBrowseEngine engine = new ProtocolAdapterBrowseEngine();
+        engine.start(adapter, new ConformanceNode("ns=0;i=85"), 0, 0, new BrowseOutcome());
+        assertThat(engine.isActive()).isTrue();
+
+        // abort() issues browseCancel (which throws) but the throw is swallowed and the slot released in a finally.
+        assertThatCode(engine::abort).doesNotThrowAnyException();
+        assertThat(adapter.browseCancelCalls).as("browseCancel was attempted").isEqualTo(1);
+        assertThat(engine.isActive())
+                .as("slot released despite the throwing cancel")
+                .isFalse();
+
+        // the slot is genuinely reusable: a fresh browse starts cleanly rather than tripping the in-flight guard.
+        final BrowseOutcome outcome = new BrowseOutcome();
+        assertThatCode(() -> engine.start(adapter, new ConformanceNode("ns=0;i=85"), 0, 0, outcome))
+                .doesNotThrowAnyException();
+        assertThat(engine.isActive()).isTrue();
+    }
+
     /** Counts the commands the engine issues; all callbacks are no-ops (the test drives events directly). */
     private static final class RecordingAdapter implements ProtocolAdapter {
         private int browseCalls;
         private int readAttrsCalls;
+        private int browseCancelCalls;
+        private boolean browseCancelThrows;
 
         @Override
         public @NotNull String adapterId() {
@@ -144,6 +171,14 @@ class ProtocolAdapterBrowseEngineTest {
 
         @Override
         public void browseNext(final int requestId, final @NotNull BrowseContinuation continuation) {}
+
+        @Override
+        public void browseCancel(final int requestId) {
+            browseCancelCalls++;
+            if (browseCancelThrows) {
+                throw new IllegalStateException("browseCancel failed");
+            }
+        }
 
         @Override
         public void readNodeAttributes(final int requestId, final @NotNull List<Node> nodes) {


### PR DESCRIPTION
Two related High-severity browse bugs from [EDG-779](https://linear.app/hivemq/issue/EDG-779) round-2 review (Sam Cao), on the Nevsky v2 browse engine.

## EDG-784 — RESOLVE silently drops discovered nodes when the result is incomplete

The RESOLVE phase never checked that the adapter returned one `ResolvedAttributes` per requested node. `onAttributesResolved` stored whatever came back and `finish()` emitted only the discovered nodes that happened to have attributes — silently omitting a **selectable** node whose attributes were missing, and completing the browse as `200 OK` short a tag. This bites a well-behaved adapter (e.g. an OPC-UA node that browses selectable but denies the attribute read), not only a buggy one.

**Fix:** track the requested node ids per RESOLVE batch; fail the whole browse on a **missing / duplicate / unrequested** attribute instead of dropping. The failure routes through a shared `failBrowse` helper (also used by `onBrowseError`). SDK javadoc (`readNodeAttributes` / `readAttributesResult`) documents the now-enforced "exactly one attribute per requested node" contract — those changes land on the matching `ma/follow-up-v2-review` branch of `hivemq-edge-adapter-sdk` (separate repo, picked up by the composite build).

## EDG-785 — `abort()` ran `browseCancel()` unguarded; a throwing adapter stranded the REST future and wedged the engine

`ProtocolAdapterBrowseEngine.abort()` ran `browseCancel()` before `reset()`, unguarded. A raw adapter throwing from `browseCancel` skipped `reset()` (slot never released → permanent `409 ALREADY_IN_FLIGHT`), skipped the caller's rejection, and — from `failPendingBrowse` — escaped into the wrapper FSM/tick loop.

**Fix:** `browseCancel()` is best-effort (catch + log) and `reset()` runs in a `finally`; the deadline and connection-loss paths complete the pending REST future in a `finally` around `abort()`, so the caller is always released with the intended `TIMED_OUT` / `NOT_CONNECTED` rejection.

## Tests

- **Engine unit** (`ProtocolAdapterBrowseEngineTest`): complete / missing / duplicate / unrequested RESOLVE batches; throwing `browseCancel` in `abort()` does not propagate and the slot is reusable.
- **Wrapper** (`ProtocolAdapterWrapperBrowseTest`): incomplete resolve fails (`FAILED`) instead of a short `200` and releases the slot; deadline and connection-loss with a throwing `browseCancel` still resolve `TIMED_OUT` / `NOT_CONNECTED` without wedging the FSM.

All pass; spotless applied. Supersedes the earlier bundled PR #1596.