### PR TITLE
feat(EDG-786): surface resolved browse data (path, tag name, data type, access, description)

### DIFF
--- a/ext/hivemq-edge-openapi-v2.yaml
+++ b/ext/hivemq-edge-openapi-v2.yaml
@@ -1147,6 +1147,20 @@ components:
         selectable:
           type: boolean
           description: Whether the node can be selected as a tag's node definition.
+        path:
+          type: string
+          description: Slash-separated path of the node from the browse root, assembled from ancestor browse names. E.g. /Plant/Line1/Temperature.
+        tagName:
+          type: string
+          description: Suggested default tag name derived from the path and deduplicated within the result. E.g. plant-line1-temperature.
+        dataType:
+          type: string
+          description: The device data type resolved for the node. E.g. Int32, String, Boolean.
+        access:
+          $ref: '#/components/schemas/AccessFlags'
+        description:
+          type: string
+          description: The node description resolved from the device. May be empty.
     BrowseResult:
       type: object
       description: The result of a browse — the enumerated child nodes.

--- a/hivemq-edge-openapi/openapi/v2/components/schemas/BrowseResultEntry.yaml
+++ b/hivemq-edge-openapi/openapi/v2/components/schemas/BrowseResultEntry.yaml
@@ -17,3 +17,17 @@ properties:
   selectable:
     type: boolean
     description: Whether the node can be selected as a tag's node definition.
+  path:
+    type: string
+    description: Slash-separated path of the node from the browse root, assembled from ancestor browse names. E.g. /Plant/Line1/Temperature.
+  tagName:
+    type: string
+    description: Suggested default tag name derived from the path and deduplicated within the result. E.g. plant-line1-temperature.
+  dataType:
+    type: string
+    description: The device data type resolved for the node. E.g. Int32, String, Boolean.
+  access:
+    $ref: ./AccessFlags.yaml
+  description:
+    type: string
+    description: The node description resolved from the device. May be empty.

--- a/hivemq-edge/src/main/java/com/hivemq/api/v2/resources/impl/ProtocolAdaptersResourceImpl.java
+++ b/hivemq-edge/src/main/java/com/hivemq/api/v2/resources/impl/ProtocolAdaptersResourceImpl.java
@@ -15,6 +15,12 @@
  */
 package com.hivemq.api.v2.resources.impl;
 
+import static com.hivemq.api.v2.errors.ProtocolAdapterErrorFactory.adapterActivationInvalidError;
+import static com.hivemq.api.v2.errors.ProtocolAdapterErrorFactory.adapterNotFoundError;
+import static com.hivemq.api.v2.errors.ProtocolAdapterErrorFactory.adapterTypeNotFoundError;
+import static com.hivemq.api.v2.errors.ProtocolAdapterErrorFactory.tagNotFoundError;
+import static com.hivemq.util.ErrorResponseUtil.errorResponse;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hivemq.adapter.sdk.api.schema.SchemaJsonRepresentation;
@@ -23,6 +29,7 @@ import com.hivemq.adapter.sdk.api.v2.ProtocolAdapterInformation;
 import com.hivemq.adapter.sdk.api.v2.factories.ProtocolAdapterFactory;
 import com.hivemq.adapter.sdk.api.v2.messaging.MailboxSender;
 import com.hivemq.adapter.sdk.api.v2.model.BrowseFilter;
+import com.hivemq.adapter.sdk.api.v2.model.BrowseNode;
 import com.hivemq.adapter.sdk.api.v2.node.Node;
 import com.hivemq.api.AbstractApi;
 import com.hivemq.api.v2.errors.ProtocolAdapterErrorFactory;
@@ -35,6 +42,7 @@ import com.hivemq.edge.api.v2.model.AdapterStatus;
 import com.hivemq.edge.api.v2.model.AdapterType;
 import com.hivemq.edge.api.v2.model.BrowseCommand;
 import com.hivemq.edge.api.v2.model.BrowseResult;
+import com.hivemq.edge.api.v2.model.BrowseResultEntry;
 import com.hivemq.edge.api.v2.model.Mapping;
 import com.hivemq.edge.api.v2.model.MappingBlockedBy;
 import com.hivemq.edge.api.v2.model.NodeTagPair;
@@ -61,7 +69,6 @@ import com.hivemq.protocols.v2.view.TagStatus;
 import com.hivemq.protocols.v2.view.TagStatusSnapshot;
 import com.hivemq.protocols.v2.wrapper.BrowseRejectedException;
 import com.hivemq.protocols.v2.wrapper.ProtocolAdapterDirection;
-import com.hivemq.util.ErrorResponseUtil;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import jakarta.ws.rs.core.Response;
@@ -77,6 +84,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NonNull;
 
 /**
  * The v2 protocol-adapters REST resource. It is <b>state-only</b>: it serves read-only views
@@ -95,6 +103,8 @@ import org.jetbrains.annotations.Nullable;
 @Singleton
 public class ProtocolAdaptersResourceImpl extends AbstractApi implements ProtocolAdaptersApi {
 
+    private static final @NotNull SchemaJsonRepresentation JSCHEMA = SchemaJsonRepresentation.INSTANCE;
+
     /**
      * The browse request timeout: the JAX-RS request thread is the only thread that blocks, and it
      * gives up after this long with {@code 504}. The wrapper's own browse deadline is the backstop that releases
@@ -110,11 +120,11 @@ public class ProtocolAdaptersResourceImpl extends AbstractApi implements Protoco
     private final long browseTimeoutMillis;
 
     /**
-     * @param manager          the manager mailbox the runtime-state commands are told to.
-     * @param handleRegistry   the REST-readable adapter registry (snapshots and senders).
-     * @param factoryRegistry  the registered adapter type factories (empty in production, D8).
-     * @param configExtractor  the read-only {@code <v2>} configuration extractor.
-     * @param objectMapper     the JSON mapper used to deserialize browse filter node strings.
+     * @param manager         the manager mailbox the runtime-state commands are told to.
+     * @param handleRegistry  the REST-readable adapter registry (snapshots and senders).
+     * @param factoryRegistry the registered adapter type factories (empty in production, D8).
+     * @param configExtractor the read-only {@code <v2>} configuration extractor.
+     * @param objectMapper    the JSON mapper used to deserialize browse filter node strings.
      */
     @Inject
     public ProtocolAdaptersResourceImpl(
@@ -141,16 +151,54 @@ public class ProtocolAdaptersResourceImpl extends AbstractApi implements Protoco
         this.browseTimeoutMillis = browseTimeoutMillis;
     }
 
-    // ── types ───────────────────────────────────────────────────────────────────────────────────────────────────
+    private static boolean hasPermanentFailure(final @NotNull TagStatusSnapshot tag) {
+        return tag.readAspectPermanentFailure() || tag.writeAspectPermanentFailure();
+    }
+
+    private static @NotNull String skipReason(final @NotNull TagStatusSnapshot tag) {
+        return !tag.readAspectGoalActive() && !tag.writeAspectGoalActive()
+                ? "tag is deactivated"
+                : "tag is not in an error state";
+    }
+
+    private static @Nullable TagStatusSnapshot findTag(
+            final @Nullable AdapterStatusSnapshot snapshot, final @NotNull String tagName) {
+        if (snapshot != null) {
+            for (final TagStatusSnapshot tag : snapshot.tags()) {
+                if (tag.tagName().equals(tagName)) {
+                    return tag;
+                }
+            }
+        }
+        return null;
+    }
+
+    private static @Nullable OffsetDateTime toOffsetDateTime(final long millis) {
+        return millis <= 0 ? null : OffsetDateTime.ofInstant(Instant.ofEpochMilli(millis), ZoneOffset.UTC);
+    }
+
+    private static @NotNull Response adapterNotFound(final @NotNull String adapterId) {
+        return errorResponse(adapterNotFoundError(adapterId));
+    }
+
+    private static @NotNull Response adapterTypeUnavailable(final @NotNull String adapterId) {
+        return errorResponse(adapterTypeNotFoundError(adapterId));
+    }
+
+    private static @NotNull Response tagNotFound(final @NotNull String adapterId, final @NotNull String tagName) {
+        return errorResponse(tagNotFoundError(adapterId, tagName));
+    }
+
+    private static com.hivemq.edge.api.v2.model.@NonNull TagStatus getTagStatus(@NonNull TagStatusSnapshot snapshot) {
+        return com.hivemq.edge.api.v2.model.TagStatus.fromValue(
+                TagStatus.of(snapshot).name());
+    }
 
     @Override
     public @NotNull Response getAdapterTypes() {
-        final List<AdapterType> types =
-                factoryRegistry.all().stream().map(this::toTypeDto).toList();
-        return Response.ok(types).build();
+        return Response.ok(factoryRegistry.all().stream().map(this::toTypeDto).toList())
+                .build();
     }
-
-    // ── status views (pure functions of snapshots) ──────────────────────────────────────────────────────────────
 
     @Override
     public @NotNull Response listAdapters() {
@@ -165,22 +213,18 @@ public class ProtocolAdaptersResourceImpl extends AbstractApi implements Protoco
     @Override
     public @NotNull Response getAdapterStatus(final @NotNull String adapterId) {
         final AdapterStatusSnapshot snapshot = snapshotOf(adapterId);
-        if (snapshot == null) {
-            return adapterNotFound(adapterId);
-        }
-        return Response.ok(toStatusDto(snapshot)).build();
+        return snapshot == null
+                ? adapterNotFound(adapterId)
+                : Response.ok(toStatusDto(snapshot)).build();
     }
 
     @Override
     public @NotNull Response getAdapter(final @NotNull String adapterId) {
         final Optional<ProtocolAdapterEntity> config = configExtractor.getAdapterByAdapterId(adapterId);
-        if (config.isEmpty()) {
-            return adapterNotFound(adapterId);
-        }
-        return Response.ok(toDefinition(config.get())).build();
+        return config.isEmpty()
+                ? adapterNotFound(adapterId)
+                : Response.ok(toDefinition(config.get())).build();
     }
-
-    // ── tags ────────────────────────────────────────────────────────────────────────────────────────────────────
 
     @Override
     public @NotNull Response getAdapterTags(final @NotNull String adapterId) {
@@ -190,10 +234,10 @@ public class ProtocolAdaptersResourceImpl extends AbstractApi implements Protoco
         }
         final AdapterStatusSnapshot snapshot = snapshotOf(adapterId);
         final Object nodeSchema = nodeSchemaProjection(config.get());
-        final List<NodeTagPair> tags = config.get().getTags().stream()
-                .map(tag -> toNodeTagPair(tag, findTag(snapshot, tag.getName()), nodeSchema))
-                .toList();
-        return Response.ok(tags).build();
+        return Response.ok(config.get().getTags().stream()
+                        .map(tag -> toNodeTagPair(tag, findTag(snapshot, tag.getName()), nodeSchema))
+                        .toList())
+                .build();
     }
 
     @Override
@@ -203,13 +247,10 @@ public class ProtocolAdaptersResourceImpl extends AbstractApi implements Protoco
             return adapterNotFound(adapterId);
         }
         final TagStatusSnapshot tag = findTag(snapshot, tagName);
-        if (tag == null) {
-            return tagNotFound(adapterId, tagName);
-        }
-        return Response.ok(toTagStatusDetail(tag)).build();
+        return tag == null
+                ? tagNotFound(adapterId, tagName)
+                : Response.ok(toTagStatusDetail(tag)).build();
     }
-
-    // ── mappings (derived status) ───────────────────────────────────────────────────────────────────────────────
 
     @Override
     public @NotNull Response getNorthboundMappings(final @NotNull String adapterId) {
@@ -239,37 +280,29 @@ public class ProtocolAdaptersResourceImpl extends AbstractApi implements Protoco
         return Response.ok(mappings).build();
     }
 
-    // ── schema projections (reused v1 Schema → JSON-Schema) ─────────────────────────────────────────────────────
-
     @Override
     public @NotNull Response getNodeSchema(final @NotNull String adapterId) {
         final Optional<ProtocolAdapterFactory> factory = factoryFor(adapterId);
-        if (factory.isEmpty()) {
-            return adapterTypeUnavailable(adapterId);
-        }
-        return Response.ok(SchemaJsonRepresentation.INSTANCE.toJsonSchema(
-                        factory.get().nodeDefinitionSchema()))
-                .build();
+        return factory.isEmpty()
+                ? adapterTypeUnavailable(adapterId)
+                : Response.ok(JSCHEMA.toJsonSchema(factory.get().nodeDefinitionSchema()))
+                        .build();
     }
 
     @Override
     public @NotNull Response getAdapterSchema(final @NotNull String adapterId) {
         final Optional<ProtocolAdapterFactory> factory = factoryFor(adapterId);
-        if (factory.isEmpty()) {
-            return adapterTypeUnavailable(adapterId);
-        }
-        return Response.ok(SchemaJsonRepresentation.INSTANCE.toJsonSchema(
-                        factory.get().adapterConfigSchema()))
-                .build();
+        return factory.isEmpty()
+                ? adapterTypeUnavailable(adapterId)
+                : Response.ok(JSCHEMA.toJsonSchema(factory.get().adapterConfigSchema()))
+                        .build();
     }
-
-    // ── runtime-state commands (tell-only) ──────────────────────────────────────────────────────────────────────
 
     @Override
     public @NotNull Response setAdapterActivation(
             final @NotNull String adapterId, final @NotNull AdapterActivation body) {
         if (body.getDirection() == null || body.getActivated() == null) {
-            return ErrorResponseUtil.errorResponse(ProtocolAdapterErrorFactory.adapterActivationInvalidError());
+            return errorResponse(adapterActivationInvalidError());
         }
         if (handleRegistry.find(adapterId) == null) {
             return adapterNotFound(adapterId);
@@ -290,24 +323,20 @@ public class ProtocolAdaptersResourceImpl extends AbstractApi implements Protoco
         if (snapshot == null) {
             return adapterNotFound(adapterId);
         }
-        if (findTag(snapshot, tagName) == null) {
-            return tagNotFound(adapterId, tagName);
-        }
-        return Response.ok(retryResult(adapterId, snapshot, List.of(tagName))).build();
+        return findTag(snapshot, tagName) == null
+                ? tagNotFound(adapterId, tagName)
+                : Response.ok(retryResult(adapterId, snapshot, List.of(tagName)))
+                        .build();
     }
 
     @Override
     public @NotNull Response retryTags(final @NotNull String adapterId, final @NotNull TagRetryRequest body) {
         final AdapterStatusSnapshot snapshot = snapshotOf(adapterId);
-        if (snapshot == null) {
-            return adapterNotFound(adapterId);
-        }
-        final List<String> requested =
-                (body.getTagNames() == null || body.getTagNames().isEmpty()) ? null : body.getTagNames();
-        return Response.ok(retryResult(adapterId, snapshot, requested)).build();
+        return snapshot == null
+                ? adapterNotFound(adapterId)
+                : Response.ok(retryResult(adapterId, snapshot, body.getTagNames()))
+                        .build();
     }
-
-    // ── browse bridge ─────────────────────────────────────────────────────────────────────────────
 
     @Override
     public @NotNull Response browseAdapter(final @NotNull String adapterId, final @Nullable BrowseCommand body) {
@@ -317,7 +346,7 @@ public class ProtocolAdaptersResourceImpl extends AbstractApi implements Protoco
         final Optional<ProtocolAdapterFactory> factory = factoryFor(adapterId);
         if (factory.isEmpty()
                 || !factory.get().information().capabilities().contains(ProtocolAdapterCapability.BROWSE)) {
-            return ErrorResponseUtil.errorResponse(ProtocolAdapterErrorFactory.browseNotSupportedError(adapterId));
+            return errorResponse(ProtocolAdapterErrorFactory.browseNotSupportedError(adapterId));
         }
         final String nodeString = (body == null
                         || body.getNodeString() == null
@@ -329,7 +358,7 @@ public class ProtocolAdaptersResourceImpl extends AbstractApi implements Protoco
             filterNode = objectMapper.readValue(
                     nodeString, factory.get().information().nodeClass());
         } catch (final JsonProcessingException exception) {
-            return ErrorResponseUtil.errorResponse(
+            return errorResponse(
                     ProtocolAdapterErrorFactory.browseFilterInvalidError(adapterId, exception.getOriginalMessage()));
         }
 
@@ -340,10 +369,10 @@ public class ProtocolAdaptersResourceImpl extends AbstractApi implements Protoco
             final List<BrowsedNode> entries = completion.get(browseTimeoutMillis, TimeUnit.MILLISECONDS);
             return Response.ok(toBrowseResult(entries)).build();
         } catch (final TimeoutException exception) {
-            return ErrorResponseUtil.errorResponse(ProtocolAdapterErrorFactory.browseTimeoutError(adapterId));
+            return errorResponse(ProtocolAdapterErrorFactory.browseTimeoutError(adapterId));
         } catch (final InterruptedException exception) {
             Thread.currentThread().interrupt();
-            return ErrorResponseUtil.errorResponse(ProtocolAdapterErrorFactory.browseInterruptedError(adapterId));
+            return errorResponse(ProtocolAdapterErrorFactory.browseInterruptedError(adapterId));
         } catch (final ExecutionException exception) {
             return browseFailure(adapterId, exception.getCause());
         }
@@ -352,25 +381,18 @@ public class ProtocolAdaptersResourceImpl extends AbstractApi implements Protoco
     private @NotNull Response browseFailure(final @NotNull String adapterId, final @Nullable Throwable cause) {
         if (cause instanceof final BrowseRejectedException rejected) {
             return switch (rejected.reason()) {
-                case NOT_CONNECTED ->
-                    ErrorResponseUtil.errorResponse(ProtocolAdapterErrorFactory.adapterNotConnectedError(adapterId));
-                case ALREADY_IN_FLIGHT ->
-                    ErrorResponseUtil.errorResponse(ProtocolAdapterErrorFactory.browseInProgressError(adapterId));
-                case UNSUPPORTED ->
-                    ErrorResponseUtil.errorResponse(ProtocolAdapterErrorFactory.browseNotSupportedError(adapterId));
-                case TIMED_OUT ->
-                    ErrorResponseUtil.errorResponse(ProtocolAdapterErrorFactory.browseTimeoutError(adapterId));
-                case FAILED ->
-                    ErrorResponseUtil.errorResponse(ProtocolAdapterErrorFactory.browseFailedError(adapterId));
+                case NOT_CONNECTED -> errorResponse(ProtocolAdapterErrorFactory.adapterNotConnectedError(adapterId));
+                case ALREADY_IN_FLIGHT -> errorResponse(ProtocolAdapterErrorFactory.browseInProgressError(adapterId));
+                case UNSUPPORTED -> errorResponse(ProtocolAdapterErrorFactory.browseNotSupportedError(adapterId));
+                case TIMED_OUT -> errorResponse(ProtocolAdapterErrorFactory.browseTimeoutError(adapterId));
+                case FAILED -> errorResponse(ProtocolAdapterErrorFactory.browseFailedError(adapterId));
             };
         }
         if (cause instanceof IllegalArgumentException) {
             return adapterNotFound(adapterId);
         }
-        return ErrorResponseUtil.errorResponse(ProtocolAdapterErrorFactory.browseFailedError(adapterId));
+        return errorResponse(ProtocolAdapterErrorFactory.browseFailedError(adapterId));
     }
-
-    // ── DTO assembly (pure functions) ────────────────────────────────────────────────────────────────────────────
 
     private @NotNull List<AdapterStatus> allStatuses() {
         final List<AdapterStatus> statuses = new ArrayList<>();
@@ -434,12 +456,10 @@ public class ProtocolAdaptersResourceImpl extends AbstractApi implements Protoco
                 .subscribable(tag.isSubscribable())
                 .access(toAccessFlags(tag.getAccess()))
                 .schema(nodeSchema)
-                .status(
-                        snapshot == null
-                                ? null
-                                : com.hivemq.edge.api.v2.model.TagStatus.fromValue(
-                                        TagStatus.of(snapshot).name()));
+                .status(snapshot == null ? null : getTagStatus(snapshot));
     }
+
+    // ── tag retry result derivation ──────────────────────────────────────────────────────────────────────────────
 
     private @NotNull AccessFlags toAccessFlags(final @NotNull AccessFlagsEntity access) {
         return new AccessFlags()
@@ -468,8 +488,7 @@ public class ProtocolAdaptersResourceImpl extends AbstractApi implements Protoco
     private @NotNull TagStatusDetail toTagStatusDetail(final @NotNull TagStatusSnapshot tag) {
         return new TagStatusDetail()
                 .tagName(tag.tagName())
-                .status(com.hivemq.edge.api.v2.model.TagStatus.fromValue(
-                        TagStatus.of(tag).name()))
+                .status(getTagStatus(tag))
                 .readAspectState(tag.readAspectStateName())
                 .writeAspectState(tag.writeAspectStateName())
                 .readActivated(tag.readActivated())
@@ -525,8 +544,8 @@ public class ProtocolAdaptersResourceImpl extends AbstractApi implements Protoco
                         .map(capability -> AdapterType.CapabilitiesEnum.fromValue(capability.name()))
                         .toList())
                 .configVersion(information.currentConfigVersion())
-                .nodeSchema(SchemaJsonRepresentation.INSTANCE.toJsonSchema(factory.nodeDefinitionSchema()))
-                .adapterSchema(SchemaJsonRepresentation.INSTANCE.toJsonSchema(factory.adapterConfigSchema()));
+                .nodeSchema(JSCHEMA.toJsonSchema(factory.nodeDefinitionSchema()))
+                .adapterSchema(JSCHEMA.toJsonSchema(factory.adapterConfigSchema()));
     }
 
     private @NotNull AdapterDefinition toDefinition(final @NotNull ProtocolAdapterEntity entity) {
@@ -542,25 +561,24 @@ public class ProtocolAdaptersResourceImpl extends AbstractApi implements Protoco
     }
 
     private @NotNull BrowseResult toBrowseResult(final @NotNull List<BrowsedNode> nodes) {
-        final List<com.hivemq.edge.api.v2.model.BrowseResultEntry> mapped = nodes.stream()
-                .map(node -> new com.hivemq.edge.api.v2.model.BrowseResultEntry()
-                        // DISCOVER-phase identity
-                        .nodeId(node.entry().node().nodeId())
-                        .nodeString(node.entry().node().nodeString())
-                        .type(com.hivemq.edge.api.v2.model.BrowseResultEntry.TypeEnum.fromValue(
-                                node.entry().type().name()))
-                        .selectable(node.entry().selectable())
-                        // RESOLVE-phase result: assembled path, suggested default tag name, and device attributes
-                        .path(node.path())
-                        .tagName(node.tagName())
-                        .dataType(node.attributes().dataType())
-                        .access(toAccessFlags(node.attributes().access()))
-                        .description(node.attributes().description()))
-                .toList();
-        return new BrowseResult().entries(mapped);
+        return new BrowseResult()
+                .entries(nodes.stream()
+                        .map(node -> {
+                            final BrowseNode entry = node.entry();
+                            return new BrowseResultEntry()
+                                    .nodeId(entry.node().nodeId())
+                                    .nodeString(entry.node().nodeString())
+                                    .type(BrowseResultEntry.TypeEnum.fromValue(
+                                            entry.type().name()))
+                                    .selectable(entry.selectable())
+                                    .path(node.path())
+                                    .tagName(node.tagName())
+                                    .dataType(node.attributes().dataType())
+                                    .access(toAccessFlags(node.attributes().access()))
+                                    .description(node.attributes().description());
+                        })
+                        .toList());
     }
-
-    // ── tag retry result derivation ──────────────────────────────────────────────────────────────────────────────
 
     private @NotNull TagRetryResult retryResult(
             final @NotNull String adapterId,
@@ -591,22 +609,9 @@ public class ProtocolAdaptersResourceImpl extends AbstractApi implements Protoco
         return new TagRetryResult().accepted(accepted).skipped(skipped);
     }
 
-    private static boolean hasPermanentFailure(final @NotNull TagStatusSnapshot tag) {
-        return tag.readAspectPermanentFailure() || tag.writeAspectPermanentFailure();
-    }
-
-    private static @NotNull String skipReason(final @NotNull TagStatusSnapshot tag) {
-        if (!tag.readAspectGoalActive() && !tag.writeAspectGoalActive()) {
-            return "tag is deactivated";
-        }
-        return "tag is not in an error state";
-    }
-
-    // ── lookups and helpers ──────────────────────────────────────────────────────────────────────────────────────
-
     private @Nullable AdapterStatusSnapshot snapshotOf(final @NotNull String adapterId) {
         final ProtocolAdapterHandle handle = handleRegistry.find(adapterId);
-        return handle == null ? null : handle.snapshot().get();
+        return handle != null ? handle.snapshot().get() : null;
     }
 
     private @NotNull Optional<ProtocolAdapterFactory> factoryFor(final @NotNull String adapterId) {
@@ -618,36 +623,7 @@ public class ProtocolAdaptersResourceImpl extends AbstractApi implements Protoco
     private @Nullable Object nodeSchemaProjection(final @NotNull ProtocolAdapterEntity entity) {
         return factoryRegistry
                 .findByProtocolId(entity.getProtocolId())
-                .map(factory -> (Object) SchemaJsonRepresentation.INSTANCE.toJsonSchema(factory.nodeDefinitionSchema()))
+                .map(factory -> (Object) JSCHEMA.toJsonSchema(factory.nodeDefinitionSchema()))
                 .orElse(null);
-    }
-
-    private static @Nullable TagStatusSnapshot findTag(
-            final @Nullable AdapterStatusSnapshot snapshot, final @NotNull String tagName) {
-        if (snapshot == null) {
-            return null;
-        }
-        for (final TagStatusSnapshot tag : snapshot.tags()) {
-            if (tag.tagName().equals(tagName)) {
-                return tag;
-            }
-        }
-        return null;
-    }
-
-    private static @Nullable OffsetDateTime toOffsetDateTime(final long millis) {
-        return millis <= 0 ? null : OffsetDateTime.ofInstant(Instant.ofEpochMilli(millis), ZoneOffset.UTC);
-    }
-
-    private static @NotNull Response adapterNotFound(final @NotNull String adapterId) {
-        return ErrorResponseUtil.errorResponse(ProtocolAdapterErrorFactory.adapterNotFoundError(adapterId));
-    }
-
-    private static @NotNull Response adapterTypeUnavailable(final @NotNull String adapterId) {
-        return ErrorResponseUtil.errorResponse(ProtocolAdapterErrorFactory.adapterTypeNotFoundError(adapterId));
-    }
-
-    private static @NotNull Response tagNotFound(final @NotNull String adapterId, final @NotNull String tagName) {
-        return ErrorResponseUtil.errorResponse(ProtocolAdapterErrorFactory.tagNotFoundError(adapterId, tagName));
     }
 }

--- a/hivemq-edge/src/main/java/com/hivemq/api/v2/resources/impl/ProtocolAdaptersResourceImpl.java
+++ b/hivemq-edge/src/main/java/com/hivemq/api/v2/resources/impl/ProtocolAdaptersResourceImpl.java
@@ -23,7 +23,6 @@ import com.hivemq.adapter.sdk.api.v2.ProtocolAdapterInformation;
 import com.hivemq.adapter.sdk.api.v2.factories.ProtocolAdapterFactory;
 import com.hivemq.adapter.sdk.api.v2.messaging.MailboxSender;
 import com.hivemq.adapter.sdk.api.v2.model.BrowseFilter;
-import com.hivemq.adapter.sdk.api.v2.model.BrowseNode;
 import com.hivemq.adapter.sdk.api.v2.node.Node;
 import com.hivemq.api.AbstractApi;
 import com.hivemq.api.v2.errors.ProtocolAdapterErrorFactory;
@@ -44,6 +43,7 @@ import com.hivemq.edge.api.v2.model.TagRetryRequest;
 import com.hivemq.edge.api.v2.model.TagRetryResult;
 import com.hivemq.edge.api.v2.model.TagStatusDetail;
 import com.hivemq.edge.api.v2.model.TagSummary;
+import com.hivemq.protocols.v2.browse.BrowsedNode;
 import com.hivemq.protocols.v2.config.AccessFlagsEntity;
 import com.hivemq.protocols.v2.config.NorthboundMappingEntity;
 import com.hivemq.protocols.v2.config.ProtocolAdapterEntity;
@@ -333,11 +333,11 @@ public class ProtocolAdaptersResourceImpl extends AbstractApi implements Protoco
                     ProtocolAdapterErrorFactory.browseFilterInvalidError(adapterId, exception.getOriginalMessage()));
         }
 
-        final CompletableFuture<List<BrowseNode>> completion = new CompletableFuture<>();
+        final CompletableFuture<List<BrowsedNode>> completion = new CompletableFuture<>();
         manager.tell(
                 new ProtocolAdapterManagerMessage.BrowseRequested(adapterId, new BrowseFilter(filterNode), completion));
         try {
-            final List<BrowseNode> entries = completion.get(browseTimeoutMillis, TimeUnit.MILLISECONDS);
+            final List<BrowsedNode> entries = completion.get(browseTimeoutMillis, TimeUnit.MILLISECONDS);
             return Response.ok(toBrowseResult(entries)).build();
         } catch (final TimeoutException exception) {
             return ErrorResponseUtil.errorResponse(ProtocolAdapterErrorFactory.browseTimeoutError(adapterId));
@@ -453,6 +453,18 @@ public class ProtocolAdaptersResourceImpl extends AbstractApi implements Protoco
                         access.getSubscribable().name()));
     }
 
+    private @NotNull AccessFlags toAccessFlags(final @NotNull com.hivemq.adapter.sdk.api.v2.node.AccessFlags access) {
+        return new AccessFlags()
+                .readable(com.hivemq.edge.api.v2.model.AccessTriState.fromValue(
+                        access.readable().name()))
+                .writable(com.hivemq.edge.api.v2.model.AccessTriState.fromValue(
+                        access.writable().name()))
+                .pollable(com.hivemq.edge.api.v2.model.AccessTriState.fromValue(
+                        access.pollable().name()))
+                .subscribable(com.hivemq.edge.api.v2.model.AccessTriState.fromValue(
+                        access.subscribable().name()));
+    }
+
     private @NotNull TagStatusDetail toTagStatusDetail(final @NotNull TagStatusSnapshot tag) {
         return new TagStatusDetail()
                 .tagName(tag.tagName())
@@ -529,14 +541,21 @@ public class ProtocolAdaptersResourceImpl extends AbstractApi implements Protoco
                 .adapterConfiguration(entity.getAdapterConfiguration());
     }
 
-    private @NotNull BrowseResult toBrowseResult(final @NotNull List<BrowseNode> entries) {
-        final List<com.hivemq.edge.api.v2.model.BrowseResultEntry> mapped = entries.stream()
-                .map(entry -> new com.hivemq.edge.api.v2.model.BrowseResultEntry()
-                        .nodeId(entry.node().nodeId())
-                        .nodeString(entry.node().nodeString())
+    private @NotNull BrowseResult toBrowseResult(final @NotNull List<BrowsedNode> nodes) {
+        final List<com.hivemq.edge.api.v2.model.BrowseResultEntry> mapped = nodes.stream()
+                .map(node -> new com.hivemq.edge.api.v2.model.BrowseResultEntry()
+                        // DISCOVER-phase identity
+                        .nodeId(node.entry().node().nodeId())
+                        .nodeString(node.entry().node().nodeString())
                         .type(com.hivemq.edge.api.v2.model.BrowseResultEntry.TypeEnum.fromValue(
-                                entry.type().name()))
-                        .selectable(entry.selectable()))
+                                node.entry().type().name()))
+                        .selectable(node.entry().selectable())
+                        // RESOLVE-phase result: assembled path, suggested default tag name, and device attributes
+                        .path(node.path())
+                        .tagName(node.tagName())
+                        .dataType(node.attributes().dataType())
+                        .access(toAccessFlags(node.attributes().access()))
+                        .description(node.attributes().description()))
                 .toList();
         return new BrowseResult().entries(mapped);
     }

--- a/hivemq-edge/src/main/java/com/hivemq/api/v2/resources/impl/ProtocolAdaptersResourceImpl.java
+++ b/hivemq-edge/src/main/java/com/hivemq/api/v2/resources/impl/ProtocolAdaptersResourceImpl.java
@@ -586,7 +586,7 @@ public class ProtocolAdaptersResourceImpl extends AbstractApi implements Protoco
             final @Nullable List<String> requestedNames) {
         final List<String> accepted = new ArrayList<>();
         final List<SkippedTagRetry> skipped = new ArrayList<>();
-        if (requestedNames == null) {
+        if (requestedNames == null || requestedNames.isEmpty()) {
             for (final TagStatusSnapshot tag : snapshot.tags()) {
                 if (hasPermanentFailure(tag)) {
                     accepted.add(tag.tagName());

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/manager/ProtocolAdapterManagerMessage.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/manager/ProtocolAdapterManagerMessage.java
@@ -18,7 +18,7 @@ package com.hivemq.protocols.v2.manager;
 import com.hivemq.adapter.sdk.api.v2.messaging.MailboxMessage;
 import com.hivemq.adapter.sdk.api.v2.messaging.MailboxMessagePriority;
 import com.hivemq.adapter.sdk.api.v2.model.BrowseFilter;
-import com.hivemq.adapter.sdk.api.v2.model.BrowseNode;
+import com.hivemq.protocols.v2.browse.BrowsedNode;
 import com.hivemq.protocols.v2.config.ProtocolAdapterEntity;
 import com.hivemq.protocols.v2.wrapper.ProtocolAdapterDirection;
 import java.util.List;
@@ -116,7 +116,7 @@ public sealed interface ProtocolAdapterManagerMessage extends MailboxMessage {
     record BrowseRequested(
             @NotNull String adapterId,
             @NotNull BrowseFilter filter,
-            @NotNull CompletableFuture<List<BrowseNode>> completion)
+            @NotNull CompletableFuture<List<BrowsedNode>> completion)
             implements ProtocolAdapterManagerMessage {
         @Override
         public @NotNull MailboxMessagePriority priority() {

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/wrapper/ProtocolAdapterWrapperBrowseRequest.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/wrapper/ProtocolAdapterWrapperBrowseRequest.java
@@ -17,7 +17,7 @@ package com.hivemq.protocols.v2.wrapper;
 
 import com.hivemq.adapter.sdk.api.v2.messaging.MailboxMessagePriority;
 import com.hivemq.adapter.sdk.api.v2.model.BrowseFilter;
-import com.hivemq.adapter.sdk.api.v2.model.BrowseNode;
+import com.hivemq.protocols.v2.browse.BrowsedNode;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import org.jetbrains.annotations.NotNull;
@@ -39,7 +39,7 @@ import org.jetbrains.annotations.NotNull;
  * @param completion the future the REST thread awaits; completed with the results or completed exceptionally.
  */
 public record ProtocolAdapterWrapperBrowseRequest(
-        @NotNull BrowseFilter filter, @NotNull CompletableFuture<List<BrowseNode>> completion)
+        @NotNull BrowseFilter filter, @NotNull CompletableFuture<List<BrowsedNode>> completion)
         implements ProtocolAdapterWrapperMessage {
 
     @Override

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/wrapper/ProtocolAdapterWrapperContext.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/wrapper/ProtocolAdapterWrapperContext.java
@@ -47,7 +47,6 @@ import com.hivemq.protocols.v2.runtime.RetryPolicy;
 import com.hivemq.protocols.v2.runtime.TimerHandle;
 import com.hivemq.protocols.v2.tag.TagAspectCoordinator;
 import com.hivemq.protocols.v2.view.AdapterStatusSnapshot;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -511,7 +510,7 @@ public final class ProtocolAdapterWrapperContext {
      * @param completion the future the REST thread awaits.
      */
     public void handleBrowseRequest(
-            final @NotNull BrowseFilter filter, final @NotNull CompletableFuture<List<BrowseNode>> completion) {
+            final @NotNull BrowseFilter filter, final @NotNull CompletableFuture<List<BrowsedNode>> completion) {
         if (machine().state() != CONNECTED) {
             completion.completeExceptionally(new BrowseRejectedException(
                     BrowseRejectedException.Reason.NOT_CONNECTED,
@@ -550,11 +549,9 @@ public final class ProtocolAdapterWrapperContext {
         }
         pendingBrowse = null;
         timers.cancel(pending.deadline());
-        final List<BrowseNode> entries = new ArrayList<>(nodes.size());
-        for (final BrowsedNode node : nodes) {
-            entries.add(node.entry());
-        }
-        pending.completion().complete(entries);
+        // Complete with the fully resolved BrowsedNode results (path, default tag name, and resolved attributes),
+        // not just the DISCOVER-phase entry — the REST resource surfaces the resolved fields (EDG-786).
+        pending.completion().complete(List.copyOf(nodes));
     }
 
     private void failBrowse(final @NotNull String reason) {
@@ -774,6 +771,6 @@ public final class ProtocolAdapterWrapperContext {
      * @param deadline   the deadline timer, canceled when the browse completes.
      */
     private record PendingBrowse(
-            @NotNull CompletableFuture<List<BrowseNode>> completion,
+            @NotNull CompletableFuture<List<BrowsedNode>> completion,
             @NotNull TimerHandle deadline) {}
 }

--- a/hivemq-edge/src/test/java/com/hivemq/api/v2/resources/impl/ProtocolAdaptersResourceImplTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/api/v2/resources/impl/ProtocolAdaptersResourceImplTest.java
@@ -32,6 +32,8 @@ import com.hivemq.adapter.sdk.api.v2.ProtocolAdapterInformation;
 import com.hivemq.adapter.sdk.api.v2.factories.ProtocolAdapterFactory;
 import com.hivemq.adapter.sdk.api.v2.messaging.MailboxSender;
 import com.hivemq.adapter.sdk.api.v2.model.BrowseNode;
+import com.hivemq.adapter.sdk.api.v2.model.ResolvedAttributes;
+import com.hivemq.adapter.sdk.api.v2.node.AccessFlags;
 import com.hivemq.adapter.sdk.api.v2.node.AccessTriState;
 import com.hivemq.adapter.sdk.api.v2.node.Node;
 import com.hivemq.adapter.sdk.api.v2.node.NodeProperty;
@@ -46,6 +48,7 @@ import com.hivemq.edge.api.v2.model.AdapterStatusColor;
 import com.hivemq.edge.api.v2.model.AdapterType;
 import com.hivemq.edge.api.v2.model.BrowseCommand;
 import com.hivemq.edge.api.v2.model.BrowseResult;
+import com.hivemq.edge.api.v2.model.BrowseResultEntry;
 import com.hivemq.edge.api.v2.model.BrowseTimeoutError;
 import com.hivemq.edge.api.v2.model.Mapping;
 import com.hivemq.edge.api.v2.model.MappingStatus;
@@ -55,6 +58,7 @@ import com.hivemq.edge.api.v2.model.TagRetryRequest;
 import com.hivemq.edge.api.v2.model.TagRetryResult;
 import com.hivemq.edge.api.v2.model.TagStatus;
 import com.hivemq.edge.api.v2.model.TagStatusDetail;
+import com.hivemq.protocols.v2.browse.BrowsedNode;
 import com.hivemq.protocols.v2.config.AccessFlagsEntity;
 import com.hivemq.protocols.v2.config.NorthboundMappingEntity;
 import com.hivemq.protocols.v2.config.ProtocolAdapterEntity;
@@ -454,12 +458,31 @@ class ProtocolAdaptersResourceImplTest {
         final ProtocolAdapterFactoryRegistry factories = browseCapableFactories();
         when(configExtractor.getAdapterByAdapterId("a")).thenReturn(Optional.of(entity("a", "chaos")));
         register("a", snapshot("a", ProtocolAdapterWrapperState.CONNECTED, List.of(), true, false, null));
-        manager.browseHandler = request ->
-                request.completion().complete(List.of(new BrowseNode(new TestNode(), NodeType.VALUE, true, "node")));
+        manager.browseHandler = request -> request.completion()
+                .complete(List.of(new BrowsedNode(
+                        new BrowseNode(new TestNode(), NodeType.VALUE, true, "node"),
+                        "/node",
+                        "node",
+                        new ResolvedAttributes(
+                                new TestNode(),
+                                "Int32",
+                                AccessFlags.builder()
+                                        .readable(AccessTriState.YES)
+                                        .pollable(AccessTriState.YES)
+                                        .build(),
+                                "a node"))));
 
         final Response response = resource(factories).browseAdapter("a", new BrowseCommand());
         assertThat(response.getStatus()).isEqualTo(200);
-        assertThat(((BrowseResult) response.getEntity()).getEntries()).hasSize(1);
+        // EDG-786: the resolved fields (path, default tag name, data type, access, description) reach the DTO,
+        // no longer discarded at the boundary.
+        final BrowseResultEntry mapped =
+                ((BrowseResult) response.getEntity()).getEntries().getFirst();
+        assertThat(mapped.getPath()).isEqualTo("/node");
+        assertThat(mapped.getTagName()).isEqualTo("node");
+        assertThat(mapped.getDataType()).isEqualTo("Int32");
+        assertThat(mapped.getDescription()).isEqualTo("a node");
+        assertThat(mapped.getAccess().getReadable()).isEqualTo(com.hivemq.edge.api.v2.model.AccessTriState.YES);
     }
 
     @Test

--- a/hivemq-edge/src/test/java/com/hivemq/protocols/v2/manager/ProtocolAdapterManagerBrowseTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/protocols/v2/manager/ProtocolAdapterManagerBrowseTest.java
@@ -22,7 +22,7 @@ import static org.assertj.core.api.Assertions.catchThrowable;
 import com.hivemq.adapter.sdk.api.v2.messaging.DefaultMailbox;
 import com.hivemq.adapter.sdk.api.v2.messaging.Mailbox;
 import com.hivemq.adapter.sdk.api.v2.model.BrowseFilter;
-import com.hivemq.adapter.sdk.api.v2.model.BrowseNode;
+import com.hivemq.protocols.v2.browse.BrowsedNode;
 import com.hivemq.protocols.v2.manager.ProtocolAdapterManagerMessage.BrowseRequested;
 import com.hivemq.protocols.v2.manager.ProtocolAdapterManagerMessage.ConfigurationChanged;
 import com.hivemq.protocols.v2.runtime.FakeClock;
@@ -71,7 +71,7 @@ class ProtocolAdapterManagerBrowseTest {
         send(new ConfigurationChanged(List.of(adapter("a").build())));
         wrapperFactory.setMachineState("a", ProtocolAdapterWrapperState.CONNECTED);
 
-        final CompletableFuture<List<BrowseNode>> future = new CompletableFuture<>();
+        final CompletableFuture<List<BrowsedNode>> future = new CompletableFuture<>();
         send(new BrowseRequested("a", filter(), future));
 
         assertThat(wrapperFactory.commands("a")).hasAtLeastOneElementOfType(ProtocolAdapterWrapperBrowseRequest.class);
@@ -83,7 +83,7 @@ class ProtocolAdapterManagerBrowseTest {
         send(new ConfigurationChanged(List.of(adapter("a").build())));
         // The recording wrapper stays STOPPED (it does not actually start), so the adapter is not connected.
 
-        final CompletableFuture<List<BrowseNode>> future = new CompletableFuture<>();
+        final CompletableFuture<List<BrowsedNode>> future = new CompletableFuture<>();
         send(new BrowseRequested("a", filter(), future));
 
         final Throwable thrown = catchThrowable(future::get);
@@ -96,7 +96,7 @@ class ProtocolAdapterManagerBrowseTest {
 
     @Test
     void browseUnknownAdapter_failsWithIllegalArgument() {
-        final CompletableFuture<List<BrowseNode>> future = new CompletableFuture<>();
+        final CompletableFuture<List<BrowsedNode>> future = new CompletableFuture<>();
         send(new BrowseRequested("ghost", filter(), future));
 
         final Throwable thrown = catchThrowable(future::get);

--- a/hivemq-edge/src/test/java/com/hivemq/protocols/v2/wrapper/ProtocolAdapterWrapperBrowseTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/protocols/v2/wrapper/ProtocolAdapterWrapperBrowseTest.java
@@ -24,6 +24,7 @@ import com.hivemq.adapter.sdk.api.v2.model.BrowseNode;
 import com.hivemq.adapter.sdk.api.v2.model.ResolvedAttributes;
 import com.hivemq.adapter.sdk.api.v2.node.AccessFlags;
 import com.hivemq.adapter.sdk.api.v2.node.AccessTriState;
+import com.hivemq.protocols.v2.browse.BrowsedNode;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import org.jetbrains.annotations.NotNull;
@@ -39,7 +40,7 @@ class ProtocolAdapterWrapperBrowseTest {
     @Test
     void browseWhenConnected_walksDiscoverThenResolveAndCompletesWithSelectableVariables() {
         final WrapperTestFixture fixture = connectedFixture();
-        final CompletableFuture<List<BrowseNode>> future = new CompletableFuture<>();
+        final CompletableFuture<List<BrowsedNode>> future = new CompletableFuture<>();
 
         // Browse below "root"; the engine issues browse(requestId=1, filter, 0) to the adapter.
         fixture.send(
@@ -77,7 +78,7 @@ class ProtocolAdapterWrapperBrowseTest {
     void browseWhenNotConnected_failsWithNotConnected() {
         final WrapperTestFixture fixture =
                 WrapperTestFixture.builder().skipVerification(true).build();
-        final CompletableFuture<List<BrowseNode>> future = new CompletableFuture<>();
+        final CompletableFuture<List<BrowsedNode>> future = new CompletableFuture<>();
 
         fixture.send(new ProtocolAdapterWrapperBrowseRequest(new BrowseFilter(fixture.nodeFor("temperature")), future));
 
@@ -88,8 +89,8 @@ class ProtocolAdapterWrapperBrowseTest {
     @Test
     void secondBrowseWhileOneIsInFlight_failsWithAlreadyInFlight() {
         final WrapperTestFixture fixture = connectedFixture();
-        final CompletableFuture<List<BrowseNode>> first = new CompletableFuture<>();
-        final CompletableFuture<List<BrowseNode>> second = new CompletableFuture<>();
+        final CompletableFuture<List<BrowsedNode>> first = new CompletableFuture<>();
+        final CompletableFuture<List<BrowsedNode>> second = new CompletableFuture<>();
 
         fixture.send(new ProtocolAdapterWrapperBrowseRequest(new BrowseFilter(fixture.nodeFor("temperature")), first));
         fixture.send(new ProtocolAdapterWrapperBrowseRequest(new BrowseFilter(fixture.nodeFor("temperature")), second));
@@ -101,7 +102,7 @@ class ProtocolAdapterWrapperBrowseTest {
     @Test
     void browseThatNeverReturns_failsOnTheDeadline() {
         final WrapperTestFixture fixture = connectedFixture();
-        final CompletableFuture<List<BrowseNode>> future = new CompletableFuture<>();
+        final CompletableFuture<List<BrowsedNode>> future = new CompletableFuture<>();
 
         fixture.send(new ProtocolAdapterWrapperBrowseRequest(new BrowseFilter(fixture.nodeFor("temperature")), future));
         assertThat(future).isNotDone();
@@ -114,7 +115,7 @@ class ProtocolAdapterWrapperBrowseTest {
     @Test
     void browsePendingWhenConnectionLost_isFailed() {
         final WrapperTestFixture fixture = connectedFixture();
-        final CompletableFuture<List<BrowseNode>> future = new CompletableFuture<>();
+        final CompletableFuture<List<BrowsedNode>> future = new CompletableFuture<>();
 
         fixture.send(new ProtocolAdapterWrapperBrowseRequest(new BrowseFilter(fixture.nodeFor("temperature")), future));
         assertThat(future).isNotDone();
@@ -132,7 +133,7 @@ class ProtocolAdapterWrapperBrowseTest {
         // not skip the caller's TIMED_OUT rejection nor wedge the in-flight slot on a permanent 409.
         final WrapperTestFixture fixture = connectedFixture();
         fixture.adapter.browseCancelThrows = true;
-        final CompletableFuture<List<BrowseNode>> future = new CompletableFuture<>();
+        final CompletableFuture<List<BrowsedNode>> future = new CompletableFuture<>();
 
         fixture.send(new ProtocolAdapterWrapperBrowseRequest(new BrowseFilter(fixture.nodeFor("temperature")), future));
         assertThat(future).isNotDone();
@@ -144,7 +145,7 @@ class ProtocolAdapterWrapperBrowseTest {
         assertThat(fixture.state()).isEqualTo(ProtocolAdapterWrapperState.CONNECTED);
 
         // the slot was genuinely released: the next browse is accepted, not rejected as already in flight.
-        final CompletableFuture<List<BrowseNode>> next = new CompletableFuture<>();
+        final CompletableFuture<List<BrowsedNode>> next = new CompletableFuture<>();
         fixture.send(new ProtocolAdapterWrapperBrowseRequest(new BrowseFilter(fixture.nodeFor("temperature")), next));
         assertThat(next).isNotDone();
     }
@@ -155,7 +156,7 @@ class ProtocolAdapterWrapperBrowseTest {
         // must be swallowed (never escaping into the tick/FSM loop) and the caller still rejected NOT_CONNECTED.
         final WrapperTestFixture fixture = connectedFixture();
         fixture.adapter.browseCancelThrows = true;
-        final CompletableFuture<List<BrowseNode>> future = new CompletableFuture<>();
+        final CompletableFuture<List<BrowsedNode>> future = new CompletableFuture<>();
 
         fixture.send(new ProtocolAdapterWrapperBrowseRequest(new BrowseFilter(fixture.nodeFor("temperature")), future));
         assertThat(future).isNotDone();
@@ -175,7 +176,7 @@ class ProtocolAdapterWrapperBrowseTest {
         // EDG-784: two selectable variables are discovered but the adapter resolves only one; the browse must fail
         // (the REST layer maps it to an error) rather than complete 200 OK with the second variable silently dropped.
         final WrapperTestFixture fixture = connectedFixture();
-        final CompletableFuture<List<BrowseNode>> future = new CompletableFuture<>();
+        final CompletableFuture<List<BrowsedNode>> future = new CompletableFuture<>();
 
         fixture.send(
                 new ProtocolAdapterWrapperBrowseRequest(new BrowseFilter(WrapperTestSupport.node("root")), future));
@@ -206,7 +207,7 @@ class ProtocolAdapterWrapperBrowseTest {
         assertThat(reasonOf(future)).isEqualTo(BrowseRejectedException.Reason.FAILED);
         // the slot is released: the adapter stays CONNECTED and a fresh browse is accepted.
         assertThat(fixture.state()).isEqualTo(ProtocolAdapterWrapperState.CONNECTED);
-        final CompletableFuture<List<BrowseNode>> next = new CompletableFuture<>();
+        final CompletableFuture<List<BrowsedNode>> next = new CompletableFuture<>();
         fixture.send(new ProtocolAdapterWrapperBrowseRequest(new BrowseFilter(fixture.nodeFor("temperature")), next));
         assertThat(next).isNotDone();
     }


### PR DESCRIPTION
## EDG-786 — stop discarding resolved browse data at the REST boundary

**Source:** EDG-779 round-2 review (IMP-001, Sam Cao).

The two-phase browse engine assembles rich `BrowsedNode` results — `{entry, path, tagName, attributes}`, where `attributes` carries the resolved `dataType`, `access`, and `description` — but the wrapper converted them back to the bare DISCOVER `BrowseNode` before returning: `completeBrowse` copied only `node.entry()`, and the `BrowseResultEntry` DTO exposed only `nodeId`/`nodeString`/`type`/`selectable`. The entire RESOLVE output (plus the assembled path and suggested default tag name) was dropped at the edge, so the browse UI couldn't pre-fill tag creation.

### Change

- **Carry the resolved result through the boundary:** the browse future and its message chain switch `BrowseNode → BrowsedNode` (`completeBrowse`, `ProtocolAdapterWrapperBrowseRequest`, `ProtocolAdapterManagerMessage.BrowseRequested`, the resource future). `completeBrowse` no longer strips the result.
- **Extend the REST DTO:** `BrowseResultEntry` (OpenAPI) gains `path`, `tagName`, `dataType`, `access`, and `description`. `access` reuses the existing `AccessFlags` schema (readable/writable/pollable/subscribable) rather than a lossy `READ|READ_WRITE|WRITE` string — faithful and consistent with how tags already expose access. The v2 spec bundle (`ext/hivemq-edge-openapi-v2.yaml`) is regenerated.
- `ProtocolAdaptersResourceImpl.toBrowseResult` maps every field; a `toAccessFlags(SDK AccessFlags)` overload mirrors the existing entity mapper.

### Tests

- `ProtocolAdaptersResourceImplTest` (27) — asserts the mapped path / tag name / data type / access / description.
- `ProtocolAdapterManagerBrowseTest` (3), `ProtocolAdapterWrapperBrowseTest` (8) — follow the boundary type change.
- Real-HTTP e2e coverage lands in the companion **hivemq-edge-test** PR (see below).

### Cross-repo

- **hivemq-edge-test** companion PR: asserts the resolved fields end-to-end over real HTTP (`BrowseAndActivationEndToEndTest`, 17 tests green).
- CI-matching branches `ma/follow-up-v2-review-imp` pushed for `hivemq-edge-adapter-sdk` and `hivemq-edge-composite` (both == their initiative tips) so the composite build resolves the `api.v2` SDK instead of falling back to `master`.

Base: `initiative/nevsky-protocol-adapter-v2`.
