### PR TITLE
EDG-786 browse discards resolved BrowsedNode data (path, default tag name, data type, access)

### DIFF
--- a/hivemq-edge/src/main/java/com/hivemq/api/v2/resources/impl/ProtocolAdaptersResourceImpl.java
+++ b/hivemq-edge/src/main/java/com/hivemq/api/v2/resources/impl/ProtocolAdaptersResourceImpl.java
@@ -29,7 +29,6 @@ import com.hivemq.adapter.sdk.api.v2.ProtocolAdapterInformation;
 import com.hivemq.adapter.sdk.api.v2.factories.ProtocolAdapterFactory;
 import com.hivemq.adapter.sdk.api.v2.messaging.MailboxSender;
 import com.hivemq.adapter.sdk.api.v2.model.BrowseFilter;
-import com.hivemq.adapter.sdk.api.v2.model.BrowseNode;
 import com.hivemq.adapter.sdk.api.v2.node.Node;
 import com.hivemq.api.AbstractApi;
 import com.hivemq.api.v2.errors.ProtocolAdapterErrorFactory;

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/browse/BrowseSink.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/browse/BrowseSink.java
@@ -25,7 +25,7 @@ import org.jetbrains.annotations.NotNull;
  * {@link ProtocolAdapterBrowseEngine#abort()} — an externally-driven interruption (a deadline or a lost
  * connection) is the caller's to surface, since only the caller knows why it aborted.
  * <p>
- * The framework's PAW supplies a sink that completes the REST request's future and maps the reason to an HTTP
+ * The framework's wrapper supplies a sink that completes the REST request's future and maps the reason to an HTTP
  * status; a test supplies {@link BrowseOutcome} and polls it.
  */
 public interface BrowseSink {

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/browse/ProtocolAdapterBrowseEngine.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/browse/ProtocolAdapterBrowseEngine.java
@@ -36,12 +36,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * The single browse traversal engine — the policy the framework's PAW drives in production <b>and</b> the
+ * The single browse traversal engine — the policy the framework's wrapper drives in production <b>and</b> the
  * reference engine the SDK-v2 conformance suites validate against a real device. Written purely against the
  * SDK v2 browse contract ({@code browse} / {@code browseNext} / {@code readNodeAttributes} and their page /
  * attribute / error answers), it has no dependency on the runtime, so the same code runs both places.
  * <p>
- * It advances <b>one PA command at a time</b>, awaiting each answer, in two phases:
+ * It advances <b>one protocol adapter command at a time</b>, awaiting each answer, in two phases:
  * <ul>
  *   <li><b>DISCOVER</b> — a breadth-first frontier walk below the filter node. Each node's continuation pages
  *       are drained ({@code browseNext}) <i>before</i> any sibling is browsed; a visited-set dedups shared
@@ -57,7 +57,7 @@ import org.slf4j.LoggerFactory;
  * with it. <b>Exactly one browse is in flight per engine</b> — {@link #start} on an {@link #isActive() active}
  * engine is a programming error. Any page, attribute result, or error carrying a different id (from a
  * superseded or already-finished browse) is silently ignored, so a late answer can never corrupt a later
- * browse. The driving thread is single-threaded (the PAW's dispatch thread in production, the test thread
+ * browse. The driving thread is single-threaded (the wrapper's dispatch thread in production, the test thread
  * under a synchronous dispatcher); the engine holds no locks.
  *
  * <h2>Termination</h2>

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/manager/DefaultProtocolAdapterWrapperFactory.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/manager/DefaultProtocolAdapterWrapperFactory.java
@@ -24,8 +24,10 @@ import com.hivemq.adapter.sdk.api.v2.ProtocolAdapter;
 import com.hivemq.adapter.sdk.api.v2.factories.ProtocolAdapterFactory;
 import com.hivemq.adapter.sdk.api.v2.messaging.DefaultMailbox;
 import com.hivemq.adapter.sdk.api.v2.messaging.Mailbox;
+import com.hivemq.adapter.sdk.api.v2.messaging.MailboxMessage;
 import com.hivemq.adapter.sdk.api.v2.messaging.MessageDispatcher;
 import com.hivemq.adapter.sdk.api.v2.messaging.MessageDispatcherHandle;
+import com.hivemq.adapter.sdk.api.v2.messaging.MessageHandler;
 import com.hivemq.adapter.sdk.api.v2.model.ProtocolAdapterInput;
 import com.hivemq.adapter.sdk.api.v2.model.ProtocolAdapterOutput;
 import com.hivemq.adapter.sdk.api.v2.node.Node;
@@ -118,9 +120,23 @@ public final class DefaultProtocolAdapterWrapperFactory implements ProtocolAdapt
         final List<NodeTagPair> nodes = translateNodes(entity, factory);
         final DataPoint adapterConfig =
                 dataPointFactory.createJsonDataPoint(adapterId, entity.getAdapterConfiguration());
-        final ProtocolAdapterService services = new WrapperServices(dataPointFactory, dispatcher);
+        // Hand the adapter a dispatcher that records every binding it opens through the framework, so the framework
+        // owns each dispatch thread for the adapter's whole lifetime — whether the adapter attaches its mailbox in its
+        // constructor or later, and whether or not it is itself AutoCloseable. A construction that fails after a
+        // binding was opened releases it here; a successful build hands the recorder to the container so teardown
+        // releases every binding then.
+        final RecordingDispatcher recordingDispatcher = new RecordingDispatcher(dispatcher);
+        final ProtocolAdapterService services = new WrapperServices(dataPointFactory, recordingDispatcher);
         final ProtocolAdapterInput input = new WrapperInput(adapterId, adapterConfig, nodes, services);
-        final ProtocolAdapter protocolAdapter = factory.createAdapter(input, output);
+        final ProtocolAdapter protocolAdapter;
+        try {
+            protocolAdapter = factory.createAdapter(input, output);
+        } catch (final RuntimeException failure) {
+            // Release every dispatch binding the half-built adapter opened before rethrowing, so a failed
+            // construction leaks no dispatch thread.
+            recordingDispatcher.close();
+            throw failure;
+        }
 
         final ProtocolAdapterMetrics metrics = new ProtocolAdapterMetrics(metricRegistry, adapterId, mailbox::size);
         final ProtocolAdapterGoalState goal = ProtocolAdapterConfigSupport.goalOf(entity);
@@ -163,9 +179,17 @@ public final class DefaultProtocolAdapterWrapperFactory implements ProtocolAdapt
         final MessageDispatcherHandle dispatcherHandle = dispatcher.attach(mailbox, wrapper);
         final AutoCloseable tickHandle =
                 clock.scheduleTick(tickPeriodMillis, mailbox, () -> new ProtocolAdapterWrapperTick(clock.nowMillis()));
+        // The container owns the teardown of everything the adapter attached through the framework dispatcher, so its
+        // dispatch threads are released when the adapter is discarded, exactly as the wrapper's binding is. The
+        // adapter's own close() (if it is AutoCloseable) runs first to release any non-dispatch resources; the
+        // recording dispatcher then closes every remaining binding it opened, each at most once — so a template's
+        // single self-closed binding is never double-closed and a non-AutoCloseable direct adapter's binding is
+        // still released.
+        final AutoCloseable adapterDispatcherHandle = adapterTeardown(protocolAdapter, recordingDispatcher);
 
         final ProtocolAdapterHandle handle = new ProtocolAdapterHandle(adapterId, mailbox, snapshot);
-        return new ProtocolAdapterContainer(handle, dispatcherHandle, tickHandle, metrics, entity);
+        return new ProtocolAdapterContainer(
+                handle, dispatcherHandle, adapterDispatcherHandle, tickHandle, metrics, entity);
     }
 
     @Override
@@ -191,6 +215,106 @@ public final class DefaultProtocolAdapterWrapperFactory implements ProtocolAdapt
                     node, tag.getName(), factory.nodeDefinitionSchema(), tag.isPollable(), tag.isSubscribable()));
         }
         return nodes;
+    }
+
+    /**
+     * The teardown of everything a successfully-built adapter owns on the framework side: the adapter's own
+     * {@link AutoCloseable} (if it is one — a template adapter, or any adapter that releases resources on teardown),
+     * then every dispatch binding it opened through the framework dispatcher. Closing both never double-closes a live
+     * binding — the recorded bindings close at most once — so a template's single binding, closed first by the
+     * adapter's own {@code close()}, is skipped by the recorder's pass. Best effort: a failing adapter close still
+     * lets the recording dispatcher release the dispatch threads.
+     *
+     * @param protocolAdapter     the constructed adapter, closed if it is {@link AutoCloseable}.
+     * @param recordingDispatcher the dispatcher that recorded every binding the adapter opened.
+     * @return the composite teardown the container closes when the adapter is discarded.
+     */
+    private static @NotNull AutoCloseable adapterTeardown(
+            final @NotNull ProtocolAdapter protocolAdapter, final @NotNull RecordingDispatcher recordingDispatcher) {
+        return () -> {
+            try {
+                if (protocolAdapter instanceof AutoCloseable closeable) {
+                    closeable.close();
+                }
+            } finally {
+                recordingDispatcher.close();
+            }
+        };
+    }
+
+    /**
+     * A {@link MessageDispatcher} that delegates to the real dispatcher while recording every binding it hands out, so
+     * the framework can release each one on teardown regardless of whether the adapter is {@link AutoCloseable}.
+     * Attach and close are serialized under this dispatcher's monitor: once {@link #close()} has released the adapter's
+     * bindings, a later {@code attach()} — a background adapter callback racing with or following the adapter's discard
+     * — is rejected rather than silently opening a binding no owner would ever release. Every recorded binding closes
+     * at most once, so closing is safe even after the adapter has already closed one itself (as a template adapter
+     * does).
+     */
+    private static final class RecordingDispatcher implements MessageDispatcher, AutoCloseable {
+
+        private final @NotNull MessageDispatcher delegate;
+        private final @NotNull List<IdempotentHandle> handles = new ArrayList<>();
+        private boolean closed;
+
+        private RecordingDispatcher(final @NotNull MessageDispatcher delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public synchronized <MessageType extends MailboxMessage> @NotNull MessageDispatcherHandle attach(
+                final @NotNull Mailbox<MessageType> mailbox, final @NotNull MessageHandler<MessageType> handler) {
+            if (closed) {
+                // The framework has already released this adapter's bindings; opening one now would leak a dispatch
+                // thread no later owner closes. Reject the attach-after-close rather than record an unowned binding.
+                throw new IllegalStateException(
+                        "the framework dispatcher is closed: the adapter that opened it has been discarded");
+            }
+            final IdempotentHandle handle = new IdempotentHandle(delegate.attach(mailbox, handler));
+            handles.add(handle);
+            return handle;
+        }
+
+        /**
+         * Mark the dispatcher closed and release every binding opened through it, each at most once. Called on a
+         * construction failure to release a half-built adapter's threads, and again on container teardown to release a
+         * successfully-built adapter's — the per-binding idempotence makes the second pass a no-op for anything a
+         * template adapter already closed itself. After this runs, {@link #attach} rejects further bindings.
+         */
+        @Override
+        public synchronized void close() {
+            closed = true;
+            for (final IdempotentHandle handle : handles) {
+                handle.close();
+            }
+        }
+    }
+
+    /**
+     * A dispatcher handle that closes its delegate at most once, so the framework can safely close it both from the
+     * adapter's own teardown and from {@link RecordingDispatcher#close()} without double-closing a live binding.
+     */
+    private static final class IdempotentHandle implements MessageDispatcherHandle {
+
+        private final @NotNull MessageDispatcherHandle delegate;
+        private boolean closed;
+
+        private IdempotentHandle(final @NotNull MessageDispatcherHandle delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public synchronized void close() {
+            if (closed) {
+                return;
+            }
+            closed = true;
+            try {
+                delegate.close();
+            } catch (final RuntimeException ignored) {
+                // Best effort: a failing detach must not mask teardown or the original construction failure.
+            }
+        }
     }
 
     /**

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/manager/ProtocolAdapterContainer.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/manager/ProtocolAdapterContainer.java
@@ -42,6 +42,7 @@ public final class ProtocolAdapterContainer implements AutoCloseable {
 
     private final @NotNull ProtocolAdapterHandle handle;
     private final @Nullable MessageDispatcherHandle dispatcherHandle;
+    private final @Nullable AutoCloseable adapterDispatcherHandle;
     private final @Nullable AutoCloseable tickHandle;
     private final @Nullable ProtocolAdapterMetrics metrics;
     private @NotNull ProtocolAdapterEntity appliedEntity;
@@ -49,20 +50,24 @@ public final class ProtocolAdapterContainer implements AutoCloseable {
     /**
      * Create a running managed adapter with its teardown resources.
      *
-     * @param handle           the REST-readable handle.
-     * @param dispatcherHandle the binding of the wrapper mailbox to the dispatcher.
-     * @param tickHandle       the periodic wrapper tick schedule.
-     * @param metrics          the per-adapter metrics.
-     * @param appliedEntity    the configuration this adapter is running.
+     * @param handle                  the REST-readable handle.
+     * @param dispatcherHandle        the binding of the wrapper mailbox to the dispatcher.
+     * @param adapterDispatcherHandle the teardown of the adapter itself: its own {@code close()} (if AutoCloseable)
+     *                                and every dispatch binding it opened through the framework dispatcher.
+     * @param tickHandle              the periodic wrapper tick schedule.
+     * @param metrics                 the per-adapter metrics.
+     * @param appliedEntity           the configuration this adapter is running.
      */
     public ProtocolAdapterContainer(
             final @NotNull ProtocolAdapterHandle handle,
             final @NotNull MessageDispatcherHandle dispatcherHandle,
+            final @NotNull AutoCloseable adapterDispatcherHandle,
             final @NotNull AutoCloseable tickHandle,
             final @NotNull ProtocolAdapterMetrics metrics,
             final @NotNull ProtocolAdapterEntity appliedEntity) {
         this.handle = handle;
         this.dispatcherHandle = dispatcherHandle;
+        this.adapterDispatcherHandle = adapterDispatcherHandle;
         this.tickHandle = tickHandle;
         this.metrics = metrics;
         this.appliedEntity = appliedEntity;
@@ -72,6 +77,7 @@ public final class ProtocolAdapterContainer implements AutoCloseable {
             final @NotNull ProtocolAdapterHandle handle, final @NotNull ProtocolAdapterEntity entity) {
         this.handle = handle;
         this.dispatcherHandle = null;
+        this.adapterDispatcherHandle = null;
         this.tickHandle = null;
         this.metrics = null;
         this.appliedEntity = entity;
@@ -130,6 +136,7 @@ public final class ProtocolAdapterContainer implements AutoCloseable {
     public void close() {
         closeQuietly(tickHandle, "tick schedule");
         closeQuietly(dispatcherHandle, "dispatcher binding");
+        closeQuietly(adapterDispatcherHandle, "adapter dispatcher bindings");
         closeQuietly(metrics, "metrics");
     }
 

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/wrapper/ProtocolAdapterWrapperContext.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/wrapper/ProtocolAdapterWrapperContext.java
@@ -503,8 +503,9 @@ public final class ProtocolAdapterWrapperContext {
      * Bridge a REST browse to the protocol adapter, on the dispatch thread. A browse runs only when
      * the adapter is {@code CONNECTED} and no browse is already in flight; otherwise the future is failed with a
      * {@link BrowseRejectedException} the resource maps to {@code 409}. On acceptance, the
-     * {@link ProtocolAdapterBrowseEngine} drives the two-phase paginated walk (DISCOVER then RESOLVE), one PA
-     * command at a time, and completes the future — with a deadline backstop that always releases the slot.
+     * {@link ProtocolAdapterBrowseEngine} drives the two-phase paginated walk (DISCOVER then RESOLVE), one
+     * protocol adapter command at a time, and completes the future — with a deadline backstop that always
+     * releases the slot.
      *
      * @param filter     the browse filter.
      * @param completion the future the REST thread awaits.

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/wrapper/ProtocolAdapterWrapperEvent.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/wrapper/ProtocolAdapterWrapperEvent.java
@@ -35,7 +35,8 @@ import org.jetbrains.annotations.Nullable;
  * matching row runs the table's defensive reset.
  * <p>
  * Band: {@link MailboxMessagePriority#EVENT} (the {@link com.hivemq.adapter.sdk.api.v2.messaging.MailboxMessage}
- * default), except {@link DataPointReceived} and {@link BrowseResultReceived}, which override to
+ * default), except {@link DataPointReceived} and the browse events ({@link BrowsePageReceived},
+ * {@link AttributesResolved}, {@link BrowseFailed}), which override to
  * {@link MailboxMessagePriority#DATA} so the chatty push channel never starves control, acknowledgments, or time
  *. The timer-expiry events ({@link WatchdogFired}, {@link BackoffFired}, {@link PollTimerFired},
  * {@link VerificationRetryTimerFired}, {@link SubscriptionRetryTimerFired}) never enter the mailbox — they are

--- a/hivemq-edge/src/test/java/com/hivemq/protocols/v2/manager/DefaultProtocolAdapterWrapperFactoryTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/protocols/v2/manager/DefaultProtocolAdapterWrapperFactoryTest.java
@@ -22,10 +22,27 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.codahale.metrics.MetricRegistry;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hivemq.adapter.sdk.api.schema.Schema;
+import com.hivemq.adapter.sdk.api.v2.ProtocolAdapter;
+import com.hivemq.adapter.sdk.api.v2.ProtocolAdapterInformation;
+import com.hivemq.adapter.sdk.api.v2.factories.ProtocolAdapterFactory;
+import com.hivemq.adapter.sdk.api.v2.messaging.DefaultMailbox;
+import com.hivemq.adapter.sdk.api.v2.messaging.Mailbox;
+import com.hivemq.adapter.sdk.api.v2.messaging.MailboxMessage;
+import com.hivemq.adapter.sdk.api.v2.messaging.MessageDispatcher;
+import com.hivemq.adapter.sdk.api.v2.messaging.MessageDispatcherHandle;
+import com.hivemq.adapter.sdk.api.v2.messaging.MessageHandler;
+import com.hivemq.adapter.sdk.api.v2.model.BrowseContinuation;
+import com.hivemq.adapter.sdk.api.v2.model.BrowseFilter;
+import com.hivemq.adapter.sdk.api.v2.model.ProtocolAdapterInput;
+import com.hivemq.adapter.sdk.api.v2.model.ProtocolAdapterOutput;
+import com.hivemq.adapter.sdk.api.v2.model.WriteEntry;
+import com.hivemq.adapter.sdk.api.v2.node.Node;
 import com.hivemq.adapter.sdk.api.v2.node.NodeTagPair;
 import com.hivemq.protocols.v2.config.ProtocolAdapterEntity;
 import com.hivemq.protocols.v2.manager.ProtocolAdapterManagerTestSupport.TestDataPointFactory;
 import com.hivemq.protocols.v2.manager.ProtocolAdapterManagerTestSupport.TestProtocolAdapterFactory;
+import com.hivemq.protocols.v2.manager.ProtocolAdapterManagerTestSupport.TestProtocolAdapterInformation;
 import com.hivemq.protocols.v2.runtime.FakeClock;
 import com.hivemq.protocols.v2.runtime.ManualDispatcher;
 import com.hivemq.protocols.v2.view.AdapterStatusSnapshot;
@@ -36,6 +53,7 @@ import com.hivemq.protocols.v2.wrapper.ProtocolAdapterWrapperState;
 import java.util.ArrayList;
 import java.util.List;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -137,6 +155,252 @@ class DefaultProtocolAdapterWrapperFactoryTest {
 
         managed.close();
     }
+
+    // ── EDG-792: the framework owns every dispatch binding an adapter opens through the service dispatcher ──────────
+
+    @Test
+    void directAdapterAttachingInItsConstructor_hasItsBindingReleasedOnContainerClose() {
+        final CountingDispatcher counting = new CountingDispatcher();
+        final DefaultProtocolAdapterWrapperFactory factoryOnCounting = new DefaultProtocolAdapterWrapperFactory(
+                clock, counting, new MetricRegistry(), new TestDataPointFactory(), new ObjectMapper(), 100);
+
+        final ProtocolAdapterContainer managed = factoryOnCounting.create(
+                adapter("a").build(), new DirectDispatchingFactory(true), ProtocolAdapterWrapperEventListener.NONE);
+
+        // A direct (non-AutoCloseable) adapter attached its own mailbox through the framework dispatcher in its
+        // constructor, so two bindings are live: the wrapper's and the adapter's.
+        assertThat(counting.liveBindings()).isEqualTo(2);
+
+        // Container teardown must release the adapter's binding even though the adapter is not AutoCloseable.
+        managed.close();
+        assertThat(counting.liveBindings()).isZero();
+    }
+
+    @Test
+    void directAdapterAttachingAfterConstruction_hasThatBindingReleasedOnContainerClose() {
+        final CountingDispatcher counting = new CountingDispatcher();
+        final DefaultProtocolAdapterWrapperFactory factoryOnCounting = new DefaultProtocolAdapterWrapperFactory(
+                clock, counting, new MetricRegistry(), new TestDataPointFactory(), new ObjectMapper(), 100);
+        final DirectDispatchingFactory directFactory = new DirectDispatchingFactory(false);
+
+        final ProtocolAdapterContainer managed =
+                factoryOnCounting.create(adapter("a").build(), directFactory, ProtocolAdapterWrapperEventListener.NONE);
+
+        // Only the wrapper is bound so far; the direct adapter attached nothing in its constructor.
+        assertThat(counting.liveBindings()).isEqualTo(1);
+
+        // The adapter stored the framework dispatcher and attaches a mailbox later — the framework still owns that
+        // binding because the recording dispatcher stays live for the adapter's whole lifetime.
+        directFactory.lastAdapter().attachLater();
+        assertThat(counting.liveBindings()).isEqualTo(2);
+
+        managed.close();
+        assertThat(counting.liveBindings()).isZero();
+    }
+
+    @Test
+    void attachThroughTheServiceDispatcherAfterContainerClose_isRejectedAndOpensNoBinding() {
+        final CountingDispatcher counting = new CountingDispatcher();
+        final DefaultProtocolAdapterWrapperFactory factoryOnCounting = new DefaultProtocolAdapterWrapperFactory(
+                clock, counting, new MetricRegistry(), new TestDataPointFactory(), new ObjectMapper(), 100);
+        final DirectDispatchingFactory directFactory = new DirectDispatchingFactory(false);
+
+        final ProtocolAdapterContainer managed =
+                factoryOnCounting.create(adapter("a").build(), directFactory, ProtocolAdapterWrapperEventListener.NONE);
+        managed.close();
+        assertThat(counting.liveBindings()).isZero();
+
+        // A background adapter callback that stored the framework dispatcher and attaches after the adapter has been
+        // discarded must not silently open a dispatch thread no owner would ever release: the closed recording
+        // dispatcher rejects the late attach and opens no binding.
+        assertThatThrownBy(() -> directFactory.lastAdapter().attachLater()).isInstanceOf(IllegalStateException.class);
+        assertThat(counting.liveBindings()).isZero();
+    }
+
+    @Test
+    void constructionThatFailsAfterOpeningABinding_releasesItBeforeRethrowing() {
+        final CountingDispatcher counting = new CountingDispatcher();
+        final DefaultProtocolAdapterWrapperFactory factoryOnCounting = new DefaultProtocolAdapterWrapperFactory(
+                clock, counting, new MetricRegistry(), new TestDataPointFactory(), new ObjectMapper(), 100);
+
+        assertThatThrownBy(() -> factoryOnCounting.create(
+                        adapter("a").build(),
+                        new FailingAfterAttachFactory(),
+                        ProtocolAdapterWrapperEventListener.NONE))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("boom");
+        // The half-built adapter opened one binding through the framework dispatcher before throwing; it must be
+        // released, and the wrapper's own binding is never opened because construction failed first.
+        assertThat(counting.liveBindings()).isZero();
+    }
+
+    /**
+     * A {@link MessageDispatcher} double that counts the bindings it hands out and the ones later closed, so a test can
+     * assert every binding an adapter opened is released on teardown and a failed construction leaves none behind.
+     */
+    private static final class CountingDispatcher implements MessageDispatcher {
+
+        private int attaches;
+        private int detaches;
+
+        @Override
+        public <MessageType extends MailboxMessage> @NotNull MessageDispatcherHandle attach(
+                final @NotNull Mailbox<MessageType> mailbox, final @NotNull MessageHandler<MessageType> handler) {
+            attaches++;
+            return () -> detaches++;
+        }
+
+        private int liveBindings() {
+            return attaches - detaches;
+        }
+    }
+
+    /**
+     * A factory whose {@code createAdapter} builds a {@link DirectDispatchingAdapter} — a direct, non-AutoCloseable
+     * adapter that opens its dispatch binding through the framework dispatcher. The last-built instance is captured so
+     * a test can drive a post-construction attach on it.
+     */
+    private static final class DirectDispatchingFactory implements ProtocolAdapterFactory {
+
+        private final @NotNull ProtocolAdapterInformation information =
+                new TestProtocolAdapterInformation(ProtocolAdapterManagerTestSupport.TEST_PROTOCOL_ID);
+        private final boolean attachInConstructor;
+        private @NotNull DirectDispatchingAdapter lastAdapter = new DirectDispatchingAdapter(null, false);
+
+        private DirectDispatchingFactory(final boolean attachInConstructor) {
+            this.attachInConstructor = attachInConstructor;
+        }
+
+        @Override
+        public @NotNull ProtocolAdapterInformation information() {
+            return information;
+        }
+
+        @Override
+        public @NotNull ProtocolAdapter createAdapter(
+                final @NotNull ProtocolAdapterInput input, final @NotNull ProtocolAdapterOutput output) {
+            lastAdapter = new DirectDispatchingAdapter(input.services().dispatcher(), attachInConstructor);
+            return lastAdapter;
+        }
+
+        private @NotNull DirectDispatchingAdapter lastAdapter() {
+            return lastAdapter;
+        }
+
+        @Override
+        public @NotNull Schema adapterConfigSchema() {
+            return ProtocolAdapterManagerTestSupport.scalarSchema();
+        }
+
+        @Override
+        public @NotNull Schema nodeDefinitionSchema() {
+            return ProtocolAdapterManagerTestSupport.scalarSchema();
+        }
+    }
+
+    /**
+     * A factory whose {@code createAdapter} opens a dispatch binding through the framework dispatcher and then throws,
+     * modelling a construction that fails after a binding was already opened — the framework must release it.
+     */
+    private static final class FailingAfterAttachFactory implements ProtocolAdapterFactory {
+
+        private final @NotNull ProtocolAdapterInformation information =
+                new TestProtocolAdapterInformation(ProtocolAdapterManagerTestSupport.TEST_PROTOCOL_ID);
+
+        @Override
+        public @NotNull ProtocolAdapterInformation information() {
+            return information;
+        }
+
+        @Override
+        public @NotNull ProtocolAdapter createAdapter(
+                final @NotNull ProtocolAdapterInput input, final @NotNull ProtocolAdapterOutput output) {
+            input.services().dispatcher().attach(new DefaultMailbox<DirectMessage>(), message -> {});
+            throw new IllegalStateException("boom while constructing the adapter");
+        }
+
+        @Override
+        public @NotNull Schema adapterConfigSchema() {
+            return ProtocolAdapterManagerTestSupport.scalarSchema();
+        }
+
+        @Override
+        public @NotNull Schema nodeDefinitionSchema() {
+            return ProtocolAdapterManagerTestSupport.scalarSchema();
+        }
+    }
+
+    /**
+     * A direct {@link ProtocolAdapter} — deliberately NOT {@link AutoCloseable} — that opens its dispatch binding
+     * through the framework {@link MessageDispatcher} the SDK exposes via {@code input.services().dispatcher()}, exactly
+     * as an author who does not use the template may. It attaches either in its constructor or, via {@link #attachLater},
+     * after construction, to prove the framework releases the binding on container teardown though it cannot close the
+     * adapter itself.
+     */
+    private static final class DirectDispatchingAdapter implements ProtocolAdapter {
+
+        private final @Nullable MessageDispatcher dispatcher;
+
+        private DirectDispatchingAdapter(
+                final @Nullable MessageDispatcher dispatcher, final boolean attachInConstructor) {
+            this.dispatcher = dispatcher;
+            if (attachInConstructor) {
+                attachLater();
+            }
+        }
+
+        private void attachLater() {
+            if (dispatcher != null) {
+                dispatcher.attach(new DefaultMailbox<DirectMessage>(), message -> {});
+            }
+        }
+
+        @Override
+        public @NotNull String adapterId() {
+            return "direct";
+        }
+
+        @Override
+        public void start() {}
+
+        @Override
+        public void stop() {}
+
+        @Override
+        public void connect() {}
+
+        @Override
+        public void disconnect() {}
+
+        @Override
+        public void verifyBatch(final @NotNull List<Node> nodes) {}
+
+        @Override
+        public void pollBatch(final @NotNull List<Node> nodes) {}
+
+        @Override
+        public void addSubscriptionBatch(final @NotNull List<Node> nodes) {}
+
+        @Override
+        public void removeSubscriptionBatch(final @NotNull List<Node> nodes) {}
+
+        @Override
+        public void writeBatch(final @NotNull List<WriteEntry> entries) {}
+
+        @Override
+        public void browse(final int requestId, final @NotNull BrowseFilter filter, final int maxReferences) {}
+
+        @Override
+        public void browseNext(final int requestId, final @NotNull BrowseContinuation continuation) {}
+
+        @Override
+        public void readNodeAttributes(final int requestId, final @NotNull List<Node> nodes) {}
+    }
+
+    /**
+     * A trivial mailbox message the direct adapter double attaches a mailbox for.
+     */
+    private record DirectMessage() implements MailboxMessage {}
 
     private static final class RecordingHealth implements ProtocolAdapterWrapperEventListener {
 

--- a/hivemq-edge/src/test/java/com/hivemq/protocols/v2/manager/RecordingWrapperFactory.java
+++ b/hivemq-edge/src/test/java/com/hivemq/protocols/v2/manager/RecordingWrapperFactory.java
@@ -68,7 +68,7 @@ final class RecordingWrapperFactory implements ProtocolAdapterWrapperFactory {
         final MailboxSender<ProtocolAdapterWrapperMessage> sender = commands::add;
         final ProtocolAdapterHandle handle = new ProtocolAdapterHandle(adapterId, sender, snapshot);
         final ProtocolAdapterMetrics metrics = new ProtocolAdapterMetrics(new MetricRegistry(), adapterId, () -> 0);
-        return new ProtocolAdapterContainer(handle, () -> {}, () -> {}, metrics, entity);
+        return new ProtocolAdapterContainer(handle, () -> {}, () -> {}, () -> {}, metrics, entity);
     }
 
     @Override


### PR DESCRIPTION
card: [EDG-786](https://linear.app/hivemq/issue/EDG-786/rest-browse-discards-resolved-browsednode-data-path-default-tag-name)