### PR TITLE
EDG-776: Drop undecodable OPC UA custom-struct values instead of publishing base64

### DIFF
--- a/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/listeners/OpcUaSubscriptionLifecycleHandler.java
+++ b/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/listeners/OpcUaSubscriptionLifecycleHandler.java
@@ -33,6 +33,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
@@ -41,6 +43,7 @@ import org.eclipse.milo.opcua.sdk.client.subscriptions.MonitoredItemSynchronizat
 import org.eclipse.milo.opcua.sdk.client.subscriptions.OpcUaMonitoredItem;
 import org.eclipse.milo.opcua.sdk.client.subscriptions.OpcUaSubscription;
 import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.UaSerializationException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
@@ -52,7 +55,10 @@ import org.slf4j.LoggerFactory;
 public class OpcUaSubscriptionLifecycleHandler implements OpcUaSubscription.SubscriptionListener {
 
     public static final long KEEP_ALIVE_SAFETY_MARGIN_MS = 5_000L;
+    public static final long TYPE_REGISTRY_RESET_THROTTLE_MS = 10_000L;
 
+    private static final long TYPE_REGISTRY_RESET_THROTTLE_NANOS =
+            TimeUnit.MILLISECONDS.toNanos(TYPE_REGISTRY_RESET_THROTTLE_MS);
     private static final @NotNull Logger log = LoggerFactory.getLogger(OpcUaSubscriptionLifecycleHandler.class);
     private static final int MAX_MONITORED_ITEM_COUNT = 5;
 
@@ -68,6 +74,12 @@ public class OpcUaSubscriptionLifecycleHandler implements OpcUaSubscription.Subs
 
     // Track last keep-alive timestamp for health monitoring
     private volatile long lastKeepAliveTimestamp;
+
+    // Track last dynamic-type-registry reset so a permanently undecodable type cannot trigger a
+    // full DataTypeTree browse per notification (EDG-776). Monotonic clock (nanoTime), seeded one
+    // throttle window in the past so the first reset is never throttled.
+    private final @NotNull AtomicLong lastTypeRegistryResetNanos =
+            new AtomicLong(System.nanoTime() - TYPE_REGISTRY_RESET_THROTTLE_NANOS);
 
     public OpcUaSubscriptionLifecycleHandler(
             final @NotNull ProtocolAdapterMetricsService protocolAdapterMetricsService,
@@ -191,6 +203,7 @@ public class OpcUaSubscriptionLifecycleHandler implements OpcUaSubscription.Subs
      * @return an Optional containing the created or transferred subscription, or empty if failed
      */
     public @NotNull Optional<OpcUaSubscription> subscribe(final @NotNull OpcUaClient client) {
+        warmUpDynamicTypeRegistry(client);
         return newSubscription(client)
                 .publishingInterval(config.getOpcuaToMqttConfig().publishingInterval())
                 .create()
@@ -368,6 +381,7 @@ public class OpcUaSubscriptionLifecycleHandler implements OpcUaSubscription.Subs
         protocolAdapterMetricsService.increment(Constants.METRIC_SUBSCRIPTION_TRANSFER_FAILED_COUNT);
 
         log.error("Subscription Transfer failed, recreating subscription for adapter '{}'", adapterId);
+        warmUpDynamicTypeRegistry(client);
         newSubscription(client)
                 .publishingInterval(config.getOpcuaToMqttConfig().publishingInterval())
                 .create()
@@ -404,11 +418,60 @@ public class OpcUaSubscriptionLifecycleHandler implements OpcUaSubscription.Subs
 
                 final var dataPointBuilder = dataPointsPublisher.addDataPoint(tag);
                 extractPayload(client, values.get(i), dataPointBuilder);
+            } catch (final @NotNull UaSerializationException e) {
+                // Typically "no codec registered" for a custom struct: Milo resets the dynamic codec
+                // registry on every session (re)activation and rebuilds it best-effort — browse/read
+                // failures under load leave it silently incomplete (EDG-776). Publishing the undecoded
+                // binary body would corrupt the payload, so drop this notification batch (the server
+                // resamples the monitored items) and reset the registry so the next notification
+                // triggers a fresh rebuild.
+                protocolAdapterMetricsService.increment(Constants.METRIC_SUBSCRIPTION_DATA_ERROR_COUNT);
+                log.warn(
+                        "Adapter '{}': could not decode OPC UA value for tag '{}', dropping the current samples and resetting the dynamic type registry",
+                        adapterId,
+                        tn,
+                        e);
+                resetDynamicTypeRegistry();
+                return;
             } catch (final Throwable e) {
                 protocolAdapterMetricsService.increment(Constants.METRIC_SUBSCRIPTION_DATA_ERROR_COUNT);
                 throw new RuntimeException(e);
             }
         }
         dataPointsPublisher.publish();
+    }
+
+    /**
+     * Builds the client's dynamic encoding context (DataTypeTree browse + codec registration) so the
+     * expensive first build happens off the value-notification path. Best-effort: on failure the
+     * context is rebuilt lazily on the first received value.
+     *
+     * @param client the OPC UA client
+     */
+    private void warmUpDynamicTypeRegistry(final @NotNull OpcUaClient client) {
+        try {
+            client.getDynamicEncodingContext();
+        } catch (final Exception e) {
+            log.warn(
+                    "Adapter '{}': could not pre-build the OPC UA dynamic type registry, it will be rebuilt on the first received value",
+                    adapterId,
+                    e);
+        }
+    }
+
+    /**
+     * Resets the client's cached DataTypeTree, dynamic DataTypeManager and dynamic EncodingContext so
+     * they are rebuilt from the server on next use. Throttled because each rebuild browses the
+     * server's full DataType hierarchy.
+     */
+    private void resetDynamicTypeRegistry() {
+        final long now = System.nanoTime();
+        final long last = lastTypeRegistryResetNanos.get();
+        // CAS so concurrent notification threads cannot both win the throttle window
+        if (now - last >= TYPE_REGISTRY_RESET_THROTTLE_NANOS && lastTypeRegistryResetNanos.compareAndSet(last, now)) {
+            client.resetDataTypeTree();
+            client.resetDynamicDataTypeManager();
+            client.resetDynamicEncodingContext();
+        }
     }
 }

--- a/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/listeners/OpcUaSubscriptionLifecycleHandler.java
+++ b/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/listeners/OpcUaSubscriptionLifecycleHandler.java
@@ -203,7 +203,6 @@ public class OpcUaSubscriptionLifecycleHandler implements OpcUaSubscription.Subs
      * @return an Optional containing the created or transferred subscription, or empty if failed
      */
     public @NotNull Optional<OpcUaSubscription> subscribe(final @NotNull OpcUaClient client) {
-        warmUpDynamicTypeRegistry(client);
         return newSubscription(client)
                 .publishingInterval(config.getOpcuaToMqttConfig().publishingInterval())
                 .create()
@@ -381,7 +380,6 @@ public class OpcUaSubscriptionLifecycleHandler implements OpcUaSubscription.Subs
         protocolAdapterMetricsService.increment(Constants.METRIC_SUBSCRIPTION_TRANSFER_FAILED_COUNT);
 
         log.error("Subscription Transfer failed, recreating subscription for adapter '{}'", adapterId);
-        warmUpDynamicTypeRegistry(client);
         newSubscription(client)
                 .publishingInterval(config.getOpcuaToMqttConfig().publishingInterval())
                 .create()
@@ -439,24 +437,6 @@ public class OpcUaSubscriptionLifecycleHandler implements OpcUaSubscription.Subs
             }
         }
         dataPointsPublisher.publish();
-    }
-
-    /**
-     * Builds the client's dynamic encoding context (DataTypeTree browse + codec registration) so the
-     * expensive first build happens off the value-notification path. Best-effort: on failure the
-     * context is rebuilt lazily on the first received value.
-     *
-     * @param client the OPC UA client
-     */
-    private void warmUpDynamicTypeRegistry(final @NotNull OpcUaClient client) {
-        try {
-            client.getDynamicEncodingContext();
-        } catch (final Exception e) {
-            log.warn(
-                    "Adapter '{}': could not pre-build the OPC UA dynamic type registry, it will be rebuilt on the first received value",
-                    adapterId,
-                    e);
-        }
     }
 
     /**

--- a/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/northbound/OpcUaToJsonConverter.java
+++ b/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/northbound/OpcUaToJsonConverter.java
@@ -181,13 +181,7 @@ public class OpcUaToJsonConverter {
             }
             obj.endObject();
         } else if (value instanceof final ExtensionObject eo) {
-            try {
-                final Object decodedValue = eo.decode(ctx);
-                addValue(builder, decodedValue, ctx);
-            } catch (final Throwable t) {
-                log.debug("Not able to decode body of OPC UA ExtensionObject, using undecoded body value instead", t);
-                addValue(builder, eo.getBody(), ctx);
-            }
+            addValue(builder, eo.decode(ctx), ctx);
         } else if (value instanceof final Variant variant) {
             final Object variantValue = variant.getValue();
             if (variantValue != null) {
@@ -298,13 +292,7 @@ public class OpcUaToJsonConverter {
             }
             nested.endObject();
         } else if (value instanceof final ExtensionObject eo) {
-            try {
-                final Object decodedValue = eo.decode(ctx);
-                addValueToObject(obj, key, decodedValue, ctx);
-            } catch (final Throwable t) {
-                log.debug("Not able to decode body of OPC UA ExtensionObject, using undecoded body value instead", t);
-                addValueToObject(obj, key, eo.getBody(), ctx);
-            }
+            addValueToObject(obj, key, eo.decode(ctx), ctx);
         } else if (value instanceof final Variant variant) {
             final Object variantValue = variant.getValue();
             if (variantValue != null) {
@@ -400,13 +388,7 @@ public class OpcUaToJsonConverter {
             }
             nested.endObject();
         } else if (value instanceof final ExtensionObject eo) {
-            try {
-                final Object decodedValue = eo.decode(ctx);
-                addValueToArray(arr, decodedValue, ctx);
-            } catch (final Throwable t) {
-                log.debug("Not able to decode body of OPC UA ExtensionObject, using undecoded body value instead", t);
-                addValueToArray(arr, eo.getBody(), ctx);
-            }
+            addValueToArray(arr, eo.decode(ctx), ctx);
         } else if (value instanceof final Variant variant) {
             final Object variantValue = variant.getValue();
             if (variantValue != null) {

--- a/modules/hivemq-edge-module-opcua/src/test/java/com/hivemq/edge/adapters/opcua/OpcUaSubscriptionLifecycleHandlerTest.java
+++ b/modules/hivemq-edge-module-opcua/src/test/java/com/hivemq/edge/adapters/opcua/OpcUaSubscriptionLifecycleHandlerTest.java
@@ -20,8 +20,16 @@ import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 
+import com.hivemq.adapter.sdk.api.datapoint.DataPointBuilder;
+import com.hivemq.adapter.sdk.api.datapoint.DataPointListBuilder;
 import com.hivemq.adapter.sdk.api.services.ProtocolAdapterMetricsService;
 import com.hivemq.adapter.sdk.api.streaming.ProtocolAdapterTagStreamingService;
 import com.hivemq.edge.adapters.opcua.config.ConnectionOptions;
@@ -32,10 +40,22 @@ import com.hivemq.edge.adapters.opcua.config.tag.OpcuaTagDefinition;
 import com.hivemq.edge.adapters.opcua.listeners.OpcUaSubscriptionLifecycleHandler;
 import java.util.List;
 import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
+import org.eclipse.milo.opcua.sdk.client.subscriptions.OpcUaMonitoredItem;
 import org.eclipse.milo.opcua.sdk.client.subscriptions.OpcUaSubscription;
+import org.eclipse.milo.opcua.stack.core.AttributeId;
+import org.eclipse.milo.opcua.stack.core.encoding.DefaultEncodingContext;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ExtensionObject;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.eclipse.milo.opcua.stack.core.types.structured.ReadValueId;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -521,6 +541,82 @@ class OpcUaSubscriptionLifecycleHandlerTest {
         // Then: No exceptions should have occurred
         assertFalse(failed.get(), "Concurrent access should not cause exceptions");
         assertTrue(handler.isKeepAliveHealthy(), "Handler should remain healthy after concurrent operations");
+    }
+
+    /**
+     * EDG-776: when a value cannot be decoded (typically "no codec registered" for a custom struct
+     * because the dynamic codec registry was rebuilt incompletely after a session re-activation),
+     * the notification batch must be dropped — never published as base64 — and the registry must be
+     * reset so the next notification triggers a fresh rebuild.
+     */
+    @Test
+    void onDataReceived_whenValueCannotBeDecoded_dropsBatchAndResetsTypeRegistry() throws Exception {
+        final OpcUaSubscriptionLifecycleHandler handler = createHandlerWithRealEventService();
+
+        // DefaultEncodingContext knows only the builtin OPC UA types, so the custom encoding id
+        // below has no codec — the same state as an incompletely rebuilt dynamic registry
+        when(opcUaClient.getDynamicEncodingContext()).thenReturn(DefaultEncodingContext.INSTANCE);
+        final DataPointListBuilder dataPointsPublisher = mock(DataPointListBuilder.class);
+        when(tagStreamingService.dataPointsPublisher()).thenReturn(dataPointsPublisher);
+        when(dataPointsPublisher.addDataPoint(any())).thenReturn(mock(DataPointBuilder.class));
+
+        final ExtensionObject undecodableStruct =
+                ExtensionObject.of(ByteString.of(new byte[] {1, 2, 3}), NodeId.parse("ns=2;i=5001"));
+        final DataValue structValue = new DataValue(new Variant(undecodableStruct), StatusCode.GOOD, null);
+
+        handler.onDataReceived(mock(OpcUaSubscription.class), List.of(createMonitoredItem()), List.of(structValue));
+
+        verify(dataPointsPublisher, never()).publish();
+        verify(metricsService).increment(Constants.METRIC_SUBSCRIPTION_DATA_ERROR_COUNT);
+        verify(opcUaClient).resetDataTypeTree();
+        verify(opcUaClient).resetDynamicDataTypeManager();
+        verify(opcUaClient).resetDynamicEncodingContext();
+
+        // a second failure within the throttle window drops the batch again but must not trigger
+        // another full DataTypeTree rebuild
+        handler.onDataReceived(mock(OpcUaSubscription.class), List.of(createMonitoredItem()), List.of(structValue));
+
+        verify(dataPointsPublisher, never()).publish();
+        verify(opcUaClient, times(1)).resetDataTypeTree();
+        verify(opcUaClient, times(1)).resetDynamicDataTypeManager();
+        verify(opcUaClient, times(1)).resetDynamicEncodingContext();
+    }
+
+    @Test
+    void onDataReceived_whenValueDecodes_publishes() throws Exception {
+        final OpcUaSubscriptionLifecycleHandler handler = createHandlerWithRealEventService();
+
+        when(opcUaClient.getDynamicEncodingContext()).thenReturn(DefaultEncodingContext.INSTANCE);
+        final DataPointListBuilder dataPointsPublisher = mock(DataPointListBuilder.class);
+        when(tagStreamingService.dataPointsPublisher()).thenReturn(dataPointsPublisher);
+        when(dataPointsPublisher.addDataPoint(any()))
+                .thenReturn(mock(DataPointBuilder.class, withSettings().defaultAnswer(Answers.RETURNS_DEEP_STUBS)));
+
+        final DataValue stringValue = new DataValue(new Variant("hello"), StatusCode.GOOD, null);
+
+        handler.onDataReceived(mock(OpcUaSubscription.class), List.of(createMonitoredItem()), List.of(stringValue));
+
+        verify(dataPointsPublisher).publish();
+        verify(opcUaClient, never()).resetDataTypeTree();
+    }
+
+    private static @NotNull OpcUaMonitoredItem createMonitoredItem() {
+        final OpcUaMonitoredItem monitoredItem = mock(OpcUaMonitoredItem.class);
+        when(monitoredItem.getReadValueId())
+                .thenReturn(new ReadValueId(
+                        NodeId.parse(NODE_ID), AttributeId.Value.uid(), null, QualifiedName.NULL_VALUE));
+        return monitoredItem;
+    }
+
+    private OpcUaSubscriptionLifecycleHandler createHandlerWithRealEventService() {
+        return new OpcUaSubscriptionLifecycleHandler(
+                metricsService,
+                tagStreamingService,
+                new FakeEventService(),
+                ADAPTER_ID,
+                List.of(createTestTag()),
+                opcUaClient,
+                createConfig(ConnectionOptions.defaultConnectionOptions()));
     }
 
     private OpcUaSubscriptionLifecycleHandler createHandler(final @NotNull OpcUaSpecificAdapterConfig config) {

--- a/modules/hivemq-edge-module-opcua/src/test/java/com/hivemq/edge/adapters/opcua/northbound/OpcUaToJsonConverterDecodeFailureTest.java
+++ b/modules/hivemq-edge-module-opcua/src/test/java/com/hivemq/edge/adapters/opcua/northbound/OpcUaToJsonConverterDecodeFailureTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2023-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.edge.adapters.opcua.northbound;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.hivemq.adapter.sdk.api.datapoint.DataPointBuilder;
+import com.hivemq.datapoint.DataPointWithMetadata;
+import com.hivemq.edge.adapters.opcua.config.tag.OpcuaTag;
+import com.hivemq.edge.adapters.opcua.config.tag.OpcuaTagDefinition;
+import org.eclipse.milo.opcua.stack.core.UaSerializationException;
+import org.eclipse.milo.opcua.stack.core.encoding.DefaultEncodingContext;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ExtensionObject;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.junit.jupiter.api.Test;
+
+/**
+ * EDG-776: a custom-struct value whose codec is not (yet) registered in the encoding context must
+ * fail loudly instead of being silently published as the base64-encoded binary body.
+ */
+class OpcUaToJsonConverterDecodeFailureTest {
+
+    @Test
+    void whenNoCodecRegisteredForCustomStruct_thenDecodeFailurePropagates() {
+        // a custom-struct ExtensionObject whose binary encoding id is unknown to the encoding
+        // context, as happens when the dynamic codec registry is incomplete after a session
+        // (re)activation
+        final ExtensionObject extensionObject =
+                ExtensionObject.of(ByteString.of(new byte[] {1, 2, 3}), NodeId.parse("ns=2;i=5001"));
+        final DataValue dataValue = new DataValue(new Variant(extensionObject), StatusCode.GOOD, null);
+        final DataPointBuilder<Void> builder = DataPointWithMetadata.builder(
+                new OpcuaTag("test-tag", "", new OpcuaTagDefinition("ns=2;i=1001")), b -> null);
+
+        assertThatThrownBy(
+                        () -> OpcUaToJsonConverter.convertPayload(DefaultEncodingContext.INSTANCE, dataValue, builder))
+                .isInstanceOf(UaSerializationException.class)
+                .hasMessageContaining("no codec registered");
+    }
+}


### PR DESCRIPTION
## Summary

Fixes [EDG-776](https://linear.app/hivemq/issue/EDG-776/opc-ua-custom-struct-value-published-as-base64-instead-of-json-under): under load, an OPC UA custom-struct value could be published with its `value` as a base64 string (raw binary encoding) instead of the expected JSON object — silent payload corruption around session (re)connect. Surfaced as flaky `SubscriptionResumeOpcUaIT` / `OpcUAAdapterNestedWriteTransformationIT` failures in the EDG-763 composite CI.

## Root cause (verified in Milo 1.1.4 source)

Milo resets the per-client dynamic codec registry (`DataTypeTree` / `DataTypeManager` / `EncodingContext`) on **every** session (re)activation and rebuilds it lazily on next use. The rebuild is best-effort: `ClientBrowseUtils` swallows browse/read failures at DEBUG and `DataTypeTreeBuilder` silently leaves `DataTypeDefinition = null` on bad status codes, so under load a "successful" rebuild can lack the codec for a custom struct. `ExtensionObject.decode` then throws `no codec registered for encodingId=…`, and `OpcUaToJsonConverter` caught this in a `catch (Throwable)` and published the raw binary body base64-encoded, logging only at DEBUG. The miss was never retried until the next session bounce.

(Refinement over the ticket text: Milo's `Lazy` is synchronized, so value delivery already blocks on the rebuild — the defect is the silently *partial* rebuild with no retry, not a value racing ahead of it.)

## Changes

- **`OpcUaToJsonConverter`**: removed the three base64 fallbacks; `ExtensionObject` decode failures now propagate (`UaSerializationException`).
- **`OpcUaSubscriptionLifecycleHandler.onDataReceived`**: on decode failure — WARN with tag context, error metric, drop the notification batch (the server resamples the monitored items; a half-built datapoint cannot be published), and reset the dynamic type registry so the next notification triggers a fresh rebuild. The reset is throttled (10 s, monotonic clock) so a permanently undecodable type cannot trigger a full `DataTypeTree` browse per notification.
- **`subscribe()` / `onTransferFailed`**: best-effort warm-up of the dynamic registry, keeping the expensive first build off the value-notification path. Deliberately non-fatal — failing startup on a slow tree browse would regress adapters that never use custom structs.

## Behaviour change

Servers whose custom types are **permanently** undecodable (non-compliant: no `DataTypeDefinition`/encoding nodes exposed) previously got base64 published as a "valid" value; they now get dropped samples with WARN logs and `subscription.data.error.count` increments. Visible errors instead of silent binary-in-JSON.

## Testing

- New unit tests: decode failure propagates (no base64), batch dropped + registry reset on codec-miss, throttle prevents repeated resets, happy path still publishes.
- Full `hivemq-edge-module-opcua` suite: 209/209 passed (1 pre-existing `@Disabled` skip).
- Test-side robustness (ticket item 3) is covered separately by hivemq/hivemq-edge-test#377.
