### PR TITLE
fix(EDG-808): publish v2 adapter values northbound

### DIFF
--- a/hivemq-edge/src/main/java/com/hivemq/protocols/northbound/NorthboundConsumerFactory.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/northbound/NorthboundConsumerFactory.java
@@ -16,6 +16,7 @@
 package com.hivemq.protocols.northbound;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hivemq.adapter.sdk.api.ProtocolAdapter;
 import com.hivemq.adapter.sdk.api.events.EventService;
 import com.hivemq.adapter.sdk.api.services.ProtocolAdapterMetricsService;
 import com.hivemq.edge.modules.adapters.impl.ProtocolAdapterPublishServiceImpl;
@@ -49,6 +50,23 @@ public class NorthboundConsumerFactory {
         return new NorthboundTagConsumer(
                 northboundMapping,
                 protocolAdapterWrapper,
+                objectMapper,
+                protocolAdapterPublishService,
+                protocolAdapterMetricsService,
+                eventService);
+    }
+
+    public @NotNull NorthboundTagConsumer build(
+            final @NotNull String adapterId,
+            final @NotNull ProtocolAdapter adapter,
+            final @NotNull String protocolId,
+            final @NotNull NorthboundMapping northboundMapping,
+            final @NotNull ProtocolAdapterMetricsService protocolAdapterMetricsService) {
+        return new NorthboundTagConsumer(
+                northboundMapping,
+                adapterId,
+                adapter,
+                protocolId,
                 objectMapper,
                 protocolAdapterPublishService,
                 protocolAdapterMetricsService,

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/northbound/NorthboundTagConsumer.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/northbound/NorthboundTagConsumer.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Preconditions;
+import com.hivemq.adapter.sdk.api.ProtocolAdapter;
 import com.hivemq.adapter.sdk.api.ProtocolAdapterPublishBuilder;
 import com.hivemq.adapter.sdk.api.ProtocolPublishResult;
 import com.hivemq.adapter.sdk.api.data.DataPoint;
@@ -45,7 +46,9 @@ public class NorthboundTagConsumer implements SingleTagConsumer {
     private static final Logger log = LoggerFactory.getLogger(NorthboundTagConsumer.class);
 
     private final @NotNull NorthboundMapping northboundMapping;
-    private final @NotNull ProtocolAdapterWrapper protocolAdapter;
+    private final @NotNull String adapterId;
+    private final @NotNull String protocolId;
+    private final @NotNull ProtocolAdapter adapter;
     private final @NotNull ObjectMapper objectMapper;
     private final @NotNull ProtocolAdapterPublishServiceImpl protocolAdapterPublishService;
     private final @NotNull ProtocolAdapterMetricsService protocolAdapterMetricsService;
@@ -59,8 +62,30 @@ public class NorthboundTagConsumer implements SingleTagConsumer {
             final @NotNull ProtocolAdapterPublishServiceImpl protocolAdapterPublishService,
             final @NotNull ProtocolAdapterMetricsService protocolAdapterMetricsService,
             final @NotNull EventService eventService) {
+        this(
+                northboundMapping,
+                protocolAdapter.getId(),
+                protocolAdapter.getAdapter(),
+                protocolAdapter.getAdapterInformation().getProtocolId(),
+                objectMapper,
+                protocolAdapterPublishService,
+                protocolAdapterMetricsService,
+                eventService);
+    }
+
+    public NorthboundTagConsumer(
+            final @NotNull NorthboundMapping northboundMapping,
+            final @NotNull String adapterId,
+            final @NotNull ProtocolAdapter adapter,
+            final @NotNull String protocolId,
+            final @NotNull ObjectMapper objectMapper,
+            final @NotNull ProtocolAdapterPublishServiceImpl protocolAdapterPublishService,
+            final @NotNull ProtocolAdapterMetricsService protocolAdapterMetricsService,
+            final @NotNull EventService eventService) {
         this.northboundMapping = northboundMapping;
-        this.protocolAdapter = protocolAdapter;
+        this.adapterId = adapterId;
+        this.adapter = adapter;
+        this.protocolId = protocolId;
         this.objectMapper = objectMapper;
         this.protocolAdapterPublishService = protocolAdapterPublishService;
         this.protocolAdapterMetricsService = protocolAdapterMetricsService;
@@ -83,23 +108,19 @@ public class NorthboundTagConsumer implements SingleTagConsumer {
                     .withTopic(northboundMapping.getMqttTopic())
                     .withQoS(northboundMapping.getMqttQos())
                     .withPayload(jsonToSend)
-                    .withAdapter(protocolAdapter.getAdapter());
+                    .withAdapter(adapter);
             final CompletableFuture<ProtocolPublishResult> publishFuture = publishBuilder.send();
             publishFuture
                     .thenAccept(publishReturnCode -> {
                         protocolAdapterMetricsService.incrementReadPublishSuccess();
                         if (publishCount.incrementAndGet() == 1) {
                             eventService
-                                    .createAdapterEvent(
-                                            protocolAdapter.getId(),
-                                            protocolAdapter
-                                                    .getAdapterInformation()
-                                                    .getProtocolId())
+                                    .createAdapterEvent(adapterId, protocolId)
                                     .withSeverity(EventImpl.SEVERITY.INFO)
                                     .withTimestamp(System.currentTimeMillis())
                                     .withMessage(String.format(
                                             "Adapter '%s' took first sample to be published to '%s'",
-                                            protocolAdapter.getId(), northboundMapping.getMqttTopic()))
+                                            adapterId, northboundMapping.getMqttTopic()))
                                     .withPayload(
                                             Payload.ContentType.JSON, new String(jsonToSend, StandardCharsets.UTF_8))
                                     .fire();
@@ -111,7 +132,7 @@ public class NorthboundTagConsumer implements SingleTagConsumer {
                         return null;
                     });
         } catch (final Exception e) {
-            log.warn("Exception during polling of data for adapters '{}':", protocolAdapter.getId(), e);
+            log.warn("Exception during polling of data for adapters '{}':", adapterId, e);
         }
     }
 
@@ -163,6 +184,6 @@ public class NorthboundTagConsumer implements SingleTagConsumer {
 
     @Override
     public @Nullable String getScope() {
-        return protocolAdapter.getId();
+        return adapterId;
     }
 }

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/manager/DefaultProtocolAdapterWrapperFactory.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/manager/DefaultProtocolAdapterWrapperFactory.java
@@ -33,9 +33,13 @@ import com.hivemq.adapter.sdk.api.v2.model.ProtocolAdapterOutput;
 import com.hivemq.adapter.sdk.api.v2.node.Node;
 import com.hivemq.adapter.sdk.api.v2.node.NodeTagPair;
 import com.hivemq.adapter.sdk.api.v2.services.ProtocolAdapterService;
+import com.hivemq.edge.modules.adapters.data.TagManager;
+import com.hivemq.edge.modules.adapters.metrics.ProtocolAdapterMetricsServiceImpl;
+import com.hivemq.protocols.northbound.NorthboundConsumerFactory;
 import com.hivemq.protocols.v2.config.ProtocolAdapterEntity;
 import com.hivemq.protocols.v2.config.TagEntity;
 import com.hivemq.protocols.v2.manager.ProtocolAdapterHandleRegistry.ProtocolAdapterHandle;
+import com.hivemq.protocols.v2.northbound.NorthboundTagConsumerRegistry;
 import com.hivemq.protocols.v2.runtime.Clock;
 import com.hivemq.protocols.v2.runtime.ProtocolAdapterMetrics;
 import com.hivemq.protocols.v2.runtime.RetryPolicy;
@@ -52,9 +56,12 @@ import com.hivemq.protocols.v2.wrapper.TagAspectActivationPreference;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Production {@link ProtocolAdapterWrapperFactory}: assembles the full wrapper/adapter actor for one configuration
@@ -82,6 +89,8 @@ public final class DefaultProtocolAdapterWrapperFactory implements ProtocolAdapt
     private final @NotNull MetricRegistry metricRegistry;
     private final @NotNull DataPointFactory dataPointFactory;
     private final @NotNull ObjectMapper objectMapper;
+    private final @Nullable TagManager tagManager;
+    private final @Nullable NorthboundConsumerFactory northboundConsumerFactory;
     private final long tickPeriodMillis;
 
     /**
@@ -99,11 +108,36 @@ public final class DefaultProtocolAdapterWrapperFactory implements ProtocolAdapt
             final @NotNull DataPointFactory dataPointFactory,
             final @NotNull ObjectMapper objectMapper,
             final long tickPeriodMillis) {
+        this(clock, dispatcher, metricRegistry, dataPointFactory, objectMapper, tickPeriodMillis, null, null);
+    }
+
+    /**
+     * @param clock                    the clock the wrapper timers and tick are scheduled against.
+     * @param dispatcher               the dispatcher each wrapper mailbox is attached to.
+     * @param metricRegistry           the shared registry per-adapter metrics are registered on.
+     * @param dataPointFactory         the reused v1 factory the protocol adapter builds its values with.
+     * @param objectMapper             the JSON mapper that deserializes a {@code node-string} into the type's node
+     *                                 class.
+     * @param tickPeriodMillis         the wrapper tick period, in milliseconds (~50 ms in production).
+     * @param tagManager               the shared tag manager used by MQTT northbound consumers.
+     * @param northboundConsumerFactory builds MQTT consumers for v2 northbound mappings.
+     */
+    public DefaultProtocolAdapterWrapperFactory(
+            final @NotNull Clock clock,
+            final @NotNull MessageDispatcher dispatcher,
+            final @NotNull MetricRegistry metricRegistry,
+            final @NotNull DataPointFactory dataPointFactory,
+            final @NotNull ObjectMapper objectMapper,
+            final long tickPeriodMillis,
+            final @Nullable TagManager tagManager,
+            final @Nullable NorthboundConsumerFactory northboundConsumerFactory) {
         this.clock = clock;
         this.dispatcher = dispatcher;
         this.metricRegistry = metricRegistry;
         this.dataPointFactory = dataPointFactory;
         this.objectMapper = objectMapper;
+        this.tagManager = tagManager;
+        this.northboundConsumerFactory = northboundConsumerFactory;
         this.tickPeriodMillis = tickPeriodMillis;
     }
 
@@ -139,6 +173,14 @@ public final class DefaultProtocolAdapterWrapperFactory implements ProtocolAdapt
         }
 
         final ProtocolAdapterMetrics metrics = new ProtocolAdapterMetrics(metricRegistry, adapterId, mailbox::size);
+        final NorthboundTagConsumerRegistry northboundConsumers = createNorthboundConsumers(adapterId, factory, entity);
+        final Consumer<DataPoint> northboundDataPointSink;
+        if (northboundConsumers == null) {
+            northboundDataPointSink = ignored -> {};
+        } else {
+            final TagManager activeTagManager = Objects.requireNonNull(tagManager);
+            northboundDataPointSink = dataPoint -> activeTagManager.feed(List.of(dataPoint));
+        }
         final ProtocolAdapterGoalState goal = ProtocolAdapterConfigSupport.goalOf(entity);
         final Map<String, TagAspectActivationPreference> activation = ProtocolAdapterConfigSupport.activationOf(entity);
         final Set<String> readUsed = entity.getReadUsedTagNames();
@@ -166,7 +208,8 @@ public final class DefaultProtocolAdapterWrapperFactory implements ProtocolAdapt
                 activation,
                 tagPlane,
                 healthListener,
-                metrics);
+                metrics,
+                northboundDataPointSink);
         tagPlane.bindRuntime(
                 context.clock(),
                 context.timers(),
@@ -190,6 +233,22 @@ public final class DefaultProtocolAdapterWrapperFactory implements ProtocolAdapt
         final ProtocolAdapterHandle handle = new ProtocolAdapterHandle(adapterId, mailbox, snapshot);
         return new ProtocolAdapterContainer(
                 handle, dispatcherHandle, adapterDispatcherHandle, tickHandle, metrics, entity);
+    }
+
+    private @Nullable NorthboundTagConsumerRegistry createNorthboundConsumers(
+            final @NotNull String adapterId,
+            final @NotNull ProtocolAdapterFactory factory,
+            final @NotNull ProtocolAdapterEntity entity) {
+        if (tagManager == null || northboundConsumerFactory == null) {
+            return null;
+        }
+        return new NorthboundTagConsumerRegistry(
+                adapterId,
+                factory.information(),
+                tagManager,
+                northboundConsumerFactory,
+                new ProtocolAdapterMetricsServiceImpl(factory.information().protocolId(), adapterId, metricRegistry),
+                entity.getNorthboundMappings());
     }
 
     @Override

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/manager/DefaultProtocolAdapterWrapperFactory.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/manager/DefaultProtocolAdapterWrapperFactory.java
@@ -232,7 +232,7 @@ public final class DefaultProtocolAdapterWrapperFactory implements ProtocolAdapt
 
         final ProtocolAdapterHandle handle = new ProtocolAdapterHandle(adapterId, mailbox, snapshot);
         return new ProtocolAdapterContainer(
-                handle, dispatcherHandle, adapterDispatcherHandle, tickHandle, metrics, entity);
+                handle, dispatcherHandle, adapterDispatcherHandle, tickHandle, metrics, northboundConsumers, entity);
     }
 
     private @Nullable NorthboundTagConsumerRegistry createNorthboundConsumers(

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/manager/ProtocolAdapterContainer.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/manager/ProtocolAdapterContainer.java
@@ -69,22 +69,25 @@ public final class ProtocolAdapterContainer implements AutoCloseable {
             final @NotNull AutoCloseable tickHandle,
             final @NotNull ProtocolAdapterMetrics metrics,
             final @NotNull ProtocolAdapterEntity appliedEntity) {
-        this(handle, dispatcherHandle, tickHandle, metrics, null, appliedEntity);
+        this(handle, dispatcherHandle, adapterDispatcherHandle, tickHandle, metrics, null, appliedEntity);
     }
 
     /**
      * Create a running managed adapter with its teardown resources.
      *
-     * @param handle              the REST-readable handle.
-     * @param dispatcherHandle    the binding of the wrapper mailbox to the dispatcher.
-     * @param tickHandle          the periodic wrapper tick schedule.
-     * @param metrics             the per-adapter metrics.
-     * @param northboundConsumers the MQTT northbound consumers registered for this adapter.
-     * @param appliedEntity       the configuration this adapter is running.
+     * @param handle                  the REST-readable handle.
+     * @param dispatcherHandle        the binding of the wrapper mailbox to the dispatcher.
+     * @param adapterDispatcherHandle the teardown of the adapter itself and every dispatch binding it opened through
+     *                                the framework dispatcher.
+     * @param tickHandle              the periodic wrapper tick schedule.
+     * @param metrics                 the per-adapter metrics.
+     * @param northboundConsumers     the MQTT northbound consumers registered for this adapter.
+     * @param appliedEntity           the configuration this adapter is running.
      */
     public ProtocolAdapterContainer(
             final @NotNull ProtocolAdapterHandle handle,
             final @NotNull MessageDispatcherHandle dispatcherHandle,
+            final @NotNull AutoCloseable adapterDispatcherHandle,
             final @NotNull AutoCloseable tickHandle,
             final @NotNull ProtocolAdapterMetrics metrics,
             final @Nullable NorthboundTagConsumerRegistry northboundConsumers,

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/manager/ProtocolAdapterContainer.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/manager/ProtocolAdapterContainer.java
@@ -16,9 +16,12 @@
 package com.hivemq.protocols.v2.manager;
 
 import com.hivemq.adapter.sdk.api.v2.messaging.MessageDispatcherHandle;
+import com.hivemq.protocols.v2.config.NorthboundMappingEntity;
 import com.hivemq.protocols.v2.config.ProtocolAdapterEntity;
 import com.hivemq.protocols.v2.manager.ProtocolAdapterHandleRegistry.ProtocolAdapterHandle;
+import com.hivemq.protocols.v2.northbound.NorthboundTagConsumerRegistry;
 import com.hivemq.protocols.v2.runtime.ProtocolAdapterMetrics;
+import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
@@ -45,6 +48,7 @@ public final class ProtocolAdapterContainer implements AutoCloseable {
     private final @Nullable AutoCloseable adapterDispatcherHandle;
     private final @Nullable AutoCloseable tickHandle;
     private final @Nullable ProtocolAdapterMetrics metrics;
+    private final @Nullable NorthboundTagConsumerRegistry northboundConsumers;
     private @NotNull ProtocolAdapterEntity appliedEntity;
 
     /**
@@ -65,11 +69,32 @@ public final class ProtocolAdapterContainer implements AutoCloseable {
             final @NotNull AutoCloseable tickHandle,
             final @NotNull ProtocolAdapterMetrics metrics,
             final @NotNull ProtocolAdapterEntity appliedEntity) {
+        this(handle, dispatcherHandle, tickHandle, metrics, null, appliedEntity);
+    }
+
+    /**
+     * Create a running managed adapter with its teardown resources.
+     *
+     * @param handle              the REST-readable handle.
+     * @param dispatcherHandle    the binding of the wrapper mailbox to the dispatcher.
+     * @param tickHandle          the periodic wrapper tick schedule.
+     * @param metrics             the per-adapter metrics.
+     * @param northboundConsumers the MQTT northbound consumers registered for this adapter.
+     * @param appliedEntity       the configuration this adapter is running.
+     */
+    public ProtocolAdapterContainer(
+            final @NotNull ProtocolAdapterHandle handle,
+            final @NotNull MessageDispatcherHandle dispatcherHandle,
+            final @NotNull AutoCloseable tickHandle,
+            final @NotNull ProtocolAdapterMetrics metrics,
+            final @Nullable NorthboundTagConsumerRegistry northboundConsumers,
+            final @NotNull ProtocolAdapterEntity appliedEntity) {
         this.handle = handle;
         this.dispatcherHandle = dispatcherHandle;
         this.adapterDispatcherHandle = adapterDispatcherHandle;
         this.tickHandle = tickHandle;
         this.metrics = metrics;
+        this.northboundConsumers = northboundConsumers;
         this.appliedEntity = appliedEntity;
     }
 
@@ -80,6 +105,7 @@ public final class ProtocolAdapterContainer implements AutoCloseable {
         this.adapterDispatcherHandle = null;
         this.tickHandle = null;
         this.metrics = null;
+        this.northboundConsumers = null;
         this.appliedEntity = entity;
     }
 
@@ -128,6 +154,17 @@ public final class ProtocolAdapterContainer implements AutoCloseable {
     }
 
     /**
+     * Refresh the registered MQTT consumers after a tags-only reload changed northbound mappings.
+     *
+     * @param mappings the updated v2 northbound mappings.
+     */
+    public void updateNorthboundMappings(final @NotNull List<NorthboundMappingEntity> mappings) {
+        if (northboundConsumers != null) {
+            northboundConsumers.updateMappings(mappings);
+        }
+    }
+
+    /**
      * Release the adapter's runtime resources: stop the periodic tick, detach the wrapper from the dispatcher, and
      * deregister the per-adapter metrics so a recreated adapter with the same id starts clean. Each step is best
      * effort; a failure in one never prevents the others. A no-op for an unknown adapter.
@@ -138,6 +175,7 @@ public final class ProtocolAdapterContainer implements AutoCloseable {
         closeQuietly(dispatcherHandle, "dispatcher binding");
         closeQuietly(adapterDispatcherHandle, "adapter dispatcher bindings");
         closeQuietly(metrics, "metrics");
+        closeQuietly(northboundConsumers, "northbound consumers");
     }
 
     private void closeQuietly(final @Nullable AutoCloseable closeable, final @NotNull String what) {

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/manager/ProtocolAdapterManager.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/manager/ProtocolAdapterManager.java
@@ -240,6 +240,7 @@ public final class ProtocolAdapterManager implements MessageHandler<ProtocolAdap
                         ProtocolAdapterConfigSupport.activationOf(updated),
                         updated.getReadUsedTagNames(),
                         updated.getWriteUsedTagNames()));
+        existing.updateNorthboundMappings(updated.getNorthboundMappings());
         if (ProtocolAdapterConfigDiffUtils.adapterDirectionChanged(running, updated)) {
             // The tag-set update does not carry the adapter direction goal; re-assert the config-declared goal when
             // it changed too. Still never reconnects.

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/northbound/NorthboundTagConsumerRegistry.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/northbound/NorthboundTagConsumerRegistry.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.protocols.v2.northbound;
+
+import com.hivemq.adapter.sdk.api.ProtocolAdapter;
+import com.hivemq.edge.modules.adapters.data.TagManager;
+import com.hivemq.edge.modules.adapters.metrics.InternalProtocolAdapterMetricsService;
+import com.hivemq.mqtt.message.QoS;
+import com.hivemq.persistence.mappings.NorthboundMapping;
+import com.hivemq.protocols.northbound.NorthboundConsumerFactory;
+import com.hivemq.protocols.northbound.NorthboundTagConsumer;
+import com.hivemq.protocols.v2.config.NorthboundMappingEntity;
+import java.util.ArrayList;
+import java.util.List;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Owns the {@link NorthboundTagConsumer}s for one v2 adapter.
+ * <p>
+ * The v2 config currently carries only a tag/topic pair, so the legacy {@link NorthboundMapping} is built with the
+ * same defaults the legacy mapping model uses: QoS 2, timestamp included, tag names and metadata omitted.
+ */
+public final class NorthboundTagConsumerRegistry implements AutoCloseable {
+
+    private static final int DEFAULT_QOS = QoS.EXACTLY_ONCE.getQosNumber();
+
+    private final @NotNull String adapterId;
+    private final @NotNull String protocolId;
+    private final @NotNull ProtocolAdapter publishIdentity;
+    private final @NotNull TagManager tagManager;
+    private final @NotNull NorthboundConsumerFactory consumerFactory;
+    private final @NotNull InternalProtocolAdapterMetricsService metricsService;
+    private final @NotNull List<NorthboundTagConsumer> consumers = new ArrayList<>();
+
+    public NorthboundTagConsumerRegistry(
+            final @NotNull String adapterId,
+            final @NotNull com.hivemq.adapter.sdk.api.v2.ProtocolAdapterInformation information,
+            final @NotNull TagManager tagManager,
+            final @NotNull NorthboundConsumerFactory consumerFactory,
+            final @NotNull InternalProtocolAdapterMetricsService metricsService,
+            final @NotNull List<NorthboundMappingEntity> mappings) {
+        this.adapterId = adapterId;
+        this.protocolId = information.protocolId();
+        this.publishIdentity = new ProtocolAdapterPublishIdentity(adapterId, information);
+        this.tagManager = tagManager;
+        this.consumerFactory = consumerFactory;
+        this.metricsService = metricsService;
+        updateMappings(mappings);
+    }
+
+    public void updateMappings(final @NotNull List<NorthboundMappingEntity> mappings) {
+        removeConsumers();
+        for (final NorthboundMappingEntity mapping : mappings) {
+            final NorthboundTagConsumer consumer = consumerFactory.build(
+                    adapterId, publishIdentity, protocolId, toNorthboundMapping(mapping), metricsService);
+            tagManager.addConsumer(consumer);
+            consumers.add(consumer);
+        }
+    }
+
+    @Override
+    public void close() {
+        removeConsumers();
+        metricsService.clearAll();
+    }
+
+    private void removeConsumers() {
+        consumers.forEach(tagManager::removeConsumer);
+        consumers.clear();
+    }
+
+    private static @NotNull NorthboundMapping toNorthboundMapping(final @NotNull NorthboundMappingEntity mapping) {
+        return new NorthboundMapping(
+                mapping.getTagName(), mapping.getTopic(), DEFAULT_QOS, false, true, false, List.of(), null);
+    }
+}

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/northbound/ProtocolAdapterPublishIdentity.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/northbound/ProtocolAdapterPublishIdentity.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.protocols.v2.northbound;
+
+import com.hivemq.adapter.sdk.api.ProtocolAdapter;
+import com.hivemq.adapter.sdk.api.ProtocolAdapterCapability;
+import com.hivemq.adapter.sdk.api.ProtocolAdapterCategory;
+import com.hivemq.adapter.sdk.api.ProtocolAdapterInformation;
+import com.hivemq.adapter.sdk.api.ProtocolAdapterTag;
+import com.hivemq.adapter.sdk.api.config.ProtocolSpecificAdapterConfig;
+import com.hivemq.adapter.sdk.api.tag.Tag;
+import com.hivemq.adapter.sdk.api.tag.TagDefinition;
+import java.util.EnumSet;
+import java.util.List;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * A legacy-SDK identity for v2 northbound publishes.
+ * <p>
+ * The existing publish service and protocol-adapter interceptors still key their context from the v1
+ * {@link ProtocolAdapter} shape. V2 northbound delivery only needs that identity surface — adapter id, protocol id,
+ * and display metadata — so this adapter deliberately implements no lifecycle behavior.
+ */
+final class ProtocolAdapterPublishIdentity implements ProtocolAdapter {
+
+    private final @NotNull String adapterId;
+    private final @NotNull ProtocolAdapterInformation information;
+
+    ProtocolAdapterPublishIdentity(
+            final @NotNull String adapterId,
+            final @NotNull com.hivemq.adapter.sdk.api.v2.ProtocolAdapterInformation information) {
+        this.adapterId = adapterId;
+        this.information = new LegacyInformation(information);
+    }
+
+    @Override
+    public @NotNull String getId() {
+        return adapterId;
+    }
+
+    @Override
+    public @NotNull ProtocolAdapterInformation getProtocolAdapterInformation() {
+        return information;
+    }
+
+    private static final class LegacyInformation implements ProtocolAdapterInformation {
+
+        private final @NotNull com.hivemq.adapter.sdk.api.v2.ProtocolAdapterInformation delegate;
+
+        private LegacyInformation(final @NotNull com.hivemq.adapter.sdk.api.v2.ProtocolAdapterInformation delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public @NotNull String getProtocolName() {
+            return delegate.displayName();
+        }
+
+        @Override
+        public @NotNull String getProtocolId() {
+            return delegate.protocolId();
+        }
+
+        @Override
+        public @NotNull String getDisplayName() {
+            return delegate.displayName();
+        }
+
+        @Override
+        public @NotNull String getDescription() {
+            return delegate.description();
+        }
+
+        @Override
+        public @NotNull String getUrl() {
+            return "";
+        }
+
+        @Override
+        public @NotNull String getVersion() {
+            return delegate.version();
+        }
+
+        @Override
+        public @NotNull String getLogoUrl() {
+            return delegate.logoUrl();
+        }
+
+        @Override
+        public @NotNull String getAuthor() {
+            return delegate.author();
+        }
+
+        @Override
+        public @NotNull ProtocolAdapterCategory getCategory() {
+            return delegate.category();
+        }
+
+        @Override
+        public @NotNull List<ProtocolAdapterTag> getTags() {
+            return delegate.tags();
+        }
+
+        @Override
+        public @NotNull Class<? extends Tag> tagConfigurationClass() {
+            return EmptyTag.class;
+        }
+
+        @Override
+        public @NotNull Class<? extends ProtocolSpecificAdapterConfig> configurationClassNorthbound() {
+            return EmptyConfig.class;
+        }
+
+        @Override
+        public @NotNull Class<? extends ProtocolSpecificAdapterConfig> configurationClassNorthAndSouthbound() {
+            return EmptyConfig.class;
+        }
+
+        @Override
+        public @NotNull EnumSet<ProtocolAdapterCapability> getCapabilities() {
+            final EnumSet<ProtocolAdapterCapability> capabilities = EnumSet.of(ProtocolAdapterCapability.READ);
+            if (delegate.capabilities().contains(com.hivemq.adapter.sdk.api.v2.ProtocolAdapterCapability.WRITE)) {
+                capabilities.add(ProtocolAdapterCapability.WRITE);
+            }
+            if (delegate.capabilities().contains(com.hivemq.adapter.sdk.api.v2.ProtocolAdapterCapability.BROWSE)) {
+                capabilities.add(ProtocolAdapterCapability.DISCOVER);
+            }
+            return capabilities;
+        }
+
+        @Override
+        public int getCurrentConfigVersion() {
+            return delegate.currentConfigVersion();
+        }
+    }
+
+    private static final class EmptyConfig implements ProtocolSpecificAdapterConfig {}
+
+    private static final class EmptyTag implements Tag {
+
+        @Override
+        public @NotNull TagDefinition getDefinition() {
+            return EmptyTagDefinition.INSTANCE;
+        }
+
+        @Override
+        public @NotNull String getName() {
+            return "";
+        }
+
+        @Override
+        public @NotNull String getDescription() {
+            return "";
+        }
+    }
+
+    private enum EmptyTagDefinition implements TagDefinition {
+        INSTANCE
+    }
+}

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/tag/TagAspectCoordinator.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/tag/TagAspectCoordinator.java
@@ -88,8 +88,12 @@ public interface TagAspectCoordinator {
      *
      * @param node  the node the value belongs to.
      * @param value the reused v1 value.
+     * @param adapterId the adapter instance id used to stamp values accepted by the read aspect.
+     * @return a stamped data point for northbound consumers when the read aspect accepted the value; {@code null}
+     *         for unknown nodes or values ignored by the aspect state machine.
      */
-    void routeDataPoint(@NotNull Node node, @NotNull DataPoint value);
+    @Nullable
+    DataPoint routeDataPoint(@NotNull Node node, @NotNull DataPoint value, @NotNull String adapterId);
 
     /**
      * Route a per-node failure to the node's read aspect.

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/tag/TagAspectRead.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/tag/TagAspectRead.java
@@ -284,9 +284,15 @@ public final class TagAspectRead implements TagAspectVerifying {
      * Feed a received value — a poll response or a subscription push.
      *
      * @param value the reused v1 value.
+     * @return whether the value was expected in the current read-aspect state.
      */
-    public void onValue(final @NotNull DataPoint value) {
+    public boolean onValue(final @NotNull DataPoint value) {
+        final TagAspectState state = machine.state();
+        final boolean accepted = state == TagAspectReadPolledState.WAITING_FOR_POLL_DATAPOINT
+                || state == TagAspectReadSubscribedState.WAITING_FOR_SUBSCRIPTION
+                || state == TagAspectReadSubscribedState.SUBSCRIBED;
         dispatch(new TagAspectEvent.ValueReceived(value));
+        return accepted;
     }
 
     /**

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/tag/TagAspectRuntimeCoordinator.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/tag/TagAspectRuntimeCoordinator.java
@@ -21,6 +21,7 @@ import com.hivemq.adapter.sdk.api.v2.node.Node;
 import com.hivemq.adapter.sdk.api.v2.node.NodeTagPair;
 import com.hivemq.protocols.v2.runtime.BatchCollector;
 import com.hivemq.protocols.v2.runtime.Clock;
+import com.hivemq.protocols.v2.runtime.DataPointStamping;
 import com.hivemq.protocols.v2.runtime.PriorityTimerQueue;
 import com.hivemq.protocols.v2.runtime.ProtocolAdapterMetrics;
 import com.hivemq.protocols.v2.runtime.RetryPolicy;
@@ -174,11 +175,15 @@ public final class TagAspectRuntimeCoordinator implements TagAspectCoordinator {
     }
 
     @Override
-    public void routeDataPoint(final @NotNull Node node, final @NotNull DataPoint value) {
+    public @Nullable DataPoint routeDataPoint(
+            final @NotNull Node node, final @NotNull DataPoint value, final @NotNull String adapterId) {
         final TagRuntime tagRuntime = findTagRuntime(node);
         if (tagRuntime != null) {
-            tagRuntime.onValue(value);
+            if (tagRuntime.onValue(value)) {
+                return DataPointStamping.stamp(value, tagRuntime.pair().tag(), adapterId);
+            }
         }
+        return null;
     }
 
     @Override

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/tag/TagAspectSnapshotOnlyCoordinator.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/tag/TagAspectSnapshotOnlyCoordinator.java
@@ -120,8 +120,10 @@ public final class TagAspectSnapshotOnlyCoordinator implements TagAspectCoordina
     }
 
     @Override
-    public void routeDataPoint(final @NotNull Node node, final @NotNull DataPoint value) {
+    public @Nullable DataPoint routeDataPoint(
+            final @NotNull Node node, final @NotNull DataPoint value, final @NotNull String adapterId) {
         // No read aspect yet; the value is absorbed.
+        return null;
     }
 
     @Override

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/tag/TagRuntime.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/tag/TagRuntime.java
@@ -212,9 +212,10 @@ public final class TagRuntime {
      * Route a received value to the read aspect.
      *
      * @param value the reused v1 value.
+     * @return whether the read aspect accepted the value as part of its operating flow.
      */
-    public void onValue(final @NotNull DataPoint value) {
-        readAspect.onValue(value);
+    public boolean onValue(final @NotNull DataPoint value) {
+        return readAspect.onValue(value);
     }
 
     /**

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/wiring/ProtocolAdapterModule.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/wiring/ProtocolAdapterModule.java
@@ -23,6 +23,8 @@ import com.hivemq.adapter.sdk.api.v2.messaging.Mailbox;
 import com.hivemq.adapter.sdk.api.v2.messaging.MailboxSender;
 import com.hivemq.adapter.sdk.api.v2.messaging.MessageDispatcher;
 import com.hivemq.edge.modules.ModuleLoader;
+import com.hivemq.edge.modules.adapters.data.TagManager;
+import com.hivemq.protocols.northbound.NorthboundConsumerFactory;
 import com.hivemq.protocols.v2.manager.DefaultProtocolAdapterWrapperFactory;
 import com.hivemq.protocols.v2.manager.ProtocolAdapterFactoryRegistry;
 import com.hivemq.protocols.v2.manager.ProtocolAdapterHandleRegistry;
@@ -129,14 +131,18 @@ public abstract class ProtocolAdapterModule {
             final @NotNull Clock clock,
             final @NotNull MessageDispatcher dispatcher,
             final @NotNull MetricRegistry metricRegistry,
-            final @NotNull ObjectMapper objectMapper) {
+            final @NotNull ObjectMapper objectMapper,
+            final @NotNull TagManager tagManager,
+            final @NotNull NorthboundConsumerFactory northboundConsumerFactory) {
         return new DefaultProtocolAdapterWrapperFactory(
                 clock,
                 dispatcher,
                 metricRegistry,
                 new DefaultDataPointFactory(),
                 objectMapper,
-                WRAPPER_TICK_PERIOD_MILLIS);
+                WRAPPER_TICK_PERIOD_MILLIS,
+                tagManager,
+                northboundConsumerFactory);
     }
 
     @Provides

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/v2/wrapper/ProtocolAdapterWrapperContext.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/v2/wrapper/ProtocolAdapterWrapperContext.java
@@ -51,6 +51,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
@@ -95,6 +96,7 @@ public final class ProtocolAdapterWrapperContext {
     private final long watchdogTimeoutMillis;
     private final boolean skipVerification;
     private final @NotNull TagAspectCoordinator tagPlane;
+    private final @NotNull Consumer<DataPoint> northboundDataPointSink;
     private final @NotNull ProtocolAdapterWrapperEventListener healthListener;
     private final @NotNull ProtocolAdapterMetrics metrics;
 
@@ -139,6 +141,53 @@ public final class ProtocolAdapterWrapperContext {
             final @NotNull TagAspectCoordinator tagPlane,
             final @NotNull ProtocolAdapterWrapperEventListener healthListener,
             final @NotNull ProtocolAdapterMetrics metrics) {
+        this(
+                adapterId,
+                protocolAdapter,
+                selfSender,
+                clock,
+                retryPolicy,
+                watchdogTimeoutMillis,
+                skipVerification,
+                initialGoal,
+                activation,
+                tagPlane,
+                healthListener,
+                metrics,
+                ignored -> {});
+    }
+
+    /**
+     * @param adapterId                the adapter instance id.
+     * @param protocolAdapter          the pure-mechanism adapter the machine commands.
+     * @param selfSender               the wrapper's own mailbox sender — used to synthesize
+     *                                 {@link ProtocolAdapterWrapperEvent.AllVerified}.
+     * @param clock                    the clock the timers are scheduled against.
+     * @param retryPolicy              the connection backoff policy.
+     * @param watchdogTimeoutMillis    the per-state acknowledgment watchdog timeout, in milliseconds.
+     * @param skipVerification         whether to skip verification and reach {@code CONNECTED} straight from
+     *                                 {@code WAITING_FOR_CONNECTED}.
+     * @param initialGoal              the initial direction goal (from the configuration).
+     * @param activation               the per-tag activation preferences.
+     * @param tagPlane                 the wrapper's view of the tag aspect machines.
+     * @param healthListener           the supervisor notification seam.
+     * @param metrics                  the per-adapter metrics.
+     * @param northboundDataPointSink  accepts stamped data points that should be offered to northbound consumers.
+     */
+    public ProtocolAdapterWrapperContext(
+            final @NotNull String adapterId,
+            final @NotNull ProtocolAdapter protocolAdapter,
+            final @NotNull MailboxSender<ProtocolAdapterWrapperMessage> selfSender,
+            final @NotNull Clock clock,
+            final @NotNull RetryPolicy retryPolicy,
+            final long watchdogTimeoutMillis,
+            final boolean skipVerification,
+            final @NotNull ProtocolAdapterGoalState initialGoal,
+            final @NotNull Map<String, TagAspectActivationPreference> activation,
+            final @NotNull TagAspectCoordinator tagPlane,
+            final @NotNull ProtocolAdapterWrapperEventListener healthListener,
+            final @NotNull ProtocolAdapterMetrics metrics,
+            final @NotNull Consumer<DataPoint> northboundDataPointSink) {
         this.adapterId = adapterId;
         this.protocolAdapter = protocolAdapter;
         this.selfSender = selfSender;
@@ -149,6 +198,7 @@ public final class ProtocolAdapterWrapperContext {
         this.goal = initialGoal;
         this.activation = Map.copyOf(activation);
         this.tagPlane = tagPlane;
+        this.northboundDataPointSink = northboundDataPointSink;
         this.healthListener = healthListener;
         this.metrics = metrics;
     }
@@ -455,7 +505,10 @@ public final class ProtocolAdapterWrapperContext {
      * @param value the reused v1 value.
      */
     public void routeDataPointToTags(final @NotNull Node node, final @NotNull DataPoint value) {
-        tagPlane.routeDataPoint(node, value);
+        final DataPoint northboundDataPoint = tagPlane.routeDataPoint(node, value, adapterId);
+        if (northboundDataPoint != null) {
+            northboundDataPointSink.accept(northboundDataPoint);
+        }
     }
 
     /**

--- a/hivemq-edge/src/test/java/com/hivemq/protocols/northbound/NorthboundTagConsumerTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/protocols/northbound/NorthboundTagConsumerTest.java
@@ -85,6 +85,10 @@ class NorthboundTagConsumerTest {
 
     @BeforeEach
     void setUp() {
+        when(protocolAdapter.getId()).thenReturn("adapter-1");
+        when(protocolAdapter.getAdapter()).thenReturn(adapter);
+        when(protocolAdapter.getAdapterInformation()).thenReturn(adapterInformation);
+        when(adapterInformation.getProtocolId()).thenReturn("modbus");
         consumer = new NorthboundTagConsumer(
                 pollingContext, protocolAdapter, objectMapper, publishService, metricsService, eventService);
     }
@@ -107,13 +111,9 @@ class NorthboundTagConsumerTest {
         when(publishBuilder.withPayload(any(byte[].class))).thenReturn(publishBuilder);
         when(publishBuilder.withAdapter(any())).thenReturn(publishBuilder);
         when(publishBuilder.send()).thenReturn(CompletableFuture.completedFuture(ProtocolPublishResult.DELIVERED));
-        when(protocolAdapter.getAdapter()).thenReturn(adapter);
     }
 
     private void setupEventBuilder() {
-        when(protocolAdapter.getId()).thenReturn("adapter-1");
-        when(protocolAdapter.getAdapterInformation()).thenReturn(adapterInformation);
-        when(adapterInformation.getProtocolId()).thenReturn("modbus");
         when(eventService.createAdapterEvent(anyString(), anyString())).thenReturn(eventBuilder);
         when(eventBuilder.withSeverity(any())).thenReturn(eventBuilder);
         when(eventBuilder.withTimestamp(any())).thenReturn(eventBuilder);
@@ -245,7 +245,6 @@ class NorthboundTagConsumerTest {
         when(publishBuilder.withPayload(any(byte[].class))).thenReturn(publishBuilder);
         when(publishBuilder.withAdapter(any())).thenReturn(publishBuilder);
         when(publishBuilder.send()).thenReturn(CompletableFuture.failedFuture(new RuntimeException("publish failed")));
-        when(protocolAdapter.getAdapter()).thenReturn(adapter);
 
         consumer.accept(createDataPoint("tag", 1));
 


### PR DESCRIPTION
Linear: https://linear.app/hivemq/issue/EDG-808/nevsky-bug-fix-missing-northboundtagconsumer

## Summary
- add the missing v2 northbound bridge that registers mapped `NorthboundTagConsumer`s with `TagManager`
- stamp accepted v2 adapter datapoints with the mapped tag name and adapter id before feeding them northbound
- keep the tag aspect state machine as the acceptance gate so ignored/deactivated datapoints are not published
- adapt the v2 adapter identity into the legacy publish service path used by `NorthboundTagConsumer`

## Root cause
The v2 wrapper accepted datapoints from protocol adapters, but only routed them into the tag aspect runtime. Unlike the v1 wrapper, it never registered northbound consumers with `TagManager` and never fed accepted mapped datapoints into the northbound publish path. As a result, mapped tags such as `t1` could update the v2 runtime without producing MQTT messages.

## Fix
The wrapper factory now creates a v2 northbound consumer registry when `TagManager` is available. The registry builds consumers from v2 northbound mappings, registers them with `TagManager`, and updates them when tag/mapping configuration changes. `routeDataPointToTags` now receives the stamped accepted datapoint from the tag runtime and feeds it to `TagManager` for MQTT publishing.

## Validation
- `./gradlew :hivemq-edge-build:hivemq-edge:test --tests com.hivemq.protocols.v2.manager.DefaultProtocolAdapterWrapperFactoryTest --tests com.hivemq.protocols.v2.runtime.DataPointStampingTest --no-daemon`
- `./gradlew :hivemq-edge-test:test --tests com.hivemq.edge.api.v2.NorthboundMqttEndToEndTest --no-daemon`
- `./gradlew :hivemq-edge-build:hivemq-edge:spotlessCheck :hivemq-edge-test:spotlessCheck --no-daemon`
- `git diff --check` in `hivemq-edge` and `hivemq-edge-test`
