### PR TITLE
Fix TLS test key store generator for BouncyCastle 1.85

### DIFF
--- a/hivemq-edge/src/test/java/util/TestKeyStoreGenerator.java
+++ b/hivemq-edge/src/test/java/util/TestKeyStoreGenerator.java
@@ -121,7 +121,9 @@ public class TestKeyStoreGenerator {
 
         if (withX500) {
             // CN = Common Name, OU = Organisational Unit, O = Organisation, C = Country, ST = State
-            x500Name = new X500Name("CN=" + name + ", OU=" + name + ", O=" + name + ", C=" + name + ", ST=" + name);
+            // C (country, OID 2.5.4.6) must be a valid 2-character ISO 3166-1 code; BouncyCastle 1.85+
+            // rejects anything else, so it is kept fixed independently of the store name.
+            x500Name = new X500Name("CN=" + name + ", OU=" + name + ", O=" + name + ", C=DE, ST=" + name);
         } else {
             // At least 1 attribute is required
             x500Name = new X500Name("CN=" + name);


### PR DESCRIPTION
## Why

PR #1617 (the `renovate/master-all-minor` dependency bump, which raised **BouncyCastle 1.84 → 1.85**) was merged, but the accompanying test fix was not included. BouncyCastle 1.85 now strictly validates the X.500 country attribute (`C`, OID `2.5.4.6`): it must be a valid 2-character ISO 3166-1 code.

`TestKeyStoreGenerator` builds the certificate subject with `C=<storeName>`, so every SSL/TLS test that generates a key store now fails at certificate construction on **current master**:

```
java.lang.IllegalArgumentException: country code attribute 2.5.4.6 must be
exactly 2 characters per ISO 3166-1 / X.520, got N: '<storeName>'
```

## What

Pin the country attribute to a fixed valid code (`C=DE`) independently of the store name. The generated country is never asserted by any test, and `DE` matches the existing convention (`SslClientCertificateImplTest` already expects country `"DE"`).

This PR contains **only** the test fix — the dependency bump itself is already on master via #1617.

## Verification

Ran the previously-failing core SSL tests against BouncyCastle 1.85:
`SslUtilTest`, `SslContextStoreTest`, `SslFactoryTest` — all green.

> Companion fixes for the same root cause are pushed to the still-open `renovate/master-all-minor` PRs in `hivemq-edge-test` (#385) and `hivemq-edge-commercial-modules` (#333).