### PR TITLE
fix(frontend): pin pnpm to 11.14.0 to avoid broken 11.13.0 release

### DIFF
--- a/hivemq-edge-frontend/build.gradle.kts
+++ b/hivemq-edge-frontend/build.gradle.kts
@@ -10,7 +10,7 @@ description = "Frontend for HiveMQ Edge"
 node {
   download.set(true)
   version.set("24.16.0")
-  pnpmVersion.set("11")
+  pnpmVersion.set("11.14.0")
 }
 
 tasks.withType<PnpmTask>().configureEach {

--- a/hivemq-edge-frontend/package.json
+++ b/hivemq-edge-frontend/package.json
@@ -195,11 +195,11 @@
   },
   "engines": {
     "node": "24",
-    "pnpm": "11"
+    "pnpm": "11.14.0"
   },
   "overrides": {
     "js-yaml": "4.3.0",
     "ajv": "^8.20.0"
   },
-  "packageManager": "pnpm@11.13.0+sha512.88d94724d8f2e6c186744a5584c6e59ecac869ec7ba15e9cb4cd628e8dc7066820b2481d8ee3b51ea8da323a7378068aa58c556a3720d32b7c20a051d088363a"
+  "packageManager": "pnpm@11.14.0+sha512.66c1ac4c7d4762d6d7dde44c7f3e5a73591ed0a0806e751d4ed32d4f004f25b2285a906b1fd8a9e3e621df3b4e2858bf88e50e0cf626bedbe977fe434a5caf85"
 }


### PR DESCRIPTION
## Summary

- pnpm v11.13.0 is a known-broken release: its `@pnpm/exe` shipped without a working binary, and pnpm's own safeguard (added in [11.11–11.14](https://pnpm.io/blog/releases/11.11-11.14)) now refuses to install it — see [pnpm/pnpm#13067](https://github.com/pnpm/pnpm/issues/13067).
- `hivemq-edge-frontend` pinned `pnpm@11.13.0` in `packageManager` and let the gradle plugin float on `"11"`, so fresh CI workspaces fetch v11.13.0 and fail at `pnpmInstall`.
- Bump `engines.pnpm` and `packageManager` to `11.14.0` and pin `pnpmVersion.set("11.14.0")` so the range can't silently drift onto the next broken v11.x.

## Motivation

`hivemq-pulse-ci/master` build [#956](https://jenkins.cicd.pd.hmq.dev/job/hivemq-pulse/job/hivemq-pulse-ci/job/master/956/) fails during composite build at:

```
> Task :hivemq-edge-build:hivemq-edge-frontend:pnpmInstall FAILED
[ERROR] pnpm v11.13.0 is a broken release and cannot be installed
Its "@pnpm/exe" build shipped without a binary and does not run.
```

Local dev machines don't repro on a straight run because they already have a cached working v11.x binary under `.gradle/pnpm/pnpm-v11/`. To repro locally: `rm -rf hivemq-edge-frontend/.gradle/pnpm` and rebuild.

Tracked in Pulse Team: [PLA-83](https://linear.app/hivemq/issue/PLA-83/fix-pulse-ci-master-hivemq-edge-pinned-to-broken-pnpm-11130).

## Test plan

- [ ] `hivemq-edge` CI green on this branch.
- [ ] Trigger `hivemq-pulse-ci` against a matching `fix-pnpnm-problem` branch (or wait for merge to master) and confirm `:hivemq-edge-build:hivemq-edge-frontend:pnpmInstall` succeeds.
- [ ] Locally: `rm -rf hivemq-edge-frontend/.gradle/pnpm && ./gradlew :hivemq-edge-frontend:pnpmInstall --rerun`.
