### PR TITLE
EDG-844: Paginate Data Hub listings so all items are shown

### DIFF
--- a/hivemq-edge-frontend/src/extensions/datahub/api/hooks/DataHubBehaviorPoliciesService/useGetAllBehaviorPolicies.ts
+++ b/hivemq-edge-frontend/src/extensions/datahub/api/hooks/DataHubBehaviorPoliciesService/useGetAllBehaviorPolicies.ts
@@ -1,27 +1,21 @@
-import { useQuery } from '@tanstack/react-query'
 import { DATAHUB_QUERY_KEYS } from '../../utils.ts'
 import { useHttpClient } from '@/api/hooks/useHttpClient/useHttpClient.ts'
-import type { ApiError, BehaviorPolicyList } from '@/api/__generated__'
+import type { BehaviorPolicy } from '@/api/__generated__'
+import { usePaginatedList } from '@datahub/api/hooks/usePaginatedList.ts'
 
 interface GetAllBehaviorPoliciesProps {
   fields?: string
   policyIds?: string
   clientIds?: string
-  limit?: number
-  cursor?: string
 }
 
-export const useGetAllBehaviorPolicies = ({
-  fields,
-  policyIds,
-  clientIds,
-  limit,
-  cursor,
-}: GetAllBehaviorPoliciesProps) => {
+export const useGetAllBehaviorPolicies = ({ fields, policyIds, clientIds }: GetAllBehaviorPoliciesProps) => {
   const appClient = useHttpClient()
-  return useQuery<BehaviorPolicyList, ApiError>({
-    queryKey: [DATAHUB_QUERY_KEYS.BEHAVIOR_POLICIES, fields, policyIds, clientIds, limit, cursor],
-    queryFn: () =>
-      appClient.dataHubBehaviorPolicies.getAllBehaviorPolicies(fields, policyIds, clientIds, limit, cursor),
-  })
+  // The listing is cursor-paginated; fetch every page so items beyond the first page
+  // (default size 50) are not hidden from the UI. See EDG-844.
+  return usePaginatedList<BehaviorPolicy>(
+    [DATAHUB_QUERY_KEYS.BEHAVIOR_POLICIES, fields, policyIds, clientIds],
+    (cursor) =>
+      appClient.dataHubBehaviorPolicies.getAllBehaviorPolicies(fields, policyIds, clientIds, undefined, cursor)
+  )
 }

--- a/hivemq-edge-frontend/src/extensions/datahub/api/hooks/DataHubBehaviorPoliciesService/useGetAllBehaviorPolicies.ts
+++ b/hivemq-edge-frontend/src/extensions/datahub/api/hooks/DataHubBehaviorPoliciesService/useGetAllBehaviorPolicies.ts
@@ -16,6 +16,6 @@ export const useGetAllBehaviorPolicies = ({ fields, policyIds, clientIds }: GetA
   return usePaginatedList<BehaviorPolicy>(
     [DATAHUB_QUERY_KEYS.BEHAVIOR_POLICIES, fields, policyIds, clientIds],
     (cursor) =>
-      appClient.dataHubBehaviorPolicies.getAllBehaviorPolicies(fields, policyIds, clientIds, undefined, cursor)
+      appClient.dataHubBehaviorPolicies.getAllBehaviorPolicies(fields, policyIds, clientIds, 500, cursor)
   )
 }

--- a/hivemq-edge-frontend/src/extensions/datahub/api/hooks/DataHubBehaviorPoliciesService/useGetAllBehaviorPolicies.ts
+++ b/hivemq-edge-frontend/src/extensions/datahub/api/hooks/DataHubBehaviorPoliciesService/useGetAllBehaviorPolicies.ts
@@ -16,6 +16,6 @@ export const useGetAllBehaviorPolicies = ({ fields, policyIds, clientIds }: GetA
   return usePaginatedList<BehaviorPolicy>(
     [DATAHUB_QUERY_KEYS.BEHAVIOR_POLICIES, fields, policyIds, clientIds],
     (cursor) =>
-      appClient.dataHubBehaviorPolicies.getAllBehaviorPolicies(fields, policyIds, clientIds, 500, cursor)
+      appClient.dataHubBehaviorPolicies.getAllBehaviorPolicies(fields, policyIds, clientIds, undefined, cursor)
   )
 }

--- a/hivemq-edge-frontend/src/extensions/datahub/api/hooks/DataHubDataPoliciesService/useGetAllDataPolicies.ts
+++ b/hivemq-edge-frontend/src/extensions/datahub/api/hooks/DataHubDataPoliciesService/useGetAllDataPolicies.ts
@@ -8,6 +8,6 @@ export const useGetAllDataPolicies = () => {
   // The listing is cursor-paginated; fetch every page so items beyond the first page
   // (default size 50) are not hidden from the UI. See EDG-844.
   return usePaginatedList<DataPolicy>([DATAHUB_QUERY_KEYS.DATA_POLICIES], (cursor) =>
-    appClient.dataHubDataPolicies.getAllDataPolicies(undefined, undefined, undefined, undefined, undefined, cursor)
+    appClient.dataHubDataPolicies.getAllDataPolicies(undefined, undefined, undefined, undefined, 500, cursor)
   )
 }

--- a/hivemq-edge-frontend/src/extensions/datahub/api/hooks/DataHubDataPoliciesService/useGetAllDataPolicies.ts
+++ b/hivemq-edge-frontend/src/extensions/datahub/api/hooks/DataHubDataPoliciesService/useGetAllDataPolicies.ts
@@ -1,12 +1,13 @@
-import { useQuery } from '@tanstack/react-query'
 import { useHttpClient } from '@/api/hooks/useHttpClient/useHttpClient.ts'
 import { DATAHUB_QUERY_KEYS } from '../../utils.ts'
-import type { ApiError, DataPolicyList } from '@/api/__generated__'
+import type { DataPolicy } from '@/api/__generated__'
+import { usePaginatedList } from '@datahub/api/hooks/usePaginatedList.ts'
 
 export const useGetAllDataPolicies = () => {
   const appClient = useHttpClient()
-  return useQuery<DataPolicyList, ApiError>({
-    queryKey: [DATAHUB_QUERY_KEYS.DATA_POLICIES],
-    queryFn: () => appClient.dataHubDataPolicies.getAllDataPolicies(),
-  })
+  // The listing is cursor-paginated; fetch every page so items beyond the first page
+  // (default size 50) are not hidden from the UI. See EDG-844.
+  return usePaginatedList<DataPolicy>([DATAHUB_QUERY_KEYS.DATA_POLICIES], (cursor) =>
+    appClient.dataHubDataPolicies.getAllDataPolicies(undefined, undefined, undefined, undefined, undefined, cursor)
+  )
 }

--- a/hivemq-edge-frontend/src/extensions/datahub/api/hooks/DataHubDataPoliciesService/useGetAllDataPolicies.ts
+++ b/hivemq-edge-frontend/src/extensions/datahub/api/hooks/DataHubDataPoliciesService/useGetAllDataPolicies.ts
@@ -8,6 +8,6 @@ export const useGetAllDataPolicies = () => {
   // The listing is cursor-paginated; fetch every page so items beyond the first page
   // (default size 50) are not hidden from the UI. See EDG-844.
   return usePaginatedList<DataPolicy>([DATAHUB_QUERY_KEYS.DATA_POLICIES], (cursor) =>
-    appClient.dataHubDataPolicies.getAllDataPolicies(undefined, undefined, undefined, undefined, 500, cursor)
+    appClient.dataHubDataPolicies.getAllDataPolicies(undefined, undefined, undefined, undefined, undefined, cursor)
   )
 }

--- a/hivemq-edge-frontend/src/extensions/datahub/api/hooks/DataHubSchemasService/useGetAllSchemas.ts
+++ b/hivemq-edge-frontend/src/extensions/datahub/api/hooks/DataHubSchemasService/useGetAllSchemas.ts
@@ -8,6 +8,6 @@ export const useGetAllSchemas = () => {
   // The listing is cursor-paginated; fetch every page so items beyond the first page
   // (default size 50) are not hidden from the UI. See EDG-844.
   return usePaginatedList<PolicySchema>([DATAHUB_QUERY_KEYS.SCHEMAS], (cursor) =>
-    appClient.dataHubSchemas.getAllSchemas(undefined, undefined, undefined, undefined, cursor)
+    appClient.dataHubSchemas.getAllSchemas(undefined, undefined, undefined, 500, cursor)
   )
 }

--- a/hivemq-edge-frontend/src/extensions/datahub/api/hooks/DataHubSchemasService/useGetAllSchemas.ts
+++ b/hivemq-edge-frontend/src/extensions/datahub/api/hooks/DataHubSchemasService/useGetAllSchemas.ts
@@ -1,12 +1,13 @@
-import { useQuery } from '@tanstack/react-query'
 import { useHttpClient } from '@/api/hooks/useHttpClient/useHttpClient.ts'
-import type { ApiError, SchemaList } from '@/api/__generated__'
+import type { PolicySchema } from '@/api/__generated__'
 import { DATAHUB_QUERY_KEYS } from '@datahub/api/utils.ts'
+import { usePaginatedList } from '@datahub/api/hooks/usePaginatedList.ts'
 
 export const useGetAllSchemas = () => {
   const appClient = useHttpClient()
-  return useQuery<SchemaList, ApiError>({
-    queryKey: [DATAHUB_QUERY_KEYS.SCHEMAS],
-    queryFn: () => appClient.dataHubSchemas.getAllSchemas(),
-  })
+  // The listing is cursor-paginated; fetch every page so items beyond the first page
+  // (default size 50) are not hidden from the UI. See EDG-844.
+  return usePaginatedList<PolicySchema>([DATAHUB_QUERY_KEYS.SCHEMAS], (cursor) =>
+    appClient.dataHubSchemas.getAllSchemas(undefined, undefined, undefined, undefined, cursor)
+  )
 }

--- a/hivemq-edge-frontend/src/extensions/datahub/api/hooks/DataHubSchemasService/useGetAllSchemas.ts
+++ b/hivemq-edge-frontend/src/extensions/datahub/api/hooks/DataHubSchemasService/useGetAllSchemas.ts
@@ -8,6 +8,6 @@ export const useGetAllSchemas = () => {
   // The listing is cursor-paginated; fetch every page so items beyond the first page
   // (default size 50) are not hidden from the UI. See EDG-844.
   return usePaginatedList<PolicySchema>([DATAHUB_QUERY_KEYS.SCHEMAS], (cursor) =>
-    appClient.dataHubSchemas.getAllSchemas(undefined, undefined, undefined, 500, cursor)
+    appClient.dataHubSchemas.getAllSchemas(undefined, undefined, undefined, undefined, cursor)
   )
 }

--- a/hivemq-edge-frontend/src/extensions/datahub/api/hooks/DataHubScriptsService/useGetAllScripts.ts
+++ b/hivemq-edge-frontend/src/extensions/datahub/api/hooks/DataHubScriptsService/useGetAllScripts.ts
@@ -14,6 +14,6 @@ export const useGetAllScripts = ({ fields, functionTypes, scriptIds }: GetAllScr
   // The listing is cursor-paginated; fetch every page so items beyond the first page
   // (default size 50) are not hidden from the UI. See EDG-844.
   return usePaginatedList<Script>([DATAHUB_QUERY_KEYS.SCRIPTS, fields, functionTypes, scriptIds], (cursor) =>
-    appClient.dataHubScripts.getAllScripts(fields, functionTypes, scriptIds, undefined, cursor)
+    appClient.dataHubScripts.getAllScripts(fields, functionTypes, scriptIds, 500, cursor)
   )
 }

--- a/hivemq-edge-frontend/src/extensions/datahub/api/hooks/DataHubScriptsService/useGetAllScripts.ts
+++ b/hivemq-edge-frontend/src/extensions/datahub/api/hooks/DataHubScriptsService/useGetAllScripts.ts
@@ -1,20 +1,19 @@
-import { useQuery } from '@tanstack/react-query'
 import { useHttpClient } from '@/api/hooks/useHttpClient/useHttpClient.ts'
-import type { ApiError, ScriptList } from '@/api/__generated__'
+import type { Script } from '@/api/__generated__'
 import { DATAHUB_QUERY_KEYS } from '@datahub/api/utils.ts'
+import { usePaginatedList } from '@datahub/api/hooks/usePaginatedList.ts'
 
 interface GetAllScriptsProps {
   fields?: string
   functionTypes?: string
   scriptIds?: string
-  limit?: number
-  cursor?: string
 }
 
-export const useGetAllScripts = ({ fields, functionTypes, scriptIds, limit, cursor }: GetAllScriptsProps) => {
+export const useGetAllScripts = ({ fields, functionTypes, scriptIds }: GetAllScriptsProps) => {
   const appClient = useHttpClient()
-  return useQuery<ScriptList, ApiError>({
-    queryKey: [DATAHUB_QUERY_KEYS.SCRIPTS, fields, functionTypes, scriptIds, limit, cursor],
-    queryFn: () => appClient.dataHubScripts.getAllScripts(fields, functionTypes, scriptIds, limit, cursor),
-  })
+  // The listing is cursor-paginated; fetch every page so items beyond the first page
+  // (default size 50) are not hidden from the UI. See EDG-844.
+  return usePaginatedList<Script>([DATAHUB_QUERY_KEYS.SCRIPTS, fields, functionTypes, scriptIds], (cursor) =>
+    appClient.dataHubScripts.getAllScripts(fields, functionTypes, scriptIds, undefined, cursor)
+  )
 }

--- a/hivemq-edge-frontend/src/extensions/datahub/api/hooks/DataHubScriptsService/useGetAllScripts.ts
+++ b/hivemq-edge-frontend/src/extensions/datahub/api/hooks/DataHubScriptsService/useGetAllScripts.ts
@@ -14,6 +14,6 @@ export const useGetAllScripts = ({ fields, functionTypes, scriptIds }: GetAllScr
   // The listing is cursor-paginated; fetch every page so items beyond the first page
   // (default size 50) are not hidden from the UI. See EDG-844.
   return usePaginatedList<Script>([DATAHUB_QUERY_KEYS.SCRIPTS, fields, functionTypes, scriptIds], (cursor) =>
-    appClient.dataHubScripts.getAllScripts(fields, functionTypes, scriptIds, 500, cursor)
+    appClient.dataHubScripts.getAllScripts(fields, functionTypes, scriptIds, undefined, cursor)
   )
 }

--- a/hivemq-edge-frontend/src/extensions/datahub/api/hooks/usePaginatedList.spec.ts
+++ b/hivemq-edge-frontend/src/extensions/datahub/api/hooks/usePaginatedList.spec.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest'
+import { http, HttpResponse } from 'msw'
+import { renderHook, waitFor } from '@testing-library/react'
+
+import { server } from '@/__test-utils__/msw/mockServer.ts'
+import { SimpleWrapper as wrapper } from '@/__test-utils__/hooks/SimpleWrapper.tsx'
+import type { Script, ScriptList } from '@/api/__generated__'
+
+import { extractCursor, usePaginatedList } from '@datahub/api/hooks/usePaginatedList.ts'
+import { useHttpClient } from '@/api/hooks/useHttpClient/useHttpClient.ts'
+import { DATAHUB_QUERY_KEYS } from '@datahub/api/utils.ts'
+
+describe('extractCursor', () => {
+  it('should return the cursor query param from an absolute next URL', () => {
+    expect(extractCursor('https://broker/api/v1/data-hub/scripts?limit=50&cursor=abc123')).toStrictEqual('abc123')
+  })
+
+  it('should return the cursor query param from a relative next URL', () => {
+    expect(extractCursor('/api/v1/data-hub/scripts?cursor=page2')).toStrictEqual('page2')
+  })
+
+  it('should return undefined when there is no next URL or no cursor', () => {
+    expect(extractCursor(undefined)).toBeUndefined()
+    expect(extractCursor('/api/v1/data-hub/scripts?limit=50')).toBeUndefined()
+  })
+})
+
+describe('usePaginatedList', () => {
+  const script = (id: string): Script => ({ id, version: 1, source: '', functionType: undefined as never })
+
+  it('should follow the cursor and return items from every page (EDG-844)', async () => {
+    // Page 1 carries a `_links.next` cursor; page 2 does not, so paging stops there.
+    server.use(
+      http.get('*/data-hub/scripts', ({ request }) => {
+        const cursor = new URL(request.url).searchParams.get('cursor')
+        if (!cursor) {
+          return HttpResponse.json<ScriptList>({
+            items: [script('page1-a'), script('page1-b')],
+            _links: { next: 'http://broker/api/v1/data-hub/scripts?cursor=CURSOR_2' },
+          })
+        }
+        return HttpResponse.json<ScriptList>({ items: [script('page2-a')] })
+      })
+    )
+
+    const { result } = renderHook(
+      () => {
+        const appClient = useHttpClient()
+        return usePaginatedList<Script>([DATAHUB_QUERY_KEYS.SCRIPTS, 'test'], (cursor) =>
+          appClient.dataHubScripts.getAllScripts(undefined, undefined, undefined, undefined, cursor)
+        )
+      },
+      { wrapper }
+    )
+
+    // All pages fetched: hook stops paging once `_links.next` is absent.
+    await waitFor(() => expect(result.current.hasNextPage).toBeFalsy())
+    await waitFor(() => expect(result.current.isFetching).toBeFalsy())
+
+    expect(result.current.data?.items.map((s) => s.id)).toStrictEqual(['page1-a', 'page1-b', 'page2-a'])
+  })
+
+  it('should return a single page unchanged when there is no next cursor', async () => {
+    server.use(http.get('*/data-hub/scripts', () => HttpResponse.json<ScriptList>({ items: [script('only')] })))
+
+    const { result } = renderHook(
+      () => {
+        const appClient = useHttpClient()
+        return usePaginatedList<Script>([DATAHUB_QUERY_KEYS.SCRIPTS, 'single'], (cursor) =>
+          appClient.dataHubScripts.getAllScripts(undefined, undefined, undefined, undefined, cursor)
+        )
+      },
+      { wrapper }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBeTruthy())
+    expect(result.current.data?.items.map((s) => s.id)).toStrictEqual(['only'])
+  })
+})

--- a/hivemq-edge-frontend/src/extensions/datahub/api/hooks/usePaginatedList.spec.ts
+++ b/hivemq-edge-frontend/src/extensions/datahub/api/hooks/usePaginatedList.spec.ts
@@ -54,7 +54,9 @@ describe('usePaginatedList', () => {
     )
 
     // All pages fetched: hook stops paging once `_links.next` is absent.
-    await waitFor(() => expect(result.current.hasNextPage).toBeFalsy())
+    await waitFor(() =>
+      expect(result.current.data?.items.map((s) => s.id)).toStrictEqual(['page1-a', 'page1-b', 'page2-a'])
+    )
     await waitFor(() => expect(result.current.isFetching).toBeFalsy())
 
     expect(result.current.data?.items.map((s) => s.id)).toStrictEqual(['page1-a', 'page1-b', 'page2-a'])

--- a/hivemq-edge-frontend/src/extensions/datahub/api/hooks/usePaginatedList.ts
+++ b/hivemq-edge-frontend/src/extensions/datahub/api/hooks/usePaginatedList.ts
@@ -1,0 +1,61 @@
+import { useEffect } from 'react'
+import { useInfiniteQuery, type QueryKey } from '@tanstack/react-query'
+import type { ApiError } from '@/api/__generated__'
+
+/**
+ * A page of a cursor-paginated Data Hub listing endpoint: a set of items plus an
+ * optional `_links.next` URL pointing at the following page.
+ */
+interface PaginatedList<T> {
+  items?: Array<T>
+  _links?: { next?: string }
+}
+
+/**
+ * Extract the `cursor` query parameter from a `_links.next` URL.
+ *
+ * The Data Hub list endpoints return the next page as a full URL in `_links.next`;
+ * the endpoints themselves expect just the opaque `cursor` token. `undefined` means
+ * there is no next page (stop paginating).
+ */
+export const extractCursor = (next: string | undefined): string | undefined => {
+  if (!next) return undefined
+  try {
+    // `next` may be absolute or relative; a base makes URL parsing tolerant of both.
+    return new URL(next, 'http://localhost').searchParams.get('cursor') ?? undefined
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * Fetch *every* page of a cursor-paginated Data Hub listing and expose it as a single
+ * flattened `{ items }` object — the same shape the callers already consume.
+ *
+ * The Data Hub list endpoints are cursor-paginated (default page size 50). Fetching only
+ * the first page hides any item beyond the 50th (EDG-844). This follows `_links.next`
+ * until it is absent, so callers always see the full list without dealing with pages.
+ *
+ * `useInfiniteQuery` fetches only the first page on its own; the effect below keeps
+ * pulling subsequent pages until the cursor is exhausted.
+ *
+ * @param queryKey  React Query key for this listing (without any cursor component).
+ * @param fetchPage Fetches one page for the given cursor (`undefined` = first page).
+ */
+export const usePaginatedList = <T>(queryKey: QueryKey, fetchPage: (cursor?: string) => Promise<PaginatedList<T>>) => {
+  const query = useInfiniteQuery<PaginatedList<T>, ApiError, { items: Array<T> }>({
+    queryKey,
+    initialPageParam: undefined as string | undefined,
+    queryFn: ({ pageParam }) => fetchPage(pageParam as string | undefined),
+    getNextPageParam: (lastPage) => extractCursor(lastPage._links?.next),
+    // Flatten every fetched page back into the single `{ items }` shape callers expect.
+    select: (data) => ({ items: data.pages.flatMap((page) => page.items ?? []) }),
+  })
+
+  const { hasNextPage, isFetchingNextPage, fetchNextPage } = query
+  useEffect(() => {
+    if (hasNextPage && !isFetchingNextPage) fetchNextPage()
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage])
+
+  return query
+}

--- a/hivemq-edge-frontend/src/extensions/datahub/api/hooks/usePaginatedList.ts
+++ b/hivemq-edge-frontend/src/extensions/datahub/api/hooks/usePaginatedList.ts
@@ -43,19 +43,19 @@ export const extractCursor = (next: string | undefined): string | undefined => {
  * @param fetchPage Fetches one page for the given cursor (`undefined` = first page).
  */
 export const usePaginatedList = <T>(queryKey: QueryKey, fetchPage: (cursor?: string) => Promise<PaginatedList<T>>) => {
-  const query = useInfiniteQuery<PaginatedList<T>, ApiError, { items: Array<T> }>({
+  const query = useInfiniteQuery<PaginatedList<T>, ApiError, { items: Array<T> }, QueryKey, string | undefined>({
     queryKey,
-    initialPageParam: undefined as string | undefined,
-    queryFn: ({ pageParam }) => fetchPage(pageParam as string | undefined),
+    initialPageParam: undefined,
+    queryFn: ({ pageParam }) => fetchPage(pageParam),
     getNextPageParam: (lastPage) => extractCursor(lastPage._links?.next),
     // Flatten every fetched page back into the single `{ items }` shape callers expect.
     select: (data) => ({ items: data.pages.flatMap((page) => page.items ?? []) }),
   })
 
-  const { hasNextPage, isFetchingNextPage, fetchNextPage } = query
+  const { hasNextPage, isFetchingNextPage, fetchNextPage, isError } = query
   useEffect(() => {
-    if (hasNextPage && !isFetchingNextPage) fetchNextPage()
-  }, [hasNextPage, isFetchingNextPage, fetchNextPage])
+    if (hasNextPage && !isFetchingNextPage && !isError) void fetchNextPage()
+  }, [hasNextPage, isFetchingNextPage, isError, fetchNextPage])
 
   return query
 }


### PR DESCRIPTION
**Motivation**

Resolves EDG-844.

On the Data Hub UI, once a customer has more than the default page size (~50) of scripts, policies, or schemas, newly created items stop appearing in the list. Reported at Knorr-Bremse: newly created scripts stopped showing past ~47–50; deleting older ones brought them back. The items were created successfully and were retrievable via the REST API — only the UI failed to list them.

**Root cause**

The Data Hub list endpoints are cursor-paginated (`limit` 10–500, default **50**; response is `{ items, _links.next }`). The frontend list hooks did a single `useQuery` fetch of the first page and never followed `_links.next`, so anything beyond the first page was never fetched → invisible in the UI. Deleting items back under 50 made them reappear (the "delete-to-restore" symptom).

**Changes**

- Add a shared `usePaginatedList` helper (`src/extensions/datahub/api/hooks/usePaginatedList.ts`): `useInfiniteQuery` that follows `_links.next` (extracting the `cursor` param from the next-page URL) until exhausted, with a `select` that flattens all pages back into the single `{ items }` shape the callers already consume.
- Route the four listing hooks through it: `useGetAllScripts`, `useGetAllSchemas`, `useGetAllDataPolicies`, `useGetAllBehaviorPolicies`.
- No component or backend changes — the tables keep calling the hooks the same way and receive the full list.

**Non-goals**

- Backend changes (the API is correct and already paginated).
- User-visible pagination controls — the lists should just show everything.

**Tests**

- New `usePaginatedList.spec.ts`: proves the cursor is followed across pages (page 1 with cursor + page 2 without → all items returned) and unit-tests `extractCursor`.
- Existing DataHub hook specs and the four table Cypress component specs (ScriptTable, PolicyTable, SchemaTable, DataHubListings) remain green.

Short-term workaround for affected customers: use the REST API with `?limit=500`.