### PR TITLE
EDG-847: refactor: fix all ErrorProne and javac warnings

### DIFF
--- a/hivemq-edge/src/main/java/com/hivemq/api/auth/oidc/OidcServiceImpl.java
+++ b/hivemq-edge/src/main/java/com/hivemq/api/auth/oidc/OidcServiceImpl.java
@@ -293,7 +293,8 @@ public class OidcServiceImpl implements OidcService {
      * Redirects are disabled: the discovery and JWKS URLs are derived from the validated issuer and answer
      * directly, so following a redirect would only widen the set of hosts Edge contacts (an SSRF surface)
      * and let a chain multiply the per-call timeout. {@link DefaultResourceRetriever} has no redirect
-     * setting, so {@link #openConnection} is overridden to turn instance-following off on the connection.
+     * setting, so {@link DefaultResourceRetriever#openConnection(URL)} is overridden to turn instance-following
+     * off on the connection.
      */
     static @NotNull DefaultResourceRetriever resourceRetriever(final @NotNull OidcConfiguration config) {
         final int timeout = config.getConnectionTimeoutMillis();

--- a/hivemq-edge/src/main/java/com/hivemq/api/json/CustomConfigSchemaGenerator.java
+++ b/hivemq-edge/src/main/java/com/hivemq/api/json/CustomConfigSchemaGenerator.java
@@ -31,8 +31,8 @@ import com.github.victools.jsonschema.generator.SchemaGeneratorConfigBuilder;
 import com.github.victools.jsonschema.generator.SchemaGeneratorConfigPart;
 import com.github.victools.jsonschema.generator.SchemaVersion;
 import com.github.victools.jsonschema.generator.TypeScope;
-import com.github.victools.jsonschema.module.jackson.JacksonModule;
 import com.github.victools.jsonschema.module.jackson.JacksonOption;
+import com.github.victools.jsonschema.module.jackson.JacksonSchemaModule;
 import com.hivemq.adapter.sdk.api.annotations.ModuleConfigField;
 import com.hivemq.adapter.sdk.api.annotations.MutuallyExclusiveFields;
 import java.math.BigDecimal;
@@ -60,7 +60,7 @@ public class CustomConfigSchemaGenerator {
     public @NotNull JsonNode generateJsonSchema(final @NotNull Class clazz) {
         SchemaGeneratorConfigBuilder configBuilder = new SchemaGeneratorConfigBuilder(
                         SchemaVersion.DRAFT_2020_12, OptionPreset.PLAIN_JSON)
-                .with(new JacksonModule(
+                .with(new JacksonSchemaModule(
                         JacksonOption.RESPECT_JSONPROPERTY_REQUIRED,
                         JacksonOption.INCLUDE_ONLY_JSONPROPERTY_ANNOTATED_METHODS,
                         JacksonOption.RESPECT_JSONPROPERTY_ORDER))

--- a/hivemq-edge/src/main/java/com/hivemq/datapoint/DataPointWithMetadata.java
+++ b/hivemq-edge/src/main/java/com/hivemq/datapoint/DataPointWithMetadata.java
@@ -31,11 +31,11 @@ import org.jetbrains.annotations.NotNull;
 
 public class DataPointWithMetadata implements DataPoint {
     private final @NotNull ObjectNode jsonNode;
-    private final @NotNull String adapterID;
+    private final @NotNull String adapterId;
 
-    public DataPointWithMetadata(final @NotNull ObjectNode jsonNode, final @NotNull String adapterID) {
+    public DataPointWithMetadata(final @NotNull ObjectNode jsonNode, final @NotNull String adapterId) {
         this.jsonNode = jsonNode;
-        this.adapterID = adapterID;
+        this.adapterId = adapterId;
     }
 
     public static <R> @NotNull DataPointBuilder<R> builder(
@@ -47,7 +47,7 @@ public class DataPointWithMetadata implements DataPoint {
 
     @Override
     public @NotNull String getAdapterId() {
-        return adapterID;
+        return adapterId;
     }
 
     @Override

--- a/hivemq-edge/src/main/java/com/hivemq/edge/modules/adapters/data/DataPointImpl.java
+++ b/hivemq-edge/src/main/java/com/hivemq/edge/modules/adapters/data/DataPointImpl.java
@@ -19,7 +19,7 @@ import com.hivemq.adapter.sdk.api.data.DataPoint;
 import java.util.Objects;
 import org.jetbrains.annotations.NotNull;
 
-public class DataPointImpl implements DataPoint {
+public final class DataPointImpl implements DataPoint {
     private final @NotNull Object tagValue;
     private final @NotNull String tagName;
     private final boolean treatAsJson;
@@ -54,6 +54,7 @@ public class DataPointImpl implements DataPoint {
         return tagName;
     }
 
+    @Override
     public @NotNull String getAdapterId() {
         return adapterId;
     }
@@ -65,8 +66,7 @@ public class DataPointImpl implements DataPoint {
 
     @Override
     public boolean equals(final Object o) {
-        if (o == null || getClass() != o.getClass()) return false;
-        final DataPointImpl dataPoint = (DataPointImpl) o;
+        if (!(o instanceof final DataPointImpl dataPoint)) return false;
         return treatAsJson == dataPoint.treatAsJson
                 && Objects.equals(getTagValue(), dataPoint.getTagValue())
                 && Objects.equals(getTagName(), dataPoint.getTagName())

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/fsm/I18nProtocolAdapterMessage.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/fsm/I18nProtocolAdapterMessage.java
@@ -17,6 +17,7 @@ package com.hivemq.protocols.fsm;
 
 import com.hivemq.common.i18n.I18nError;
 import com.hivemq.common.i18n.I18nErrorTemplate;
+import java.util.Locale;
 import java.util.Map;
 import org.jetbrains.annotations.NotNull;
 
@@ -40,7 +41,7 @@ public enum I18nProtocolAdapterMessage implements I18nError {
     private final @NotNull String key;
 
     I18nProtocolAdapterMessage() {
-        key = name().toLowerCase().replace("_", ".");
+        key = name().toLowerCase(Locale.ROOT).replace("_", ".");
     }
 
     @Override

--- a/hivemq-edge/src/test/java/com/hivemq/api/auth/BasicAuthenticationHandler.java
+++ b/hivemq-edge/src/test/java/com/hivemq/api/auth/BasicAuthenticationHandler.java
@@ -41,7 +41,9 @@ public class BasicAuthenticationHandler extends AbstractHeaderAuthenticationHand
     public static String getBasicAuthenticationHeaderValue(
             final @NotNull String username, final @NotNull String password) {
         final var usernamePasswordDecodedString = username + SEP + password;
-        return METHOD + " " + Base64.getEncoder().encodeToString(usernamePasswordDecodedString.getBytes());
+        return METHOD
+                + " "
+                + Base64.getEncoder().encodeToString(usernamePasswordDecodedString.getBytes(StandardCharsets.UTF_8));
     }
 
     public BasicAuthenticationHandler(final @NotNull IUsernameRolesProvider provider) {
@@ -74,12 +76,13 @@ public class BasicAuthenticationHandler extends AbstractHeaderAuthenticationHand
     protected static Optional<UsernamePasswordRoles> parseValue(final @NotNull String headerValue) {
         Preconditions.checkNotNull(headerValue);
 
-        final var usernamePasswordDecodedString = new String(Base64.getDecoder().decode(headerValue.trim()));
+        final var usernamePasswordDecodedString =
+                new String(Base64.getDecoder().decode(headerValue.trim()), StandardCharsets.UTF_8);
         if (!usernamePasswordDecodedString.contains(SEP)) {
             return Optional.empty();
         }
 
-        final var usernamePasswordStringList = usernamePasswordDecodedString.split(SEP);
+        final var usernamePasswordStringList = usernamePasswordDecodedString.split(SEP, -1);
         if (usernamePasswordStringList.length != 2) {
             return Optional.empty();
         }

--- a/hivemq-edge/src/test/java/com/hivemq/edge/adapters/browse/file/DeviceTagCsvSerializerTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/edge/adapters/browse/file/DeviceTagCsvSerializerTest.java
@@ -343,7 +343,7 @@ class DeviceTagCsvSerializerTest {
         try (final ExecutorService executor = Executors.newFixedThreadPool(threadCount)) {
             for (int t = 0; t < threadCount; t++) {
                 final int threadIdx = t;
-                executor.submit(() -> {
+                var unused = executor.submit(() -> {
                     try {
                         startLatch.await();
                         final List<DeviceTagRow> rows = new ArrayList<>();

--- a/hivemq-edge/src/test/java/com/hivemq/edge/adapters/browse/file/DeviceTagJsonSerializerTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/edge/adapters/browse/file/DeviceTagJsonSerializerTest.java
@@ -313,7 +313,7 @@ class DeviceTagJsonSerializerTest {
 
         for (int t = 0; t < threadCount; t++) {
             final int threadIdx = t;
-            executor.submit(() -> {
+            var unused = executor.submit(() -> {
                 try {
                     startLatch.await();
                     final List<DeviceTagRow> rows = new ArrayList<>();

--- a/hivemq-edge/src/test/java/com/hivemq/edge/adapters/browse/file/DeviceTagYamlSerializerTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/edge/adapters/browse/file/DeviceTagYamlSerializerTest.java
@@ -219,7 +219,7 @@ class DeviceTagYamlSerializerTest {
 
         for (int t = 0; t < threadCount; t++) {
             final int threadIdx = t;
-            executor.submit(() -> {
+            var unused = executor.submit(() -> {
                 try {
                     startLatch.await();
                     final List<DeviceTagRow> rows = new ArrayList<>();

--- a/hivemq-edge/src/test/java/com/hivemq/edge/adapters/browse/validate/DeviceTagValidatorTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/edge/adapters/browse/validate/DeviceTagValidatorTest.java
@@ -69,7 +69,7 @@ class DeviceTagValidatorTest {
 
         final List<ValidationError> errors = validator.validate(rows, ImportMode.CREATE, "adapter1");
 
-        assertThat(errors).noneMatch(e -> e.code().equals("DUPLICATE_NODE"));
+        assertThat(errors).noneMatch(e -> e.code() == ValidationError.Code.DUPLICATE_NODE);
     }
 
     @Test
@@ -137,7 +137,7 @@ class DeviceTagValidatorTest {
 
         final List<ValidationError> errors = validator.validate(rows, ImportMode.CREATE, "adapter1");
 
-        assertThat(errors).noneMatch(e -> e.code().equals("INVALID_TAG_NAME"));
+        assertThat(errors).noneMatch(e -> e.code() == ValidationError.Code.INVALID_TAG_NAME);
     }
 
     @Test
@@ -211,7 +211,7 @@ class DeviceTagValidatorTest {
 
         final List<ValidationError> errors = validator.validate(rows, ImportMode.CREATE, "adapter1");
 
-        assertThat(errors).noneMatch(e -> e.code().equals("INVALID_QOS"));
+        assertThat(errors).noneMatch(e -> e.code() == ValidationError.Code.INVALID_QOS);
     }
 
     @Test
@@ -252,7 +252,7 @@ class DeviceTagValidatorTest {
 
         final List<ValidationError> errors = validator.validate(rows, ImportMode.CREATE, "adapter1");
 
-        assertThat(errors).noneMatch(e -> e.code().equals("INVALID_TOPIC"));
+        assertThat(errors).noneMatch(e -> e.code() == ValidationError.Code.INVALID_TOPIC);
     }
 
     @Test
@@ -295,7 +295,8 @@ class DeviceTagValidatorTest {
         final List<ValidationError> errors = validator.validate(rows, ImportMode.CREATE, "adapter1");
 
         assertThat(errors)
-                .noneMatch(e -> e.code().equals("INVALID_TOPIC") && e.column().equals("southbound_topic"));
+                .noneMatch(
+                        e -> e.code() == ValidationError.Code.INVALID_TOPIC && "southbound_topic".equals(e.column()));
     }
 
     // --- Expiry validation ---
@@ -310,7 +311,7 @@ class DeviceTagValidatorTest {
 
         final List<ValidationError> errors = validator.validate(rows, ImportMode.CREATE, "adapter1");
 
-        assertThat(errors).noneMatch(e -> e.code().equals("INVALID_EXPIRY"));
+        assertThat(errors).noneMatch(e -> e.code() == ValidationError.Code.INVALID_EXPIRY);
     }
 
     @Test
@@ -351,7 +352,7 @@ class DeviceTagValidatorTest {
 
         final List<ValidationError> errors = validator.validate(rows, ImportMode.CREATE, "adapter1");
 
-        assertThat(errors).noneMatch(e -> e.code().equals("INVALID_FIELD_MAPPING"));
+        assertThat(errors).noneMatch(e -> e.code() == ValidationError.Code.INVALID_FIELD_MAPPING);
     }
 
     @Test
@@ -453,7 +454,7 @@ class DeviceTagValidatorTest {
 
         final List<ValidationError> errors = validator.validate(rows, ImportMode.CREATE, "adapter1");
 
-        assertThat(errors).noneMatch(e -> e.code().equals("INVALID_NODE_ID"));
+        assertThat(errors).noneMatch(e -> e.code() == ValidationError.Code.INVALID_NODE_ID);
     }
 
     // --- Multiple errors collected ---
@@ -765,7 +766,7 @@ class DeviceTagValidatorTest {
 
         final List<ValidationError> errors = validator.validate(rows, ImportMode.MERGE_SAFE, "adapter1");
 
-        assertThat(errors).noneMatch(e -> e.code().equals("TAG_CONFLICT"));
+        assertThat(errors).noneMatch(e -> e.code() == ValidationError.Code.TAG_CONFLICT);
     }
 
     @Test
@@ -822,8 +823,8 @@ class DeviceTagValidatorTest {
         final List<ValidationError> errors = validator.validate(rows, ImportMode.CREATE, "adapter1");
 
         // No row-level validation errors for rows without tags
-        assertThat(errors).noneMatch(e -> e.code().equals("INVALID_TAG_NAME"));
-        assertThat(errors).noneMatch(e -> e.code().equals("INVALID_NODE_ID"));
+        assertThat(errors).noneMatch(e -> e.code() == ValidationError.Code.INVALID_TAG_NAME);
+        assertThat(errors).noneMatch(e -> e.code() == ValidationError.Code.INVALID_NODE_ID);
     }
 
     // --- Expiry upper bound (MQTT uint32 max) ---

--- a/hivemq-edge/src/test/java/com/hivemq/edge/utils/HiveMQEdgeEnvironmentUtilsTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/edge/utils/HiveMQEdgeEnvironmentUtilsTest.java
@@ -50,7 +50,7 @@ class HiveMQEdgeEnvironmentUtilsTest {
         final ExecutorService executor = Executors.newFixedThreadPool(threadCount);
 
         for (int i = 0; i < threadCount; i++) {
-            executor.submit(() -> {
+            var unused = executor.submit(() -> {
                 ready.countDown();
                 try {
                     go.await(5, TimeUnit.SECONDS);

--- a/modules/hivemq-edge-module-etherip/build.gradle.kts
+++ b/modules/hivemq-edge-module-etherip/build.gradle.kts
@@ -38,6 +38,8 @@ dependencies {
 
 dependencies {
     testImplementation("com.hivemq:hivemq-edge")
+    // hivemq-edge config entities are JAXB annotated; javac needs the annotation types to read their class files
+    testCompileOnly(libs.jaxb4.bind)
     testImplementation(libs.apache.commons.io)
     testImplementation(platform(libs.junit.bom))
     testImplementation("org.junit.jupiter:junit-jupiter")

--- a/modules/hivemq-edge-module-etherip/src/test/java/com/hivemq/edge/adapters/etherip/EipPollingProtocolAdapterIT.java
+++ b/modules/hivemq-edge-module-etherip/src/test/java/com/hivemq/edge/adapters/etherip/EipPollingProtocolAdapterIT.java
@@ -23,7 +23,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.hivemq.adapter.sdk.api.config.MessageHandlingOptions;
 import com.hivemq.adapter.sdk.api.model.ProtocolAdapterInput;
 import com.hivemq.adapter.sdk.api.model.ProtocolAdapterStartOutput;
 import com.hivemq.adapter.sdk.api.polling.batch.BatchPollingInput;
@@ -31,7 +30,6 @@ import com.hivemq.adapter.sdk.api.polling.batch.BatchPollingOutput;
 import com.hivemq.edge.adapters.etherip.config.EipDataType;
 import com.hivemq.edge.adapters.etherip.config.EipSpecificAdapterConfig;
 import com.hivemq.edge.adapters.etherip.config.EipToMqttConfig;
-import com.hivemq.edge.adapters.etherip.config.EipToMqttMapping;
 import com.hivemq.edge.adapters.etherip.config.tag.EipTag;
 import com.hivemq.edge.adapters.etherip.config.tag.EipTagDefinition;
 import java.util.List;
@@ -75,9 +73,6 @@ public class EipPollingProtocolAdapterIT {
             final @NotNull String expectedName,
             final @NotNull Object expectedValue) {
 
-        final EipToMqttMapping eipToMqttMapping = new EipToMqttMapping(
-                "topic", 1, MessageHandlingOptions.MQTTMessagePerTag, true, true, tagAddress, List.of());
-
         final EipSpecificAdapterConfig config =
                 new EipSpecificAdapterConfig(44818, HOST, 1, 0, new EipToMqttConfig(1000, 10, true));
 
@@ -87,7 +82,6 @@ public class EipPollingProtocolAdapterIT {
                 .thenReturn(List.of(new EipTag(tagAddress, tagAddress, new EipTagDefinition(tagAddress, tagType))));
 
         final BatchPollingInput input = mock(BatchPollingInput.class);
-        final List eipToMqttMapping1 = List.of(eipToMqttMapping);
 
         final BatchPollingOutput output = mock();
 
@@ -103,11 +97,11 @@ public class EipPollingProtocolAdapterIT {
         verify(output).addDataPoint(captorName.capture(), captorValue.capture());
 
         assertThat(captorName.getAllValues()).first().isEqualTo(expectedName);
-        if (expectedValue instanceof Double) {
+        if (expectedValue instanceof final Double expectedDouble) {
             assertThat(captorValue.getValue())
                     .isInstanceOf(Double.class)
                     .asInstanceOf(InstanceOfAssertFactories.DOUBLE)
-                    .isEqualTo((Double) expectedValue, withPrecision(2d));
+                    .isEqualTo(expectedDouble, withPrecision(2d));
         } else {
             assertThat(captorValue.getValue()).isEqualTo(expectedValue);
         }
@@ -115,9 +109,6 @@ public class EipPollingProtocolAdapterIT {
 
     @Test
     public void test_PublishChangedDataOnly_False() {
-        final EipToMqttMapping eipToMqttMapping = new EipToMqttMapping(
-                "topic", 1, MessageHandlingOptions.MQTTMessagePerTag, true, true, TAG_INT, List.of());
-
         final EipSpecificAdapterConfig config =
                 new EipSpecificAdapterConfig(44818, HOST, 1, 0, new EipToMqttConfig(1000, 10, false));
 

--- a/modules/hivemq-edge-module-file/build.gradle.kts
+++ b/modules/hivemq-edge-module-file/build.gradle.kts
@@ -41,6 +41,8 @@ dependencies {
     testImplementation(libs.assertj)
     testImplementation(libs.mockito.junit.jupiter)
     testImplementation("com.hivemq:hivemq-edge")
+    // hivemq-edge config entities are JAXB annotated; javac needs the annotation types to read their class files
+    testCompileOnly(libs.jaxb4.bind)
 }
 
 tasks.test {

--- a/modules/hivemq-edge-module-http/build.gradle.kts
+++ b/modules/hivemq-edge-module-http/build.gradle.kts
@@ -36,6 +36,8 @@ dependencies {
 
 dependencies {
     testImplementation("com.hivemq:hivemq-edge")
+    // hivemq-edge config entities are JAXB annotated; javac needs the annotation types to read their class files
+    testCompileOnly(libs.jaxb4.bind)
     testImplementation(libs.apache.commons.io)
     testImplementation(libs.assertj)
     testImplementation(libs.hivemq.edge.adaptersdk)

--- a/modules/hivemq-edge-module-modbus/build.gradle.kts
+++ b/modules/hivemq-edge-module-modbus/build.gradle.kts
@@ -45,6 +45,8 @@ dependencies {
     testImplementation(libs.mockito.junit.jupiter)
     testImplementation(libs.guava)
     testImplementation("com.hivemq:hivemq-edge")
+    // hivemq-edge config entities are JAXB annotated; javac needs the annotation types to read their class files
+    testCompileOnly(libs.jaxb4.bind)
 }
 
 tasks.test {

--- a/modules/hivemq-edge-module-mtconnect/src/main/java/com/hivemq/edge/adapters/mtconnect/MtConnectProtocolAdapter.java
+++ b/modules/hivemq-edge-module-mtconnect/src/main/java/com/hivemq/edge/adapters/mtconnect/MtConnectProtocolAdapter.java
@@ -55,7 +55,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import javax.management.modelmbean.XMLParseException;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.TrustManager;
@@ -256,7 +255,7 @@ public class MtConnectProtocolAdapter implements BatchPollingProtocolAdapter {
 
     protected @NotNull JsonNode processXml(
             final @NotNull String body, final @NotNull MtConnectAdapterTagDefinition definition)
-            throws JsonProcessingException, XMLParseException, JAXBException {
+            throws JsonProcessingException, MtConnectXmlParseException, JAXBException {
         final ObjectMapper objectMapper =
                 definition.isIncludeNull() ? OBJECT_MAPPER_INCLUDE_NULL : OBJECT_MAPPER_EXCLUDE_NULL;
         // There are some custom schemas not supported by this module.
@@ -265,25 +264,25 @@ public class MtConnectProtocolAdapter implements BatchPollingProtocolAdapter {
             final @Nullable String schemaLocation = MtConnectSchema.extractSchemaLocation(body);
             final @Nullable MtConnectSchema schema = MtConnectSchema.of(schemaLocation);
             if (schema == null) {
-                throw new XMLParseException("Schema " + schemaLocation + " is not support");
+                throw new MtConnectXmlParseException("Schema " + schemaLocation + " is not support");
             }
             // The unmarshal call brings additional performance overhead.
             final @Nullable Unmarshaller unmarshaller = schema.getUnmarshaller();
             if (unmarshaller == null) {
-                throw new XMLParseException("Schema " + schemaLocation + " is to be supported");
+                throw new MtConnectXmlParseException("Schema " + schemaLocation + " is to be supported");
             } else {
                 try (StringReader stringReader = new StringReader(body)) {
                     final JAXBElement<?> element = (JAXBElement<?>) unmarshaller.unmarshal(stringReader);
                     return objectMapper.convertValue(element.getValue(), JsonNode.class);
                 } catch (final Exception e) {
-                    throw new XMLParseException(e, "Incoming XML message failed to conform " + schemaLocation);
+                    throw new MtConnectXmlParseException("Incoming XML message failed to conform " + schemaLocation, e);
                 }
             }
         }
         final @NotNull JsonNode rootNode = XML_MAPPER.readTree(body);
         final @Nullable JsonNode jsonNodeSchemaLocation = rootNode.get(NODE_SCHEMA_LOCATION);
         if (jsonNodeSchemaLocation == null) {
-            throw new XMLParseException("Attribute schemaLocation is not found");
+            throw new MtConnectXmlParseException("Attribute schemaLocation is not found");
         }
         return rootNode;
     }

--- a/modules/hivemq-edge-module-mtconnect/src/main/java/com/hivemq/edge/adapters/mtconnect/MtConnectXmlParseException.java
+++ b/modules/hivemq-edge-module-mtconnect/src/main/java/com/hivemq/edge/adapters/mtconnect/MtConnectXmlParseException.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2023-present HiveMQ GmbH
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package com.hivemq.edge.adapters.mtconnect;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Signals that an MTConnect XML response could not be parsed or does not conform to a supported schema.
+ */
+public class MtConnectXmlParseException extends Exception {
+
+    public MtConnectXmlParseException(final @NotNull String message) {
+        super(message);
+    }
+
+    public MtConnectXmlParseException(final @NotNull String message, final @Nullable Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/modules/hivemq-edge-module-mtconnect/src/test/java/com/hivemq/edge/adapters/mtconnect/MtConnectProtocolAdapterTest.java
+++ b/modules/hivemq-edge-module-mtconnect/src/test/java/com/hivemq/edge/adapters/mtconnect/MtConnectProtocolAdapterTest.java
@@ -27,7 +27,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.NullNode;
 import com.hivemq.adapter.sdk.api.ProtocolAdapterInformation;
 import com.hivemq.adapter.sdk.api.datapoint.DataPointBuilder;
@@ -56,7 +55,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import javax.management.modelmbean.XMLParseException;
 import org.apache.commons.io.IOUtils;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
@@ -66,7 +64,6 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.ArgumentCaptor;
 
 public class MtConnectProtocolAdapterTest {
-    private static final @NotNull ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private @NotNull ProtocolAdapterInput<MtConnectAdapterConfig> adapterInput;
     private @NotNull MtConnectAdapterConfig config;
     private @NotNull HttpClient httpClient;
@@ -245,7 +242,7 @@ public class MtConnectProtocolAdapterTest {
 
     @Test
     public void whenSchemaValidationIsDisabled_thenCustomSchemaShouldPass()
-            throws IOException, XMLParseException, JAXBException {
+            throws IOException, MtConnectXmlParseException, JAXBException {
         final MtConnectProtocolAdapter adapter = new MtConnectProtocolAdapter(information, adapterInput);
         final JsonNode jsonNode = adapter.processXml(
                 IOUtils.resourceToString("/streams/streams-1-3-smstestbed-time-series.xml", StandardCharsets.UTF_8),
@@ -258,7 +255,8 @@ public class MtConnectProtocolAdapterTest {
     @ParameterizedTest
     @CsvSource({"true,true", "true,false", "false,true", "false,false"})
     public void whenSchemaValidationIsEnabledOrDisabled_thenStandardSchemaShouldPass(
-            boolean enableSchemaValidation, boolean includeNull) throws IOException, XMLParseException, JAXBException {
+            boolean enableSchemaValidation, boolean includeNull)
+            throws IOException, MtConnectXmlParseException, JAXBException {
         final MtConnectProtocolAdapter adapter = new MtConnectProtocolAdapter(information, adapterInput);
         final JsonNode jsonNode = adapter.processXml(
                 IOUtils.resourceToString("/devices/devices-1-3-smstestbed.xml", StandardCharsets.UTF_8),
@@ -290,8 +288,7 @@ public class MtConnectProtocolAdapterTest {
         assertThatThrownBy(() -> adapter.processXml(
                         IOUtils.resourceToString("/streams/streams-1-3-smstestbed-current.xml", StandardCharsets.UTF_8),
                         new MtConnectAdapterTagDefinition("", true, true, 10, List.of())))
-                .isInstanceOf(XMLParseException.class)
-                .hasMessage(
-                        "XML Parse Exception: Schema urn:nist.gov:NistStreams:1.3 /schemas/NistStreams_1.3.xsd is not support");
+                .isInstanceOf(MtConnectXmlParseException.class)
+                .hasMessage("Schema urn:nist.gov:NistStreams:1.3 /schemas/NistStreams_1.3.xsd is not support");
     }
 }

--- a/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/browse/OpcUaNodeBrowser.java
+++ b/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/browse/OpcUaNodeBrowser.java
@@ -455,7 +455,9 @@ public class OpcUaNodeBrowser {
 
         @Override
         public long estimateSize() {
-            return variables.size() - globalOffset + (currentBatch != null ? currentBatch.size() - batchIndex : 0);
+            return (long) variables.size()
+                    - globalOffset
+                    + (currentBatch != null ? currentBatch.size() - batchIndex : 0);
         }
 
         @Override
@@ -558,7 +560,7 @@ public class OpcUaNodeBrowser {
         if (stripped.isEmpty()) {
             return "";
         }
-        final String[] segments = stripped.split("/");
+        final String[] segments = stripped.split("/", -1);
         final StringBuilder sb = new StringBuilder();
         for (int i = 0; i < segments.length; i++) {
             if (i > 0) {
@@ -591,7 +593,7 @@ public class OpcUaNodeBrowser {
         if (stripped.isEmpty()) {
             return "";
         }
-        final String[] segments = stripped.split("/");
+        final String[] segments = stripped.split("/", -1);
         final StringBuilder sb = new StringBuilder();
         for (int i = 0; i < segments.length; i++) {
             if (i > 0) {

--- a/modules/hivemq-edge-module-opcua/src/test/java/com/hivemq/edge/adapters/opcua/northbound/AbstractOpcUaPayloadConverterTest.java
+++ b/modules/hivemq-edge-module-opcua/src/test/java/com/hivemq/edge/adapters/opcua/northbound/AbstractOpcUaPayloadConverterTest.java
@@ -76,7 +76,7 @@ abstract class AbstractOpcUaPayloadConverterTest {
         final var tagManager = mock(TagManager.class);
         doAnswer(invocation -> {
                     final List<DataPoint> dataPointList = invocation.getArgument(0, List.class);
-                    final var dataPoint = (DataPointWithMetadata) (dataPointList.get(0));
+                    final var dataPoint = (DataPointWithMetadata) dataPointList.get(0);
                     receivedDataPoints.put(dataPoint.getTagName(), dataPoint);
                     return null;
                 })

--- a/modules/hivemq-edge-module-opcua/src/test/java/com/hivemq/edge/adapters/opcua/northbound/OpcUaStringPayloadConverterTest.java
+++ b/modules/hivemq-edge-module-opcua/src/test/java/com/hivemq/edge/adapters/opcua/northbound/OpcUaStringPayloadConverterTest.java
@@ -24,6 +24,7 @@ import com.hivemq.adapter.sdk.api.state.ProtocolAdapterState;
 import com.hivemq.datapoint.DataPointWithMetadata;
 import com.hivemq.edge.adapters.opcua.OpcUaProtocolAdapter;
 import com.hivemq.protocols.ProtocolAdapterStopOutputImpl;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.stream.Stream;
 import org.assertj.core.api.InstanceOfAssertFactories;
@@ -43,14 +44,18 @@ import org.junit.jupiter.params.provider.MethodSource;
 class OpcUaStringPayloadConverterTest extends AbstractOpcUaPayloadConverterTest {
 
     public static final @NotNull String TEST_UUID = "b12776f9-bf9f-460a-9984-89c5ac1ea724";
-    public static final byte @NotNull [] TEST_BYTES = {1, 2, 3, 4, 5};
+    private static final byte @NotNull [] TEST_BYTES = {1, 2, 3, 4, 5};
 
     private static @NotNull Stream<Arguments> provideBaseTypes() {
         return Stream.of(
                 Arguments.of("Boolean", NodeIds.Boolean, true, "true"),
                 Arguments.of("Byte", NodeIds.Byte, 0, "0"),
                 Arguments.of("Byte", NodeIds.Byte, 255, "255"),
-                Arguments.of("ByteString", NodeIds.ByteString, new ByteString(TEST_BYTES), new String(TEST_BYTES)),
+                Arguments.of(
+                        "ByteString",
+                        NodeIds.ByteString,
+                        new ByteString(TEST_BYTES),
+                        new String(TEST_BYTES, StandardCharsets.UTF_8)),
                 Arguments.of(
                         "DateTime",
                         NodeIds.DateTime,

--- a/modules/hivemq-edge-module-opcua/src/test/java/util/EmbeddedOpcUaServerExtension.java
+++ b/modules/hivemq-edge-module-opcua/src/test/java/util/EmbeddedOpcUaServerExtension.java
@@ -25,6 +25,7 @@ import java.security.cert.X509Certificate;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.RSAPrivateCrtKeySpec;
 import java.security.spec.RSAPublicKeySpec;
+import java.time.Instant;
 import java.util.Date;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -108,8 +109,8 @@ public class EmbeddedOpcUaServerExtension implements BeforeEachCallback, AfterEa
                 new X500Name(
                         "CN=Test commonName, C=DE, O=Test organization, OU=Test Unit, T=Test Title, L=Test locality, ST=Test state"),
                 BigInteger.valueOf(123456789),
-                new Date(System.currentTimeMillis() - 10000),
-                new Date(System.currentTimeMillis() + 10000),
+                Date.from(Instant.now().minusSeconds(10)),
+                Date.from(Instant.now().plusSeconds(10)),
                 new X500Name(
                         "CN=Test commonName, C=DE, O=Test organization, OU=Test Unit, T=Test Title, L=Test locality, ST=Test state"),
                 keyPair.getPublic());

--- a/modules/hivemq-edge-module-plc4x/build.gradle.kts
+++ b/modules/hivemq-edge-module-plc4x/build.gradle.kts
@@ -53,6 +53,8 @@ dependencies {
 
 dependencies {
     testImplementation("com.hivemq:hivemq-edge")
+    // hivemq-edge config entities are JAXB annotated; javac needs the annotation types to read their class files
+    testCompileOnly(libs.jaxb4.bind)
     testImplementation(libs.hivemq.edge.adaptersdk)
     testImplementation(libs.plc4j.api)
 

--- a/modules/hivemq-edge-module-plc4x/src/test/java/com/hivemq/edge/adapters/plc4x/impl/Plc4xDataUtilsTest.java
+++ b/modules/hivemq-edge-module-plc4x/src/test/java/com/hivemq/edge/adapters/plc4x/impl/Plc4xDataUtilsTest.java
@@ -53,8 +53,8 @@ public class Plc4xDataUtilsTest {
 
     @Test
     public void whenConvertBool_thenReturnBool() {
-        assertEquals(Boolean.FALSE, convertObject(new PlcBOOL(false)));
-        assertEquals(Boolean.TRUE, convertObject(new PlcBOOL(true)));
+        assertEquals(false, convertObject(new PlcBOOL(false)));
+        assertEquals(true, convertObject(new PlcBOOL(true)));
     }
 
     @Test

--- a/modules/hivemq-edge-module-plc4x/src/test/java/com/hivemq/edge/adapters/plc4x/types/siemens/S7ProtocolAdapterTest.java
+++ b/modules/hivemq-edge-module-plc4x/src/test/java/com/hivemq/edge/adapters/plc4x/types/siemens/S7ProtocolAdapterTest.java
@@ -19,14 +19,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import com.hivemq.adapter.sdk.api.config.MessageHandlingOptions;
 import com.hivemq.adapter.sdk.api.model.ProtocolAdapterInput;
 import com.hivemq.adapter.sdk.api.services.ModuleServices;
 import com.hivemq.edge.adapters.plc4x.config.Plc4xDataType;
-import com.hivemq.edge.adapters.plc4x.config.Plc4xToMqttMapping;
 import com.hivemq.edge.adapters.plc4x.config.tag.Plc4xTag;
 import com.hivemq.edge.adapters.plc4x.config.tag.Plc4xTagDefinition;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -115,13 +112,6 @@ public class S7ProtocolAdapterTest {
         @Override
         public @NotNull String createTagAddressForSubscription(final @NotNull Plc4xTag tag) {
             return super.createTagAddressForSubscription(tag);
-        }
-    }
-
-    private static class S7TestSub extends Plc4xToMqttMapping {
-
-        public S7TestSub() {
-            super("mqttTopic", 1, MessageHandlingOptions.MQTTMessagePerTag, true, true, "tag", List.of());
         }
     }
 }


### PR DESCRIPTION
Fixes every warning reported by the core, adapter-module and SDK compile tasks. Part of [EDG-847](https://linear.app/hivemq/issue/EDG-847/errorprone-fix-2026-07-29); the commercial-module half is in hivemq/hivemq-edge-commercial-modules.

## Verification

- All listed `compileJava` / `compileTestJava` tasks re-run with `--rerun-tasks --no-build-cache`: **0 warnings, 0 errors**.
- `:hivemq-edge:test`, `:hivemq-edge-module-opcua:test`, `:hivemq-edge-module-mtconnect:test`, `:hivemq-edge-module-plc4x:test` all green.
- `spotlessApply` is a no-op on this branch.

## Cross-cutting policies applied

| Check | Count | Fix |
| --- | --- | --- |
| `DefaultCharset` | 86 (whole task set) | explicit `StandardCharsets.UTF_8` |
| `StringSplitter` | 10 (whole task set) | `split(x, -1)` |
| `EqualsGetClass` | 20 (whole task set) | class marked `final` + `instanceof` pattern |
| `MutablePublicArray` | 27 (whole task set) | visibility narrowed, or `clone()` accessor |

For `EqualsGetClass` every affected class was checked for subclasses first (none had any), so `final` + `instanceof` is provably equivalent to the previous `getClass()` comparison.

## Two latent bugs the checks surfaced

**`DeviceTagValidatorTest`** — 11 assertions compared a `ValidationError.Code` enum against a `String` literal:

```java
assertThat(errors).noneMatch(e -> e.code().equals("DUPLICATE_NODE"));
```

`equals` was always `false`, so every one of these `noneMatch` assertions passed vacuously. They now compare enum constants (`e.code() == ValidationError.Code.DUPLICATE_NODE`), matching the idiom already used elsewhere in the same file, and all 11 pass for real.

**MTConnect adapter** — `MtConnectProtocolAdapter` threw `javax.management.modelmbean.XMLParseException`, a JMX ModelMBean class that has nothing to do with MTConnect XML and is deprecated for removal in the JDK. Replaced with a module-local `MtConnectXmlParseException` (the only new file). One test assertion drops the `"XML Parse Exception: "` prefix that the JMX class injected into its message.

## Other changes worth a look

- **`CustomConfigSchemaGenerator`** — victools `JacksonModule` → `JacksonSchemaModule`. The former is `@Deprecated(forRemoval = true, since = "5.0.0")` and is a trivial subclass of the latter with identical constructors, so this is a drop-in swap.
- **`DataPointWithMetadata`** — field `adapterID` renamed to `adapterId` (`InconsistentCapitalization`; the builder parameter already used the lowercase spelling).
- **`OpcUaNodeBrowser.estimateSize()`** — `int` arithmetic was assigned to a `long` return; now widened before the subtraction (`IntLongMath`).
- **`FutureReturnValueIgnored`** in four concurrency tests — the ignored futures use ErrorProne's documented `var unused = ...` idiom. Each lambda already catches its own exceptions and reports through a latch/counter, so the future genuinely carries nothing.
- **5 module `build.gradle.kts`** gain `testCompileOnly(libs.jaxb4.bind)`. `hivemq-edge` declares JAXB as `implementation`, so adapter modules could not resolve the annotations on its JAXB-annotated config entities and javac emitted `unknown enum constant XmlAccessType.NONE` on every test compile.

## Behaviour note

`split(x, -1)` keeps trailing empty segments where the single-argument form dropped them. The only site where that is observable is the test-scope `BasicAuthenticationHandler.parseValue`: a header decoding to `"user:"` now reaches the credentials provider with an empty password instead of being short-circuited. The provider still rejects it.
