### PR TITLE
EDG-845: Separate northbound (read) and southbound (write) tag schemas

### DIFF
--- a/ext/hivemq-edge-openapi.yaml
+++ b/ext/hivemq-edge-openapi.yaml
@@ -4646,6 +4646,16 @@ paths:
           schema:
             type: string
             format: urlencoded
+        - description: The direction of the schema to retrieve. READ (default) returns the northbound schema describing the full data shape published for the tag; WRITE returns the southbound schema describing only what can be written to the tag (read-only fields omitted).
+          in: query
+          name: direction
+          required: false
+          schema:
+            type: string
+            enum:
+              - READ
+              - WRITE
+            default: READ
       responses:
         '200':
           content:

--- a/ext/hivemq-edge-openapi.yaml
+++ b/ext/hivemq-edge-openapi.yaml
@@ -4592,7 +4592,7 @@ paths:
   /api/v1/management/protocol-adapters/writing-schema/{adapterId}/{tagName}:
     get:
       deprecated: true
-      description: '**Deprecated:** Use `GET /api/v1/management/protocol-adapters/schema/{adapterId}/{tagName}` instead. This endpoint now returns a 301 redirect to the replacement.'
+      description: '**Deprecated:** Use `GET /api/v1/management/protocol-adapters/schema/{adapterId}/{tagName}?direction=SOUTHBOUND` instead. This endpoint now returns a 301 redirect to the replacement.'
       operationId: get-writing-schema
       x-roles-allowed:
         - admin
@@ -4614,7 +4614,7 @@ paths:
             format: urlencoded
       responses:
         '301':
-          description: Moved Permanently. The schema endpoint has moved to `/api/v1/management/protocol-adapters/schema/{adapterId}/{tagName}`.
+          description: Moved Permanently. The schema endpoint has moved to `/api/v1/management/protocol-adapters/schema/{adapterId}/{tagName}?direction=SOUTHBOUND`.
           headers:
             Location:
               description: The new URL for this resource.
@@ -4646,15 +4646,15 @@ paths:
           schema:
             type: string
             format: urlencoded
-        - description: The direction of the schema to retrieve. WRITE returns the southbound schema describing only what can be written to the tag (read-only fields omitted). When omitted, the northbound schema describing the full data shape published for the tag is returned.
+        - description: 'The direction of the schema to retrieve. SOUTHBOUND returns the southbound (write) schema: the non-writable envelope (tagName, timestamp, metadata, context) is dropped, leaving the value shape that a write targets. Whether an individual field can be written is carried per field as readOnly and enforced when the write is validated. When omitted, the NORTHBOUND schema describing the full data shape published for the tag is returned. Any other value is rejected with a 400.'
           in: query
           name: direction
           required: false
           schema:
             type: string
             enum:
-              - READ
-              - WRITE
+              - NORTHBOUND
+              - SOUTHBOUND
       responses:
         '200':
           content:
@@ -4674,6 +4674,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/JsonNode'
           description: Success
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+          description: Unknown schema direction
         '404':
           content:
             application/json:

--- a/ext/hivemq-edge-openapi.yaml
+++ b/ext/hivemq-edge-openapi.yaml
@@ -4646,7 +4646,7 @@ paths:
           schema:
             type: string
             format: urlencoded
-        - description: 'The direction of the schema to retrieve. SOUTHBOUND returns the southbound (write) schema: the non-writable envelope (tagName, timestamp, metadata, context) is dropped, leaving the value shape that a write targets. Whether an individual field can be written is carried per field as readOnly and enforced when the write is validated. When omitted, the NORTHBOUND schema describing the full data shape published for the tag is returned. Any other value is rejected with a 400.'
+        - description: 'The direction of the schema to retrieve. SOUTHBOUND returns the southbound (write) schema: the non-writable envelope (tagName, timestamp, metadata, context) is dropped, leaving the value shape that a write targets. Fields inside the value that the device does not accept a write for are marked readOnly. That flag is descriptive metadata only - it is a JSON Schema annotation rather than an assertion, and it is not currently enforced when a write is validated; use it to decide what to offer as a write destination, not as a safety boundary. When omitted, the NORTHBOUND schema describing the full data shape published for the tag is returned. Any other value is rejected with a 400.'
           in: query
           name: direction
           required: false

--- a/ext/hivemq-edge-openapi.yaml
+++ b/ext/hivemq-edge-openapi.yaml
@@ -4646,7 +4646,7 @@ paths:
           schema:
             type: string
             format: urlencoded
-        - description: The direction of the schema to retrieve. READ (default) returns the northbound schema describing the full data shape published for the tag; WRITE returns the southbound schema describing only what can be written to the tag (read-only fields omitted).
+        - description: The direction of the schema to retrieve. WRITE returns the southbound schema describing only what can be written to the tag (read-only fields omitted). When omitted, the northbound schema describing the full data shape published for the tag is returned.
           in: query
           name: direction
           required: false
@@ -4655,7 +4655,6 @@ paths:
             enum:
               - READ
               - WRITE
-            default: READ
       responses:
         '200':
           content:

--- a/hivemq-edge-frontend/src/api/__generated__/services/ProtocolAdaptersService.ts
+++ b/hivemq-edge-frontend/src/api/__generated__/services/ProtocolAdaptersService.ts
@@ -658,7 +658,7 @@ export class ProtocolAdaptersService {
      * Get a json schema that explains the json schema that represents the tag with the provided name."
      * @param adapterId The id of the adapter for which the Json Schema should be retrieved.
      * @param tagName The tag name (urlencoded) for which the Json Schema should be retrieved.
-     * @param direction The direction of the schema to retrieve. SOUTHBOUND returns the southbound (write) schema: the non-writable envelope (tagName, timestamp, metadata, context) is dropped, leaving the value shape that a write targets. Whether an individual field can be written is carried per field as readOnly and enforced when the write is validated. When omitted, the NORTHBOUND schema describing the full data shape published for the tag is returned. Any other value is rejected with a 400.
+     * @param direction The direction of the schema to retrieve. SOUTHBOUND returns the southbound (write) schema: the non-writable envelope (tagName, timestamp, metadata, context) is dropped, leaving the value shape that a write targets. Fields inside the value that the device does not accept a write for are marked readOnly. That flag is descriptive metadata only - it is a JSON Schema annotation rather than an assertion, and it is not currently enforced when a write is validated; use it to decide what to offer as a write destination, not as a safety boundary. When omitted, the NORTHBOUND schema describing the full data shape published for the tag is returned. Any other value is rejected with a 400.
      * @returns JsonNode Success
      * @throws ApiError
      */

--- a/hivemq-edge-frontend/src/api/__generated__/services/ProtocolAdaptersService.ts
+++ b/hivemq-edge-frontend/src/api/__generated__/services/ProtocolAdaptersService.ts
@@ -658,12 +658,14 @@ export class ProtocolAdaptersService {
      * Get a json schema that explains the json schema that represents the tag with the provided name."
      * @param adapterId The id of the adapter for which the Json Schema should be retrieved.
      * @param tagName The tag name (urlencoded) for which the Json Schema should be retrieved.
+     * @param direction The direction of the schema to retrieve. WRITE returns the southbound schema describing only what can be written to the tag (read-only fields omitted). When omitted, the northbound schema describing the full data shape published for the tag is returned.
      * @returns JsonNode Success
      * @throws ApiError
      */
     public getSchema(
         adapterId: string,
         tagName: string,
+        direction?: 'READ' | 'WRITE',
     ): CancelablePromise<JsonNode> {
         return this.httpRequest.request({
             method: 'GET',
@@ -671,6 +673,9 @@ export class ProtocolAdaptersService {
             path: {
                 'adapterId': adapterId,
                 'tagName': tagName,
+            },
+            query: {
+                'direction': direction,
             },
             errors: {
                 404: `Adapter not found`,

--- a/hivemq-edge-frontend/src/api/__generated__/services/ProtocolAdaptersService.ts
+++ b/hivemq-edge-frontend/src/api/__generated__/services/ProtocolAdaptersService.ts
@@ -630,7 +630,7 @@ export class ProtocolAdaptersService {
     /**
      * @deprecated
      * Deprecated. Redirects to the replacement schema endpoint.
-     * **Deprecated:** Use `GET /api/v1/management/protocol-adapters/schema/{adapterId}/{tagName}` instead. This endpoint now returns a 301 redirect to the replacement.
+     * **Deprecated:** Use `GET /api/v1/management/protocol-adapters/schema/{adapterId}/{tagName}?direction=SOUTHBOUND` instead. This endpoint now returns a 301 redirect to the replacement.
      * @param adapterId The id of the adapter for which the Json Schema for writing to a PLC gets created.
      * @param tagName The tag name (urlencoded) for which the Json Schema for writing to a PLC gets created.
      * @returns void
@@ -648,7 +648,7 @@ export class ProtocolAdaptersService {
                 'tagName': tagName,
             },
             errors: {
-                301: `Moved Permanently. The schema endpoint has moved to \`/api/v1/management/protocol-adapters/schema/{adapterId}/{tagName}\`.`,
+                301: `Moved Permanently. The schema endpoint has moved to \`/api/v1/management/protocol-adapters/schema/{adapterId}/{tagName}?direction=SOUTHBOUND\`.`,
             },
         });
     }
@@ -658,14 +658,14 @@ export class ProtocolAdaptersService {
      * Get a json schema that explains the json schema that represents the tag with the provided name."
      * @param adapterId The id of the adapter for which the Json Schema should be retrieved.
      * @param tagName The tag name (urlencoded) for which the Json Schema should be retrieved.
-     * @param direction The direction of the schema to retrieve. WRITE returns the southbound schema describing only what can be written to the tag (read-only fields omitted). When omitted, the northbound schema describing the full data shape published for the tag is returned.
+     * @param direction The direction of the schema to retrieve. SOUTHBOUND returns the southbound (write) schema: the non-writable envelope (tagName, timestamp, metadata, context) is dropped, leaving the value shape that a write targets. Whether an individual field can be written is carried per field as readOnly and enforced when the write is validated. When omitted, the NORTHBOUND schema describing the full data shape published for the tag is returned. Any other value is rejected with a 400.
      * @returns JsonNode Success
      * @throws ApiError
      */
     public getSchema(
         adapterId: string,
         tagName: string,
-        direction?: 'READ' | 'WRITE',
+        direction?: 'NORTHBOUND' | 'SOUTHBOUND',
     ): CancelablePromise<JsonNode> {
         return this.httpRequest.request({
             method: 'GET',
@@ -678,6 +678,7 @@ export class ProtocolAdaptersService {
                 'direction': direction,
             },
             errors: {
+                400: `Unknown schema direction`,
                 404: `Adapter not found`,
                 500: `Internal Server Error`,
             },

--- a/hivemq-edge-frontend/src/api/hooks/useProtocolAdapters/useGetSchema.ts
+++ b/hivemq-edge-frontend/src/api/hooks/useProtocolAdapters/useGetSchema.ts
@@ -6,18 +6,24 @@ import { useHttpClient } from '@/api/hooks/useHttpClient/useHttpClient.ts'
 
 /**
  * The direction of the tag schema to fetch.
- * - WRITE describes only what can be written to the tag; the non-writable envelope is omitted.
- * - Omitted (the default) describes the full data shape published for the tag (tagName, timestamp, value,
- *   metadata). The parameter is then left off the request entirely, so the URL is unchanged for read callers.
+ * - SOUTHBOUND (write) describes the shape a write targets; the non-writable envelope is omitted. Whether an
+ *   individual field can be written is carried per field as readOnly.
+ * - Omitted (the default) fetches the NORTHBOUND (read) schema: the full data shape published for the tag
+ *   (tagName, timestamp, value, metadata). The parameter is then left off the request entirely, so the URL is
+ *   unchanged for read callers.
  */
-export type SchemaDirection = 'READ' | 'WRITE'
+export type SchemaDirection = 'NORTHBOUND' | 'SOUTHBOUND'
 
 export const useGetSchema = (adapterId: string, tagName: string, direction?: SchemaDirection) => {
   const appClient = useHttpClient()
 
   return useQuery<JsonNode, ApiError>({
-    // The direction is part of the key: READ and WRITE are different schemas for the same tag.
-    queryKey: [QUERY_KEYS.ADAPTERS, adapterId, QUERY_KEYS.DISCOVERY_TAGS, tagName, direction],
+    // The direction is part of the key: the two directions are different schemas for the same tag. The
+    // northbound (default) key deliberately has no direction slot so it stays identical to the key used by
+    // useGetCombinedDataSchemas for the same document — one cache entry, one fetch.
+    queryKey: direction
+      ? [QUERY_KEYS.ADAPTERS, adapterId, QUERY_KEYS.DISCOVERY_TAGS, tagName, direction]
+      : [QUERY_KEYS.ADAPTERS, adapterId, QUERY_KEYS.DISCOVERY_TAGS, tagName],
     queryFn: () => appClient.protocolAdapters.getSchema(adapterId, encodeURIComponent(tagName), direction),
   })
 }

--- a/hivemq-edge-frontend/src/api/hooks/useProtocolAdapters/useGetSchema.ts
+++ b/hivemq-edge-frontend/src/api/hooks/useProtocolAdapters/useGetSchema.ts
@@ -4,11 +4,20 @@ import type { ApiError, JsonNode } from '@/api/__generated__'
 import { QUERY_KEYS } from '@/api/utils.ts'
 import { useHttpClient } from '@/api/hooks/useHttpClient/useHttpClient.ts'
 
-export const useGetSchema = (adapterId: string, tagName: string) => {
+/**
+ * The direction of the tag schema to fetch.
+ * - WRITE describes only what can be written to the tag; the non-writable envelope is omitted.
+ * - Omitted (the default) describes the full data shape published for the tag (tagName, timestamp, value,
+ *   metadata). The parameter is then left off the request entirely, so the URL is unchanged for read callers.
+ */
+export type SchemaDirection = 'READ' | 'WRITE'
+
+export const useGetSchema = (adapterId: string, tagName: string, direction?: SchemaDirection) => {
   const appClient = useHttpClient()
 
   return useQuery<JsonNode, ApiError>({
-    queryKey: [QUERY_KEYS.ADAPTERS, adapterId, QUERY_KEYS.DISCOVERY_TAGS, tagName],
-    queryFn: () => appClient.protocolAdapters.getSchema(adapterId, encodeURIComponent(tagName)),
+    // The direction is part of the key: READ and WRITE are different schemas for the same tag.
+    queryKey: [QUERY_KEYS.ADAPTERS, adapterId, QUERY_KEYS.DISCOVERY_TAGS, tagName, direction],
+    queryFn: () => appClient.protocolAdapters.getSchema(adapterId, encodeURIComponent(tagName), direction),
   })
 }

--- a/hivemq-edge-frontend/src/components/rjsf/MqttTransformation/components/DataModelDestination.spec.cy.tsx
+++ b/hivemq-edge-frontend/src/components/rjsf/MqttTransformation/components/DataModelDestination.spec.cy.tsx
@@ -12,7 +12,12 @@ const mockTopic = 'test/topic'
 describe('DataModelDestination', () => {
   beforeEach(() => {
     cy.viewport(800, 900)
-    cy.intercept('/api/v1/management/protocol-adapters/schema/*/*', GENERATE_DATA_MODELS(true, mockTopic))
+    // The intercept requires direction=SOUTHBOUND: this is the write target of a southbound mapping, and a
+    // regression to the northbound default would leave this request unmatched and fail the test.
+    cy.intercept(
+      { method: 'GET', pathname: '**/protocol-adapters/schema/**', query: { direction: 'SOUTHBOUND' } },
+      GENERATE_DATA_MODELS(true, mockTopic)
+    )
   })
 
   it('should render properly', () => {

--- a/hivemq-edge-frontend/src/components/rjsf/MqttTransformation/components/DataModelDestination.tsx
+++ b/hivemq-edge-frontend/src/components/rjsf/MqttTransformation/components/DataModelDestination.tsx
@@ -19,7 +19,9 @@ interface DataModelDestinationProps extends CardProps {
 
 const DataModelDestination: FC<DataModelDestinationProps> = ({ topic, adapterId, validation, ...props }) => {
   const { t } = useTranslation()
-  const { data, isLoading, isError, error } = useGetSchema(adapterId, topic)
+  // This is the write target of a southbound mapping, so it needs the WRITE schema: the backend omits the
+  // fields that can never be written (tagName, timestamp, metadata) rather than the UI hiding them.
+  const { data, isLoading, isError, error } = useGetSchema(adapterId, topic, 'WRITE')
 
   return (
     <Card {...props} size="sm">

--- a/hivemq-edge-frontend/src/components/rjsf/MqttTransformation/components/DataModelDestination.tsx
+++ b/hivemq-edge-frontend/src/components/rjsf/MqttTransformation/components/DataModelDestination.tsx
@@ -19,9 +19,9 @@ interface DataModelDestinationProps extends CardProps {
 
 const DataModelDestination: FC<DataModelDestinationProps> = ({ topic, adapterId, validation, ...props }) => {
   const { t } = useTranslation()
-  // This is the write target of a southbound mapping, so it needs the WRITE schema: the backend omits the
-  // fields that can never be written (tagName, timestamp, metadata) rather than the UI hiding them.
-  const { data, isLoading, isError, error } = useGetSchema(adapterId, topic, 'WRITE')
+  // This is the write target of a southbound mapping, so it needs the SOUTHBOUND schema: the backend omits
+  // the fields that can never be written (tagName, timestamp, metadata) rather than the UI hiding them.
+  const { data, isLoading, isError, error } = useGetSchema(adapterId, topic, 'SOUTHBOUND')
 
   return (
     <Card {...props} size="sm">

--- a/hivemq-edge-frontend/src/components/rjsf/MqttTransformation/components/MappingContainer.tsx
+++ b/hivemq-edge-frontend/src/components/rjsf/MqttTransformation/components/MappingContainer.tsx
@@ -85,7 +85,9 @@ const MappingContainer: FC<SubscriptionContainerProps> = ({ adapterId, adapterTy
                 if (!mappings) {
                   return
                 }
-                onChange('fieldMapping', { instructions: [...(item.fieldMapping?.instructions || []), ...mappings] })
+                // The list emits a complete replacement (already pruned of read-only destinations) — appending
+                // it to the old list would duplicate every kept instruction and resurrect the pruned ones.
+                onChange('fieldMapping', { ...item.fieldMapping, instructions: mappings })
               }}
               onSchemaReady={onSchemaReadyHandler}
             />

--- a/hivemq-edge-frontend/src/components/rjsf/MqttTransformation/components/MappingEditor.spec.cy.tsx
+++ b/hivemq-edge-frontend/src/components/rjsf/MqttTransformation/components/MappingEditor.spec.cy.tsx
@@ -12,7 +12,12 @@ describe('MappingEditor', () => {
   })
 
   it('should render properly', () => {
-    cy.intercept('/api/v1/management/protocol-adapters/schema/**', GENERATE_DATA_MODELS(true, 'test'))
+    // The intercept requires direction=SOUTHBOUND: the editor is a southbound destination, and a regression
+    // to the northbound default would leave this request unmatched and fail the test.
+    cy.intercept(
+      { method: 'GET', pathname: '**/protocol-adapters/schema/**', query: { direction: 'SOUTHBOUND' } },
+      GENERATE_DATA_MODELS(true, 'test')
+    )
 
     cy.mountWithProviders(
       <MappingEditor
@@ -40,7 +45,12 @@ describe('MappingEditor', () => {
   it('should be accessible ', () => {
     cy.injectAxe()
 
-    cy.intercept('/api/v1/management/protocol-adapters/schema/**', GENERATE_DATA_MODELS(true, 'test'))
+    // The intercept requires direction=SOUTHBOUND: the editor is a southbound destination, and a regression
+    // to the northbound default would leave this request unmatched and fail the test.
+    cy.intercept(
+      { method: 'GET', pathname: '**/protocol-adapters/schema/**', query: { direction: 'SOUTHBOUND' } },
+      GENERATE_DATA_MODELS(true, 'test')
+    )
     cy.mountWithProviders(
       <MappingEditor
         topic="test"

--- a/hivemq-edge-frontend/src/components/rjsf/MqttTransformation/components/MappingEditor.tsx
+++ b/hivemq-edge-frontend/src/components/rjsf/MqttTransformation/components/MappingEditor.tsx
@@ -36,8 +36,9 @@ const MappingEditor: FC<MappingEditorProps> = ({
 }) => {
   const { t } = useTranslation('components')
   // The properties listed here are the destination of a southbound mapping, i.e. what the user may write to.
-  // The WRITE schema contains only those, so the list no longer has to mark most entries as read-only.
-  const { data, isLoading, isError, error, isSuccess } = useGetSchema(adapterId, topic, 'WRITE')
+  // The SOUTHBOUND schema drops the non-writable envelope; any remaining read-only fields inside the value
+  // are hidden by MappingInstructionList (EDG-59).
+  const { data, isLoading, isError, error, isSuccess } = useGetSchema(adapterId, topic, 'SOUTHBOUND')
 
   const properties = useMemo(() => {
     const allProperties = data ? getPropertyListFrom(data) : []

--- a/hivemq-edge-frontend/src/components/rjsf/MqttTransformation/components/MappingEditor.tsx
+++ b/hivemq-edge-frontend/src/components/rjsf/MqttTransformation/components/MappingEditor.tsx
@@ -35,7 +35,9 @@ const MappingEditor: FC<MappingEditorProps> = ({
   ...props
 }) => {
   const { t } = useTranslation('components')
-  const { data, isLoading, isError, error, isSuccess } = useGetSchema(adapterId, topic)
+  // The properties listed here are the destination of a southbound mapping, i.e. what the user may write to.
+  // The WRITE schema contains only those, so the list no longer has to mark most entries as read-only.
+  const { data, isLoading, isError, error, isSuccess } = useGetSchema(adapterId, topic, 'WRITE')
 
   const properties = useMemo(() => {
     const allProperties = data ? getPropertyListFrom(data) : []

--- a/hivemq-edge-frontend/src/components/rjsf/MqttTransformation/components/MappingInstructionList.spec.cy.tsx
+++ b/hivemq-edge-frontend/src/components/rjsf/MqttTransformation/components/MappingInstructionList.spec.cy.tsx
@@ -20,6 +20,51 @@ const MOCK_INSTRUCTIONS: Instruction[] = [
   { source: '$.b', destination: '$.unit' },
 ]
 
+/**
+ * The southbound document served for an OPC-UA A&C condition tag — the case EDG-845 exists for, where the
+ * write target {eventId, method, comment} is not a projection of the read shape.
+ *
+ * This is a verbatim copy of the backend output, pinned by
+ * `TagSchemaCreationOutputImplSchemaBuilderTest.test_southboundSchema_conditionCommandDocumentIsPinned`.
+ * Do not "tidy" it: the readOnly on the root is really there (it is on the wrapper Edge builds, not on the
+ * adapter's command schema), and the absence of readOnly on the three command fields is exactly what this
+ * fixture is here to prove — an earlier hand-written fixture omitted those annotations altogether and so
+ * could not have caught a backend that marked every field read-only.
+ */
+const MOCK_SOUTHBOUND_CONDITION_SCHEMA: RJSFSchema = {
+  type: 'object',
+  properties: {
+    value: {
+      type: 'object',
+      properties: {
+        eventId: { type: 'string' },
+        method: { type: 'integer' },
+        comment: { type: 'string' },
+      },
+      required: ['eventId', 'method'],
+    },
+  },
+  required: ['value'],
+  readOnly: true,
+  $schema: 'https://json-schema.org/draft/2019-09/schema',
+}
+
+// A read-only container whose child carries no flag of its own — the shape an uploaded or inferred combiner
+// destination schema routinely has, since JSON Schema does not require readOnly to be repeated on every leaf.
+const MOCK_READONLY_ANCESTOR_SCHEMA: RJSFSchema = {
+  type: 'object',
+  properties: {
+    deviceInfo: {
+      type: 'object',
+      readOnly: true,
+      properties: {
+        serial: { type: 'string' },
+      },
+    },
+    setpoint: { type: 'number', title: 'setpoint' },
+  },
+}
+
 describe('MappingInstructionList', () => {
   beforeEach(() => {
     cy.viewport(800, 600)
@@ -34,8 +79,50 @@ describe('MappingInstructionList', () => {
     cy.get('[role="alert"]').should('not.exist')
   })
 
-  it('should prune persisted instructions that target a read-only property', () => {
-    // An instruction created before the property became read-only must not survive the next edit.
+  it('should offer every command field of an explicit southbound schema as a destination', () => {
+    // The defining EDG-845 case. If the adapter's command schema were built without .writable(), every field
+    // would render readOnly and this list would be empty — which is the whole feature failing silently.
+    cy.mountWithProviders(
+      <MappingInstructionList schema={MOCK_SOUTHBOUND_CONDITION_SCHEMA} instructions={[]} onChange={cy.stub()} />
+    )
+
+    cy.getByTestId('property-name').should('have.length', 4)
+    cy.getByTestId('property-name').eq(1).should('have.text', 'value.eventId')
+    cy.getByTestId('property-name').eq(2).should('have.text', 'value.method')
+    cy.getByTestId('property-name').eq(3).should('have.text', 'value.comment')
+
+    // `value` is the object wrapper, which is not itself mappable; the three command fields are.
+    cy.getByTestId('mapping-instruction-dropzone').should('have.length', 3)
+    cy.getByTestId('property-readonly').should('not.exist')
+  })
+
+  it('should emit the pruned instructions on load, without any user interaction', () => {
+    // The renderer hiding a stale instruction is not enough: unless the sanitised list reaches the parent, the
+    // instruction stays in the form data, invisible, and is still submitted and executed.
+    const onChange = cy.stub().as('onChange')
+    cy.mountWithProviders(
+      <MappingInstructionList schema={MOCK_SCHEMA} instructions={MOCK_INSTRUCTIONS} onChange={onChange} />
+    )
+
+    cy.get('@onChange').should('have.been.calledOnceWith', [{ source: '$.a', destination: '$.setpoint' }])
+  })
+
+  it('should not emit anything when there is nothing to prune', () => {
+    // Guards against an effect that re-fires and fights the parent's state on every render.
+    const onChange = cy.stub().as('onChange')
+    cy.mountWithProviders(
+      <MappingInstructionList
+        schema={MOCK_SCHEMA}
+        instructions={[{ source: '$.a', destination: '$.setpoint' }]}
+        onChange={onChange}
+      />
+    )
+
+    cy.getByTestId('mapping-instruction-dropzone').should('have.length', 1)
+    cy.get('@onChange').should('not.have.been.called')
+  })
+
+  it('should prune persisted instructions that target a read-only property on the next edit', () => {
     const onChange = cy.stub().as('onChange')
     cy.mountWithProviders(
       <MappingInstructionList schema={MOCK_SCHEMA} instructions={MOCK_INSTRUCTIONS} onChange={onChange} />
@@ -44,6 +131,25 @@ describe('MappingInstructionList', () => {
     cy.getByTestId('mapping-instruction-dropzone').should('have.length', 1).should('have.text', 'a')
     cy.getByAriaLabel('Clear mapping').click()
     cy.get('@onChange').should('have.been.calledWith', [])
+  })
+
+  it('should treat descendants of a read-only object as non-writable', () => {
+    // A read-only container cannot be written, so nothing beneath it can be either — even though `serial`
+    // carries no flag of its own.
+    const onChange = cy.stub().as('onChange')
+    cy.mountWithProviders(
+      <MappingInstructionList
+        schema={MOCK_READONLY_ANCESTOR_SCHEMA}
+        instructions={[
+          { source: '$.a', destination: '$.setpoint' },
+          { source: '$.b', destination: '$.deviceInfo.serial' },
+        ]}
+        onChange={onChange}
+      />
+    )
+
+    cy.getByTestId('property-name').should('have.length', 1).should('have.text', 'setpoint')
+    cy.get('@onChange').should('have.been.calledOnceWith', [{ source: '$.a', destination: '$.setpoint' }])
   })
 
   it('should be accessible', () => {

--- a/hivemq-edge-frontend/src/components/rjsf/MqttTransformation/components/MappingInstructionList.spec.cy.tsx
+++ b/hivemq-edge-frontend/src/components/rjsf/MqttTransformation/components/MappingInstructionList.spec.cy.tsx
@@ -1,0 +1,56 @@
+/// <reference types="cypress" />
+
+import type { RJSFSchema } from '@rjsf/utils'
+
+import type { Instruction } from '@/api/__generated__'
+import { MappingInstructionList } from './MappingInstructionList'
+
+// A southbound value shape with one genuinely read-only field: the envelope is already gone from the
+// southbound schema, so read-only can only occur on a device-level non-writable field.
+const MOCK_SCHEMA: RJSFSchema = {
+  type: 'object',
+  properties: {
+    setpoint: { type: 'number', title: 'setpoint' },
+    unit: { type: 'string', title: 'unit', readOnly: true },
+  },
+}
+
+const MOCK_INSTRUCTIONS: Instruction[] = [
+  { source: '$.a', destination: '$.setpoint' },
+  { source: '$.b', destination: '$.unit' },
+]
+
+describe('MappingInstructionList', () => {
+  beforeEach(() => {
+    cy.viewport(800, 600)
+  })
+
+  it('should hide read-only properties instead of rendering a neutralised card', () => {
+    // EDG-59: a read-only property is not a writable destination, so it must not appear in the list at all.
+    cy.mountWithProviders(<MappingInstructionList schema={MOCK_SCHEMA} instructions={[]} onChange={cy.stub()} />)
+
+    cy.get('[role="list"] li').should('have.length', 1)
+    cy.getByTestId('property-name').should('have.text', 'setpoint')
+    cy.get('[role="alert"]').should('not.exist')
+  })
+
+  it('should prune persisted instructions that target a read-only property', () => {
+    // An instruction created before the property became read-only must not survive the next edit.
+    const onChange = cy.stub().as('onChange')
+    cy.mountWithProviders(
+      <MappingInstructionList schema={MOCK_SCHEMA} instructions={MOCK_INSTRUCTIONS} onChange={onChange} />
+    )
+
+    cy.getByTestId('mapping-instruction-dropzone').should('have.length', 1).should('have.text', 'a')
+    cy.getByAriaLabel('Clear mapping').click()
+    cy.get('@onChange').should('have.been.calledWith', [])
+  })
+
+  it('should be accessible', () => {
+    cy.injectAxe()
+    cy.mountWithProviders(
+      <MappingInstructionList schema={MOCK_SCHEMA} instructions={MOCK_INSTRUCTIONS} onChange={cy.stub()} />
+    )
+    cy.checkAccessibility()
+  })
+})

--- a/hivemq-edge-frontend/src/components/rjsf/MqttTransformation/components/MappingInstructionList.spec.cy.tsx
+++ b/hivemq-edge-frontend/src/components/rjsf/MqttTransformation/components/MappingInstructionList.spec.cy.tsx
@@ -49,6 +49,25 @@ const MOCK_SOUTHBOUND_CONDITION_SCHEMA: RJSFSchema = {
   $schema: 'https://json-schema.org/draft/2019-09/schema',
 }
 
+/**
+ * The A&C command shape as an adapter produces it when it forgets to chain `.writable()` — the trap the SDK
+ * Javadoc warns about, rendered exactly as `TagSchemaCreationOutputImplSchemaBuilderTest` pins it.
+ */
+const MOCK_ALL_READ_ONLY_SCHEMA: RJSFSchema = {
+  type: 'object',
+  properties: {
+    value: {
+      type: 'object',
+      readOnly: true,
+      properties: {
+        eventId: { type: 'string', readOnly: true },
+        method: { type: 'integer', readOnly: true },
+        comment: { type: 'string', readOnly: true },
+      },
+    },
+  },
+}
+
 // A read-only container whose child carries no flag of its own — the shape an uploaded or inferred combiner
 // destination schema routinely has, since JSON Schema does not require readOnly to be repeated on every leaf.
 const MOCK_READONLY_ANCESTOR_SCHEMA: RJSFSchema = {
@@ -152,10 +171,57 @@ describe('MappingInstructionList', () => {
     cy.get('@onChange').should('have.been.calledOnceWith', [{ source: '$.a', destination: '$.setpoint' }])
   })
 
+  it('should explain an empty list when every field is read-only', () => {
+    // Hiding read-only properties (EDG-59) can hide all of them — e.g. an adapter that supplies a southbound
+    // schema without marking it writable. A blank panel is indistinguishable from "still loading" or "broken",
+    // so the list must say which it is.
+    cy.mountWithProviders(
+      <MappingInstructionList schema={MOCK_ALL_READ_ONLY_SCHEMA} instructions={[]} onChange={cy.stub()} />
+    )
+
+    cy.get('[role="list"]').should('not.exist')
+    cy.getByTestId('mapping-instruction-empty')
+      .should('be.visible')
+      .should('contain.text', "None of this tag's fields can be written to")
+  })
+
+  it('should distinguish a schema with no fields at all', () => {
+    // A different problem with a different remedy: nothing was hidden, there was simply nothing there.
+    cy.mountWithProviders(
+      <MappingInstructionList schema={{ type: 'object', properties: {} }} instructions={[]} onChange={cy.stub()} />
+    )
+
+    cy.getByTestId('mapping-instruction-empty').should('contain.text', 'This schema defines no fields')
+  })
+
+  it('should still prune stale instructions when every field is hidden', () => {
+    // The empty state must not short-circuit the sanitising: an instruction targeting a now-read-only field
+    // has to leave the parent's form data whether or not anything remains to render.
+    const onChange = cy.stub().as('onChange')
+    cy.mountWithProviders(
+      <MappingInstructionList
+        schema={MOCK_ALL_READ_ONLY_SCHEMA}
+        instructions={[{ source: '$.a', destination: '$.value.eventId' }]}
+        onChange={onChange}
+      />
+    )
+
+    cy.getByTestId('mapping-instruction-empty').should('exist')
+    cy.get('@onChange').should('have.been.calledOnceWith', [])
+  })
+
   it('should be accessible', () => {
     cy.injectAxe()
     cy.mountWithProviders(
       <MappingInstructionList schema={MOCK_SCHEMA} instructions={MOCK_INSTRUCTIONS} onChange={cy.stub()} />
+    )
+    cy.checkAccessibility()
+  })
+
+  it('should be accessible when empty', () => {
+    cy.injectAxe()
+    cy.mountWithProviders(
+      <MappingInstructionList schema={MOCK_ALL_READ_ONLY_SCHEMA} instructions={[]} onChange={cy.stub()} />
     )
     cy.checkAccessibility()
   })

--- a/hivemq-edge-frontend/src/components/rjsf/MqttTransformation/components/MappingInstructionList.spec.cy.tsx
+++ b/hivemq-edge-frontend/src/components/rjsf/MqttTransformation/components/MappingInstructionList.spec.cy.tsx
@@ -26,10 +26,9 @@ const MOCK_INSTRUCTIONS: Instruction[] = [
  *
  * This is a verbatim copy of the backend output, pinned by
  * `TagSchemaCreationOutputImplSchemaBuilderTest.test_southboundSchema_conditionCommandDocumentIsPinned`.
- * Do not "tidy" it: the readOnly on the root is really there (it is on the wrapper Edge builds, not on the
- * adapter's command schema), and the absence of readOnly on the three command fields is exactly what this
- * fixture is here to prove — an earlier hand-written fixture omitted those annotations altogether and so
- * could not have caught a backend that marked every field read-only.
+ * Do not "tidy" it, and do not add annotations to it: the absence of readOnly anywhere — the root included —
+ * is exactly what this fixture exists to prove. Its predecessor was hand-written and simply omitted every
+ * readOnly, so it could not have caught a backend that marked the whole document read-only.
  */
 const MOCK_SOUTHBOUND_CONDITION_SCHEMA: RJSFSchema = {
   type: 'object',
@@ -45,7 +44,6 @@ const MOCK_SOUTHBOUND_CONDITION_SCHEMA: RJSFSchema = {
     },
   },
   required: ['value'],
-  readOnly: true,
   $schema: 'https://json-schema.org/draft/2019-09/schema',
 }
 

--- a/hivemq-edge-frontend/src/components/rjsf/MqttTransformation/components/MappingInstructionList.tsx
+++ b/hivemq-edge-frontend/src/components/rjsf/MqttTransformation/components/MappingInstructionList.tsx
@@ -8,7 +8,11 @@ import { List, ListItem } from '@chakra-ui/react'
 import type { Instruction } from '@/api/__generated__'
 import MappingInstruction from '@/components/rjsf/MqttTransformation/components/mapping/MappingInstruction.tsx'
 import { getPropertyListFrom } from '@/components/rjsf/MqttTransformation/utils/json-schema.utils.ts'
-import { filterReadOnlyInstructions, toJsonPath } from '@/components/rjsf/MqttTransformation/utils/data-type.utils'
+import {
+  filterReadOnlyInstructions,
+  isReadOnly,
+  toJsonPath,
+} from '@/components/rjsf/MqttTransformation/utils/data-type.utils'
 
 interface MappingEditorProps extends Omit<ListProps, 'onChange'> {
   instructions: Instruction[]
@@ -25,8 +29,16 @@ export const MappingInstructionList: FC<MappingEditorProps> = ({
   ...props
 }) => {
   const { properties, validInstructions } = useMemo(() => {
-    const properties = getPropertyListFrom(schema)
-    const validInstructions = filterReadOnlyInstructions(instructions, properties)
+    const allProperties = getPropertyListFrom(schema)
+    // Persisted instructions may still target a read-only property (created before the property became
+    // read-only, or before it was hidden); they are pruned against the full list so they cannot ghost-match.
+    const validInstructions = filterReadOnlyInstructions(instructions, allProperties)
+    // A read-only property is not a writable destination, so it is hidden rather than rendered as a
+    // neutralised card (EDG-59). This applies to both consumers: in the southbound editor the envelope is
+    // already gone, so it only fires for a genuinely read-only field inside the value; in the combiner
+    // destination editor, schemas inferred from northbound documents routinely carry read-only envelope
+    // fields (tagName, timestamp, metadata) — those were never mappable and are now hidden too.
+    const properties = allProperties.filter((property) => !isReadOnly(property))
     return { properties, validInstructions }
   }, [schema, instructions])
 

--- a/hivemq-edge-frontend/src/components/rjsf/MqttTransformation/components/MappingInstructionList.tsx
+++ b/hivemq-edge-frontend/src/components/rjsf/MqttTransformation/components/MappingInstructionList.tsx
@@ -1,5 +1,5 @@
 import type { FC } from 'react'
-import { useMemo } from 'react'
+import { useEffect, useMemo } from 'react'
 import type { RJSFSchema } from '@rjsf/utils'
 
 import type { ListProps } from '@chakra-ui/react'
@@ -41,6 +41,21 @@ export const MappingInstructionList: FC<MappingEditorProps> = ({
     const properties = allProperties.filter((property) => !isReadOnly(property))
     return { properties, validInstructions }
   }, [schema, instructions])
+
+  // Pruning only inside the renderer would leave the stale instruction in the parent's form data: it is
+  // invisible here but still submitted and still executed. Hiding the read-only card (above) makes that harder
+  // to notice, not easier, so the sanitised list is pushed up as soon as the destination schema resolves rather
+  // than waiting for the user to happen to edit some other, visible mapping.
+  const hasPrunedInstructions = validInstructions.length !== instructions.length
+
+  useEffect(() => {
+    // filterReadOnlyInstructions only ever removes entries, so a length difference is exactly "something was
+    // pruned" — no deep comparison needed.
+    if (hasPrunedInstructions) onChange?.(validInstructions)
+    // onChange is deliberately not a dependency: parents pass a fresh closure on every render, and including it
+    // would re-fire this effect on each one for as long as the parent has not persisted the sanitised list.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [hasPrunedInstructions, validInstructions])
 
   return (
     <List {...props} gap={2}>

--- a/hivemq-edge-frontend/src/components/rjsf/MqttTransformation/components/MappingInstructionList.tsx
+++ b/hivemq-edge-frontend/src/components/rjsf/MqttTransformation/components/MappingInstructionList.tsx
@@ -1,11 +1,13 @@
 import type { FC } from 'react'
 import { useEffect, useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
 import type { RJSFSchema } from '@rjsf/utils'
 
 import type { ListProps } from '@chakra-ui/react'
 import { List, ListItem } from '@chakra-ui/react'
 
 import type { Instruction } from '@/api/__generated__'
+import ErrorMessage from '@/components/ErrorMessage.tsx'
 import MappingInstruction from '@/components/rjsf/MqttTransformation/components/mapping/MappingInstruction.tsx'
 import { getPropertyListFrom } from '@/components/rjsf/MqttTransformation/utils/json-schema.utils.ts'
 import {
@@ -28,7 +30,9 @@ export const MappingInstructionList: FC<MappingEditorProps> = ({
   showTransformation = false,
   ...props
 }) => {
-  const { properties, validInstructions } = useMemo(() => {
+  const { t } = useTranslation('components')
+
+  const { properties, validInstructions, hasHiddenProperties } = useMemo(() => {
     const allProperties = getPropertyListFrom(schema)
     // Persisted instructions may still target a read-only property (created before the property became
     // read-only, or before it was hidden); they are pruned against the full list so they cannot ghost-match.
@@ -39,7 +43,7 @@ export const MappingInstructionList: FC<MappingEditorProps> = ({
     // destination editor, schemas inferred from northbound documents routinely carry read-only envelope
     // fields (tagName, timestamp, metadata) — those were never mappable and are now hidden too.
     const properties = allProperties.filter((property) => !isReadOnly(property))
-    return { properties, validInstructions }
+    return { properties, validInstructions, hasHiddenProperties: allProperties.length > properties.length }
   }, [schema, instructions])
 
   // Pruning only inside the renderer would leave the stale instruction in the parent's form data: it is
@@ -56,6 +60,24 @@ export const MappingInstructionList: FC<MappingEditorProps> = ({
     // would re-fire this effect on each one for as long as the parent has not persisted the sanitised list.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [hasPrunedInstructions, validInstructions])
+
+  // Hiding every property leaves an empty panel, and blank reads as "still loading" or "broken" rather than
+  // "there is nothing to map". Say which of the two it is: a tag whose fields are all read-only is a different
+  // problem from a schema that declares no fields at all — the first is the device's doing, the second is the
+  // schema's. This is what the read-only cards used to convey before EDG-59 removed them.
+  if (properties.length === 0) {
+    return (
+      <ErrorMessage
+        status="info"
+        data-testid="mapping-instruction-empty"
+        message={t(
+          hasHiddenProperties
+            ? 'rjsf.MqttTransformationField.destination.empty.allReadOnly'
+            : 'rjsf.MqttTransformationField.destination.empty.noProperties'
+        )}
+      />
+    )
+  }
 
   return (
     <List {...props} gap={2}>

--- a/hivemq-edge-frontend/src/components/rjsf/MqttTransformation/components/mapping/MappingInstruction.spec.cy.tsx
+++ b/hivemq-edge-frontend/src/components/rjsf/MqttTransformation/components/mapping/MappingInstruction.spec.cy.tsx
@@ -30,15 +30,6 @@ const MOCK_PROPERTY_STRING_REQUIRED: FlatJSONSchema7 = {
   required: true,
 }
 
-const MOCK_PROPERTY_READONLY: FlatJSONSchema7 = {
-  description: undefined,
-  path: [],
-  key: 'system-id',
-  title: 'System ID',
-  type: 'string',
-  readOnly: true,
-}
-
 // ─── Mock instructions ────────────────────────────────────────────────────────
 
 const MOCK_INSTRUCTION_NO_REF: Instruction = {
@@ -173,25 +164,6 @@ describe('MappingInstruction', () => {
     cy.getByTestId('mapping-instruction-dropzone').should('not.exist')
     cy.getByAriaLabel('Clear mapping').should('not.exist')
     cy.get('[role="alert"]').should('contain.text', 'Not supported').should('have.attr', 'data-status', 'warning')
-  })
-
-  it('should render readonly property properly', () => {
-    cy.mountWithProviders(
-      <MappingInstruction
-        property={MOCK_PROPERTY_READONLY}
-        showTransformation={false}
-        onChange={cy.stub()}
-        instruction={undefined}
-      />
-    )
-
-    cy.getByTestId('mapping-instruction-readonly').should('exist')
-    cy.getByTestId('property-name').should('have.text', 'System ID')
-    cy.getByAriaLabel('Property').should('have.attr', 'data-type', 'string').should('not.have.attr', 'draggable')
-    cy.getByTestId('property-readonly').should('exist')
-    cy.getByTestId('mapping-instruction-dropzone').should('not.exist')
-    cy.getByAriaLabel('Clear mapping').should('not.exist')
-    cy.get('[role="alert"]').should('contain.text', 'Read-only').should('have.attr', 'data-status', 'info')
   })
 
   // ── Ownership row: TAG sources ───────────────────────────────────────────────
@@ -329,19 +301,6 @@ describe('MappingInstruction', () => {
   })
 
   // ── Accessibility ─────────────────────────────────────────────────────────────
-
-  it('should be accessible with readonly property', () => {
-    cy.injectAxe()
-    cy.mountWithProviders(
-      <MappingInstruction
-        property={MOCK_PROPERTY_READONLY}
-        showTransformation={false}
-        onChange={cy.stub()}
-        instruction={undefined}
-      />
-    )
-    cy.checkAccessibility()
-  })
 
   it('should be accessible without instruction', () => {
     cy.injectAxe()

--- a/hivemq-edge-frontend/src/components/rjsf/MqttTransformation/components/mapping/MappingInstruction.tsx
+++ b/hivemq-edge-frontend/src/components/rjsf/MqttTransformation/components/mapping/MappingInstruction.tsx
@@ -31,7 +31,6 @@ import {
   formatPath,
   fromJsonPath,
   isMappingSupported,
-  isReadOnly,
   toJsonPath,
 } from '@/components/rjsf/MqttTransformation/utils/data-type.utils.ts'
 import type { FlatJSONSchema7 } from '@/components/rjsf/MqttTransformation/utils/json-schema.utils.ts'
@@ -131,19 +130,6 @@ const MappingInstruction: FC<MappingInstructionProps> = ({
           <Alert status="warning" size="sm" variant="left-accent" w="140px">
             <AlertIcon />
             {t('rjsf.MqttTransformationField.validation.notSupported')}
-          </Alert>
-        </CardHeader>
-      </Card>
-    )
-
-  if (isReadOnly(property))
-    return (
-      <Card size="sm" variant="outline" w="100%" data-testid="mapping-instruction-readonly">
-        <CardHeader as={HStack} justifyContent="space-between">
-          <PropertyItem property={property} hasTooltip hasPathAsName={showPathAsName} />
-          <Alert status="info" size="sm" variant="left-accent" w="140px">
-            <AlertIcon />
-            {t('rjsf.MqttTransformationField.validation.readOnly')}
           </Alert>
         </CardHeader>
       </Card>

--- a/hivemq-edge-frontend/src/components/rjsf/MqttTransformation/utils/json-schema.utils.spec.ts
+++ b/hivemq-edge-frontend/src/components/rjsf/MqttTransformation/utils/json-schema.utils.spec.ts
@@ -187,6 +187,47 @@ describe('getPropertyListFrom', () => {
     expect(nameProperty).toBeDefined()
     expect(nameProperty?.required).toBeUndefined()
   })
+
+  it('should inherit readOnly from a read-only ancestor', () => {
+    // A read-only container cannot be written, so nothing beneath it can be either. JSON Schema does not
+    // require the flag to be repeated on every leaf, and uploaded/inferred combiner schemas rarely do.
+    const properties = getPropertyListFrom({
+      type: 'object',
+      properties: {
+        deviceInfo: {
+          type: 'object',
+          readOnly: true,
+          properties: {
+            serial: { type: 'string' },
+            nested: { type: 'object', properties: { deep: { type: 'string' } } },
+          },
+        },
+        setpoint: { type: 'number' },
+      },
+    })
+
+    expect(properties.find((p) => p.key === 'deviceInfo')?.readOnly).toBe(true)
+    expect(properties.find((p) => p.key === 'serial')?.readOnly).toBe(true)
+    // Inheritance must survive more than one level.
+    expect(properties.find((p) => p.key === 'deep')?.readOnly).toBe(true)
+    // ...and must not leak to a sibling of the read-only container.
+    expect(properties.find((p) => p.key === 'setpoint')?.readOnly).toBeUndefined()
+  })
+
+  it('should not override an own readOnly:false under a writable ancestor', () => {
+    const properties = getPropertyListFrom({
+      type: 'object',
+      properties: {
+        container: {
+          type: 'object',
+          properties: { writableChild: { type: 'string' } },
+        },
+      },
+    })
+
+    expect(properties.find((p) => p.key === 'container')?.readOnly).toBeUndefined()
+    expect(properties.find((p) => p.key === 'writableChild')?.readOnly).toBeUndefined()
+  })
 })
 
 describe('reducerSchemaExamples', () => {

--- a/hivemq-edge-frontend/src/components/rjsf/MqttTransformation/utils/json-schema.utils.ts
+++ b/hivemq-edge-frontend/src/components/rjsf/MqttTransformation/utils/json-schema.utils.ts
@@ -47,12 +47,20 @@ export interface FlatJSONSchema7 extends Omit<JSONSchema7, 'required'> {
   required?: boolean
 }
 
+/**
+ * `readOnly` is inherited: a read-only container cannot be written, so nothing below it can be either, and
+ * JSON Schema does not require the flag to be repeated on every leaf. Callers that use `readOnly` to decide
+ * what may be a write destination need the *effective* value, so it is resolved here while flattening rather
+ * than left to each consumer. Schemas reaching this function are not only Edge-generated — the combiner
+ * accepts uploaded and inferred schemas, where an unrepeated flag is the norm rather than the exception.
+ */
 export const getProperty = (
   key: string,
   path: string[],
   property: JSONSchema7Definition,
   definitions: { [p: string]: JSONSchema7Definition } | undefined,
-  parentRequired: string[] = []
+  parentRequired: string[] = [],
+  parentReadOnly = false
 ): FlatJSONSchema7[] => {
   let tempProperty = property
 
@@ -81,6 +89,8 @@ export const getProperty = (
   // Check if this property is in the parent's required array
   const isRequired = parentRequired.includes(key)
 
+  const effectiveReadOnly = parentReadOnly || (tempProperty as JSONSchema7).readOnly === true
+
   const mainProps: FlatJSONSchema7 = {
     // internal properties
     key,
@@ -94,6 +104,8 @@ export const getProperty = (
     ...(isRequired && { required: true }),
     // other valid properties
     ...validProperties,
+    // inherited from an ancestor, so it must override the (possibly absent) own flag in validProperties
+    ...(effectiveReadOnly && { readOnly: true }),
   }
 
   const subProperties: FlatJSONSchema7[] = []
@@ -102,7 +114,9 @@ export const getProperty = (
     const { properties, required: objectRequired } = tempProperty as JSONSchema7
     if (properties) {
       for (const [subKey, subProp] of Object.entries(properties)) {
-        subProperties.push(...getProperty(subKey, [...path, key], subProp, definitions, objectRequired))
+        subProperties.push(
+          ...getProperty(subKey, [...path, key], subProp, definitions, objectRequired, effectiveReadOnly)
+        )
       }
     }
   } else if (type === 'array') {

--- a/hivemq-edge-frontend/src/locales/en/components.json
+++ b/hivemq-edge-frontend/src/locales/en/components.json
@@ -296,6 +296,10 @@
         "header": "Destination output",
         "check": {
           "aria-label": "Mapping valid"
+        },
+        "empty": {
+          "allReadOnly": "None of this tag's fields can be written to, so there is nothing to map here.",
+          "noProperties": "This schema defines no fields, so there is nothing to map here."
         }
       },
       "instructions": {

--- a/hivemq-edge-frontend/src/locales/en/components.json
+++ b/hivemq-edge-frontend/src/locales/en/components.json
@@ -323,7 +323,6 @@
       "validation": {
         "required": "Required",
         "notSupported": "Not supported",
-        "readOnly": "Read-only",
         "matching": "Matching",
         "error": {
           "noValidation": "There is a problem validating the mapping instructions",

--- a/hivemq-edge-frontend/src/locales/en/translation.json
+++ b/hivemq-edge-frontend/src/locales/en/translation.json
@@ -712,7 +712,7 @@
           "edit": "Edit the tag",
           "delete": "Delete the tag",
           "add": "Add a new tag",
-          "schema": "View the WRITE schema",
+          "schema": "View the tag schemas",
           "submit": "Submit"
         }
       },
@@ -742,17 +742,17 @@
         "header": "Edit the tag"
       },
       "schema": {
-        "header": "Manage the schema for the tag",
+        "header": "Tag schemas",
         "action": {
           "download": "Download the schema",
           "close": "Close"
         },
         "label": "Current schema",
-        "labelRead": "Read schema",
-        "labelWrite": "Write schema",
-        "helperRead": "The data published for this tag. A valid source for data transformation.",
-        "helperWrite": "The shape of a write to this tag. Whether an individual field can be written is shown per field.",
-        "identical": "Reading and writing this tag use the same schema."
+        "labelNorthbound": "Northbound schema",
+        "labelSouthbound": "Southbound schema",
+        "helperNorthbound": "The data published for this tag. A valid source for data transformation.",
+        "helperSouthbound": "The shape of a southbound message to this tag. Whether an individual field can be written is shown per field.",
+        "identical": "Both directions use the same schema for this tag."
       }
     },
     "errors": {
@@ -760,8 +760,8 @@
       "noAdapter": "The protocol adapter for this device cannot be found",
       "noMetadataLoaded": "Uploading device metadata is not yet supported",
       "noTagLoaded": "Cannot load the tags",
-      "noSchemaLoaded": "Cannot load the schema",
-      "noWriteSchemaLoaded": "Cannot load the write schema",
+      "noNorthboundSchemaLoaded": "Cannot load the northbound schema",
+      "noSouthboundSchemaLoaded": "Cannot load the southbound schema",
       "noTagCreated": "There is no tag created yet",
       "invalidData": "Invalid data"
     },

--- a/hivemq-edge-frontend/src/locales/en/translation.json
+++ b/hivemq-edge-frontend/src/locales/en/translation.json
@@ -748,7 +748,12 @@
           "close": "Close"
         },
         "label": "Current schema",
-        "helper": "This schema will be a valid source for data transformation"
+        "helper": "This schema will be a valid source for data transformation",
+        "labelRead": "Read schema",
+        "labelWrite": "Write schema",
+        "helperRead": "The data published for this tag. A valid source for data transformation.",
+        "helperWrite": "The shape of a write to this tag. Whether an individual field can be written is shown per field.",
+        "identical": "Reading and writing this tag use the same schema."
       }
     },
     "errors": {

--- a/hivemq-edge-frontend/src/locales/en/translation.json
+++ b/hivemq-edge-frontend/src/locales/en/translation.json
@@ -748,7 +748,6 @@
           "close": "Close"
         },
         "label": "Current schema",
-        "helper": "This schema will be a valid source for data transformation",
         "labelRead": "Read schema",
         "labelWrite": "Write schema",
         "helperRead": "The data published for this tag. A valid source for data transformation.",
@@ -762,6 +761,7 @@
       "noMetadataLoaded": "Uploading device metadata is not yet supported",
       "noTagLoaded": "Cannot load the tags",
       "noSchemaLoaded": "Cannot load the schema",
+      "noWriteSchemaLoaded": "Cannot load the write schema",
       "noTagCreated": "There is no tag created yet",
       "invalidData": "Invalid data"
     },

--- a/hivemq-edge-frontend/src/modules/Device/components/TagSchemaDrawer.spec.cy.tsx
+++ b/hivemq-edge-frontend/src/modules/Device/components/TagSchemaDrawer.spec.cy.tsx
@@ -29,7 +29,7 @@ describe('TagSchemaDrawer', () => {
 
     cy.getByTestId('dev-trigger').click()
     cy.get('[role="dialog"]#chakra-modal-tag-schema').within(() => {
-      cy.get('header').should('have.text', 'Manage the schema for the tag')
+      cy.get('header').should('have.text', 'Tag schemas')
       cy.get('footer').within(() => {
         cy.get('button').as('close').should('have.text', 'Close')
       })

--- a/hivemq-edge-frontend/src/modules/Device/components/TagSchemaPanel.spec.cy.tsx
+++ b/hivemq-edge-frontend/src/modules/Device/components/TagSchemaPanel.spec.cy.tsx
@@ -10,12 +10,12 @@ import { TagSchemaPanel } from './TagSchemaPanel'
 
 const mocTag = MOCK_DEVICE_TAGS('opcua-1', MockAdapterType.OPC_UA)[0]
 
-// The mocks mirror the real backend documents: the read (northbound) document wraps the value in the
-// non-writable envelope, the write (southbound) document is value-only. The backend guarantees the value
-// sub-schemas are identical for a plain value tag (pinned in TagSchemaCreationOutputImplSchemaBuilderTest).
+// The mocks mirror the real backend documents: the northbound document wraps the value in the non-writable
+// envelope, the southbound document is value-only. The backend guarantees the value sub-schemas are
+// identical for a plain value tag (pinned in TagSchemaCreationOutputImplSchemaBuilderTest).
 const MOCK_VALUE_SCHEMA = GENERATE_DATA_MODELS(true, 'test')
 
-const MOCK_READ_SCHEMA: RJSFSchema = {
+const MOCK_NORTHBOUND_SCHEMA: RJSFSchema = {
   $schema: 'https://json-schema.org/draft/2019-09/schema',
   title: 'test',
   type: 'object',
@@ -27,7 +27,7 @@ const MOCK_READ_SCHEMA: RJSFSchema = {
   },
 }
 
-const MOCK_WRITE_SCHEMA: RJSFSchema = {
+const MOCK_SOUTHBOUND_SCHEMA: RJSFSchema = {
   $schema: 'https://json-schema.org/draft/2019-09/schema',
   title: 'test',
   type: 'object',
@@ -52,13 +52,13 @@ const reverseKeyOrder = (value: unknown): unknown => {
   )
 }
 
-const MOCK_WRITE_SCHEMA_REORDERED: RJSFSchema = {
-  ...MOCK_WRITE_SCHEMA,
+const MOCK_SOUTHBOUND_SCHEMA_REORDERED: RJSFSchema = {
+  ...MOCK_SOUTHBOUND_SCHEMA,
   properties: { value: reverseKeyOrder(MOCK_VALUE_SCHEMA) as RJSFSchema },
 }
 
-// A tag whose write shape is not a projection of its read shape, e.g. an OPC-UA condition tag.
-const MOCK_WRITE_SCHEMA_INDEPENDENT: RJSFSchema = {
+// A tag whose southbound shape is not a projection of its northbound shape, e.g. an OPC-UA condition tag.
+const MOCK_SOUTHBOUND_SCHEMA_INDEPENDENT: RJSFSchema = {
   $schema: 'https://json-schema.org/draft/2019-09/schema',
   title: 'test',
   type: 'object',
@@ -80,18 +80,19 @@ const MOCK_WRITE_SCHEMA_INDEPENDENT: RJSFSchema = {
 describe('TagSchemaPanel', () => {
   beforeEach(() => {
     cy.viewport(800, 800)
-    // The read request carries no `direction` (it is the default); the write request is intercepted per test.
-    cy.intercept('/api/v1/management/protocol-adapters/schema/**', MOCK_READ_SCHEMA)
+    // The northbound request carries no `direction` (it is the default); the southbound request is
+    // intercepted per test.
+    cy.intercept('/api/v1/management/protocol-adapters/schema/**', MOCK_NORTHBOUND_SCHEMA)
   })
 
-  const interceptWriteSchema = (response: RJSFSchema | { statusCode: number }) =>
+  const interceptSouthboundSchema = (response: RJSFSchema | { statusCode: number }) =>
     cy.intercept(
       { method: 'GET', pathname: '**/protocol-adapters/schema/**', query: { direction: 'SOUTHBOUND' } },
       'statusCode' in response ? response : { body: response }
     )
 
   it('should render properly', () => {
-    interceptWriteSchema(MOCK_WRITE_SCHEMA)
+    interceptSouthboundSchema(MOCK_SOUTHBOUND_SCHEMA)
     cy.mountWithProviders(<TagSchemaPanel adapterId="test" tag={mocTag} />)
 
     cy.getByTestId('tag-schema-header').should('have.text', 'Tag')
@@ -100,83 +101,84 @@ describe('TagSchemaPanel', () => {
       cy.get('label').should('have.text', 'Current schema')
       cy.get('h3').should('have.text', 'test')
       cy.get('[role="list"] li').should('length', 11)
-      cy.get('#tag-schema-panel-helptext').should('have.text', 'Reading and writing this tag use the same schema.')
+      cy.get('#tag-schema-panel-helptext').should('have.text', 'Both directions use the same schema for this tag.')
     })
     cy.getByTestId('tag-schema-download').should('have.text', 'Download the schema').should('not.be.disabled')
   })
 
-  it('should show a single schema when the read and write value shapes are identical', () => {
-    interceptWriteSchema(MOCK_WRITE_SCHEMA)
+  it('should show a single schema when the northbound and southbound value shapes are identical', () => {
+    interceptSouthboundSchema(MOCK_SOUTHBOUND_SCHEMA)
     cy.mountWithProviders(<TagSchemaPanel adapterId="test" tag={mocTag} />)
 
     // The documents differ (envelope vs value-only) but the value shapes match, so only one panel renders.
-    cy.getByTestId('tag-schema-read').should('be.visible')
+    cy.getByTestId('tag-schema-northbound').should('be.visible')
     cy.getByTestId('tag-schema-panel').find('label').should('have.text', 'Current schema')
-    cy.getByTestId('tag-schema-panel-write').should('not.exist')
+    cy.getByTestId('tag-schema-panel-southbound').should('not.exist')
   })
 
   it('should show a single schema when the value shapes differ only in member order', () => {
-    interceptWriteSchema(MOCK_WRITE_SCHEMA_REORDERED)
+    interceptSouthboundSchema(MOCK_SOUTHBOUND_SCHEMA_REORDERED)
     cy.mountWithProviders(<TagSchemaPanel adapterId="test" tag={mocTag} />)
 
     // Same shape, different insertion order — a stringify-based comparison would split this into two panels
-    // and tell the user the tag reads and writes differently, which is false.
-    cy.getByTestId('tag-schema-read').should('be.visible')
+    // and tell the user the two directions differ, which is false.
+    cy.getByTestId('tag-schema-northbound').should('be.visible')
     cy.getByTestId('tag-schema-panel').find('label').should('have.text', 'Current schema')
-    cy.getByTestId('tag-schema-panel-write').should('not.exist')
+    cy.getByTestId('tag-schema-panel-southbound').should('not.exist')
   })
 
-  it('should show both schemas when the write shape is independent of the read shape', () => {
-    interceptWriteSchema(MOCK_WRITE_SCHEMA_INDEPENDENT)
+  it('should show both schemas when the southbound shape is independent of the northbound shape', () => {
+    interceptSouthboundSchema(MOCK_SOUTHBOUND_SCHEMA_INDEPENDENT)
     cy.mountWithProviders(<TagSchemaPanel adapterId="test" tag={mocTag} />)
 
     cy.getByTestId('tag-schema-panel').within(() => {
-      cy.get('label').should('have.text', 'Read schema')
+      cy.get('label').should('have.text', 'Northbound schema')
       cy.get('#tag-schema-panel-helptext').should(
         'have.text',
         'The data published for this tag. A valid source for data transformation.'
       )
     })
 
-    cy.getByTestId('tag-schema-panel-write').within(() => {
-      cy.get('label').should('have.text', 'Write schema')
-      cy.get('#tag-schema-panel-write-helptext').should(
+    cy.getByTestId('tag-schema-panel-southbound').within(() => {
+      cy.get('label').should('have.text', 'Southbound schema')
+      cy.get('#tag-schema-panel-southbound-helptext').should(
         'have.text',
-        'The shape of a write to this tag. Whether an individual field can be written is shown per field.'
+        'The shape of a southbound message to this tag. Whether an individual field can be written is shown per field.'
       )
     })
   })
 
-  it('should render the read schema without waiting for a slow write request', () => {
-    // The two queries are independent: the read panel must appear while the write request is still in flight.
+  it('should render the northbound schema without waiting for a slow southbound request', () => {
+    // The two queries are independent: the northbound panel must appear while the southbound request is
+    // still in flight.
     cy.intercept(
       { method: 'GET', pathname: '**/protocol-adapters/schema/**', query: { direction: 'SOUTHBOUND' } },
-      { body: MOCK_WRITE_SCHEMA, delay: 8000 }
+      { body: MOCK_SOUTHBOUND_SCHEMA, delay: 8000 }
     )
     // Distinct adapterId: the query client is shared across tests, and this test deliberately leaves an
-    // 8s-pending write request behind — a colliding query key would leak it into the next test.
+    // 8s-pending southbound request behind — a colliding query key would leak it into the next test.
     cy.mountWithProviders(<TagSchemaPanel adapterId="test-slow" tag={mocTag} />)
 
-    // Asserted well inside the 8s write delay (default 4s command timeout): the read panel is up while the
-    // write query still loads.
-    cy.getByTestId('tag-schema-read').should('be.visible')
-    cy.getByTestId('tag-schema-panel').find('label').should('have.text', 'Read schema')
+    // Asserted well inside the 8s southbound delay (default 4s command timeout): the northbound panel is up
+    // while the southbound query still loads.
+    cy.getByTestId('tag-schema-northbound').should('be.visible')
+    cy.getByTestId('tag-schema-panel').find('label').should('have.text', 'Northbound schema')
   })
 
-  it('should still render the read schema and an error when the write schema cannot be loaded', () => {
-    interceptWriteSchema({ statusCode: 500 })
+  it('should still render the northbound schema and an error when the southbound schema cannot be loaded', () => {
+    interceptSouthboundSchema({ statusCode: 500 })
     cy.mountWithProviders(<TagSchemaPanel adapterId="test" tag={mocTag} />)
 
-    // The write failure must be visible, not silently swallowed into a half-answer.
-    cy.getByTestId('tag-schema-read').should('be.visible')
-    cy.getByTestId('tag-schema-panel').find('label').should('have.text', 'Read schema')
-    cy.get('[role="alert"]').should('contain.text', 'Cannot load the write schema')
-    cy.getByTestId('tag-schema-panel-write').should('not.exist')
+    // The southbound failure must be visible, not silently swallowed into a half-answer.
+    cy.getByTestId('tag-schema-northbound').should('be.visible')
+    cy.getByTestId('tag-schema-panel').find('label').should('have.text', 'Northbound schema')
+    cy.get('[role="alert"]').should('contain.text', 'Cannot load the southbound schema')
+    cy.getByTestId('tag-schema-panel-southbound').should('not.exist')
   })
 
   it('should be accessible', () => {
     cy.injectAxe()
-    interceptWriteSchema(MOCK_WRITE_SCHEMA)
+    interceptSouthboundSchema(MOCK_SOUTHBOUND_SCHEMA)
     cy.mountWithProviders(<TagSchemaPanel adapterId="test" tag={mocTag} />)
 
     cy.checkAccessibility()

--- a/hivemq-edge-frontend/src/modules/Device/components/TagSchemaPanel.spec.cy.tsx
+++ b/hivemq-edge-frontend/src/modules/Device/components/TagSchemaPanel.spec.cy.tsx
@@ -22,12 +22,46 @@ describe('TagSchemaPanel', () => {
       cy.get('label').should('have.text', 'Current schema')
       cy.get('h3').should('have.text', 'test')
       cy.get('[role="list"] li').should('length', 8)
-      cy.get('#tag-schema-panel-helptext').should(
-        'have.text',
-        'This schema will be a valid source for data transformation'
-      )
+      cy.get('#tag-schema-panel-helptext').should('have.text', 'Reading and writing this tag use the same schema.')
     })
     cy.getByTestId('tag-schema-download').should('have.text', 'Download the schema').should('not.be.disabled')
+  })
+
+  it('should show a single schema when reading and writing are identical', () => {
+    cy.mountWithProviders(<TagSchemaPanel adapterId="test" tag={mocTag} />)
+
+    // Both directions return the same mock, so only the read panel is rendered.
+    cy.getByTestId('tag-schema-read').should('be.visible')
+    cy.getByTestId('tag-schema-panel-write').should('not.exist')
+    cy.getByTestId('tag-schema-panel').find('label').should('have.text', 'Current schema')
+  })
+
+  it('should show both schemas when reading and writing differ', () => {
+    // A tag whose write shape is not a projection of its read shape, e.g. an OPC-UA condition tag.
+    // The read request carries no `direction` (it is the default), so only WRITE needs its own intercept;
+    // reads fall through to the wildcard registered in beforeEach.
+    cy.intercept(
+      { method: 'GET', pathname: '**/protocol-adapters/schema/**', query: { direction: 'WRITE' } },
+      GENERATE_DATA_MODELS(true, 'writeModel')
+    )
+
+    cy.mountWithProviders(<TagSchemaPanel adapterId="test" tag={mocTag} />)
+
+    cy.getByTestId('tag-schema-panel').within(() => {
+      cy.get('label').should('have.text', 'Read schema')
+      cy.get('#tag-schema-panel-helptext').should(
+        'have.text',
+        'The data published for this tag. A valid source for data transformation.'
+      )
+    })
+
+    cy.getByTestId('tag-schema-panel-write').within(() => {
+      cy.get('label').should('have.text', 'Write schema')
+      cy.get('#tag-schema-panel-write-helptext').should(
+        'have.text',
+        'The shape of a write to this tag. Whether an individual field can be written is shown per field.'
+      )
+    })
   })
 
   it('should be accessible', () => {

--- a/hivemq-edge-frontend/src/modules/Device/components/TagSchemaPanel.spec.cy.tsx
+++ b/hivemq-edge-frontend/src/modules/Device/components/TagSchemaPanel.spec.cy.tsx
@@ -1,50 +1,102 @@
 /// <reference types="cypress" />
 
+import type { RJSFSchema } from '@rjsf/utils'
+
 import { MockAdapterType } from '@/__test-utils__/adapters/types'
 import { GENERATE_DATA_MODELS } from '@/api/hooks/useDomainModel/__handlers__'
 import { MOCK_DEVICE_TAGS } from '@/api/hooks/useProtocolAdapters/__handlers__'
+import { formatTopicString } from '@/components/MQTT/topic-utils.ts'
 import { TagSchemaPanel } from './TagSchemaPanel'
 
 const mocTag = MOCK_DEVICE_TAGS('opcua-1', MockAdapterType.OPC_UA)[0]
 
+// The mocks mirror the real backend documents: the read (northbound) document wraps the value in the
+// non-writable envelope, the write (southbound) document is value-only. The backend guarantees the value
+// sub-schemas are identical for a plain value tag (pinned in TagSchemaCreationOutputImplSchemaBuilderTest).
+const MOCK_VALUE_SCHEMA = GENERATE_DATA_MODELS(true, 'test')
+
+const MOCK_READ_SCHEMA: RJSFSchema = {
+  $schema: 'https://json-schema.org/draft/2019-09/schema',
+  title: 'test',
+  type: 'object',
+  required: ['value'],
+  properties: {
+    tagName: { type: 'string', readOnly: true },
+    timestamp: { type: 'integer', readOnly: true },
+    value: MOCK_VALUE_SCHEMA,
+  },
+}
+
+const MOCK_WRITE_SCHEMA: RJSFSchema = {
+  $schema: 'https://json-schema.org/draft/2019-09/schema',
+  title: 'test',
+  type: 'object',
+  required: ['value'],
+  properties: {
+    value: MOCK_VALUE_SCHEMA,
+  },
+}
+
+// A tag whose write shape is not a projection of its read shape, e.g. an OPC-UA condition tag.
+const MOCK_WRITE_SCHEMA_INDEPENDENT: RJSFSchema = {
+  $schema: 'https://json-schema.org/draft/2019-09/schema',
+  title: 'test',
+  type: 'object',
+  required: ['value'],
+  properties: {
+    value: {
+      type: 'object',
+      title: 'writeModel',
+      required: ['eventId', 'method'],
+      properties: {
+        eventId: { type: 'string', title: 'eventId' },
+        method: { type: 'integer', title: 'method' },
+        comment: { type: 'string', title: 'comment' },
+      },
+    },
+  },
+}
+
 describe('TagSchemaPanel', () => {
   beforeEach(() => {
     cy.viewport(800, 800)
-    cy.intercept('/api/v1/management/protocol-adapters/schema/**', GENERATE_DATA_MODELS(true, 'test'))
+    // The read request carries no `direction` (it is the default); the write request is intercepted per test.
+    cy.intercept('/api/v1/management/protocol-adapters/schema/**', MOCK_READ_SCHEMA)
   })
 
+  const interceptWriteSchema = (response: RJSFSchema | { statusCode: number }) =>
+    cy.intercept(
+      { method: 'GET', pathname: '**/protocol-adapters/schema/**', query: { direction: 'SOUTHBOUND' } },
+      'statusCode' in response ? response : { body: response }
+    )
+
   it('should render properly', () => {
+    interceptWriteSchema(MOCK_WRITE_SCHEMA)
     cy.mountWithProviders(<TagSchemaPanel adapterId="test" tag={mocTag} />)
 
     cy.getByTestId('tag-schema-header').should('have.text', 'Tag')
-    cy.getByTestId('topic-wrapper').should('have.text', 'opcua-1 / power / off')
+    cy.getByTestId('topic-wrapper').should('have.text', formatTopicString('opcua-1/power/off'))
     cy.getByTestId('tag-schema-panel').within(() => {
       cy.get('label').should('have.text', 'Current schema')
       cy.get('h3').should('have.text', 'test')
-      cy.get('[role="list"] li').should('length', 8)
+      cy.get('[role="list"] li').should('length', 11)
       cy.get('#tag-schema-panel-helptext').should('have.text', 'Reading and writing this tag use the same schema.')
     })
     cy.getByTestId('tag-schema-download').should('have.text', 'Download the schema').should('not.be.disabled')
   })
 
-  it('should show a single schema when reading and writing are identical', () => {
+  it('should show a single schema when the read and write value shapes are identical', () => {
+    interceptWriteSchema(MOCK_WRITE_SCHEMA)
     cy.mountWithProviders(<TagSchemaPanel adapterId="test" tag={mocTag} />)
 
-    // Both directions return the same mock, so only the read panel is rendered.
+    // The documents differ (envelope vs value-only) but the value shapes match, so only one panel renders.
     cy.getByTestId('tag-schema-read').should('be.visible')
-    cy.getByTestId('tag-schema-panel-write').should('not.exist')
     cy.getByTestId('tag-schema-panel').find('label').should('have.text', 'Current schema')
+    cy.getByTestId('tag-schema-panel-write').should('not.exist')
   })
 
-  it('should show both schemas when reading and writing differ', () => {
-    // A tag whose write shape is not a projection of its read shape, e.g. an OPC-UA condition tag.
-    // The read request carries no `direction` (it is the default), so only WRITE needs its own intercept;
-    // reads fall through to the wildcard registered in beforeEach.
-    cy.intercept(
-      { method: 'GET', pathname: '**/protocol-adapters/schema/**', query: { direction: 'WRITE' } },
-      GENERATE_DATA_MODELS(true, 'writeModel')
-    )
-
+  it('should show both schemas when the write shape is independent of the read shape', () => {
+    interceptWriteSchema(MOCK_WRITE_SCHEMA_INDEPENDENT)
     cy.mountWithProviders(<TagSchemaPanel adapterId="test" tag={mocTag} />)
 
     cy.getByTestId('tag-schema-panel').within(() => {
@@ -64,8 +116,36 @@ describe('TagSchemaPanel', () => {
     })
   })
 
+  it('should render the read schema without waiting for a slow write request', () => {
+    // The two queries are independent: the read panel must appear while the write request is still in flight.
+    cy.intercept(
+      { method: 'GET', pathname: '**/protocol-adapters/schema/**', query: { direction: 'SOUTHBOUND' } },
+      { body: MOCK_WRITE_SCHEMA, delay: 8000 }
+    )
+    // Distinct adapterId: the query client is shared across tests, and this test deliberately leaves an
+    // 8s-pending write request behind — a colliding query key would leak it into the next test.
+    cy.mountWithProviders(<TagSchemaPanel adapterId="test-slow" tag={mocTag} />)
+
+    // Asserted well inside the 8s write delay (default 4s command timeout): the read panel is up while the
+    // write query still loads.
+    cy.getByTestId('tag-schema-read').should('be.visible')
+    cy.getByTestId('tag-schema-panel').find('label').should('have.text', 'Read schema')
+  })
+
+  it('should still render the read schema and an error when the write schema cannot be loaded', () => {
+    interceptWriteSchema({ statusCode: 500 })
+    cy.mountWithProviders(<TagSchemaPanel adapterId="test" tag={mocTag} />)
+
+    // The write failure must be visible, not silently swallowed into a half-answer.
+    cy.getByTestId('tag-schema-read').should('be.visible')
+    cy.getByTestId('tag-schema-panel').find('label').should('have.text', 'Read schema')
+    cy.get('[role="alert"]').should('contain.text', 'Cannot load the write schema')
+    cy.getByTestId('tag-schema-panel-write').should('not.exist')
+  })
+
   it('should be accessible', () => {
     cy.injectAxe()
+    interceptWriteSchema(MOCK_WRITE_SCHEMA)
     cy.mountWithProviders(<TagSchemaPanel adapterId="test" tag={mocTag} />)
 
     cy.checkAccessibility()

--- a/hivemq-edge-frontend/src/modules/Device/components/TagSchemaPanel.spec.cy.tsx
+++ b/hivemq-edge-frontend/src/modules/Device/components/TagSchemaPanel.spec.cy.tsx
@@ -37,6 +37,26 @@ const MOCK_WRITE_SCHEMA: RJSFSchema = {
   },
 }
 
+/**
+ * Rebuilds a value with every object's members in the opposite insertion order, recursively. JSON object
+ * member order carries no meaning, and the two directions are assembled independently, so a schema that only
+ * differs this way is the same shape and must still collapse to a single panel.
+ */
+const reverseKeyOrder = (value: unknown): unknown => {
+  if (Array.isArray(value)) return value.map(reverseKeyOrder)
+  if (value === null || typeof value !== 'object') return value
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>)
+      .reverse()
+      .map(([key, member]) => [key, reverseKeyOrder(member)])
+  )
+}
+
+const MOCK_WRITE_SCHEMA_REORDERED: RJSFSchema = {
+  ...MOCK_WRITE_SCHEMA,
+  properties: { value: reverseKeyOrder(MOCK_VALUE_SCHEMA) as RJSFSchema },
+}
+
 // A tag whose write shape is not a projection of its read shape, e.g. an OPC-UA condition tag.
 const MOCK_WRITE_SCHEMA_INDEPENDENT: RJSFSchema = {
   $schema: 'https://json-schema.org/draft/2019-09/schema',
@@ -90,6 +110,17 @@ describe('TagSchemaPanel', () => {
     cy.mountWithProviders(<TagSchemaPanel adapterId="test" tag={mocTag} />)
 
     // The documents differ (envelope vs value-only) but the value shapes match, so only one panel renders.
+    cy.getByTestId('tag-schema-read').should('be.visible')
+    cy.getByTestId('tag-schema-panel').find('label').should('have.text', 'Current schema')
+    cy.getByTestId('tag-schema-panel-write').should('not.exist')
+  })
+
+  it('should show a single schema when the value shapes differ only in member order', () => {
+    interceptWriteSchema(MOCK_WRITE_SCHEMA_REORDERED)
+    cy.mountWithProviders(<TagSchemaPanel adapterId="test" tag={mocTag} />)
+
+    // Same shape, different insertion order — a stringify-based comparison would split this into two panels
+    // and tell the user the tag reads and writes differently, which is false.
     cy.getByTestId('tag-schema-read').should('be.visible')
     cy.getByTestId('tag-schema-panel').find('label').should('have.text', 'Current schema')
     cy.getByTestId('tag-schema-panel-write').should('not.exist')

--- a/hivemq-edge-frontend/src/modules/Device/components/TagSchemaPanel.tsx
+++ b/hivemq-edge-frontend/src/modules/Device/components/TagSchemaPanel.tsx
@@ -30,9 +30,9 @@ interface TagSchemaPanelProps {
 }
 
 /**
- * The read document wraps the value in a fixed envelope (tagName, timestamp, metadata) while the write
- * document is value-only, so the two documents as wholes are never equal. "The same schema" to someone
- * looking at this panel means the value shape, so that is what is compared.
+ * The northbound document wraps the value in a fixed envelope (tagName, timestamp, metadata) while the
+ * southbound document is value-only, so the two documents as wholes are never equal. "The same schema" to
+ * someone looking at this panel means the value shape, so that is what is compared.
  */
 const valueShape = (schema: JsonNode): JsonNode => ((schema as JSONSchema7).properties?.value as JsonNode) ?? schema
 
@@ -65,25 +65,30 @@ const isSameShape = (a: JsonNode, b: JsonNode): boolean => isSameStructure(value
 
 export const TagSchemaPanel: FC<TagSchemaPanelProps> = ({ tag, adapterId }) => {
   // This panel is pure inspection, so it shows both directions. They are usually the same for a plain value
-  // tag; they differ when a tag's write shape is not a projection of its read shape (e.g. a condition tag).
-  const { data: readSchema, isLoading: isLoadingRead, isError: isErrorRead } = useGetSchema(adapterId, tag.name)
+  // tag; they differ when a tag's southbound shape is not a projection of its northbound shape (e.g. a
+  // condition tag).
   const {
-    data: writeSchema,
-    isLoading: isLoadingWrite,
-    isError: isErrorWrite,
+    data: northboundSchema,
+    isLoading: isLoadingNorthbound,
+    isError: isErrorNorthbound,
+  } = useGetSchema(adapterId, tag.name)
+  const {
+    data: southboundSchema,
+    isLoading: isLoadingSouthbound,
+    isError: isErrorSouthbound,
   } = useGetSchema(adapterId, tag.name, 'SOUTHBOUND')
   const { t } = useTranslation()
 
   const areIdentical = useMemo(
-    () => Boolean(readSchema && writeSchema && isSameShape(readSchema, writeSchema)),
-    [readSchema, writeSchema]
+    () => Boolean(northboundSchema && southboundSchema && isSameShape(northboundSchema, southboundSchema)),
+    [northboundSchema, southboundSchema]
   )
 
   const handleSchemaDownload = () => {
-    if (!readSchema) return
+    if (!northboundSchema) return
 
     // TODO[NVL] This should be transformed into an async method (react-query type) with error management and testing
-    downloadJSON<JSONSchema7>(readSchema.title || 'topic-untitled', readSchema)
+    downloadJSON<JSONSchema7>(northboundSchema.title || 'topic-untitled', northboundSchema)
   }
 
   return (
@@ -95,36 +100,36 @@ export const TagSchemaPanel: FC<TagSchemaPanelProps> = ({ tag, adapterId }) => {
         <PLCTag tagTitle={tag.name} mr={3} />
       </CardHeader>
       <CardBody>
-        {/* The two queries are independent: the read panel renders as soon as its own request settles. */}
-        {isLoadingRead && <LoaderSpinner />}
-        {isErrorRead && <ErrorMessage message={t('device.errors.noSchemaLoaded')} />}
-        {readSchema && (
+        {/* The two queries are independent: the northbound panel renders as soon as its own request settles. */}
+        {isLoadingNorthbound && <LoaderSpinner />}
+        {isErrorNorthbound && <ErrorMessage message={t('device.errors.noNorthboundSchemaLoaded')} />}
+        {northboundSchema && (
           <FormControl data-testid="tag-schema-panel" id="tag-schema-panel">
             <FormLabel>
-              {areIdentical ? t('device.drawer.schema.label') : t('device.drawer.schema.labelRead')}
+              {areIdentical ? t('device.drawer.schema.label') : t('device.drawer.schema.labelNorthbound')}
             </FormLabel>
-            <Box borderWidth={1} p={2} data-testid="tag-schema-read">
-              <JsonSchemaBrowser schema={readSchema} hasExamples />
+            <Box borderWidth={1} p={2} data-testid="tag-schema-northbound">
+              <JsonSchemaBrowser schema={northboundSchema} hasExamples />
             </Box>
             <FormHelperText>
-              {areIdentical ? t('device.drawer.schema.identical') : t('device.drawer.schema.helperRead')}
+              {areIdentical ? t('device.drawer.schema.identical') : t('device.drawer.schema.helperNorthbound')}
             </FormHelperText>
           </FormControl>
         )}
 
-        {isLoadingWrite && !isLoadingRead && <LoaderSpinner />}
-        {isErrorWrite && <ErrorMessage message={t('device.errors.noWriteSchemaLoaded')} />}
-        {!areIdentical && writeSchema && (
-          <FormControl mt={4} data-testid="tag-schema-panel-write" id="tag-schema-panel-write">
-            <FormLabel>{t('device.drawer.schema.labelWrite')}</FormLabel>
-            <Box borderWidth={1} p={2} data-testid="tag-schema-write">
-              <JsonSchemaBrowser schema={writeSchema} hasExamples />
+        {isLoadingSouthbound && !isLoadingNorthbound && <LoaderSpinner />}
+        {isErrorSouthbound && <ErrorMessage message={t('device.errors.noSouthboundSchemaLoaded')} />}
+        {!areIdentical && southboundSchema && (
+          <FormControl mt={4} data-testid="tag-schema-panel-southbound" id="tag-schema-panel-southbound">
+            <FormLabel>{t('device.drawer.schema.labelSouthbound')}</FormLabel>
+            <Box borderWidth={1} p={2} data-testid="tag-schema-southbound">
+              <JsonSchemaBrowser schema={southboundSchema} hasExamples />
             </Box>
-            <FormHelperText>{t('device.drawer.schema.helperWrite')}</FormHelperText>
+            <FormHelperText>{t('device.drawer.schema.helperSouthbound')}</FormHelperText>
           </FormControl>
         )}
       </CardBody>
-      {readSchema && (
+      {northboundSchema && (
         <CardFooter>
           <ButtonGroup>
             <Button data-testid="tag-schema-download" onClick={handleSchemaDownload}>

--- a/hivemq-edge-frontend/src/modules/Device/components/TagSchemaPanel.tsx
+++ b/hivemq-edge-frontend/src/modules/Device/components/TagSchemaPanel.tsx
@@ -37,23 +37,31 @@ interface TagSchemaPanelProps {
 const valueShape = (schema: JsonNode): JsonNode => ((schema as JSONSchema7).properties?.value as JsonNode) ?? schema
 
 /**
- * Object member order carries no meaning in JSON, and the two directions are assembled independently, so
- * `{eventId, method}` and `{method, eventId}` are the same shape and must compare equal. Array order is
- * preserved: `required`, `enum` and `anyOf` are sequences, not sets, as far as this panel's display is
- * concerned.
+ * Structural equality: object member order carries no meaning in JSON, and the two directions are assembled
+ * independently, so `{eventId, method}` and `{method, eventId}` are the same shape and must compare equal.
+ * Array order *is* significant — `required`, `enum` and `anyOf` are sequences, not sets, as far as this
+ * panel's display is concerned.
+ *
+ * Compared structurally rather than by sorting keys and stringifying: sorting would need a comparator, and a
+ * locale-aware one would make the result depend on the machine's locale, which is the opposite of what a
+ * canonical form is for.
  */
-const canonical = (value: unknown): unknown => {
-  if (Array.isArray(value)) return value.map(canonical)
-  if (value === null || typeof value !== 'object') return value
-  return Object.fromEntries(
-    Object.keys(value as Record<string, unknown>)
-      .sort()
-      .map((key) => [key, canonical((value as Record<string, unknown>)[key])])
-  )
+const isSameStructure = (a: unknown, b: unknown): boolean => {
+  if (a === b) return true
+  if (Array.isArray(a) || Array.isArray(b)) {
+    if (!Array.isArray(a) || !Array.isArray(b) || a.length !== b.length) return false
+    return a.every((item, index) => isSameStructure(item, b[index]))
+  }
+  if (a === null || b === null || typeof a !== 'object' || typeof b !== 'object') return false
+
+  const left = a as Record<string, unknown>
+  const right = b as Record<string, unknown>
+  const leftKeys = Object.keys(left)
+  if (leftKeys.length !== Object.keys(right).length) return false
+  return leftKeys.every((key) => Object.hasOwn(right, key) && isSameStructure(left[key], right[key]))
 }
 
-const isSameShape = (a: JsonNode, b: JsonNode): boolean =>
-  JSON.stringify(canonical(valueShape(a))) === JSON.stringify(canonical(valueShape(b)))
+const isSameShape = (a: JsonNode, b: JsonNode): boolean => isSameStructure(valueShape(a), valueShape(b))
 
 export const TagSchemaPanel: FC<TagSchemaPanelProps> = ({ tag, adapterId }) => {
   // This panel is pure inspection, so it shows both directions. They are usually the same for a plain value

--- a/hivemq-edge-frontend/src/modules/Device/components/TagSchemaPanel.tsx
+++ b/hivemq-edge-frontend/src/modules/Device/components/TagSchemaPanel.tsx
@@ -16,7 +16,7 @@ import {
   Text,
 } from '@chakra-ui/react'
 
-import type { DomainTag } from '@/api/__generated__'
+import type { DomainTag, JsonNode } from '@/api/__generated__'
 import { useGetSchema } from '@/api/hooks/useProtocolAdapters/useGetSchema'
 import { PLCTag } from '@/components/MQTT/EntityTag.tsx'
 import JsonSchemaBrowser from '@/components/rjsf/MqttTransformation/JsonSchemaBrowser'
@@ -29,16 +29,29 @@ interface TagSchemaPanelProps {
   adapterId: string
 }
 
+/**
+ * The read document wraps the value in a fixed envelope (tagName, timestamp, metadata) while the write
+ * document is value-only, so the two documents as wholes are never equal. "The same schema" to someone
+ * looking at this panel means the value shape, so that is what is compared.
+ */
+const valueShape = (schema: JsonNode): JsonNode => ((schema as JSONSchema7).properties?.value as JsonNode) ?? schema
+
 export const TagSchemaPanel: FC<TagSchemaPanelProps> = ({ tag, adapterId }) => {
   // This panel is pure inspection, so it shows both directions. They are usually the same for a plain value
   // tag; they differ when a tag's write shape is not a projection of its read shape (e.g. a condition tag).
   const { data: readSchema, isLoading: isLoadingRead, isError: isErrorRead } = useGetSchema(adapterId, tag.name)
-  const { data: writeSchema, isLoading: isLoadingWrite } = useGetSchema(adapterId, tag.name, 'WRITE')
+  const {
+    data: writeSchema,
+    isLoading: isLoadingWrite,
+    isError: isErrorWrite,
+  } = useGetSchema(adapterId, tag.name, 'SOUTHBOUND')
   const { t } = useTranslation()
 
-  const isLoading = isLoadingRead || isLoadingWrite
   const areIdentical = useMemo(
-    () => Boolean(readSchema && writeSchema && JSON.stringify(readSchema) === JSON.stringify(writeSchema)),
+    () =>
+      Boolean(
+        readSchema && writeSchema && JSON.stringify(valueShape(readSchema)) === JSON.stringify(valueShape(writeSchema))
+      ),
     [readSchema, writeSchema]
   )
 
@@ -58,11 +71,11 @@ export const TagSchemaPanel: FC<TagSchemaPanelProps> = ({ tag, adapterId }) => {
         <PLCTag tagTitle={tag.name} mr={3} />
       </CardHeader>
       <CardBody>
-        {isLoading && <LoaderSpinner />}
-
+        {/* The two queries are independent: the read panel renders as soon as its own request settles. */}
+        {isLoadingRead && <LoaderSpinner />}
         {isErrorRead && <ErrorMessage message={t('device.errors.noSchemaLoaded')} />}
-        {!isLoading && readSchema && (
-          <FormControl isInvalid={isErrorRead} data-testid="tag-schema-panel" id="tag-schema-panel">
+        {readSchema && (
+          <FormControl data-testid="tag-schema-panel" id="tag-schema-panel">
             <FormLabel>
               {areIdentical ? t('device.drawer.schema.label') : t('device.drawer.schema.labelRead')}
             </FormLabel>
@@ -75,7 +88,9 @@ export const TagSchemaPanel: FC<TagSchemaPanelProps> = ({ tag, adapterId }) => {
           </FormControl>
         )}
 
-        {!isLoading && !areIdentical && writeSchema && (
+        {isLoadingWrite && !isLoadingRead && <LoaderSpinner />}
+        {isErrorWrite && <ErrorMessage message={t('device.errors.noWriteSchemaLoaded')} />}
+        {!areIdentical && writeSchema && (
           <FormControl mt={4} data-testid="tag-schema-panel-write" id="tag-schema-panel-write">
             <FormLabel>{t('device.drawer.schema.labelWrite')}</FormLabel>
             <Box borderWidth={1} p={2} data-testid="tag-schema-write">

--- a/hivemq-edge-frontend/src/modules/Device/components/TagSchemaPanel.tsx
+++ b/hivemq-edge-frontend/src/modules/Device/components/TagSchemaPanel.tsx
@@ -36,6 +36,25 @@ interface TagSchemaPanelProps {
  */
 const valueShape = (schema: JsonNode): JsonNode => ((schema as JSONSchema7).properties?.value as JsonNode) ?? schema
 
+/**
+ * Object member order carries no meaning in JSON, and the two directions are assembled independently, so
+ * `{eventId, method}` and `{method, eventId}` are the same shape and must compare equal. Array order is
+ * preserved: `required`, `enum` and `anyOf` are sequences, not sets, as far as this panel's display is
+ * concerned.
+ */
+const canonical = (value: unknown): unknown => {
+  if (Array.isArray(value)) return value.map(canonical)
+  if (value === null || typeof value !== 'object') return value
+  return Object.fromEntries(
+    Object.keys(value as Record<string, unknown>)
+      .sort()
+      .map((key) => [key, canonical((value as Record<string, unknown>)[key])])
+  )
+}
+
+const isSameShape = (a: JsonNode, b: JsonNode): boolean =>
+  JSON.stringify(canonical(valueShape(a))) === JSON.stringify(canonical(valueShape(b)))
+
 export const TagSchemaPanel: FC<TagSchemaPanelProps> = ({ tag, adapterId }) => {
   // This panel is pure inspection, so it shows both directions. They are usually the same for a plain value
   // tag; they differ when a tag's write shape is not a projection of its read shape (e.g. a condition tag).
@@ -48,10 +67,7 @@ export const TagSchemaPanel: FC<TagSchemaPanelProps> = ({ tag, adapterId }) => {
   const { t } = useTranslation()
 
   const areIdentical = useMemo(
-    () =>
-      Boolean(
-        readSchema && writeSchema && JSON.stringify(valueShape(readSchema)) === JSON.stringify(valueShape(writeSchema))
-      ),
+    () => Boolean(readSchema && writeSchema && isSameShape(readSchema, writeSchema)),
     [readSchema, writeSchema]
   )
 

--- a/hivemq-edge-frontend/src/modules/Device/components/TagSchemaPanel.tsx
+++ b/hivemq-edge-frontend/src/modules/Device/components/TagSchemaPanel.tsx
@@ -1,5 +1,6 @@
 import type { JSONSchema7 } from 'json-schema'
 import type { FC } from 'react'
+import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import {
   Box,
@@ -29,14 +30,23 @@ interface TagSchemaPanelProps {
 }
 
 export const TagSchemaPanel: FC<TagSchemaPanelProps> = ({ tag, adapterId }) => {
-  const { data, isLoading, isError } = useGetSchema(adapterId, tag.name)
+  // This panel is pure inspection, so it shows both directions. They are usually the same for a plain value
+  // tag; they differ when a tag's write shape is not a projection of its read shape (e.g. a condition tag).
+  const { data: readSchema, isLoading: isLoadingRead, isError: isErrorRead } = useGetSchema(adapterId, tag.name)
+  const { data: writeSchema, isLoading: isLoadingWrite } = useGetSchema(adapterId, tag.name, 'WRITE')
   const { t } = useTranslation()
 
+  const isLoading = isLoadingRead || isLoadingWrite
+  const areIdentical = useMemo(
+    () => Boolean(readSchema && writeSchema && JSON.stringify(readSchema) === JSON.stringify(writeSchema)),
+    [readSchema, writeSchema]
+  )
+
   const handleSchemaDownload = () => {
-    if (!data) return
+    if (!readSchema) return
 
     // TODO[NVL] This should be transformed into an async method (react-query type) with error management and testing
-    downloadJSON<JSONSchema7>(data.title || 'topic-untitled', data)
+    downloadJSON<JSONSchema7>(readSchema.title || 'topic-untitled', readSchema)
   }
 
   return (
@@ -50,18 +60,32 @@ export const TagSchemaPanel: FC<TagSchemaPanelProps> = ({ tag, adapterId }) => {
       <CardBody>
         {isLoading && <LoaderSpinner />}
 
-        {isError && <ErrorMessage message={t('device.errors.noSchemaLoaded')} />}
-        {data && (
-          <FormControl isInvalid={isError} data-testid="tag-schema-panel" id="tag-schema-panel">
-            <FormLabel>{t('device.drawer.schema.label')}</FormLabel>
-            <Box borderWidth={1} p={2}>
-              <JsonSchemaBrowser schema={data} hasExamples />
+        {isErrorRead && <ErrorMessage message={t('device.errors.noSchemaLoaded')} />}
+        {!isLoading && readSchema && (
+          <FormControl isInvalid={isErrorRead} data-testid="tag-schema-panel" id="tag-schema-panel">
+            <FormLabel>
+              {areIdentical ? t('device.drawer.schema.label') : t('device.drawer.schema.labelRead')}
+            </FormLabel>
+            <Box borderWidth={1} p={2} data-testid="tag-schema-read">
+              <JsonSchemaBrowser schema={readSchema} hasExamples />
             </Box>
-            <FormHelperText>{t('device.drawer.schema.helper')}</FormHelperText>
+            <FormHelperText>
+              {areIdentical ? t('device.drawer.schema.identical') : t('device.drawer.schema.helperRead')}
+            </FormHelperText>
+          </FormControl>
+        )}
+
+        {!isLoading && !areIdentical && writeSchema && (
+          <FormControl mt={4} data-testid="tag-schema-panel-write" id="tag-schema-panel-write">
+            <FormLabel>{t('device.drawer.schema.labelWrite')}</FormLabel>
+            <Box borderWidth={1} p={2} data-testid="tag-schema-write">
+              <JsonSchemaBrowser schema={writeSchema} hasExamples />
+            </Box>
+            <FormHelperText>{t('device.drawer.schema.helperWrite')}</FormHelperText>
           </FormControl>
         )}
       </CardBody>
-      {data && (
+      {readSchema && (
         <CardFooter>
           <ButtonGroup>
             <Button data-testid="tag-schema-download" onClick={handleSchemaDownload}>

--- a/hivemq-edge-frontend/src/modules/Device/components/TagTableField.spec.cy.tsx
+++ b/hivemq-edge-frontend/src/modules/Device/components/TagTableField.spec.cy.tsx
@@ -115,14 +115,14 @@ describe('TagTableField', () => {
       .within(() => {
         cy.get('button').eq(0).as('actEdit').should('have.attr', 'aria-label', 'Edit the tag')
         cy.get('button').eq(1).as('actDelete').should('have.attr', 'aria-label', 'Delete the tag')
-        cy.get('button').eq(2).as('actSchema').should('have.attr', 'aria-label', 'View the WRITE schema')
+        cy.get('button').eq(2).as('actSchema').should('have.attr', 'aria-label', 'View the tag schemas')
       })
 
     cy.get('[role="dialog"]').should('not.exist')
     cy.get('@actSchema').click()
     cy.get('[role="dialog"]').should('be.visible')
     cy.get('[role="dialog"]').within(() => {
-      cy.get('header').should('have.text', 'Manage the schema for the tag')
+      cy.get('header').should('have.text', 'Tag schemas')
 
       cy.getByAriaLabel('Close').click()
     })
@@ -176,7 +176,7 @@ describe('TagTableField', () => {
       .within(() => {
         cy.get('button').eq(0).should('have.attr', 'aria-label', 'Edit the tag')
         cy.get('button').eq(1).should('have.attr', 'aria-label', 'Delete the tag')
-        cy.getByAriaLabel('View the WRITE schema').should('not.exist')
+        cy.getByAriaLabel('View the tag schemas').should('not.exist')
       })
   })
 

--- a/hivemq-edge-openapi/openapi/paths/api_v1_management_protocol-adapters_schema_{adapterId}_{tagName}.yaml
+++ b/hivemq-edge-openapi/openapi/paths/api_v1_management_protocol-adapters_schema_{adapterId}_{tagName}.yaml
@@ -23,6 +23,19 @@ get:
       schema:
         type: string
         format: urlencoded
+    - description: >-
+        The direction of the schema to retrieve. READ (default) returns the northbound schema describing the
+        full data shape published for the tag; WRITE returns the southbound schema describing only what can be
+        written to the tag (read-only fields omitted).
+      in: query
+      name: direction
+      required: false
+      schema:
+        type: string
+        enum:
+          - READ
+          - WRITE
+        default: READ
   responses:
     '200':
       content:

--- a/hivemq-edge-openapi/openapi/paths/api_v1_management_protocol-adapters_schema_{adapterId}_{tagName}.yaml
+++ b/hivemq-edge-openapi/openapi/paths/api_v1_management_protocol-adapters_schema_{adapterId}_{tagName}.yaml
@@ -24,17 +24,19 @@ get:
         type: string
         format: urlencoded
     - description: >-
-        The direction of the schema to retrieve. WRITE returns the southbound schema describing only what can
-        be written to the tag (read-only fields omitted). When omitted, the northbound schema describing the
-        full data shape published for the tag is returned.
+        The direction of the schema to retrieve. SOUTHBOUND returns the southbound (write) schema: the
+        non-writable envelope (tagName, timestamp, metadata, context) is dropped, leaving the value shape that
+        a write targets. Whether an individual field can be written is carried per field as readOnly and
+        enforced when the write is validated. When omitted, the NORTHBOUND schema describing the full data
+        shape published for the tag is returned. Any other value is rejected with a 400.
       in: query
       name: direction
       required: false
       schema:
         type: string
         enum:
-          - READ
-          - WRITE
+          - NORTHBOUND
+          - SOUTHBOUND
   responses:
     '200':
       content:
@@ -54,6 +56,12 @@ get:
           schema:
             $ref: ../components/schemas/JsonNode.yaml
       description: Success
+    '400':
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/ProblemDetails.yaml
+      description: Unknown schema direction
     '404':
       content:
         application/json:

--- a/hivemq-edge-openapi/openapi/paths/api_v1_management_protocol-adapters_schema_{adapterId}_{tagName}.yaml
+++ b/hivemq-edge-openapi/openapi/paths/api_v1_management_protocol-adapters_schema_{adapterId}_{tagName}.yaml
@@ -26,9 +26,11 @@ get:
     - description: >-
         The direction of the schema to retrieve. SOUTHBOUND returns the southbound (write) schema: the
         non-writable envelope (tagName, timestamp, metadata, context) is dropped, leaving the value shape that
-        a write targets. Whether an individual field can be written is carried per field as readOnly and
-        enforced when the write is validated. When omitted, the NORTHBOUND schema describing the full data
-        shape published for the tag is returned. Any other value is rejected with a 400.
+        a write targets. Fields inside the value that the device does not accept a write for are marked
+        readOnly. That flag is descriptive metadata only - it is a JSON Schema annotation rather than an
+        assertion, and it is not currently enforced when a write is validated; use it to decide what to offer
+        as a write destination, not as a safety boundary. When omitted, the NORTHBOUND schema describing the
+        full data shape published for the tag is returned. Any other value is rejected with a 400.
       in: query
       name: direction
       required: false

--- a/hivemq-edge-openapi/openapi/paths/api_v1_management_protocol-adapters_schema_{adapterId}_{tagName}.yaml
+++ b/hivemq-edge-openapi/openapi/paths/api_v1_management_protocol-adapters_schema_{adapterId}_{tagName}.yaml
@@ -24,9 +24,9 @@ get:
         type: string
         format: urlencoded
     - description: >-
-        The direction of the schema to retrieve. READ (default) returns the northbound schema describing the
-        full data shape published for the tag; WRITE returns the southbound schema describing only what can be
-        written to the tag (read-only fields omitted).
+        The direction of the schema to retrieve. WRITE returns the southbound schema describing only what can
+        be written to the tag (read-only fields omitted). When omitted, the northbound schema describing the
+        full data shape published for the tag is returned.
       in: query
       name: direction
       required: false
@@ -35,7 +35,6 @@ get:
         enum:
           - READ
           - WRITE
-        default: READ
   responses:
     '200':
       content:

--- a/hivemq-edge-openapi/openapi/paths/api_v1_management_protocol-adapters_writing-schema_{adapterId}_{tagName}.yaml
+++ b/hivemq-edge-openapi/openapi/paths/api_v1_management_protocol-adapters_writing-schema_{adapterId}_{tagName}.yaml
@@ -2,8 +2,8 @@ get:
   deprecated: true
   description: >-
     **Deprecated:** Use `GET
-    /api/v1/management/protocol-adapters/schema/{adapterId}/{tagName}` instead.
-    This endpoint now returns a 301 redirect to the replacement.
+    /api/v1/management/protocol-adapters/schema/{adapterId}/{tagName}?direction=SOUTHBOUND`
+    instead. This endpoint now returns a 301 redirect to the replacement.
   operationId: get-writing-schema
   x-roles-allowed:
     - admin
@@ -31,7 +31,7 @@ get:
     '301':
       description: >-
         Moved Permanently. The schema endpoint has moved to
-        `/api/v1/management/protocol-adapters/schema/{adapterId}/{tagName}`.
+        `/api/v1/management/protocol-adapters/schema/{adapterId}/{tagName}?direction=SOUTHBOUND`.
       headers:
         Location:
           description: The new URL for this resource.

--- a/hivemq-edge/src/main/java/com/hivemq/api/resources/impl/ProtocolAdaptersResourceImpl.java
+++ b/hivemq-edge/src/main/java/com/hivemq/api/resources/impl/ProtocolAdaptersResourceImpl.java
@@ -707,8 +707,14 @@ public class ProtocolAdaptersResourceImpl extends AbstractApi implements Protoco
     }
 
     @Override
-    public @NotNull Response getSchema(final @NotNull String adapterId, final @NotNull String tagName) {
+    public @NotNull Response getSchema(
+            final @NotNull String adapterId, final @NotNull String tagName, final @Nullable String direction) {
         final String decodedTagName = URLDecoder.decode(tagName, StandardCharsets.UTF_8);
+
+        // READ (northbound) is the default; WRITE (southbound) returns only the writable fields.
+        final TagSchemaCreationOutputImpl.Direction schemaDirection = "WRITE".equalsIgnoreCase(direction)
+                ? TagSchemaCreationOutputImpl.Direction.WRITE
+                : TagSchemaCreationOutputImpl.Direction.READ;
 
         final Optional<ProtocolAdapterWrapper> maybeWrapper =
                 protocolAdapterManager.getProtocolAdapterWrapperByAdapterId(adapterId);
@@ -724,7 +730,8 @@ public class ProtocolAdaptersResourceImpl extends AbstractApi implements Protoco
         adapter.createTagSchema(new TagSchemaCreationInputImpl(decodedTagName), tagSchemaCreationOutput);
 
         try {
-            return Response.ok(tagSchemaCreationOutput.getFuture().get()).build(); // JSON schema root node
+            return Response.ok(tagSchemaCreationOutput.getSchema(schemaDirection))
+                    .build(); // JSON schema root
         } catch (final @NotNull InterruptedException e) {
             Thread.currentThread().interrupt();
             log.warn("Creation of json schema for writing to PLCs were interrupted.");

--- a/hivemq-edge/src/main/java/com/hivemq/api/resources/impl/ProtocolAdaptersResourceImpl.java
+++ b/hivemq-edge/src/main/java/com/hivemq/api/resources/impl/ProtocolAdaptersResourceImpl.java
@@ -94,6 +94,7 @@ import com.hivemq.protocols.ProtocolAdapterSchemaManager;
 import com.hivemq.protocols.ProtocolAdapterWrapper;
 import com.hivemq.protocols.tag.TagSchemaCreationInputImpl;
 import com.hivemq.protocols.tag.TagSchemaCreationOutputImpl;
+import com.hivemq.protocols.tag.TagSchemaDirection;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import jakarta.ws.rs.core.Response;
@@ -711,10 +712,18 @@ public class ProtocolAdaptersResourceImpl extends AbstractApi implements Protoco
             final @NotNull String adapterId, final @NotNull String tagName, final @Nullable String direction) {
         final String decodedTagName = URLDecoder.decode(tagName, StandardCharsets.UTF_8);
 
-        // READ (northbound) is the default; WRITE (southbound) returns only the writable fields.
-        final TagSchemaCreationOutputImpl.Direction schemaDirection = "WRITE".equalsIgnoreCase(direction)
-                ? TagSchemaCreationOutputImpl.Direction.WRITE
-                : TagSchemaCreationOutputImpl.Direction.READ;
+        // NORTHBOUND (read) is the default; SOUTHBOUND (write) drops the non-writable envelope. Anything else is
+        // a client error — silently falling back to NORTHBOUND would hand a typoed caller the wrong document.
+        final TagSchemaDirection schemaDirection;
+        if (direction == null) {
+            schemaDirection = TagSchemaDirection.NORTHBOUND;
+        } else {
+            try {
+                schemaDirection = TagSchemaDirection.valueOf(direction);
+            } catch (final IllegalArgumentException ignored) {
+                return errorResponse(new BadRequestError("Unknown schema direction: " + direction));
+            }
+        }
 
         final Optional<ProtocolAdapterWrapper> maybeWrapper =
                 protocolAdapterManager.getProtocolAdapterWrapperByAdapterId(adapterId);
@@ -765,7 +774,10 @@ public class ProtocolAdaptersResourceImpl extends AbstractApi implements Protoco
 
     @Override
     public @NotNull Response getWritingSchema(final @NotNull String adapterId, final @NotNull String tagName) {
+        // This endpoint's name means "the schema for writing", so the redirect must carry the direction — without
+        // it the replacement endpoint defaults to the northbound (read) schema.
         final URI newLocation = UriBuilder.fromPath("/api/v1/management/protocol-adapters/schema/{adapterId}/{tagName}")
+                .queryParam("direction", TagSchemaDirection.SOUTHBOUND.name())
                 .build(adapterId, tagName);
         return Response.status(Response.Status.MOVED_PERMANENTLY)
                 .location(newLocation)

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/tag/TagSchemaCreationOutputImpl.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/tag/TagSchemaCreationOutputImpl.java
@@ -31,18 +31,6 @@ import org.jetbrains.annotations.Nullable;
 
 public class TagSchemaCreationOutputImpl implements TagSchemaCreationOutput {
 
-    /**
-     * The direction of the tag schema requested by a consumer.
-     */
-    public enum Direction {
-        /** Northbound / read: the full data shape — {@code tagName}, {@code timestamp}, {@code value}, and any
-         * {@code metadata} / {@code context}. */
-        READ,
-        /** Southbound / write: only what can be written — just the {@code value}, with the non-writable
-         * {@code tagName} / {@code timestamp} / {@code metadata} / {@code context} dropped. */
-        WRITE
-    }
-
     private volatile @Nullable String message = null;
     private volatile @NotNull Status status = Status.SUCCESS;
 
@@ -56,47 +44,52 @@ public class TagSchemaCreationOutputImpl implements TagSchemaCreationOutput {
     }
 
     /**
-     * The composed schema as a future, in the read (northbound) direction.
+     * The composed schema as a future, in the northbound (read) direction.
      *
      * @deprecated retained for source compatibility with callers outside this repository (e.g. the commercial
      *     bidirectional adapter and the integration tests in hivemq-edge-test). Use
-     *     {@link #getSchema(Direction)} instead, which makes the direction explicit. Note this returns the READ
-     *     schema, which is what this method always produced.
+     *     {@link #getSchema(TagSchemaDirection)} instead, which makes the direction explicit. Note this returns
+     *     the NORTHBOUND schema, which is what this method always produced — the southbound DataHub resources in
+     *     {@code ProtocolAdapterWritingServiceImpl.createDataHubResources} rely on that.
      */
     @Deprecated(forRemoval = true)
     public @NotNull CompletableFuture<ObjectNode> getFuture() {
         return future.thenApply(
-                tagSchemas -> SchemaJsonRepresentation.INSTANCE.toJsonSchemaDocument(readSchema(tagSchemas)));
+                tagSchemas -> SchemaJsonRepresentation.INSTANCE.toJsonSchemaDocument(northboundSchema(tagSchemas)));
     }
 
     /**
      * Resolves the produced schema, selects the schema for the requested direction, and renders it as a
      * JSON Schema document.
      * <p>
-     * Which aspects belong to a read vs a write shape is this class's concern, because it owns the
+     * Which aspects belong to a northbound vs a southbound shape is this class's concern, because it owns the
      * {@link DataPointSchema}. {@link SchemaJsonRepresentation} is direction-agnostic: it only converts a
      * {@link Schema} to its JSON representation.
      *
-     * @param direction READ (northbound) or WRITE (southbound).
+     * @param direction NORTHBOUND (read) or SOUTHBOUND (write).
      * @return the JSON schema document for that direction.
      */
-    public @NotNull ObjectNode getSchema(final @NotNull Direction direction)
+    public @NotNull ObjectNode getSchema(final @NotNull TagSchemaDirection direction)
             throws ExecutionException, InterruptedException {
         final DataPointSchema tagSchemas = future.get();
         final Schema schema =
                 switch (direction) {
-                    case READ -> readSchema(tagSchemas);
-                    case WRITE -> writeSchema(tagSchemas);
+                    case NORTHBOUND -> northboundSchema(tagSchemas);
+                    case SOUTHBOUND -> southboundSchema(tagSchemas);
                 };
         return SchemaJsonRepresentation.INSTANCE.toJsonSchemaDocument(schema);
     }
 
     /**
-     * The schema for the <em>read</em> (northbound) direction: the envelope ({@code tagName}, {@code timestamp})
+     * The schema for the <em>northbound</em> (read) direction: the envelope ({@code tagName}, {@code timestamp})
      * wrapping {@code value}, plus optional {@code metadata} / {@code context}. Writability is irrelevant here — a
      * read consumer observes the full data shape.
+     * <p>
+     * Must stay semantically identical to the deprecated
+     * {@link SchemaJsonRepresentation#toCompositeSchema(DataPointSchema)}, which adapters built against an older
+     * SDK still see; the equality is pinned by {@code TagSchemaCreationOutputImplSchemaBuilderTest}.
      */
-    private static @NotNull Schema readSchema(final @NotNull DataPointSchema tagSchemas) {
+    private static @NotNull Schema northboundSchema(final @NotNull DataPointSchema tagSchemas) {
         final var builder = new SchemaBuilder().startObject();
 
         builder.property("tagName").scalar(ScalarType.STRING).readable().writable(false);
@@ -121,7 +114,7 @@ public class TagSchemaCreationOutputImpl implements TagSchemaCreationOutput {
     }
 
     /**
-     * The schema for the <em>write</em> (southbound) direction: only what can be written. The non-writable
+     * The schema for the <em>southbound</em> (write) direction: only what a write targets. The non-writable
      * envelope ({@code tagName}, {@code timestamp}, {@code metadata}, {@code context}) is dropped entirely — a write
      * form should never present fields that cannot be written. The {@code value} is the adapter's explicit
      * {@link DataPointSchema#writeSchema() writeSchema} when it provides one (e.g. a condition tag's
@@ -132,12 +125,16 @@ public class TagSchemaCreationOutputImpl implements TagSchemaCreationOutput {
      * makes the object unsatisfiable) — that is a runtime concern (the {@code readOnly ⇒ ⊥} matcher rule) left to
      * Nevsky. Only the non-writable envelope is stripped here.
      */
-    private static @NotNull Schema writeSchema(final @NotNull DataPointSchema tagSchemas) {
+    private static @NotNull Schema southboundSchema(final @NotNull DataPointSchema tagSchemas) {
         final Schema writeValue =
                 tagSchemas.writeSchema() != null ? tagSchemas.writeSchema() : tagSchemas.valueSchema();
 
         final var builder = new SchemaBuilder().startObject();
-        builder.property("value").required().schema(writeValue).readable(false).writable();
+        // No readable/writable annotations here: a property defined via schema() renders the prebuilt schema
+        // as-is (SchemaBuilder ignores annotations chained after schema()), so the value's flags are whatever
+        // the adapter put on its own schema root — identical to the northbound rendering of the same value,
+        // which is what lets a consumer detect "read and write use the same schema" by comparing value shapes.
+        builder.property("value").required().schema(writeValue);
         return builder.endObject().build();
     }
 

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/tag/TagSchemaCreationOutputImpl.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/tag/TagSchemaCreationOutputImpl.java
@@ -56,6 +56,20 @@ public class TagSchemaCreationOutputImpl implements TagSchemaCreationOutput {
     }
 
     /**
+     * The composed schema as a future, in the read (northbound) direction.
+     *
+     * @deprecated retained for source compatibility with callers outside this repository (e.g. the commercial
+     *     bidirectional adapter and the integration tests in hivemq-edge-test). Use
+     *     {@link #getSchema(Direction)} instead, which makes the direction explicit. Note this returns the READ
+     *     schema, which is what this method always produced.
+     */
+    @Deprecated(forRemoval = true)
+    public @NotNull CompletableFuture<ObjectNode> getFuture() {
+        return future.thenApply(
+                tagSchemas -> SchemaJsonRepresentation.INSTANCE.toJsonSchemaDocument(readSchema(tagSchemas)));
+    }
+
+    /**
      * Resolves the produced schema, selects the schema for the requested direction, and renders it as a
      * JSON Schema document.
      * <p>

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/tag/TagSchemaCreationOutputImpl.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/tag/TagSchemaCreationOutputImpl.java
@@ -147,15 +147,9 @@ public class TagSchemaCreationOutputImpl implements TagSchemaCreationOutput {
      * on the root and on each writable member — otherwise the whole shape renders {@code readOnly} and offers no
      * destinations at all. See {@code TagSchemaCreationOutputImplSchemaBuilderTest} for both cases.
      */
-    @SuppressWarnings({"deprecation", "removal"})
     private static @NotNull Schema southboundSchema(final @NotNull DataPointSchema tagSchemas) {
-        // Deliberately the deprecated accessor. The SDK renames this component to southboundSchema in a
-        // separate PR, and CI resolves the adapter SDK by matching the branch name — a PR whose branch has no
-        // SDK counterpart builds against SDK master. writeSchema() exists on both the current SDK and the
-        // renamed one (which keeps it as a delegate), so this compiles either way; switching to
-        // southboundSchema() here before the SDK rename lands would break every PR stacked on this branch.
         final Schema writeValue =
-                tagSchemas.writeSchema() != null ? tagSchemas.writeSchema() : tagSchemas.valueSchema();
+                tagSchemas.southboundSchema() != null ? tagSchemas.southboundSchema() : tagSchemas.valueSchema();
 
         final var builder = new SchemaBuilder().startObject();
         // No readable/writable annotations here: a property defined via schema() renders the prebuilt schema

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/tag/TagSchemaCreationOutputImpl.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/tag/TagSchemaCreationOutputImpl.java
@@ -45,12 +45,19 @@ public class TagSchemaCreationOutputImpl implements TagSchemaCreationOutput {
 
     /**
      * The composed schema as a future, in the northbound (read) direction.
+     * <p>
+     * Each call composes a fresh document. Composition is a pure function of the {@link DataPointSchema} the
+     * adapter finished with, so repeated calls are equal in value; they are deliberately <em>not</em> the same
+     * instance, because {@link ObjectNode} is mutable and a shared one would let one caller's edit rewrite what
+     * every other caller already holds. Pinned by
+     * {@code TagSchemaCreationOutputImplSchemaBuilderTest.test_repeatedCalls_produceEqualButIndependentDocuments}.
      *
-     * @deprecated retained for source compatibility with callers outside this repository (e.g. the commercial
-     *     bidirectional adapter and the integration tests in hivemq-edge-test). Use
-     *     {@link #getSchema(TagSchemaDirection)} instead, which makes the direction explicit. Note this returns
-     *     the NORTHBOUND schema, which is what this method always produced — the southbound DataHub resources in
-     *     {@code ProtocolAdapterWritingServiceImpl.createDataHubResources} rely on that.
+     * @deprecated retained for source compatibility with callers outside this repository (the integration tests
+     *     in hivemq-edge-test). Use {@link #getSchema(TagSchemaDirection)} instead, which makes the direction
+     *     explicit. Note this returns the NORTHBOUND schema, which is what this method always produced. The
+     *     southbound DataHub resources in {@code ProtocolAdapterWritingServiceImpl.createDataHubResources} used
+     *     to obtain the schema through here and therefore registered the northbound document as the destination
+     *     of a write; they now request {@link TagSchemaDirection#SOUTHBOUND} explicitly.
      */
     @Deprecated(forRemoval = true)
     public @NotNull CompletableFuture<ObjectNode> getFuture() {
@@ -117,15 +124,31 @@ public class TagSchemaCreationOutputImpl implements TagSchemaCreationOutput {
      * The schema for the <em>southbound</em> (write) direction: only what a write targets. The non-writable
      * envelope ({@code tagName}, {@code timestamp}, {@code metadata}, {@code context}) is dropped entirely — a write
      * form should never present fields that cannot be written. The {@code value} is the adapter's explicit
-     * {@link DataPointSchema#writeSchema() writeSchema} when it provides one (e.g. a condition tag's
-     * {@code {eventId, method, comment}}); otherwise the plain {@code valueSchema}.
+     * southbound schema when it provides one (e.g. a condition tag's {@code {eventId, method, comment}});
+     * otherwise the plain {@code valueSchema}.
      * <p>
-     * <b>Note:</b> read-only fields are <em>not</em> pruned. A statically-derived write schema cannot express
-     * write-validity correctly (an array of read-only items admits only {@code []}; a required read-only member
-     * makes the object unsatisfiable) — that is a runtime concern (the {@code readOnly ⇒ ⊥} matcher rule) left to
-     * Nevsky. Only the non-writable envelope is stripped here.
+     * <b>Note:</b> read-only fields inside the value are <em>not</em> pruned. A statically-derived write schema
+     * cannot express write-validity correctly (an array of read-only items admits only {@code []}; a required
+     * read-only member makes the object unsatisfiable). Only the non-writable envelope is stripped here.
+     * <p>
+     * <b>{@code readOnly} is descriptive metadata, not a safety boundary.</b> It is a JSON Schema annotation, not
+     * an assertion: the DataHub validator on the southbound path (networknt, default configuration) does not
+     * reject an instance for carrying a read-only field. Consumers use it to decide what to <em>offer</em> as a
+     * write destination. Turning it into an enforced rule ({@code readOnly ⇒ ⊥}) is runtime matcher work left to
+     * Nevsky; until then nothing in Edge rejects a write on the strength of this flag.
+     * <p>
+     * Because {@link com.hivemq.adapter.sdk.api.schema.SchemaBuilder} defaults every node to
+     * {@code writable = false}, an adapter supplying an explicit southbound schema must chain {@code .writable()}
+     * on the root and on each writable member — otherwise the whole shape renders {@code readOnly} and offers no
+     * destinations at all. See {@code TagSchemaCreationOutputImplSchemaBuilderTest} for both cases.
      */
+    @SuppressWarnings({"deprecation", "removal"})
     private static @NotNull Schema southboundSchema(final @NotNull DataPointSchema tagSchemas) {
+        // Deliberately the deprecated accessor. The SDK renames this component to southboundSchema in a
+        // separate PR, and CI resolves the adapter SDK by matching the branch name — a PR whose branch has no
+        // SDK counterpart builds against SDK master. writeSchema() exists on both the current SDK and the
+        // renamed one (which keeps it as a delegate), so this compiles either way; switching to
+        // southboundSchema() here before the SDK rename lands would break every PR stacked on this branch.
         final Schema writeValue =
                 tagSchemas.writeSchema() != null ? tagSchemas.writeSchema() : tagSchemas.valueSchema();
 

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/tag/TagSchemaCreationOutputImpl.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/tag/TagSchemaCreationOutputImpl.java
@@ -137,6 +137,11 @@ public class TagSchemaCreationOutputImpl implements TagSchemaCreationOutput {
      * write destination. Turning it into an enforced rule ({@code readOnly ⇒ ⊥}) is runtime matcher work left to
      * Nevsky; until then nothing in Edge rejects a write on the strength of this flag.
      * <p>
+     * Because that rule is coming, the flags this method emits must already be true rather than merely
+     * harmless: the document root is marked writable below, and
+     * {@code test_southboundRoot_isNeverReadOnly_soEnforcementWouldNotRejectEveryWrite} pins it by running a
+     * conforming write through networknt with enforcement switched on.
+     * <p>
      * Because {@link com.hivemq.adapter.sdk.api.schema.SchemaBuilder} defaults every node to
      * {@code writable = false}, an adapter supplying an explicit southbound schema must chain {@code .writable()}
      * on the root and on each writable member — otherwise the whole shape renders {@code readOnly} and offers no
@@ -158,7 +163,17 @@ public class TagSchemaCreationOutputImpl implements TagSchemaCreationOutput {
         // the adapter put on its own schema root — identical to the northbound rendering of the same value,
         // which is what lets a consumer detect "read and write use the same schema" by comparing value shapes.
         builder.property("value").required().schema(writeValue);
-        return builder.endObject().build();
+        // The wrapper itself is writable, and saying so matters. SchemaBuilder defaults every node to
+        // writable = false, which renders readOnly on the document root — on the one document whose entire
+        // purpose is to be written. Harmless while readOnly is only an annotation, but the moment it becomes
+        // an assertion (the readOnly ⇒ ⊥ rule) a read-only root rejects EVERY southbound write for EVERY tag,
+        // arrays or not: networknt's readOnly check fires on the node being present at all, so the root error
+        // lands on every instance. Verified against networknt with readOnly enforcement enabled — with the
+        // default flag a conforming command produces "$: is a readonly field, it cannot be changed".
+        //
+        // The northbound wrapper keeps its readOnly, and correctly so: that document describes what is
+        // published, and it genuinely cannot be written. The asymmetry is the point, not an oversight.
+        return builder.endObject().writable().build();
     }
 
     @Override

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/tag/TagSchemaCreationOutputImpl.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/tag/TagSchemaCreationOutputImpl.java
@@ -17,33 +17,119 @@ package com.hivemq.protocols.tag;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.hivemq.adapter.sdk.api.schema.ScalarType;
+import com.hivemq.adapter.sdk.api.schema.Schema;
+import com.hivemq.adapter.sdk.api.schema.SchemaBuilder;
 import com.hivemq.adapter.sdk.api.schema.SchemaJsonRepresentation;
 import com.hivemq.adapter.sdk.api.schema.TagSchemaCreationOutput;
 import com.hivemq.exceptions.StackLessProtocolAdapterException;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class TagSchemaCreationOutputImpl implements TagSchemaCreationOutput {
 
+    /**
+     * The direction of the tag schema requested by a consumer.
+     */
+    public enum Direction {
+        /** Northbound / read: the full data shape — {@code tagName}, {@code timestamp}, {@code value}, and any
+         * {@code metadata} / {@code context}. */
+        READ,
+        /** Southbound / write: only what can be written — just the {@code value}, with the non-writable
+         * {@code tagName} / {@code timestamp} / {@code metadata} / {@code context} dropped. */
+        WRITE
+    }
+
     private volatile @Nullable String message = null;
     private volatile @NotNull Status status = Status.SUCCESS;
-    private final @NotNull CompletableFuture<ObjectNode> future =
-            new CompletableFuture<ObjectNode>().orTimeout(30, TimeUnit.SECONDS);
+
+    // The adapter provides the raw DataPointSchema; the direction (read/write) is chosen at the consuming edge,
+    // so the future carries the schema itself rather than a pre-composed JSON node.
+    private final @NotNull CompletableFuture<DataPointSchema> future =
+            new CompletableFuture<DataPointSchema>().orTimeout(30, TimeUnit.SECONDS);
 
     public @Nullable String getMessage() {
         return message;
     }
 
-    public @NotNull CompletableFuture<ObjectNode> getFuture() {
-        return future;
+    /**
+     * Resolves the produced schema, selects the schema for the requested direction, and renders it as a
+     * JSON Schema document.
+     * <p>
+     * Which aspects belong to a read vs a write shape is this class's concern, because it owns the
+     * {@link DataPointSchema}. {@link SchemaJsonRepresentation} is direction-agnostic: it only converts a
+     * {@link Schema} to its JSON representation.
+     *
+     * @param direction READ (northbound) or WRITE (southbound).
+     * @return the JSON schema document for that direction.
+     */
+    public @NotNull ObjectNode getSchema(final @NotNull Direction direction)
+            throws ExecutionException, InterruptedException {
+        final DataPointSchema tagSchemas = future.get();
+        final Schema schema =
+                switch (direction) {
+                    case READ -> readSchema(tagSchemas);
+                    case WRITE -> writeSchema(tagSchemas);
+                };
+        return SchemaJsonRepresentation.INSTANCE.toJsonSchemaDocument(schema);
+    }
+
+    /**
+     * The schema for the <em>read</em> (northbound) direction: the envelope ({@code tagName}, {@code timestamp})
+     * wrapping {@code value}, plus optional {@code metadata} / {@code context}. Writability is irrelevant here — a
+     * read consumer observes the full data shape.
+     */
+    private static @NotNull Schema readSchema(final @NotNull DataPointSchema tagSchemas) {
+        final var builder = new SchemaBuilder().startObject();
+
+        builder.property("tagName").scalar(ScalarType.STRING).readable().writable(false);
+        builder.property("timestamp").scalar(ScalarType.LONG).readable().writable(false);
+        builder.property("value")
+                .required()
+                .schema(tagSchemas.valueSchema())
+                .readable()
+                .writable();
+
+        if (tagSchemas.metadataSchema() != null) {
+            builder.property("metadata")
+                    .schema(tagSchemas.metadataSchema())
+                    .readable()
+                    .writable(false);
+        }
+        if (tagSchemas.context() != null) {
+            builder.property("context").schema(tagSchemas.context()).readable().writable(false);
+        }
+
+        return builder.endObject().build();
+    }
+
+    /**
+     * The schema for the <em>write</em> (southbound) direction: only what can be written. The non-writable
+     * envelope ({@code tagName}, {@code timestamp}, {@code metadata}, {@code context}) is dropped entirely — a write
+     * form should never present fields that cannot be written. The {@code value} is the adapter's explicit
+     * {@link DataPointSchema#writeSchema() writeSchema} when it provides one (e.g. a condition tag's
+     * {@code {eventId, method, comment}}); otherwise the plain {@code valueSchema}.
+     * <p>
+     * <b>Note:</b> read-only fields are <em>not</em> pruned. A statically-derived write schema cannot express
+     * write-validity correctly (an array of read-only items admits only {@code []}; a required read-only member
+     * makes the object unsatisfiable) — that is a runtime concern (the {@code readOnly ⇒ ⊥} matcher rule) left to
+     * Nevsky. Only the non-writable envelope is stripped here.
+     */
+    private static @NotNull Schema writeSchema(final @NotNull DataPointSchema tagSchemas) {
+        final Schema writeValue =
+                tagSchemas.writeSchema() != null ? tagSchemas.writeSchema() : tagSchemas.valueSchema();
+
+        final var builder = new SchemaBuilder().startObject();
+        builder.property("value").required().schema(writeValue).readable(false).writable();
+        return builder.endObject().build();
     }
 
     @Override
     public void finish(@NotNull final DataPointSchema schema) {
-        final SchemaJsonRepresentation instance = SchemaJsonRepresentation.INSTANCE;
-        future.complete(instance.toCompositeSchema(schema));
+        future.complete(schema);
     }
 
     @Override

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/tag/TagSchemaDirection.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/tag/TagSchemaDirection.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.protocols.tag;
+
+/**
+ * The direction of the tag schema requested by a consumer. The values follow Edge's data-flow vocabulary
+ * rather than read/write: "read/write" only holds for variable-shaped tags, while for method- or
+ * condition-shaped tags the southbound schema is a request shape, not the writable subset of the northbound
+ * one. The names are also the public REST vocabulary (the {@code direction} query parameter of
+ * {@code GET /api/v1/management/protocol-adapters/schema/{adapterId}/{tagName}}).
+ */
+public enum TagSchemaDirection {
+    /**
+     * Northbound (adapter → broker, "read"): the full data shape published for the tag — {@code tagName},
+     * {@code timestamp}, {@code value}, and any {@code metadata} / {@code context}.
+     */
+    NORTHBOUND,
+    /**
+     * Southbound (broker → adapter, "write"): the shape a write targets — only the {@code value}, with the
+     * non-writable {@code tagName} / {@code timestamp} / {@code metadata} / {@code context} envelope dropped.
+     */
+    SOUTHBOUND
+}

--- a/hivemq-edge/src/test/java/com/hivemq/api/resources/impl/ProtocolAdaptersResourceImplTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/api/resources/impl/ProtocolAdaptersResourceImplTest.java
@@ -20,10 +20,16 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hivemq.adapter.sdk.api.ProtocolAdapter;
+import com.hivemq.adapter.sdk.api.schema.ScalarType;
+import com.hivemq.adapter.sdk.api.schema.SchemaBuilder;
+import com.hivemq.adapter.sdk.api.schema.TagSchemaCreationOutput;
 import com.hivemq.combining.model.DataIdentifierReference;
 import com.hivemq.configuration.entity.adapter.DomainTagOwnerConverter;
 import com.hivemq.configuration.entity.adapter.NorthboundMappingEntity;
@@ -51,6 +57,7 @@ import com.hivemq.persistence.domain.DomainTagAddResult;
 import com.hivemq.persistence.topicfilter.TopicFilterPersistence;
 import com.hivemq.protocols.InternalProtocolAdapterWritingService;
 import com.hivemq.protocols.ProtocolAdapterManager;
+import com.hivemq.protocols.ProtocolAdapterWrapper;
 import jakarta.ws.rs.core.Response;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -827,5 +834,76 @@ class ProtocolAdaptersResourceImplTest {
         final Response response = protocolAdaptersResource.updateAdapterDomainTags(adapterId, uniqueTagList);
 
         assertEquals(200, response.getStatus());
+    }
+
+    private void mockAdapterWithTagSchema(final @NotNull String adapterId) {
+        final ProtocolAdapterWrapper wrapper = mock();
+        final ProtocolAdapter adapter = mock();
+        when(wrapper.getAdapter()).thenReturn(adapter);
+        doAnswer(invocation -> {
+                    final TagSchemaCreationOutput output = invocation.getArgument(1);
+                    output.finish(new TagSchemaCreationOutput.DataPointSchema(
+                            new SchemaBuilder()
+                                    .scalar(ScalarType.LONG)
+                                    .title("RPM")
+                                    .build(),
+                            null,
+                            null));
+                    return null;
+                })
+                .when(adapter)
+                .createTagSchema(any(), any());
+        when(protocolAdapterManager.getProtocolAdapterWrapperByAdapterId(adapterId))
+                .thenReturn(Optional.of(wrapper));
+    }
+
+    @Test
+    void getSchema_whenDirectionOmitted_thenReturnsTheNorthboundSchema() {
+        mockAdapterWithTagSchema("adapter");
+
+        final Response response = protocolAdaptersResource.getSchema("adapter", "tag", null);
+
+        assertEquals(200, response.getStatus());
+        final JsonNode schema = (JsonNode) response.getEntity();
+        assertThat(schema.get("properties").has("tagName")).isTrue();
+        assertThat(schema.get("properties").has("value")).isTrue();
+    }
+
+    @Test
+    void getSchema_whenDirectionIsSouthbound_thenReturnsTheEnvelopeFreeSchema() {
+        mockAdapterWithTagSchema("adapter");
+
+        final Response response = protocolAdaptersResource.getSchema("adapter", "tag", "SOUTHBOUND");
+
+        assertEquals(200, response.getStatus());
+        final JsonNode schema = (JsonNode) response.getEntity();
+        assertThat(schema.get("properties").has("tagName")).isFalse();
+        assertThat(schema.get("properties").has("value")).isTrue();
+    }
+
+    @Test
+    void getSchema_whenDirectionIsUnknown_thenReturns400() {
+        // A typo must fail loudly: silently defaulting to NORTHBOUND would hand the caller a
+        // differently-shaped document with no signal.
+        final Response response = protocolAdaptersResource.getSchema("adapter", "tag", "SOUTBOUND");
+
+        assertEquals(400, response.getStatus());
+    }
+
+    @Test
+    void getSchema_whenDirectionIsLowercase_thenReturns400() {
+        // The OpenAPI enum is uppercase-only; the implementation must not be more lenient than the contract.
+        final Response response = protocolAdaptersResource.getSchema("adapter", "tag", "southbound");
+
+        assertEquals(400, response.getStatus());
+    }
+
+    @Test
+    void getWritingSchema_redirectsWithTheSouthboundDirection() {
+        final Response response = protocolAdaptersResource.getWritingSchema("adapter", "tag");
+
+        assertEquals(301, response.getStatus());
+        assertThat(response.getLocation().toString())
+                .isEqualTo("/api/v1/management/protocol-adapters/schema/adapter/tag?direction=SOUTHBOUND");
     }
 }

--- a/hivemq-edge/src/test/java/com/hivemq/edge/modules/adapters/simulation/SimulationProtocolAdapterTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/edge/modules/adapters/simulation/SimulationProtocolAdapterTest.java
@@ -50,6 +50,7 @@ import com.hivemq.edge.modules.adapters.simulation.tag.SimulationValueType;
 import com.hivemq.edge.modules.adapters.simulation.tag.StaticValueConfig;
 import com.hivemq.protocols.tag.TagSchemaCreationInputImpl;
 import com.hivemq.protocols.tag.TagSchemaCreationOutputImpl;
+import com.hivemq.protocols.tag.TagSchemaDirection;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
@@ -451,7 +452,7 @@ class SimulationProtocolAdapterTest {
         final TagSchemaCreationOutputImpl output = new TagSchemaCreationOutputImpl();
         simulationProtocolAdapter.createTagSchema(new TagSchemaCreationInputImpl("does-not-exist"), output);
 
-        assertThatThrownBy(() -> output.getSchema(TagSchemaCreationOutputImpl.Direction.READ))
+        assertThatThrownBy(() -> output.getSchema(TagSchemaDirection.NORTHBOUND))
                 .isInstanceOf(ExecutionException.class);
         assertThat(output.getStatus()).isEqualTo(TagSchemaCreationOutputImpl.Status.UNSPECIFIED_FAILURE);
         assertThat(output.getMessage()).contains("does-not-exist");
@@ -518,7 +519,7 @@ class SimulationProtocolAdapterTest {
     private @NotNull ObjectNode resolveSchema(final @NotNull String tagName) throws Exception {
         final TagSchemaCreationOutputImpl output = new TagSchemaCreationOutputImpl();
         simulationProtocolAdapter.createTagSchema(new TagSchemaCreationInputImpl(tagName), output);
-        return output.getSchema(TagSchemaCreationOutputImpl.Direction.READ);
+        return output.getSchema(TagSchemaDirection.NORTHBOUND);
     }
 
     private static void assertValueScalarType(final @NotNull ObjectNode schema, final @NotNull String scalarType) {

--- a/hivemq-edge/src/test/java/com/hivemq/edge/modules/adapters/simulation/SimulationProtocolAdapterTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/edge/modules/adapters/simulation/SimulationProtocolAdapterTest.java
@@ -451,7 +451,8 @@ class SimulationProtocolAdapterTest {
         final TagSchemaCreationOutputImpl output = new TagSchemaCreationOutputImpl();
         simulationProtocolAdapter.createTagSchema(new TagSchemaCreationInputImpl("does-not-exist"), output);
 
-        assertThatThrownBy(() -> output.getFuture().get()).isInstanceOf(ExecutionException.class);
+        assertThatThrownBy(() -> output.getSchema(TagSchemaCreationOutputImpl.Direction.READ))
+                .isInstanceOf(ExecutionException.class);
         assertThat(output.getStatus()).isEqualTo(TagSchemaCreationOutputImpl.Status.UNSPECIFIED_FAILURE);
         assertThat(output.getMessage()).contains("does-not-exist");
     }
@@ -517,7 +518,7 @@ class SimulationProtocolAdapterTest {
     private @NotNull ObjectNode resolveSchema(final @NotNull String tagName) throws Exception {
         final TagSchemaCreationOutputImpl output = new TagSchemaCreationOutputImpl();
         simulationProtocolAdapter.createTagSchema(new TagSchemaCreationInputImpl(tagName), output);
-        return output.getFuture().get();
+        return output.getSchema(TagSchemaCreationOutputImpl.Direction.READ);
     }
 
     private static void assertValueScalarType(final @NotNull ObjectNode schema, final @NotNull String scalarType) {

--- a/hivemq-edge/src/test/java/com/hivemq/schema/TagSchemaCreationOutputImplSchemaBuilderTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/schema/TagSchemaCreationOutputImplSchemaBuilderTest.java
@@ -297,8 +297,8 @@ class TagSchemaCreationOutputImplSchemaBuilderTest {
     @Test
     void test_repeatedCalls_produceEqualButIndependentDocuments() throws ExecutionException, InterruptedException {
         final var output = new TagSchemaCreationOutputImpl();
-        output.finish(new TagSchemaCreationOutput.DataPointSchema(
-                alarmEventSchema(), null, null, conditionCommandSchema()));
+        output.finish(
+                new TagSchemaCreationOutput.DataPointSchema(alarmEventSchema(), null, null, conditionCommandSchema()));
 
         // Both accessors compose a document per call rather than handing out one shared instance. Composition is
         // a pure function of the DataPointSchema the adapter finished with, so every call must produce an equal
@@ -318,8 +318,7 @@ class TagSchemaCreationOutputImplSchemaBuilderTest {
 
         first.put("$id", "urn:mutated-by-a-caller");
         assertThat(second.has("$id")).isFalse();
-        assertThat(output.getSchema(TagSchemaDirection.NORTHBOUND).has("$id"))
-                .isFalse();
+        assertThat(output.getSchema(TagSchemaDirection.NORTHBOUND).has("$id")).isFalse();
         assertThat(output.getFuture().get().has("$id")).isFalse();
     }
 
@@ -330,8 +329,8 @@ class TagSchemaCreationOutputImplSchemaBuilderTest {
 
         // A tag whose write shape is not a projection of its read shape — e.g. an OPC-UA condition tag, whose
         // northbound shape is the alarm event but whose write target is {eventId, method, comment}.
-        output.finish(new TagSchemaCreationOutput.DataPointSchema(
-                alarmEventSchema(), null, null, conditionCommandSchema()));
+        output.finish(
+                new TagSchemaCreationOutput.DataPointSchema(alarmEventSchema(), null, null, conditionCommandSchema()));
 
         final JsonNode writeValue = output.getSchema(TagSchemaDirection.SOUTHBOUND)
                 .get("properties")
@@ -356,8 +355,8 @@ class TagSchemaCreationOutputImplSchemaBuilderTest {
     void test_southboundSchema_writableCommandFieldsAreNotRenderedReadOnly()
             throws ExecutionException, InterruptedException {
         final var output = new TagSchemaCreationOutputImpl();
-        output.finish(new TagSchemaCreationOutput.DataPointSchema(
-                alarmEventSchema(), null, null, conditionCommandSchema()));
+        output.finish(
+                new TagSchemaCreationOutput.DataPointSchema(alarmEventSchema(), null, null, conditionCommandSchema()));
 
         final JsonNode writeValue = output.getSchema(TagSchemaDirection.SOUTHBOUND)
                 .get("properties")
@@ -376,8 +375,8 @@ class TagSchemaCreationOutputImplSchemaBuilderTest {
     @Test
     void test_southboundSchema_conditionCommandDocumentIsPinned() throws Exception {
         final var output = new TagSchemaCreationOutputImpl();
-        output.finish(new TagSchemaCreationOutput.DataPointSchema(
-                alarmEventSchema(), null, null, conditionCommandSchema()));
+        output.finish(
+                new TagSchemaCreationOutput.DataPointSchema(alarmEventSchema(), null, null, conditionCommandSchema()));
 
         // The exact document the REST endpoint serves for an A&C condition tag. It is pinned here because the
         // frontend fixture in MappingInstructionList.spec.cy.tsx is a copy of it: a hand-written fixture that
@@ -386,8 +385,7 @@ class TagSchemaCreationOutputImplSchemaBuilderTest {
         //
         // Note the readOnly on the root: that flag is on the wrapper this class builds, not on the adapter's
         // command schema, and no consumer reads it (getPropertyListFrom only walks `properties`).
-        final String expected =
-                """
+        final String expected = """
                 {
                   "type": "object",
                   "properties": {

--- a/hivemq-edge/src/test/java/com/hivemq/schema/TagSchemaCreationOutputImplSchemaBuilderTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/schema/TagSchemaCreationOutputImplSchemaBuilderTest.java
@@ -20,11 +20,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.hivemq.adapter.sdk.api.schema.ScalarType;
 import com.hivemq.adapter.sdk.api.schema.SchemaBuilder;
+import com.hivemq.adapter.sdk.api.schema.SchemaJsonRepresentation;
 import com.hivemq.adapter.sdk.api.schema.TagSchemaCreationOutput;
 import com.hivemq.protocols.tag.TagSchemaCreationOutputImpl;
+import com.hivemq.protocols.tag.TagSchemaDirection;
 import java.util.concurrent.ExecutionException;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
+// The class-level timeout keeps a schema that never completes from stalling a test for the future's
+// internal 30s orTimeout: every test here completes the future synchronously, so a hang is a bug.
+@Timeout(5)
 class TagSchemaCreationOutputImplSchemaBuilderTest {
 
     @Test
@@ -34,7 +40,7 @@ class TagSchemaCreationOutputImplSchemaBuilderTest {
         output.finish(new TagSchemaCreationOutput.DataPointSchema(
                 new SchemaBuilder().scalar(ScalarType.LONG).title("RPM").build(), null, null));
 
-        final JsonNode result = output.getSchema(TagSchemaCreationOutputImpl.Direction.READ);
+        final JsonNode result = output.getSchema(TagSchemaDirection.NORTHBOUND);
         assertThat(result).isNotNull();
         assertThat(result.get("properties").get("value").get("type").asText()).isEqualTo("integer");
         assertThat(result.get("properties").get("value").get("title").asText()).isEqualTo("RPM");
@@ -60,8 +66,7 @@ class TagSchemaCreationOutputImplSchemaBuilderTest {
                 null,
                 null));
 
-        final JsonNode result = output.getSchema(TagSchemaCreationOutputImpl.Direction.READ);
-        System.out.println(result);
+        final JsonNode result = output.getSchema(TagSchemaDirection.NORTHBOUND);
         assertThat(result.get("type").asText()).isEqualTo("object");
         assertThat(result.get("properties").get("value").get("properties").has("temperature"))
                 .isTrue();
@@ -72,7 +77,7 @@ class TagSchemaCreationOutputImplSchemaBuilderTest {
     }
 
     @Test
-    void test_writeSchema_dropsTheNonWritableEnvelope() throws ExecutionException, InterruptedException {
+    void test_southboundSchema_dropsTheNonWritableEnvelope() throws ExecutionException, InterruptedException {
         final var output = new TagSchemaCreationOutputImpl();
 
         output.finish(new TagSchemaCreationOutput.DataPointSchema(
@@ -85,7 +90,7 @@ class TagSchemaCreationOutputImplSchemaBuilderTest {
                         .build(),
                 null));
 
-        final JsonNode result = output.getSchema(TagSchemaCreationOutputImpl.Direction.WRITE);
+        final JsonNode result = output.getSchema(TagSchemaDirection.SOUTHBOUND);
 
         // Only the value survives; tagName / timestamp / metadata can never be written.
         final JsonNode properties = result.get("properties");
@@ -97,7 +102,7 @@ class TagSchemaCreationOutputImplSchemaBuilderTest {
     }
 
     @Test
-    void test_readSchema_keepsTheEnvelope() throws ExecutionException, InterruptedException {
+    void test_northboundSchema_keepsTheEnvelope() throws ExecutionException, InterruptedException {
         final var output = new TagSchemaCreationOutputImpl();
 
         output.finish(new TagSchemaCreationOutput.DataPointSchema(
@@ -111,9 +116,9 @@ class TagSchemaCreationOutputImplSchemaBuilderTest {
                 null));
 
         final JsonNode properties =
-                output.getSchema(TagSchemaCreationOutputImpl.Direction.READ).get("properties");
+                output.getSchema(TagSchemaDirection.NORTHBOUND).get("properties");
 
-        // The read direction observes the full data shape — the counterpart to the write test above.
+        // The northbound direction observes the full data shape — the counterpart to the southbound test above.
         assertThat(properties.has("value")).isTrue();
         assertThat(properties.has("tagName")).isTrue();
         assertThat(properties.has("timestamp")).isTrue();
@@ -121,7 +126,133 @@ class TagSchemaCreationOutputImplSchemaBuilderTest {
     }
 
     @Test
-    void test_writeSchema_explicitWriteSchemaIsUsedInsteadOfTheValue() throws ExecutionException, InterruptedException {
+    void test_context_appearsNorthboundOnly() throws ExecutionException, InterruptedException {
+        final var output = new TagSchemaCreationOutputImpl();
+
+        output.finish(new TagSchemaCreationOutput.DataPointSchema(
+                new SchemaBuilder().scalar(ScalarType.LONG).build(),
+                null,
+                new SchemaBuilder()
+                        .startObject()
+                        .property("sourceNode")
+                        .scalar(ScalarType.STRING)
+                        .endObject()
+                        .build()));
+
+        final JsonNode northbound =
+                output.getSchema(TagSchemaDirection.NORTHBOUND).get("properties");
+        assertThat(northbound.has("context")).isTrue();
+        assertThat(northbound.get("context").get("readOnly").asBoolean()).isTrue();
+        // No metadata was provided, so the northbound envelope must not invent one.
+        assertThat(northbound.has("metadata")).isFalse();
+
+        final JsonNode southbound =
+                output.getSchema(TagSchemaDirection.SOUTHBOUND).get("properties");
+        assertThat(southbound.has("context")).isFalse();
+    }
+
+    @Test
+    void test_southboundValue_equalsNorthboundValue_forPlainValueTags()
+            throws ExecutionException, InterruptedException {
+        final var output = new TagSchemaCreationOutputImpl();
+
+        // A writable plain tag: the adapter marks its value schema's root writable; one member is read-only.
+        output.finish(new TagSchemaCreationOutput.DataPointSchema(
+                new SchemaBuilder()
+                        .startObject()
+                        .property("temperature")
+                        .required()
+                        .scalar(ScalarType.DOUBLE)
+                        .property("unit")
+                        .scalar(ScalarType.STRING)
+                        .readable(true)
+                        .writable(false)
+                        .endObject()
+                        .writable()
+                        .build(),
+                null,
+                null));
+
+        final JsonNode northboundValue = output.getSchema(TagSchemaDirection.NORTHBOUND)
+                .get("properties")
+                .get("value");
+        final JsonNode southboundValue = output.getSchema(TagSchemaDirection.SOUTHBOUND)
+                .get("properties")
+                .get("value");
+
+        // The frontend decides "read and write use the same schema" by comparing the value sub-schemas, so
+        // for a plain value tag the two directions must render the value identically. Both render the
+        // adapter's schema as-is: its root flags pass through untouched (no readOnly for this writable tag)
+        // and per-field flags inside the value are preserved.
+        assertThat(southboundValue).isEqualTo(northboundValue);
+        assertThat(southboundValue.has("readOnly")).isFalse();
+        assertThat(southboundValue.has("writeOnly")).isFalse();
+        assertThat(southboundValue.get("properties").get("unit").get("readOnly").asBoolean())
+                .isTrue();
+    }
+
+    @SuppressWarnings({"deprecation", "removal"})
+    @Test
+    void test_northboundSchema_pinnedToDeprecatedSdkCompositeSchema() throws ExecutionException, InterruptedException {
+        // The SDK keeps toCompositeSchema for adapters built against an older SDK, and the dependency direction
+        // prevents either side from delegating to the other. This pin fails the day one of the two copies drifts:
+        // third-party adapters see the SDK copy, Edge serves the northbound schema.
+        final var dps = new TagSchemaCreationOutput.DataPointSchema(
+                new SchemaBuilder()
+                        .startObject()
+                        .property("temperature")
+                        .required()
+                        .scalar(ScalarType.DOUBLE)
+                        .property("unit")
+                        .scalar(ScalarType.STRING)
+                        .readable(true)
+                        .writable(false)
+                        .endObject()
+                        .build(),
+                new SchemaBuilder()
+                        .startObject()
+                        .property("quality")
+                        .scalar(ScalarType.LONG)
+                        .endObject()
+                        .build(),
+                new SchemaBuilder()
+                        .startObject()
+                        .property("sourceNode")
+                        .scalar(ScalarType.STRING)
+                        .endObject()
+                        .build());
+
+        final var output = new TagSchemaCreationOutputImpl();
+        output.finish(dps);
+
+        assertThat(output.getSchema(TagSchemaDirection.NORTHBOUND))
+                .isEqualTo(SchemaJsonRepresentation.INSTANCE.toCompositeSchema(dps));
+    }
+
+    @SuppressWarnings({"deprecation", "removal"})
+    @Test
+    void test_getFuture_returnsTheNorthboundSchema() throws ExecutionException, InterruptedException {
+        // getFuture() is the compatibility surface for callers outside this repository — most importantly the
+        // southbound DataHub resources (ProtocolAdapterWritingServiceImpl.createDataHubResources): if this pin
+        // breaks, southbound policy validation silently changes shape.
+        final var output = new TagSchemaCreationOutputImpl();
+
+        output.finish(new TagSchemaCreationOutput.DataPointSchema(
+                new SchemaBuilder().scalar(ScalarType.LONG).title("RPM").build(),
+                new SchemaBuilder()
+                        .startObject()
+                        .property("unit")
+                        .scalar(ScalarType.STRING)
+                        .endObject()
+                        .build(),
+                null));
+
+        assertThat(output.getFuture().get()).isEqualTo(output.getSchema(TagSchemaDirection.NORTHBOUND));
+    }
+
+    @Test
+    void test_southboundSchema_explicitWriteSchemaIsUsedInsteadOfTheValue()
+            throws ExecutionException, InterruptedException {
         final var output = new TagSchemaCreationOutputImpl();
 
         // A tag whose write shape is not a projection of its read shape — e.g. an OPC-UA condition tag, whose
@@ -150,19 +281,19 @@ class TagSchemaCreationOutputImplSchemaBuilderTest {
                         .endObject()
                         .build()));
 
-        final JsonNode writeValue = output.getSchema(TagSchemaCreationOutputImpl.Direction.WRITE)
+        final JsonNode writeValue = output.getSchema(TagSchemaDirection.SOUTHBOUND)
                 .get("properties")
                 .get("value");
 
         assertThat(writeValue.get("properties").has("eventId")).isTrue();
         assertThat(writeValue.get("properties").has("method")).isTrue();
         assertThat(writeValue.get("properties").has("comment")).isTrue();
-        // The read-side value shape must not leak into the write direction.
+        // The northbound value shape must not leak into the southbound direction.
         assertThat(writeValue.get("properties").has("active")).isFalse();
         assertThat(writeValue.get("properties").has("severity")).isFalse();
 
-        // ...while the read direction still shows the alarm-event shape.
-        final JsonNode readValue = output.getSchema(TagSchemaCreationOutputImpl.Direction.READ)
+        // ...while the northbound direction still shows the alarm-event shape.
+        final JsonNode readValue = output.getSchema(TagSchemaDirection.NORTHBOUND)
                 .get("properties")
                 .get("value");
         assertThat(readValue.get("properties").has("active")).isTrue();
@@ -186,7 +317,7 @@ class TagSchemaCreationOutputImplSchemaBuilderTest {
         output.finish(new TagSchemaCreationOutput.DataPointSchema(
                 new SchemaBuilder().scalar(ScalarType.BOOLEAN).build(), null, null));
 
-        output.getSchema(TagSchemaCreationOutputImpl.Direction.READ);
+        output.getSchema(TagSchemaDirection.NORTHBOUND);
         assertThat(output.getStatus()).isEqualTo(TagSchemaCreationOutputImpl.Status.SUCCESS);
     }
 }

--- a/hivemq-edge/src/test/java/com/hivemq/schema/TagSchemaCreationOutputImplSchemaBuilderTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/schema/TagSchemaCreationOutputImplSchemaBuilderTest.java
@@ -383,8 +383,9 @@ class TagSchemaCreationOutputImplSchemaBuilderTest {
         // drifts from this output tests the mock rather than the feature (which is how the missing readOnly
         // annotations went unnoticed). Change one, change the other.
         //
-        // Note the readOnly on the root: that flag is on the wrapper this class builds, not on the adapter's
-        // command schema, and no consumer reads it (getPropertyListFrom only walks `properties`).
+        // Note the absence of readOnly anywhere: the wrapper root is writable (it is the document being
+        // written) and the adapter marked its command fields writable. Any readOnly in here is a bug — see
+        // test_southboundRoot_isNeverReadOnly_soEnforcementWouldNotRejectEveryWrite.
         final String expected = """
                 {
                   "type": "object",
@@ -400,13 +401,96 @@ class TagSchemaCreationOutputImplSchemaBuilderTest {
                     }
                   },
                   "required": [ "value" ],
-                  "readOnly": true,
                   "$schema": "https://json-schema.org/draft/2019-09/schema"
                 }
                 """;
 
         assertThat(output.getSchema(TagSchemaDirection.SOUTHBOUND))
                 .isEqualTo(new com.fasterxml.jackson.databind.ObjectMapper().readTree(expected));
+    }
+
+    /**
+     * The southbound document's <em>root</em> must never be {@code readOnly}, and this asserts it the only way
+     * that is convincing: by switching {@code readOnly} enforcement on and writing to it.
+     * <p>
+     * networknt's read-only check fires on the node being <em>present</em>, not on it changing, so a read-only
+     * root rejects every instance — i.e. every southbound write for every tag, arrays or not. While
+     * {@code readOnly} is a bare annotation that costs nothing and is easy to dismiss as cosmetic; the day the
+     * {@code readOnly ⇒ ⊥} rule is switched on it would reject 100% of writes and look like the rule itself
+     * being unimplementable. Pinning it under enforcement is what stops that.
+     */
+    @Test
+    void test_southboundRoot_isNeverReadOnly_soEnforcementWouldNotRejectEveryWrite() throws Exception {
+        final var output = new TagSchemaCreationOutputImpl();
+        output.finish(
+                new TagSchemaCreationOutput.DataPointSchema(alarmEventSchema(), null, null, conditionCommandSchema()));
+
+        final var mapper = new com.fasterxml.jackson.databind.ObjectMapper();
+        final JsonNode document = output.getSchema(TagSchemaDirection.SOUTHBOUND);
+        final String command = "{\"value\":{\"eventId\":\"evt-1\",\"method\":7,\"comment\":\"ack\"}}";
+
+        final var enforcing = com.networknt.schema.SchemaValidatorsConfig.builder()
+                .readOnly(true)
+                .build();
+        final var errors = com.networknt.schema.JsonSchemaFactory.getInstance(
+                        com.networknt.schema.SpecVersion.VersionFlag.V201909)
+                .getSchema(document, enforcing)
+                .validate(mapper.readTree(command));
+
+        assertThat(errors)
+                .as(
+                        "a conforming southbound command must survive readOnly enforcement; a readOnly root or "
+                                + "readOnly command fields would reject it: %s",
+                        errors)
+                .isEmpty();
+        assertThat(document.has("readOnly"))
+                .as("the document being written must not declare itself read-only")
+                .isFalse();
+    }
+
+    /**
+     * The counterpart: the northbound wrapper keeps {@code readOnly}, and that is correct. The published shape
+     * genuinely cannot be written, so the asymmetry between the two roots is meaningful rather than an
+     * oversight — and a future enforcement pass must not "tidy" it away.
+     */
+    @Test
+    void test_northboundRoot_staysReadOnly() throws ExecutionException, InterruptedException {
+        final var output = new TagSchemaCreationOutputImpl();
+        output.finish(
+                new TagSchemaCreationOutput.DataPointSchema(alarmEventSchema(), null, null, conditionCommandSchema()));
+
+        assertThat(output.getSchema(TagSchemaDirection.NORTHBOUND)
+                        .get("readOnly")
+                        .asBoolean())
+                .isTrue();
+    }
+
+    /** A read-only tag must still be refused under enforcement — the fix must not make everything writable. */
+    @Test
+    void test_readOnlyValue_isStillRejectedUnderEnforcement() throws Exception {
+        final var output = new TagSchemaCreationOutputImpl();
+        // A tag the device does not accept writes for: the adapter leaves its value schema non-writable.
+        output.finish(new TagSchemaCreationOutput.DataPointSchema(
+                new SchemaBuilder()
+                        .scalar(ScalarType.LONG)
+                        .readable()
+                        .writable(false)
+                        .build(),
+                null,
+                null));
+
+        final var mapper = new com.fasterxml.jackson.databind.ObjectMapper();
+        final var enforcing = com.networknt.schema.SchemaValidatorsConfig.builder()
+                .readOnly(true)
+                .build();
+        final var errors = com.networknt.schema.JsonSchemaFactory.getInstance(
+                        com.networknt.schema.SpecVersion.VersionFlag.V201909)
+                .getSchema(output.getSchema(TagSchemaDirection.SOUTHBOUND), enforcing)
+                .validate(mapper.readTree("{\"value\":42}"));
+
+        assertThat(errors)
+                .as("writing to a read-only tag must be refused once enforcement exists")
+                .isNotEmpty();
     }
 
     @Test

--- a/hivemq-edge/src/test/java/com/hivemq/schema/TagSchemaCreationOutputImplSchemaBuilderTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/schema/TagSchemaCreationOutputImplSchemaBuilderTest.java
@@ -23,29 +23,25 @@ import com.hivemq.adapter.sdk.api.schema.SchemaBuilder;
 import com.hivemq.adapter.sdk.api.schema.TagSchemaCreationOutput;
 import com.hivemq.protocols.tag.TagSchemaCreationOutputImpl;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import org.junit.jupiter.api.Test;
 
 class TagSchemaCreationOutputImplSchemaBuilderTest {
 
     @Test
-    void test_tagSchemaBuilder_build_completesTheFuture()
-            throws ExecutionException, InterruptedException, TimeoutException {
+    void test_tagSchemaBuilder_build_completesTheFuture() throws ExecutionException, InterruptedException {
         final var output = new TagSchemaCreationOutputImpl();
 
         output.finish(new TagSchemaCreationOutput.DataPointSchema(
                 new SchemaBuilder().scalar(ScalarType.LONG).title("RPM").build(), null, null));
 
-        final JsonNode result = output.getFuture().get(1, TimeUnit.SECONDS);
+        final JsonNode result = output.getSchema(TagSchemaCreationOutputImpl.Direction.READ);
         assertThat(result).isNotNull();
         assertThat(result.get("properties").get("value").get("type").asText()).isEqualTo("integer");
         assertThat(result.get("properties").get("value").get("title").asText()).isEqualTo("RPM");
     }
 
     @Test
-    void test_tagSchemaBuilder_object_completesWithJsonSchema()
-            throws ExecutionException, InterruptedException, TimeoutException {
+    void test_tagSchemaBuilder_object_completesWithJsonSchema() throws ExecutionException, InterruptedException {
         final var output = new TagSchemaCreationOutputImpl();
 
         output.finish(new TagSchemaCreationOutput.DataPointSchema(
@@ -64,7 +60,7 @@ class TagSchemaCreationOutputImplSchemaBuilderTest {
                 null,
                 null));
 
-        final JsonNode result = output.getFuture().get(1, TimeUnit.SECONDS);
+        final JsonNode result = output.getSchema(TagSchemaCreationOutputImpl.Direction.READ);
         System.out.println(result);
         assertThat(result.get("type").asText()).isEqualTo("object");
         assertThat(result.get("properties").get("value").get("properties").has("temperature"))
@@ -73,6 +69,104 @@ class TagSchemaCreationOutputImplSchemaBuilderTest {
                 .isTrue();
         assertThat(result.get("properties").get("value").get("required").get(0).asText())
                 .isEqualTo("temperature");
+    }
+
+    @Test
+    void test_writeSchema_dropsTheNonWritableEnvelope() throws ExecutionException, InterruptedException {
+        final var output = new TagSchemaCreationOutputImpl();
+
+        output.finish(new TagSchemaCreationOutput.DataPointSchema(
+                new SchemaBuilder().scalar(ScalarType.LONG).title("RPM").build(),
+                new SchemaBuilder()
+                        .startObject()
+                        .property("unit")
+                        .scalar(ScalarType.STRING)
+                        .endObject()
+                        .build(),
+                null));
+
+        final JsonNode result = output.getSchema(TagSchemaCreationOutputImpl.Direction.WRITE);
+
+        // Only the value survives; tagName / timestamp / metadata can never be written.
+        final JsonNode properties = result.get("properties");
+        assertThat(properties.has("value")).isTrue();
+        assertThat(properties.has("tagName")).isFalse();
+        assertThat(properties.has("timestamp")).isFalse();
+        assertThat(properties.has("metadata")).isFalse();
+        assertThat(properties.get("value").get("type").asText()).isEqualTo("integer");
+    }
+
+    @Test
+    void test_readSchema_keepsTheEnvelope() throws ExecutionException, InterruptedException {
+        final var output = new TagSchemaCreationOutputImpl();
+
+        output.finish(new TagSchemaCreationOutput.DataPointSchema(
+                new SchemaBuilder().scalar(ScalarType.LONG).build(),
+                new SchemaBuilder()
+                        .startObject()
+                        .property("unit")
+                        .scalar(ScalarType.STRING)
+                        .endObject()
+                        .build(),
+                null));
+
+        final JsonNode properties =
+                output.getSchema(TagSchemaCreationOutputImpl.Direction.READ).get("properties");
+
+        // The read direction observes the full data shape — the counterpart to the write test above.
+        assertThat(properties.has("value")).isTrue();
+        assertThat(properties.has("tagName")).isTrue();
+        assertThat(properties.has("timestamp")).isTrue();
+        assertThat(properties.has("metadata")).isTrue();
+    }
+
+    @Test
+    void test_writeSchema_explicitWriteSchemaIsUsedInsteadOfTheValue() throws ExecutionException, InterruptedException {
+        final var output = new TagSchemaCreationOutputImpl();
+
+        // A tag whose write shape is not a projection of its read shape — e.g. an OPC-UA condition tag, whose
+        // northbound shape is the alarm event but whose write target is {eventId, method, comment}.
+        output.finish(new TagSchemaCreationOutput.DataPointSchema(
+                new SchemaBuilder()
+                        .startObject()
+                        .property("active")
+                        .scalar(ScalarType.BOOLEAN)
+                        .property("severity")
+                        .scalar(ScalarType.LONG)
+                        .endObject()
+                        .build(),
+                null,
+                null,
+                new SchemaBuilder()
+                        .startObject()
+                        .property("eventId")
+                        .required()
+                        .scalar(ScalarType.STRING)
+                        .property("method")
+                        .required()
+                        .scalar(ScalarType.LONG)
+                        .property("comment")
+                        .scalar(ScalarType.STRING)
+                        .endObject()
+                        .build()));
+
+        final JsonNode writeValue = output.getSchema(TagSchemaCreationOutputImpl.Direction.WRITE)
+                .get("properties")
+                .get("value");
+
+        assertThat(writeValue.get("properties").has("eventId")).isTrue();
+        assertThat(writeValue.get("properties").has("method")).isTrue();
+        assertThat(writeValue.get("properties").has("comment")).isTrue();
+        // The read-side value shape must not leak into the write direction.
+        assertThat(writeValue.get("properties").has("active")).isFalse();
+        assertThat(writeValue.get("properties").has("severity")).isFalse();
+
+        // ...while the read direction still shows the alarm-event shape.
+        final JsonNode readValue = output.getSchema(TagSchemaCreationOutputImpl.Direction.READ)
+                .get("properties")
+                .get("value");
+        assertThat(readValue.get("properties").has("active")).isTrue();
+        assertThat(readValue.get("properties").has("eventId")).isFalse();
     }
 
     @Test
@@ -86,14 +180,13 @@ class TagSchemaCreationOutputImplSchemaBuilderTest {
     }
 
     @Test
-    void test_tagSchemaBuilder_statusRemainsSuccess()
-            throws ExecutionException, InterruptedException, TimeoutException {
+    void test_tagSchemaBuilder_statusRemainsSuccess() throws ExecutionException, InterruptedException {
         final var output = new TagSchemaCreationOutputImpl();
 
         output.finish(new TagSchemaCreationOutput.DataPointSchema(
                 new SchemaBuilder().scalar(ScalarType.BOOLEAN).build(), null, null));
 
-        output.getFuture().get(1, TimeUnit.SECONDS);
+        output.getSchema(TagSchemaCreationOutputImpl.Direction.READ);
         assertThat(output.getStatus()).isEqualTo(TagSchemaCreationOutputImpl.Status.SUCCESS);
     }
 }

--- a/hivemq-edge/src/test/java/com/hivemq/schema/TagSchemaCreationOutputImplSchemaBuilderTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/schema/TagSchemaCreationOutputImplSchemaBuilderTest.java
@@ -18,13 +18,16 @@ package com.hivemq.schema;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.hivemq.adapter.sdk.api.schema.ScalarType;
+import com.hivemq.adapter.sdk.api.schema.Schema;
 import com.hivemq.adapter.sdk.api.schema.SchemaBuilder;
 import com.hivemq.adapter.sdk.api.schema.SchemaJsonRepresentation;
 import com.hivemq.adapter.sdk.api.schema.TagSchemaCreationOutput;
 import com.hivemq.protocols.tag.TagSchemaCreationOutputImpl;
 import com.hivemq.protocols.tag.TagSchemaDirection;
 import java.util.concurrent.ExecutionException;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -232,9 +235,9 @@ class TagSchemaCreationOutputImplSchemaBuilderTest {
     @SuppressWarnings({"deprecation", "removal"})
     @Test
     void test_getFuture_returnsTheNorthboundSchema() throws ExecutionException, InterruptedException {
-        // getFuture() is the compatibility surface for callers outside this repository — most importantly the
-        // southbound DataHub resources (ProtocolAdapterWritingServiceImpl.createDataHubResources): if this pin
-        // breaks, southbound policy validation silently changes shape.
+        // getFuture() is the compatibility surface for callers outside this repository (the hivemq-edge-test
+        // integration tests). It must keep producing the northbound document it always produced. The southbound
+        // DataHub resources used to read the schema through here — they now ask for SOUTHBOUND explicitly.
         final var output = new TagSchemaCreationOutputImpl();
 
         output.finish(new TagSchemaCreationOutput.DataPointSchema(
@@ -250,6 +253,76 @@ class TagSchemaCreationOutputImplSchemaBuilderTest {
         assertThat(output.getFuture().get()).isEqualTo(output.getSchema(TagSchemaDirection.NORTHBOUND));
     }
 
+    /**
+     * The condition-command shape exactly as an adapter must build it: {@code .writable()} on the root and on
+     * every writable member. {@link com.hivemq.adapter.sdk.api.schema.SchemaBuilder} defaults to
+     * {@code writable = false}, and the mapping editor does not offer a read-only field as a write destination,
+     * so omitting these calls yields a southbound schema with no destinations —
+     * {@link #test_southboundSchema_unmarkedExplicitSchemaRendersReadOnly()} pins that trap.
+     * <p>
+     * This is also the fixture used by {@code MappingInstructionList.spec.cy.tsx}: the frontend test must see the
+     * document this builder actually produces, so if this shape changes, that fixture changes with it.
+     */
+    private static @NotNull Schema conditionCommandSchema() {
+        return new SchemaBuilder()
+                .startObject()
+                .property("eventId")
+                .required()
+                .scalar(ScalarType.STRING)
+                .writable()
+                .property("method")
+                .required()
+                .scalar(ScalarType.LONG)
+                .writable()
+                .property("comment")
+                .scalar(ScalarType.STRING)
+                .writable()
+                .endObject()
+                .writable()
+                .build();
+    }
+
+    private static @NotNull Schema alarmEventSchema() {
+        return new SchemaBuilder()
+                .startObject()
+                .property("active")
+                .scalar(ScalarType.BOOLEAN)
+                .property("severity")
+                .scalar(ScalarType.LONG)
+                .endObject()
+                .build();
+    }
+
+    @SuppressWarnings({"deprecation", "removal"})
+    @Test
+    void test_repeatedCalls_produceEqualButIndependentDocuments() throws ExecutionException, InterruptedException {
+        final var output = new TagSchemaCreationOutputImpl();
+        output.finish(new TagSchemaCreationOutput.DataPointSchema(
+                alarmEventSchema(), null, null, conditionCommandSchema()));
+
+        // Both accessors compose a document per call rather than handing out one shared instance. Composition is
+        // a pure function of the DataPointSchema the adapter finished with, so every call must produce an equal
+        // document — repeated calls are interchangeable in value.
+        assertThat(output.getFuture().get()).isEqualTo(output.getFuture().get());
+        assertThat(output.getSchema(TagSchemaDirection.NORTHBOUND))
+                .isEqualTo(output.getSchema(TagSchemaDirection.NORTHBOUND));
+        assertThat(output.getSchema(TagSchemaDirection.SOUTHBOUND))
+                .isEqualTo(output.getSchema(TagSchemaDirection.SOUTHBOUND));
+
+        // ...and they must be *separate* instances. ObjectNode is mutable: handing every caller the same node
+        // would let one caller's edit rewrite what the others already hold. That was the situation while this
+        // future carried a pre-composed ObjectNode; per-call composition is what removes it.
+        final ObjectNode first = output.getSchema(TagSchemaDirection.NORTHBOUND);
+        final ObjectNode second = output.getSchema(TagSchemaDirection.NORTHBOUND);
+        assertThat(first).isNotSameAs(second);
+
+        first.put("$id", "urn:mutated-by-a-caller");
+        assertThat(second.has("$id")).isFalse();
+        assertThat(output.getSchema(TagSchemaDirection.NORTHBOUND).has("$id"))
+                .isFalse();
+        assertThat(output.getFuture().get().has("$id")).isFalse();
+    }
+
     @Test
     void test_southboundSchema_explicitWriteSchemaIsUsedInsteadOfTheValue()
             throws ExecutionException, InterruptedException {
@@ -258,14 +331,96 @@ class TagSchemaCreationOutputImplSchemaBuilderTest {
         // A tag whose write shape is not a projection of its read shape — e.g. an OPC-UA condition tag, whose
         // northbound shape is the alarm event but whose write target is {eventId, method, comment}.
         output.finish(new TagSchemaCreationOutput.DataPointSchema(
-                new SchemaBuilder()
-                        .startObject()
-                        .property("active")
-                        .scalar(ScalarType.BOOLEAN)
-                        .property("severity")
-                        .scalar(ScalarType.LONG)
-                        .endObject()
-                        .build(),
+                alarmEventSchema(), null, null, conditionCommandSchema()));
+
+        final JsonNode writeValue = output.getSchema(TagSchemaDirection.SOUTHBOUND)
+                .get("properties")
+                .get("value");
+
+        assertThat(writeValue.get("properties").has("eventId")).isTrue();
+        assertThat(writeValue.get("properties").has("method")).isTrue();
+        assertThat(writeValue.get("properties").has("comment")).isTrue();
+        // The northbound value shape must not leak into the southbound direction.
+        assertThat(writeValue.get("properties").has("active")).isFalse();
+        assertThat(writeValue.get("properties").has("severity")).isFalse();
+
+        // ...while the northbound direction still shows the alarm-event shape.
+        final JsonNode readValue = output.getSchema(TagSchemaDirection.NORTHBOUND)
+                .get("properties")
+                .get("value");
+        assertThat(readValue.get("properties").has("active")).isTrue();
+        assertThat(readValue.get("properties").has("eventId")).isFalse();
+    }
+
+    @Test
+    void test_southboundSchema_writableCommandFieldsAreNotRenderedReadOnly()
+            throws ExecutionException, InterruptedException {
+        final var output = new TagSchemaCreationOutputImpl();
+        output.finish(new TagSchemaCreationOutput.DataPointSchema(
+                alarmEventSchema(), null, null, conditionCommandSchema()));
+
+        final JsonNode writeValue = output.getSchema(TagSchemaDirection.SOUTHBOUND)
+                .get("properties")
+                .get("value");
+
+        // The whole point of an explicit southbound schema is to give a write somewhere to land. A consumer
+        // treats readOnly as "not a destination", so neither the command object nor any of its members may
+        // carry it — this is what makes the A&C mapping editor show three destinations rather than none.
+        assertThat(writeValue.has("readOnly")).isFalse();
+        final JsonNode properties = writeValue.get("properties");
+        assertThat(properties.get("eventId").has("readOnly")).isFalse();
+        assertThat(properties.get("method").has("readOnly")).isFalse();
+        assertThat(properties.get("comment").has("readOnly")).isFalse();
+    }
+
+    @Test
+    void test_southboundSchema_conditionCommandDocumentIsPinned() throws Exception {
+        final var output = new TagSchemaCreationOutputImpl();
+        output.finish(new TagSchemaCreationOutput.DataPointSchema(
+                alarmEventSchema(), null, null, conditionCommandSchema()));
+
+        // The exact document the REST endpoint serves for an A&C condition tag. It is pinned here because the
+        // frontend fixture in MappingInstructionList.spec.cy.tsx is a copy of it: a hand-written fixture that
+        // drifts from this output tests the mock rather than the feature (which is how the missing readOnly
+        // annotations went unnoticed). Change one, change the other.
+        //
+        // Note the readOnly on the root: that flag is on the wrapper this class builds, not on the adapter's
+        // command schema, and no consumer reads it (getPropertyListFrom only walks `properties`).
+        final String expected =
+                """
+                {
+                  "type": "object",
+                  "properties": {
+                    "value": {
+                      "type": "object",
+                      "properties": {
+                        "eventId": { "type": "string" },
+                        "method": { "type": "integer" },
+                        "comment": { "type": "string" }
+                      },
+                      "required": [ "eventId", "method" ]
+                    }
+                  },
+                  "required": [ "value" ],
+                  "readOnly": true,
+                  "$schema": "https://json-schema.org/draft/2019-09/schema"
+                }
+                """;
+
+        assertThat(output.getSchema(TagSchemaDirection.SOUTHBOUND))
+                .isEqualTo(new com.fasterxml.jackson.databind.ObjectMapper().readTree(expected));
+    }
+
+    @Test
+    void test_southboundSchema_unmarkedExplicitSchemaRendersReadOnly() throws ExecutionException, InterruptedException {
+        final var output = new TagSchemaCreationOutputImpl();
+
+        // The same command shape, built the way it reads most naturally — without a single .writable() call.
+        // SchemaBuilder's default is writable = false, so every node renders readOnly and the mapping editor
+        // offers nothing. This test exists to make that failure visible here rather than in the UI; it pins the
+        // reason the SDK Javadoc on DataPointSchema.southboundSchema insists on .writable().
+        output.finish(new TagSchemaCreationOutput.DataPointSchema(
+                alarmEventSchema(),
                 null,
                 null,
                 new SchemaBuilder()
@@ -285,19 +440,11 @@ class TagSchemaCreationOutputImplSchemaBuilderTest {
                 .get("properties")
                 .get("value");
 
-        assertThat(writeValue.get("properties").has("eventId")).isTrue();
-        assertThat(writeValue.get("properties").has("method")).isTrue();
-        assertThat(writeValue.get("properties").has("comment")).isTrue();
-        // The northbound value shape must not leak into the southbound direction.
-        assertThat(writeValue.get("properties").has("active")).isFalse();
-        assertThat(writeValue.get("properties").has("severity")).isFalse();
-
-        // ...while the northbound direction still shows the alarm-event shape.
-        final JsonNode readValue = output.getSchema(TagSchemaDirection.NORTHBOUND)
-                .get("properties")
-                .get("value");
-        assertThat(readValue.get("properties").has("active")).isTrue();
-        assertThat(readValue.get("properties").has("eventId")).isFalse();
+        assertThat(writeValue.get("readOnly").asBoolean()).isTrue();
+        final JsonNode properties = writeValue.get("properties");
+        assertThat(properties.get("eventId").get("readOnly").asBoolean()).isTrue();
+        assertThat(properties.get("method").get("readOnly").asBoolean()).isTrue();
+        assertThat(properties.get("comment").get("readOnly").asBoolean()).isTrue();
     }
 
     @Test

--- a/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/OpcUaProtocolAdapter.java
+++ b/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/OpcUaProtocolAdapter.java
@@ -81,6 +81,9 @@ import org.slf4j.LoggerFactory;
 public class OpcUaProtocolAdapter implements WritingProtocolAdapter, BulkTagBrowser {
     private static final @NotNull Logger log = LoggerFactory.getLogger(OpcUaProtocolAdapter.class);
 
+    /** OPC UA's standard Objects folder — the conventional entry point when a browse names no root. */
+    private static final @NotNull String OBJECTS_FOLDER_NODE_ID = "i=85";
+
     private final @NotNull ProtocolAdapterInformation adapterInformation;
     private final @NotNull ProtocolAdapterState protocolAdapterState;
     private final @NotNull String adapterId;
@@ -540,11 +543,10 @@ public class OpcUaProtocolAdapter implements WritingProtocolAdapter, BulkTagBrow
             output.fail("Discovery failed: Adapter has been stopped");
             return;
         }
-        if (input.getRootNode() == null) {
-            log.error("Discovery failed: Root node is null");
-            output.fail("Root node is null");
-            return;
-        }
+        // No root means "start from the top", which for OPC UA is the standard Objects folder (i=85). Failing
+        // instead turned the ordinary "browse this server" call into a 500 with no indication of what was
+        // missing; every caller that wanted the whole address space had to know to pass i=85 itself.
+        final String rootNode = input.getRootNode() == null ? OBJECTS_FOLDER_NODE_ID : input.getRootNode();
         final OpcUaClientConnection conn = opcUaClientConnection.get();
         if (conn == null) {
             output.fail("Discovery failed: ClientConnection not connected or not initialized");
@@ -554,8 +556,7 @@ public class OpcUaProtocolAdapter implements WritingProtocolAdapter, BulkTagBrow
                 .ifPresentOrElse(
                         client -> {
                             @SuppressWarnings("unused")
-                            final var unused = OpcUaNodeDiscovery.discoverValues(
-                                            client, input.getRootNode(), input.getDepth())
+                            final var unused = OpcUaNodeDiscovery.discoverValues(client, rootNode, input.getDepth())
                                     .whenComplete((collectedNodes, throwable) -> {
                                         if (throwable == null) {
                                             final NodeTree nodeTree = output.getNodeTree();

--- a/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/southbound/JsonSchemaGenerator.java
+++ b/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/southbound/JsonSchemaGenerator.java
@@ -389,7 +389,8 @@ public class JsonSchemaGenerator {
             final @NotNull SchemaBuilder schema, final @NotNull FieldInformation info) {
         schema.readable(info.readable()).writable(info.writable());
         if (info.arrayDimensions() != null && info.arrayDimensions().length > 0) {
-            applyArrayType(schema.startArray(), info.dataType(), info.arrayDimensions(), 0);
+            applyArrayType(
+                    schema.startArray(), info.dataType(), info.arrayDimensions(), 0, info.readable(), info.writable());
         } else if (!info.nestedFields().isEmpty()) {
             applyObjectProperties(schema.startObject(), info);
         } else if (info.dataType() != null) {
@@ -406,7 +407,9 @@ public class JsonSchemaGenerator {
                     prop.startArray().readable(info.readable()).writable(info.writable()),
                     info.dataType(),
                     info.arrayDimensions(),
-                    0);
+                    0,
+                    info.readable(),
+                    info.writable());
         } else if (!info.nestedFields().isEmpty()) {
             applyObjectProperties(prop.startObject(), info);
         } else if (info.dataType() != null) {
@@ -416,11 +419,23 @@ public class JsonSchemaGenerator {
         }
     }
 
+    /**
+     * Builds the item schema for an array-valued node.
+     * <p>
+     * The elements carry the node's own access flags. A writable node is written by supplying its elements, so
+     * elements that claim to be read-only describe a shape nothing can be written to — the degenerate
+     * "array of read-only items admits only {@code []}" case. Without this the elements fell back to
+     * {@link com.hivemq.adapter.sdk.api.schema.SchemaBuilder}'s {@code writable = false} default and every
+     * writable array node advertised read-only elements. Applies at every nesting depth, so a
+     * multi-dimensional array is writable all the way down.
+     */
     private static <P> void applyArrayType(
             final @NotNull ItemSchemaBuilder<P> items,
             final @Nullable OpcUaDataType opcUaType,
             final @NotNull UInteger @NotNull [] dimensions,
-            final int depth) {
+            final int depth,
+            final boolean readable,
+            final boolean writable) {
         if (depth == dimensions.length - 1) {
             if (opcUaType != null) {
                 applyScalarType(items, opcUaType);
@@ -428,8 +443,9 @@ public class JsonSchemaGenerator {
                 items.any();
             }
         } else {
-            applyArrayType(items.startArray(), opcUaType, dimensions, depth + 1);
+            applyArrayType(items.startArray(), opcUaType, dimensions, depth + 1, readable, writable);
         }
+        items.readable(readable).writable(writable);
         final long maxSize = dimensions[depth].longValue();
         if (maxSize > 0) {
             items.minContains((int) maxSize).maxContains((int) maxSize);

--- a/modules/hivemq-edge-module-opcua/src/test/java/com/hivemq/edge/adapters/opcua/OpcUaProtocolAdapterTest.java
+++ b/modules/hivemq-edge-module-opcua/src/test/java/com/hivemq/edge/adapters/opcua/OpcUaProtocolAdapterTest.java
@@ -23,6 +23,9 @@ import static org.mockito.Mockito.when;
 
 import com.hivemq.adapter.sdk.api.ProtocolAdapterConnectionDirection;
 import com.hivemq.adapter.sdk.api.ProtocolAdapterInformation;
+import com.hivemq.adapter.sdk.api.discovery.NodeTree;
+import com.hivemq.adapter.sdk.api.discovery.ProtocolAdapterDiscoveryInput;
+import com.hivemq.adapter.sdk.api.discovery.ProtocolAdapterDiscoveryOutput;
 import com.hivemq.adapter.sdk.api.events.model.Event;
 import com.hivemq.adapter.sdk.api.factories.AdapterFactories;
 import com.hivemq.adapter.sdk.api.model.ProtocolAdapterInput;
@@ -42,6 +45,8 @@ import com.hivemq.edge.modules.adapters.impl.ProtocolAdapterStateImpl;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.AfterEach;
@@ -141,6 +146,104 @@ public class OpcUaProtocolAdapterTest {
         assertThat(eventService.readEvents(null, null))
                 .as("No error events should be recorded on successful connection")
                 .noneMatch(event -> "ERROR".equals(event.getSeverity().name()));
+    }
+
+    /** Starts an adapter against the embedded server and waits until its client is usable. */
+    private @NotNull OpcUaProtocolAdapter startAdapterAgainstEmbeddedServer() {
+        final OpcUaSpecificAdapterConfig config = new OpcUaSpecificAdapterConfig(
+                opcUaServerExtension.getServerUri(),
+                false,
+                null,
+                null,
+                null,
+                new OpcUaToMqttConfig(1, 1000),
+                null,
+                null);
+        final OpcuaTag tag = new OpcuaTag(
+                "testTag",
+                "Test tag",
+                new OpcuaTagDefinition(
+                        "ns=" + opcUaServerExtension.getTestNamespace().getNamespaceIndex() + ";i=10"));
+
+        final ProtocolAdapterInformation adapterInformation = mock(ProtocolAdapterInformation.class);
+        when(adapterInformation.getProtocolId()).thenReturn("opcua");
+
+        adapter = new OpcUaProtocolAdapter(adapterInformation, createMockedInput(config, List.of(tag)));
+
+        final ModuleServices moduleServices = mock(ModuleServices.class);
+        when(moduleServices.eventService()).thenReturn(eventService);
+        when(moduleServices.protocolAdapterTagStreamingService())
+                .thenReturn(mock(ProtocolAdapterTagStreamingService.class));
+        final ProtocolAdapterStartInput startInput = mock(ProtocolAdapterStartInput.class);
+        when(startInput.moduleServices()).thenReturn(moduleServices);
+
+        adapter.start(
+                ProtocolAdapterConnectionDirection.Northbound, startInput, mock(ProtocolAdapterStartOutput.class));
+
+        await().untilAsserted(() -> assertThat(protocolAdapterState.getConnectionStatus())
+                .isEqualTo(ProtocolAdapterState.ConnectionStatus.CONNECTED));
+        return adapter;
+    }
+
+    /**
+     * A browse that names no root means "start from the top", which for OPC-UA is the Objects folder (i=85).
+     * It used to fail outright, so the plain "show me this server" call returned a 500 with nothing to indicate
+     * that a root was the missing ingredient — every caller had to know to pass i=85 itself.
+     */
+    @Test
+    @Timeout(120)
+    void whenDiscoveryHasNoRootNode_thenItBrowsesFromTheObjectsFolder() throws Exception {
+        final OpcUaProtocolAdapter startedAdapter = startAdapterAgainstEmbeddedServer();
+
+        final List<String> failures = new ArrayList<>();
+        final AtomicBoolean finished = new AtomicBoolean();
+        final List<String> discovered = new CopyOnWriteArrayList<>();
+        final NodeTree nodeTree = (id, name, value, description, parentId, nodeType, selectable) -> discovered.add(id);
+
+        startedAdapter.discoverValues(
+                new ProtocolAdapterDiscoveryInput() {
+                    @Override
+                    public @Nullable String getRootNode() {
+                        return null; // the case under test
+                    }
+
+                    @Override
+                    public int getDepth() {
+                        return 1;
+                    }
+                },
+                new ProtocolAdapterDiscoveryOutput() {
+                    @Override
+                    public @NotNull NodeTree getNodeTree() {
+                        return nodeTree;
+                    }
+
+                    @Override
+                    public void finish() {
+                        finished.set(true);
+                    }
+
+                    @Override
+                    public void fail(final @NotNull Throwable t, final @Nullable String errorMessage) {
+                        failures.add(String.valueOf(errorMessage));
+                    }
+
+                    @Override
+                    public void fail(final @NotNull String errorMessage) {
+                        failures.add(errorMessage);
+                    }
+                });
+
+        await().untilAsserted(() -> assertThat(finished.get() || !failures.isEmpty())
+                .as("discovery must complete one way or the other")
+                .isTrue());
+
+        assertThat(failures)
+                .as("a browse with no root must not fail — it defaults to the Objects folder")
+                .isEmpty();
+        assertThat(discovered)
+                .as("browsing from the Objects folder must return the server's top-level objects")
+                .isNotEmpty();
     }
 
     @Test

--- a/modules/hivemq-edge-module-opcua/src/test/java/com/hivemq/edge/adapters/opcua/southbound/JsonSchemaGeneratorArrayWritabilityTest.java
+++ b/modules/hivemq-edge-module-opcua/src/test/java/com/hivemq/edge/adapters/opcua/southbound/JsonSchemaGeneratorArrayWritabilityTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.edge.adapters.opcua.southbound;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.hivemq.adapter.sdk.api.schema.SchemaJsonRepresentation;
+import com.hivemq.adapter.sdk.api.schema.TagSchemaCreationOutput;
+import java.util.List;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+/**
+ * Writability of array <em>elements</em>.
+ * <p>
+ * An array-valued node is written by supplying its elements. Elements that render {@code readOnly} therefore
+ * describe a shape nothing can be written to — the degenerate "array of read-only items admits only
+ * {@code []}" case the SDK Javadoc warns about. Before this was fixed the elements fell through to
+ * {@code SchemaBuilder}'s {@code writable = false} default, so <em>every</em> writable array node on every
+ * OPC-UA server advertised read-only elements; observed live against a Prosys server on
+ * {@code AccessLevelCurrentReadWrite}, whose southbound document carried {@code "readOnly": true} on its items.
+ * <p>
+ * The rule under test: <b>when a tag is writable, so are the elements of any array carrying its data</b> — at
+ * every nesting depth.
+ */
+class JsonSchemaGeneratorArrayWritabilityTest {
+
+    private static final UInteger @NotNull [] ONE_DIMENSION = {UInteger.valueOf(0)};
+    private static final UInteger @NotNull [] THREE_DIMENSIONS = {
+        UInteger.valueOf(0), UInteger.valueOf(0), UInteger.valueOf(0)
+    };
+
+    private static @NotNull JsonSchemaGenerator.FieldInformation arrayField(
+            final UInteger @NotNull [] dimensions, final boolean readable, final boolean writable) {
+        return new JsonSchemaGenerator.FieldInformation(
+                "value", null, OpcUaDataType.Int32, null, false, dimensions, false, readable, writable, List.of());
+    }
+
+    private static @NotNull JsonNode render(final @NotNull JsonSchemaGenerator.FieldInformation info) {
+        final TagSchemaCreationOutput.DataPointSchema dps = JsonSchemaGenerator.buildSchema(info);
+        return SchemaJsonRepresentation.INSTANCE.toJsonSchemaDocument(dps.valueSchema());
+    }
+
+    @Test
+    void test_writableArray_hasWritableItems() {
+        final JsonNode schema = render(arrayField(ONE_DIMENSION, true, true));
+
+        assertThat(schema.get("type").asText()).isEqualTo("array");
+        assertThat(schema.has("readOnly")).as("the array itself is writable").isFalse();
+        assertThat(schema.get("items").has("readOnly"))
+                .as("...and so are its elements — otherwise only [] could ever be written")
+                .isFalse();
+    }
+
+    @Test
+    void test_readOnlyArray_keepsReadOnlyItems() {
+        final JsonNode schema = render(arrayField(ONE_DIMENSION, true, false));
+
+        assertThat(schema.get("readOnly").asBoolean()).isTrue();
+        assertThat(schema.get("items").get("readOnly").asBoolean())
+                .as("a read-only node's elements stay read-only — the fix must not make everything writable")
+                .isTrue();
+    }
+
+    @Test
+    void test_writeOnlyArray_propagatesWriteOnlyToItems() {
+        final JsonNode schema = render(arrayField(ONE_DIMENSION, false, true));
+
+        assertThat(schema.get("writeOnly").asBoolean()).isTrue();
+        assertThat(schema.get("items").get("writeOnly").asBoolean()).isTrue();
+    }
+
+    @Test
+    void test_multiDimensionalWritableArray_isWritableAllTheWayDown() {
+        final JsonNode schema = render(arrayField(THREE_DIMENSIONS, true, true));
+
+        JsonNode level = schema;
+        for (int depth = 0; depth < 3; depth++) {
+            assertThat(level.get("type").asText())
+                    .as("depth %s is an array", depth)
+                    .isEqualTo("array");
+            assertThat(level.has("readOnly"))
+                    .as("depth %s must be writable", depth)
+                    .isFalse();
+            level = level.get("items");
+        }
+        assertThat(level.get("type").asText()).isEqualTo("integer");
+        assertThat(level.has("readOnly"))
+                .as("the innermost scalar element is the thing actually written")
+                .isFalse();
+    }
+
+    @Test
+    void test_multiDimensionalReadOnlyArray_isReadOnlyAllTheWayDown() {
+        final JsonNode schema = render(arrayField(THREE_DIMENSIONS, true, false));
+
+        JsonNode level = schema;
+        for (int depth = 0; depth < 3; depth++) {
+            assertThat(level.get("readOnly").asBoolean())
+                    .as("depth %s must stay read-only", depth)
+                    .isTrue();
+            level = level.get("items");
+        }
+        assertThat(level.get("readOnly").asBoolean()).isTrue();
+    }
+
+    /** The access-flag combinations an OPC-UA AccessLevel can produce, end to end. */
+    @ParameterizedTest(name = "readable={0} writable={1}")
+    @CsvSource({"true,true", "true,false", "false,true", "false,false"})
+    void test_itemsAlwaysMatchTheNodesOwnAccessFlags(final boolean readable, final boolean writable) {
+        final JsonNode schema = render(arrayField(ONE_DIMENSION, readable, writable));
+        final JsonNode items = schema.get("items");
+
+        assertThat(items.has("readOnly"))
+                .as("items readOnly must mirror the node")
+                .isEqualTo(schema.has("readOnly"));
+        assertThat(items.has("writeOnly"))
+                .as("items writeOnly must mirror the node")
+                .isEqualTo(schema.has("writeOnly"));
+    }
+
+    @Test
+    void test_scalarNode_isUnaffected() {
+        // Guards the blast radius: only the array path changed.
+        final JsonNode schema = render(new JsonSchemaGenerator.FieldInformation(
+                "value", null, OpcUaDataType.Int32, null, false, null, false, true, true, List.of()));
+
+        assertThat(schema.get("type").asText()).isEqualTo("integer");
+        assertThat(schema.has("readOnly")).isFalse();
+        assertThat(schema.has("items")).isFalse();
+    }
+}


### PR DESCRIPTION
**Motivation**

[EDG-845](https://linear.app/hivemq/issue/EDG-845/separate-northbound-read-and-southbound-write-tag-schemas)

A tag has one schema today, used for both directions. It wraps the value in an envelope (`tagName`, `timestamp`, `metadata`, `context`) that can never be written, and marks per-field writability with flags. The southbound mapping editor is handed that schema and has to neutralise most of it in the UI — the screenshot before this change shows one settable property and seven marked *Read-only* or *Not supported*. Meanwhile the same schema is shown in the tag inspection panel behind a button labelled "View the WRITE schema" while its own helper text calls it a valid *source* for transformation.

This also unblocks OPC-UA Alarms & Conditions ([EDG-835](https://linear.app/hivemq/issue/EDG-835/implement-opc-ua-alarms-and-conditions-support-in-edge)): a condition tag reads an alarm event but writes `{eventId, method, comment}`, so one schema plus flags cannot represent it.

Supersedes the never-done frontend cleanup in EDG-59 by solving it on the backend side — the read-only fields are no longer sent to the write form, so there is nothing for the UI to hide.

**Changes**

Backend — one seam, no adapter touched:

- `TagSchemaCreationOutputImpl` now assembles the schema per direction, because it owns the `DataPointSchema`. READ keeps the envelope and the full value; WRITE drops the non-writable envelope and uses the adapter's explicit `writeSchema` when present, else the plain value.
- The future carries the raw `DataPointSchema` rather than a pre-rendered JSON node, so the direction is chosen at the consuming edge.
- The REST endpoint gains an optional `direction` query parameter. It has no default in the spec, so a read caller sends no parameter and produces exactly the URL it did before — existing callers, intercepts and caches are unaffected.

Frontend — each consumer asks for the direction it needs:

- Southbound mapping editor and its destination data model → WRITE.
- Data combiner and other source-side consumers → unchanged (read).
- Tag inspection panel → both, compared: a single "Current schema" when identical, a labelled "Read schema" / "Write schema" pair when they differ.

The write schema does not hide fields that cannot be written; it drops the non-writable envelope, and per-field write permission stays visible as the existing read-only marker. A statically derived write schema cannot express write validity correctly — an array of read-only items admits only `[]`, a required read-only member makes the object unsatisfiable — so enforcement belongs at validation time and is left to Nevsky.

Separately, the second commit restores `TagSchemaCreationOutputImpl.getFuture()` as a deprecated method returning the read schema. Removing it in the first commit broke callers outside this repository — the commercial bidirectional adapter and three integration tests in `hivemq-edge-test` — which surfaced as a `NoSuchMethodError` during `startWriting`. Because adapters start in sequence, that aborted the loop and every adapter after the first writing one silently failed to start. The shim returns the read schema, which is what the method always produced; migrating those callers, and deciding whether the commercial module wants WRITE there, belongs in their own repositories.

**Verification**

- Java: 35 tests (schema + simulation), including new coverage that WRITE drops the envelope, READ keeps it, and an explicit `writeSchema` is used instead of the value. Mutation-checked — reverting either behaviour fails the tests.
- Frontend: 30 Cypress component tests across all specs touching the schema endpoint; `pnpm lint:all` clean.
- Manually against a live OPC-UA device: `Test` (writable node) shows an unlocked `VALUE` in both panels, while `sim-sqr` (read-only signal node) shows it locked — the per-field AccessLevel is real, not decoration.

Requires hivemq/hivemq-edge-adapter-sdk#132 (same branch name).