### PR TITLE
EDG-855: Log PASSED and SKIPPED events for hivemq-edge unit tests

### DIFF
--- a/hivemq-edge/build.gradle.kts
+++ b/hivemq-edge/build.gradle.kts
@@ -327,7 +327,17 @@ tasks.test {
     }
 
     testLogging {
-        events = setOf(TestLogEvent.STARTED, TestLogEvent.FAILED)
+        // EDG-855: PASSED and SKIPPED matter as much as STARTED and FAILED. Without them a passing test
+        // logs when it began and never when it finished, so per-class durations cannot be derived from the
+        // console log — and this is the composite's largest unit-test project (~500 classes). Every other
+        // test project already logs the full set; this one was the gap.
+        events =
+            setOf(
+                TestLogEvent.STARTED,
+                TestLogEvent.PASSED,
+                TestLogEvent.SKIPPED,
+                TestLogEvent.FAILED
+            )
         exceptionFormat = TestExceptionFormat.FULL
     }
 }


### PR DESCRIPTION
## Description (the why)

`hivemq-edge/build.gradle.kts` listed only `STARTED` and `FAILED` in `testLogging`, so a passing test logged when it *began* and never when it *finished*. Per-class durations are therefore not derivable from the console log for this project — and it is the composite's largest unit-test project, ~500 classes.

That matters because the console log is the only per-build source of test timings: Jenkins' JUnit API aggregates results across builds and cannot be used for per-build comparison. In a build where `:hivemq-edge:test` actually ran (rather than returning `FROM-CACHE`), **503 of 868 classes had a start and no end** — contributing nothing to work accounting and dragging apparent concurrency toward zero, so those runs had to be excluded from timing analysis entirely.

Timestamp inference is not a substitute. Gradle buffers each task's output and flushes it in blocks, so up to 95 events share a single console timestamp; estimating a completion from the next event's timestamp is off by more than a second in **65%** of cases, worst case 236s.

Every other test project in the composite already logs the full event set — the nine adapter modules, `hivemq-edge-module-bacnetip` in its own repo, the commercial modules, and `hivemq-edge-test`. This one was the only gap.

Linear: EDG-855

## Acceptance Criteria (the what)

- [ ] `:hivemq-edge:test` emits a `PASSED` line for each passing test and `SKIPPED` for each skipped one.
- [ ] No change to test behaviour, selection, timeouts, or retry policy.
- [ ] Cache-miss builds become comparable with cache-hit builds in per-class timing analysis.

## Non-Goals

- Changing the other repos' `testLogging` configuration — they are already correct.
- Any change to test behaviour or CI configuration beyond the log events.

## Test plan

Verified locally with the exact class that was previously invisible:

```
AdapterModelConverterTest > testProtocolAdapterModuleConversionUtils() STARTED
AdapterModelConverterTest > testProtocolAdapterModuleConversionUtils() PASSED
... six pairs, BUILD SUCCESSFUL
```

Before this change the same class emitted six `STARTED` lines and no completions.

**Note on log size:** this adds one line per passing test in a ~500-class project. The composite console log is already ~850k lines, so the increase is modest, but worth watching that it does not approach any Jenkins log-size limit.