### PR TITLE
EDG-811: Bound the message expiry setters, normalize the "no expiry" markers at the copy boundary

### DIFF
--- a/hivemq-edge/src/main/java/com/hivemq/codec/encoder/mqtt5/Mqtt5MessageEncoderUtil.java
+++ b/hivemq-edge/src/main/java/com/hivemq/codec/encoder/mqtt5/Mqtt5MessageEncoderUtil.java
@@ -59,13 +59,29 @@ final class Mqtt5MessageEncoderUtil {
     }
 
     /**
-     * EDG-811: must agree exactly with {@link #encodeIntProperty} on whether the property is emitted. This
-     * declares the property length; that writes the bytes. If they disagree the packet claims more property
-     * bytes than it carries, the receiver reads payload as if it were a property, and the connection dies with
-     * a protocol error — which is what happened when only the encoder learned to skip out-of-range values.
+     * EDG-811: the single decision on whether a four-byte integer property is emitted, shared by
+     * {@link #intPropertyEncodedLength} and {@link #encodeIntProperty}. One declares how many property bytes
+     * the packet claims, the other writes them; if they ever disagree the packet claims more property bytes
+     * than it carries, the receiver reads payload as if it were a property, and the connection dies with a
+     * protocol error. That is not hypothetical — it happened on this branch when only the encoder learned to
+     * skip out-of-range values. Hence one predicate rather than two conditions that have to be kept in sync.
+     * <p>
+     * {@code defaultValue} carries two different meanings across the call sites. For MAXIMUM_PACKET_SIZE it is
+     * a genuine default — a legal value the receiver reconstructs from the spec, so omitting it merely saves
+     * bytes. For MESSAGE_EXPIRY_INTERVAL and SESSION_EXPIRY_INTERVAL it is an out-of-range marker meaning
+     * "absent", where omission is the only correct encoding.
+     * <p>
+     * The range check is needed on top of the equality: the markers are not the only values outside the
+     * four-byte range, and anything else out there used to reach {@code writeInt} and be silently truncated to
+     * its low 32 bits — 2^40 encoding as 0, "expire immediately". A value that does not fit in an MQTT
+     * four-byte integer has no correct encoding, so the property is dropped rather than corrupted.
      */
+    private static boolean shouldEncodeIntProperty(final long value, final long defaultValue) {
+        return value != defaultValue && UnsignedDataTypes.isUnsignedInt(value);
+    }
+
     static int intPropertyEncodedLength(final long value, final long defaultValue) {
-        return (value == defaultValue || value > UnsignedDataTypes.UNSIGNED_INT_MAX_VALUE) ? 0 : 5;
+        return shouldEncodeIntProperty(value, defaultValue) ? 5 : 0;
     }
 
     static int variableByteIntegerPropertyEncodedLength(final int value) {
@@ -133,24 +149,10 @@ final class Mqtt5MessageEncoderUtil {
         }
     }
 
-    /**
-     * EDG-811: {@code defaultValue} carries two different meanings across the call sites. For
-     * MAXIMUM_PACKET_SIZE it is a genuine default — a legal value the receiver reconstructs from the spec, so
-     * omitting it merely saves bytes. For MESSAGE_EXPIRY_INTERVAL and SESSION_EXPIRY_INTERVAL it is an
-     * out-of-range marker meaning "absent", where omission is the only correct encoding.
-     * <p>
-     * The second case needs the range check as well as the equality: the markers are not the only values above
-     * the four-byte range, and anything else up there used to reach {@code writeInt} and be silently truncated
-     * to its low 32 bits — 2^40 encoding as 0, "expire immediately". Values at or above 2^32 all mean "no
-     * expiry", so the property is dropped rather than corrupted.
-     * <p>
-     * Keep this condition identical to {@link #intPropertyEncodedLength}. That function declares how many
-     * property bytes the packet claims; this one writes them. Any disagreement produces a malformed packet.
-     */
     static void encodeIntProperty(
             final int propertyIdentifier, final long value, final long defaultValue, final @NotNull ByteBuf out) {
 
-        if (value != defaultValue && value <= UnsignedDataTypes.UNSIGNED_INT_MAX_VALUE) {
+        if (shouldEncodeIntProperty(value, defaultValue)) {
             out.writeByte(propertyIdentifier);
             out.writeInt((int) value);
         }

--- a/hivemq-edge/src/main/java/com/hivemq/codec/encoder/mqtt5/Mqtt5MessageEncoderUtil.java
+++ b/hivemq-edge/src/main/java/com/hivemq/codec/encoder/mqtt5/Mqtt5MessageEncoderUtil.java
@@ -58,8 +58,14 @@ final class Mqtt5MessageEncoderUtil {
         return (value == defaultValue) ? 0 : 3;
     }
 
+    /**
+     * EDG-811: must agree exactly with {@link #encodeIntProperty} on whether the property is emitted. This
+     * declares the property length; that writes the bytes. If they disagree the packet claims more property
+     * bytes than it carries, the receiver reads payload as if it were a property, and the connection dies with
+     * a protocol error — which is what happened when only the encoder learned to skip out-of-range values.
+     */
     static int intPropertyEncodedLength(final long value, final long defaultValue) {
-        return (value == defaultValue) ? 0 : 5;
+        return (value == defaultValue || value > UnsignedDataTypes.UNSIGNED_INT_MAX_VALUE) ? 0 : 5;
     }
 
     static int variableByteIntegerPropertyEncodedLength(final int value) {
@@ -137,6 +143,9 @@ final class Mqtt5MessageEncoderUtil {
      * the four-byte range, and anything else up there used to reach {@code writeInt} and be silently truncated
      * to its low 32 bits — 2^40 encoding as 0, "expire immediately". Values at or above 2^32 all mean "no
      * expiry", so the property is dropped rather than corrupted.
+     * <p>
+     * Keep this condition identical to {@link #intPropertyEncodedLength}. That function declares how many
+     * property bytes the packet claims; this one writes them. Any disagreement produces a malformed packet.
      */
     static void encodeIntProperty(
             final int propertyIdentifier, final long value, final long defaultValue, final @NotNull ByteBuf out) {

--- a/hivemq-edge/src/main/java/com/hivemq/codec/encoder/mqtt5/Mqtt5MessageEncoderUtil.java
+++ b/hivemq-edge/src/main/java/com/hivemq/codec/encoder/mqtt5/Mqtt5MessageEncoderUtil.java
@@ -127,10 +127,21 @@ final class Mqtt5MessageEncoderUtil {
         }
     }
 
+    /**
+     * EDG-811: {@code defaultValue} carries two different meanings across the call sites. For
+     * MAXIMUM_PACKET_SIZE it is a genuine default — a legal value the receiver reconstructs from the spec, so
+     * omitting it merely saves bytes. For MESSAGE_EXPIRY_INTERVAL and SESSION_EXPIRY_INTERVAL it is an
+     * out-of-range marker meaning "absent", where omission is the only correct encoding.
+     * <p>
+     * The second case needs the range check as well as the equality: the markers are not the only values above
+     * the four-byte range, and anything else up there used to reach {@code writeInt} and be silently truncated
+     * to its low 32 bits — 2^40 encoding as 0, "expire immediately". Values at or above 2^32 all mean "no
+     * expiry", so the property is dropped rather than corrupted.
+     */
     static void encodeIntProperty(
             final int propertyIdentifier, final long value, final long defaultValue, final @NotNull ByteBuf out) {
 
-        if (value != defaultValue) {
+        if (value != defaultValue && value <= UnsignedDataTypes.UNSIGNED_INT_MAX_VALUE) {
             out.writeByte(propertyIdentifier);
             out.writeInt((int) value);
         }

--- a/hivemq-edge/src/main/java/com/hivemq/extensions/services/builder/PluginBuilderUtil.java
+++ b/hivemq-edge/src/main/java/com/hivemq/extensions/services/builder/PluginBuilderUtil.java
@@ -17,6 +17,7 @@ package com.hivemq.extensions.services.builder;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
+import static com.hivemq.configuration.entity.mqtt.MqttConfigurationDefaults.MAX_EXPIRY_INTERVAL_DEFAULT;
 
 import com.google.common.base.Preconditions;
 import com.hivemq.extension.sdk.api.packets.general.Qos;
@@ -42,8 +43,28 @@ public class PluginBuilderUtil {
         return !validateUTF8 || !Utf8Utils.hasControlOrNonCharacter(stringToValidate);
     }
 
+    /**
+     * EDG-811: the message expiry interval has two ranges, and only one of them is a duration.
+     * <ul>
+     *     <li>{@code 0 .. 2^32-1} — a real duration, checked against the configured maximum and written to
+     *     the wire as the four-byte Message Expiry Interval property.</li>
+     *     <li>{@code >= 2^32} — "no expiry". MQTT expresses this by omitting the property, so there is no
+     *     wire value to bound; several such markers exist internally ({@code MAX_EXPIRY_INTERVAL_DEFAULT},
+     *     {@code MESSAGE_EXPIRY_INTERVAL_NOT_SET}, {@code JS_MAX_SAFE_INTEGER}) and all mean the same thing.</li>
+     * </ul>
+     * Validating the second range as if it were a duration is what broke the bidirectional adapter's
+     * dead-letter repost: copying a publish that had no expiry threw, because the "absent" marker is
+     * {@code Long.MAX_VALUE} and therefore far above any configured maximum.
+     * <p>
+     * Note the resulting asymmetry: an operator who configures a one-hour maximum rejects a client asking
+     * for two hours but accepts one asking for no expiry at all. That matches MQTT, where an absent property
+     * is the protocol default and already outlives any configured bound.
+     */
     public static void checkMessageExpiryInterval(
             final long messageExpiryInterval, final long maxMessageExpiryInterval) {
+        if (messageExpiryInterval >= MAX_EXPIRY_INTERVAL_DEFAULT) {
+            return;
+        }
         checkArgument(
                 messageExpiryInterval <= maxMessageExpiryInterval,
                 "Message expiry interval %s not allowed. Maximum = %s",

--- a/hivemq-edge/src/main/java/com/hivemq/extensions/services/builder/PluginBuilderUtil.java
+++ b/hivemq-edge/src/main/java/com/hivemq/extensions/services/builder/PluginBuilderUtil.java
@@ -18,8 +18,6 @@ package com.hivemq.extensions.services.builder;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.hivemq.configuration.entity.mqtt.MqttConfigurationDefaults.MAX_EXPIRY_INTERVAL_DEFAULT;
-import static com.hivemq.mqtt.message.publish.PUBLISH.MESSAGE_EXPIRY_INTERVAL_MAX;
-import static com.hivemq.mqtt.message.publish.PUBLISH.MESSAGE_EXPIRY_INTERVAL_NOT_SET;
 
 import com.google.common.base.Preconditions;
 import com.hivemq.codec.encoder.mqtt5.UnsignedDataTypes;
@@ -48,38 +46,33 @@ public class PluginBuilderUtil {
     }
 
     /**
-     * EDG-811: a message expiry interval is a duration in seconds, except for the two values that are not
-     * durations at all.
-     * <ul>
-     *     <li>{@link PUBLISH#MESSAGE_EXPIRY_INTERVAL_NOT_SET} and {@code MAX_EXPIRY_INTERVAL_DEFAULT} — the
-     *     two "no expiry" markers this codebase actually uses. MQTT expresses "no expiry" by omitting the
-     *     Message Expiry Interval property, so there is no wire value for the configured maximum to bound,
-     *     and both markers are recognised as "absent" downstream: the MQTT 5 encoder omits them and
-     *     {@code MessageExpiryHandler} does not count them down. Rejecting the first as an oversized duration
-     *     is what broke the bidirectional adapter's dead-letter repost — it is {@code Long.MAX_VALUE} and so
-     *     sits above every configured maximum.</li>
-     *     <li>{@code 0 .. 2^32-1} — a real duration, bounded by the operator's configured maximum and written
-     *     to the wire as the four-byte Message Expiry Interval property. Zero is legal and means "expires
-     *     immediately": MQTT 5 allows it, the decoders accept it, and the extension SDK documents only a
-     *     negative interval as throwing.</li>
-     * </ul>
-     * Everything else is rejected — a negative interval, and any other value above the four-byte range. Those
-     * have no MQTT representation, so accepting them would admit a publish into the domain model that no
-     * encoder can emit faithfully, while also handing extensions a way around the configured maximum.
+     * Validates a message expiry interval offered through a public extension SDK setter.
      * <p>
-     * Deliberately, the marker test is by exact value rather than by range. A caller holding an internal
-     * publish whose interval might be any of the historical "infinity" values must normalize it first with
-     * {@link #normalizeCopiedMessageExpiryInterval}; reinterpreting arbitrary out-of-range input as "no
-     * expiry" is not this public setter's job.
+     * This is a bounded contract and stays one: the accepted range is {@code 0 ..
+     * min(maxMessageExpiryInterval, MAX_EXPIRY_INTERVAL_DEFAULT)}. {@code <message-expiry>} exists to
+     * guarantee that no message outlives it, so no input — however it is spelled — may pass this check
+     * unbounded. Zero is legal and means "expires immediately": MQTT 5 allows it, the decoders accept it, and
+     * the extension SDK documents only a negative interval as throwing (EDG-811 CR-5).
+     * <p>
+     * The four-byte cap is not redundant with the configured maximum. {@code MqttConfigurator} bounds the
+     * maximum at {@code MAX_EXPIRY_INTERVAL_DEFAULT}, but only when parsing {@code config.xml};
+     * {@code MqttConfigurationServiceImpl.setMaxMessageExpiryInterval} is unchecked, so without the cap a
+     * programmatically raised maximum would let a value with no MQTT representation into the domain model.
+     * The cap is {@code MAX_EXPIRY_INTERVAL_DEFAULT} (2^32) rather than {@link PUBLISH#MESSAGE_EXPIRY_INTERVAL_MAX}
+     * (2^32-1) because 2^32 is the default configured maximum itself — the value the decoders clamp an absent
+     * property to, and the value the encoder omits — so it must remain settable while it is the operator's bound.
+     * <p>
+     * <b>Internal "no expiry" markers do not belong here (EDG-811 CR2-1).</b>
+     * {@link PUBLISH#MESSAGE_EXPIRY_INTERVAL_NOT_SET} is {@code Long.MAX_VALUE} and therefore sits above every
+     * finite maximum; exempting it — or 2^32 — from the bound would let an extension mint a message that
+     * {@code MessageExpiryHandler} never counts down and the MQTT 5 encoder never emits, i.e. a genuine
+     * no-expiry publish under a ten-second maximum. A caller copying an existing publish must instead route
+     * the value through {@link #isCopyableMessageExpiryDuration} and assign the canonical marker directly,
+     * where {@code build()} resolves it to the configured maximum.
      */
     public static void checkMessageExpiryInterval(
             final long messageExpiryInterval, final long maxMessageExpiryInterval) {
-        if (isNoExpiryMarker(messageExpiryInterval)) {
-            return;
-        }
-        // The four-byte cap is not redundant with the configured maximum: config.xml is validated against
-        // MAX_EXPIRY_INTERVAL_DEFAULT, but setMaxMessageExpiryInterval() itself is unchecked.
-        final long effectiveMaximum = Math.min(maxMessageExpiryInterval, MESSAGE_EXPIRY_INTERVAL_MAX);
+        final long effectiveMaximum = Math.min(maxMessageExpiryInterval, MAX_EXPIRY_INTERVAL_DEFAULT);
         checkArgument(
                 messageExpiryInterval <= effectiveMaximum,
                 "Message expiry interval %s not allowed. Maximum = %s",
@@ -92,29 +85,25 @@ public class PluginBuilderUtil {
     }
 
     /**
-     * EDG-811: maps an internal message expiry interval onto the one representation the builders and the
-     * public setters agree on, for use when copying an existing publish.
+     * EDG-811: tells a copy boundary whether the interval it was handed is a real duration that must stay
+     * subject to the operator's configured maximum, or one of the internal "no expiry" markers that has to
+     * bypass the public setter entirely.
      * <p>
      * Internally "not a real duration" has been spelled at least four ways —
      * {@link PUBLISH#MESSAGE_EXPIRY_INTERVAL_NOT_SET}, {@code MAX_EXPIRY_INTERVAL_DEFAULT} (what the decoders
      * clamp an absent property to), {@code TTL_DISABLED}, and {@code JS_MAX_SAFE_INTEGER} from the northbound
      * mapping defaults. A copy boundary cannot know which one it is being handed, and once the configured
-     * maximum is finite every one of them fails {@link #checkMessageExpiryInterval}.
+     * maximum is finite every one of them fails {@link #checkMessageExpiryInterval} — which is exactly the
+     * exception the bidirectional adapter's dead-letter repost hit. So the test is "is this an MQTT four-byte
+     * duration?" rather than an enumeration of markers, and anything that is not one collapses to the
+     * canonical marker at the caller. This mirrors the guard {@code RemoteMqttForwarder} already applies when
+     * converting a PUBLISH for a bridge client.
      * <p>
-     * So anything that is not an MQTT four-byte duration collapses to the canonical marker here, before it
-     * reaches the setter. Real durations pass through untouched and stay subject to the configured maximum —
-     * copying a publish must not become a way around the operator's bound. This mirrors the guard
-     * {@code RemoteMqttForwarder} already applies when converting a PUBLISH for a bridge client.
+     * Real durations deliberately keep going through the bounded setter: copying a publish must not become a
+     * way around {@code <message-expiry>}.
      */
-    public static long normalizeCopiedMessageExpiryInterval(final long messageExpiryInterval) {
-        return UnsignedDataTypes.isUnsignedInt(messageExpiryInterval)
-                ? messageExpiryInterval
-                : MESSAGE_EXPIRY_INTERVAL_NOT_SET;
-    }
-
-    private static boolean isNoExpiryMarker(final long messageExpiryInterval) {
-        return (messageExpiryInterval == MESSAGE_EXPIRY_INTERVAL_NOT_SET)
-                || (messageExpiryInterval == MAX_EXPIRY_INTERVAL_DEFAULT);
+    public static boolean isCopyableMessageExpiryDuration(final long messageExpiryInterval) {
+        return UnsignedDataTypes.isUnsignedInt(messageExpiryInterval);
     }
 
     public static void checkResponseTopic(final @Nullable String responseTopic, final boolean validateUTF8) {

--- a/hivemq-edge/src/main/java/com/hivemq/extensions/services/builder/PluginBuilderUtil.java
+++ b/hivemq-edge/src/main/java/com/hivemq/extensions/services/builder/PluginBuilderUtil.java
@@ -18,9 +18,13 @@ package com.hivemq.extensions.services.builder;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.hivemq.configuration.entity.mqtt.MqttConfigurationDefaults.MAX_EXPIRY_INTERVAL_DEFAULT;
+import static com.hivemq.mqtt.message.publish.PUBLISH.MESSAGE_EXPIRY_INTERVAL_MAX;
+import static com.hivemq.mqtt.message.publish.PUBLISH.MESSAGE_EXPIRY_INTERVAL_NOT_SET;
 
 import com.google.common.base.Preconditions;
+import com.hivemq.codec.encoder.mqtt5.UnsignedDataTypes;
 import com.hivemq.extension.sdk.api.packets.general.Qos;
+import com.hivemq.mqtt.message.publish.PUBLISH;
 import com.hivemq.util.Topics;
 import com.hivemq.util.Utf8Utils;
 import org.jetbrains.annotations.NotNull;
@@ -44,36 +48,73 @@ public class PluginBuilderUtil {
     }
 
     /**
-     * EDG-811: the message expiry interval has two ranges, and only one of them is a duration.
+     * EDG-811: a message expiry interval is a duration in seconds, except for the two values that are not
+     * durations at all.
      * <ul>
-     *     <li>{@code 0 .. 2^32-1} — a real duration, checked against the configured maximum and written to
-     *     the wire as the four-byte Message Expiry Interval property.</li>
-     *     <li>{@code >= 2^32} — "no expiry". MQTT expresses this by omitting the property, so there is no
-     *     wire value to bound; several such markers exist internally ({@code MAX_EXPIRY_INTERVAL_DEFAULT},
-     *     {@code MESSAGE_EXPIRY_INTERVAL_NOT_SET}, {@code JS_MAX_SAFE_INTEGER}) and all mean the same thing.</li>
+     *     <li>{@link PUBLISH#MESSAGE_EXPIRY_INTERVAL_NOT_SET} and {@code MAX_EXPIRY_INTERVAL_DEFAULT} — the
+     *     two "no expiry" markers this codebase actually uses. MQTT expresses "no expiry" by omitting the
+     *     Message Expiry Interval property, so there is no wire value for the configured maximum to bound,
+     *     and both markers are recognised as "absent" downstream: the MQTT 5 encoder omits them and
+     *     {@code MessageExpiryHandler} does not count them down. Rejecting the first as an oversized duration
+     *     is what broke the bidirectional adapter's dead-letter repost — it is {@code Long.MAX_VALUE} and so
+     *     sits above every configured maximum.</li>
+     *     <li>{@code 0 .. 2^32-1} — a real duration, bounded by the operator's configured maximum and written
+     *     to the wire as the four-byte Message Expiry Interval property. Zero is legal and means "expires
+     *     immediately": MQTT 5 allows it, the decoders accept it, and the extension SDK documents only a
+     *     negative interval as throwing.</li>
      * </ul>
-     * Validating the second range as if it were a duration is what broke the bidirectional adapter's
-     * dead-letter repost: copying a publish that had no expiry threw, because the "absent" marker is
-     * {@code Long.MAX_VALUE} and therefore far above any configured maximum.
+     * Everything else is rejected — a negative interval, and any other value above the four-byte range. Those
+     * have no MQTT representation, so accepting them would admit a publish into the domain model that no
+     * encoder can emit faithfully, while also handing extensions a way around the configured maximum.
      * <p>
-     * Note the resulting asymmetry: an operator who configures a one-hour maximum rejects a client asking
-     * for two hours but accepts one asking for no expiry at all. That matches MQTT, where an absent property
-     * is the protocol default and already outlives any configured bound.
+     * Deliberately, the marker test is by exact value rather than by range. A caller holding an internal
+     * publish whose interval might be any of the historical "infinity" values must normalize it first with
+     * {@link #normalizeCopiedMessageExpiryInterval}; reinterpreting arbitrary out-of-range input as "no
+     * expiry" is not this public setter's job.
      */
     public static void checkMessageExpiryInterval(
             final long messageExpiryInterval, final long maxMessageExpiryInterval) {
-        if (messageExpiryInterval >= MAX_EXPIRY_INTERVAL_DEFAULT) {
+        if (isNoExpiryMarker(messageExpiryInterval)) {
             return;
         }
+        // The four-byte cap is not redundant with the configured maximum: config.xml is validated against
+        // MAX_EXPIRY_INTERVAL_DEFAULT, but setMaxMessageExpiryInterval() itself is unchecked.
+        final long effectiveMaximum = Math.min(maxMessageExpiryInterval, MESSAGE_EXPIRY_INTERVAL_MAX);
         checkArgument(
-                messageExpiryInterval <= maxMessageExpiryInterval,
+                messageExpiryInterval <= effectiveMaximum,
                 "Message expiry interval %s not allowed. Maximum = %s",
                 messageExpiryInterval,
-                maxMessageExpiryInterval);
+                effectiveMaximum);
         checkArgument(
-                messageExpiryInterval > 0,
-                "Message expiry interval must be bigger than 0 was %s.",
+                messageExpiryInterval >= 0,
+                "Message expiry interval must not be negative was %s.",
                 messageExpiryInterval);
+    }
+
+    /**
+     * EDG-811: maps an internal message expiry interval onto the one representation the builders and the
+     * public setters agree on, for use when copying an existing publish.
+     * <p>
+     * Internally "not a real duration" has been spelled at least four ways —
+     * {@link PUBLISH#MESSAGE_EXPIRY_INTERVAL_NOT_SET}, {@code MAX_EXPIRY_INTERVAL_DEFAULT} (what the decoders
+     * clamp an absent property to), {@code TTL_DISABLED}, and {@code JS_MAX_SAFE_INTEGER} from the northbound
+     * mapping defaults. A copy boundary cannot know which one it is being handed, and once the configured
+     * maximum is finite every one of them fails {@link #checkMessageExpiryInterval}.
+     * <p>
+     * So anything that is not an MQTT four-byte duration collapses to the canonical marker here, before it
+     * reaches the setter. Real durations pass through untouched and stay subject to the configured maximum —
+     * copying a publish must not become a way around the operator's bound. This mirrors the guard
+     * {@code RemoteMqttForwarder} already applies when converting a PUBLISH for a bridge client.
+     */
+    public static long normalizeCopiedMessageExpiryInterval(final long messageExpiryInterval) {
+        return UnsignedDataTypes.isUnsignedInt(messageExpiryInterval)
+                ? messageExpiryInterval
+                : MESSAGE_EXPIRY_INTERVAL_NOT_SET;
+    }
+
+    private static boolean isNoExpiryMarker(final long messageExpiryInterval) {
+        return (messageExpiryInterval == MESSAGE_EXPIRY_INTERVAL_NOT_SET)
+                || (messageExpiryInterval == MAX_EXPIRY_INTERVAL_DEFAULT);
     }
 
     public static void checkResponseTopic(final @Nullable String responseTopic, final boolean validateUTF8) {

--- a/hivemq-edge/src/main/java/com/hivemq/extensions/services/builder/PublishBuilderImpl.java
+++ b/hivemq-edge/src/main/java/com/hivemq/extensions/services/builder/PublishBuilderImpl.java
@@ -142,8 +142,7 @@ public class PublishBuilderImpl implements PublishBuilder {
         if (publish.getPayloadFormatIndicator() != null) {
             this.payloadFormatIndicator = publish.getPayloadFormatIndicator().toPayloadFormatIndicator();
         }
-        this.messageExpiryInterval(
-                PluginBuilderUtil.normalizeCopiedMessageExpiryInterval(publish.getMessageExpiryInterval()));
+        this.copyMessageExpiryInterval(publish.getMessageExpiryInterval());
         this.responseTopic(publish.getResponseTopic());
         if (publish.getCorrelationData() != null) {
             this.correlationData(ByteBuffer.wrap(publish.getCorrelationData()));
@@ -175,8 +174,7 @@ public class PublishBuilderImpl implements PublishBuilder {
         this.retain(retain);
         this.topic(topic);
         this.payloadFormatIndicator(payloadFormatIndicator.orElse(null));
-        this.messageExpiryInterval(PluginBuilderUtil.normalizeCopiedMessageExpiryInterval(
-                messageExpiryInterval.orElse(PUBLISH.MESSAGE_EXPIRY_INTERVAL_NOT_SET)));
+        this.copyMessageExpiryInterval(messageExpiryInterval.orElse(PUBLISH.MESSAGE_EXPIRY_INTERVAL_NOT_SET));
         this.responseTopic(responseTopic.orElse(null));
         this.correlationData(correlationData.orElse(null));
         this.contentType(contentType.orElse(null));
@@ -185,6 +183,22 @@ public class PublishBuilderImpl implements PublishBuilder {
             this.userProperty(userProperty.getName(), userProperty.getValue());
         }
         return this;
+    }
+
+    /**
+     * EDG-811: the copy boundary the reported failure came through. A real duration keeps going through the
+     * bounded public setter — copying must not become a way around {@code <message-expiry>} — while anything
+     * that is not an MQTT four-byte duration is one of the internal "no expiry" markers and is assigned
+     * directly. It deliberately does not go through {@link #messageExpiryInterval(long)}: that setter is part
+     * of the extension SDK's bounded contract and must keep rejecting values above the configured maximum
+     * (EDG-811 CR2-1). {@link #build()} resolves the marker to the configured maximum.
+     */
+    private void copyMessageExpiryInterval(final long sourceInterval) {
+        if (PluginBuilderUtil.isCopyableMessageExpiryDuration(sourceInterval)) {
+            this.messageExpiryInterval(sourceInterval);
+        } else {
+            this.messageExpiryInterval = MESSAGE_EXPIRY_INTERVAL_NOT_SET;
+        }
     }
 
     @NotNull

--- a/hivemq-edge/src/main/java/com/hivemq/extensions/services/builder/PublishBuilderImpl.java
+++ b/hivemq-edge/src/main/java/com/hivemq/extensions/services/builder/PublishBuilderImpl.java
@@ -142,7 +142,8 @@ public class PublishBuilderImpl implements PublishBuilder {
         if (publish.getPayloadFormatIndicator() != null) {
             this.payloadFormatIndicator = publish.getPayloadFormatIndicator().toPayloadFormatIndicator();
         }
-        this.messageExpiryInterval(publish.getMessageExpiryInterval());
+        this.messageExpiryInterval(
+                PluginBuilderUtil.normalizeCopiedMessageExpiryInterval(publish.getMessageExpiryInterval()));
         this.responseTopic(publish.getResponseTopic());
         if (publish.getCorrelationData() != null) {
             this.correlationData(ByteBuffer.wrap(publish.getCorrelationData()));
@@ -174,7 +175,8 @@ public class PublishBuilderImpl implements PublishBuilder {
         this.retain(retain);
         this.topic(topic);
         this.payloadFormatIndicator(payloadFormatIndicator.orElse(null));
-        this.messageExpiryInterval(messageExpiryInterval.orElse(PUBLISH.MESSAGE_EXPIRY_INTERVAL_NOT_SET));
+        this.messageExpiryInterval(PluginBuilderUtil.normalizeCopiedMessageExpiryInterval(
+                messageExpiryInterval.orElse(PUBLISH.MESSAGE_EXPIRY_INTERVAL_NOT_SET)));
         this.responseTopic(responseTopic.orElse(null));
         this.correlationData(correlationData.orElse(null));
         this.contentType(contentType.orElse(null));
@@ -282,6 +284,12 @@ public class PublishBuilderImpl implements PublishBuilder {
         checkNotNull(topic, "Topic must never be null");
         checkNotNull(payload, "Payload must never be null");
 
+        // "No expiry configured" resolves to the operator's configured maximum, which is what
+        // <message-expiry> means: no message may outlive it. This is not a fallback that loses information,
+        // it is the same rule both PUBLISH decoders apply — an inbound publish whose Message Expiry Interval
+        // property is absent is clamped to maxMessageExpiryInterval() too, so a publish built here behaves
+        // exactly like the equivalent publish from a client. Left at the default 2^32 the encoder omits the
+        // property again, so the common case still goes out as a genuine "no expiry".
         if (messageExpiryInterval == MESSAGE_EXPIRY_INTERVAL_NOT_SET) {
             messageExpiryInterval = mqttConfigurationService.maxMessageExpiryInterval();
         }

--- a/hivemq-edge/src/main/java/com/hivemq/extensions/services/builder/RetainedPublishBuilderImpl.java
+++ b/hivemq-edge/src/main/java/com/hivemq/extensions/services/builder/RetainedPublishBuilderImpl.java
@@ -151,8 +151,7 @@ public class RetainedPublishBuilderImpl implements RetainedPublishBuilder {
         this.qos(qos);
         this.topic(topic);
         this.payloadFormatIndicator(payloadFormatIndicator.orElse(null));
-        this.messageExpiryInterval(PluginBuilderUtil.normalizeCopiedMessageExpiryInterval(
-                messageExpiryInterval.orElse(PUBLISH.MESSAGE_EXPIRY_INTERVAL_NOT_SET)));
+        this.copyMessageExpiryInterval(messageExpiryInterval.orElse(PUBLISH.MESSAGE_EXPIRY_INTERVAL_NOT_SET));
         this.responseTopic(responseTopic.orElse(null));
         this.correlationData(correlationData.orElse(null));
         this.contentType(contentType.orElse(null));
@@ -161,6 +160,20 @@ public class RetainedPublishBuilderImpl implements RetainedPublishBuilder {
             this.userProperty(userProperty.getName(), userProperty.getValue());
         }
         return this;
+    }
+
+    /**
+     * EDG-811: the latent twin of {@code PublishBuilderImpl}'s copy boundary — a retained message stored
+     * while the maximum was the 2^32 default still carries that marker after the operator lowers it. Real
+     * durations stay bounded by the configured maximum; the internal markers are assigned directly rather
+     * than routed through the bounded public setter, and {@link #build()} resolves them.
+     */
+    private void copyMessageExpiryInterval(final long sourceInterval) {
+        if (PluginBuilderUtil.isCopyableMessageExpiryDuration(sourceInterval)) {
+            this.messageExpiryInterval(sourceInterval);
+        } else {
+            this.messageExpiryInterval = MESSAGE_EXPIRY_INTERVAL_NOT_SET;
+        }
     }
 
     @NotNull

--- a/hivemq-edge/src/main/java/com/hivemq/extensions/services/builder/RetainedPublishBuilderImpl.java
+++ b/hivemq-edge/src/main/java/com/hivemq/extensions/services/builder/RetainedPublishBuilderImpl.java
@@ -151,7 +151,8 @@ public class RetainedPublishBuilderImpl implements RetainedPublishBuilder {
         this.qos(qos);
         this.topic(topic);
         this.payloadFormatIndicator(payloadFormatIndicator.orElse(null));
-        this.messageExpiryInterval(messageExpiryInterval.orElse(PUBLISH.MESSAGE_EXPIRY_INTERVAL_NOT_SET));
+        this.messageExpiryInterval(PluginBuilderUtil.normalizeCopiedMessageExpiryInterval(
+                messageExpiryInterval.orElse(PUBLISH.MESSAGE_EXPIRY_INTERVAL_NOT_SET)));
         this.responseTopic(responseTopic.orElse(null));
         this.correlationData(correlationData.orElse(null));
         this.contentType(contentType.orElse(null));

--- a/hivemq-edge/src/test/java/com/hivemq/codec/encoder/mqtt5/Mqtt5PublishEncoderTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/codec/encoder/mqtt5/Mqtt5PublishEncoderTest.java
@@ -22,6 +22,7 @@ import static com.hivemq.mqtt.message.mqtt5.Mqtt5UserProperties.NO_USER_PROPERTI
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.google.common.collect.ImmutableList;
+import com.hivemq.api.model.JavaScriptConstants;
 import com.hivemq.bootstrap.ClientConnection;
 import com.hivemq.configuration.HivemqId;
 import com.hivemq.configuration.entity.mqtt.MqttConfigurationDefaults;
@@ -34,8 +35,11 @@ import io.netty.buffer.Unpooled;
 import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.TreeSet;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import util.TestMessageUtil;
 
 /**
@@ -1384,5 +1388,114 @@ public class Mqtt5PublishEncoderTest extends AbstractMqtt5EncoderTest {
         assertEquals(0, buf.readableBytes());
 
         expected.release();
+    }
+
+    @Test
+    public void test_encode_expiryInterval_fourByteMaximum_isEncodedInFull() {
+        // EDG-811: the guard against out-of-range intervals has to start one above the four-byte maximum, not
+        // at it. 2^32-1 is the largest interval MQTT can carry and must still go out as four bytes.
+        final byte[] expected = {
+            // fixed header
+            //   type, flags
+            0b0011_0000,
+            //   remaining length
+            20,
+            // variable header
+            //   topic name
+            0,
+            5,
+            't',
+            'o',
+            'p',
+            'i',
+            'c',
+            //   properties
+            7,
+            //     message expiry interval
+            0x02,
+            (byte) 0xFF,
+            (byte) 0xFF,
+            (byte) 0xFF,
+            (byte) 0xFF,
+            //     payload format indicator
+            0x01,
+            0,
+            // payload
+            1,
+            2,
+            3,
+            4,
+            5
+        };
+
+        encodeTestBufferSize(expected, publishWithExpiryInterval(PUBLISH.MESSAGE_EXPIRY_INTERVAL_MAX));
+    }
+
+    /**
+     * EDG-811: an interval that does not fit in four bytes has no encoding, so the property is dropped
+     * instead of being truncated to its low 32 bits — 2^40 used to go out as 0, "expire immediately".
+     * <p>
+     * These assertions also pin the invariant that broke this branch once already: {@code encodeTestBufferSize}
+     * checks the exact byte sequence and that nothing is left unread, so a property length that disagrees with
+     * the bytes actually written fails here rather than in production as a protocol error.
+     */
+    @ParameterizedTest
+    @ValueSource(
+            longs = {
+                MqttConfigurationDefaults.MAX_EXPIRY_INTERVAL_DEFAULT,
+                PUBLISH.MESSAGE_EXPIRY_INTERVAL_NOT_SET,
+                1L << 40,
+                JavaScriptConstants.JS_MAX_SAFE_INTEGER
+            })
+    public void test_encode_expiryInterval_outOfRange_isOmitted(final long messageExpiryInterval) {
+        final byte[] expected = {
+            // fixed header
+            //   type, flags
+            0b0011_0000,
+            //   remaining length
+            15,
+            // variable header
+            //   topic name
+            0,
+            5,
+            't',
+            'o',
+            'p',
+            'i',
+            'c',
+            //   properties — no message expiry interval
+            2,
+            //     payload format indicator
+            0x01,
+            0,
+            // payload
+            1,
+            2,
+            3,
+            4,
+            5
+        };
+
+        encodeTestBufferSize(expected, publishWithExpiryInterval(messageExpiryInterval));
+    }
+
+    private @NotNull PUBLISH publishWithExpiryInterval(final long messageExpiryInterval) {
+        return TestMessageUtil.createMqtt5Publish(
+                hiveMQId.get(),
+                "topic",
+                new byte[] {1, 2, 3, 4, 5},
+                QoS.AT_MOST_ONCE,
+                QoS.AT_MOST_ONCE,
+                false,
+                messageExpiryInterval,
+                Mqtt5PayloadFormatIndicator.UNSPECIFIED,
+                null,
+                null,
+                null,
+                NO_USER_PROPERTIES,
+                -1,
+                false,
+                true,
+                null);
     }
 }

--- a/hivemq-edge/src/test/java/com/hivemq/extensions/packets/publish/ModifiableOutboundPublishImplTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/extensions/packets/publish/ModifiableOutboundPublishImplTest.java
@@ -21,11 +21,13 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.ImmutableIntArray;
+import com.hivemq.configuration.entity.mqtt.MqttConfigurationDefaults;
 import com.hivemq.configuration.service.ConfigurationService;
 import com.hivemq.extension.sdk.api.packets.general.Qos;
 import com.hivemq.extension.sdk.api.packets.publish.PayloadFormatIndicator;
 import com.hivemq.extensions.packets.general.UserPropertiesImpl;
 import com.hivemq.mqtt.message.mqtt5.MqttUserProperty;
+import com.hivemq.mqtt.message.publish.PUBLISH;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Optional;
@@ -480,6 +482,42 @@ public class ModifiableOutboundPublishImplTest {
         configurationService.mqttConfiguration().setMaxMessageExpiryInterval(240L);
         assertThatThrownBy(() -> modifiablePacket.setMessageExpiryInterval(241))
                 .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void setMessageExpiryInterval_noExpiryMarkersRejected() {
+        // EDG-811 CR2-1: this class has no build() step that resolves a marker, so accepting one would leave
+        // the packet holding an interval the encoder omits and MessageExpiryHandler cannot count down — a
+        // no-expiry outbound publish under a finite <message-expiry>. It would also widen the pre-existing
+        // sentinel leak in getMessageExpiryInterval(), which returns Optional.of(Long.MAX_VALUE) here while
+        // ModifiablePublishPacketImpl returns Optional.empty() for the same value.
+        final PublishPacketImpl packet = new PublishPacketImpl(
+                "topic",
+                Qos.AT_LEAST_ONCE,
+                Qos.AT_LEAST_ONCE,
+                1,
+                false,
+                ByteBuffer.wrap("payload".getBytes(UTF_8)),
+                false,
+                60,
+                null,
+                null,
+                null,
+                null,
+                ImmutableIntArray.of(),
+                UserPropertiesImpl.of(ImmutableList.of()),
+                System.currentTimeMillis());
+        final ModifiableOutboundPublishImpl modifiablePacket =
+                new ModifiableOutboundPublishImpl(packet, configurationService);
+
+        configurationService.mqttConfiguration().setMaxMessageExpiryInterval(240L);
+        assertThatThrownBy(() -> modifiablePacket.setMessageExpiryInterval(PUBLISH.MESSAGE_EXPIRY_INTERVAL_NOT_SET))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> modifiablePacket.setMessageExpiryInterval(
+                        MqttConfigurationDefaults.MAX_EXPIRY_INTERVAL_DEFAULT))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertEquals(Optional.of(60L), modifiablePacket.getMessageExpiryInterval());
+        assertFalse(modifiablePacket.isModified());
     }
 
     @Test

--- a/hivemq-edge/src/test/java/com/hivemq/extensions/packets/publish/ModifiablePublishPacketImplTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/extensions/packets/publish/ModifiablePublishPacketImplTest.java
@@ -21,12 +21,14 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.ImmutableIntArray;
+import com.hivemq.configuration.entity.mqtt.MqttConfigurationDefaults;
 import com.hivemq.configuration.service.ConfigurationService;
 import com.hivemq.extension.sdk.api.packets.general.Qos;
 import com.hivemq.extension.sdk.api.packets.publish.PayloadFormatIndicator;
 import com.hivemq.extensions.packets.general.UserPropertiesImpl;
 import com.hivemq.mqtt.message.QoS;
 import com.hivemq.mqtt.message.mqtt5.MqttUserProperty;
+import com.hivemq.mqtt.message.publish.PUBLISH;
 import java.nio.ByteBuffer;
 import java.util.Optional;
 import nl.jqno.equalsverifier.EqualsVerifier;
@@ -615,6 +617,40 @@ public class ModifiablePublishPacketImplTest {
         configurationService.mqttConfiguration().setMaxMessageExpiryInterval(240L);
         assertThatThrownBy(() -> modifiablePacket.setMessageExpiryInterval(241))
                 .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void setMessageExpiryInterval_noExpiryMarkersRejected() {
+        // EDG-811 CR2-1: like ModifiableOutboundPublishImpl there is no build() step here to resolve a marker
+        // against the configured maximum, so a marker accepted at this setter is a no-expiry publish under a
+        // finite <message-expiry>.
+        final PublishPacketImpl packet = new PublishPacketImpl(
+                "topic",
+                Qos.AT_LEAST_ONCE,
+                Qos.AT_LEAST_ONCE,
+                1,
+                false,
+                ByteBuffer.wrap("payload".getBytes(UTF_8)),
+                false,
+                60,
+                null,
+                null,
+                null,
+                null,
+                ImmutableIntArray.of(),
+                UserPropertiesImpl.of(ImmutableList.of()),
+                System.currentTimeMillis());
+        final ModifiablePublishPacketImpl modifiablePacket =
+                new ModifiablePublishPacketImpl(packet, configurationService);
+
+        configurationService.mqttConfiguration().setMaxMessageExpiryInterval(240L);
+        assertThatThrownBy(() -> modifiablePacket.setMessageExpiryInterval(PUBLISH.MESSAGE_EXPIRY_INTERVAL_NOT_SET))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> modifiablePacket.setMessageExpiryInterval(
+                        MqttConfigurationDefaults.MAX_EXPIRY_INTERVAL_DEFAULT))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertEquals(Optional.of(60L), modifiablePacket.getMessageExpiryInterval());
+        assertFalse(modifiablePacket.isModified());
     }
 
     @Test

--- a/hivemq-edge/src/test/java/com/hivemq/extensions/services/builder/PublishBuilderImplTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/extensions/services/builder/PublishBuilderImplTest.java
@@ -93,14 +93,51 @@ public class PublishBuilderImplTest {
     }
 
     @Test
-    public void test_message_expiry_no_expiry_markers_are_accepted_above_the_configured_maximum() {
-        // EDG-811: the two "no expiry" markers are not durations, so the configured maximum does not apply to
-        // them. MESSAGE_EXPIRY_INTERVAL_NOT_SET is Long.MAX_VALUE; validating it as a numeric bound rejected
-        // it outright, which is what broke every copy of a publish that had no expiry.
+    public void test_message_expiry_no_expiry_markers_are_rejected_under_a_finite_maximum() {
+        // EDG-811 CR2-1: <message-expiry> is the one bound the setting exists to enforce, so nothing gets past
+        // it through a public SDK setter — not even the internal "no expiry" markers. Exempting them here is
+        // what let an extension mint a message that MessageExpiryHandler never counts down and the MQTT 5
+        // encoder never emits, i.e. a real no-expiry publish under a ten-second maximum.
         configurationService.mqttConfiguration().setMaxMessageExpiryInterval(10);
-        new PublishBuilderImpl(configurationService).messageExpiryInterval(PUBLISH.MESSAGE_EXPIRY_INTERVAL_NOT_SET);
-        new PublishBuilderImpl(configurationService)
-                .messageExpiryInterval(MqttConfigurationDefaults.MAX_EXPIRY_INTERVAL_DEFAULT);
+
+        assertThatThrownBy(() -> new PublishBuilderImpl(configurationService)
+                        .messageExpiryInterval(PUBLISH.MESSAGE_EXPIRY_INTERVAL_NOT_SET))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new PublishBuilderImpl(configurationService)
+                        .messageExpiryInterval(MqttConfigurationDefaults.MAX_EXPIRY_INTERVAL_DEFAULT))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void test_message_expiry_default_marker_cannot_be_built_into_a_no_expiry_publish() {
+        // EDG-811 CR2-1, followed through to the observable consequence the setter-level test stopped short
+        // of: 2^32 survives build() untouched (only MESSAGE_EXPIRY_INTERVAL_NOT_SET is resolved), and it is
+        // precisely the value MessageExpiryHandler refuses to count down and Mqtt5MessageEncoderUtil omits.
+        // Accepting it under a ten-second maximum therefore produced a genuine no-expiry publish.
+        configurationService.mqttConfiguration().setMaxMessageExpiryInterval(10);
+
+        assertThatThrownBy(() -> new PublishBuilderImpl(configurationService)
+                        .topic("topic")
+                        .payload(ByteBuffer.wrap(new byte[] {1}))
+                        .messageExpiryInterval(MqttConfigurationDefaults.MAX_EXPIRY_INTERVAL_DEFAULT)
+                        .build())
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void test_message_expiry_default_marker_is_accepted_while_it_is_the_configured_maximum() {
+        // The flip side: 2^32 is the default configured maximum, so it stays settable as long as it is the
+        // operator's bound. This is what the pre-existing test_max_message_expiry_value_validation pins; the
+        // build() assertion here shows the resulting publish is the same "no expiry" a fresh builder produces.
+        final Publish publish = new PublishBuilderImpl(configurationService)
+                .topic("topic")
+                .payload(ByteBuffer.wrap(new byte[] {1}))
+                .messageExpiryInterval(MqttConfigurationDefaults.MAX_EXPIRY_INTERVAL_DEFAULT)
+                .build();
+
+        assertEquals(
+                MqttConfigurationDefaults.MAX_EXPIRY_INTERVAL_DEFAULT,
+                publish.getMessageExpiryInterval().get().longValue());
     }
 
     @Test
@@ -121,8 +158,16 @@ public class PublishBuilderImplTest {
         // setMaxMessageExpiryInterval() performs no validation of its own — only config.xml parsing does — so
         // the four-byte cap has to be enforced here rather than inferred from the configured maximum.
         configurationService.mqttConfiguration().setMaxMessageExpiryInterval(Long.MAX_VALUE - 1);
-        assertThatThrownBy(() -> new PublishBuilderImpl(configurationService).messageExpiryInterval(1L << 40))
-                .isInstanceOf(IllegalArgumentException.class);
+        for (final long interval : new long[] {
+            1L << 40,
+            JavaScriptConstants.JS_MAX_SAFE_INTEGER,
+            PUBLISH.MESSAGE_EXPIRY_INTERVAL_NOT_SET,
+            MqttConfigurationDefaults.MAX_EXPIRY_INTERVAL_DEFAULT + 1
+        }) {
+            assertThatThrownBy(() -> new PublishBuilderImpl(configurationService).messageExpiryInterval(interval))
+                    .describedAs("interval %s", interval)
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
     }
 
     @Test
@@ -223,6 +268,32 @@ public class PublishBuilderImplTest {
         final PUBLISH aboveMaximum = publishWithExpiry(7_200L);
         assertThatThrownBy(() -> new PublishBuilderImpl(configurationService).fromPublish(aboveMaximum))
                 .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void test_from_PUBLISH_does_not_smuggle_a_marker_past_the_configured_maximum() {
+        // EDG-811 CR2-1: the copy boundary bypasses the bounded setter, so it must not become the bypass the
+        // setter exemption was. A marker copied under a ten-second maximum has to come out as ten seconds —
+        // a countable, encodable duration — not as the marker MessageExpiryHandler and the encoder ignore.
+        configurationService.mqttConfiguration().setMaxMessageExpiryInterval(10);
+
+        for (final long sourceInterval : new long[] {
+            PUBLISH.MESSAGE_EXPIRY_INTERVAL_NOT_SET,
+            MqttConfigurationDefaults.MAX_EXPIRY_INTERVAL_DEFAULT,
+            JavaScriptConstants.JS_MAX_SAFE_INTEGER,
+            1L << 40,
+            MqttConfigurationDefaults.TTL_DISABLED
+        }) {
+            final Publish copy = new PublishBuilderImpl(configurationService)
+                    .fromPublish(publishWithExpiry(sourceInterval))
+                    .topic("topic")
+                    .build();
+
+            assertEquals(
+                    10L,
+                    copy.getMessageExpiryInterval().get().longValue(),
+                    "source interval " + sourceInterval + " must be bounded by the configured maximum");
+        }
     }
 
     private static @NotNull PUBLISH publishWithoutExpiry() {

--- a/hivemq-edge/src/test/java/com/hivemq/extensions/services/builder/PublishBuilderImplTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/extensions/services/builder/PublishBuilderImplTest.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.hivemq.api.model.JavaScriptConstants;
+import com.hivemq.configuration.entity.mqtt.MqttConfigurationDefaults;
 import com.hivemq.configuration.service.ConfigurationService;
 import com.hivemq.extension.sdk.api.packets.general.Qos;
 import com.hivemq.extension.sdk.api.packets.general.UserProperties;
@@ -30,9 +31,11 @@ import com.hivemq.extension.sdk.api.services.exception.DoNotImplementException;
 import com.hivemq.extension.sdk.api.services.publish.Publish;
 import com.hivemq.mqtt.message.QoS;
 import com.hivemq.mqtt.message.publish.PUBLISH;
+import com.hivemq.mqtt.message.publish.PUBLISHFactory;
 import java.nio.ByteBuffer;
 import java.util.Optional;
 import org.apache.commons.lang3.RandomStringUtils;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import util.TestConfigurationBootstrap;
@@ -90,23 +93,36 @@ public class PublishBuilderImplTest {
     }
 
     @Test
-    public void test_message_expiry_not_set_sentinel_is_accepted() {
-        // EDG-811: MESSAGE_EXPIRY_INTERVAL_NOT_SET means "no expiry configured", not a duration. It is
-        // Long.MAX_VALUE, so validating it as a numeric bound rejected it and any copy of a publish without
-        // an expiry failed outright.
+    public void test_message_expiry_no_expiry_markers_are_accepted_above_the_configured_maximum() {
+        // EDG-811: the two "no expiry" markers are not durations, so the configured maximum does not apply to
+        // them. MESSAGE_EXPIRY_INTERVAL_NOT_SET is Long.MAX_VALUE; validating it as a numeric bound rejected
+        // it outright, which is what broke every copy of a publish that had no expiry.
         configurationService.mqttConfiguration().setMaxMessageExpiryInterval(10);
         new PublishBuilderImpl(configurationService).messageExpiryInterval(PUBLISH.MESSAGE_EXPIRY_INTERVAL_NOT_SET);
+        new PublishBuilderImpl(configurationService)
+                .messageExpiryInterval(MqttConfigurationDefaults.MAX_EXPIRY_INTERVAL_DEFAULT);
     }
 
     @Test
-    public void test_message_expiry_at_or_above_four_byte_range_means_no_expiry() {
-        // Everything at or above 2^32 means "no expiry" and is accepted: the two-billion-wide range between
-        // the four-byte maximum and Long.MAX_VALUE previously either threw here or, on paths that skip
-        // validation, reached the encoder and was truncated to its low 32 bits.
+    public void test_message_expiry_out_of_range_values_that_are_not_markers_are_rejected() {
+        // Not every large value means "no expiry". An interval that is neither a marker nor representable in
+        // MQTT's four bytes has no correct encoding, and accepting it would also hand extensions a way past
+        // the operator's configured maximum.
         configurationService.mqttConfiguration().setMaxMessageExpiryInterval(10);
-        new PublishBuilderImpl(configurationService).messageExpiryInterval(4_294_967_296L); // 2^32
-        new PublishBuilderImpl(configurationService).messageExpiryInterval(1L << 40);
-        new PublishBuilderImpl(configurationService).messageExpiryInterval(JavaScriptConstants.JS_MAX_SAFE_INTEGER);
+        assertThatThrownBy(() -> new PublishBuilderImpl(configurationService).messageExpiryInterval(1L << 40))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new PublishBuilderImpl(configurationService)
+                        .messageExpiryInterval(JavaScriptConstants.JS_MAX_SAFE_INTEGER))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void test_message_expiry_out_of_range_value_is_rejected_even_when_the_maximum_is_unchecked() {
+        // setMaxMessageExpiryInterval() performs no validation of its own — only config.xml parsing does — so
+        // the four-byte cap has to be enforced here rather than inferred from the configured maximum.
+        configurationService.mqttConfiguration().setMaxMessageExpiryInterval(Long.MAX_VALUE - 1);
+        assertThatThrownBy(() -> new PublishBuilderImpl(configurationService).messageExpiryInterval(1L << 40))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
@@ -116,6 +132,120 @@ public class PublishBuilderImplTest {
         assertThatThrownBy(() ->
                         new PublishBuilderImpl(configurationService).messageExpiryInterval(4_294_967_295L)) // 2^32-1
                 .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void test_message_expiry_zero_is_accepted() {
+        // The extension SDK documents only a negative interval as throwing, MQTT 5 allows zero, and the
+        // decoders accept it — so a publish that expires immediately must survive the builder rather than
+        // blow up the moment anything copies it.
+        final Publish publish = new PublishBuilderImpl(configurationService)
+                .topic("topic")
+                .payload(ByteBuffer.wrap(new byte[] {1, 2, 3}))
+                .messageExpiryInterval(0)
+                .build();
+
+        assertEquals(0L, publish.getMessageExpiryInterval().get().longValue());
+    }
+
+    @Test
+    public void test_from_PUBLISH_without_expiry_builds_without_throwing() {
+        // EDG-811 as reported: the bidirectional adapter's dead-letter repost is exactly this sequence, and
+        // it threw at fromPublish() because the source carried MESSAGE_EXPIRY_INTERVAL_NOT_SET.
+        configurationService.mqttConfiguration().setMaxMessageExpiryInterval(3_600);
+
+        final PUBLISH source = publishWithoutExpiry();
+        assertEquals(PUBLISH.MESSAGE_EXPIRY_INTERVAL_NOT_SET, source.getMessageExpiryInterval());
+
+        final Publish repost = new PublishBuilderImpl(configurationService)
+                .fromPublish(source)
+                .topic("$failed/topic")
+                .build();
+
+        assertEquals("$failed/topic", repost.getTopic());
+        // "No expiry" resolves to the configured maximum, which is the same rule the PUBLISH decoders apply
+        // to an inbound publish whose Message Expiry Interval property is absent.
+        assertEquals(3_600L, repost.getMessageExpiryInterval().get().longValue());
+    }
+
+    @Test
+    public void test_from_PUBLISH_without_expiry_keeps_no_expiry_under_the_default_maximum() {
+        final PUBLISH source = publishWithoutExpiry();
+
+        final Publish repost = new PublishBuilderImpl(configurationService)
+                .fromPublish(source)
+                .topic("topic")
+                .build();
+
+        assertEquals(
+                MqttConfigurationDefaults.MAX_EXPIRY_INTERVAL_DEFAULT,
+                repost.getMessageExpiryInterval().get().longValue());
+    }
+
+    @Test
+    public void test_from_PUBLISH_normalizes_every_out_of_range_interval() {
+        // A copy boundary cannot know which of the historical "infinity" spellings it is handed, so anything
+        // that is not a four-byte duration collapses to "no expiry" before it reaches the validating setter.
+        configurationService.mqttConfiguration().setMaxMessageExpiryInterval(3_600);
+
+        for (final long sourceInterval : new long[] {
+            PUBLISH.MESSAGE_EXPIRY_INTERVAL_NOT_SET,
+            MqttConfigurationDefaults.MAX_EXPIRY_INTERVAL_DEFAULT,
+            JavaScriptConstants.JS_MAX_SAFE_INTEGER,
+            1L << 40,
+            MqttConfigurationDefaults.TTL_DISABLED
+        }) {
+            final PUBLISH source = publishWithExpiry(sourceInterval);
+
+            final Publish copy = new PublishBuilderImpl(configurationService)
+                    .fromPublish(source)
+                    .topic("topic")
+                    .build();
+
+            assertEquals(
+                    3_600L,
+                    copy.getMessageExpiryInterval().get().longValue(),
+                    "source interval " + sourceInterval + " should be treated as no expiry");
+        }
+    }
+
+    @Test
+    public void test_from_PUBLISH_keeps_a_real_duration_bounded_by_the_configured_maximum() {
+        // Normalizing the markers must not turn copying into a way around the operator's bound.
+        configurationService.mqttConfiguration().setMaxMessageExpiryInterval(3_600);
+
+        final Publish copy = new PublishBuilderImpl(configurationService)
+                .fromPublish(publishWithExpiry(120L))
+                .topic("topic")
+                .build();
+        assertEquals(120L, copy.getMessageExpiryInterval().get().longValue());
+
+        final PUBLISH aboveMaximum = publishWithExpiry(7_200L);
+        assertThatThrownBy(() -> new PublishBuilderImpl(configurationService).fromPublish(aboveMaximum))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    private static @NotNull PUBLISH publishWithoutExpiry() {
+        // PUBLISHFactory defaults the interval to MESSAGE_EXPIRY_INTERVAL_NOT_SET, which is what every
+        // internally generated publish carries when nothing configured an expiry.
+        return new PUBLISHFactory.Mqtt5Builder()
+                .withHivemqId("hivemqId")
+                .withTopic("topic")
+                .withPayload(new byte[] {1, 2, 3})
+                .withQoS(QoS.AT_MOST_ONCE)
+                .withOnwardQos(QoS.AT_MOST_ONCE)
+                .build();
+    }
+
+    private static @NotNull PUBLISH publishWithExpiry(final long messageExpiryInterval) {
+        return new PUBLISHFactory.Mqtt5Builder()
+                .withHivemqId("hivemqId")
+                .withTopic("topic")
+                .withPayload(new byte[] {1, 2, 3})
+                .withQoS(QoS.AT_MOST_ONCE)
+                .withOnwardQos(QoS.AT_MOST_ONCE)
+                .withMessageExpiryInterval(messageExpiryInterval)
+                .build();
     }
 
     @Test

--- a/hivemq-edge/src/test/java/com/hivemq/extensions/services/builder/PublishBuilderImplTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/extensions/services/builder/PublishBuilderImplTest.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.hivemq.api.model.JavaScriptConstants;
 import com.hivemq.configuration.service.ConfigurationService;
 import com.hivemq.extension.sdk.api.packets.general.Qos;
 import com.hivemq.extension.sdk.api.packets.general.UserProperties;
@@ -28,6 +29,7 @@ import com.hivemq.extension.sdk.api.packets.publish.PayloadFormatIndicator;
 import com.hivemq.extension.sdk.api.services.exception.DoNotImplementException;
 import com.hivemq.extension.sdk.api.services.publish.Publish;
 import com.hivemq.mqtt.message.QoS;
+import com.hivemq.mqtt.message.publish.PUBLISH;
 import java.nio.ByteBuffer;
 import java.util.Optional;
 import org.apache.commons.lang3.RandomStringUtils;
@@ -85,6 +87,35 @@ public class PublishBuilderImplTest {
 
         assertThrows(IllegalArgumentException.class, () -> new PublishBuilderImpl(configurationService)
                 .messageExpiryInterval(-1));
+    }
+
+    @Test
+    public void test_message_expiry_not_set_sentinel_is_accepted() {
+        // EDG-811: MESSAGE_EXPIRY_INTERVAL_NOT_SET means "no expiry configured", not a duration. It is
+        // Long.MAX_VALUE, so validating it as a numeric bound rejected it and any copy of a publish without
+        // an expiry failed outright.
+        configurationService.mqttConfiguration().setMaxMessageExpiryInterval(10);
+        new PublishBuilderImpl(configurationService).messageExpiryInterval(PUBLISH.MESSAGE_EXPIRY_INTERVAL_NOT_SET);
+    }
+
+    @Test
+    public void test_message_expiry_at_or_above_four_byte_range_means_no_expiry() {
+        // Everything at or above 2^32 means "no expiry" and is accepted: the two-billion-wide range between
+        // the four-byte maximum and Long.MAX_VALUE previously either threw here or, on paths that skip
+        // validation, reached the encoder and was truncated to its low 32 bits.
+        configurationService.mqttConfiguration().setMaxMessageExpiryInterval(10);
+        new PublishBuilderImpl(configurationService).messageExpiryInterval(4_294_967_296L); // 2^32
+        new PublishBuilderImpl(configurationService).messageExpiryInterval(1L << 40);
+        new PublishBuilderImpl(configurationService).messageExpiryInterval(JavaScriptConstants.JS_MAX_SAFE_INTEGER);
+    }
+
+    @Test
+    public void test_message_expiry_real_duration_above_maximum_is_still_rejected() {
+        // Below 2^32 the value is a real duration, so the operator's configured maximum still binds.
+        configurationService.mqttConfiguration().setMaxMessageExpiryInterval(10);
+        assertThatThrownBy(() ->
+                        new PublishBuilderImpl(configurationService).messageExpiryInterval(4_294_967_295L)) // 2^32-1
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test

--- a/hivemq-edge/src/test/java/com/hivemq/extensions/services/builder/RetainedPublishBuilderImplTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/extensions/services/builder/RetainedPublishBuilderImplTest.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.common.collect.ImmutableList;
+import com.hivemq.configuration.entity.mqtt.MqttConfigurationDefaults;
 import com.hivemq.configuration.service.ConfigurationService;
 import com.hivemq.extension.sdk.api.packets.general.Qos;
 import com.hivemq.extension.sdk.api.packets.general.UserProperties;
@@ -35,6 +36,7 @@ import com.hivemq.extensions.packets.publish.PublishPacketImpl;
 import com.hivemq.extensions.services.publish.RetainedPublishImpl;
 import com.hivemq.mqtt.message.QoS;
 import com.hivemq.mqtt.message.mqtt5.MqttUserProperty;
+import com.hivemq.mqtt.message.publish.PUBLISH;
 import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Optional;
@@ -272,6 +274,60 @@ public class RetainedPublishBuilderImplTest {
         assertEquals(
                 userProperties.asList().size(),
                 built.getUserProperties().asList().size());
+    }
+
+    @Test
+    public void test_from_retained_publish_without_expiry() {
+        // EDG-811: the same copy boundary as PublishBuilderImpl. A retained message stored while the maximum
+        // was the 2^32 default still carries that marker after the operator lowers the maximum, and copying it
+        // used to throw because the marker is above the new bound.
+        configurationService.mqttConfiguration().setMaxMessageExpiryInterval(3_600);
+
+        for (final long storedInterval : new long[] {
+            PUBLISH.MESSAGE_EXPIRY_INTERVAL_NOT_SET,
+            MqttConfigurationDefaults.MAX_EXPIRY_INTERVAL_DEFAULT,
+            1L << 40,
+            MqttConfigurationDefaults.TTL_DISABLED
+        }) {
+            final RetainedPublishImpl stored = new RetainedPublishImpl(
+                    Qos.AT_MOST_ONCE,
+                    "topic",
+                    PayloadFormatIndicator.UTF_8,
+                    storedInterval,
+                    null,
+                    null,
+                    null,
+                    ByteBuffer.wrap("payload".getBytes(UTF_8)),
+                    UserPropertiesImpl.of(ImmutableList.of()));
+
+            final RetainedPublish built = new RetainedPublishBuilderImpl(configurationService)
+                    .fromPublish(stored)
+                    .build();
+
+            assertEquals(
+                    3_600L,
+                    built.getMessageExpiryInterval().get().longValue(),
+                    "stored interval " + storedInterval + " should be treated as no expiry");
+        }
+    }
+
+    @Test
+    public void test_from_retained_publish_keeps_a_real_duration_bounded_by_the_configured_maximum() {
+        configurationService.mqttConfiguration().setMaxMessageExpiryInterval(3_600);
+
+        final RetainedPublishImpl aboveMaximum = new RetainedPublishImpl(
+                Qos.AT_MOST_ONCE,
+                "topic",
+                PayloadFormatIndicator.UTF_8,
+                7_200L,
+                null,
+                null,
+                null,
+                ByteBuffer.wrap("payload".getBytes(UTF_8)),
+                UserPropertiesImpl.of(ImmutableList.of()));
+
+        assertThatThrownBy(() -> new RetainedPublishBuilderImpl(configurationService).fromPublish(aboveMaximum))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test

--- a/hivemq-edge/src/test/java/com/hivemq/extensions/services/builder/RetainedPublishBuilderImplTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/extensions/services/builder/RetainedPublishBuilderImplTest.java
@@ -277,6 +277,44 @@ public class RetainedPublishBuilderImplTest {
     }
 
     @Test
+    public void test_message_expiry_no_expiry_markers_are_rejected_under_a_finite_maximum() {
+        // EDG-811 CR2-1: the shared validator backs five public SDK setters, and none of them may let a value
+        // past <message-expiry>. The markers are handled at the copy boundary instead, not here.
+        configurationService.mqttConfiguration().setMaxMessageExpiryInterval(10);
+
+        assertThatThrownBy(() -> new RetainedPublishBuilderImpl(configurationService)
+                        .messageExpiryInterval(PUBLISH.MESSAGE_EXPIRY_INTERVAL_NOT_SET))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new RetainedPublishBuilderImpl(configurationService)
+                        .messageExpiryInterval(MqttConfigurationDefaults.MAX_EXPIRY_INTERVAL_DEFAULT))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void test_from_retained_publish_does_not_smuggle_a_marker_past_the_configured_maximum() {
+        // The copy boundary bypasses the bounded setter, so it must resolve to the configured maximum rather
+        // than keep a marker the expiry handler and encoder would both treat as "no expiry".
+        configurationService.mqttConfiguration().setMaxMessageExpiryInterval(10);
+
+        final RetainedPublishImpl stored = new RetainedPublishImpl(
+                Qos.AT_MOST_ONCE,
+                "topic",
+                PayloadFormatIndicator.UTF_8,
+                MqttConfigurationDefaults.MAX_EXPIRY_INTERVAL_DEFAULT,
+                null,
+                null,
+                null,
+                ByteBuffer.wrap("payload".getBytes(UTF_8)),
+                UserPropertiesImpl.of(ImmutableList.of()));
+
+        final RetainedPublish built = new RetainedPublishBuilderImpl(configurationService)
+                .fromPublish(stored)
+                .build();
+
+        assertEquals(10L, built.getMessageExpiryInterval().get().longValue());
+    }
+
+    @Test
     public void test_from_retained_publish_without_expiry() {
         // EDG-811: the same copy boundary as PublishBuilderImpl. A retained message stored while the maximum
         // was the 2^32 default still carries that marker after the operator lowers the maximum, and copying it

--- a/hivemq-edge/src/test/java/com/hivemq/extensions/services/builder/WillPublishBuilderImplTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/extensions/services/builder/WillPublishBuilderImplTest.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.collect.ImmutableList;
+import com.hivemq.configuration.entity.mqtt.MqttConfigurationDefaults;
 import com.hivemq.configuration.service.ConfigurationService;
 import com.hivemq.extension.sdk.api.packets.connect.WillPublishPacket;
 import com.hivemq.extension.sdk.api.packets.general.Qos;
@@ -35,6 +36,7 @@ import com.hivemq.extensions.packets.general.UserPropertiesImpl;
 import com.hivemq.extensions.packets.publish.PublishPacketImpl;
 import com.hivemq.mqtt.message.QoS;
 import com.hivemq.mqtt.message.mqtt5.MqttUserProperty;
+import com.hivemq.mqtt.message.publish.PUBLISH;
 import com.hivemq.util.Bytes;
 import java.nio.ByteBuffer;
 import java.util.List;
@@ -59,6 +61,35 @@ public class WillPublishBuilderImplTest {
     public void setUp() throws Exception {
         final ConfigurationService service = new TestConfigurationBootstrap().getConfigurationService();
         willPublishBuilder = new WillPublishBuilderImpl(service);
+    }
+
+    @Test
+    public void test_message_expiry_no_expiry_markers_are_rejected_under_a_finite_maximum() {
+        // EDG-811 CR2-1: WillPublishBuilder.messageExpiryInterval is one of the five public setters backed by
+        // the shared validator. It has no copy-boundary need for the markers, so <message-expiry> binds here
+        // exactly as the extension SDK documents.
+        final ConfigurationService service = new TestConfigurationBootstrap().getConfigurationService();
+        service.mqttConfiguration().setMaxMessageExpiryInterval(10);
+        final WillPublishBuilderImpl builder = new WillPublishBuilderImpl(service);
+
+        assertThatThrownBy(() -> builder.messageExpiryInterval(PUBLISH.MESSAGE_EXPIRY_INTERVAL_NOT_SET))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> builder.messageExpiryInterval(MqttConfigurationDefaults.MAX_EXPIRY_INTERVAL_DEFAULT))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> builder.messageExpiryInterval(11)).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void test_message_expiry_zero_is_accepted() {
+        // EDG-811 CR-5: the SDK documents only a negative interval as throwing.
+        final ConfigurationService service = new TestConfigurationBootstrap().getConfigurationService();
+        final WillPublishPacket willPublishPacket = new WillPublishBuilderImpl(service)
+                .topic("topic")
+                .payload(ByteBuffer.wrap(new byte[] {1, 2, 3}))
+                .messageExpiryInterval(0)
+                .build();
+
+        assertEquals(0L, willPublishPacket.getMessageExpiryInterval().get().longValue());
     }
 
     @Test


### PR DESCRIPTION
## Description (the why)

A message expiry interval is a duration in seconds — except that internally "no expiry" has been spelled at least four different ways, none of which is a duration and none of which converts to the others:

| constant | value | where it comes from |
|---|---|---|
| `MAX_EXPIRY_INTERVAL_DEFAULT` | 2³² | what both PUBLISH decoders clamp an absent property to; the default `<message-expiry>` |
| `MESSAGE_EXPIRY_INTERVAL_NOT_SET` | `Long.MAX_VALUE` | `PUBLISHFactory`'s default — every internally generated publish |
| `NorthboundMapping.DEFAULT_MESSAGE_EXPIRY` | `JS_MAX_SAFE_INTEGER` (2⁵³−1) | the API/config layer |
| `TTL_DISABLED` | −1 | retained-message TTL |

Two independent defects came out of that, both fixed here.

**1. The copy boundary rejected the markers.** `PublishBuilderImpl.fromPublish` copied the source publish's interval straight into the *public, bounded* setter, so a publish that had no expiry arrived at `checkMessageExpiryInterval` as `Long.MAX_VALUE` and threw `Message expiry interval 9223372036854775807 not allowed`. That is how the bidirectional adapter's dead-letter repost silently stopped happening (observed on Edge 2026.12-SNAPSHOT, once per poll): the exception was swallowed by `validateAndWrite`'s outer catch and the message never reached `$invalid/`.

**2. The encoder truncated out-of-range values.** `encodeIntProperty` tested only for equality with the caller's default, so any *other* out-of-range value reached `writeInt((int) value)` and kept its low 32 bits — 2⁴⁰ encoding as **0** ("expire immediately"), `Long.MAX_VALUE` as 4294967295.

Linear: EDG-811

## What changed

Validation and normalization are two different jobs, done in two different places.

**The public setter stays bounded.** `PluginBuilderUtil.checkMessageExpiryInterval` accepts `0 .. min(configuredMaximum, MAX_EXPIRY_INTERVAL_DEFAULT)` and nothing else. No value — however it is spelled — gets past `<message-expiry>` through a public extension SDK setter. Two deliberate deltas from the previous behaviour:

- **Zero is now accepted.** The SDK javadoc documents only a *negative* interval as throwing, MQTT 5 permits zero, and `Mqtt5PublishDecoder` reads it without a lower-bound check. Rejecting it was itself a live instance of this bug class: a client publishing with expiry 0 and failing its southbound schema hit the same exception on the repost.
- **The four-byte cap is enforced explicitly.** `MqttConfigurator` bounds `<message-expiry>` at 2³², but only on the `config.xml` path — `MqttConfigurationServiceImpl.setMaxMessageExpiryInterval` is unchecked. Without the cap a programmatically raised maximum would let a value with no MQTT representation into the domain model.

**The copy boundary normalizes first, and bypasses the setter.** `PublishBuilderImpl.fromPublish(PUBLISH)`, `PublishBuilderImpl.fromComplete(...)` and `RetainedPublishBuilderImpl.fromComplete(...)` ask `PluginBuilderUtil.isCopyableMessageExpiryDuration(...)` whether they were handed a real four-byte duration. If yes it goes through the bounded setter as before; if no — any marker, any spelling, present or future — the canonical `MESSAGE_EXPIRY_INTERVAL_NOT_SET` is assigned to the field directly, and `build()` resolves it to the operator's configured maximum. This mirrors the guard `RemoteMqttForwarder` already applies at the same kind of boundary, and it is why the fix does not need to enumerate the four constants.

**The encoder never truncates.** `intPropertyEncodedLength` and `encodeIntProperty` share one `shouldEncodeIntProperty` predicate, so the declared property length and the bytes actually written cannot drift apart. (They did once on this branch, producing malformed packets and widespread timeouts.) The equality half of the predicate is kept because `MAXIMUM_PACKET_SIZE` passes a *genuine* default — a legal value the receiver reconstructs from the spec — where omission is a size optimisation. Packet-size and session-expiry behaviour are unchanged.

### Behaviour, per boundary

| input | public setter, `<message-expiry>` = 10 | public setter, default max (2³²) | copy boundary, `<message-expiry>` = 10 |
|---|---|---|---|
| `0 .. 10` | accepted | accepted | passed through unchanged |
| `11 .. 2³²−1` | **rejected** | accepted | **rejected** — copying is not a way around the bound |
| `2³²` (`MAX_EXPIRY_INTERVAL_DEFAULT`) | **rejected** | accepted — it *is* the maximum | → no expiry → `build()` = 10 |
| `Long.MAX_VALUE` (`MESSAGE_EXPIRY_INTERVAL_NOT_SET`) | **rejected** | **rejected** | → no expiry → `build()` = 10 |
| `JS_MAX_SAFE_INTEGER`, 2⁴⁰ | **rejected** | **rejected** | → no expiry → `build()` = 10 |
| `TTL_DISABLED` (−1) | **rejected** | **rejected** | → no expiry → `build()` = 10 |

"No expiry" resolving to the configured maximum during `build()` is deliberate and is **not** a fallback that loses information: it is the rule the rest of the broker already applies. `Mqtt5PublishDecoder` clamps an absent Message Expiry Interval property to `maxMessageExpiryInterval()`, `Mqtt3PublishDecoder` sets it unconditionally, and the extension SDK documents `<message-expiry>` as this builder's default. A publish built here therefore behaves exactly like the equivalent publish from a client. Left at the default 2³² the encoder omits the property again, so the common case still goes out as a genuine "no expiry".

## Acceptance Criteria (the what)

- [x] `PublishBuilderImpl.fromPublish` and the shared expiry-copy boundary treat "not a real duration" as unset rather than validating it as a numeric bound.
- [x] The three (four) expiry "infinity" constants are reconciled at that boundary, without migrating any of them.
- [x] A real duration above the operator's configured maximum is **still** rejected — through the setter and through a copy.
- [x] No internal marker can pass a public SDK setter and become a no-expiry message under a finite `<message-expiry>`.
- [x] No value above the four-byte range can reach `writeInt` and be truncated.
- [x] Packet-size and session-expiry encoding are unchanged.
- [x] Regression: a rejected southbound write for a no-expiry message publishes the `$invalid/` repost without throwing — see the companion PR below.

## Non-Goals

- **Migrating the four constants to one.** The copy boundary makes them behave identically; unifying them touches config, domain and API models and belongs in its own change.
- `ModifiableOutboundPublishImpl.getMessageExpiryInterval()` returns `Optional.of(Long.MAX_VALUE)` for the sentinel while `PublishPacketImpl` and `ModifiablePublishPacketImpl` return `Optional.empty()`. Pre-existing, unrelated to this fix, and changing it changes behaviour for existing publishes.
- `NorthboundMapping.messageExpiryInterval` has no consumer in main source and appears to have no effect. Pre-existing; worth its own ticket.

## Test plan

Full `hivemq-edge` unit suite green; `:hivemq-edge:check` (Spotless + ErrorProne + NullAway + tests) green.

**Setter contract, all five shared call sites** — `PublishBuilderImpl`, `RetainedPublishBuilderImpl`, `WillPublishBuilderImpl`, `ModifiablePublishPacketImpl`, `ModifiableOutboundPublishImpl`: both markers are rejected under a finite maximum, real durations above the maximum are rejected, zero is accepted, negatives are rejected, and 2⁴⁰ / `JS_MAX_SAFE_INTEGER` are rejected even when `setMaxMessageExpiryInterval` was raised past the four-byte range.

**Build-through, not just the setter** — `test_message_expiry_default_marker_cannot_be_built_into_a_no_expiry_publish` follows 2³² under a ten-second maximum all the way to `build()`, which is where the earlier revision of this PR produced a publish that `MessageExpiryHandler` never counts down and the encoder never emits.

**Copy boundary** — `fromPublish` / `fromComplete` normalize `MESSAGE_EXPIRY_INTERVAL_NOT_SET`, `MAX_EXPIRY_INTERVAL_DEFAULT`, `JS_MAX_SAFE_INTEGER`, 2⁴⁰ and `TTL_DISABLED`; real durations stay bounded; a marker copied under a ten-second maximum comes out as ten seconds, not as a marker.

**Byte level** — `Mqtt5PublishEncoderTest` asserts the exact wire bytes for `2³²−1` (written in full) and for four out-of-range values (property absent, declared property length matching the bytes written, payload intact).

**Mutation-checked.** Reintroducing the marker exemption in the validator fails 7 tests across all five call sites; reintroducing the raw `messageExpiryInterval(publish.getMessageExpiryInterval())` copy fails the `ReactiveWriter` regression with the original `IllegalArgumentException`; reintroducing the encoder length/write desync fails 3 of the 4 out-of-range byte-level cases.

## Companion PR

[hivemq/hivemq-edge-commercial-modules#359](https://github.com/hivemq/hivemq-edge-commercial-modules/pull/359) — **merge this PR first**; that one's repost test fails against a core build without this fix.

The end-to-end acceptance criterion is covered there: `ReactiveWriterTest` now drives a queued no-expiry `PUBLISH` through a rejecting `DataHubService.validatePublish(...)` and asserts the captured `Publish` lands on `$invalid/<topic>` with the expiry resolved to the configured maximum, that the failure metric fires, the queue entry is removed, polling continues, exactly one repost is issued, and a message already on `$invalid/` is not reposted recursively.
