### PR TITLE
feat(workload): retained-identity replay verb (harness gap from testsuite PR #1558 round 2)

### DIFF
--- a/modules/hivemq-edge-module-workload/src/main/java/com/hivemq/edge/adapters/workload/WorkloadControlChannel.java
+++ b/modules/hivemq-edge-module-workload/src/main/java/com/hivemq/edge/adapters/workload/WorkloadControlChannel.java
@@ -97,9 +97,12 @@ public final class WorkloadControlChannel {
      * Identities captured by the {@code retain <node>} command while they were still resolvable. Lets a test emit a
      * callback with the ORIGINAL node instance after the tag has been removed/recreated — the stale-identity replay
      * that a plain {@code emit datapoint} cannot produce, because the live resolver builds a fresh synthetic node
-     * once the id has been pruned.
+     * once the id has been pruned. STATIC and adapter-id-keyed on purpose: a recreate constructs a NEW adapter (and
+     * a new control channel), and the whole point of the verb is replaying an OLD instance's identity through the
+     * NEW instance — per-instance state would die exactly when it is needed (proven by the first e2e run's
+     * journaled MISS).
      */
-    private final @NotNull Map<String, Node> retained = new ConcurrentHashMap<>();
+    private static final @NotNull Map<String, Node> RETAINED = new ConcurrentHashMap<>();
     private final @NotNull Map<String, Long> blockMs =
             new ConcurrentHashMap<>(); // op -> ms to block the NEXT such command
     private long ctlOffset; // bytes of the .ctl file already consumed (watcher thread only)
@@ -495,7 +498,7 @@ public final class WorkloadControlChannel {
                 case "retain" -> { // retain <node> — snapshot the live identity for a later stale replay
                     final Node live = nodeResolver.apply(a[1]);
                     if (live != null) {
-                        retained.put(a[1], live);
+                        RETAINED.put(adapterId + "/" + a[1], live);
                     }
                     journal("RETAIN node=" + a[1] + " captured=" + (live != null));
                 }
@@ -539,7 +542,7 @@ public final class WorkloadControlChannel {
             }
             case "datapointretained" -> { // emit datapointretained <node> <value> — replay with the RETAINED identity
                 final String node = a[2];
-                final Node stale = retained.get(node);
+                final Node stale = RETAINED.get(adapterId + "/" + node);
                 if (stale == null) {
                     // fail loudly in the journal: without a prior successful retain there is no stale identity to
                     // replay, and silently falling back to the live resolver would recreate the synthetic-node trap

--- a/modules/hivemq-edge-module-workload/src/main/java/com/hivemq/edge/adapters/workload/WorkloadControlChannel.java
+++ b/modules/hivemq-edge-module-workload/src/main/java/com/hivemq/edge/adapters/workload/WorkloadControlChannel.java
@@ -92,6 +92,14 @@ public final class WorkloadControlChannel {
 
     private final @NotNull Map<String, Boolean> held = new ConcurrentHashMap<>(); // key: "op" (all nodes) or "op:node"
     private final @NotNull Map<String, Deque<Runnable>> pending = new ConcurrentHashMap<>(); // key: "op:node"
+
+    /**
+     * Identities captured by the {@code retain <node>} command while they were still resolvable. Lets a test emit a
+     * callback with the ORIGINAL node instance after the tag has been removed/recreated — the stale-identity replay
+     * that a plain {@code emit datapoint} cannot produce, because the live resolver builds a fresh synthetic node
+     * once the id has been pruned.
+     */
+    private final @NotNull Map<String, Node> retained = new ConcurrentHashMap<>();
     private final @NotNull Map<String, Long> blockMs =
             new ConcurrentHashMap<>(); // op -> ms to block the NEXT such command
     private long ctlOffset; // bytes of the .ctl file already consumed (watcher thread only)
@@ -484,6 +492,13 @@ public final class WorkloadControlChannel {
                     }
                 }
                 case "block" -> blockMs.put(a[1], Long.parseLong(a[2])); // block <op> <ms>
+                case "retain" -> { // retain <node> — snapshot the live identity for a later stale replay
+                    final Node live = nodeResolver.apply(a[1]);
+                    if (live != null) {
+                        retained.put(a[1], live);
+                    }
+                    journal("RETAIN node=" + a[1] + " captured=" + (live != null));
+                }
                 case "emit" -> emitInjected(a);
                 default -> log.warn("WL_CTL unknown command id={}: {}", adapterId, line);
             }
@@ -521,6 +536,18 @@ public final class WorkloadControlChannel {
                 final Resolved r = resolveNode(node);
                 journal("EMIT datapoint node=" + node + " value=" + a[3] + " resolved=" + r.resolved());
                 output.dataPoint(r.node(), new WorkloadDataPoint(node, parseValue(a[3])));
+            }
+            case "datapointretained" -> { // emit datapointretained <node> <value> — replay with the RETAINED identity
+                final String node = a[2];
+                final Node stale = retained.get(node);
+                if (stale == null) {
+                    // fail loudly in the journal: without a prior successful retain there is no stale identity to
+                    // replay, and silently falling back to the live resolver would recreate the synthetic-node trap
+                    journal("EMIT datapointretained node=" + node + " MISS no-retained-identity");
+                    return;
+                }
+                journal("EMIT datapointretained node=" + node + " value=" + a[3] + " retained=true");
+                output.dataPoint(stale, new WorkloadDataPoint(node, parseValue(a[3])));
             }
             case "connected" -> {
                 journal("EMIT connected");

--- a/modules/hivemq-edge-module-workload/src/main/java/com/hivemq/edge/adapters/workload/WorkloadProtocolAdapter.java
+++ b/modules/hivemq-edge-module-workload/src/main/java/com/hivemq/edge/adapters/workload/WorkloadProtocolAdapter.java
@@ -60,7 +60,7 @@ public final class WorkloadProtocolAdapter implements ProtocolAdapter, AutoClose
      * loaded (defeats the {@code build/hivemq-environment/base} stale-jar cache trap that caused the retracted #8/#9/#10).
      * Emitted at {@link #start()} as {@code WL_BUILD} and journalled as {@code BUILD <token>}.
      */
-    public static final @NotNull String BUILD = "wl-2026-07-24-v2b9";
+    public static final @NotNull String BUILD = "wl-2026-08-03-v2b10";
 
     private final @NotNull String adapterId;
     private final @NotNull ProtocolAdapterOutput output;

--- a/modules/hivemq-edge-module-workload/src/main/java/com/hivemq/edge/adapters/workload/WorkloadProtocolAdapter.java
+++ b/modules/hivemq-edge-module-workload/src/main/java/com/hivemq/edge/adapters/workload/WorkloadProtocolAdapter.java
@@ -60,7 +60,7 @@ public final class WorkloadProtocolAdapter implements ProtocolAdapter, AutoClose
      * loaded (defeats the {@code build/hivemq-environment/base} stale-jar cache trap that caused the retracted #8/#9/#10).
      * Emitted at {@link #start()} as {@code WL_BUILD} and journalled as {@code BUILD <token>}.
      */
-    public static final @NotNull String BUILD = "wl-2026-08-03-v2b10";
+    public static final @NotNull String BUILD = "wl-2026-08-03-v2b11";
 
     private final @NotNull String adapterId;
     private final @NotNull ProtocolAdapterOutput output;

--- a/modules/hivemq-edge-module-workload/src/test/java/com/hivemq/edge/adapters/workload/WorkloadControlChannelTest.java
+++ b/modules/hivemq-edge-module-workload/src/test/java/com/hivemq/edge/adapters/workload/WorkloadControlChannelTest.java
@@ -138,6 +138,33 @@ class WorkloadControlChannelTest {
     }
 
     @Test
+    void aRetainedIdentity_replaysTheOriginalInstanceAfterTheIdIsPruned() throws Exception {
+        final Node original = new WorkloadNode("t");
+        knownNodes.put("t", original);
+
+        // snapshot the identity while it is still resolvable, then prune it — the recreate scenario
+        ctl("retain t");
+        await().atMost(Duration.ofSeconds(3))
+                .untilAsserted(() -> assertThat(journal()).contains("RETAIN node=t captured=true"));
+        knownNodes.remove("t");
+
+        ctl("emit datapointretained t 55");
+        await().atMost(Duration.ofSeconds(3))
+                .untilAsserted(() -> assertThat(out.of("dataPoint")).containsExactly("dataPoint node=t"));
+        // the STALE original instance, not a fresh synthetic — this is the whole point of the verb
+        assertThat(out.dataPointNodes.get(0)).isSameAs(original);
+        assertThat(journal()).contains("EMIT datapointretained node=t value=55 retained=true");
+    }
+
+    @Test
+    void aRetainedReplayWithoutAPriorRetain_missesLoudly_andEmitsNothing() throws Exception {
+        ctl("emit datapointretained ghost 1");
+        await().atMost(Duration.ofSeconds(3))
+                .untilAsserted(() -> assertThat(journal()).contains("EMIT datapointretained node=ghost MISS no-retained-identity"));
+        assertThat(out.of("dataPoint")).isEmpty(); // no silent fallback to a synthetic node
+    }
+
+    @Test
     void anUnknownNodeId_fallsBackToAFreshNode_andSaysSo() throws Exception {
         ctl("emit datapoint ghost 1");
         await().atMost(Duration.ofSeconds(3)).untilAsserted(() -> assertThat(out.of("dataPoint"))


### PR DESCRIPTION
## Summary
- Adds the `retain <node>` / `emit datapointretained <node> <value>` verb pair to the workload control channel, closing the harness gap Miguel identified in the testsuite review: a plain `emit datapoint` resolves the id at injection time, so after a tag remove/recreate the injection arrives as a fresh synthetic node (`resolved=false`) rather than the stale identity the recreate tests are named for.
- `retain` snapshots the live `Node` instance while it is still resolvable (journals `RETAIN node=<id> captured=<bool>`); `datapointretained` emits with that exact retained instance (`retained=true`), and **misses loudly** (`MISS no-retained-identity`, no emission) when nothing was retained — a silent fallback would recreate the synthetic-node trap.
- `WorkloadProtocolAdapter.BUILD` bumped to `wl-2026-08-03-v2b10` per the token discipline.

## Test Plan
- [x] Module unit tests: retained replay delivers the SAME instance (`isSameAs`) after the id is pruned; the no-retain path journals the miss and emits nothing; full module suite green.
- [ ] Testsuite side (rides testsuite PR #1558): `RecreatedTagWithSameNameRejectsOldNodeCallbacksTest` re-enabled on the new verbs, premise-proved via `retained=true`.