### PR TITLE
EDG-868: Log the call site when an adapter is removed from the map

### DIFF
--- a/hivemq-edge/src/main/java/com/hivemq/protocols/ProtocolAdapterManager.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/ProtocolAdapterManager.java
@@ -603,7 +603,21 @@ public class ProtocolAdapterManager {
     protected @NotNull Optional<ProtocolAdapterWrapper> deleteProtocolAdapterWrapperByAdapterId(
             final @NotNull String adapterId) {
         Preconditions.checkNotNull(adapterId);
-        return Optional.ofNullable(protocolAdapterMap.remove(adapterId));
+        final ProtocolAdapterWrapper removed = protocolAdapterMap.remove(adapterId);
+        if (removed != null && LOGGER.isDebugEnabled()) {
+            // EDG-868: this is the ONLY path that takes an adapter out of the map — stop, restart and the
+            // atomic update all leave the entry in place. When an adapter unexpectedly turns up missing, the
+            // question is always "was it removed, or not yet registered", and this line is what answers it.
+            // Logged with a stack trace because the caller is the interesting part: a config refresh whose
+            // snapshot omitted the adapter looks identical, from the map's point of view, to a deliberate
+            // delete.
+            LOGGER.debug(
+                    "Removing adapter '{}' from the adapter map (remaining: {})",
+                    adapterId,
+                    protocolAdapterMap.keySet(),
+                    new Exception("EDG-868 adapter removal call site"));
+        }
+        return Optional.ofNullable(removed);
     }
 
     protected void deleteProtocolAdapterByAdapterId(final @NotNull String adapterId) {


### PR DESCRIPTION
## Description (the why)

[EDG-868](https://linear.app/hivemq/issue/EDG-868/investigate-why-the-adapter-is-transiently-absent-from)

Diagnostic only — one DEBUG log line, no behaviour change.

`AdapterLifecycleApiIT` fails intermittently on CI because `test-simulation-server-1` is absent from `ProtocolAdapterManager`'s map when the test reads it. Two explanations remain, and they need different fixes:

1. **Never registered yet.** Registration is asynchronous — `start()` only registers a config consumer, and `refresh(...)` hands adapter creation to `executorService.execute(...)`. Nothing waits for it.
2. **Registered, then removed.** Which would be the more serious finding, because no ordinary lifecycle operation should remove an adapter.

Reading the code, (2) has no obvious mechanism: `stop(id, destroy=false)` → `stopWrapper(...)` stops the wrapper in place and never touches `protocolAdapterMap`, and `updateProtocolAdapterAtomically` guarantees the id stays resolvable throughout (EDG-602). `deleteProtocolAdapterWrapperByAdapterId` is the **only** path that removes an entry.

So a log line there settles which explanation holds. The **caller** is the interesting part: a config refresh whose snapshot omits an adapter reaches the same delete path as a deliberate delete, and from the map's point of view the two are indistinguishable — hence the stack trace.

## What changed

`deleteProtocolAdapterWrapperByAdapterId` logs at DEBUG when it actually removes something, including the remaining keys and the call site.

Guarded by `LOGGER.isDebugEnabled()`, so there is no cost when DEBUG is off. The removal path runs on adapter delete and config refresh, not on any hot path.

## Acceptance Criteria (the what)

- [x] No behaviour change — the method returns exactly what it returned before
- [x] Nothing logged unless an adapter was genuinely removed
- [x] `spotlessCheck` clean

## Non-Goals

- Fixing the underlying flake. The test-side fix is the companion PR in `hivemq-edge-test`; this only makes the remaining ambiguity observable.
- Deciding whether an adapter should ever be absent from the manager mid-lifecycle — that question stays on EDG-868 until the logging answers it.

## Note

Paired with the `hivemq-edge-test` PR on the identically-named branch, so the composite resolves them together. This change is independently droppable: if the test-side fix proves sufficient and the ambiguity is resolved, this can be reverted without touching anything else.
