### PR TITLE
EDG-876: Explain why the defensive remove() in onReset must stay

### DIFF
--- a/hivemq-edge/src/main/java/com/hivemq/bootstrap/LoggingBootstrap.java
+++ b/hivemq-edge/src/main/java/com/hivemq/bootstrap/LoggingBootstrap.java
@@ -212,7 +212,13 @@ public class LoggingBootstrap {
          */
         @Override
         public void onReset(final @NotNull LoggerContext context) {
-            log.trace("logback.xml was changed");
+            // Please don't delete this. Normally the filter list is empty here, because
+            // LoggerContext.reset() cleared it before calling us — but if it is not, better safe than
+            // sorry. Filters have a real runtime cost, so we want no redundant ones.
+            //
+            // We cannot log the surprise, or anything else from here: reset() has already detached the
+            // appenders and restored the root logger to its default level. Any message we emit is
+            // silently dropped.
             context.getTurboFilterList().remove(logLevelModifierTurboFilter);
             context.addTurboFilter(logLevelModifierTurboFilter);
         }


### PR DESCRIPTION
## Description (the why)

[EDG-876](https://linear.app/hivemq/issue/EDG-876/turbofilterlistit-races-setups-own-logback-reload-and-times-out)

Small change to `LogbackChangeListener.onReset`: a comment explaining why the defensive `remove()` must stay, and the removal of a `log.trace` that has never printed anything.

## Why the remove() needs a comment

`onReset` does `remove()` then `addTurboFilter()`. The `remove()` looks redundant, and it is easy to delete in good faith — on the reset path `LoggerContext.reset()` has already cleared the turbo filter list before this listener runs, so there is normally nothing to remove, and deleting the line leaves every test green.

It matters if the filter is ever re-added on a path where the list was *not* cleared. Adding without removing first would leave two entries, and logback's `TurboFilterList` copies its array on every logging call once it holds more than one — a silent cost on every log statement in the product.

`TurboFilterListIT` asserts the **behaviour** — exactly one turbo filter after a reload — not the implementation, and it is not a test's job to pin how many lines of defence the code has. So the protection belongs in a comment at the line itself.

## Why the log.trace goes

`LoggerContext.reset()` calls `recursiveReset()` and `resetTurboFilterList()` **before** `fireOnReset()`. By the time `onReset` runs, the root logger has no appenders and has been restored to its default level, so nothing logged from here reaches anywhere.

Verified against our exact logback 1.6.0 with a standalone probe that reproduces this listener and logs from inside a real reset:

```
PROBE: --- sanity check, appenders are live ---
APPENDER-SAW: this one should be visible
PROBE: --- now the real thing: reset() + reconfigure ---
PROBE: inside onReset -> root appenders = 0, root level = DEBUG, effective = DEBUG, turbo filters = 0, TRACE enabled = false
PROBE: --- after reconfigure, appenders are live again ---
APPENDER-SAW: this one should also be visible
```

The bracketing messages show the harness works — the same logger writes visibly before and after. From inside `onReset` nothing appears, for two independent reasons: `TRACE` is no longer enabled after the level reset, and an `ERROR` message (which passes the level check) is also dropped for want of an appender.

That is also why the surprise the comment describes cannot itself be logged, which the comment now says so nobody adds a log call back.

## Acceptance Criteria (the what)

- [x] No behaviour change beyond removing a statement that produced no output
- [x] Compiles; `spotlessCheck` clean
- [ ] Green on CI

## Note

Paired with [hivemq-edge-test#426](https://github.com/hivemq/hivemq-edge-test/pull/426) on the identically-named branch, which fixes the flaky test itself. This change is independent and could stand alone.
