### PR TITLE
EDG-862: Extract the bridge reconnect schedule into BridgeReconnectDelay

### DIFF
--- a/hivemq-edge/src/main/java/com/hivemq/bridge/BRIDGES.md
+++ b/hivemq-edge/src/main/java/com/hivemq/bridge/BRIDGES.md
@@ -131,9 +131,9 @@ When the bridge connection to the remote broker is lost:
 
 1. **Connection Monitoring**: The `BridgeMqttClient` detects disconnection via MQTT client listeners
 2. **Automatic Reconnection**: Exponential backoff reconnection strategy is triggered
-   - Initial delay: 1 second
-   - Maximum delay: 2 minutes
-   - 25% jitter to prevent thundering herd
+   - Initial delay: 1 second, doubling with each consecutive failure
+   - Ceiling: 128 seconds, reached after seven failures and held for every attempt after that
+   - Up to 25% jitter on top, to prevent thundering herd
 3. **Message Buffering**: Messages continue to be queued
 
 ### Two-Level Queueing System

--- a/hivemq-edge/src/main/java/com/hivemq/bridge/BridgeService.java
+++ b/hivemq-edge/src/main/java/com/hivemq/bridge/BridgeService.java
@@ -48,6 +48,21 @@ import org.slf4j.LoggerFactory;
 public class BridgeService {
     private static final @NotNull Logger log = LoggerFactory.getLogger(BridgeService.class);
 
+    /**
+     * How long {@link #updateBridges} waits for a bridge to stop before giving up on it and
+     * disconnecting its client the hard way.
+     * <p>
+     * Generous because a bridge that is mid-reconnect or draining a queue should be allowed to
+     * finish rather than be cut off; the forced disconnect below exists for the case where it never
+     * will.
+     */
+    static final long STOP_TIMEOUT_SECONDS = 30;
+
+    /**
+     * How long the forced disconnect that follows a stop timeout is itself given.
+     */
+    static final long FORCED_DISCONNECT_TIMEOUT_SECONDS = 5;
+
     private final @NotNull MessageForwarder messageForwarder;
     private final @NotNull BridgeMqttClientFactory bridgeMqttClientFactory;
     private final @NotNull ExecutorService executorService;
@@ -75,6 +90,24 @@ public class BridgeService {
         metricRegistry.registerGauge(HiveMQMetrics.BRIDGES_CURRENT.name(), allKnownBridgeConfigs::size);
         shutdownHooks.add(new BridgeShutdownHook(this));
         bridgeConfig.registerConsumer(this::updateBridges);
+    }
+
+    /**
+     * How long to wait for a bridge to stop, in seconds.
+     * <p>
+     * Overridable so that a test can exercise the timeout path without waiting out the production
+     * budget: the branch it guards is reached only by letting the wait expire, so a fixed 30 seconds
+     * would mean 30 seconds of wall clock per test. Production behaviour is the default.
+     */
+    long stopTimeoutSeconds() {
+        return STOP_TIMEOUT_SECONDS;
+    }
+
+    /**
+     * How long to wait for the forced disconnect that follows a stop timeout, in seconds.
+     */
+    long forcedDisconnectTimeoutSeconds() {
+        return FORCED_DISCONNECT_TIMEOUT_SECONDS;
     }
 
     /**
@@ -308,7 +341,7 @@ public class BridgeService {
         }
 
         try {
-            bridgeAndClient.mqttClient().stop().get(30, TimeUnit.SECONDS);
+            bridgeAndClient.mqttClient().stop().get(stopTimeoutSeconds(), TimeUnit.SECONDS);
         } catch (final InterruptedException e) {
             Thread.currentThread().interrupt();
             log.warn("Interrupted while stopping bridge '{}': {}", bridgeId, e.getMessage());
@@ -317,11 +350,14 @@ public class BridgeService {
             log.warn("Execution error while stopping bridge '{}': {}", bridgeId, e.getMessage());
             log.debug("Execution exception details", e);
         } catch (final TimeoutException e) {
-            log.warn("Timeout (30s) while stopping bridge '{}', attempting forced disconnect", bridgeId);
+            log.warn(
+                    "Timeout ({}s) while stopping bridge '{}', attempting forced disconnect",
+                    stopTimeoutSeconds(),
+                    bridgeId);
             log.debug("Timeout exception details", e);
             try {
                 // Attempt forced disconnect on timeout - the underlying client may still have pending reconnections
-                client.getMqtt5Client().disconnect().get(5, TimeUnit.SECONDS);
+                client.getMqtt5Client().disconnect().get(forcedDisconnectTimeoutSeconds(), TimeUnit.SECONDS);
                 log.info("Forced disconnect of bridge '{}' succeeded", bridgeId);
             } catch (final Exception forcedDisconnectEx) {
                 log.error(

--- a/hivemq-edge/src/main/java/com/hivemq/bridge/mqtt/BridgeMqttClient.java
+++ b/hivemq-edge/src/main/java/com/hivemq/bridge/mqtt/BridgeMqttClient.java
@@ -67,7 +67,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
@@ -82,11 +81,6 @@ import org.slf4j.LoggerFactory;
 public class BridgeMqttClient {
 
     private static final @NotNull Logger log = LoggerFactory.getLogger(BridgeMqttClient.class);
-
-    private static final long RECONNECT_MIN_DELAY_MS = 1_000; // 1 second
-    private static final long RECONNECT_MAX_DELAY_MS = 120_000; // 2 minutes
-    private static final double RECONNECT_JITTER_FACTOR = 0.25; // 25% max jitter
-    private static final int RECONNECT_MAX_BACKOFF_EXPONENT = 10; // 2^10 = 1024 seconds max
 
     private final @NotNull MqttBridge bridge;
     private final @NotNull BridgeInterceptorHandler bridgeInterceptorHandler;
@@ -563,28 +557,22 @@ public class BridgeMqttClient {
                 return;
             }
             if (context.getSource() != MqttDisconnectSource.USER) {
-                // exponential backoff with 1s-2min range, 25% additive jitter for thundering herd prevention
                 final MqttClientReconnector reconnector = context.getReconnector();
                 final int attempts = reconnector.getAttempts();
-                final int exponent = Math.min(attempts, RECONNECT_MAX_BACKOFF_EXPONENT);
-                final long calculatedDelay = RECONNECT_MIN_DELAY_MS << exponent;
-                final long delayMs = Math.min(calculatedDelay, RECONNECT_MAX_DELAY_MS);
-                // Full jitter is often better for reducing load spikes
-                // This gives random delay between 0 and delayMs * JITTER_FACTOR
-                final long jitterMs = (long) (delayMs
-                        * RECONNECT_JITTER_FACTOR
-                        * ThreadLocalRandom.current().nextDouble());
-                final long totalDelayMs = delayMs + jitterMs;
+                // The whole schedule, jitter included, lives in BridgeReconnectDelay: it can be
+                // asserted there, and tests can select a non-exponential one.
+                final BridgeReconnectDelay.Delay delay = BridgeReconnectDelay.nextDelay(attempts);
                 if (log.isInfoEnabled()) {
                     log.info(
-                            "Bridge '{}' will attempt reconnection #{} in {} ms (delay: {} ms, jitter: {} ms)",
+                            "Bridge '{}' will attempt reconnection #{} in {} ms (delay: {} ms, jitter: {} ms, schedule: {})",
                             bridge.getId(),
                             attempts + 1,
-                            totalDelayMs,
-                            delayMs,
-                            jitterMs);
+                            delay.totalMs(),
+                            delay.baseDelayMs(),
+                            delay.jitterMs(),
+                            delay.mode());
                 }
-                reconnector.reconnect(true).delay(totalDelayMs, TimeUnit.MILLISECONDS);
+                reconnector.reconnect(true).delay(delay.totalMs(), TimeUnit.MILLISECONDS);
             } else {
                 if (log.isDebugEnabled()) {
                     log.debug("Bridge '{}' disconnected by user, not attempting auto-reconnection", bridge.getId());

--- a/hivemq-edge/src/main/java/com/hivemq/bridge/mqtt/BridgeReconnectDelay.java
+++ b/hivemq-edge/src/main/java/com/hivemq/bridge/mqtt/BridgeReconnectDelay.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.bridge.mqtt;
+
+import java.util.concurrent.ThreadLocalRandom;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Decides how long a bridge waits before its next reconnection attempt.
+ * <p>
+ * The production schedule is exponential: the delay doubles with every consecutive failed attempt,
+ * so a remote broker that stays down is retried ever more rarely instead of being hammered. On top
+ * of that sits additive jitter, which spreads the attempts of many bridges that lost the same remote
+ * broker at the same moment.
+ * <p>
+ * That schedule is a poor fit for tests that reproduce reconnection defects. Such a test breaks the
+ * connection, waits for the bridge to give up, restores the connection and then waits for it to come
+ * back. Under the exponential schedule the second wait is not bounded by how quickly the bridge
+ * <i>can</i> reconnect but by how much backoff the first wait accumulated: after five failures the
+ * next attempt is already 16 seconds away, and after seven it has reached its ceiling of 128 seconds.
+ * Tests therefore end up sleeping for the backoff rather than waiting for the bridge, which is why
+ * the Toxiproxy bridge tests carried 30-second toxic windows.
+ * <p>
+ * {@link Mode#CONSTANT} exists for those tests. It retries at a fixed one-second interval, so the
+ * time to the next attempt never exceeds one second no matter how long the outage lasted, and a test
+ * can wait for the reconnection itself instead of for the schedule. It is deliberately not reachable
+ * from configuration: it is selected by the system property {@value #MODE_PROPERTY}, which a test
+ * sets on the JVM that runs it.
+ *
+ * @see <a href="https://linear.app/hivemq/issue/EDG-862">EDG-862</a>
+ */
+public final class BridgeReconnectDelay {
+
+    private static final @NotNull Logger log = LoggerFactory.getLogger(BridgeReconnectDelay.class);
+
+    /**
+     * System property selecting the retry schedule. Unset means {@link Mode#EXPONENTIAL}.
+     * <p>
+     * This is a testing switch, not a configuration option. It is read from the system properties
+     * rather than the Edge configuration so that it cannot be set by a deployment, and it is
+     * deliberately noisy: selecting a non-production schedule is logged at WARN, and an unrecognised
+     * value fails rather than silently reverting to the production schedule. A test that believes it
+     * disabled backoff but did not would not fail, it would flake.
+     */
+    public static final @NotNull String MODE_PROPERTY = "hivemq.bridge.reconnect.mode";
+
+    /**
+     * Delay before the first retry, and the fixed delay of {@link Mode#CONSTANT}.
+     */
+    static final long MIN_DELAY_MS = 1_000; // 1 second
+
+    /**
+     * Upper bound on the exponent, and so on the delay: the doubling stops at
+     * {@code MIN_DELAY_MS << MAX_BACKOFF_EXPONENT}, and every further attempt waits that long.
+     * <p>
+     * It bounds the exponent rather than the delay because it does two jobs at once. The delay it
+     * yields is the policy — a bridge whose remote broker stays down still retries about every two
+     * minutes, so it recovers on its own once the broker returns. Capping the exponent is also what
+     * keeps {@code MIN_DELAY_MS << attempts} in range: Java shifts a long by only the low six bits
+     * of its operand, so an uncapped exponent would turn negative at 54 consecutive failures and
+     * wrap back to a one-second delay at 64, converting the backoff into the hot retry loop it
+     * exists to prevent.
+     * <p>
+     * Expressing the ceiling this way costs the freedom to choose a round number: the reachable
+     * ceilings are powers of two times a second, so 128 seconds rather than 120. At the point where
+     * a bridge has failed seven times in a row that difference is immaterial — jitter already
+     * spreads the delay across a wider range than that — and the alternative, a second constant
+     * clamping the result, reads as redundant with this one and invites deleting whichever of the
+     * two looks unused.
+     */
+    static final int MAX_BACKOFF_EXPONENT = 7; // 2^7 = 128 seconds, about two minutes
+
+    /**
+     * Fraction of the delay that may be added as jitter, so that bridges which failed together do
+     * not retry together.
+     */
+    static final double JITTER_FACTOR = 0.25; // 25% max jitter
+
+    public enum Mode {
+        /**
+         * Production: 1s, 2s, 4s, 8s, 16s, 32s, 64s, then 128s for every further attempt.
+         */
+        EXPONENTIAL,
+
+        /**
+         * Testing only: 1s before every attempt, however many have failed. Retry moments are then
+         * one second apart, so a test can bound how long a reconnection takes.
+         */
+        CONSTANT;
+
+        static @NotNull Mode parse(final @NotNull String value) {
+            for (final Mode mode : values()) {
+                if (mode.name().equalsIgnoreCase(value)) {
+                    return mode;
+                }
+            }
+            throw new IllegalArgumentException("Unknown bridge reconnect mode '"
+                    + value
+                    + "' in system property '"
+                    + MODE_PROPERTY
+                    + "'. Known modes: EXPONENTIAL, CONSTANT.");
+        }
+    }
+
+    private BridgeReconnectDelay() {}
+
+    /**
+     * The currently selected mode.
+     * <p>
+     * Read on every call rather than cached, because the tests that set it share a JVM with tests
+     * that must not have it: a value captured when this class was first loaded would leak the
+     * schedule of whichever test happened to run first.
+     *
+     * @throws IllegalArgumentException if the property holds a value that is not a mode
+     */
+    public static @NotNull Mode currentMode() {
+        final String configured = System.getProperty(MODE_PROPERTY);
+        if (configured == null || configured.isBlank()) {
+            return Mode.EXPONENTIAL;
+        }
+        final Mode mode = Mode.parse(configured.trim());
+        if (mode != Mode.EXPONENTIAL) {
+            log.warn(
+                    "Bridge reconnection is using the non-production '{}' schedule, selected by system property '{}'. "
+                            + "This disables exponential backoff and is intended for tests only.",
+                    mode,
+                    MODE_PROPERTY);
+        }
+        return mode;
+    }
+
+    /**
+     * How long to wait before the next reconnection attempt, and why.
+     *
+     * @param mode     the schedule that produced it
+     * @param baseDelayMs the delay the schedule gives for this attempt count
+     * @param jitterMs    the spread added on top
+     */
+    public record Delay(@NotNull Mode mode, long baseDelayMs, long jitterMs) {
+
+        /**
+         * What the caller waits: the schedule's delay plus its jitter.
+         */
+        public long totalMs() {
+            return baseDelayMs + jitterMs;
+        }
+    }
+
+    /**
+     * How long to wait before the next reconnection attempt.
+     * <p>
+     * The randomness for the jitter is drawn here rather than asked of the caller, so that deciding
+     * a reconnection delay is one call and callers cannot get the spread wrong. The parts are
+     * returned alongside the total because the caller logs them separately, and a bridge that
+     * reconnects later than expected is much easier to explain when the log distinguishes a long
+     * schedule from a large draw.
+     *
+     * @param attempts number of attempts that have already failed in this reconnection chain; zero
+     *                 for the first retry after a connection that had been established
+     * @return the delay, its jitter, and the schedule they came from
+     * @throws IllegalArgumentException if {@value #MODE_PROPERTY} holds a value that is not a mode
+     */
+    public static @NotNull Delay nextDelay(final int attempts) {
+        final Mode mode = currentMode();
+        final long baseDelayMs = baseDelayMs(attempts, mode);
+        return new Delay(
+                mode,
+                baseDelayMs,
+                jitterMs(baseDelayMs, mode, ThreadLocalRandom.current().nextDouble()));
+    }
+
+    /**
+     * Delay before the next attempt under an explicitly given mode, without jitter.
+     * <p>
+     * Pure: the same arguments always give the same answer, which is what lets the schedule be
+     * asserted exactly rather than by its range.
+     *
+     * @param attempts number of attempts that have already failed in this reconnection chain
+     * @param mode     the schedule to apply
+     * @return the delay in milliseconds, at least {@link #MIN_DELAY_MS} and at most
+     * {@code MIN_DELAY_MS << MAX_BACKOFF_EXPONENT}
+     */
+    static long baseDelayMs(final int attempts, final @NotNull Mode mode) {
+        if (mode == Mode.CONSTANT) {
+            return MIN_DELAY_MS;
+        }
+        final int exponent = Math.min(Math.max(attempts, 0), MAX_BACKOFF_EXPONENT);
+        return MIN_DELAY_MS << exponent;
+    }
+
+    /**
+     * Jitter to add to a base delay, spreading the retries of bridges that failed together.
+     * <p>
+     * {@link Mode#CONSTANT} adds none: a test selects it precisely to know when the retries happen,
+     * and jitter would blur those moments for no benefit, since a test runs one bridge rather than a
+     * fleet of them.
+     *
+     * @param baseDelayMs the delay from {@link #baseDelayMs(int, Mode)}
+     * @param mode        the schedule in effect
+     * @param random      a value in {@code [0, 1)}; taken as a parameter rather than drawn here so
+     *                    that the spread can be asserted exactly
+     * @return milliseconds to add, in {@code [0, baseDelayMs * JITTER_FACTOR)}
+     */
+    static long jitterMs(final long baseDelayMs, final @NotNull Mode mode, final double random) {
+        if (mode == Mode.CONSTANT) {
+            return 0;
+        }
+        return (long) (baseDelayMs * JITTER_FACTOR * random);
+    }
+}

--- a/hivemq-edge/src/test/java/com/hivemq/bridge/BridgeServiceConcurrentOperationsTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/bridge/BridgeServiceConcurrentOperationsTest.java
@@ -16,6 +16,7 @@
 package com.hivemq.bridge;
 
 import static java.util.Objects.requireNonNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -51,6 +52,17 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class BridgeServiceConcurrentOperationsTest {
+
+    /**
+     * Stop timeout used in place of the production 30 seconds.
+     * <p>
+     * The timeout path can only be reached by letting the wait expire, so testing it at the
+     * production value costs 30 seconds of wall clock per test — and this class did exactly that,
+     * making it the slowest unit test in the suite at 56s. Shortening the budget exercises the same
+     * branch; what is being tested is that the fallback happens when the budget runs out, not how
+     * long the budget is.
+     */
+    private static final long TEST_STOP_TIMEOUT_SECONDS = 1;
 
     private @Nullable BridgeService bridgeService;
     private @Nullable BridgeMqttClientFactory clientFactory;
@@ -106,14 +118,20 @@ class BridgeServiceConcurrentOperationsTest {
         final MetricRegistry metricRegistry = new MetricRegistry();
         final BridgeExtractor bridgeExtractor = mock(BridgeExtractor.class);
         final ShutdownHooks shutdownHooks = new ShutdownHooks();
-        bridgeService = new BridgeService(
-                bridgeExtractor,
-                messageForwarder,
-                requireNonNull(clientFactory),
-                executorService,
-                remoteService,
-                shutdownHooks,
-                metricRegistry);
+        bridgeService =
+                new BridgeService(
+                        bridgeExtractor,
+                        messageForwarder,
+                        requireNonNull(clientFactory),
+                        executorService,
+                        remoteService,
+                        shutdownHooks,
+                        metricRegistry) {
+                    @Override
+                    long stopTimeoutSeconds() {
+                        return TEST_STOP_TIMEOUT_SECONDS;
+                    }
+                };
     }
 
     /**
@@ -572,12 +590,21 @@ class BridgeServiceConcurrentOperationsTest {
      * The key test is testStopTimeout_attemptsForcedDisconnect which verifies
      * the forced disconnect logic without needing to wait for actual timeouts.
      */
+    /**
+     * A bridge that is slow to stop but does stop within the budget must be waited for, not cut off
+     * and force-disconnected.
+     * <p>
+     * This is the other side of {@link #testStopTimeout_attemptsForcedDisconnect()}: together they
+     * pin both branches of the timeout. The distinguishing observation is whether the forced
+     * disconnect happened, not how long the call took — the previous version of this test asserted
+     * only that the elapsed time fell between 24 and 35 seconds, which would have passed just as
+     * happily had the timeout been raised to a minute.
+     */
     @Test
-    void testStopTimeout_uses30Seconds() {
-        final long startTime = System.currentTimeMillis();
+    void testSlowButSuccessfulStop_isWaitedForRatherThanForced() throws Exception {
         final SettableFuture<Void> stopFuture = SettableFuture.create();
+        final AtomicInteger forcedDisconnectCalls = new AtomicInteger(0);
 
-        // Create bridge and mock client with delayed stop
         final MqttBridge bridge = createTestBridge("slow-bridge");
         final BridgeMqttClient mockClient = mock(BridgeMqttClient.class);
 
@@ -587,32 +614,34 @@ class BridgeServiceConcurrentOperationsTest {
         when(mockClient.getActiveForwarders()).thenReturn(List.of());
         when(mockClient.getBridge()).thenReturn(bridge);
         when(mockClient.createForwarders()).thenReturn(List.of());
-        when(mockClient.getMqtt5Client()).thenReturn(mock(Mqtt5AsyncClient.class));
+
+        final Mqtt5AsyncClient mqtt5Client = mock(Mqtt5AsyncClient.class);
+        when(mockClient.getMqtt5Client()).thenReturn(mqtt5Client);
+        when(mqtt5Client.disconnect()).thenAnswer(invocation -> {
+            forcedDisconnectCalls.incrementAndGet();
+            return CompletableFuture.completedFuture(null);
+        });
 
         when(requireNonNull(clientFactory).createRemoteClient(bridge)).thenReturn(mockClient);
 
-        // Add bridge
         requireNonNull(bridgeService).updateBridges(List.of(bridge));
 
-        // Complete the stop future after 25 seconds in a background thread
-        new Thread(() -> {
-                    try {
-                        Thread.sleep(25000);
-                        stopFuture.set(null);
-                    } catch (final InterruptedException e) {
-                        Thread.currentThread().interrupt();
-                    }
-                })
-                .start();
+        // Complete the stop well inside the budget, so the wait ends because the bridge stopped
+        // rather than because the clock ran out.
+        final Thread completer = new Thread(() -> {
+            try {
+                Thread.sleep(TimeUnit.SECONDS.toMillis(TEST_STOP_TIMEOUT_SECONDS) / 4);
+                stopFuture.set(null);
+            } catch (final InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        });
+        completer.start();
 
-        // Remove bridge (should wait up to 30 seconds)
         requireNonNull(bridgeService).updateBridges(List.of());
+        completer.join(TimeUnit.SECONDS.toMillis(TEST_STOP_TIMEOUT_SECONDS));
 
-        final long duration = System.currentTimeMillis() - startTime;
-
-        // Should have waited at least 25 seconds (when we complete the future)
-        // but less than 30 seconds (the timeout)
-        assertTrue(duration >= 24000, "Should wait for slow stop: " + duration + "ms");
-        assertTrue(duration < 35000, "Should not wait much longer than timeout: " + duration + "ms");
+        assertEquals(
+                0, forcedDisconnectCalls.get(), "A bridge that stops within the budget must not be force-disconnected");
     }
 }

--- a/hivemq-edge/src/test/java/com/hivemq/bridge/mqtt/BridgeReconnectDelayTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/bridge/mqtt/BridgeReconnectDelayTest.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.bridge.mqtt;
+
+import static com.hivemq.bridge.mqtt.BridgeReconnectDelay.MODE_PROPERTY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.hivemq.bridge.mqtt.BridgeReconnectDelay.Delay;
+import com.hivemq.bridge.mqtt.BridgeReconnectDelay.Mode;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.IntStream;
+import org.jetbrains.annotations.Nullable;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class BridgeReconnectDelayTest {
+
+    private @Nullable String propertyBeforeTest;
+
+    @BeforeEach
+    void saveProperty() {
+        propertyBeforeTest = System.getProperty(MODE_PROPERTY);
+        System.clearProperty(MODE_PROPERTY);
+    }
+
+    @AfterEach
+    void restoreProperty() {
+        if (propertyBeforeTest == null) {
+            System.clearProperty(MODE_PROPERTY);
+        } else {
+            System.setProperty(MODE_PROPERTY, propertyBeforeTest);
+        }
+    }
+
+    @Test
+    void baseDelayMs_whenExponential_thenDoublesUntilTheCeiling() {
+        // The head of the sequence is the doubling; the tail is the plateau at
+        // MIN_DELAY_MS << MAX_BACKOFF_EXPONENT, which every attempt from the seventh onwards waits.
+        // Both halves are asserted here because the head alone would still pass if the cap were
+        // raised, and the cap is the only thing keeping the shift in range.
+        assertEquals(
+                List.of(1_000L, 2_000L, 4_000L, 8_000L, 16_000L, 32_000L, 64_000L, 128_000L, 128_000L, 128_000L),
+                delaysForFirstAttempts(10, Mode.EXPONENTIAL));
+    }
+
+    @Test
+    void baseDelayMs_whenExponentialAndAttemptsAbsurdlyHigh_thenStillTheCeilingAndPositive() {
+        // Java shifts a long by only the low six bits of the operand, so without the exponent cap
+        // 1000L << 54 would be negative and 1000L << 64 would wrap back to 1000 — a bridge down for
+        // long enough would wait a negative time, then retry every second. Reaching 54 consecutive
+        // failures takes around 100 minutes of continuous outage, so this is a case production can
+        // arrive at rather than a theoretical one.
+        assertEquals(128_000L, BridgeReconnectDelay.baseDelayMs(54, Mode.EXPONENTIAL));
+        assertEquals(128_000L, BridgeReconnectDelay.baseDelayMs(64, Mode.EXPONENTIAL));
+        assertEquals(128_000L, BridgeReconnectDelay.baseDelayMs(Integer.MAX_VALUE, Mode.EXPONENTIAL));
+    }
+
+    @Test
+    void baseDelayMs_whenConstant_thenAlwaysOneSecond() {
+        // The point of the mode: the wait before the next attempt never grows, so a test that
+        // restores a broken connection can bound how long the bridge takes to come back.
+        assertEquals(
+                List.of(1_000L, 1_000L, 1_000L, 1_000L, 1_000L, 1_000L, 1_000L, 1_000L, 1_000L, 1_000L),
+                delaysForFirstAttempts(10, Mode.CONSTANT));
+        assertEquals(1_000L, BridgeReconnectDelay.baseDelayMs(Integer.MAX_VALUE, Mode.CONSTANT));
+    }
+
+    @Test
+    void baseDelayMs_whenAttemptsNegative_thenTreatedAsFirstAttempt() {
+        assertEquals(1_000L, BridgeReconnectDelay.baseDelayMs(-1, Mode.EXPONENTIAL));
+        assertEquals(1_000L, BridgeReconnectDelay.baseDelayMs(-1, Mode.CONSTANT));
+    }
+
+    @Test
+    void jitterMs_whenExponential_thenAtMostAQuarterOfTheDelay() {
+        assertEquals(0L, BridgeReconnectDelay.jitterMs(8_000L, Mode.EXPONENTIAL, 0.0));
+        assertEquals(1_000L, BridgeReconnectDelay.jitterMs(8_000L, Mode.EXPONENTIAL, 0.5));
+        // Callers pass a value below 1.0, so the quarter is approached but not reached.
+        assertEquals(1_999L, BridgeReconnectDelay.jitterMs(8_000L, Mode.EXPONENTIAL, 0.9999));
+    }
+
+    @Test
+    void jitterMs_whenConstant_thenNone() {
+        // A test selects CONSTANT to know when the retries happen; jitter would blur exactly that,
+        // and the fleet-spreading it buys is pointless for the single bridge a test runs.
+        assertEquals(0L, BridgeReconnectDelay.jitterMs(1_000L, Mode.CONSTANT, 0.9999));
+    }
+
+    @Test
+    void currentMode_whenPropertyUnset_thenExponential() {
+        assertEquals(Mode.EXPONENTIAL, BridgeReconnectDelay.currentMode());
+    }
+
+    @Test
+    void currentMode_whenPropertyBlank_thenExponential() {
+        System.setProperty(MODE_PROPERTY, "   ");
+        assertEquals(Mode.EXPONENTIAL, BridgeReconnectDelay.currentMode());
+    }
+
+    @Test
+    void currentMode_whenPropertySet_thenParsedIgnoringCaseAndSurroundingSpace() {
+        System.setProperty(MODE_PROPERTY, " constant ");
+        assertEquals(Mode.CONSTANT, BridgeReconnectDelay.currentMode());
+    }
+
+    @Test
+    void currentMode_whenPropertyUnrecognised_thenFailsRatherThanFallingBack() {
+        // Silently falling back to EXPONENTIAL would turn a typo in a test's JVM arguments into a
+        // flaky test rather than a failing one: the test would wait five seconds for a reconnection
+        // that backoff had pushed sixteen seconds out.
+        System.setProperty(MODE_PROPERTY, "linear");
+        final IllegalArgumentException exception =
+                assertThrows(IllegalArgumentException.class, BridgeReconnectDelay::currentMode);
+        assertEquals(
+                "Unknown bridge reconnect mode 'linear' in system property '"
+                        + MODE_PROPERTY
+                        + "'. Known modes: EXPONENTIAL, CONSTANT.",
+                exception.getMessage());
+    }
+
+    @Test
+    void nextDelay_thenReadsTheProperty() {
+        System.setProperty(MODE_PROPERTY, "CONSTANT");
+        assertEquals(new Delay(Mode.CONSTANT, 1_000L, 0L), BridgeReconnectDelay.nextDelay(5));
+
+        // Read per call rather than cached, so that a test setting the property does not impose its
+        // schedule on whatever else shares the JVM.
+        System.clearProperty(MODE_PROPERTY);
+        assertEquals(Mode.EXPONENTIAL, BridgeReconnectDelay.nextDelay(5).mode());
+        assertEquals(32_000L, BridgeReconnectDelay.nextDelay(5).baseDelayMs());
+    }
+
+    @Test
+    void nextDelay_whenExponential_thenTotalWithinTheJitterRange() {
+        // nextDelay draws its own randomness, so the schedule is asserted exactly elsewhere and this
+        // pins what the draw may do: never shorter than the schedule, never more than a quarter over.
+        for (int attempts = 0; attempts < 10; attempts++) {
+            final Delay delay = BridgeReconnectDelay.nextDelay(attempts);
+            final long base = BridgeReconnectDelay.baseDelayMs(attempts, Mode.EXPONENTIAL);
+            assertEquals(base, delay.baseDelayMs());
+            assertTrue(delay.jitterMs() >= 0, "jitter must not shorten the delay: " + delay);
+            assertTrue(
+                    delay.jitterMs() <= (long) (base * BridgeReconnectDelay.JITTER_FACTOR),
+                    "jitter must stay within JITTER_FACTOR of the delay: " + delay);
+            assertEquals(delay.baseDelayMs() + delay.jitterMs(), delay.totalMs());
+        }
+    }
+
+    @Test
+    void nextDelay_whenConstant_thenExactlyOneSecondEveryTime() {
+        // The property the Toxiproxy bridge tests rest on: with no jitter and no growth, the moment
+        // of the next attempt is known, so a test can bound how long a reconnection takes.
+        System.setProperty(MODE_PROPERTY, "CONSTANT");
+        for (int attempts = 0; attempts < 10; attempts++) {
+            assertEquals(new Delay(Mode.CONSTANT, 1_000L, 0L), BridgeReconnectDelay.nextDelay(attempts));
+            assertEquals(1_000L, BridgeReconnectDelay.nextDelay(attempts).totalMs());
+        }
+    }
+
+    private static List<Long> delaysForFirstAttempts(final int count, final Mode mode) {
+        final List<Long> delays = new ArrayList<>();
+        IntStream.range(0, count).forEach(attempts -> delays.add(BridgeReconnectDelay.baseDelayMs(attempts, mode)));
+        return delays;
+    }
+}


### PR DESCRIPTION
**Motivation**

[EDG-862](https://linear.app/hivemq/issue/EDG-862/replace-the-toxiproxy-bridge-tests-backoff-sleeps-with-waits-on-the)

The bridge's reconnection schedule lived inline in `BridgeMqttClient`'s disconnect listener — four private constants and a dozen lines of arithmetic. Nothing could assert it, and no test could vary it.

That second part had a cost. The Toxiproxy bridge tests break a bridge's connection and wait for it to come back, and under exponential backoff that second wait is bounded not by how quickly the bridge *can* reconnect but by how much backoff the outage accumulated. So the tests waited out the schedule with fixed 30-second sleeps, which is what made them the two longest classes in the suite. The test-side change is hivemq/hivemq-edge-test#427 and depends on this one.

**Changes**

`BridgeReconnectDelay` now owns the schedule:

- `baseDelayMs(attempts, mode)` is pure, so the sequence can be asserted exactly
- `nextDelay(attempts)` draws its own jitter and returns a `Delay(mode, baseDelayMs, jitterMs)`, so the caller logs the parts separately without knowing randomness is involved
- a `CONSTANT` mode retries at a fixed 1s with no jitter, selected by the system property `hivemq.bridge.reconnect.mode`

The switch is deliberately defended: not reachable from configuration, an unrecognised value throws rather than silently reverting to production behaviour, and the mode is logged on every reconnection attempt. A test whose switch failed to apply should fail, not flake.

**Behaviour change — the plateau moves from 120s to 128s**

`MAX_DELAY_MS` (120s) and `MAX_BACKOFF_EXPONENT` (10 → 1024s) were redundant: the former clamped at exponent 7, so the latter was unreachable and read as dead. A reader would reasonably delete whichever looked unused — and deleting the exponent cap is the dangerous one. Java shifts a long by only the low six bits of its operand, so an uncapped exponent turns negative at 54 consecutive failures and wraps back to a 1s delay at 64, inverting the backoff into the hot retry loop it exists to prevent. Around 100 minutes of continuous outage reaches that, so it is not theoretical.

`MAX_BACKOFF_EXPONENT = 7` now expresses both the policy and the guard, at the cost of only reaching ceilings that are powers of two seconds. Jitter already made "2 minutes" a range (120–150s) rather than a figure, and at seven consecutive failures 8 seconds is immaterial. `BRIDGES.md` updated to match.

**Acceptance criteria**

- [x] Reconnect delays follow 1, 2, 4, 8, 16, 32, 64, then 128s for every further attempt
- [x] The schedule is unaffected by attempt counts large enough to overflow the shift
- [x] `CONSTANT` returns exactly 1000ms with no jitter, at any attempt count
- [x] An unrecognised `hivemq.bridge.reconnect.mode` value fails loudly
- [x] The mode is read per call, so a test setting it cannot impose its schedule on others sharing the JVM
- [x] 13 unit tests pass; all `com.hivemq.bridge.*` tests pass; `spotlessCheck` clean

**Non-goals**

- Fixing the bridge defects the Toxiproxy tests reproduce
- Making the schedule configurable by deployments
