### PR TITLE
EDG-882: stop the periodic clean-up from clearing live bridge and sampler queues

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,6 +33,7 @@ javassist = "3.32.0-GA"
 jaxb4-bind = "4.0.5"
 jaxb4-impl = "4.0.9"
 jctools = "4.0.6"
+jimfs = "1.3.1"
 jersey = "4.0.2"
 jose4j = "0.9.6"
 json = "20250517"
@@ -127,6 +128,7 @@ javassist = { module = "org.javassist:javassist", version.ref = "javassist" }
 jaxb4-bind = { module = "jakarta.xml.bind:jakarta.xml.bind-api", version.ref = "jaxb4-bind" }
 jaxb4-impl = { module = "org.glassfish.jaxb:jaxb-runtime", version.ref = "jaxb4-impl" }
 jctools = { module = "org.jctools:jctools-core", version.ref = "jctools" }
+jimfs = { module = "com.google.jimfs:jimfs", version.ref = "jimfs" }
 jersey-container-jdk-http = { module = "org.glassfish.jersey.containers:jersey-container-jdk-http", version.ref = "jersey" }
 jersey-hk2 = { module = "org.glassfish.jersey.inject:jersey-hk2", version.ref = "jersey" }
 jersey-media-json-jackson = { module = "org.glassfish.jersey.media:jersey-media-json-jackson", version.ref = "jersey" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,8 +33,8 @@ javassist = "3.32.0-GA"
 jaxb4-bind = "4.0.5"
 jaxb4-impl = "4.0.9"
 jctools = "4.0.6"
-jimfs = "1.3.1"
 jersey = "4.0.2"
+jimfs = "1.3.1"
 jose4j = "0.9.6"
 json = "20250517"
 json-path = "2.10.0"
@@ -128,11 +128,11 @@ javassist = { module = "org.javassist:javassist", version.ref = "javassist" }
 jaxb4-bind = { module = "jakarta.xml.bind:jakarta.xml.bind-api", version.ref = "jaxb4-bind" }
 jaxb4-impl = { module = "org.glassfish.jaxb:jaxb-runtime", version.ref = "jaxb4-impl" }
 jctools = { module = "org.jctools:jctools-core", version.ref = "jctools" }
-jimfs = { module = "com.google.jimfs:jimfs", version.ref = "jimfs" }
 jersey-container-jdk-http = { module = "org.glassfish.jersey.containers:jersey-container-jdk-http", version.ref = "jersey" }
 jersey-hk2 = { module = "org.glassfish.jersey.inject:jersey-hk2", version.ref = "jersey" }
 jersey-media-json-jackson = { module = "org.glassfish.jersey.media:jersey-media-json-jackson", version.ref = "jersey" }
 jersey-media-multipart = { module = "org.glassfish.jersey.media:jersey-media-multipart", version.ref = "jersey" }
+jimfs = { module = "com.google.jimfs:jimfs", version.ref = "jimfs" }
 jose4j = { module = "org.bitbucket.b_c:jose4j", version.ref = "jose4j" }
 json-path = { module = "com.jayway.jsonpath:json-path", version.ref = "json-path" }
 json-schema-inferrer = { module = "com.github.saasquatch:json-schema-inferrer", version.ref = "json-schema-inferrer" }

--- a/hivemq-edge/build.gradle.kts
+++ b/hivemq-edge/build.gradle.kts
@@ -299,6 +299,7 @@ dependencies {
     testImplementation(libs.awaitility)
     testImplementation(libs.assertj)
     testImplementation(libs.systemstubs)
+    testImplementation(libs.jimfs)
 }
 
 tasks.test {

--- a/hivemq-edge/src/main/java/com/hivemq/api/resources/impl/BridgeResourceImpl.java
+++ b/hivemq-edge/src/main/java/com/hivemq/api/resources/impl/BridgeResourceImpl.java
@@ -251,11 +251,27 @@ public class BridgeResourceImpl extends AbstractApi implements BridgesApi {
                 return ErrorResponseUtil.errorResponse(new InvalidQueryParameterErrors(errorMessages.toErrorList()));
             } else {
                 // -- Modify the configuration atomically
-                configurationService.bridgeExtractor().removeBridge(bridgeId);
+                //
+                // One transition, not remove-then-add. Each of those notified the bridge subsystem
+                // separately, so the removal half was seen as "this bridge is gone from the
+                // configuration" and stopped it with clearQueue = true and an empty retain list: every
+                // forwarder queue of the bridge was cleared, including the subscriptions this request
+                // did not touch. Editing one subscription through the API destroyed the backlog of all
+                // the others (EDG-882 QA round 1). Replacing in place lets updateBridges classify it as
+                // an update and route it through restartBridge, which retains the surviving forwarders'
+                // queues and holds them across the hand-over.
                 final MqttBridge newBridgeConfig = unconvert(bridge);
-                configurationService.bridgeExtractor().addBridge(newBridgeConfig);
-                // -- Restart the new configuration on a new connection
-                bridgeService.restartBridge(bridgeId, newBridgeConfig);
+                if (!configurationService.bridgeExtractor().replaceBridge(bridgeId, newBridgeConfig)) {
+                    return ErrorResponseUtil.errorResponse(
+                            new BridgeNotFoundError(String.format("Bridge not found by id '%s'", bridgeId)));
+                }
+                // A bridge that was stopped through the API stays stopped by the update itself, so it is
+                // started here to keep the previous outcome of this endpoint: an update leaves the
+                // bridge running. A running bridge has already been restarted by the synchronization
+                // above and is left alone.
+                if (!bridgeService.isRunning(bridgeId)) {
+                    bridgeService.startBridge(bridgeId);
+                }
                 return Response.ok().build();
             }
         }

--- a/hivemq-edge/src/main/java/com/hivemq/api/utils/BridgeUtils.java
+++ b/hivemq-edge/src/main/java/com/hivemq/api/utils/BridgeUtils.java
@@ -65,9 +65,13 @@ public class BridgeUtils {
             return null;
         }
         return new LocalBridgeSubscription()
-                .filters(localSubscription.getFilters())
+                // The configured order, not the canonical one. Canonicalisation exists so that a reorder
+                // is not a configuration change; serving the sorted order here meant that any edit made
+                // through the UI wrote the sorted order back into the operator's file, which is the
+                // write-back damage EDG-882 QA round 2 removed from the reload path (round 3).
+                .filters(localSubscription.getConfiguredFilters())
                 .destination(localSubscription.getDestination())
-                .excludes(localSubscription.getExcludes())
+                .excludes(localSubscription.getConfiguredExcludes())
                 .customUserProperties(localSubscription.getCustomUserProperties().stream()
                         .map(BridgeUtils::convertProperty)
                         .collect(Collectors.toList()))

--- a/hivemq-edge/src/main/java/com/hivemq/api/utils/BridgeUtils.java
+++ b/hivemq-edge/src/main/java/com/hivemq/api/utils/BridgeUtils.java
@@ -86,7 +86,8 @@ public class BridgeUtils {
             return null;
         }
         return new BridgeSubscription()
-                .filters(remoteSubscription.getFilters())
+                // The configured order, not the canonical one; see convertLocalSubscription above.
+                .filters(remoteSubscription.getConfiguredFilters())
                 .destination(remoteSubscription.getDestination())
                 .customUserProperties(remoteSubscription.getCustomUserProperties().stream()
                         .map(BridgeUtils::convertProperty)

--- a/hivemq-edge/src/main/java/com/hivemq/bootstrap/provider/ClientQueueLocalPersistenceProvider.java
+++ b/hivemq-edge/src/main/java/com/hivemq/bootstrap/provider/ClientQueueLocalPersistenceProvider.java
@@ -15,18 +15,23 @@
  */
 package com.hivemq.bootstrap.provider;
 
+import static com.hivemq.configuration.service.MqttConfigurationService.QueuedMessagesStrategy;
+
+import com.google.common.annotations.VisibleForTesting;
 import com.hivemq.bootstrap.factories.ClientQueueLocalPersistenceFactory;
 import com.hivemq.configuration.service.PersistenceConfigurationService;
 import com.hivemq.configuration.service.PersistenceMode;
 import com.hivemq.exceptions.UnrecoverableException;
 import com.hivemq.extensions.core.PersistencesService;
 import com.hivemq.mqtt.message.dropping.MessageDroppedService;
+import com.hivemq.mqtt.message.publish.PUBLISH;
 import com.hivemq.persistence.PersistenceStartup;
 import com.hivemq.persistence.clientqueue.ClientQueueLocalPersistence;
 import com.hivemq.persistence.local.memory.ClientQueueMemoryLocalPersistence;
 import com.hivemq.persistence.payload.PublishPayloadPersistence;
 import com.hivemq.util.LocalPersistenceFileUtil;
 import jakarta.inject.Inject;
+import java.lang.reflect.Method;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -77,7 +82,66 @@ public class ClientQueueLocalPersistenceProvider {
             throw new UnrecoverableException();
         }
 
-        return persistenceFactory.buildClientSessionLocalPersistence(
+        final ClientQueueLocalPersistence persistence = persistenceFactory.buildClientSessionLocalPersistence(
                 localPersistenceFileUtil, payloadPersistence, messageDroppedService, persistenceStartup);
+        warnIfModulePredatesQueuePolicy(persistence);
+        return persistence;
+    }
+
+    /**
+     * Says out loud what a module older than this core gives up, once, at start-up.
+     * <p>
+     * The module in {@code HIVEMQ_HOME/modules} is compiled separately from core and the two meet only
+     * here, so an operator who replaces the core zip and leaves {@code modules/} alone gets a pairing
+     * nobody built together. {@link ClientQueueLocalPersistence} keeps that pairing working — the
+     * signature core calls carries the default, so an older module degrades instead of dying with
+     * {@code AbstractMethodError} on the first queued publish. Degrading quietly is its own problem,
+     * which is what this answers (EDG-882 review v02, R2-01).
+     * <p>
+     * A WARN rather than a refusal: what is lost is a bound that did not exist before, so the node is
+     * exactly as correct as the previous release. Refusing to boot over it would turn a stale module
+     * into an outage, which is the failure this whole change exists to remove.
+     */
+    private static void warnIfModulePredatesQueuePolicy(final @NotNull ClientQueueLocalPersistence persistence) {
+        if (implementsQueuePolicyAdd(persistence.getClass())) {
+            return;
+        }
+        log.warn(
+                "The file persistence module '{}' was built before the queue-policy contract (EDG-882) and cannot"
+                        + " bound QoS 0 messages by queue limit. The node runs normally, but payload sampling is"
+                        + " unbounded on this node: one sampled QoS 0 topic can grow until it exhausts the"
+                        + " node-wide QoS 0 memory budget and QoS 0 publishes start being dropped for every"
+                        + " client (EDG-885). Replace the module in the modules folder with the one shipped"
+                        + " alongside this HiveMQ Edge version.",
+                persistence.getClass().getName());
+    }
+
+    /**
+     * @return whether the loaded implementation supplies its own {@code applyMaxToQos0} overload. Read
+     *     off the resolved method's declaring class rather than by calling it: a class that does not
+     *     override it resolves to the interface's default, and a default is not distinguishable from an
+     *     override by any cheaper means.
+     */
+    @VisibleForTesting
+    static boolean implementsQueuePolicyAdd(
+            final @NotNull Class<? extends ClientQueueLocalPersistence> implementation) {
+        try {
+            final Method add = implementation.getMethod(
+                    "add",
+                    String.class,
+                    boolean.class,
+                    PUBLISH.class,
+                    long.class,
+                    QueuedMessagesStrategy.class,
+                    boolean.class,
+                    boolean.class,
+                    int.class);
+            return !add.getDeclaringClass().isInterface();
+        } catch (final NoSuchMethodException | SecurityException e) {
+            // Neither can happen for a class that satisfies the interface at all, and the answer to a
+            // probe that cannot run is not to refuse the node: say nothing and let it start.
+            log.debug("Could not determine the queue-policy contract of '{}'", implementation.getName(), e);
+            return true;
+        }
     }
 }

--- a/hivemq-edge/src/main/java/com/hivemq/bootstrap/provider/ClientQueueLocalPersistenceProvider.java
+++ b/hivemq-edge/src/main/java/com/hivemq/bootstrap/provider/ClientQueueLocalPersistenceProvider.java
@@ -32,6 +32,7 @@ import com.hivemq.persistence.payload.PublishPayloadPersistence;
 import com.hivemq.util.LocalPersistenceFileUtil;
 import jakarta.inject.Inject;
 import java.lang.reflect.Method;
+import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -117,20 +118,31 @@ public class ClientQueueLocalPersistenceProvider {
     }
 
     /**
-     * @return whether the loaded implementation supplies its own {@code applyMaxToQos0} overload. Read
+     * @return whether the loaded implementation supplies its own {@code applyMaxToQos0} overloads. Read
      *     off the resolved method's declaring class rather than by calling it: a class that does not
-     *     override it resolves to the interface's default, and a default is not distinguishable from an
+     *     override one resolves to the interface's default, and a default is not distinguishable from an
      *     override by any cheaper means.
+     *     <p>
+     *     <b>Both</b> overloads are probed, single-publish and batch, because the parameter was added to
+     *     both and each has its own default. Probing one and reporting on "the queue-policy contract"
+     *     would answer for a contract half of which had not been looked at, and it is the batch form the
+     *     poll path uses (EDG-882 QA, 2026-08-25).
      */
     @VisibleForTesting
     static boolean implementsQueuePolicyAdd(
             final @NotNull Class<? extends ClientQueueLocalPersistence> implementation) {
+        return overridesAdd(implementation, PUBLISH.class) && overridesAdd(implementation, List.class);
+    }
+
+    private static boolean overridesAdd(
+            final @NotNull Class<? extends ClientQueueLocalPersistence> implementation,
+            final @NotNull Class<?> publishParameter) {
         try {
             final Method add = implementation.getMethod(
                     "add",
                     String.class,
                     boolean.class,
-                    PUBLISH.class,
+                    publishParameter,
                     long.class,
                     QueuedMessagesStrategy.class,
                     boolean.class,

--- a/hivemq-edge/src/main/java/com/hivemq/bridge/BridgeService.java
+++ b/hivemq-edge/src/main/java/com/hivemq/bridge/BridgeService.java
@@ -38,6 +38,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -527,6 +528,20 @@ public class BridgeService {
 
                     @Override
                     public void onFailure(final @NotNull Throwable t) {
+                        // A cancellation is this generation being stopped on purpose, not a bridge that
+                        // could not start. BridgeMqttClient.stop() cancels the pending start future, and
+                        // this callback then runs asynchronously -- after stopBridge has already cleared
+                        // bridgeNameToLastError -- so recording it left a bridge that goes on to connect
+                        // normally reporting an error through the API, under a log line saying it could
+                        // not be started. Reachable on every update of a bridge whose remote is down,
+                        // because an update is now one transition through restartBridge rather than a
+                        // removal and an addition (EDG-882, seen on a real node).
+                        if (t instanceof CancellationException) {
+                            if (log.isDebugEnabled()) {
+                                log.debug("Start of bridge '{}' was cancelled because it was stopped", bridge.getId());
+                            }
+                            return;
+                        }
                         log.error(
                                 "Unable to start bridge '{}' to {}:{}: {}",
                                 bridge.getId(),

--- a/hivemq-edge/src/main/java/com/hivemq/bridge/BridgeService.java
+++ b/hivemq-edge/src/main/java/com/hivemq/bridge/BridgeService.java
@@ -235,11 +235,34 @@ public class BridgeService {
         }
     }
 
+    /**
+     * Stops a bridge and starts it again, keeping the queues of every forwarder that survives into
+     * {@code newBridgeConfig}.
+     * <p>
+     * Those queues change hands here, and between the two generations nothing owns them: the old
+     * forwarders are removed and released by the stop, and the replacements are not registered until
+     * the start. The periodic clean-up runs on its own schedule and clears forwarder queues it finds
+     * unowned, so a sweep landing in that gap deletes exactly the messages this restart was careful
+     * not to clear — and the bridge comes back to an empty queue with nothing logged. The gap is
+     * short, the sweep is every few seconds, and the customer this ticket came from restarts bridges
+     * to change a filter.
+     * <p>
+     * So the queues are held across the hand-over: claimed before the old generation lets go, dropped
+     * by {@link #internalStartBridge} once the replacements have registered — and if the start fails,
+     * the hold simply stays in place, which is what a bridge that cannot start needs anyway.
+     */
     public synchronized boolean restartBridge(
             final @NotNull String bridgeId, final @Nullable MqttBridge newBridgeConfig) {
         final var client = activeBridgeNamesToClient.get(bridgeId);
         if (client != null) {
             log.info("Restarting bridge '{}'", bridgeId);
+            // Exactly the retained set: the forwarder ids of the replacement configuration are the ones
+            // stopBridge is told not to clear, and an id determines its topics because it is a digest
+            // over them. Nothing is held when there is no replacement, which is the case in which the
+            // stop clears every queue anyway.
+            if (newBridgeConfig != null) {
+                messageForwarder.reserveQueues(bridgeId, topicsByForwarderId(newBridgeConfig));
+            }
             stopBridge(bridgeId, true, newForwarderIds(newBridgeConfig));
             final MqttBridge effectiveBridge = newBridgeConfig != null ? newBridgeConfig : client.bridge();
             activeBridgeNamesToClient.put(
@@ -275,6 +298,14 @@ public class BridgeService {
                     bridge.getLocalSubscriptions().size(),
                     bridge.getRemoteSubscriptions().size());
         }
+        // Hold this bridge's queues for the length of the start. The clean-up service is scheduled
+        // during persistence bootstrap, before any bridge has registered a forwarder, so at node start
+        // its persisted queues are visible and unowned — and the clean-up deletes forwarder queues
+        // nobody owns. The hold covers the rest of that window and is dropped the moment the forwarders
+        // take over below; a start that fails replaces it with one that stands until the configuration
+        // is corrected. Superseding an existing hold is exactly right on the restart path, which took
+        // one before it stopped the previous generation.
+        messageForwarder.reserveQueues(bridgeId, topicsByForwarderId(bridge));
         final BridgeMqttClient bridgeMqttClient = bridgeMqttClientFactory.createRemoteClient(bridge);
         try {
             final var forwarders = bridgeMqttClient.createForwarders();
@@ -292,12 +323,10 @@ public class BridgeService {
             // exception escaping here would leave the bridges after this one unstarted. Reported the
             // same way an unsuccessful connect is, which is what surfaces it in the API and the UI.
             //
-            // Nothing is cleared on this path, and the queues are held so that nothing else clears them
-            // either: with no forwarder registered they read as unowned, and the periodic clean-up
-            // deletes unowned forwarder queues within seconds. Without the hold, refusing to start a
-            // bridge would destroy the very messages the refusal exists to protect. The hold is dropped
-            // when the bridge starts or is removed.
-            messageForwarder.reserveQueues(bridgeId, topicsByForwarderId(bridge));
+            // Nothing is cleared on this path, and the hold taken above simply stays: with no forwarder
+            // registered the queues read as unowned, and the periodic clean-up deletes unowned forwarder
+            // queues within seconds. Without it, refusing to start a bridge would destroy the very
+            // messages the refusal exists to protect. It is dropped when the bridge starts or is removed.
             log.error("Bridge '{}' could not be started: {}", bridgeId, e.getMessage());
             log.debug("Forwarder registration failure details", e);
             bridgeNameToLastError.put(bridgeId, e);

--- a/hivemq-edge/src/main/java/com/hivemq/bridge/BridgeService.java
+++ b/hivemq-edge/src/main/java/com/hivemq/bridge/BridgeService.java
@@ -614,6 +614,7 @@ public class BridgeService {
             }
             try {
                 int removedCount = 0;
+                int failedCount = 0;
                 for (final MqttForwarder forwarder : client.getActiveForwarders()) {
                     final boolean shouldClearQueue =
                             clearQueue && !retainQueueForForwarders.contains(forwarder.getId());
@@ -624,10 +625,31 @@ public class BridgeService {
                                 bridgeId,
                                 shouldClearQueue);
                     }
-                    messageForwarder.removeForwarder(forwarder, shouldClearQueue);
-                    removedCount++;
+                    // Per forwarder, not around the loop. Catching outside it meant the first forwarder
+                    // whose teardown threw took every forwarder after it down with it -- they stayed in
+                    // the ownership index, so their queues were never reclaimed and the bridge could not
+                    // be restarted under the same ids. removeForwarder now completes its own teardown
+                    // before reporting, so what arrives here is a forwarder already released; continuing
+                    // is what lets the rest of the bridge be released too (EDG-882 review v03, R3-04).
+                    try {
+                        messageForwarder.removeForwarder(forwarder, shouldClearQueue);
+                        removedCount++;
+                    } catch (final Throwable e) {
+                        failedCount++;
+                        log.error(
+                                "Removing forwarder '{}' of bridge '{}' did not complete cleanly; continuing with the rest",
+                                forwarder.getId(),
+                                bridgeId,
+                                e);
+                    }
                 }
-                if (log.isDebugEnabled()) {
+                if (failedCount > 0) {
+                    log.warn(
+                            "Bridge '{}' released {} forwarder(s), {} of which reported a teardown failure",
+                            bridgeId,
+                            removedCount + failedCount,
+                            failedCount);
+                } else if (log.isDebugEnabled()) {
                     log.debug("Removed {} forwarder(s) for bridge '{}'", removedCount, bridgeId);
                 }
                 Checkpoints.checkpoint("mqtt-bridge-stopped");

--- a/hivemq-edge/src/main/java/com/hivemq/bridge/BridgeService.java
+++ b/hivemq-edge/src/main/java/com/hivemq/bridge/BridgeService.java
@@ -209,7 +209,21 @@ public class BridgeService {
             // change and cleared the queues of the subscriptions that "disappeared" (EDG-882 QA round 1).
             final var previous = allKnownBridgeConfigs.put(bridgeId, newBridge);
             if (active == null) {
-                if (!newBridge.equals(previous)) {
+                if (newBridge.equals(previous)) {
+                    return;
+                }
+                if (bridgeNameToLastError.containsKey(bridgeId)) {
+                    // The bridge failed to start and its configuration has just changed: an operator
+                    // editing a bridge that is reporting an error is asking for it to be tried again,
+                    // and until this branch existed the correction was recorded and never acted on --
+                    // the queues held for the failed bridge stayed held and nothing forwarded them
+                    // (EDG-882 QA round 3).
+                    log.info("Retrying bridge '{}' with the corrected configuration", bridgeId);
+                    final var retried = internalStartBridge(newBridge);
+                    if (retried != null) {
+                        activeBridgeNamesToClient.put(bridgeId, new MqttBridgeAndClient(newBridge, retried));
+                    }
+                } else {
                     log.info(
                             "Bridge '{}' is not running; its new configuration takes effect when it is started",
                             bridgeId);
@@ -258,7 +272,12 @@ public class BridgeService {
         return activeBridgeNamesToClient.containsKey(bridgeName);
     }
 
-    public void stopBridgeAndRemoveQueues(final @NotNull String bridgeName) {
+    /**
+     * Synchronized like every other path that mutates a reservation: the stop and the release must be
+     * one transition, or a start running concurrently can have the hold it just took released out from
+     * under it and its queues reaped while it is still coming up (EDG-882 QA round 3).
+     */
+    public synchronized void stopBridgeAndRemoveQueues(final @NotNull String bridgeName) {
         stopBridge(bridgeName, true, List.of());
         // "and remove queues" is the operator asking for them to go, which for a bridge that never
         // started means dropping the hold that keeps the clean-up off them.
@@ -421,7 +440,14 @@ public class BridgeService {
             errorEvent.addUserData("name", bridgeId);
             remoteService.fireUsageEvent(errorEvent);
             Checkpoints.checkpoint("mqtt-bridge-forwarder-start-failed");
-            return bridgeMqttClient;
+            // Null, not the client: the rollback above un-registered every forwarder this bridge had
+            // managed to add, so what is left is an object that was never started and owns nothing.
+            // Recording it made isRunning() report the bridge as STARTED and turned the API's START
+            // command into a permanent no-op, because startBridge refuses a bridge that is already in
+            // the map -- the operator was left with a bridge that says it is running, forwards nothing,
+            // and cannot be started (EDG-882 QA round 3). The queues are unaffected either way: the
+            // reservation taken above holds them until the bridge starts or leaves the configuration.
+            return null;
         }
         Checkpoints.checkpoint("mqtt-bridge-forwarder-started");
         // Non-null on this path by construction: the only assignment is the first statement of the try,

--- a/hivemq-edge/src/main/java/com/hivemq/bridge/BridgeService.java
+++ b/hivemq-edge/src/main/java/com/hivemq/bridge/BridgeService.java
@@ -320,6 +320,14 @@ public class BridgeService {
         final var client = activeBridgeNamesToClient.remove(bridgeName);
         if (client != null) {
             log.info("Stopping bridge '{}'", bridgeName);
+            // Cleared here because bridgeNameToLastError is also written by the connect failure of a
+            // bridge that did start, and was cleared only by a later successful connect. A bridge whose
+            // remote was unreachable and which the operator then stopped kept its error, and the next
+            // hot reload read that as "failed to start, and the configuration has just been corrected"
+            // and started a bridge the operator had deliberately stopped (EDG-882 review v02, R2-07).
+            // Only on the path where a bridge was actually running: a refused bridge never gets here,
+            // and its error is the reason the API reports for why it is not running.
+            bridgeNameToLastError.remove(bridgeName);
             internalStopBridge(client, clearQueue, retainQueueForForwarders);
         } else {
             log.debug("Not stopping bridge '{}' since it wasn't started", bridgeName);
@@ -461,6 +469,14 @@ public class BridgeService {
             log.error("Bridge '{}' could not be started: {}", bridgeId, e.getMessage());
             log.debug("Forwarder registration failure details", e);
             bridgeNameToLastError.put(bridgeId, e);
+            // PerBridgeMetrics registers its counters in the BridgeMqttClient constructor and clearAll
+            // runs only in stop(), which this path never reaches -- so a refused bridge left its metrics
+            // registered, reporting zeros for something that is not running (EDG-882 review v02, R2-13).
+            // Cosmetic, because MetricRegistry.counter() is get-or-create and a retry re-registers the
+            // same instruments, but a gauge that reads zero is worse than one that is absent.
+            if (bridgeMqttClient != null) {
+                bridgeMqttClient.clearMetrics();
+            }
             final HiveMQEdgeRemoteEvent errorEvent =
                     new HiveMQEdgeRemoteEvent(HiveMQEdgeRemoteEvent.EVENT_TYPE.BRIDGE_ERROR);
             errorEvent.addUserData(

--- a/hivemq-edge/src/main/java/com/hivemq/bridge/BridgeService.java
+++ b/hivemq-edge/src/main/java/com/hivemq/bridge/BridgeService.java
@@ -172,10 +172,13 @@ public class BridgeService {
                     log.debug("Not restarting bridge {} because config is unchanged", bridgeId);
                 } else {
                     log.info("Restarting bridge {} because config has changed", bridgeId);
-                    allKnownBridgeConfigs.put(bridgeId, newBridge);
-                    internalStopBridge(active, true, List.of());
-                    activeBridgeNamesToClient.put(
-                            bridgeId, new MqttBridgeAndClient(newBridge, internalStartBridge(newBridge)));
+                    // Through restartBridge rather than stop-with-an-empty-retain-list, which cleared
+                    // every queue of the bridge whatever had changed: editing one subscription's filter
+                    // threw away the messages queued for all the others, and a bridge with one busy
+                    // subscription and one being tuned lost the busy one's backlog on every save
+                    // (EDG-882 F-07). restartBridge keeps the queues of the forwarders that survive
+                    // into the new configuration, and holds them across the hand-over.
+                    restartBridge(bridgeId, newBridge);
                 }
             }
         });

--- a/hivemq-edge/src/main/java/com/hivemq/bridge/BridgeService.java
+++ b/hivemq-edge/src/main/java/com/hivemq/bridge/BridgeService.java
@@ -31,10 +31,13 @@ import com.hivemq.metrics.HiveMQMetrics;
 import com.hivemq.util.Checkpoints;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -146,6 +149,36 @@ public class BridgeService {
                     toRemove.size());
         }
 
+        try {
+            synchronizeBridges(bridgeIdToConfig, toRemove, toUpdate, toAdd);
+        } finally {
+            // From here on, a forwarder queue nobody owns is genuinely orphaned. Before it, ownership
+            // had not been claimed yet -- the clean-up service is scheduled during persistence
+            // bootstrap, well before this runs -- and a sweep in that window deletes the queues of
+            // every bridge on the node while they wait to be started.
+            //
+            // In a finally block because the alternative failure is silent and permanent: anything
+            // escaping the synchronization left the gate closed for the life of the node, and forwarder
+            // queues were then never reclaimed at all -- a storage leak in place of a message loss.
+            messageForwarder.markBridgeConfigurationApplied();
+        }
+
+        final long durationMs = System.currentTimeMillis() - start;
+        if (log.isInfoEnabled()) {
+            log.info(
+                    "Bridge synchronization completed in {} ms: {} added, {} updated, {} removed",
+                    durationMs,
+                    toAdd.size(),
+                    toUpdate.size(),
+                    toRemove.size());
+        }
+    }
+
+    private void synchronizeBridges(
+            final @NotNull Map<String, MqttBridge> bridgeIdToConfig,
+            final @NotNull Set<String> toRemove,
+            final @NotNull Set<String> toUpdate,
+            final @NotNull Set<String> toAdd) {
         // first stop bridges as they might use the same clientId in case the id of a bridge was changed
         // remove any orphaned connections
         toRemove.forEach(bridgeId -> {
@@ -167,19 +200,33 @@ public class BridgeService {
         toUpdate.forEach(bridgeId -> {
             final var active = activeBridgeNamesToClient.get(bridgeId);
             final var newBridge = bridgeIdToConfig.get(bridgeId);
-            if (active != null && newBridge != null) {
-                if (active.bridge().equals(newBridge)) {
-                    log.debug("Not restarting bridge {} because config is unchanged", bridgeId);
-                } else {
-                    log.info("Restarting bridge {} because config has changed", bridgeId);
-                    // Through restartBridge rather than stop-with-an-empty-retain-list, which cleared
-                    // every queue of the bridge whatever had changed: editing one subscription's filter
-                    // threw away the messages queued for all the others, and a bridge with one busy
-                    // subscription and one being tuned lost the busy one's backlog on every save
-                    // (EDG-882 F-07). restartBridge keeps the queues of the forwarders that survive
-                    // into the new configuration, and holds them across the hand-over.
-                    restartBridge(bridgeId, newBridge);
+            if (newBridge == null) {
+                return;
+            }
+            // Recorded whether or not the bridge is running. Only restartBridge used to write this map,
+            // so a bridge stopped through the API kept the configuration it was stopped with: a later
+            // start ran a stale subscription set, and the next reload then saw the difference as a
+            // change and cleared the queues of the subscriptions that "disappeared" (EDG-882 QA round 1).
+            final var previous = allKnownBridgeConfigs.put(bridgeId, newBridge);
+            if (active == null) {
+                if (!newBridge.equals(previous)) {
+                    log.info(
+                            "Bridge '{}' is not running; its new configuration takes effect when it is started",
+                            bridgeId);
                 }
+                return;
+            }
+            if (active.bridge().equals(newBridge)) {
+                log.debug("Not restarting bridge {} because config is unchanged", bridgeId);
+            } else {
+                log.info("Restarting bridge {} because config has changed", bridgeId);
+                // Through restartBridge rather than stop-with-an-empty-retain-list, which cleared
+                // every queue of the bridge whatever had changed: editing one subscription's filter
+                // threw away the messages queued for all the others, and a bridge with one busy
+                // subscription and one being tuned lost the busy one's backlog on every save
+                // (EDG-882 F-07). restartBridge keeps the queues of the forwarders that survive
+                // into the new configuration, and holds them across the hand-over.
+                restartBridge(bridgeId, newBridge);
             }
         });
 
@@ -191,24 +238,11 @@ public class BridgeService {
             }
             log.info("Adding bridge '{}' ({}:{})", bridgeId, newBridge.getHost(), newBridge.getPort());
             allKnownBridgeConfigs.put(bridgeId, newBridge);
-            activeBridgeNamesToClient.put(bridgeId, new MqttBridgeAndClient(newBridge, internalStartBridge(newBridge)));
+            final var client = internalStartBridge(newBridge);
+            if (client != null) {
+                activeBridgeNamesToClient.put(bridgeId, new MqttBridgeAndClient(newBridge, client));
+            }
         });
-
-        // From here on, a forwarder queue nobody owns is genuinely orphaned. Before it, ownership had
-        // not been claimed yet -- the clean-up service is scheduled during persistence bootstrap, well
-        // before this runs -- and a sweep in that window deletes the queues of every bridge on the node
-        // while they wait to be started.
-        messageForwarder.markBridgeConfigurationApplied();
-
-        final long durationMs = System.currentTimeMillis() - start;
-        if (log.isInfoEnabled()) {
-            log.info(
-                    "Bridge synchronization completed in {} ms: {} added, {} updated, {} removed",
-                    durationMs,
-                    toAdd.size(),
-                    toUpdate.size(),
-                    toRemove.size());
-        }
     }
 
     public @Nullable Throwable getLastError(final @NotNull String bridgeName) {
@@ -274,8 +308,10 @@ public class BridgeService {
             }
             stopBridge(bridgeId, true, newForwarderIds(newBridgeConfig));
             final MqttBridge effectiveBridge = newBridgeConfig != null ? newBridgeConfig : client.bridge();
-            activeBridgeNamesToClient.put(
-                    bridgeId, new MqttBridgeAndClient(effectiveBridge, internalStartBridge(effectiveBridge)));
+            final var replacement = internalStartBridge(effectiveBridge);
+            if (replacement != null) {
+                activeBridgeNamesToClient.put(bridgeId, new MqttBridgeAndClient(effectiveBridge, replacement));
+            }
             if (newBridgeConfig != null) {
                 allKnownBridgeConfigs.put(bridgeId, newBridgeConfig);
             }
@@ -290,7 +326,10 @@ public class BridgeService {
         final var bridge = allKnownBridgeConfigs.get(bridgeId);
         if (bridge != null && !activeBridgeNamesToClient.containsKey(bridgeId)) {
             log.info("Starting bridge '{}'", bridgeId);
-            activeBridgeNamesToClient.put(bridgeId, new MqttBridgeAndClient(bridge, internalStartBridge(bridge)));
+            final var client = internalStartBridge(bridge);
+            if (client != null) {
+                activeBridgeNamesToClient.put(bridgeId, new MqttBridgeAndClient(bridge, client));
+            }
             return true;
         } else {
             log.debug("Not starting bridge '{}' since it was already started", bridgeId);
@@ -298,7 +337,14 @@ public class BridgeService {
         }
     }
 
-    private BridgeMqttClient internalStartBridge(final @NotNull MqttBridge bridge) {
+    /**
+     * Starts one bridge, or reports why it could not start.
+     *
+     * @return the client, or {@code null} when the bridge could not even be constructed — the caller
+     *     must not record a client it does not have, because every reader of
+     *     {@code activeBridgeNamesToClient} dereferences it.
+     */
+    private @Nullable BridgeMqttClient internalStartBridge(final @NotNull MqttBridge bridge) {
         final var bridgeId = bridge.getId();
         if (log.isDebugEnabled()) {
             log.debug(
@@ -315,18 +361,46 @@ public class BridgeService {
         // is corrected. Superseding an existing hold is exactly right on the restart path, which took
         // one before it stopped the previous generation.
         messageForwarder.reserveQueues(bridgeId, topicsByForwarderId(bridge));
-        final BridgeMqttClient bridgeMqttClient = bridgeMqttClientFactory.createRemoteClient(bridge);
+        BridgeMqttClient bridgeMqttClient = null;
+        final List<MqttForwarder> registered = new ArrayList<>();
         try {
+            // Inside the try, one statement further in than it used to be. Constructing the client reads
+            // the TLS material, so a mistyped keystore path threw straight past the guard below: the
+            // exception escaped updateBridges and every bridge after this one in the iteration was never
+            // started, exactly what the comment in the catch says cannot happen (EDG-882 QA round 1).
+            bridgeMqttClient = bridgeMqttClientFactory.createRemoteClient(bridge);
             final var forwarders = bridgeMqttClient.createForwarders();
             if (log.isDebugEnabled()) {
                 log.debug("Created {} forwarder(s) for bridge '{}'", forwarders.size(), bridgeId);
             }
-            forwarders.forEach(messageForwarder::addForwarder);
+            for (final MqttForwarder forwarder : forwarders) {
+                messageForwarder.addForwarder(forwarder);
+                registered.add(forwarder);
+            }
             // The forwarders own the queues now, so any hold taken by an earlier failed start can go.
             // After the registrations, never before: releasing first would leave the queues unowned for
             // an instant, which is all a clean-up sweep needs to clear them.
             messageForwarder.releaseReservedQueues(bridgeId);
         } catch (final Exception e) {
+            // Un-register the forwarders of this bridge that did register before the failure. Without
+            // this, a bridge reported as failed left live forwarders polling its persisted queues into
+            // an MQTT client that was never started and would never reconnect -- the messages were
+            // drained out of persistence and dropped. The bridge-level counterpart of the per-forwarder
+            // rollback in MessageForwarderImpl.addForwarder (EDG-882 F-10, QA round 2).
+            //
+            // clearQueue = false: nothing is destroyed, and the hold taken above keeps the periodic
+            // clean-up off those queues until the configuration is corrected.
+            for (final MqttForwarder forwarder : registered) {
+                try {
+                    messageForwarder.removeForwarder(forwarder, false);
+                } catch (final Throwable rollbackFailure) {
+                    log.error(
+                            "Could not un-register forwarder '{}' of failed bridge '{}'",
+                            forwarder.getId(),
+                            bridgeId,
+                            rollbackFailure);
+                }
+            }
             // A bridge that cannot register its forwarders must not take the rest of the
             // synchronization down with it: updateBridges iterates over every configured bridge, so an
             // exception escaping here would leave the bridges after this one unstarted. Reported the
@@ -350,7 +424,9 @@ public class BridgeService {
             return bridgeMqttClient;
         }
         Checkpoints.checkpoint("mqtt-bridge-forwarder-started");
-        return internalStartBridgeMqttClient(bridge, bridgeMqttClient);
+        // Non-null on this path by construction: the only assignment is the first statement of the try,
+        // and any failure of it leaves through the catch above.
+        return internalStartBridgeMqttClient(bridge, Objects.requireNonNull(bridgeMqttClient));
     }
 
     private BridgeMqttClient internalStartBridgeMqttClient(

--- a/hivemq-edge/src/main/java/com/hivemq/bridge/BridgeService.java
+++ b/hivemq-edge/src/main/java/com/hivemq/bridge/BridgeService.java
@@ -149,6 +149,34 @@ public class BridgeService {
                     toRemove.size());
         }
 
+        // Claimed before the gate below can open, so that both ways out of the synchronization are safe.
+        //
+        // The gate is a latch: it only ever transitions on the first call, and on that call
+        // allKnownBridgeConfigs is still empty, so toRemove and toUpdate are empty and toAdd is every
+        // configured bridge. Each of them claims its own queues inside internalStartBridge -- but only
+        // when its turn comes, and the finally below runs whether or not every turn came. Anything
+        // escaping synchronizeBridges part way (an Error, or a throw from a path internalStartBridge's
+        // catch does not cover) therefore used to open the gate with the bridges after it neither
+        // registered nor held, and their backlog from before the restart was reclaimable within minutes
+        // (EDG-882 review v02, R2-03).
+        //
+        // Restricted to toAdd rather than every inactive bridge: it is the whole at-risk set by the
+        // reasoning above, and a hold is not free -- IncomingSubscribeService refuses a client's
+        // SUBSCRIBE to a held queue's group, which on every later call, with the gate already open,
+        // would cost something and buy nothing.
+        //
+        // internalStartBridge reserves under the same id, so the hold is superseded rather than
+        // duplicated, and released once that bridge's forwarders have registered. A bridge whose turn
+        // never came keeps it, exactly as a bridge whose start failed does: held until it starts or
+        // leaves the configuration. That is a leak in place of a deletion, which is the trade this
+        // ticket exists to make.
+        for (final String bridgeId : toAdd) {
+            final var bridge = bridgeIdToConfig.get(bridgeId);
+            if (bridge != null) {
+                messageForwarder.reserveQueues(bridgeId, topicsByForwarderId(bridge));
+            }
+        }
+
         try {
             synchronizeBridges(bridgeIdToConfig, toRemove, toUpdate, toAdd);
         } finally {
@@ -160,6 +188,7 @@ public class BridgeService {
             // In a finally block because the alternative failure is silent and permanent: anything
             // escaping the synchronization left the gate closed for the life of the node, and forwarder
             // queues were then never reclaimed at all -- a storage leak in place of a message loss.
+            // Safe in both directions now that the queues above are held before it can run.
             messageForwarder.markBridgeConfigurationApplied();
         }
 

--- a/hivemq-edge/src/main/java/com/hivemq/bridge/BridgeService.java
+++ b/hivemq-edge/src/main/java/com/hivemq/bridge/BridgeService.java
@@ -16,8 +16,10 @@
 package com.hivemq.bridge;
 
 import com.codahale.metrics.MetricRegistry;
+import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
+import com.hivemq.bridge.config.LocalSubscription;
 import com.hivemq.bridge.config.MqttBridge;
 import com.hivemq.bridge.mqtt.BridgeMqttClient;
 import com.hivemq.common.shutdown.HiveMQShutdownHook;
@@ -29,6 +31,7 @@ import com.hivemq.metrics.HiveMQMetrics;
 import com.hivemq.util.Checkpoints;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -154,6 +157,11 @@ public class BridgeService {
             } else {
                 log.debug("Bridge {} not active", bridgeId);
             }
+            // The bridge is gone from the configuration, so any queues held for it while it could not
+            // start may be reclaimed. Deliberately not done when a bridge merely stops: a node shutting
+            // down would otherwise drop the hold on the way out and let a last clean-up pass delete the
+            // messages the operator is about to come back for.
+            messageForwarder.releaseReservedQueues(bridgeId);
         });
 
         toUpdate.forEach(bridgeId -> {
@@ -209,6 +217,9 @@ public class BridgeService {
 
     public void stopBridgeAndRemoveQueues(final @NotNull String bridgeName) {
         stopBridge(bridgeName, true, List.of());
+        // "and remove queues" is the operator asking for them to go, which for a bridge that never
+        // started means dropping the hold that keeps the clean-up off them.
+        messageForwarder.releaseReservedQueues(bridgeName);
     }
 
     public synchronized void stopBridge(
@@ -265,11 +276,41 @@ public class BridgeService {
                     bridge.getRemoteSubscriptions().size());
         }
         final BridgeMqttClient bridgeMqttClient = bridgeMqttClientFactory.createRemoteClient(bridge);
-        final var forwarders = bridgeMqttClient.createForwarders();
-        if (log.isDebugEnabled()) {
-            log.debug("Created {} forwarder(s) for bridge '{}'", forwarders.size(), bridgeId);
+        try {
+            final var forwarders = bridgeMqttClient.createForwarders();
+            if (log.isDebugEnabled()) {
+                log.debug("Created {} forwarder(s) for bridge '{}'", forwarders.size(), bridgeId);
+            }
+            forwarders.forEach(messageForwarder::addForwarder);
+            // The forwarders own the queues now, so any hold taken by an earlier failed start can go.
+            // After the registrations, never before: releasing first would leave the queues unowned for
+            // an instant, which is all a clean-up sweep needs to clear them.
+            messageForwarder.releaseReservedQueues(bridgeId);
+        } catch (final Exception e) {
+            // A bridge that cannot register its forwarders must not take the rest of the
+            // synchronization down with it: updateBridges iterates over every configured bridge, so an
+            // exception escaping here would leave the bridges after this one unstarted. Reported the
+            // same way an unsuccessful connect is, which is what surfaces it in the API and the UI.
+            //
+            // Nothing is cleared on this path, and the queues are held so that nothing else clears them
+            // either: with no forwarder registered they read as unowned, and the periodic clean-up
+            // deletes unowned forwarder queues within seconds. Without the hold, refusing to start a
+            // bridge would destroy the very messages the refusal exists to protect. The hold is dropped
+            // when the bridge starts or is removed.
+            messageForwarder.reserveQueues(bridgeId, topicsByForwarderId(bridge));
+            log.error("Bridge '{}' could not be started: {}", bridgeId, e.getMessage());
+            log.debug("Forwarder registration failure details", e);
+            bridgeNameToLastError.put(bridgeId, e);
+            final HiveMQEdgeRemoteEvent errorEvent =
+                    new HiveMQEdgeRemoteEvent(HiveMQEdgeRemoteEvent.EVENT_TYPE.BRIDGE_ERROR);
+            errorEvent.addUserData(
+                    "cloudBridge", String.valueOf(bridge.getHost().endsWith("hivemq.cloud")));
+            errorEvent.addUserData("cause", e.getMessage());
+            errorEvent.addUserData("name", bridgeId);
+            remoteService.fireUsageEvent(errorEvent);
+            Checkpoints.checkpoint("mqtt-bridge-forwarder-start-failed");
+            return bridgeMqttClient;
         }
-        forwarders.forEach(messageForwarder::addForwarder);
         Checkpoints.checkpoint("mqtt-bridge-forwarder-started");
         return internalStartBridgeMqttClient(bridge, bridgeMqttClient);
     }
@@ -395,6 +436,27 @@ public class BridgeService {
                 log.debug("Forwarder removal exception details", e);
             }
         }
+    }
+
+    /**
+     * The topics each of a bridge's forwarders would register, keyed by forwarder id.
+     * <p>
+     * Merged rather than overwritten on a repeated key: two local subscriptions of one bridge can
+     * derive the same forwarder id — that collision is why the bridge is being refused in the first
+     * place — and the queues of both must be held, not just those of whichever came last.
+     */
+    private static @NotNull Map<String, List<String>> topicsByForwarderId(final @NotNull MqttBridge bridge) {
+        final Map<String, List<String>> topicsByForwarderId = new HashMap<>();
+        for (final LocalSubscription subscription : bridge.getLocalSubscriptions()) {
+            topicsByForwarderId.merge(
+                    BridgeMqttClient.createForwarderId(bridge.getId(), subscription),
+                    List.copyOf(subscription.getFilters()),
+                    (existing, added) -> ImmutableList.<String>builder()
+                            .addAll(existing)
+                            .addAll(added)
+                            .build());
+        }
+        return topicsByForwarderId;
     }
 
     private @NotNull List<String> newForwarderIds(final @Nullable MqttBridge newBridgeConfig) {

--- a/hivemq-edge/src/main/java/com/hivemq/bridge/BridgeService.java
+++ b/hivemq-edge/src/main/java/com/hivemq/bridge/BridgeService.java
@@ -194,6 +194,12 @@ public class BridgeService {
             activeBridgeNamesToClient.put(bridgeId, new MqttBridgeAndClient(newBridge, internalStartBridge(newBridge)));
         });
 
+        // From here on, a forwarder queue nobody owns is genuinely orphaned. Before it, ownership had
+        // not been claimed yet -- the clean-up service is scheduled during persistence bootstrap, well
+        // before this runs -- and a sweep in that window deletes the queues of every bridge on the node
+        // while they wait to be started.
+        messageForwarder.markBridgeConfigurationApplied();
+
         final long durationMs = System.currentTimeMillis() - start;
         if (log.isInfoEnabled()) {
             log.info(

--- a/hivemq-edge/src/main/java/com/hivemq/bridge/MessageForwarder.java
+++ b/hivemq-edge/src/main/java/com/hivemq/bridge/MessageForwarder.java
@@ -46,4 +46,14 @@ public interface MessageForwarder {
      * Check if new messages need to be polled for the buffer.
      */
     void checkBuffers();
+
+    /**
+     * Check whether a queue belongs to a currently registered forwarder.
+     * Forwarder queue IDs cannot be parsed positionally: the embedded subscription hash is standard
+     * Base64 and may itself contain '/', so ownership must be resolved against the registry instead.
+     *
+     * @param queueId the shared queue ID to check
+     * @return true if a registered forwarder owns this queue
+     */
+    boolean isForwarderQueue(@NotNull String queueId);
 }

--- a/hivemq-edge/src/main/java/com/hivemq/bridge/MessageForwarder.java
+++ b/hivemq-edge/src/main/java/com/hivemq/bridge/MessageForwarder.java
@@ -15,6 +15,8 @@
  */
 package com.hivemq.bridge;
 
+import java.util.List;
+import java.util.Map;
 import org.jetbrains.annotations.NotNull;
 
 public interface MessageForwarder {
@@ -46,6 +48,31 @@ public interface MessageForwarder {
      * Check if new messages need to be polled for the buffer.
      */
     void checkBuffers();
+
+    /**
+     * Claims the queues of a bridge that could not register its forwarders, so that the periodic
+     * clean-up leaves them alone.
+     * <p>
+     * The clean-up clears every forwarder queue no registered forwarder owns, which is right for a
+     * queue whose bridge is gone and fatal for one whose bridge merely failed to start: the messages
+     * waiting in it are deleted within seconds, and the operator's chance to correct the configuration
+     * with them still there is lost. A reservation is ownership without a forwarder — it makes
+     * {@link #isForwarderQueue(String)} answer true, and nothing else. Messages are neither polled nor
+     * forwarded while it stands.
+     *
+     * @param reservationId         identifies the reservation, so it can be released again; the bridge id
+     * @param topicsByForwarderId   the topics each forwarder of the bridge would have registered. Passed
+     *                              rather than the queue ids themselves so that the one place that
+     *                              knows how a queue is named stays the one place that builds them.
+     */
+    void reserveQueues(@NotNull String reservationId, @NotNull Map<String, List<String>> topicsByForwarderId);
+
+    /**
+     * Drops a reservation made by {@link #reserveQueues}, either because the bridge has started and its
+     * forwarders now own the queues, or because it is gone and they may be reclaimed. A no-op when
+     * there is no reservation under this id.
+     */
+    void releaseReservedQueues(@NotNull String reservationId);
 
     /**
      * Check whether a queue belongs to a currently registered forwarder.

--- a/hivemq-edge/src/main/java/com/hivemq/bridge/MessageForwarder.java
+++ b/hivemq-edge/src/main/java/com/hivemq/bridge/MessageForwarder.java
@@ -75,6 +75,23 @@ public interface MessageForwarder {
     void releaseReservedQueues(@NotNull String reservationId);
 
     /**
+     * Records that the bridge configuration has been applied at least once, so that forwarder
+     * ownership can be trusted from now on.
+     */
+    void markBridgeConfigurationApplied();
+
+    /**
+     * Whether any bridge configuration has been applied yet.
+     * <p>
+     * Until it has, {@link #isForwarderQueue(String)} answering false means "nobody has had the chance
+     * to claim this queue", not "nobody owns it" — and the periodic clean-up deletes what nobody owns.
+     * The clean-up service is scheduled during persistence bootstrap, before the bridge subsystem
+     * exists, so a sweep landing in between would delete the queues of every bridge on the node while
+     * they were waiting to be started (EDG-882, found while testing F-02).
+     */
+    boolean hasAppliedBridgeConfiguration();
+
+    /**
      * Check whether a queue belongs to a currently registered forwarder.
      * Forwarder queue IDs cannot be parsed positionally: the embedded subscription hash is standard
      * Base64 and may itself contain '/', so ownership must be resolved against the registry instead.

--- a/hivemq-edge/src/main/java/com/hivemq/bridge/MessageForwarder.java
+++ b/hivemq-edge/src/main/java/com/hivemq/bridge/MessageForwarder.java
@@ -22,6 +22,18 @@ import org.jetbrains.annotations.NotNull;
 public interface MessageForwarder {
 
     /**
+     * Visited once a subscription taken from a forwarder's shared subscription group has actually been
+     * removed, so that a test can wait for the thing it means to observe rather than for time to pass.
+     * <p>
+     * On the interface rather than the implementation for the same reason as
+     * {@link com.hivemq.persistence.clientqueue.ClientQueuePersistence#CLIENT_QUEUE_CLEAN_UP_FINISHED}:
+     * an integration test cannot reference the implementation class. A checkpoint is inert unless a test
+     * enables it.
+     */
+    @NotNull
+    String FOREIGN_SUBSCRIBER_EVICTED = "forwarder-foreign-subscriber-evicted";
+
+    /**
      * Add forwarder to the service.
      * Multiple topic filters must be added separately.
      *

--- a/hivemq-edge/src/main/java/com/hivemq/bridge/MessageForwarderImpl.java
+++ b/hivemq-edge/src/main/java/com/hivemq/bridge/MessageForwarderImpl.java
@@ -73,6 +73,13 @@ public class MessageForwarderImpl implements MessageForwarder {
     private final @NotNull Set<String> notEmptyQueues;
     private final @NotNull Map<String, MqttForwarder> forwarders;
     private final @NotNull Map<String, Set<String>> queueIdsForForwarder;
+    /**
+     * How many registered forwarders own each queue ID. Exactly the multiset union of the values of
+     * {@link #queueIdsForForwarder}, maintained so {@link #isForwarderQueue(String)} answers in
+     * constant time instead of scanning every forwarder.
+     */
+    private final @NotNull Map<String, Integer> forwarderQueueRefs;
+
     private final @NotNull ExecutorService executorService;
     private final @NotNull Lock pollLock;
     private volatile boolean polling;
@@ -92,6 +99,7 @@ public class MessageForwarderImpl implements MessageForwarder {
         this.notEmptyQueues = new ConcurrentSkipListSet<>();
         this.forwarders = new ConcurrentHashMap<>(0);
         this.queueIdsForForwarder = new ConcurrentHashMap<>(0);
+        this.forwarderQueueRefs = new ConcurrentHashMap<>(0);
         this.pollLock = new ReentrantLock();
         final int threadCount = InternalConfigurations.BRIDGE_MESSAGE_FORWARDER_POOL_THREADS_COUNT.get();
         this.executorService =
@@ -137,6 +145,24 @@ public class MessageForwarderImpl implements MessageForwarder {
         return FORWARDER_PREFIX + forwarderId + "/" + topic;
     }
 
+    /**
+     * Claims one reference on each queue ID. Every {@code retain} is paired with exactly one
+     * {@link #release(Set)} of the same set — the value a {@code put} displaces, or the value the
+     * final {@code remove} returns — which is what keeps the counts exact under any interleaving.
+     */
+    private void retain(final @NotNull Set<String> queueIds) {
+        for (final String queueId : queueIds) {
+            forwarderQueueRefs.merge(queueId, 1, Integer::sum);
+        }
+    }
+
+    /** Drops one reference on each queue ID, removing the entry when the last owner lets go. */
+    private void release(final @NotNull Set<String> queueIds) {
+        for (final String queueId : queueIds) {
+            forwarderQueueRefs.computeIfPresent(queueId, (key, count) -> count == 1 ? null : count - 1);
+        }
+    }
+
     @Override
     public void addForwarder(final @NotNull MqttForwarder mqttForwarder) {
         final String forwarderId = mqttForwarder.getId();
@@ -156,10 +182,33 @@ public class MessageForwarderImpl implements MessageForwarder {
             queueIdsBuilder.add(createQueueId(forwarderId, topic));
         }
         final ImmutableSet<@NotNull String> queueIds = queueIdsBuilder.build();
-        // register the queue IDs before anything else can observe the queues: the periodic clean-up
+        // Ownership is registered before anything else can observe the queues: the periodic clean-up
         // clears forwarder queues it finds unowned, so a pre-existing persisted queue must never be
-        // visible while its forwarder is mid-registration
-        queueIdsForForwarder.put(forwarderId, queueIds);
+        // visible while its forwarder is mid-registration.
+        //
+        // The statement order below is load-bearing. None of these four rules can be pinned by a test
+        // without a seam into this class -- they are intra-method orderings only observable from
+        // another thread -- so they are enforced here and in review. Getting any of them wrong loses
+        // customer messages silently.
+        //
+        //   O0  ownership is claimed before the topicTree.addTopic loop, or a persisted queue becomes
+        //       pollable while still reading as unowned.
+        //   O1  retain() runs before the put. forwarderQueueRefs -- not queueIdsForForwarder -- is the
+        //       map isForwarderQueue reads, so it, not the put, is the moment registration takes
+        //       effect. Publishing first opens a window in which the clean-up clears a live queue.
+        //   O2  retain(new) runs before release(superseded). For a queue in both sets the count would
+        //       otherwise go 1 -> absent -> 1, and a sweep landing in that instant clears a queue that
+        //       is live, registered and in the current sweep set.
+        //   O3  see removeForwarder.
+        //
+        // Re-registration takes the difference rather than skipping: one forwarder ID does not imply
+        // one queue set, because the ID embeds a digest over the filters joined with an empty
+        // separator, so {"ab","c"} and {"a","bc"} share an ID with different queue sets.
+        retain(queueIds);
+        final Set<String> superseded = queueIdsForForwarder.put(forwarderId, queueIds);
+        if (superseded != null) {
+            release(superseded);
+        }
         for (final String topic : mqttForwarder.getTopics()) {
             topicTree.addTopic(
                     clientId,
@@ -294,7 +343,14 @@ public class MessageForwarderImpl implements MessageForwarder {
                 }
             }
         }
-        queueIdsForForwarder.remove(forwarderId);
+        // O3: drop the registration first, release its queues second. The reverse order would let the
+        // reference count reach zero while the forwarder is still published and still polling, so a
+        // clean-up sweep in that window would clear a live queue. The set the map returns -- not
+        // mqttForwarder.getTopics() -- is what was actually registered, and is what must be released.
+        final Set<String> removedQueueIds = queueIdsForForwarder.remove(forwarderId);
+        if (removedQueueIds != null) {
+            release(removedQueueIds);
+        }
         final MqttForwarder removed = forwarders.remove(forwarderId);
         if (removed != null) {
             removed.stop();
@@ -368,14 +424,18 @@ public class MessageForwarderImpl implements MessageForwarder {
         });
     }
 
+    /**
+     * Whether any registered forwarder owns this queue.
+     * <p>
+     * A reference count rather than a queue-ID-to-owner map: a share name may contain '/', so
+     * concatenating it with the topic filter is not injective and two forwarders can in principle mint
+     * the same queue ID. A plain map would drop the entry when the first of them unregisters, and the
+     * periodic clean-up would then clear a queue the second still owns. Counting owners is exact for
+     * every input without depending on that argument.
+     */
     @Override
     public boolean isForwarderQueue(final @NotNull String queueId) {
-        for (final Set<String> queueIds : queueIdsForForwarder.values()) {
-            if (queueIds.contains(queueId)) {
-                return true;
-            }
-        }
-        return false;
+        return forwarderQueueRefs.containsKey(queueId);
     }
 
     @Override

--- a/hivemq-edge/src/main/java/com/hivemq/bridge/MessageForwarderImpl.java
+++ b/hivemq-edge/src/main/java/com/hivemq/bridge/MessageForwarderImpl.java
@@ -723,6 +723,16 @@ public class MessageForwarderImpl implements MessageForwarder {
             // single writer and the answer can have changed by now: removeForwarder releases ownership
             // before it prunes, so re-checking here is what keeps an entry for a retired queue out of the
             // set for good (EDG-882 review v02, R2-06).
+            //
+            // isForwarderQueue is true for a queue that is only *reserved* -- held for a bridge that is
+            // starting or that failed to start -- and that is deliberate, both here and at the caller:
+            // a publish arriving mid-start must be queued and noted, or the hand-over would drop it.
+            // The accepted cost is that a bridge which never starts leaves its queue ids in this set for
+            // the life of the node. Bounded by the bridge's configured subscriptions, one string each,
+            // and it costs nothing to poll: pollForBuffer iterates registered forwarders, so a set entry
+            // nobody owns is never visited. The alternative -- deriving the forwarder from the queue id
+            // to see whether it is registered -- is the queue-name parsing this whole ticket exists to
+            // remove, so it is not worth having (EDG-882 QA, 2026-08-25).
             if (!isForwarderQueue(queueId)) {
                 return null;
             }
@@ -783,11 +793,32 @@ public class MessageForwarderImpl implements MessageForwarder {
 
     private void checkBuffersAfterLock() {
         if (notEmptyQueues.isEmpty()) {
-            if (log.isTraceEnabled()) {
-                log.trace("No queues to poll, ending polling cycle");
+            // Under the lock, and only when nothing asked for another pass. checkBuffers answers
+            // "already polling" by setting pollAgain and returning, so between the emptiness check above
+            // and clearing the flag there is a window in which another thread adds a queue, sees polling
+            // still true, sets pollAgain -- and then this cleared polling without ever looking at it.
+            // The wake-up was lost: the queue sits in notEmptyQueues with no cycle running, and nothing
+            // polls it until the next unrelated message or a reconnect. On a bridge whose last message
+            // before a quiet period lands in that window, that is a message that simply waits.
+            //
+            // This mirrors the end of the poll callback below, which has always done it this way.
+            // Pre-existing (EDG-882 QA, 2026-08-25); the branch made these paths busier.
+            pollLock.lock();
+            try {
+                if (!pollAgain) {
+                    if (log.isTraceEnabled()) {
+                        log.trace("No queues to poll, ending polling cycle");
+                    }
+                    polling = false;
+                    return;
+                }
+                pollAgain = false;
+            } finally {
+                pollLock.unlock();
             }
-            polling = false;
-            return;
+            if (log.isTraceEnabled()) {
+                log.trace("pollAgain was set while the queue set read empty, polling again");
+            }
         }
 
         final int forwarderCount = forwarders.size();

--- a/hivemq-edge/src/main/java/com/hivemq/bridge/MessageForwarderImpl.java
+++ b/hivemq-edge/src/main/java/com/hivemq/bridge/MessageForwarderImpl.java
@@ -403,14 +403,15 @@ public class MessageForwarderImpl implements MessageForwarder {
                 }
             }
         }
-        // O3: drop the registration first, release its queues second. The reverse order would let the
-        // reference count reach zero while the forwarder is still published and still polling, so a
-        // clean-up sweep in that window would clear a live queue. The set the map returns -- not
-        // mqttForwarder.getTopics() -- is what was actually registered, and is what must be released.
-        final Set<String> removedQueueIds = queueIdsForForwarder.remove(forwarderId);
-        if (removedQueueIds != null) {
-            release(removedQueueIds);
-        }
+        // O3: unpublish and stop the forwarder first, drop its ownership second. Ownership is what the
+        // periodic clean-up reads, so releasing it while the object is still in `forwarders` and still
+        // polling leaves a live queue reading as unowned -- a sweep landing in that window clears a
+        // queue that is being filled and drained as it does so. The reverse order is safe: for the
+        // instant between the stop and the release the queue reads as owned by a forwarder that has
+        // gone, which costs one clean-up cycle and no messages.
+        //
+        // The set the map returns -- not mqttForwarder.getTopics() -- is what was actually registered,
+        // and is what must be released.
         final MqttForwarder removed = forwarders.remove(forwarderId);
         if (removed != null) {
             removed.stop();
@@ -422,6 +423,10 @@ public class MessageForwarderImpl implements MessageForwarder {
             }
         } else {
             log.warn("Attempted to remove forwarder '{}' but it was not found in active forwarders", forwarderId);
+        }
+        final Set<String> removedQueueIds = queueIdsForForwarder.remove(forwarderId);
+        if (removedQueueIds != null) {
+            release(removedQueueIds);
         }
     }
 

--- a/hivemq-edge/src/main/java/com/hivemq/bridge/MessageForwarderImpl.java
+++ b/hivemq-edge/src/main/java/com/hivemq/bridge/MessageForwarderImpl.java
@@ -392,26 +392,54 @@ public class MessageForwarderImpl implements MessageForwarder {
             final @NotNull Set<String> queueIds,
             final @NotNull List<String> subscribedTopics) {
         log.error("Registration of forwarder '{}' failed, undoing it", forwarderId);
+        // A try per phase, not one around all three. Sharing a single try meant a stop() that threw --
+        // an ordinary outcome, since it drains buffers through persistence futures -- skipped the
+        // topic-tree removal and the poll-set prune, leaving this forwarder subscribed to topics it can
+        // no longer serve. Ownership was released either way in the finally, so a queue was never
+        // stranded; the subscriptions were (EDG-882 review v03, R3-04).
         try {
             if (forwarders.remove(forwarderId, mqttForwarder)) {
                 mqttForwarder.stop();
             }
-            for (final String topic : subscribedTopics) {
-                topicTree.removeSubscriber(clientId, topic, shareName);
-            }
-            notEmptyQueues.removeAll(queueIds);
         } catch (final Throwable rollbackFailure) {
             // Reported, never rethrown: the caller must see why the registration failed, not why the
             // clean-up after it did.
             log.error(
-                    "Undoing the failed registration of forwarder '{}' did not complete", forwarderId, rollbackFailure);
-        } finally {
+                    "Stopping forwarder '{}' while undoing its failed registration failed",
+                    forwarderId,
+                    rollbackFailure);
+        }
+        for (final String topic : subscribedTopics) {
+            try {
+                topicTree.removeSubscriber(clientId, topic, shareName);
+            } catch (final Throwable rollbackFailure) {
+                log.error(
+                        "Removing forwarder '{}' from the topic tree for topic '{}' while undoing its failed registration failed",
+                        forwarderId,
+                        topic,
+                        rollbackFailure);
+            }
+        }
+        try {
+            notEmptyQueues.removeAll(queueIds);
+        } catch (final Throwable rollbackFailure) {
+            log.error(
+                    "Pruning the poll set of forwarder '{}' while undoing its failed registration failed",
+                    forwarderId,
+                    rollbackFailure);
+        }
+        try {
             // Last, and unconditionally: ownership is what the periodic clean-up reads, so releasing it
             // before the forwarder is unpublished would expose a live queue, and not releasing it at all
             // would keep a queue nobody drains alive for the life of the node.
             if (queueIdsForForwarder.remove(forwarderId, queueIds)) {
                 release(queueIds);
             }
+        } catch (final Throwable rollbackFailure) {
+            log.error(
+                    "Releasing the queue ownership of forwarder '{}' while undoing its failed registration failed",
+                    forwarderId,
+                    rollbackFailure);
         }
     }
 
@@ -579,16 +607,39 @@ public class MessageForwarderImpl implements MessageForwarder {
         // registration passed to addTopic.
         final Set<String> registeredQueueIds = queueIdsForForwarder.get(forwarderId);
 
+        // Every phase below runs, whatever the ones before it did. A teardown that stops half way leaves
+        // this forwarder's queue IDs in the ownership index with no forwarder behind them: the periodic
+        // clean-up then reads those queues as owned for the life of the node -- so they are never
+        // reclaimed -- and addForwarder refuses a replacement under the same id, because putIfAbsent
+        // still finds the abandoned claim. A bridge that cannot be restarted and storage that cannot be
+        // freed, out of one exception during a stop. The failures are collected and rethrown at the end
+        // so the caller still learns, but they no longer decide how much of the teardown happens
+        // (EDG-882 review v03, R3-04).
+        //
+        // The ordering the phases run in is unchanged and still load-bearing: unpublish and stop before
+        // ownership is dropped, prune the poll set last. See the note above the removal below.
+        final List<Throwable> teardownFailures = new ArrayList<>();
+
         for (final String topic : mqttForwarder.getTopics()) {
-            topicTree.removeSubscriber(clientId, topic, FORWARDER_PREFIX + forwarderId);
+            try {
+                topicTree.removeSubscriber(clientId, topic, FORWARDER_PREFIX + forwarderId);
+            } catch (final Throwable t) {
+                teardownFailures.add(t);
+                log.error("Removing forwarder '{}' from the topic tree for topic '{}' failed", forwarderId, topic, t);
+            }
             final String queueId = createQueueId(forwarderId, topic);
             if (clearQueue) {
-                final var qPersistence = queuePersistence.get();
-                if (qPersistence != null) {
-                    qPersistence.clear(queueId, true); // clear up queue
-                    if (log.isTraceEnabled()) {
-                        log.trace("Cleared queue '{}' for forwarder '{}'", queueId, forwarderId);
+                try {
+                    final var qPersistence = queuePersistence.get();
+                    if (qPersistence != null) {
+                        qPersistence.clear(queueId, true); // clear up queue
+                        if (log.isTraceEnabled()) {
+                            log.trace("Cleared queue '{}' for forwarder '{}'", queueId, forwarderId);
+                        }
                     }
+                } catch (final Throwable t) {
+                    teardownFailures.add(t);
+                    log.error("Clearing queue '{}' of forwarder '{}' failed", queueId, forwarderId, t);
                 }
             }
         }
@@ -612,12 +663,23 @@ public class MessageForwarderImpl implements MessageForwarder {
         // permanent leak is the wrong direction for this ticket.
         final MqttForwarder removed = forwarders.remove(forwarderId);
         if (removed != null) {
-            removed.stop();
-            if (log.isInfoEnabled()) {
-                log.info(
-                        "Forwarder '{}' removed and stopped, total active forwarders: {}",
+            // RemoteMqttForwarder.stop() drains its buffers through reset callbacks that wait on
+            // persistence futures and rethrow an ExecutionException as a RuntimeException, so this
+            // throwing is an ordinary consequence of a persistence hiccup, not a contrived case.
+            try {
+                removed.stop();
+                if (log.isInfoEnabled()) {
+                    log.info(
+                            "Forwarder '{}' removed and stopped, total active forwarders: {}",
+                            forwarderId,
+                            forwarders.size());
+                }
+            } catch (final Throwable t) {
+                teardownFailures.add(t);
+                log.error(
+                        "Stopping forwarder '{}' failed; its ownership and poll state are still being released",
                         forwarderId,
-                        forwarders.size());
+                        t);
             }
         } else {
             log.warn("Attempted to remove forwarder '{}' but it was not found in active forwarders", forwarderId);
@@ -642,6 +704,17 @@ public class MessageForwarderImpl implements MessageForwarder {
         for (final String queueId :
                 requireNonNullElseGet(registeredQueueIds, () -> queueIdsOf(forwarderId, mqttForwarder.getTopics()))) {
             notEmptyQueues.remove(queueId);
+        }
+
+        // Reported only once every phase above has run. The caller still sees that the teardown was not
+        // clean -- BridgeService logs it and carries on to the next forwarder -- but by this point the
+        // index is in the state it would have reached anyway, so nothing is left claiming a queue.
+        if (!teardownFailures.isEmpty()) {
+            final RuntimeException aggregate = new IllegalStateException(String.format(
+                    "Forwarder '%s' was removed and its queue ownership released, but %d step(s) of the teardown failed",
+                    forwarderId, teardownFailures.size()));
+            teardownFailures.forEach(aggregate::addSuppressed);
+            throw aggregate;
         }
     }
 

--- a/hivemq-edge/src/main/java/com/hivemq/bridge/MessageForwarderImpl.java
+++ b/hivemq-edge/src/main/java/com/hivemq/bridge/MessageForwarderImpl.java
@@ -17,7 +17,9 @@ package com.hivemq.bridge;
 
 import static com.hivemq.configuration.service.InternalConfigurations.FORWARDER_POLL_THRESHOLD_MESSAGES;
 import static com.hivemq.configuration.service.InternalConfigurations.PUBLISH_POLL_BATCH_SIZE_BYTES;
+import static java.util.Objects.requireNonNullElse;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.FutureCallback;
@@ -45,6 +47,7 @@ import dagger.Lazy;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -566,10 +569,16 @@ public class MessageForwarderImpl implements MessageForwarder {
                     clearQueue);
         }
 
+        // Read before anything is torn down: what was actually registered under this id, which is what
+        // has to be released and what has to be pruned from notEmptyQueues. mqttForwarder.getTopics() is
+        // only what the caller believes it registered, and the two can differ (EDG-882 review v02,
+        // R2-05). The topic-tree removal below still uses the caller's topics, because that is what the
+        // registration passed to addTopic.
+        final Set<String> registeredQueueIds = queueIdsForForwarder.get(forwarderId);
+
         for (final String topic : mqttForwarder.getTopics()) {
             topicTree.removeSubscriber(clientId, topic, FORWARDER_PREFIX + forwarderId);
             final String queueId = createQueueId(forwarderId, topic);
-            notEmptyQueues.remove(queueId);
             if (clearQueue) {
                 final var qPersistence = queuePersistence.get();
                 if (qPersistence != null) {
@@ -587,18 +596,20 @@ public class MessageForwarderImpl implements MessageForwarder {
         // instant between the stop and the release the queue reads as owned by a forwarder that has
         // gone, which costs one clean-up cycle and no messages.
         //
-        // The set the map returns -- not mqttForwarder.getTopics() -- is what was actually registered,
-        // and is what must be released.
+        // By id, not conditional on this instance -- and that is a decision, not an oversight
+        // (EDG-882 review v02, R2-05). Making it instance-conditional, as rollbackRegistration is, was
+        // tried and reverted: it breaks the case test_removal_releases_the_registered_set_not_the_current
+        // _topics pins, where the caller holds a forwarder object rebuilt since registration. That remove
+        // would then release nothing and the queue would be claimed for the life of the node, with no
+        // caller able to free it. The hazard the instance check defends against -- a stale remove tearing
+        // down a successor under the same id -- cannot arise: addForwarder refuses a second registration
+        // while one is live (putIfAbsent, then throw), so a successor can only exist after the incumbent
+        // was removed, and BridgeService performs both under its own monitor with the old client out of
+        // activeBridgeNamesToClient first. Trading an unreachable message-loss path for a reachable
+        // permanent leak is the wrong direction for this ticket.
         final MqttForwarder removed = forwarders.remove(forwarderId);
         if (removed != null) {
             removed.stop();
-            // After the stop, not before: stopping drains the forwarder's buffers, and every message it
-            // hands back re-adds its queue id through messageProcessed. Removing the ids first left an
-            // entry for a queue no forwarder owns, which nothing ever takes out again -- a set that
-            // grows by one per retired subscription for the life of the node (EDG-882 QA round 3).
-            for (final String topic : mqttForwarder.getTopics()) {
-                notEmptyQueues.remove(createQueueId(forwarderId, topic));
-            }
             if (log.isInfoEnabled()) {
                 log.info(
                         "Forwarder '{}' removed and stopped, total active forwarders: {}",
@@ -612,6 +623,32 @@ public class MessageForwarderImpl implements MessageForwarder {
         if (removedQueueIds != null) {
             release(removedQueueIds);
         }
+        // Last, after the ownership is gone. Stopping drains the forwarder's buffers and every message it
+        // hands back re-adds its queue id, so pruning before the stop left an entry nothing ever removed
+        // again -- one string per retired subscription, for the life of the node (EDG-882 QA round 3).
+        // Pruning after the stop was not enough either: those re-adds are submitted to the single writer
+        // and run later, so they could land after the prune (R2-06). They are now guarded, on the
+        // registration and on ownership respectively, and both of those are dropped above -- so a re-add
+        // can only happen before this point, and this prune is what takes it out. notEmptyQueues drives
+        // polling only, so moving it behind the release costs nothing: nothing polls a forwarder that has
+        // gone.
+        //
+        // Against the registered set rather than mqttForwarder.getTopics(), which is only what the caller
+        // believes it registered; the two can differ, and the entry left behind by the difference is one
+        // nothing else removes (R2-05).
+        for (final String queueId :
+                requireNonNullElse(registeredQueueIds, queueIdsOf(forwarderId, mqttForwarder.getTopics()))) {
+            notEmptyQueues.remove(queueId);
+        }
+    }
+
+    private static @NotNull Set<String> queueIdsOf(
+            final @NotNull String forwarderId, final @NotNull List<String> topics) {
+        final ImmutableSet.Builder<@NotNull String> queueIds = ImmutableSet.builder();
+        for (final String topic : topics) {
+            queueIds.add(createQueueId(forwarderId, topic));
+        }
+        return queueIds.build();
     }
 
     @SuppressWarnings("NullAway") // Task<Void> lambda returning null is required for Void type
@@ -635,9 +672,13 @@ public class MessageForwarderImpl implements MessageForwarder {
 
         FutureUtils.addExceptionLogger(
                 singleWriterService.getQueuedMessagesQueue().submit(queueId, bucketIndex -> {
-                    notEmptyQueues.add(queueId);
                     final MqttForwarder forwarder = forwarders.get(forwarderId);
+                    // Guarded on the registration, and read here rather than at submit time: this task
+                    // runs on the single writer, so it can land after removeForwarder has stopped the
+                    // forwarder and pruned the set. Adding then would leave an entry for a queue nobody
+                    // owns and nothing ever takes out again (EDG-882 review v02, R2-06).
                     if (forwarder != null) {
+                        notEmptyQueues.add(queueId);
                         final int inflightCount = forwarder.getInflightCount();
                         if (inflightCount < FORWARDER_POLL_THRESHOLD_MESSAGES) {
                             if (log.isTraceEnabled()) {
@@ -667,10 +708,30 @@ public class MessageForwarderImpl implements MessageForwarder {
             log.trace("Message available notification for queue '{}'", queueId);
         }
         singleWriterService.getQueuedMessagesQueue().submit(queueId, bucketIndex -> {
+            // The caller checked isForwarderQueue before notifying, but this task runs later on the
+            // single writer and the answer can have changed by now: removeForwarder releases ownership
+            // before it prunes, so re-checking here is what keeps an entry for a retired queue out of the
+            // set for good (EDG-882 review v02, R2-06).
+            if (!isForwarderQueue(queueId)) {
+                return null;
+            }
             notEmptyQueues.add(queueId);
             checkBuffers();
             return null;
         });
+    }
+
+    /**
+     * The queue ids the poll loop still has work for.
+     * <p>
+     * Exposed because it is otherwise unobservable, which is how it came to leak an entry per retired
+     * subscription without anything noticing (EDG-882 QA round 3, review v02 R2-06). Read-only: adding to
+     * it outside the single writer is what the ordering rules in {@code addForwarder} exist to prevent.
+     */
+    @VisibleForTesting
+    @NotNull
+    Set<String> notEmptyQueues() {
+        return Collections.unmodifiableSet(notEmptyQueues);
     }
 
     /**

--- a/hivemq-edge/src/main/java/com/hivemq/bridge/MessageForwarderImpl.java
+++ b/hivemq-edge/src/main/java/com/hivemq/bridge/MessageForwarderImpl.java
@@ -31,10 +31,13 @@ import com.hivemq.configuration.service.InternalConfigurations;
 import com.hivemq.mqtt.message.QoS;
 import com.hivemq.mqtt.message.publish.PUBLISH;
 import com.hivemq.mqtt.message.subscribe.Topic;
+import com.hivemq.mqtt.services.PublishDistributorImpl;
+import com.hivemq.mqtt.topic.SubscriberWithQoS;
 import com.hivemq.mqtt.topic.SubscriptionFlag;
 import com.hivemq.mqtt.topic.tree.LocalTopicTree;
 import com.hivemq.persistence.SingleWriterService;
 import com.hivemq.persistence.clientqueue.ClientQueuePersistence;
+import com.hivemq.persistence.clientsession.ClientSessionSubscriptionPersistence;
 import com.hivemq.persistence.util.FutureUtils;
 import com.hivemq.util.ThreadFactoryUtil;
 import dagger.Lazy;
@@ -64,12 +67,16 @@ public class MessageForwarderImpl implements MessageForwarder {
 
     public static final @NotNull String FORWARDER_PREFIX = "$FORWARDER::";
 
+    /** How a client writes a shared subscription, and therefore how one is stored for its session. */
+    private static final @NotNull String SHARED_SUBSCRIPTION_PREFIX = "$share/";
+
     private static final @NotNull Logger log = LoggerFactory.getLogger(MessageForwarderImpl.class);
     public static final int RESET_INFLIGHT_COUNTERS_TIMEOUT_IN_SECONDS = 30;
 
     private final @NotNull LocalTopicTree topicTree;
     private final @NotNull HivemqId hivemqId;
     private final @NotNull Lazy<ClientQueuePersistence> queuePersistence;
+    private final @NotNull Lazy<ClientSessionSubscriptionPersistence> subscriptionPersistence;
     private final @NotNull SingleWriterService singleWriterService;
     private final @NotNull Set<String> notEmptyQueues;
     private final @NotNull Map<String, MqttForwarder> forwarders;
@@ -103,11 +110,13 @@ public class MessageForwarderImpl implements MessageForwarder {
             final @NotNull LocalTopicTree topicTree,
             final @NotNull HivemqId hivemqId,
             final @NotNull Lazy<ClientQueuePersistence> queuePersistence,
+            final @NotNull Lazy<ClientSessionSubscriptionPersistence> subscriptionPersistence,
             final @NotNull SingleWriterService singleWriterService,
             final @NotNull ShutdownHooks shutdownHooks) {
         this.topicTree = topicTree;
         this.hivemqId = hivemqId;
         this.queuePersistence = queuePersistence;
+        this.subscriptionPersistence = subscriptionPersistence;
         this.singleWriterService = singleWriterService;
         this.notEmptyQueues = new ConcurrentSkipListSet<>();
         this.forwarders = new ConcurrentHashMap<>(0);
@@ -196,6 +205,7 @@ public class MessageForwarderImpl implements MessageForwarder {
             queueIdsBuilder.add(createQueueId(forwarderId, topic));
         }
         final ImmutableSet<@NotNull String> queueIds = queueIdsBuilder.build();
+        evictForeignSubscribers(forwarderId, shareName, mqttForwarder.getTopics());
         // Ownership is registered before anything else can observe the queues: the periodic clean-up
         // clears forwarder queues it finds unowned, so a pre-existing persisted queue must never be
         // visible while its forwarder is mid-registration.
@@ -401,6 +411,56 @@ public class MessageForwarderImpl implements MessageForwarder {
             // would keep a queue nobody drains alive for the life of the node.
             if (queueIdsForForwarder.remove(forwarderId, queueIds)) {
                 release(queueIds);
+            }
+        }
+    }
+
+    /**
+     * Takes this forwarder's shared-subscription group back from any external client that holds it.
+     * <p>
+     * Shared subscribers of one group take turns, so a client subscribed to
+     * {@code $share/$FORWARDER::<this forwarder's id>/<its filter>} receives the messages this bridge is
+     * meant to forward, and they never reach the remote broker. The group name embeds a digest a client
+     * can compute from the bridge's own configuration, which makes it reachable rather than theoretical
+     * (EDG-882 QA round 2).
+     * <p>
+     * A SUBSCRIBE is already refused while the queue is claimed —
+     * {@link com.hivemq.mqtt.handler.subscribe.IncomingSubscribeService} asks
+     * {@link #isForwarderQueue(String)}, and the queues are claimed by
+     * {@code BridgeService.internalStartBridge}'s reservation from the top of every start, restart and
+     * node bootstrap. That leaves exactly one window this cannot cover: a client subscribing to the
+     * group of a bridge that does not exist yet, which is legal at the time and becomes a collision the
+     * moment the operator creates that bridge. This is that window, closed from the other side.
+     * <p>
+     * The subscription is removed rather than the bridge refused: a bridge that an arbitrary client can
+     * stop from starting would be a worse defect than the one being fixed. Removal goes through the
+     * subscription persistence, not the topic tree alone, or the client's session would restore it on
+     * its next reconnect and take the group straight back.
+     * <p>
+     * Deliberately outside the registration rollback: the subscription being removed is one that must
+     * not exist while this forwarder does, so putting it back if the registration then fails would be
+     * restoring the defect.
+     */
+    private void evictForeignSubscribers(
+            final @NotNull String forwarderId, final @NotNull String shareName, final @NotNull List<String> topics) {
+        for (final String topic : topics) {
+            for (final SubscriberWithQoS subscriber : topicTree.getSharedSubscriber(shareName, topic)) {
+                final String client = subscriber.getSubscriber();
+                // An internal component's own entry is not an intruder -- including a previous
+                // generation of this forwarder, which a slow stop can leave behind for an instant.
+                if (PublishDistributorImpl.isReservedClientId(client)) {
+                    continue;
+                }
+                log.warn(
+                        "Client '{}' holds the shared subscription group of bridge forwarder '{}'; removing its"
+                                + " subscription to '{}', because it would otherwise receive the messages the bridge"
+                                + " is there to forward and they would never reach the remote broker.",
+                        client,
+                        forwarderId,
+                        topic);
+                FutureUtils.addExceptionLogger(subscriptionPersistence
+                        .get()
+                        .remove(client, SHARED_SUBSCRIPTION_PREFIX + shareName + "/" + topic));
             }
         }
     }

--- a/hivemq-edge/src/main/java/com/hivemq/bridge/MessageForwarderImpl.java
+++ b/hivemq-edge/src/main/java/com/hivemq/bridge/MessageForwarderImpl.java
@@ -206,7 +206,7 @@ public class MessageForwarderImpl implements MessageForwarder {
             queueIdsBuilder.add(createQueueId(forwarderId, topic));
         }
         final ImmutableSet<@NotNull String> queueIds = queueIdsBuilder.build();
-        evictForeignSubscribers(forwarderId, shareName, mqttForwarder.getTopics());
+        evictForeignSubscribers(forwarderId, mqttForwarder.getTopics());
         // Ownership is registered before anything else can observe the queues: the periodic clean-up
         // clears forwarder queues it finds unowned, so a pre-existing persisted queue must never be
         // visible while its forwarder is mid-registration.
@@ -441,45 +441,68 @@ public class MessageForwarderImpl implements MessageForwarder {
      * Deliberately outside the registration rollback: the subscription being removed is one that must
      * not exist while this forwarder does, so putting it back if the registration then fails would be
      * restoring the defect.
+     * <p>
+     * <b>Every decomposition of the queue ID is searched, not just this forwarder's own</b> (EDG-882
+     * review v02, R2-02). A forwarder registers its node by passing the group and the filter to
+     * {@link LocalTopicTree#addTopic} directly, so its own node is split where this class puts the '/'.
+     * A client cannot do that: it sends one string, and {@link com.hivemq.util.Topics} splits it at the
+     * <em>first</em> '/' after {@code $share/} -- which, for the slash-bearing digest this ticket exists
+     * for, falls inside the digest and puts the client on an entirely different node. Looking only under
+     * this forwarder's own split therefore finds nothing and evicts nothing, while
+     * {@code PublishPollServiceImpl} keys the queue the client polls off the concatenated string, which
+     * is the same string whichever '/' it was split at -- so the intruder drains this queue anyway.
+     * <p>
+     * Enumerating the splits is both simpler than special-casing the two that can hold a subscriber and
+     * independent of how {@code Topics} chooses to split, which is the assumption that broke here in the
+     * first place. The extra nodes cannot hold an innocent client: a group taken from beyond the first
+     * '/' contains a '/' itself, and no SUBSCRIBE can be stored under such a group. The cost is the
+     * topic's depth in lookups, on a registration.
      */
-    private void evictForeignSubscribers(
-            final @NotNull String forwarderId, final @NotNull String shareName, final @NotNull List<String> topics) {
+    private void evictForeignSubscribers(final @NotNull String forwarderId, final @NotNull List<String> topics) {
         for (final String topic : topics) {
-            for (final SubscriberWithQoS subscriber : topicTree.getSharedSubscriber(shareName, topic)) {
-                final String client = subscriber.getSubscriber();
-                // An internal component's own entry is not an intruder -- including a previous
-                // generation of this forwarder, which a slow stop can leave behind for an instant.
-                if (PublishDistributorImpl.isReservedClientId(client)) {
-                    continue;
-                }
-                log.warn(
-                        "Client '{}' holds the shared subscription group of bridge forwarder '{}'; removing its"
-                                + " subscription to '{}', because it would otherwise receive the messages the bridge"
-                                + " is there to forward and they would never reach the remote broker.",
-                        client,
-                        forwarderId,
-                        topic);
-                // The full '$share/<group>/<filter>' string, because that is what the client subscribed
-                // with and therefore what its session stores: removing it from the topic tree alone
-                // would let the next reconnect restore it.
-                final ListenableFuture<Void> removed = subscriptionPersistence
-                        .get()
-                        .remove(client, SHARED_SUBSCRIPTION_PREFIX + shareName + "/" + topic);
-                FutureUtils.addExceptionLogger(removed);
-                Futures.addCallback(
-                        removed,
-                        new FutureCallback<>() {
-                            @Override
-                            public void onSuccess(final @Nullable Void result) {
-                                Checkpoints.checkpoint(MessageForwarder.FOREIGN_SUBSCRIBER_EVICTED);
-                            }
+            final String queueId = createQueueId(forwarderId, topic);
+            for (int slash = queueId.indexOf('/'); slash >= 0; slash = queueId.indexOf('/', slash + 1)) {
+                final String group = queueId.substring(0, slash);
+                final String filter = queueId.substring(slash + 1);
+                for (final SubscriberWithQoS subscriber : topicTree.getSharedSubscriber(group, filter)) {
+                    final String client = subscriber.getSubscriber();
+                    // An internal component's own entry is not an intruder -- including a previous
+                    // generation of this forwarder, which a slow stop can leave behind for an instant.
+                    if (PublishDistributorImpl.isReservedClientId(client)) {
+                        continue;
+                    }
+                    log.warn(
+                            "Client '{}' holds the shared subscription group of bridge forwarder '{}' (as group"
+                                    + " '{}', filter '{}'); removing its subscription to '{}', because it would"
+                                    + " otherwise receive the messages the bridge is there to forward and they"
+                                    + " would never reach the remote broker.",
+                            client,
+                            forwarderId,
+                            group,
+                            filter,
+                            topic);
+                    // The full '$share/' + queue ID string, because that is what the client subscribed
+                    // with and therefore what its session stores: removing it from the topic tree alone
+                    // would let the next reconnect restore it. It does not depend on which split found
+                    // the client -- group + '/' + filter is the queue ID however it was cut.
+                    final ListenableFuture<Void> removed =
+                            subscriptionPersistence.get().remove(client, SHARED_SUBSCRIPTION_PREFIX + queueId);
+                    FutureUtils.addExceptionLogger(removed);
+                    Futures.addCallback(
+                            removed,
+                            new FutureCallback<>() {
+                                @Override
+                                public void onSuccess(final @Nullable Void result) {
+                                    Checkpoints.checkpoint(MessageForwarder.FOREIGN_SUBSCRIBER_EVICTED);
+                                }
 
-                            @Override
-                            public void onFailure(final @NotNull Throwable throwable) {
-                                // already reported by the exception logger above
-                            }
-                        },
-                        MoreExecutors.directExecutor());
+                                @Override
+                                public void onFailure(final @NotNull Throwable throwable) {
+                                    // already reported by the exception logger above
+                                }
+                            },
+                            MoreExecutors.directExecutor());
+                }
             }
         }
     }

--- a/hivemq-edge/src/main/java/com/hivemq/bridge/MessageForwarderImpl.java
+++ b/hivemq-edge/src/main/java/com/hivemq/bridge/MessageForwarderImpl.java
@@ -87,6 +87,12 @@ public class MessageForwarderImpl implements MessageForwarder {
      */
     private final @NotNull Map<String, Set<String>> reservedQueues;
 
+    /**
+     * Whether the bridge configuration has been applied at least once. Read by the periodic clean-up
+     * through {@link #hasAppliedBridgeConfiguration()}; see {@link MessageForwarder} for why.
+     */
+    private volatile boolean bridgeConfigurationApplied;
+
     private final @NotNull ExecutorService executorService;
     private final @NotNull Lock pollLock;
     private volatile boolean polling;
@@ -397,6 +403,16 @@ public class MessageForwarderImpl implements MessageForwarder {
                 release(queueIds);
             }
         }
+    }
+
+    @Override
+    public void markBridgeConfigurationApplied() {
+        bridgeConfigurationApplied = true;
+    }
+
+    @Override
+    public boolean hasAppliedBridgeConfiguration() {
+        return bridgeConfigurationApplied;
     }
 
     @Override

--- a/hivemq-edge/src/main/java/com/hivemq/bridge/MessageForwarderImpl.java
+++ b/hivemq-edge/src/main/java/com/hivemq/bridge/MessageForwarderImpl.java
@@ -153,14 +153,20 @@ public class MessageForwarderImpl implements MessageForwarder {
 
         final ImmutableSet.Builder<@NotNull String> queueIdsBuilder = ImmutableSet.builder();
         for (final String topic : mqttForwarder.getTopics()) {
+            queueIdsBuilder.add(createQueueId(forwarderId, topic));
+        }
+        final ImmutableSet<@NotNull String> queueIds = queueIdsBuilder.build();
+        // register the queue IDs before anything else can observe the queues: the periodic clean-up
+        // clears forwarder queues it finds unowned, so a pre-existing persisted queue must never be
+        // visible while its forwarder is mid-registration
+        queueIdsForForwarder.put(forwarderId, queueIds);
+        for (final String topic : mqttForwarder.getTopics()) {
             topicTree.addTopic(
                     clientId,
                     new Topic(topic, QoS.AT_LEAST_ONCE, false, true),
                     SubscriptionFlag.getDefaultFlags(true, true, false),
                     shareName);
-            queueIdsBuilder.add(createQueueId(forwarderId, topic));
         }
-        final ImmutableSet<@NotNull String> queueIds = queueIdsBuilder.build();
         mqttForwarder.setExecutorService(executorService);
         mqttForwarder.setAfterForwardCallback(
                 (qos, uniqueId, queueId, cancelled) -> messageProcessed(qos, uniqueId, forwarderId, queueId));
@@ -250,7 +256,6 @@ public class MessageForwarderImpl implements MessageForwarder {
         });
 
         forwarders.put(forwarderId, mqttForwarder);
-        queueIdsForForwarder.put(forwarderId, queueIds);
         notEmptyQueues.addAll(queueIds);
         mqttForwarder.start();
 
@@ -361,6 +366,16 @@ public class MessageForwarderImpl implements MessageForwarder {
             checkBuffers();
             return null;
         });
+    }
+
+    @Override
+    public boolean isForwarderQueue(final @NotNull String queueId) {
+        for (final Set<String> queueIds : queueIdsForForwarder.values()) {
+            if (queueIds.contains(queueId)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override

--- a/hivemq-edge/src/main/java/com/hivemq/bridge/MessageForwarderImpl.java
+++ b/hivemq-edge/src/main/java/com/hivemq/bridge/MessageForwarderImpl.java
@@ -39,6 +39,7 @@ import com.hivemq.persistence.SingleWriterService;
 import com.hivemq.persistence.clientqueue.ClientQueuePersistence;
 import com.hivemq.persistence.clientsession.ClientSessionSubscriptionPersistence;
 import com.hivemq.persistence.util.FutureUtils;
+import com.hivemq.util.Checkpoints;
 import com.hivemq.util.ThreadFactoryUtil;
 import dagger.Lazy;
 import jakarta.inject.Inject;
@@ -458,9 +459,27 @@ public class MessageForwarderImpl implements MessageForwarder {
                         client,
                         forwarderId,
                         topic);
-                FutureUtils.addExceptionLogger(subscriptionPersistence
+                // The full '$share/<group>/<filter>' string, because that is what the client subscribed
+                // with and therefore what its session stores: removing it from the topic tree alone
+                // would let the next reconnect restore it.
+                final ListenableFuture<Void> removed = subscriptionPersistence
                         .get()
-                        .remove(client, SHARED_SUBSCRIPTION_PREFIX + shareName + "/" + topic));
+                        .remove(client, SHARED_SUBSCRIPTION_PREFIX + shareName + "/" + topic);
+                FutureUtils.addExceptionLogger(removed);
+                Futures.addCallback(
+                        removed,
+                        new FutureCallback<>() {
+                            @Override
+                            public void onSuccess(final @Nullable Void result) {
+                                Checkpoints.checkpoint(MessageForwarder.FOREIGN_SUBSCRIBER_EVICTED);
+                            }
+
+                            @Override
+                            public void onFailure(final @NotNull Throwable throwable) {
+                                // already reported by the exception logger above
+                            }
+                        },
+                        MoreExecutors.directExecutor());
             }
         }
     }
@@ -550,6 +569,13 @@ public class MessageForwarderImpl implements MessageForwarder {
         final MqttForwarder removed = forwarders.remove(forwarderId);
         if (removed != null) {
             removed.stop();
+            // After the stop, not before: stopping drains the forwarder's buffers, and every message it
+            // hands back re-adds its queue id through messageProcessed. Removing the ids first left an
+            // entry for a queue no forwarder owns, which nothing ever takes out again -- a set that
+            // grows by one per retired subscription for the life of the node (EDG-882 QA round 3).
+            for (final String topic : mqttForwarder.getTopics()) {
+                notEmptyQueues.remove(createQueueId(forwarderId, topic));
+            }
             if (log.isInfoEnabled()) {
                 log.info(
                         "Forwarder '{}' removed and stopped, total active forwarders: {}",

--- a/hivemq-edge/src/main/java/com/hivemq/bridge/MessageForwarderImpl.java
+++ b/hivemq-edge/src/main/java/com/hivemq/bridge/MessageForwarderImpl.java
@@ -40,6 +40,7 @@ import com.hivemq.util.ThreadFactoryUtil;
 import dagger.Lazy;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -233,111 +234,169 @@ public class MessageForwarderImpl implements MessageForwarder {
                     + " unique among registered forwarders, and a forwarder must be removed before an"
                     + " object with the same ID is added.");
         }
-        for (final String topic : mqttForwarder.getTopics()) {
-            topicTree.addTopic(
-                    clientId,
-                    new Topic(topic, QoS.AT_LEAST_ONCE, false, true),
-                    SubscriptionFlag.getDefaultFlags(true, true, false),
-                    shareName);
-        }
-        mqttForwarder.setExecutorService(executorService);
-        mqttForwarder.setAfterForwardCallback(
-                (qos, uniqueId, queueId, cancelled) -> messageProcessed(qos, uniqueId, forwarderId, queueId));
-        mqttForwarder.setResetInflightMarkerCallback((sharedSubscriptionId, uniqueId) -> {
-            final var qPersistence = queuePersistence.get();
-            try {
-                if (qPersistence != null) {
-                    qPersistence
-                            .removeInFlightMarker(sharedSubscriptionId, uniqueId)
-                            .get();
-                }
-            } catch (final InterruptedException | ExecutionException e) {
-                if (e instanceof InterruptedException) {
-                    Thread.currentThread().interrupt();
-                }
-                log.error(
-                        "Failed to remove inflight marker for forwarder '{}', queue '{}', messageId '{}'",
-                        forwarderId,
-                        sharedSubscriptionId,
-                        uniqueId,
-                        e);
-                throw new RuntimeException(e);
+        // Everything from here to the start() below is fallible, and a registration that fails part way
+        // used to stay claimed for ever: ownership held by an object that never ran, so the periodic
+        // clean-up preserved a queue nobody would ever drain, and the ID could not be registered again
+        // (EDG-882 F-10). The rollback undoes exactly the steps that were taken, in the reverse of the
+        // order they were taken in -- unpublish and stop before releasing ownership, as removeForwarder
+        // does -- and only for this instance and this claim, so a concurrent registration of the same
+        // ID cannot be torn down by another's failure.
+        final List<String> subscribedTopics = new ArrayList<>();
+        boolean registered = false;
+        try {
+            for (final String topic : mqttForwarder.getTopics()) {
+                topicTree.addTopic(
+                        clientId,
+                        new Topic(topic, QoS.AT_LEAST_ONCE, false, true),
+                        SubscriptionFlag.getDefaultFlags(true, true, false),
+                        shareName);
+                subscribedTopics.add(topic);
             }
-        });
-        mqttForwarder.setResetAllInflightMarkersCallback((fwdId) -> {
-            // Reset ALL inflight markers for all queues associated with this forwarder.
-            // This is called on reconnection to handle messages that were read from persistence
-            // but never made it to the forwarder's local queues.
-            //
-            // IMPORTANT: We collect all futures and wait for them using Futures.allAsList to
-            // ensure all inflight markers are reset before onReconnect triggers checkBuffers().
-            // This is safe because the persistence operations are submitted to SingleWriter
-            // and don't hold any locks that could cause deadlock.
-            final Set<String> forwarderQueueIds = queueIdsForForwarder.get(fwdId);
-            if (forwarderQueueIds != null && !forwarderQueueIds.isEmpty()) {
-                if (log.isDebugEnabled()) {
-                    log.debug(
-                            "Resetting inflight markers for forwarder '{}', {} queue(s)",
-                            fwdId,
-                            forwarderQueueIds.size());
-                }
-                final ImmutableList.Builder<ListenableFuture<Void>> futuresBuilder = ImmutableList.builder();
+            mqttForwarder.setExecutorService(executorService);
+            mqttForwarder.setAfterForwardCallback(
+                    (qos, uniqueId, queueId, cancelled) -> messageProcessed(qos, uniqueId, forwarderId, queueId));
+            mqttForwarder.setResetInflightMarkerCallback((sharedSubscriptionId, uniqueId) -> {
                 final var qPersistence = queuePersistence.get();
-                if (qPersistence != null) {
-                    for (final String queueIdToReset : forwarderQueueIds) {
-                        futuresBuilder.add(qPersistence.removeAllInFlightMarkers(queueIdToReset));
-                    }
-                }
                 try {
-                    // Wait for all inflight markers to be reset before returning
-                    // This ensures onReconnect() will see clean queues when it triggers checkBuffers()
-                    Futures.allAsList(futuresBuilder.build())
-                            .get(RESET_INFLIGHT_COUNTERS_TIMEOUT_IN_SECONDS, TimeUnit.SECONDS);
+                    if (qPersistence != null) {
+                        qPersistence
+                                .removeInFlightMarker(sharedSubscriptionId, uniqueId)
+                                .get();
+                    }
+                } catch (final InterruptedException | ExecutionException e) {
+                    if (e instanceof InterruptedException) {
+                        Thread.currentThread().interrupt();
+                    }
+                    log.error(
+                            "Failed to remove inflight marker for forwarder '{}', queue '{}', messageId '{}'",
+                            forwarderId,
+                            sharedSubscriptionId,
+                            uniqueId,
+                            e);
+                    throw new RuntimeException(e);
+                }
+            });
+            mqttForwarder.setResetAllInflightMarkersCallback((fwdId) -> {
+                // Reset ALL inflight markers for all queues associated with this forwarder.
+                // This is called on reconnection to handle messages that were read from persistence
+                // but never made it to the forwarder's local queues.
+                //
+                // IMPORTANT: We collect all futures and wait for them using Futures.allAsList to
+                // ensure all inflight markers are reset before onReconnect triggers checkBuffers().
+                // This is safe because the persistence operations are submitted to SingleWriter
+                // and don't hold any locks that could cause deadlock.
+                final Set<String> forwarderQueueIds = queueIdsForForwarder.get(fwdId);
+                if (forwarderQueueIds != null && !forwarderQueueIds.isEmpty()) {
                     if (log.isDebugEnabled()) {
                         log.debug(
-                                "Reset all inflight markers for forwarder '{}', {} queue(s)",
+                                "Resetting inflight markers for forwarder '{}', {} queue(s)",
                                 fwdId,
                                 forwarderQueueIds.size());
                     }
-                } catch (final InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                    log.error("Interrupted while resetting inflight markers for forwarder '{}'", fwdId, e);
-                } catch (final ExecutionException e) {
-                    log.error("Failed to reset inflight markers for forwarder '{}'", fwdId, e);
-                } catch (final TimeoutException e) {
-                    log.warn(
-                            "Timeout resetting inflight markers for forwarder '{}' - forcing reconnect to retry",
-                            fwdId,
-                            e);
-                    final MqttForwarder forwarder = forwarders.get(fwdId);
-                    if (forwarder != null) {
-                        forwarder.forceReconnect();
+                    final ImmutableList.Builder<ListenableFuture<Void>> futuresBuilder = ImmutableList.builder();
+                    final var qPersistence = queuePersistence.get();
+                    if (qPersistence != null) {
+                        for (final String queueIdToReset : forwarderQueueIds) {
+                            futuresBuilder.add(qPersistence.removeAllInFlightMarkers(queueIdToReset));
+                        }
+                    }
+                    try {
+                        // Wait for all inflight markers to be reset before returning
+                        // This ensures onReconnect() will see clean queues when it triggers checkBuffers()
+                        Futures.allAsList(futuresBuilder.build())
+                                .get(RESET_INFLIGHT_COUNTERS_TIMEOUT_IN_SECONDS, TimeUnit.SECONDS);
+                        if (log.isDebugEnabled()) {
+                            log.debug(
+                                    "Reset all inflight markers for forwarder '{}', {} queue(s)",
+                                    fwdId,
+                                    forwarderQueueIds.size());
+                        }
+                    } catch (final InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        log.error("Interrupted while resetting inflight markers for forwarder '{}'", fwdId, e);
+                    } catch (final ExecutionException e) {
+                        log.error("Failed to reset inflight markers for forwarder '{}'", fwdId, e);
+                    } catch (final TimeoutException e) {
+                        log.warn(
+                                "Timeout resetting inflight markers for forwarder '{}' - forcing reconnect to retry",
+                                fwdId,
+                                e);
+                        final MqttForwarder forwarder = forwarders.get(fwdId);
+                        if (forwarder != null) {
+                            forwarder.forceReconnect();
+                        }
                     }
                 }
-            }
-        });
-        mqttForwarder.setOnReconnectCallback(() -> {
-            if (log.isDebugEnabled()) {
-                log.debug("OnReconnect callback triggered for forwarder '{}', checking buffers", forwarderId);
-            }
-            // Re-add all queue IDs to notEmptyQueues to ensure they get polled after reconnect
-            final Set<String> forwarderQueueIds = queueIdsForForwarder.get(forwarderId);
-            if (forwarderQueueIds != null) {
-                notEmptyQueues.addAll(forwarderQueueIds);
-            }
-            checkBuffers();
-        });
+            });
+            mqttForwarder.setOnReconnectCallback(() -> {
+                if (log.isDebugEnabled()) {
+                    log.debug("OnReconnect callback triggered for forwarder '{}', checking buffers", forwarderId);
+                }
+                // Re-add all queue IDs to notEmptyQueues to ensure they get polled after reconnect
+                final Set<String> forwarderQueueIds = queueIdsForForwarder.get(forwarderId);
+                if (forwarderQueueIds != null) {
+                    notEmptyQueues.addAll(forwarderQueueIds);
+                }
+                checkBuffers();
+            });
 
-        forwarders.put(forwarderId, mqttForwarder);
-        notEmptyQueues.addAll(queueIds);
-        mqttForwarder.start();
+            forwarders.put(forwarderId, mqttForwarder);
+            notEmptyQueues.addAll(queueIds);
+            mqttForwarder.start();
+            registered = true;
+        } finally {
+            if (!registered) {
+                rollbackRegistration(mqttForwarder, forwarderId, clientId, shareName, queueIds, subscribedTopics);
+            }
+        }
 
         if (log.isInfoEnabled()) {
             log.info(
                     "Forwarder '{}' started successfully, total active forwarders: {}", forwarderId, forwarders.size());
         }
 
+        // Outside the rollback on purpose: by now the forwarder is registered, started and owns its
+        // queues, so a failure to kick off a poll is a poll that did not happen, not a registration
+        // that did not happen. Undoing a live forwarder here would be the more destructive answer.
         checkBuffers();
+    }
+
+    /**
+     * Undoes a registration that threw part way, leaving the index exactly as it was before it started.
+     * <p>
+     * Every removal is conditional on this instance and this claim. A plain {@code remove(forwarderId)}
+     * would let one failed registration tear down a different forwarder that had since taken the same
+     * ID, which is the failure this whole ticket is about, arrived at from the other direction.
+     */
+    private void rollbackRegistration(
+            final @NotNull MqttForwarder mqttForwarder,
+            final @NotNull String forwarderId,
+            final @NotNull String clientId,
+            final @NotNull String shareName,
+            final @NotNull Set<String> queueIds,
+            final @NotNull List<String> subscribedTopics) {
+        log.error("Registration of forwarder '{}' failed, undoing it", forwarderId);
+        try {
+            if (forwarders.remove(forwarderId, mqttForwarder)) {
+                mqttForwarder.stop();
+            }
+            for (final String topic : subscribedTopics) {
+                topicTree.removeSubscriber(clientId, topic, shareName);
+            }
+            notEmptyQueues.removeAll(queueIds);
+        } catch (final Throwable rollbackFailure) {
+            // Reported, never rethrown: the caller must see why the registration failed, not why the
+            // clean-up after it did.
+            log.error(
+                    "Undoing the failed registration of forwarder '{}' did not complete", forwarderId, rollbackFailure);
+        } finally {
+            // Last, and unconditionally: ownership is what the periodic clean-up reads, so releasing it
+            // before the forwarder is unpublished would expose a live queue, and not releasing it at all
+            // would keep a queue nobody drains alive for the life of the node.
+            if (queueIdsForForwarder.remove(forwarderId, queueIds)) {
+                release(queueIds);
+            }
+        }
     }
 
     @Override

--- a/hivemq-edge/src/main/java/com/hivemq/bridge/MessageForwarderImpl.java
+++ b/hivemq-edge/src/main/java/com/hivemq/bridge/MessageForwarderImpl.java
@@ -17,7 +17,7 @@ package com.hivemq.bridge;
 
 import static com.hivemq.configuration.service.InternalConfigurations.FORWARDER_POLL_THRESHOLD_MESSAGES;
 import static com.hivemq.configuration.service.InternalConfigurations.PUBLISH_POLL_BATCH_SIZE_BYTES;
-import static java.util.Objects.requireNonNullElse;
+import static java.util.Objects.requireNonNullElseGet;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
@@ -204,11 +204,7 @@ public class MessageForwarderImpl implements MessageForwarder {
                     mqttForwarder.getTopics());
         }
 
-        final ImmutableSet.Builder<@NotNull String> queueIdsBuilder = ImmutableSet.builder();
-        for (final String topic : mqttForwarder.getTopics()) {
-            queueIdsBuilder.add(createQueueId(forwarderId, topic));
-        }
-        final ImmutableSet<@NotNull String> queueIds = queueIdsBuilder.build();
+        final Set<String> queueIds = queueIdsOf(forwarderId, mqttForwarder.getTopics());
         evictForeignSubscribers(forwarderId, mqttForwarder.getTopics());
         // Ownership is registered before anything else can observe the queues: the periodic clean-up
         // clears forwarder queues it finds unowned, so a pre-existing persisted queue must never be
@@ -455,6 +451,17 @@ public class MessageForwarderImpl implements MessageForwarder {
      * {@code PublishPollServiceImpl} keys the queue the client polls off the concatenated string, which
      * is the same string whichever '/' it was split at -- so the intruder drains this queue anyway.
      * <p>
+     * <b>Samplers are deliberately not given the same protection</b> (EDG-882 review v02, R2-02). A
+     * client can squat on a sampler's group the same way — {@code SamplingService} registers its node
+     * under {@code $SAMPLER::<topic>} and a client's SUBSCRIBE is stored split at the first '/' of the
+     * topic — and nothing evicts it when sampling starts. The asymmetry is intentional: what a squatter
+     * takes there is sample fidelity, a diagnostic that regenerates in seconds, not customer messages
+     * queued for a remote broker. The subscribe-time refusal in
+     * {@link com.hivemq.mqtt.handler.subscribe.IncomingSubscribeService} covers a sampler that is
+     * already live, which leaves only the "sampling had not started yet" window open. Closing it means
+     * the same enumeration in {@code SamplingService.startSampling}, and it was left rather than
+     * forgotten.
+     * <p>
      * Enumerating the splits is both simpler than special-casing the two that can hold a subscriber and
      * independent of how {@code Topics} chooses to split, which is the assumption that broke here in the
      * first place. The extra nodes cannot hold an innocent client: a group taken from beyond the first
@@ -524,11 +531,7 @@ public class MessageForwarderImpl implements MessageForwarder {
     public void reserveQueues(
             final @NotNull String reservationId, final @NotNull Map<String, List<String>> topicsByForwarderId) {
         final ImmutableSet.Builder<@NotNull String> queueIdsBuilder = ImmutableSet.builder();
-        topicsByForwarderId.forEach((forwarderId, topics) -> {
-            for (final String topic : topics) {
-                queueIdsBuilder.add(createQueueId(forwarderId, topic));
-            }
-        });
+        topicsByForwarderId.forEach((forwarderId, topics) -> queueIdsBuilder.addAll(queueIdsOf(forwarderId, topics)));
         final ImmutableSet<@NotNull String> queueIds = queueIdsBuilder.build();
         // Same ordering as addForwarder, for the same reason (O2): retain the new set before releasing
         // the one it replaces, so a queue held by both never drops to zero references in between.
@@ -637,11 +640,19 @@ public class MessageForwarderImpl implements MessageForwarder {
         // believes it registered; the two can differ, and the entry left behind by the difference is one
         // nothing else removes (R2-05).
         for (final String queueId :
-                requireNonNullElse(registeredQueueIds, queueIdsOf(forwarderId, mqttForwarder.getTopics()))) {
+                requireNonNullElseGet(registeredQueueIds, () -> queueIdsOf(forwarderId, mqttForwarder.getTopics()))) {
             notEmptyQueues.remove(queueId);
         }
     }
 
+    /**
+     * The queue ids a forwarder owns, derived from its id and its topics.
+     * <p>
+     * The one place that turns the two into a set, used by every caller that needs it — registration,
+     * reservation and removal. These ids name the persisted queues, and the ownership index is keyed by
+     * them, so two spellings of the same derivation that drift apart would mean a queue that is owned
+     * under one name and reclaimed under the other.
+     */
     private static @NotNull Set<String> queueIdsOf(
             final @NotNull String forwarderId, final @NotNull List<String> topics) {
         final ImmutableSet.Builder<@NotNull String> queueIds = ImmutableSet.builder();

--- a/hivemq-edge/src/main/java/com/hivemq/bridge/MessageForwarderImpl.java
+++ b/hivemq-edge/src/main/java/com/hivemq/bridge/MessageForwarderImpl.java
@@ -79,6 +79,12 @@ public class MessageForwarderImpl implements MessageForwarder {
      * constant time instead of scanning every forwarder.
      */
     private final @NotNull Map<String, Integer> forwarderQueueRefs;
+    /**
+     * Queue sets held for bridges that could not register their forwarders, keyed by reservation id.
+     * Counted in {@link #forwarderQueueRefs} exactly as a forwarder's own set is, which is what keeps
+     * the periodic clean-up off them; see {@link MessageForwarder#reserveQueues}.
+     */
+    private final @NotNull Map<String, Set<String>> reservedQueues;
 
     private final @NotNull ExecutorService executorService;
     private final @NotNull Lock pollLock;
@@ -100,6 +106,7 @@ public class MessageForwarderImpl implements MessageForwarder {
         this.forwarders = new ConcurrentHashMap<>(0);
         this.queueIdsForForwarder = new ConcurrentHashMap<>(0);
         this.forwarderQueueRefs = new ConcurrentHashMap<>(0);
+        this.reservedQueues = new ConcurrentHashMap<>(0);
         this.pollLock = new ReentrantLock();
         final int threadCount = InternalConfigurations.BRIDGE_MESSAGE_FORWARDER_POOL_THREADS_COUNT.get();
         this.executorService =
@@ -147,8 +154,8 @@ public class MessageForwarderImpl implements MessageForwarder {
 
     /**
      * Claims one reference on each queue ID. Every {@code retain} is paired with exactly one
-     * {@link #release(Set)} of the same set — the value a {@code put} displaces, or the value the
-     * final {@code remove} returns — which is what keeps the counts exact under any interleaving.
+     * {@link #release(Set)} of the same set — the set itself when the registration is refused, or the
+     * value the {@code remove} returns — which is what keeps the counts exact under any interleaving.
      */
     private void retain(final @NotNull Set<String> queueIds) {
         for (final String queueId : queueIds) {
@@ -201,13 +208,30 @@ public class MessageForwarderImpl implements MessageForwarder {
         //       is live, registered and in the current sweep set.
         //   O3  see removeForwarder.
         //
-        // Re-registration takes the difference rather than skipping: one forwarder ID does not imply
-        // one queue set, because the ID embeds a digest over the filters joined with an empty
-        // separator, so {"ab","c"} and {"a","bc"} share an ID with different queue sets.
+        // A forwarder ID does not imply one queue set -- the ID embeds a digest over the filters
+        // joined with an empty separator, so {"ab","c"} and {"a","bc"} share an ID with different
+        // queue sets -- which is why a registration may not displace an existing one under the same
+        // ID: the displaced queue set would be un-owned while its forwarder is still live and
+        // polling, and the next clean-up sweep would delete the messages in it. Distinct IDs are
+        // established one level up, by BridgeMqttClient.verifyForwarderIdsAreUnique; this is the
+        // invariant that makes the index sound on its own, and it is enforced rather than assumed.
+        //
+        // putIfAbsent is the claim, so two threads racing the same ID cannot both proceed; the loser
+        // undoes exactly the references it took, which for a queue ID it shares with the incumbent
+        // moves the count 1 -> 2 -> 1 and never through zero (O2 again).
         retain(queueIds);
-        final Set<String> superseded = queueIdsForForwarder.put(forwarderId, queueIds);
-        if (superseded != null) {
-            release(superseded);
+        final Set<String> incumbent = queueIdsForForwarder.putIfAbsent(forwarderId, queueIds);
+        if (incumbent != null) {
+            release(queueIds);
+            throw new IllegalStateException("Forwarder '"
+                    + forwarderId
+                    + "' is already registered with queues "
+                    + incumbent
+                    + "; registering it again with queues "
+                    + queueIds
+                    + " would leave the first set un-owned while it is still live. Forwarder IDs must be"
+                    + " unique among registered forwarders, and a forwarder must be removed before an"
+                    + " object with the same ID is added.");
         }
         for (final String topic : mqttForwarder.getTopics()) {
             topicTree.addTopic(
@@ -314,6 +338,42 @@ public class MessageForwarderImpl implements MessageForwarder {
         }
 
         checkBuffers();
+    }
+
+    @Override
+    public void reserveQueues(
+            final @NotNull String reservationId, final @NotNull Map<String, List<String>> topicsByForwarderId) {
+        final ImmutableSet.Builder<@NotNull String> queueIdsBuilder = ImmutableSet.builder();
+        topicsByForwarderId.forEach((forwarderId, topics) -> {
+            for (final String topic : topics) {
+                queueIdsBuilder.add(createQueueId(forwarderId, topic));
+            }
+        });
+        final ImmutableSet<@NotNull String> queueIds = queueIdsBuilder.build();
+        // Same ordering as addForwarder, for the same reason (O2): retain the new set before releasing
+        // the one it replaces, so a queue held by both never drops to zero references in between.
+        retain(queueIds);
+        final Set<String> superseded = reservedQueues.put(reservationId, queueIds);
+        if (superseded != null) {
+            release(superseded);
+        }
+        if (log.isInfoEnabled()) {
+            log.info(
+                    "Holding {} queue(s) of '{}' against the periodic clean-up until it can be started or is removed",
+                    queueIds.size(),
+                    reservationId);
+        }
+    }
+
+    @Override
+    public void releaseReservedQueues(final @NotNull String reservationId) {
+        final Set<String> released = reservedQueues.remove(reservationId);
+        if (released != null) {
+            release(released);
+            if (log.isDebugEnabled()) {
+                log.debug("Released {} held queue(s) of '{}'", released.size(), reservationId);
+            }
+        }
     }
 
     @Override

--- a/hivemq-edge/src/main/java/com/hivemq/bridge/config/LocalSubscription.java
+++ b/hivemq-edge/src/main/java/com/hivemq/bridge/config/LocalSubscription.java
@@ -133,6 +133,28 @@ public class LocalSubscription {
         return result;
     }
 
+    /**
+     * The identity a bridge forwarder — and therefore the name of every queue it owns — is derived
+     * from: an MD5 digest over the sorted filters and the destination, rendered in standard Base64.
+     * <p>
+     * <b>This function is not injective, deliberately so.</b> The filters are joined with an
+     * <em>empty</em> separator, so any two filter lists with the same sorted concatenation hash to the
+     * same value: {@code ["ab", "c"]} and {@code ["a", "bc"]} both digest the bytes {@code abc}. Two
+     * such subscriptions on one bridge would own queues under a single identity, and registering the
+     * second would take the first's queues out of the ownership index — leaving live queues looking
+     * orphaned to the periodic clean-up, which is exactly the EDG-882 message-loss path.
+     * <p>
+     * The ambiguity is <b>not</b> fixed here, and must not be: any change to this encoding — a
+     * separator, length prefixes, a URL-safe alphabet — changes the digest of <em>every</em>
+     * configuration, renaming every persisted bridge queue on upgrade and stranding the messages
+     * already sitting in them. Trading silent loss for loss-on-upgrade is not a fix; EDG-882 rejected
+     * re-encoding for that reason. Removing the ambiguity requires versioned identities with a
+     * migration or dual lookup, which is a change of its own.
+     * <p>
+     * What guards the defect instead is {@link com.hivemq.bridge.mqtt.BridgeMqttClient#createForwarders()},
+     * which refuses to start a bridge whose local subscriptions do not resolve to distinct forwarder
+     * ids. An operator sees a startup error naming both subscriptions; nothing is silently discarded.
+     */
     public @NotNull String calculateUniqueId() {
         if (uniqueId != null) {
             return uniqueId;

--- a/hivemq-edge/src/main/java/com/hivemq/bridge/config/LocalSubscription.java
+++ b/hivemq-edge/src/main/java/com/hivemq/bridge/config/LocalSubscription.java
@@ -35,7 +35,7 @@ public class LocalSubscription {
     private final @Nullable Long queueLimit;
 
     public LocalSubscription(final @NotNull List<String> filters, final @Nullable String destination) {
-        this.filters = filters;
+        this.filters = canonical(filters);
         this.destination = destination;
         this.excludes = List.of();
         this.customUserProperties = List.of();
@@ -53,13 +53,38 @@ public class LocalSubscription {
             final int maxQoS,
             final @Nullable Long queueLimit) {
 
-        this.filters = filters;
+        this.filters = canonical(filters);
         this.destination = destination;
-        this.excludes = excludes;
+        this.excludes = canonical(excludes);
         this.customUserProperties = customUserProperties;
         this.maxQoS = maxQoS;
         this.preserveRetain = preserveRetain;
         this.queueLimit = queueLimit;
+    }
+
+    /**
+     * Sorts a list of topic filters, so that two subscriptions differing only in the order they were
+     * written in are one subscription (EDG-882 F-05's sibling, F-07).
+     * <p>
+     * Order carries no meaning for either list: the filters are what the forwarder subscribes to, and
+     * the excludes are a match-any test. But {@link #equals(Object)} compared them positionally while
+     * {@link #calculateUniqueId()} sorted them, so reordering a filter in the configuration file
+     * produced a subscription that was "changed" for the reload path and identical for the queue
+     * naming — and the reload path answers a change by restarting the bridge in the mode that clears
+     * its queues. A formatting edit destroyed every message waiting to be forwarded.
+     * <p>
+     * <b>Sorted, not de-duplicated.</b> The digest that names every persisted queue is taken over the
+     * sorted filters <i>including</i> repeats, so collapsing {@code ["a", "a"]} to {@code ["a"]} would
+     * change that name and strand the messages already queued under the old one on upgrade — the same
+     * trade this ticket refused for the encoding itself. Repeats stay, and two configurations that
+     * differ by one are still different.
+     * <p>
+     * {@code customUserProperties} is deliberately left alone: MQTT user properties are ordered, and
+     * two properties with the same key are legal, so their order is part of the configuration rather
+     * than an accident of how it was written.
+     */
+    private static @NotNull List<String> canonical(final @NotNull List<String> topicFilters) {
+        return topicFilters.stream().sorted().toList();
     }
 
     public @NotNull List<String> getFilters() {
@@ -164,7 +189,10 @@ public class LocalSubscription {
         final byte[] digestOverAll = new byte[digestSize];
 
         if (!filters.isEmpty()) {
-            // input list is immutable, need mutable list
+            // Sorted again rather than trusting the constructor's canonical order: this digest names
+            // every persisted queue of the subscription, so it must not become sensitive to how the
+            // list arrived here if a future path ever bypasses canonicalisation. Sorting a sorted list
+            // costs nothing and the digest is unchanged either way.
             final ArrayList<String> strings = new ArrayList<>(filters);
             strings.sort(String::compareTo);
             final byte[] filtersAsBytes = String.join("", strings).getBytes(StandardCharsets.UTF_8);

--- a/hivemq-edge/src/main/java/com/hivemq/bridge/config/LocalSubscription.java
+++ b/hivemq-edge/src/main/java/com/hivemq/bridge/config/LocalSubscription.java
@@ -90,6 +90,21 @@ public class LocalSubscription {
         return queueLimit;
     }
 
+    /**
+     * Compares the configured state only.
+     * <p>
+     * {@code uniqueId} is deliberately excluded: it is derived data — a digest over {@link #filters}
+     * and {@link #destination}, both of which are compared here — and it is computed lazily by
+     * {@link #calculateUniqueId()} rather than at construction. A running bridge has therefore had it
+     * filled in, while a subscription freshly read from the configuration file has not, so including
+     * it made two identical configurations compare as different (EDG-882's sibling defect, EDG-884).
+     * The config-reload path takes that as "the bridge changed", restarts the bridge in the mode that
+     * discards its queue, and destroys every message waiting to be forwarded — under an identity that
+     * recomputes to exactly the same value.
+     * <p>
+     * Excluding it is behaviour-preserving for genuine configuration changes: any change that would
+     * alter the digest necessarily alters {@code filters} or {@code destination} first.
+     */
     @Override
     public boolean equals(final Object o) {
         if (this == o) return true;
@@ -101,10 +116,11 @@ public class LocalSubscription {
         if (!Objects.equals(destination, that.destination)) return false;
         if (!excludes.equals(that.excludes)) return false;
         if (!customUserProperties.equals(that.customUserProperties)) return false;
-        if (!Objects.equals(uniqueId, that.uniqueId)) return false;
         return Objects.equals(queueLimit, that.queueLimit);
     }
 
+    /** Mirrors {@link #equals(Object)}: {@code uniqueId} is excluded, so the hash is stable over the
+     * object's lifetime rather than changing the first time the digest is memoised. */
     @Override
     public int hashCode() {
         int result = filters.hashCode();
@@ -113,7 +129,6 @@ public class LocalSubscription {
         result = 31 * result + customUserProperties.hashCode();
         result = 31 * result + (preserveRetain ? 1 : 0);
         result = 31 * result + maxQoS;
-        result = 31 * result + (uniqueId != null ? uniqueId.hashCode() : 0);
         result = 31 * result + (queueLimit != null ? queueLimit.hashCode() : 0);
         return result;
     }

--- a/hivemq-edge/src/main/java/com/hivemq/bridge/config/LocalSubscription.java
+++ b/hivemq-edge/src/main/java/com/hivemq/bridge/config/LocalSubscription.java
@@ -26,8 +26,10 @@ import org.jetbrains.annotations.Nullable;
 
 public class LocalSubscription {
     private final @NotNull List<String> filters;
+    private final @NotNull List<String> configuredFilters;
     private final @Nullable String destination;
     private final @NotNull List<String> excludes;
+    private final @NotNull List<String> configuredExcludes;
     private final @NotNull List<CustomUserProperty> customUserProperties;
     private final boolean preserveRetain;
     private final int maxQoS;
@@ -36,8 +38,10 @@ public class LocalSubscription {
 
     public LocalSubscription(final @NotNull List<String> filters, final @Nullable String destination) {
         this.filters = canonical(filters);
+        this.configuredFilters = List.copyOf(filters);
         this.destination = destination;
         this.excludes = List.of();
+        this.configuredExcludes = List.of();
         this.customUserProperties = List.of();
         this.maxQoS = 2;
         this.preserveRetain = false;
@@ -54,8 +58,10 @@ public class LocalSubscription {
             final @Nullable Long queueLimit) {
 
         this.filters = canonical(filters);
+        this.configuredFilters = List.copyOf(filters);
         this.destination = destination;
         this.excludes = canonical(excludes);
+        this.configuredExcludes = List.copyOf(excludes);
         this.customUserProperties = customUserProperties;
         this.maxQoS = maxQoS;
         this.preserveRetain = preserveRetain;
@@ -89,6 +95,28 @@ public class LocalSubscription {
 
     public @NotNull List<String> getFilters() {
         return filters;
+    }
+
+    /**
+     * The filters in the order they were configured, for writing the configuration back out.
+     * <p>
+     * Canonicalisation exists so that reordering a filter is not a configuration change; it was never
+     * meant to reorder the operator's file. Every write of {@code config.xml} rebuilds the bridge
+     * entities from these objects, and any REST write of any subsystem triggers one, so returning the
+     * sorted list here rewrote {@code <mqtt-topic-filter>} elements the operator had put in a
+     * deliberate order — in a file that is usually under version control (EDG-882 QA round 2).
+     * <p>
+     * Deliberately not part of {@link #equals(Object)} or {@link #hashCode()}: two subscriptions that
+     * differ only in the order they were written in are one subscription, which is the whole point of
+     * {@link #canonical(List)}.
+     */
+    public @NotNull List<String> getConfiguredFilters() {
+        return configuredFilters;
+    }
+
+    /** The excludes in the order they were configured; see {@link #getConfiguredFilters()}. */
+    public @NotNull List<String> getConfiguredExcludes() {
+        return configuredExcludes;
     }
 
     public @Nullable String getDestination() {

--- a/hivemq-edge/src/main/java/com/hivemq/bridge/config/MqttBridge.java
+++ b/hivemq-edge/src/main/java/com/hivemq/bridge/config/MqttBridge.java
@@ -286,6 +286,20 @@ public class MqttBridge {
         if (loopPreventionHopCount != that.loopPreventionHopCount) {
             return false;
         }
+        // Compared, and it was not before — while hashCode has always included it, which is an
+        // equals/hashCode contract violation on its own. It became observable when the REST update path
+        // changed: an update used to be expressed as remove-then-add, so every PUT restarted the bridge
+        // whatever equals said. Now an update is one transition and this comparison is what decides
+        // whether the bridge restarts, so toggling only `persist` was classified as "config is
+        // unchanged" and the bridge was never restarted under its new configuration.
+        //
+        // Scope, honestly: the publish path reads the flag from the live configuration
+        // (PublishDistributorImpl.getBridgeConfig), so the QoS downgrade itself follows the new value
+        // without a restart. What this fixes is the classification — a configuration change that Edge
+        // reported as no change at all — and the contract violation (EDG-882 QA round 4).
+        if (persist != that.persist) {
+            return false;
+        }
         if (!id.equals(that.id)) {
             return false;
         }

--- a/hivemq-edge/src/main/java/com/hivemq/bridge/config/MqttBridge.java
+++ b/hivemq-edge/src/main/java/com/hivemq/bridge/config/MqttBridge.java
@@ -15,6 +15,7 @@
  */
 package com.hivemq.bridge.config;
 
+import com.google.common.collect.HashMultiset;
 import java.util.List;
 import java.util.Objects;
 import org.jetbrains.annotations.NotNull;
@@ -306,10 +307,19 @@ public class MqttBridge {
         if (!Objects.equals(bridgeWebsocketConfig, that.bridgeWebsocketConfig)) {
             return false;
         }
-        if (!remoteSubscriptions.equals(that.remoteSubscriptions)) {
+        // As multisets, not as lists. The order of the <forwarded-topic> blocks in the configuration
+        // file carries no meaning -- each one is an independent subscription with its own forwarder and
+        // its own queues -- but comparing positionally made a reorder-only edit a "changed" bridge, and
+        // the reload path answers a change by restarting the bridge and clearing the queues of anything
+        // it cannot match. That is EDG-882 F-07 one level up: F-07 canonicalised the filters inside a
+        // subscription and left the order of the subscriptions themselves (QA round 1).
+        //
+        // A multiset rather than a set: two identical subscription blocks are a different configuration
+        // from one, and repeats must keep comparing as such.
+        if (!HashMultiset.create(remoteSubscriptions).equals(HashMultiset.create(that.remoteSubscriptions))) {
             return false;
         }
-        return localSubscriptions.equals(that.localSubscriptions);
+        return HashMultiset.create(localSubscriptions).equals(HashMultiset.create(that.localSubscriptions));
     }
 
     @Override
@@ -325,8 +335,9 @@ public class MqttBridge {
         result = 31 * result + Objects.hashCode(password);
         result = 31 * result + Objects.hashCode(bridgeTls);
         result = 31 * result + Objects.hashCode(bridgeWebsocketConfig);
-        result = 31 * result + remoteSubscriptions.hashCode();
-        result = 31 * result + localSubscriptions.hashCode();
+        // Order-independent, to agree with equals.
+        result = 31 * result + HashMultiset.create(remoteSubscriptions).hashCode();
+        result = 31 * result + HashMultiset.create(localSubscriptions).hashCode();
         result = 31 * result + Boolean.hashCode(loopPreventionEnabled);
         result = 31 * result + loopPreventionHopCount;
         result = 31 * result + Boolean.hashCode(persist);

--- a/hivemq-edge/src/main/java/com/hivemq/bridge/config/RemoteSubscription.java
+++ b/hivemq-edge/src/main/java/com/hivemq/bridge/config/RemoteSubscription.java
@@ -23,13 +23,15 @@ import org.jetbrains.annotations.Nullable;
 public class RemoteSubscription {
 
     private final @NotNull List<String> filters;
+    private final @NotNull List<String> configuredFilters;
     private final @Nullable String destination;
     private final @NotNull List<CustomUserProperty> customUserProperties;
     private final boolean preserveRetain;
     private final int maxQoS;
 
     public RemoteSubscription(final @NotNull List<String> filters, final @Nullable String destination) {
-        this.filters = filters;
+        this.filters = canonical(filters);
+        this.configuredFilters = List.copyOf(filters);
         this.destination = destination;
         this.customUserProperties = List.of();
         this.maxQoS = 2;
@@ -42,15 +44,59 @@ public class RemoteSubscription {
             @NotNull final List<CustomUserProperty> customUserProperties,
             final boolean preserveRetain,
             final int maxQoS) {
-        this.filters = filters;
+        this.filters = canonical(filters);
+        this.configuredFilters = List.copyOf(filters);
         this.destination = destination;
         this.customUserProperties = customUserProperties;
         this.preserveRetain = preserveRetain;
         this.maxQoS = maxQoS;
     }
 
+    /**
+     * Sorts the topic filters, so that two subscriptions differing only in the order they were written
+     * in are one subscription — the same rule {@code LocalSubscription} applies to the local half,
+     * applied here (EDG-882 QA, 2026-08-25).
+     * <p>
+     * Order carries no meaning: the filters become one SUBSCRIBE packet sent to the remote broker when
+     * the bridge connects, and nothing downstream reads them in order. But {@link #equals(Object)}
+     * compared them positionally, so reordering a {@code <mqtt-topic-filter>} inside a
+     * {@code <remote-subscription>} made the bridge compare as changed, and the reload path answers a
+     * change by restarting the bridge. F-07 canonicalised {@code LocalSubscription} and left this half
+     * as it was — EDG-884's own yardstick, that an unchanged configuration must compare equal, failing
+     * on the remote side.
+     * <p>
+     * <b>Cheaper here than it was for the local half, and for a reason worth knowing.</b>
+     * {@code LocalSubscription}'s canonical order feeds {@code calculateUniqueId()}, which names every
+     * persisted queue of the subscription, so changing what it sees is a decision about queue naming.
+     * A remote subscription has no derived identity and owns no queue, so this is purely a change to
+     * what counts as equal.
+     * <p>
+     * Sorted, not de-duplicated: two identical filters are a different configuration from one, and
+     * {@code customUserProperties} is left alone because MQTT user properties are ordered and
+     * duplicate keys are legal, so their order is part of the configuration.
+     */
+    private static @NotNull List<String> canonical(final @NotNull List<String> topicFilters) {
+        return topicFilters.stream().sorted().toList();
+    }
+
     public @NotNull List<String> getFilters() {
         return filters;
+    }
+
+    /**
+     * The filters in the order they were configured, for writing the configuration back out and for
+     * serving over the API.
+     * <p>
+     * Canonicalisation exists so that reordering a filter is not a configuration change; it was never
+     * meant to reorder the operator's file. Every write of {@code config.xml} rebuilds the bridge
+     * entities from these objects, and any REST write of any subsystem triggers one, so returning the
+     * sorted list to the write-back would rewrite elements the operator put in a deliberate order —
+     * exactly the damage {@link LocalSubscription#getConfiguredFilters()} exists to avoid.
+     * <p>
+     * Deliberately not part of {@link #equals(Object)} or {@link #hashCode()}.
+     */
+    public @NotNull List<String> getConfiguredFilters() {
+        return configuredFilters;
     }
 
     public @Nullable String getDestination() {
@@ -85,6 +131,10 @@ public class RemoteSubscription {
                 + '}';
     }
 
+    /**
+     * Compares the configured state; {@code configuredFilters} is excluded, because two subscriptions
+     * that differ only in the order they were written in are one subscription. See {@link #canonical}.
+     */
     @Override
     public boolean equals(final @Nullable Object o) {
         if (this == o) return true;

--- a/hivemq-edge/src/main/java/com/hivemq/bridge/mqtt/BridgeMqttClient.java
+++ b/hivemq-edge/src/main/java/com/hivemq/bridge/mqtt/BridgeMqttClient.java
@@ -60,6 +60,7 @@ import com.hivemq.configuration.info.SystemInformation;
 import com.hivemq.edge.model.TypeIdentifierImpl;
 import com.hivemq.edge.modules.api.events.model.EventImpl;
 import com.hivemq.security.ssl.SslUtil;
+import com.hivemq.util.Checkpoints;
 import com.hivemq.util.StoreTypeUtil;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -81,6 +82,9 @@ import org.slf4j.LoggerFactory;
 
 @SuppressWarnings("FutureReturnValueIgnored")
 public class BridgeMqttClient {
+
+    /** Checkpoint visited when the bridge has connected to its remote broker, before it forwards. */
+    public static final @NotNull String REMOTE_CONNECTED = "mqtt-bridge-remote-connected";
 
     private static final @NotNull Logger log = LoggerFactory.getLogger(BridgeMqttClient.class);
 
@@ -520,6 +524,12 @@ public class BridgeMqttClient {
             }
             log.info("Bridge '{}' connected to {}:{}", bridge.getId(), bridge.getHost(), bridge.getPort());
             connected.set(true);
+            // Visited before anything is forwarded, on every connect rather than only the first, so
+            // that a test can attach its oracle to the remote broker while the bridge is held here.
+            // Without it a regression that asserts which messages arrived has to subscribe after the
+            // remote comes up and race the reconnect, and loses the messages forwarded in between --
+            // the assertion then fails with nothing wrong in the product (EDG-882 F-08).
+            Checkpoints.checkpoint(REMOTE_CONNECTED);
 
             // Check if this is a reconnection (not the initial connection)
             // On initial connection, we only flush buffered messages without resetting persistence state.

--- a/hivemq-edge/src/main/java/com/hivemq/bridge/mqtt/BridgeMqttClient.java
+++ b/hivemq-edge/src/main/java/com/hivemq/bridge/mqtt/BridgeMqttClient.java
@@ -441,6 +441,18 @@ public class BridgeMqttClient {
         return forwarders;
     }
 
+    /**
+     * Removes this bridge's counters from the registry.
+     * <p>
+     * {@link PerBridgeMetrics} registers them in this client's constructor, so a bridge that is refused
+     * before it ever starts has registered instruments and will never reach {@link #stop()}, which is
+     * where they are otherwise cleared. Called from {@code BridgeService.internalStartBridge}'s failure
+     * path (EDG-882 review v02, R2-13).
+     */
+    public void clearMetrics() {
+        perBridgeMetrics.clearAll(metricRegistry);
+    }
+
     public @NotNull MqttBridge getBridge() {
         return bridge;
     }

--- a/hivemq-edge/src/main/java/com/hivemq/bridge/mqtt/BridgeMqttClient.java
+++ b/hivemq-edge/src/main/java/com/hivemq/bridge/mqtt/BridgeMqttClient.java
@@ -372,6 +372,12 @@ public class BridgeMqttClient {
                                 exception);
                     }
                 }
+                // Before the stop future completes, not after: whoever is waiting on that future starts
+                // the replacement bridge, and the replacement registers its own counters under the same
+                // names in the same registry. Clearing afterwards deleted the new client's metrics --
+                // the hand-over is now every configuration change, so the race is no longer rare
+                // (EDG-882 QA round 1).
+                perBridgeMetrics.clearAll(metricRegistry);
                 final var future = stopFutureRef.getAndSet(null);
                 if (future != null) {
                     future.set(null);
@@ -379,7 +385,6 @@ public class BridgeMqttClient {
                 // Only reset to IDLE if we're still in STOPPING state.
                 // Prevents overwriting a concurrent start()'s STARTING state.
                 operationState.compareAndSet(OperationState.STOPPING, OperationState.IDLE);
-                perBridgeMetrics.clearAll(metricRegistry);
                 if (log.isInfoEnabled()) {
                     log.info("Bridge '{}' stopped successfully", bridge.getId());
                 }

--- a/hivemq-edge/src/main/java/com/hivemq/bridge/mqtt/BridgeMqttClient.java
+++ b/hivemq-edge/src/main/java/com/hivemq/bridge/mqtt/BridgeMqttClient.java
@@ -63,7 +63,9 @@ import com.hivemq.security.ssl.SslUtil;
 import com.hivemq.util.StoreTypeUtil;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -127,6 +129,48 @@ public class BridgeMqttClient {
     public static @NotNull String createForwarderId(
             final @NotNull String bridgeId, final @NotNull LocalSubscription sub) {
         return bridgeId + '-' + sub.calculateUniqueId();
+    }
+
+    /**
+     * Refuses a bridge whose local subscriptions do not resolve to distinct forwarder ids (EDG-882).
+     * <p>
+     * {@link LocalSubscription#calculateUniqueId()} joins the filters with an empty separator, so
+     * {@code ["ab", "c"]} and {@code ["a", "bc"]} — with the same destination — produce the same id.
+     * Both subscriptions are live at once: {@link #createForwarders()} builds one forwarder per local
+     * subscription and every one of them is registered. Under a shared id the second registration
+     * takes the first's queues out of the ownership index, the periodic clean-up then finds those live
+     * queues unowned, and it deletes the messages waiting in them. The digest itself commonly contains
+     * a '/', so the generic queue-name parser cannot recover the owner either.
+     * <p>
+     * Rejecting the configuration is the fix, rather than disambiguating the id: the id names every
+     * persisted queue of the bridge, so re-encoding it renames those queues on upgrade and strands the
+     * messages already in them. Failing at startup, loudly and naming both subscriptions, is the only
+     * outcome here that loses nothing. A collision needs two subscriptions whose sorted filters
+     * concatenate to the same string, so a configuration that has never collided cannot start
+     * colliding on upgrade.
+     *
+     * @throws IllegalStateException if two local subscriptions share a forwarder id
+     */
+    static void verifyForwarderIdsAreUnique(final @NotNull MqttBridge bridge) {
+        final Map<String, LocalSubscription> subscriptionByForwarderId = new HashMap<>();
+        for (final LocalSubscription sub : bridge.getLocalSubscriptions()) {
+            final String forwarderId = createForwarderId(bridge.getId(), sub);
+            final LocalSubscription previous = subscriptionByForwarderId.putIfAbsent(forwarderId, sub);
+            if (previous != null) {
+                throw new IllegalStateException(String.format(
+                        "Bridge '%s' cannot start: the local subscriptions with filters %s (destination '%s') and %s "
+                                + "(destination '%s') both resolve to the internal forwarder id '%s'. That id names "
+                                + "the internal queues of the subscription, so the two would share one set of queues "
+                                + "and the messages of one of them would be discarded. Change or remove one of the "
+                                + "two subscriptions; altering any topic filter or the destination is enough.",
+                        bridge.getId(),
+                        previous.getFilters(),
+                        previous.getDestination(),
+                        sub.getFilters(),
+                        sub.getDestination(),
+                        forwarderId));
+            }
+        }
     }
 
     public synchronized @NotNull ListenableFuture<Void> start() {
@@ -353,7 +397,13 @@ public class BridgeMqttClient {
         return mqtt5Client;
     }
 
+    /**
+     * @throws IllegalStateException if two local subscriptions of this bridge resolve to the same
+     *     forwarder id — see {@link #verifyForwarderIdsAreUnique(MqttBridge)}. Thrown before any
+     *     forwarder is built, so nothing is registered, started or cleared for a rejected bridge.
+     */
     public @NotNull List<MqttForwarder> createForwarders() {
+        verifyForwarderIdsAreUnique(bridge);
         final ImmutableList.Builder<@NotNull MqttForwarder> builder = ImmutableList.builder();
         final int localSubCount = bridge.getLocalSubscriptions().size();
         if (log.isDebugEnabled()) {

--- a/hivemq-edge/src/main/java/com/hivemq/configuration/entity/bridge/ForwardedTopicEntity.java
+++ b/hivemq-edge/src/main/java/com/hivemq/configuration/entity/bridge/ForwardedTopicEntity.java
@@ -110,6 +110,17 @@ public class ForwardedTopicEntity {
         return queueLimit;
     }
 
+    /**
+     * Without this the write-back path could not carry the element at all: {@code sync} rebuilds every
+     * bridge entity from the runtime configuration, so a field with no setter is silently dropped from
+     * {@code config.xml} on the next write — and any REST write of any subsystem triggers one. The
+     * operator's {@code <queue-limit>} vanished, the reload that followed saw a changed bridge, and the
+     * bridge was restarted for a change nobody made (EDG-882 QA round 2).
+     */
+    public void setQueueLimit(final @Nullable Long queueLimit) {
+        this.queueLimit = queueLimit;
+    }
+
     @Override
     public boolean equals(final Object o) {
         if (this == o) return true;

--- a/hivemq-edge/src/main/java/com/hivemq/configuration/reader/AclComparison.java
+++ b/hivemq-edge/src/main/java/com/hivemq/configuration/reader/AclComparison.java
@@ -1,0 +1,241 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.configuration.reader;
+
+import java.nio.file.attribute.AclEntry;
+import java.nio.file.attribute.AclEntryFlag;
+import java.nio.file.attribute.AclEntryPermission;
+import java.nio.file.attribute.AclEntryType;
+import java.nio.file.attribute.UserPrincipal;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Whether one access-control list grants anybody anything another one does not.
+ * <p>
+ * {@code config.xml} holds bridge passwords, keystore and truststore passwords and adapter credentials, and
+ * it is replaced by writing a new file beside it and moving that onto it. On a store that expresses
+ * protection as an access-control list rather than as a mode, something has to decide whether the
+ * replacement is safe to write those credentials into. This is that decision and nothing else.
+ *
+ * <h2>Why the obvious implementations are wrong</h2>
+ *
+ * Two specifications govern the lists this code sees, and neither evaluates a list against <em>a</em>
+ * principal:
+ * <ul>
+ *   <li><b>RFC 7530 §6.2.1</b> — the NFSv4 model that
+ *       {@link java.nio.file.attribute.AclFileAttributeView} declares itself to be based on. The list is
+ *       ordered; the first entry whose <em>who</em> matches the requester and whose mask covers a requested
+ *       permission settles it. The <em>who</em> may be a group or a special identifier such as
+ *       {@code EVERYONE@}.</li>
+ *   <li><b>MS-DTYP §2.5.3.2</b> — the Windows access check, which is what actually runs once the JDK has
+ *       written one of these lists to NTFS. The DACL is walked in order against the requester's <em>access
+ *       token</em>: their own SID, every group SID they hold, and well-known SIDs. Any entry naming any of
+ *       them matches.</li>
+ * </ul>
+ * So a check is made against a <em>set</em> of identities, and an entry naming a group can settle a
+ * permission for a user before a later entry naming that user is reached. Comparing per-principal
+ * summaries misses it, comparing entry lists for equality refuses every store that normalises anything, and
+ * evaluating faithfully looks like it needs group membership — which {@code java.nio} does not expose:
+ * {@link java.nio.file.attribute.UserPrincipalLookupService} maps a name to a principal and nothing in the
+ * other direction. {@link java.nio.file.attribute.GroupPrincipal} is a <em>subtype</em> of
+ * {@link UserPrincipal}, so a structure keyed by {@link AclEntry#principal()} treats a group as a peer of a
+ * user rather than a superset of them, and no compiler will say so (EDG-882 reviews v04, v05, v06).
+ *
+ * <h2>The observation this is built on</h2>
+ *
+ * The unknown is which principals share a token, so no assumption is made about it: the comparison
+ * quantifies over <em>every</em> token, which is the conservative closure over what we are not told. That
+ * is finite because of one fact.
+ * <p>
+ * <b>A witness never needs more than two principals.</b> Suppose some token is granted a permission by the
+ * candidate and not by the reference. Let {@code x} be the principal of the candidate entry that settled it
+ * and {@code y} the principal of the reference entry that settled it the other way — or {@code y = x} when
+ * the reference has no entry that matches at all. Then {@code {x, y}} is a witness too: every entry ahead
+ * of the deciding one failed to match the larger token, so it fails to match the smaller one, and both
+ * deciding entries still match.
+ * <p>
+ * Trying every pair is therefore not an approximation of quantifying over tokens, it <em>is</em> quantifying
+ * over tokens — so this accepts exactly what a real access check accepts, and there is no arrangement of
+ * groups, however contrived, that it gets wrong. {@code AclComparisonOracleTest} asserts that agreement
+ * against a direct implementation of the access check rather than leaving it as an argument.
+ * <p>
+ * The rest is bookkeeping. Both specifications settle one permission bit at a time — Windows refuses a
+ * request when any requested bit meets a {@code DENY} and grants it when every bit meets an {@code ALLOW} —
+ * so each bit is decided on its own, and only the bits the candidate can actually grant are worth trying.
+ * For one bit, all that matters about a principal is where the list first mentions them and which way that
+ * entry went; {@link #firstDecisions} reduces a list to exactly that, once per bit, and a pair is then
+ * decided by whichever of its two principals the list reaches first.
+ *
+ * <h2>What takes part</h2>
+ *
+ * <ul>
+ *   <li>{@code ALLOW} and {@code DENY} decide. {@code AUDIT} and {@code ALARM} grant nothing and take no
+ *       part — read as decisions they would stand in front of the entry behind them and hide it, so a
+ *       replacement that grants access would look like one that grants none.</li>
+ *   <li>{@code INHERIT_ONLY} says the entry does not apply to the object carrying it, so it decides nothing
+ *       about this file. It is not a propagation flag, and reading it as one was an error of ours rather
+ *       than a gap (review v05).</li>
+ *   <li>{@code FILE_INHERIT}, {@code DIRECTORY_INHERIT} and {@code NO_PROPAGATE_INHERIT} govern what a
+ *       <em>directory</em> gives to what is created inside it. A file gives nothing to anything, so they
+ *       change no answer here and are never interpreted.</li>
+ *   <li>Two principals are the same when they are {@link Object#equals equal} — SID or UID equality on the
+ *       stores this runs on, and what the platform itself compares.</li>
+ *   <li>An empty list grants nobody anything. On Windows a NULL DACL (everyone, full access) and an empty
+ *       DACL (nobody, anything) both arrive here as an empty list and mean opposite things; reading it as
+ *       the narrow one can cost a refused write and cannot cost a disclosure.</li>
+ * </ul>
+ *
+ * <p>
+ * Stateless, and safe to call from any number of threads at once.
+ */
+final class AclComparison {
+
+    private AclComparison() {}
+
+    /**
+     * Whether {@code candidate} grants no principal, under any token, anything {@code reference} does not.
+     * <p>
+     * Precise in both directions rather than merely safe in one: a list granting strictly less than the
+     * reference is accepted, because nobody gains anything by it, and a caller that cares about a narrowing
+     * asks the question the other way round.
+     */
+    static boolean grantsNoMoreThan(final @NotNull List<AclEntry> candidate, final @NotNull List<AclEntry> reference) {
+        for (final AclEntryPermission bit : bitsTheCandidateCanGrant(candidate)) {
+            final Map<UserPrincipal, Decision> byCandidate = firstDecisions(candidate, bit);
+            final List<UserPrincipal> allowed = principalsAllowedBy(byCandidate);
+            if (allowed.isEmpty()) {
+                continue;
+            }
+            final Map<UserPrincipal, Decision> byReference = firstDecisions(reference, bit);
+            final Set<UserPrincipal> named = principalsNamedBy(byCandidate, byReference);
+            // One of a witness pair is always a principal the candidate allows -- it is the entry that
+            // settled the bit for that token, and it settled it by allowing. The other can be anyone
+            // either list names, itself included: that is the token of one identity.
+            for (final UserPrincipal one : allowed) {
+                for (final UserPrincipal other : named) {
+                    if (grants(byCandidate, one, other) && !grants(byReference, one, other)) {
+                        return false;
+                    }
+                }
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Where a list first mentions a principal for one permission, and which way that entry went.
+     * <p>
+     * Everything an access check for that permission can observe about that principal. The position is an
+     * index into the list the decision came from, and only ever compared with another index from the same
+     * list.
+     */
+    private record Decision(int position, boolean allows) {}
+
+    /**
+     * Whether a list grants a permission to a requester holding exactly these two identities.
+     * <p>
+     * The list is walked in order, so of the two entries that could settle it the earlier one does, and a
+     * list that mentions neither identity grants nothing — which is the default in both specifications.
+     */
+    private static boolean grants(
+            final @NotNull Map<UserPrincipal, Decision> decisions,
+            final @NotNull UserPrincipal one,
+            final @NotNull UserPrincipal other) {
+        final Decision settled = earlier(decisions.get(one), decisions.get(other));
+        return settled != null && settled.allows();
+    }
+
+    private static @Nullable Decision earlier(final @Nullable Decision one, final @Nullable Decision other) {
+        if (one == null) {
+            return other;
+        }
+        if (other == null) {
+            return one;
+        }
+        return one.position() <= other.position() ? one : other;
+    }
+
+    /**
+     * The list reduced to what an access check for one permission can see: for each principal it names, the
+     * entry that settles that permission for them.
+     * <p>
+     * {@code putIfAbsent} is the ordering rule itself — the first entry that applies to the file, names the
+     * principal and mentions the permission settles it, and no later entry can reopen it.
+     */
+    private static @NotNull Map<UserPrincipal, Decision> firstDecisions(
+            final @NotNull List<AclEntry> acl, final @NotNull AclEntryPermission bit) {
+        final Map<UserPrincipal, Decision> decisions = new HashMap<>();
+        int position = 0;
+        for (final AclEntry entry : acl) {
+            position++;
+            if (decides(entry) && entry.permissions().contains(bit)) {
+                decisions.putIfAbsent(entry.principal(), new Decision(position, entry.type() == AclEntryType.ALLOW));
+            }
+        }
+        return decisions;
+    }
+
+    /** Whether an entry decides access to the object carrying the list, rather than to something else. */
+    private static boolean decides(final @NotNull AclEntry entry) {
+        return (entry.type() == AclEntryType.ALLOW || entry.type() == AclEntryType.DENY)
+                && !entry.flags().contains(AclEntryFlag.INHERIT_ONLY);
+    }
+
+    /**
+     * The permissions the candidate could grant anybody at all. One it never allows is one it cannot grant
+     * where the reference does not, whatever the reference says about it.
+     */
+    private static @NotNull Set<AclEntryPermission> bitsTheCandidateCanGrant(final @NotNull List<AclEntry> candidate) {
+        final Set<AclEntryPermission> bits = EnumSet.noneOf(AclEntryPermission.class);
+        for (final AclEntry entry : candidate) {
+            if (entry.type() == AclEntryType.ALLOW && decides(entry)) {
+                bits.addAll(entry.permissions());
+            }
+        }
+        return bits;
+    }
+
+    private static @NotNull List<UserPrincipal> principalsAllowedBy(
+            final @NotNull Map<UserPrincipal, Decision> decisions) {
+        final List<UserPrincipal> allowed = new ArrayList<>(decisions.size());
+        for (final Map.Entry<UserPrincipal, Decision> decision : decisions.entrySet()) {
+            if (decision.getValue().allows()) {
+                allowed.add(decision.getKey());
+            }
+        }
+        return allowed;
+    }
+
+    /**
+     * Every principal either list settles this permission for. A principal neither of them names is matched
+     * by neither, so it cannot tell them apart and adding it to a token changes no answer.
+     */
+    private static @NotNull Set<UserPrincipal> principalsNamedBy(
+            final @NotNull Map<UserPrincipal, Decision> byCandidate,
+            final @NotNull Map<UserPrincipal, Decision> byReference) {
+        final Set<UserPrincipal> named = new HashSet<>(byCandidate.keySet());
+        named.addAll(byReference.keySet());
+        return named;
+    }
+}

--- a/hivemq-edge/src/main/java/com/hivemq/configuration/reader/BridgeExtractor.java
+++ b/hivemq-edge/src/main/java/com/hivemq/configuration/reader/BridgeExtractor.java
@@ -15,6 +15,8 @@
  */
 package com.hivemq.configuration.reader;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.google.common.collect.ImmutableList;
 import com.hivemq.bridge.config.BridgeTls;
 import com.hivemq.bridge.config.BridgeWebsocketConfig;
@@ -122,6 +124,19 @@ public class BridgeExtractor
      * @return {@code false} if no bridge with that id is configured, in which case nothing changed.
      */
     public synchronized boolean replaceBridge(final @NotNull String id, final @NotNull MqttBridge mqttBridge) {
+        // The contract enforced where it is relied upon (EDG-882 review v02, R2-09). The REST layer
+        // rejects an id change, so today the two always agree; a caller that passed a body with a
+        // different id would leave the list without the old id and with a new one, which updateBridges
+        // classifies as remove + add -- and the removal clears every queue of the old bridge, silently.
+        // That is the defect this method exists to prevent, arrived at from the other side.
+        checkArgument(
+                id.equals(mqttBridge.getId()),
+                "Cannot replace bridge '%s' with a configuration carrying id '%s': replacing in place is"
+                        + " what keeps the bridge present across the transition, and a different id makes"
+                        + " it a removal followed by an addition, which clears the queues of the bridge"
+                        + " being replaced.",
+                id,
+                mqttBridge.getId());
         if (bridgeEntities.stream().noneMatch(entry -> entry.getId().equals(id))) {
             return false;
         }
@@ -487,9 +502,9 @@ public class BridgeExtractor
             final Long queueLimit = subscription.getQueueLimit();
             if (queueLimit != null && (queueLimit > Integer.MAX_VALUE || queueLimit < Integer.MIN_VALUE)) {
                 log.warn(
-                        "The queue limit {} of a forwarded topic of bridge '{}' does not fit the configuration"
-                                + " file's queue-limit element and cannot be written to it; the limit stays in"
-                                + " effect for this node but will not survive a restart.",
+                        "The queue limit {} of the forwarded topic with destination '{}' does not fit the"
+                                + " configuration file's queue-limit element and cannot be written to it; the"
+                                + " limit stays in effect for this node but will not survive a restart.",
                         queueLimit,
                         subscription.getDestination());
             } else {

--- a/hivemq-edge/src/main/java/com/hivemq/configuration/reader/BridgeExtractor.java
+++ b/hivemq-edge/src/main/java/com/hivemq/configuration/reader/BridgeExtractor.java
@@ -500,9 +500,9 @@ public class BridgeExtractor
         for (final RemoteSubscription subscription : remoteSubscriptionList) {
             final RemoteSubscriptionEntity subscriptionEntity = new RemoteSubscriptionEntity();
             subscriptionEntity.setDestination(subscription.getDestination());
-            if (subscription.getFilters() != null) {
-                subscriptionEntity.setFilters(new ArrayList<>(subscription.getFilters()));
-            }
+            // The configured order, not the canonical one: sorting exists so that a reorder is not a
+            // configuration change, not so that writing the file reorders the operator's elements.
+            subscriptionEntity.setFilters(new ArrayList<>(subscription.getConfiguredFilters()));
             subscriptionEntity.setPreserveRetain(subscription.isPreserveRetain());
             subscriptionEntity.setMaxQoS(subscription.getMaxQoS());
             if (subscription.getCustomUserProperties() != null) {

--- a/hivemq-edge/src/main/java/com/hivemq/configuration/reader/BridgeExtractor.java
+++ b/hivemq-edge/src/main/java/com/hivemq/configuration/reader/BridgeExtractor.java
@@ -68,27 +68,34 @@ public class BridgeExtractor
         this.configFileReaderWriter = configFileReaderWriter;
     }
 
-    public void addBridge(final @NotNull MqttBridge mqttBridge) {
+    /**
+     * These three mutators hold the extractor's monitor across {@code writeConfigWithSync()}, and that
+     * is deliberate even though it is a lock-order inversion against the configuration watcher, which
+     * takes {@code ConfigFileReaderWriter}'s lock first and then calls into {@link #updateConfig}.
+     * <p>
+     * Releasing the monitor before the write — tried in EDG-882 QA round 3 to close that inversion —
+     * opens a worse window: {@code updateConfig} is itself synchronized, so between the model mutation
+     * and the file write the watcher can read the not-yet-written file, overwrite {@code bridgeEntities}
+     * with the pre-edit configuration and notify the bridge subsystem, which reverts the operator's
+     * change and clears the queues of whatever the reverted configuration no longer contains. Trading a
+     * pre-existing deadlock for a new path that silently discards a REST change and its messages is not
+     * a fix. Closing both properly needs one configuration-transition lock shared by the reload and the
+     * mutators, which is a change to the shared configuration subsystem and belongs to its own ticket
+     * (EDG-882 QA round 4).
+     */
+    public synchronized void addBridge(final @NotNull MqttBridge mqttBridge) {
         if (!mqttBridge.isPersist()) {
             log.info(
                     "MQTT Bridge '{}' has persist flag set to false, QoS for publishes from local subscriptions will be downgraded to AT_MOST_ONCE.",
                     mqttBridge.getId());
         }
 
-        synchronized (this) {
-            bridgeEntities = new ImmutableList.Builder<MqttBridge>()
-                    .addAll(bridgeEntities)
-                    .add(mqttBridge)
-                    .build();
-            notifyConsumer();
-        }
-        // The configuration file is written after the monitor is released, never while holding it.
-        // notifyConsumer runs BridgeService.updateBridges inline, which can wait up to the bridge stop
-        // timeout, and writeConfigWithSync takes ConfigFileReaderWriter's lock -- the lock the config
-        // watcher already holds when it calls back into this extractor. Holding both in that order is
-        // the inverse of the watcher's, and the two together wedge the watcher and every REST write in
-        // every subsystem, permanently (EDG-882 QA round 3). sync() re-reads the volatile field, so a
-        // write that lands after another thread's change simply writes the newer configuration.
+        bridgeEntities = new ImmutableList.Builder<MqttBridge>()
+                .addAll(bridgeEntities)
+                .add(mqttBridge)
+                .build();
+
+        notifyConsumer();
         configFileReaderWriter.writeConfigWithSync();
     }
 
@@ -114,36 +121,31 @@ public class BridgeExtractor
      *
      * @return {@code false} if no bridge with that id is configured, in which case nothing changed.
      */
-    public boolean replaceBridge(final @NotNull String id, final @NotNull MqttBridge mqttBridge) {
-        synchronized (this) {
-            if (bridgeEntities.stream().noneMatch(entry -> entry.getId().equals(id))) {
-                return false;
-            }
-            if (!mqttBridge.isPersist()) {
-                log.info(
-                        "MQTT Bridge '{}' has persist flag set to false, QoS for publishes from local subscriptions will be downgraded to AT_MOST_ONCE.",
-                        mqttBridge.getId());
-            }
-
-            bridgeEntities = bridgeEntities.stream()
-                    .map(entry -> entry.getId().equals(id) ? mqttBridge : entry)
-                    .collect(ImmutableList.toImmutableList());
-
-            notifyConsumer();
+    public synchronized boolean replaceBridge(final @NotNull String id, final @NotNull MqttBridge mqttBridge) {
+        if (bridgeEntities.stream().noneMatch(entry -> entry.getId().equals(id))) {
+            return false;
         }
-        // after the monitor is released -- see addBridge for why
+        if (!mqttBridge.isPersist()) {
+            log.info(
+                    "MQTT Bridge '{}' has persist flag set to false, QoS for publishes from local subscriptions will be downgraded to AT_MOST_ONCE.",
+                    mqttBridge.getId());
+        }
+
+        bridgeEntities = bridgeEntities.stream()
+                .map(entry -> entry.getId().equals(id) ? mqttBridge : entry)
+                .collect(ImmutableList.toImmutableList());
+
+        notifyConsumer();
         configFileReaderWriter.writeConfigWithSync();
         return true;
     }
 
-    public void removeBridge(final @NotNull String id) {
-        synchronized (this) {
-            bridgeEntities = bridgeEntities.stream()
-                    .filter(entry -> !entry.getId().equals(id))
-                    .toList();
-            notifyConsumer();
-        }
-        // after the monitor is released -- see addBridge for why
+    public synchronized void removeBridge(final @NotNull String id) {
+        bridgeEntities = bridgeEntities.stream()
+                .filter(entry -> !entry.getId().equals(id))
+                .toList();
+
+        notifyConsumer();
         configFileReaderWriter.writeConfigWithSync();
     }
 

--- a/hivemq-edge/src/main/java/com/hivemq/configuration/reader/BridgeExtractor.java
+++ b/hivemq-edge/src/main/java/com/hivemq/configuration/reader/BridgeExtractor.java
@@ -155,6 +155,39 @@ public class BridgeExtractor
         return true;
     }
 
+    /**
+     * Names a credential that carries leading or trailing whitespace, because nothing else will.
+     * <p>
+     * An element's text is its text: {@code <password>\n    ${ENV:PW}\n</password>} is rendered before
+     * the file is parsed, so the value the bridge ends up sending carries the operator's indentation.
+     * The remote rejects it, the log says the credentials were refused, and the configuration looks
+     * correct to anyone reading it — the difference is invisible in a diff and in the REST response
+     * alike. Writing a placeholder on its own indented line is the natural way to write one, so this is
+     * a trap an operator falls into by formatting their file tidily (EDG-882 QA, 2026-08-25).
+     * <p>
+     * <b>Reported, not trimmed</b>, for two reasons. Whitespace is legal in an MQTT password and
+     * trimming would silently break anyone who means it, with no way to opt out. And the placeholder
+     * restore that keeps this credential out of {@code config.xml} on write-back
+     * ({@link com.hivemq.util.render.EnvVarUtil#restorePlaceholders}) anchors on the element's text
+     * exactly as the marshaller writes it: trimming here would make the search string miss, the restore
+     * give up, and the secret land on disk — trading a failed connection for a disclosure. Whether to
+     * trim is a product decision about every string in {@code config.xml}, not a repair to this method.
+     */
+    private static void warnIfPadded(
+            final @NotNull String bridgeId, final @NotNull String element, final @Nullable String value) {
+        if (value == null || value.isEmpty() || value.equals(value.strip())) {
+            return;
+        }
+        log.warn(
+                "The <{}> of bridge '{}' begins or ends with whitespace, and that whitespace is part of the"
+                        + " value the bridge sends. If the element was written across several lines -- a"
+                        + " '${ENV:...}' placeholder indented on its own line, for instance -- the indentation"
+                        + " is in the credential and the remote broker will refuse the connection. Put the value"
+                        + " on the same line as its element, or remove the padding.",
+                element,
+                bridgeId);
+    }
+
     public synchronized void removeBridge(final @NotNull String id) {
         bridgeEntities = bridgeEntities.stream()
                 .filter(entry -> !entry.getId().equals(id))
@@ -251,14 +284,17 @@ public class BridgeExtractor
 
                     if (remoteBroker.getAuthentication() != null
                             && remoteBroker.getAuthentication().getMqttSimpleAuthenticationEntity() != null) {
-                        builder.withUsername(remoteBroker
-                                        .getAuthentication()
-                                        .getMqttSimpleAuthenticationEntity()
-                                        .getUser())
-                                .withPassword(remoteBroker
-                                        .getAuthentication()
-                                        .getMqttSimpleAuthenticationEntity()
-                                        .getPassword());
+                        final String user = remoteBroker
+                                .getAuthentication()
+                                .getMqttSimpleAuthenticationEntity()
+                                .getUser();
+                        final String password = remoteBroker
+                                .getAuthentication()
+                                .getMqttSimpleAuthenticationEntity()
+                                .getPassword();
+                        warnIfPadded(bridgeConfig.getId(), "username", user);
+                        warnIfPadded(bridgeConfig.getId(), "password", password);
+                        builder.withUsername(user).withPassword(password);
                     }
 
                     if (remoteBroker.getMqtt().getClientId() != null) {

--- a/hivemq-edge/src/main/java/com/hivemq/configuration/reader/BridgeExtractor.java
+++ b/hivemq-edge/src/main/java/com/hivemq/configuration/reader/BridgeExtractor.java
@@ -68,19 +68,27 @@ public class BridgeExtractor
         this.configFileReaderWriter = configFileReaderWriter;
     }
 
-    public synchronized void addBridge(final @NotNull MqttBridge mqttBridge) {
+    public void addBridge(final @NotNull MqttBridge mqttBridge) {
         if (!mqttBridge.isPersist()) {
             log.info(
                     "MQTT Bridge '{}' has persist flag set to false, QoS for publishes from local subscriptions will be downgraded to AT_MOST_ONCE.",
                     mqttBridge.getId());
         }
 
-        bridgeEntities = new ImmutableList.Builder<MqttBridge>()
-                .addAll(bridgeEntities)
-                .add(mqttBridge)
-                .build();
-
-        notifyConsumer();
+        synchronized (this) {
+            bridgeEntities = new ImmutableList.Builder<MqttBridge>()
+                    .addAll(bridgeEntities)
+                    .add(mqttBridge)
+                    .build();
+            notifyConsumer();
+        }
+        // The configuration file is written after the monitor is released, never while holding it.
+        // notifyConsumer runs BridgeService.updateBridges inline, which can wait up to the bridge stop
+        // timeout, and writeConfigWithSync takes ConfigFileReaderWriter's lock -- the lock the config
+        // watcher already holds when it calls back into this extractor. Holding both in that order is
+        // the inverse of the watcher's, and the two together wedge the watcher and every REST write in
+        // every subsystem, permanently (EDG-882 QA round 3). sync() re-reads the volatile field, so a
+        // write that lands after another thread's change simply writes the newer configuration.
         configFileReaderWriter.writeConfigWithSync();
     }
 
@@ -106,31 +114,36 @@ public class BridgeExtractor
      *
      * @return {@code false} if no bridge with that id is configured, in which case nothing changed.
      */
-    public synchronized boolean replaceBridge(final @NotNull String id, final @NotNull MqttBridge mqttBridge) {
-        if (bridgeEntities.stream().noneMatch(entry -> entry.getId().equals(id))) {
-            return false;
-        }
-        if (!mqttBridge.isPersist()) {
-            log.info(
-                    "MQTT Bridge '{}' has persist flag set to false, QoS for publishes from local subscriptions will be downgraded to AT_MOST_ONCE.",
-                    mqttBridge.getId());
-        }
+    public boolean replaceBridge(final @NotNull String id, final @NotNull MqttBridge mqttBridge) {
+        synchronized (this) {
+            if (bridgeEntities.stream().noneMatch(entry -> entry.getId().equals(id))) {
+                return false;
+            }
+            if (!mqttBridge.isPersist()) {
+                log.info(
+                        "MQTT Bridge '{}' has persist flag set to false, QoS for publishes from local subscriptions will be downgraded to AT_MOST_ONCE.",
+                        mqttBridge.getId());
+            }
 
-        bridgeEntities = bridgeEntities.stream()
-                .map(entry -> entry.getId().equals(id) ? mqttBridge : entry)
-                .collect(ImmutableList.toImmutableList());
+            bridgeEntities = bridgeEntities.stream()
+                    .map(entry -> entry.getId().equals(id) ? mqttBridge : entry)
+                    .collect(ImmutableList.toImmutableList());
 
-        notifyConsumer();
+            notifyConsumer();
+        }
+        // after the monitor is released -- see addBridge for why
         configFileReaderWriter.writeConfigWithSync();
         return true;
     }
 
-    public synchronized void removeBridge(final @NotNull String id) {
-        bridgeEntities = bridgeEntities.stream()
-                .filter(entry -> !entry.getId().equals(id))
-                .toList();
-
-        notifyConsumer();
+    public void removeBridge(final @NotNull String id) {
+        synchronized (this) {
+            bridgeEntities = bridgeEntities.stream()
+                    .filter(entry -> !entry.getId().equals(id))
+                    .toList();
+            notifyConsumer();
+        }
+        // after the monitor is released -- see addBridge for why
         configFileReaderWriter.writeConfigWithSync();
     }
 
@@ -464,7 +477,22 @@ public class BridgeExtractor
             forwardedTopicEntity.setPreserveRetain(subscription.isPreserveRetain());
             // Dropped silently until now, so any write of config.xml deleted the operator's
             // <queue-limit> and the reload that followed restarted the bridge for a change nobody made.
-            forwardedTopicEntity.setQueueLimit(subscription.getQueueLimit());
+            //
+            // Only when it fits the element: config.xsd declares queue-limit as xs:int, and the REST API
+            // takes an int64 that nothing bounds, so a larger value would fail schema-validated
+            // marshalling -- and writeConfigWithSync logs that failure and carries on, which would lose
+            // the whole write, including whatever unrelated subsystem triggered it (EDG-882 QA round 3).
+            final Long queueLimit = subscription.getQueueLimit();
+            if (queueLimit != null && (queueLimit > Integer.MAX_VALUE || queueLimit < Integer.MIN_VALUE)) {
+                log.warn(
+                        "The queue limit {} of a forwarded topic of bridge '{}' does not fit the configuration"
+                                + " file's queue-limit element and cannot be written to it; the limit stays in"
+                                + " effect for this node but will not survive a restart.",
+                        queueLimit,
+                        subscription.getDestination());
+            } else {
+                forwardedTopicEntity.setQueueLimit(queueLimit);
+            }
             if (subscription.getCustomUserProperties() != null) {
                 forwardedTopicEntity.setCustomUserProperties(subscription.getCustomUserProperties().stream()
                         .map(this::unconvertCustomUserProperty)
@@ -503,6 +531,13 @@ public class BridgeExtractor
         remoteBrokerEntity.setMqtt(bridgeMqttEntity);
 
         // Authentication
+        // Both halves, because config.xsd requires both elements: a bridge created over REST with a
+        // username and no password -- legal MQTT, and rejected nowhere -- has its username silently
+        // dropped here, and the reload that follows reads a changed bridge and restarts it for a change
+        // nobody made. Writing the element with one half would fail schema-validated marshalling and
+        // abort the whole configuration write instead, which is worse. Closing this properly means
+        // either relaxing the schema or refusing the combination at the API; both are decisions of their
+        // own and neither belongs to EDG-882 (QA round 3).
         if (from.getUsername() != null && from.getPassword() != null) {
             final BridgeAuthenticationEntity authentication = new BridgeAuthenticationEntity();
             final MqttSimpleAuthenticationEntity simpleAuthenticationEntity = new MqttSimpleAuthenticationEntity();

--- a/hivemq-edge/src/main/java/com/hivemq/configuration/reader/BridgeExtractor.java
+++ b/hivemq-edge/src/main/java/com/hivemq/configuration/reader/BridgeExtractor.java
@@ -88,6 +88,43 @@ public class BridgeExtractor
         return new ImmutableList.Builder<MqttBridge>().addAll(bridgeEntities).build();
     }
 
+    /**
+     * Replaces the configuration of one bridge in place, as a single configuration transition.
+     * <p>
+     * An update used to be expressed as {@link #removeBridge(String)} followed by
+     * {@link #addBridge(MqttBridge)}. Each of those notifies the consumer, so
+     * {@code BridgeService.updateBridges} saw the bridge disappear from the configuration and treated
+     * it as a removal: {@code internalStopBridge(active, clearQueue = true, retain = List.of())} —
+     * an empty retain list, so every forwarder queue of the bridge was cleared, including the
+     * subscriptions the operator had not touched. Editing one subscription through the API destroyed
+     * the backlog of all the others, which is exactly the loss EDG-882 exists to stop, arrived at
+     * through the path the UI uses (EDG-882 QA round 1).
+     * <p>
+     * Replacing in place keeps the bridge present across the transition, so it is classified as an
+     * update and goes through {@code restartBridge}, which retains the queues of the forwarders that
+     * survive into the new configuration and holds them across the hand-over.
+     *
+     * @return {@code false} if no bridge with that id is configured, in which case nothing changed.
+     */
+    public synchronized boolean replaceBridge(final @NotNull String id, final @NotNull MqttBridge mqttBridge) {
+        if (bridgeEntities.stream().noneMatch(entry -> entry.getId().equals(id))) {
+            return false;
+        }
+        if (!mqttBridge.isPersist()) {
+            log.info(
+                    "MQTT Bridge '{}' has persist flag set to false, QoS for publishes from local subscriptions will be downgraded to AT_MOST_ONCE.",
+                    mqttBridge.getId());
+        }
+
+        bridgeEntities = bridgeEntities.stream()
+                .map(entry -> entry.getId().equals(id) ? mqttBridge : entry)
+                .collect(ImmutableList.toImmutableList());
+
+        notifyConsumer();
+        configFileReaderWriter.writeConfigWithSync();
+        return true;
+    }
+
     public synchronized void removeBridge(final @NotNull String id) {
         bridgeEntities = bridgeEntities.stream()
                 .filter(entry -> !entry.getId().equals(id))
@@ -419,14 +456,15 @@ public class BridgeExtractor
         for (final LocalSubscription subscription : localSubscriptionList) {
             final ForwardedTopicEntity forwardedTopicEntity = new ForwardedTopicEntity();
             forwardedTopicEntity.setDestination(subscription.getDestination());
-            if (subscription.getExcludes() != null) {
-                forwardedTopicEntity.setExcludes(new ArrayList<>(subscription.getExcludes()));
-            }
-            if (subscription.getFilters() != null) {
-                forwardedTopicEntity.setFilters(new ArrayList<>(subscription.getFilters()));
-            }
+            // The configured order, not the canonical one: sorting exists so that a reorder is not a
+            // configuration change, not so that writing the file reorders the operator's elements.
+            forwardedTopicEntity.setExcludes(new ArrayList<>(subscription.getConfiguredExcludes()));
+            forwardedTopicEntity.setFilters(new ArrayList<>(subscription.getConfiguredFilters()));
             forwardedTopicEntity.setMaxQoS(subscription.getMaxQoS());
             forwardedTopicEntity.setPreserveRetain(subscription.isPreserveRetain());
+            // Dropped silently until now, so any write of config.xml deleted the operator's
+            // <queue-limit> and the reload that followed restarted the bridge for a change nobody made.
+            forwardedTopicEntity.setQueueLimit(subscription.getQueueLimit());
             if (subscription.getCustomUserProperties() != null) {
                 forwardedTopicEntity.setCustomUserProperties(subscription.getCustomUserProperties().stream()
                         .map(this::unconvertCustomUserProperty)
@@ -453,7 +491,13 @@ public class BridgeExtractor
         // Bridge MqttEntity
         final BridgeMqttEntity bridgeMqttEntity = new BridgeMqttEntity();
         bridgeMqttEntity.setCleanStart(from.isCleanStart());
-        bridgeMqttEntity.setClientId(from.getClientId());
+        // Only when it is not the default. convertBridgeConfigs fills the client id in from the bridge
+        // id when the element is absent, so writing it back unconditionally added a <client-id> element
+        // to the operator's file that they never wrote -- on every REST write of any subsystem
+        // (EDG-882 QA round 2). Same configuration either way; the file just stops growing elements.
+        if (!from.getId().equals(from.getClientId())) {
+            bridgeMqttEntity.setClientId(from.getClientId());
+        }
         bridgeMqttEntity.setKeepAlive(from.getKeepAlive());
         bridgeMqttEntity.setSessionExpiry(from.getSessionExpiry());
         remoteBrokerEntity.setMqtt(bridgeMqttEntity);

--- a/hivemq-edge/src/main/java/com/hivemq/configuration/reader/ConfigFileReaderWriter.java
+++ b/hivemq-edge/src/main/java/com/hivemq/configuration/reader/ConfigFileReaderWriter.java
@@ -53,6 +53,7 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.StringWriter;
 import java.io.Writer;
 import java.net.URL;
 import java.net.URLConnection;
@@ -165,6 +166,15 @@ public class ConfigFileReaderWriter {
     private final @NotNull SystemInformation sysInfo;
     private final @NotNull AtomicLong lastWrite;
     private final @NotNull AtomicReference<HiveMQConfigEntity> configEntity;
+
+    /**
+     * The {@code ${ENV:...}} placeholders of the configuration file as it was written, and the file's
+     * text at the point they were still in it. Both are needed to put them back when the configuration
+     * is written out again; see {@link EnvVarUtil#restorePlaceholders}.
+     */
+    private final @NotNull AtomicReference<Map<String, String>> envPlaceholders;
+
+    private final @NotNull AtomicReference<String> renderedText;
     private final @NotNull Lock lock;
     private final @NotNull AtomicReference<ScheduledExecutorService> executorService;
     private boolean defaultBackupConfig;
@@ -192,6 +202,8 @@ public class ConfigFileReaderWriter {
         this.postApplyCallbacks = new CopyOnWriteArrayList<>();
         this.fragmentToModificationTime = new ConcurrentHashMap<>();
         this.configEntity = new AtomicReference<>();
+        this.envPlaceholders = new AtomicReference<>(Map.of());
+        this.renderedText = new AtomicReference<>("");
         this.lastWrite = new AtomicLong();
         this.lock = new ReentrantLock();
         this.executorService = new AtomicReference<>();
@@ -363,7 +375,18 @@ public class ConfigFileReaderWriter {
     public void writeConfigToXML(final @NotNull Writer writer) {
         lock.lock();
         try {
-            createMarshaller().marshal(configEntity.get(), writer);
+            // Marshalled to a string first so that the environment-variable placeholders can be put back
+            // before anything reaches the file. Rendering happens once, on the whole file, before it is
+            // parsed, so what is held in memory -- and what a marshaller would write -- is the resolved
+            // value: writing it out put a bridge password supplied through ${ENV:...} into config.xml in
+            // plain text, on any REST change to any subsystem (EDG-882 QA round 2).
+            final StringWriter marshalled = new StringWriter();
+            createMarshaller().marshal(configEntity.get(), marshalled);
+            writer.write(EnvVarUtil.restorePlaceholders(
+                    marshalled.toString(),
+                    Objects.requireNonNullElse(envPlaceholders.get(), Map.of()),
+                    Objects.requireNonNullElse(renderedText.get(), "")));
+            writer.flush();
         } catch (final Throwable e) {
             log.error("Original error message:", e);
             throw new UnrecoverableException(false);
@@ -426,6 +449,11 @@ public class ConfigFileReaderWriter {
             final var fragment = replaceFragmentPlaceHolders(content, sysInfo.isConfigFragmentBase64Zip());
             content = fragment.getRenderResult(); // must happen before env rendering so templates can be used with envs
             content = IfUtil.replaceIfPlaceHolders(content);
+            // Remembered before rendering, so that writing the configuration back out restores the
+            // operator's placeholders instead of the secrets they stand for -- see
+            // EnvVarUtil.restorePlaceholders.
+            renderedText.set(content);
+            envPlaceholders.set(EnvVarUtil.collectPlaceholders(content));
             content = EnvVarUtil.replaceEnvironmentVariablePlaceholders(content);
 
             fragmentToModificationTime.putAll(fragment.getFragmentToModificationTime());

--- a/hivemq-edge/src/main/java/com/hivemq/configuration/reader/ConfigFileReaderWriter.java
+++ b/hivemq-edge/src/main/java/com/hivemq/configuration/reader/ConfigFileReaderWriter.java
@@ -61,12 +61,19 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.AclEntry;
+import java.nio.file.attribute.AclFileAttributeView;
 import java.nio.file.attribute.BasicFileAttributeView;
+import java.nio.file.attribute.GroupPrincipal;
+import java.nio.file.attribute.PosixFileAttributeView;
+import java.nio.file.attribute.PosixFileAttributes;
 import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
+import java.nio.file.attribute.UserPrincipal;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -178,7 +185,7 @@ public class ConfigFileReaderWriter {
      * the configuration back out restores them instead of the values they stand for; see
      * {@link EnvVarUtil#restorePlaceholders}. Replaced only when a configuration is actually accepted.
      */
-    private final @NotNull AtomicReference<List<EnvVarUtil.ElementPlaceholder>> envPlaceholders;
+    private final @NotNull AtomicReference<EnvVarUtil.CollectedPlaceholders> envPlaceholders;
 
     private final @NotNull Lock lock;
     private final @NotNull AtomicReference<ScheduledExecutorService> executorService;
@@ -207,7 +214,7 @@ public class ConfigFileReaderWriter {
         this.postApplyCallbacks = new CopyOnWriteArrayList<>();
         this.fragmentToModificationTime = new ConcurrentHashMap<>();
         this.configEntity = new AtomicReference<>();
-        this.envPlaceholders = new AtomicReference<>(List.of());
+        this.envPlaceholders = new AtomicReference<>(EnvVarUtil.CollectedPlaceholders.NONE);
         this.lastWrite = new AtomicLong();
         this.lock = new ReentrantLock();
         this.executorService = new AtomicReference<>();
@@ -387,7 +394,8 @@ public class ConfigFileReaderWriter {
             final StringWriter marshalled = new StringWriter();
             createMarshaller().marshal(configEntity.get(), marshalled);
             writer.write(EnvVarUtil.restorePlaceholders(
-                    marshalled.toString(), Objects.requireNonNullElse(envPlaceholders.get(), List.of())));
+                    marshalled.toString(),
+                    Objects.requireNonNullElse(envPlaceholders.get(), EnvVarUtil.CollectedPlaceholders.NONE)));
             writer.flush();
         } catch (final Throwable e) {
             log.error("Original error message:", e);
@@ -461,18 +469,18 @@ public class ConfigFileReaderWriter {
                 // inode and therefore its own mode, so the secrets never touched a wider file. It is a
                 // disclosure this change would have introduced, which is why it fails closed rather than
                 // best-effort (EDG-882 review v03, R3-07).
-                final Set<PosixFilePermission> targetPermissions = posixPermissionsOf(target);
-                createPartialFile(partial, targetPermissions);
+                final PreservedAttributes preserved = preservedAttributesOf(target);
+                createPartialFile(partial, preserved);
                 try (final FileWriter writer = new FileWriter(partial.toFile(), StandardCharsets.UTF_8)) {
                     writer.write(rendered.toString());
                     writer.flush();
                 }
-                // Widened to exactly the target's mode only once the content is on disk, so the file is
-                // never wider than its eventual self while it is being filled. A failure here aborts the
-                // replacement: moving a file whose protections could not be reproduced would either
-                // widen a deliberately restricted config.xml or narrow one an operator shares
+                // Widened to exactly the target's protections only once the content is on disk, so the
+                // file is never wider than its eventual self while it is being filled. A failure here
+                // aborts the replacement: moving a file whose protections could not be reproduced would
+                // either widen a deliberately restricted config.xml or narrow one an operator shares
                 // deliberately, and the original on disk is still valid and still correct.
-                applyPermissions(partial, targetPermissions);
+                applyPreservedAttributes(partial, preserved);
                 try {
                     Files.move(partial, target, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
                 } catch (final AtomicMoveNotSupportedException atomicNotSupported) {
@@ -503,44 +511,123 @@ public class ConfigFileReaderWriter {
             Collections.unmodifiableSet(EnumSet.of(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE));
 
     /**
-     * The POSIX permissions of the file about to be replaced, or {@code null} when there are none to
-     * reproduce — the file does not exist yet, or its file store has no POSIX view.
+     * Everything about the file being replaced that decides who can read it.
      * <p>
-     * {@code null} is the "nothing to preserve" answer, not a failure: a configuration file being
-     * created for the first time has no mode of its own to carry, and on a store without POSIX
-     * permissions there is nothing a replacement could get wrong.
+     * The mode alone is not that. {@code 0640} names a group without naming <em>which</em> group, and a
+     * freshly created file takes its group from the creating process or, on macOS and on any directory
+     * with the setgid bit, from the directory — so reproducing only the mode can hand group-read of a
+     * file full of credentials to a completely different set of principals than the file it replaced had
+     * (EDG-882 review v03, R3-09). Owner, group and any ACL are therefore carried with it.
+     *
+     * @param permissions the POSIX mode, or {@code null} on a store with no POSIX view
+     * @param owner       the owning principal, or {@code null} when the store exposes none
+     * @param group       the owning group, or {@code null} on a store with no POSIX view
+     * @param acl         the access-control list, or {@code null} on a store that has no ACL view
      */
     @VisibleForTesting
-    static @Nullable Set<PosixFilePermission> posixPermissionsOf(final @NotNull Path path) {
-        if (!Files.exists(path)) {
-            return null;
+    record PreservedAttributes(
+            @Nullable Set<PosixFilePermission> permissions,
+            @Nullable UserPrincipal owner,
+            @Nullable GroupPrincipal group,
+            @Nullable List<AclEntry> acl) {
+
+        /** Nothing to reproduce: the configuration file is being created for the first time. */
+        static final @NotNull PreservedAttributes NONE = new PreservedAttributes(null, null, null, null);
+
+        boolean nothingToReproduce() {
+            return permissions == null && owner == null && group == null && acl == null;
         }
-        try {
-            return Files.getPosixFilePermissions(path);
-        } catch (final UnsupportedOperationException | IOException | SecurityException e) {
-            log.debug("No POSIX permissions to carry over from {}", path, e);
-            return null;
+    }
+
+    /**
+     * Reads the protections of the file about to be replaced, or {@link PreservedAttributes#NONE} when
+     * there are none to reproduce.
+     * <p>
+     * <b>"Nothing to preserve" and "could not find out" are different answers and only the first one is
+     * safe.</b> The previous version returned "nothing" for both, so an {@code IOException} or a
+     * {@code SecurityException} on a file that exists and is protected ended with the replacement taking
+     * the process umask — the write proceeded and the protection was silently dropped (R3-09). Only a
+     * genuinely absent file, or a store that positively does not support a view, is "nothing"; a failure
+     * to read one that should be there aborts the write before the partial file is even created.
+     *
+     * @throws IOException when the file exists but its protections cannot be determined
+     */
+    @VisibleForTesting
+    static @NotNull PreservedAttributes preservedAttributesOf(final @NotNull Path path) throws IOException {
+        Set<PosixFilePermission> permissions = null;
+        UserPrincipal owner = null;
+        GroupPrincipal group = null;
+        List<AclEntry> acl = null;
+
+        final PosixFileAttributeView posixView = Files.getFileAttributeView(path, PosixFileAttributeView.class);
+        if (posixView != null) {
+            try {
+                final PosixFileAttributes attributes = posixView.readAttributes();
+                permissions = attributes.permissions();
+                owner = attributes.owner();
+                group = attributes.group();
+            } catch (final NoSuchFileException absent) {
+                return PreservedAttributes.NONE;
+            } catch (final IOException | SecurityException e) {
+                throw new IOException(
+                        "Could not read the permissions of the configuration file being replaced, so a"
+                                + " replacement carrying the same protections cannot be produced; the existing"
+                                + " file has been left untouched",
+                        e);
+            }
         }
+
+        final AclFileAttributeView aclView = Files.getFileAttributeView(path, AclFileAttributeView.class);
+        if (aclView != null) {
+            try {
+                final List<AclEntry> entries = aclView.getAcl();
+                // Only a non-empty list is worth carrying. Several stores expose an ACL view for every
+                // file and answer with an empty list when none is set; reproducing that would mean an
+                // otherwise pointless setAcl on the ordinary path, which can fail for its own reasons and
+                // would then refuse a write that had nothing to preserve in the first place.
+                acl = entries.isEmpty() ? null : entries;
+                if (owner == null) {
+                    owner = aclView.getOwner();
+                }
+            } catch (final NoSuchFileException absent) {
+                return PreservedAttributes.NONE;
+            } catch (final IOException | SecurityException e) {
+                throw new IOException(
+                        "Could not read the access-control list of the configuration file being replaced, so a"
+                                + " replacement carrying the same protections cannot be produced; the existing"
+                                + " file has been left untouched",
+                        e);
+            }
+        }
+
+        if (posixView == null && aclView == null) {
+            // A store that exposes neither view has no protections a replacement could get wrong.
+            if (!Files.exists(path)) {
+                return PreservedAttributes.NONE;
+            }
+            log.debug("{} is on a file store with no POSIX or ACL view; nothing to reproduce", path);
+            return PreservedAttributes.NONE;
+        }
+        return new PreservedAttributes(permissions, owner, group, acl);
     }
 
     /**
      * Creates the file the configuration is rendered into, narrow from the moment it exists.
      * <p>
-     * When there is a mode to reproduce, the file is created owner-only and widened to the target's
-     * mode after it has been written — the permissions are an attribute of the {@code createFile} call
-     * rather than a {@code chmod} after the fact, so there is no instant at which the file exists and is
-     * readable by anyone else. With nothing to reproduce, it is created normally and takes the umask,
-     * which is what a first-time configuration file would have had anyway.
+     * When there is anything to reproduce, the file is created owner-read/write and widened to the
+     * target's protections after it has been written — the permissions are an attribute of the
+     * {@code createFile} call rather than a {@code chmod} after the fact, so there is no instant at which
+     * the file exists and is readable by anyone else. With nothing to reproduce, it is created normally
+     * and takes the umask, which is what a first-time configuration file would have had anyway.
      * <p>
      * A partial file left behind by a killed process is deleted rather than reused: reopening it would
      * inherit whatever mode <em>it</em> was left with.
      */
     @VisibleForTesting
-    static void createPartialFile(
-            final @NotNull Path partial, final @Nullable Set<PosixFilePermission> targetPermissions)
+    static void createPartialFile(final @NotNull Path partial, final @NotNull PreservedAttributes preserved)
             throws IOException {
         Files.deleteIfExists(partial);
-        if (targetPermissions == null) {
+        if (preserved.nothingToReproduce() || preserved.permissions() == null) {
             Files.createFile(partial);
         } else {
             Files.createFile(partial, PosixFilePermissions.asFileAttribute(OWNER_ONLY));
@@ -548,28 +635,96 @@ public class ConfigFileReaderWriter {
     }
 
     /**
-     * Gives the written replacement exactly the mode of the file it is about to replace.
+     * Gives the written replacement exactly the protections of the file it is about to replace, and
+     * proves it before the move.
      * <p>
-     * Throws rather than warns. The alternative — carry the mode if you can, move it either way — is
-     * what {@code R3-07} reported: a failure there leaves the umask's mode on a file full of
-     * credentials, permanently, announced at debug level. Refusing the replacement keeps the previous
-     * configuration file, which is intact, correctly permissioned and still the one the running node
-     * matches.
+     * Order matters: owner and group are set while the file is still owner-only, then the ACL, then the
+     * mode last. Setting the mode first would open a window in which the file is already group- or
+     * world-readable but still owned by the wrong principals.
+     * <p>
+     * Throws rather than warns, at every step. The alternative — carry what you can, move it either way —
+     * is what R3-07 and R3-09 reported between them: a failure leaves a file full of credentials with the
+     * umask's mode and the creating process's group, permanently, announced at debug level. Refusing the
+     * replacement keeps the previous configuration file, which is intact, correctly permissioned and
+     * still the one the running node matches.
      */
     @VisibleForTesting
-    static void applyPermissions(
-            final @NotNull Path partial, final @Nullable Set<PosixFilePermission> targetPermissions)
+    static void applyPreservedAttributes(final @NotNull Path partial, final @NotNull PreservedAttributes preserved)
             throws IOException {
-        if (targetPermissions == null) {
+        if (preserved.nothingToReproduce()) {
             return;
         }
         try {
-            Files.setPosixFilePermissions(partial, targetPermissions);
-        } catch (final UnsupportedOperationException | SecurityException e) {
+            final PosixFileAttributeView partialPosix =
+                    Files.getFileAttributeView(partial, PosixFileAttributeView.class);
+            if (partialPosix != null) {
+                // Only when they differ. Changing owner is a privileged operation on every platform this
+                // runs on, and changing group requires membership; asking for a change that is already
+                // true would fail for no reason on the ordinary path, where the node replaces a file it
+                // owns.
+                final PosixFileAttributes current = partialPosix.readAttributes();
+                if (preserved.owner() != null && !preserved.owner().equals(current.owner())) {
+                    partialPosix.setOwner(preserved.owner());
+                }
+                if (preserved.group() != null && !preserved.group().equals(current.group())) {
+                    partialPosix.setGroup(preserved.group());
+                }
+            }
+            if (preserved.acl() != null) {
+                final AclFileAttributeView partialAcl = Files.getFileAttributeView(partial, AclFileAttributeView.class);
+                if (partialAcl == null) {
+                    throw new IOException("The replacement cannot carry an access-control list on this file store");
+                }
+                partialAcl.setAcl(preserved.acl());
+            }
+            if (preserved.permissions() != null) {
+                Files.setPosixFilePermissions(partial, preserved.permissions());
+            }
+        } catch (final UnsupportedOperationException | SecurityException | IOException e) {
             throw new IOException(
-                    "Could not reproduce the permissions of the configuration file being replaced; "
+                    "Could not reproduce the protections of the configuration file being replaced; "
                             + "the existing file has been left untouched",
                     e);
+        }
+        verifyPreservedAttributes(partial, preserved);
+    }
+
+    /**
+     * Re-reads what was just applied and refuses the replacement if any of it did not take.
+     * <p>
+     * Every setter above can succeed on a store that then quietly reports something else back —
+     * a mapped volume that ignores ownership, a mode masked by a mount option. The whole point of this
+     * code is that the replacement is no more readable than the file it replaces, and that is a claim
+     * worth checking rather than assuming, because the cost of it being wrong is every credential in the
+     * configuration.
+     */
+    private static void verifyPreservedAttributes(
+            final @NotNull Path partial, final @NotNull PreservedAttributes preserved) throws IOException {
+        final PosixFileAttributeView view = Files.getFileAttributeView(partial, PosixFileAttributeView.class);
+        if (view == null) {
+            return;
+        }
+        final PosixFileAttributes actual = view.readAttributes();
+        if (preserved.permissions() != null && !preserved.permissions().equals(actual.permissions())) {
+            throw new IOException("The replacement's permissions are "
+                    + PosixFilePermissions.toString(actual.permissions())
+                    + " but the configuration file being replaced has "
+                    + PosixFilePermissions.toString(preserved.permissions())
+                    + "; the existing file has been left untouched");
+        }
+        if (preserved.owner() != null && !preserved.owner().equals(actual.owner())) {
+            throw new IOException(
+                    "The replacement is owned by '" + actual.owner().getName() + "' but the"
+                            + " configuration file being replaced is owned by '"
+                            + preserved.owner().getName()
+                            + "'; the existing file has been left untouched");
+        }
+        if (preserved.group() != null && !preserved.group().equals(actual.group())) {
+            throw new IOException(
+                    "The replacement's group is '" + actual.group().getName() + "' but the"
+                            + " configuration file being replaced has group '"
+                            + preserved.group().getName()
+                            + "'; the existing file has been left untouched");
         }
     }
 
@@ -599,7 +754,7 @@ public class ConfigFileReaderWriter {
             // accepted: a file that fails to parse must not replace the placeholders of the
             // configuration still running, or the next write would marshal that older configuration --
             // with its resolved secrets -- against a map that no longer describes it.
-            final List<EnvVarUtil.ElementPlaceholder> placeholders = EnvVarUtil.collectPlaceholders(content);
+            final EnvVarUtil.CollectedPlaceholders placeholders = EnvVarUtil.collectPlaceholders(content);
             content = EnvVarUtil.replaceEnvironmentVariablePlaceholders(content);
 
             fragmentToModificationTime.putAll(fragment.getFragmentToModificationTime());

--- a/hivemq-edge/src/main/java/com/hivemq/configuration/reader/ConfigFileReaderWriter.java
+++ b/hivemq-edge/src/main/java/com/hivemq/configuration/reader/ConfigFileReaderWriter.java
@@ -68,6 +68,7 @@ import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.AclEntry;
+import java.nio.file.attribute.AclEntryFlag;
 import java.nio.file.attribute.AclEntryPermission;
 import java.nio.file.attribute.AclEntryType;
 import java.nio.file.attribute.AclFileAttributeView;
@@ -776,10 +777,12 @@ public class ConfigFileReaderWriter {
      * <p>
      * <b>Narrow enough, not identical.</b> The first version demanded that the list read back be equal to
      * the list set, which is a claim about how a file store represents an access-control list rather than
-     * about who can read the file. A store that reorders entries, normalises a permission mask, or hands
-     * back an inherited entry alongside the one just written would have failed that comparison and refused
-     * every configuration write — on the only kind of store this code path exists for, and in a way
-     * nothing off that platform can reproduce (EDG-882 review v04). What has to be true is that nobody
+     * about who can read the file. A store that reorders entries without changing what they decide,
+     * normalises a permission mask, or hands back an inherited entry alongside the one just written would
+     * have failed that comparison and refused every configuration write — on the only kind of store this
+     * code path exists for, and in a way nothing off that platform can reproduce (EDG-882 review v04).
+     * The list is compared by what it decides instead, which is order- and flag-aware where those change
+     * the decision and indifferent to them where they do not. What has to be true is that nobody
      * else can read the file while the credentials go into it: owner-only if the store took it, and
      * otherwise no wider than the file about to be replaced, which the replacement is entitled to be
      * because that is what it is about to become.
@@ -831,34 +834,66 @@ public class ConfigFileReaderWriter {
      * Whether an access-control list grants nobody anything that another one does not.
      * <p>
      * The question every check on this path actually wants to ask, and the only one that can be answered
-     * without knowing how a particular file store chooses to represent a list. Two lists that grant the
-     * same access are the same answer here whatever order they are in, however their permissions are split
-     * across entries, and whatever inheritance flags they carry — flags govern what a <em>directory</em>
-     * propagates to things created inside it, and a file propagates to nothing.
+     * without knowing how a particular file store chooses to represent a list. It is asked of what each
+     * list <em>decides</em>, not of how it is written down: two lists that decide the same access are the
+     * same answer here whatever order their entries are in and however their permissions are split across
+     * entries.
      * <p>
-     * Conservative in both directions that can widen access: an {@code ALLOW} the reference does not have
-     * widens, and so does losing a {@code DENY} the reference does have, because a denial can be the only
-     * thing keeping a member of an allowed group out. Entries that are neither — audit and alarm entries —
-     * grant no access and are ignored.
+     * Deciding is where order lives. A list is evaluated in sequence and the first entry that names a
+     * principal and mentions a permission settles that permission for that principal, so
+     * {@code DENY Alice READ} followed by {@code ALLOW Alice READ} keeps Alice out while the same two
+     * entries the other way round let her in — the same entries, opposite access (EDG-882 review v05,
+     * finding 1). {@link #effective} is that evaluation; the comparison then runs over its result.
+     * <p>
+     * Flags are read the same way. {@code FILE_INHERIT} and {@code DIRECTORY_INHERIT} govern what a
+     * <em>directory</em> propagates to what is created inside it, and the file being written propagates to
+     * nothing, so they change no answer here. {@code INHERIT_ONLY} is not one of those: it says the entry
+     * does not apply to the object carrying it, so such an entry decides nothing about this file and
+     * dropping it grants access the reference did not.
+     * <p>
+     * Conservative in both directions that can widen access: an {@code ALLOW} in effect that the reference
+     * does not have widens, and so does losing a {@code DENY} the reference has in effect, because a denial
+     * can be the only thing keeping a member of an allowed group out. Entries that are neither — audit and
+     * alarm entries — grant no access and are ignored.
      */
     @VisibleForTesting
     static boolean grantsNoMoreThan(final @NotNull List<AclEntry> candidate, final @NotNull List<AclEntry> reference) {
-        return contains(byPrincipal(reference, AclEntryType.ALLOW), byPrincipal(candidate, AclEntryType.ALLOW))
-                && contains(byPrincipal(candidate, AclEntryType.DENY), byPrincipal(reference, AclEntryType.DENY));
+        return contains(effective(reference, AclEntryType.ALLOW), effective(candidate, AclEntryType.ALLOW))
+                && contains(effective(candidate, AclEntryType.DENY), effective(reference, AclEntryType.DENY));
     }
 
-    /** The permissions each principal is given by the entries of one type, merged across entries. */
-    private static @NotNull Map<UserPrincipal, Set<AclEntryPermission>> byPrincipal(
+    /**
+     * The permissions each principal is actually left with by the entries of one type, once the list has
+     * been evaluated in order.
+     * <p>
+     * A permission belongs to the first entry that names the principal and mentions it; every later entry
+     * for that principal and permission has already been settled and cannot change it. Entries that do not
+     * apply to the object itself, and entries that grant nothing, take no part.
+     */
+    private static @NotNull Map<UserPrincipal, Set<AclEntryPermission>> effective(
             final @NotNull List<AclEntry> acl, final @NotNull AclEntryType type) {
-        final Map<UserPrincipal, Set<AclEntryPermission>> permissions = new HashMap<>();
+        final Map<UserPrincipal, Set<AclEntryPermission>> settled = new HashMap<>();
+        final Map<UserPrincipal, Set<AclEntryPermission>> ofThisType = new HashMap<>();
         for (final AclEntry entry : acl) {
-            if (entry.type() == type) {
-                permissions
-                        .computeIfAbsent(entry.principal(), principal -> EnumSet.noneOf(AclEntryPermission.class))
-                        .addAll(entry.permissions());
+            if (entry.type() != AclEntryType.ALLOW && entry.type() != AclEntryType.DENY) {
+                continue;
             }
+            if (entry.flags().contains(AclEntryFlag.INHERIT_ONLY)) {
+                continue;
+            }
+            final Set<AclEntryPermission> alreadySettled =
+                    settled.computeIfAbsent(entry.principal(), principal -> EnumSet.noneOf(AclEntryPermission.class));
+            final Set<AclEntryPermission> decidedHere = EnumSet.noneOf(AclEntryPermission.class);
+            decidedHere.addAll(entry.permissions());
+            decidedHere.removeAll(alreadySettled);
+            if (entry.type() == type) {
+                ofThisType
+                        .computeIfAbsent(entry.principal(), principal -> EnumSet.noneOf(AclEntryPermission.class))
+                        .addAll(decidedHere);
+            }
+            alreadySettled.addAll(decidedHere);
         }
-        return permissions;
+        return ofThisType;
     }
 
     /** Whether every principal in {@code subset} is given no more there than {@code superset} gives it. */

--- a/hivemq-edge/src/main/java/com/hivemq/configuration/reader/ConfigFileReaderWriter.java
+++ b/hivemq-edge/src/main/java/com/hivemq/configuration/reader/ConfigFileReaderWriter.java
@@ -433,13 +433,28 @@ public class ConfigFileReaderWriter {
             //
             // Same directory on purpose: ATOMIC_MOVE is only guaranteed within a file store, and the
             // temporary file has to be one the configuration watcher will not try to parse.
-            final Path target = file.toPath();
-            final Path partial = target.resolveSibling(file.getName() + ".partial");
+            //
+            // The real path, not the configured one: replacing a path is replacing whatever the last
+            // component *is*, so when config.xml is a symbolic link -- a mounted configuration
+            // directory, an operator's link into a versioned tree -- the move would delete the link and
+            // leave a regular file in its place. Writing in place followed it, which is the behaviour
+            // being preserved here; resolving it also keeps the partial file in the same real directory,
+            // which is what ATOMIC_MOVE needs.
+            final Path configured = file.toPath();
+            final Path target = Files.exists(configured) ? configured.toRealPath() : configured;
+            final Path partial = target.resolveSibling(target.getFileName() + ".partial");
             try {
                 try (final FileWriter writer = new FileWriter(partial.toFile(), StandardCharsets.UTF_8)) {
                     writer.write(rendered.toString());
                     writer.flush();
                 }
+                // The replacement is a new file, so it carries this process's umask rather than the mode
+                // of the file it replaces -- and config.xml holds bridge passwords, keystore passwords
+                // and client secrets. Writing in place preserved whatever the operator had set; the
+                // first REST write after this change would otherwise widen a deliberately restricted
+                // file, silently. Best effort: a file store without POSIX permissions has nothing to
+                // carry over, and failing the whole write over the mode would be the worse outcome.
+                copyPermissions(target, partial);
                 try {
                     Files.move(partial, target, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
                 } catch (final AtomicMoveNotSupportedException atomicNotSupported) {
@@ -457,6 +472,27 @@ public class ConfigFileReaderWriter {
             throw new UnrecoverableException(false);
         } finally {
             lock.unlock();
+        }
+    }
+
+    /**
+     * Gives {@code replacement} the POSIX permissions of {@code existing}, so that replacing a file
+     * does not change who can read it.
+     * <p>
+     * Best effort by design. A file store with no POSIX view has nothing to carry over, and a
+     * permission that cannot be set is not a reason to fail a configuration write that has already been
+     * rendered successfully — the previous behaviour, writing into the original file, simply left the
+     * mode alone. Reported at debug rather than warn for the same reason: on the platforms where this
+     * does nothing, it does nothing on every write.
+     */
+    private static void copyPermissions(final @NotNull Path existing, final @NotNull Path replacement) {
+        if (!Files.exists(existing)) {
+            return;
+        }
+        try {
+            Files.setPosixFilePermissions(replacement, Files.getPosixFilePermissions(existing));
+        } catch (final UnsupportedOperationException | IOException | SecurityException e) {
+            log.debug("Could not carry the permissions of {} over to the replacement file", existing, e);
         }
     }
 

--- a/hivemq-edge/src/main/java/com/hivemq/configuration/reader/ConfigFileReaderWriter.java
+++ b/hivemq-edge/src/main/java/com/hivemq/configuration/reader/ConfigFileReaderWriter.java
@@ -922,6 +922,9 @@ public class ConfigFileReaderWriter {
         final List<ValidationEvent> validationErrors = Collections.synchronizedList(new ArrayList<>());
 
         lock.lock();
+        // Kept for the diagnostic in the catch below, which needs the placeholders as the operator wrote
+        // them rather than what they resolved to.
+        String beforeRendering = null;
         try {
 
             // replace environment variable placeholders
@@ -936,6 +939,7 @@ public class ConfigFileReaderWriter {
             // configuration still running, or the next write would marshal that older configuration --
             // with its resolved secrets -- against a map that no longer describes it.
             final EnvVarUtil.CollectedPlaceholders placeholders = EnvVarUtil.collectPlaceholders(content);
+            beforeRendering = content;
             content = EnvVarUtil.replaceEnvironmentVariablePlaceholders(content);
 
             fragmentToModificationTime.putAll(fragment.getFragmentToModificationTime());
@@ -974,6 +978,7 @@ public class ConfigFileReaderWriter {
                 }
             }
             log.error("Not able to parse configuration file because {}", sb);
+            reportValuesThatAreNotText(beforeRendering);
             throw new UnrecoverableException(false);
         } catch (final Exception e) {
             if (e.getCause() instanceof UnrecoverableException unrecoverableException) {
@@ -991,6 +996,34 @@ public class ConfigFileReaderWriter {
         } finally {
             lock.unlock();
         }
+    }
+
+    /**
+     * Names the environment variables that made the configuration unparseable, when that is what happened.
+     * <p>
+     * A value is put into the file as raw text before it is parsed, so one containing {@code <} or
+     * {@code &} makes the document malformed -- and the parser then reports a line the operator never
+     * wrote, about content they cannot see, with no hint that a variable is responsible. A credential
+     * containing an ampersand is the ordinary way to arrive here (EDG-882 review v04).
+     * <p>
+     * Only when the parse actually failed, and only the variable names: a configuration that deliberately
+     * brings in markup through a variable keeps working and says nothing, and no value reaches the log.
+     */
+    private static void reportValuesThatAreNotText(final @Nullable String beforeRendering) {
+        if (beforeRendering == null) {
+            return;
+        }
+        final List<String> names = EnvVarUtil.variablesWhoseValueIsNotText(beforeRendering);
+        if (names.isEmpty()) {
+            return;
+        }
+        log.error(
+                "These environment variables resolve to a value containing '<' or '&': {}. Their values are put"
+                        + " into the configuration as raw XML before it is parsed, so a value containing either"
+                        + " only works when the value itself is well-formed XML -- a credential containing an"
+                        + " ampersand cannot be supplied this way. That is the likely cause of the parse error"
+                        + " above.",
+                names);
     }
 
     @VisibleForTesting

--- a/hivemq-edge/src/main/java/com/hivemq/configuration/reader/ConfigFileReaderWriter.java
+++ b/hivemq-edge/src/main/java/com/hivemq/configuration/reader/ConfigFileReaderWriter.java
@@ -765,16 +765,27 @@ public class ConfigFileReaderWriter {
             Files.createFile(partial);
         }
         if (preserved.acl() != null) {
-            narrowToItsOwner(partial);
+            narrowToItsOwner(partial, preserved.acl());
         }
     }
 
     /**
      * Replaces the inherited access-control list of the just-created, still-empty replacement with one
-     * that grants its own owner everything and everyone else nothing, and refuses to go on if that did
-     * not take.
+     * that grants its own owner everything and everyone else nothing, and refuses to go on unless the
+     * result is narrow enough to write the configuration into.
+     * <p>
+     * <b>Narrow enough, not identical.</b> The first version demanded that the list read back be equal to
+     * the list set, which is a claim about how a file store represents an access-control list rather than
+     * about who can read the file. A store that reorders entries, normalises a permission mask, or hands
+     * back an inherited entry alongside the one just written would have failed that comparison and refused
+     * every configuration write — on the only kind of store this code path exists for, and in a way
+     * nothing off that platform can reproduce (EDG-882 review v04). What has to be true is that nobody
+     * else can read the file while the credentials go into it: owner-only if the store took it, and
+     * otherwise no wider than the file about to be replaced, which the replacement is entitled to be
+     * because that is what it is about to become.
      */
-    private static void narrowToItsOwner(final @NotNull Path partial) throws IOException {
+    private static void narrowToItsOwner(final @NotNull Path partial, final @NotNull List<AclEntry> targetAcl)
+            throws IOException {
         final AclFileAttributeView view = Files.getFileAttributeView(partial, AclFileAttributeView.class);
         if (view == null) {
             throw new IOException("The replacement for the configuration file cannot be given an access-control"
@@ -794,11 +805,72 @@ public class ConfigFileReaderWriter {
                             + " being written; the existing file has been left untouched",
                     e);
         }
-        if (!ownerOnly.equals(view.getAcl())) {
-            throw new IOException("The replacement for the configuration file did not keep the access-control"
-                    + " list restricting it to its owner, so the configuration cannot be written into it;"
-                    + " the existing file has been left untouched");
+        final List<AclEntry> actual = view.getAcl();
+        if (grantsNoMoreThan(actual, ownerOnly)) {
+            return;
         }
+        if (grantsNoMoreThan(actual, targetAcl)) {
+            // Not owner-only, but no wider than the file it is about to replace -- which is the property
+            // that matters: the replacement is never readable by anyone the configuration it replaces is
+            // not, at any point while it holds the configuration. Worth saying out loud, because it means
+            // the store did not do what it was asked.
+            log.warn(
+                    "The replacement for the configuration file could not be restricted to its owner: {} keeps"
+                            + " an access-control list this node did not set. It is no wider than the"
+                            + " configuration file being replaced, so the configuration is written into it"
+                            + " anyway.",
+                    partial);
+            return;
+        }
+        throw new IOException("The replacement for the configuration file is readable by principals the"
+                + " configuration file being replaced is not, so the configuration cannot be written into it;"
+                + " the existing file has been left untouched");
+    }
+
+    /**
+     * Whether an access-control list grants nobody anything that another one does not.
+     * <p>
+     * The question every check on this path actually wants to ask, and the only one that can be answered
+     * without knowing how a particular file store chooses to represent a list. Two lists that grant the
+     * same access are the same answer here whatever order they are in, however their permissions are split
+     * across entries, and whatever inheritance flags they carry — flags govern what a <em>directory</em>
+     * propagates to things created inside it, and a file propagates to nothing.
+     * <p>
+     * Conservative in both directions that can widen access: an {@code ALLOW} the reference does not have
+     * widens, and so does losing a {@code DENY} the reference does have, because a denial can be the only
+     * thing keeping a member of an allowed group out. Entries that are neither — audit and alarm entries —
+     * grant no access and are ignored.
+     */
+    @VisibleForTesting
+    static boolean grantsNoMoreThan(final @NotNull List<AclEntry> candidate, final @NotNull List<AclEntry> reference) {
+        return contains(byPrincipal(reference, AclEntryType.ALLOW), byPrincipal(candidate, AclEntryType.ALLOW))
+                && contains(byPrincipal(candidate, AclEntryType.DENY), byPrincipal(reference, AclEntryType.DENY));
+    }
+
+    /** The permissions each principal is given by the entries of one type, merged across entries. */
+    private static @NotNull Map<UserPrincipal, Set<AclEntryPermission>> byPrincipal(
+            final @NotNull List<AclEntry> acl, final @NotNull AclEntryType type) {
+        final Map<UserPrincipal, Set<AclEntryPermission>> permissions = new HashMap<>();
+        for (final AclEntry entry : acl) {
+            if (entry.type() == type) {
+                permissions
+                        .computeIfAbsent(entry.principal(), principal -> EnumSet.noneOf(AclEntryPermission.class))
+                        .addAll(entry.permissions());
+            }
+        }
+        return permissions;
+    }
+
+    /** Whether every principal in {@code subset} is given no more there than {@code superset} gives it. */
+    private static boolean contains(
+            final @NotNull Map<UserPrincipal, Set<AclEntryPermission>> superset,
+            final @NotNull Map<UserPrincipal, Set<AclEntryPermission>> subset) {
+        for (final Map.Entry<UserPrincipal, Set<AclEntryPermission>> granted : subset.entrySet()) {
+            if (!superset.getOrDefault(granted.getKey(), Set.of()).containsAll(granted.getValue())) {
+                return false;
+            }
+        }
+        return true;
     }
 
     /**
@@ -952,11 +1024,21 @@ public class ConfigFileReaderWriter {
         if (preserved.acl() != null) {
             final AclFileAttributeView aclView = Files.getFileAttributeView(partial, AclFileAttributeView.class);
             final List<AclEntry> actualAcl = aclView == null ? null : aclView.getAcl();
-            if (!preserved.acl().equals(actualAcl)) {
-                throw new IOException(
-                        "The replacement's access-control list is " + actualAcl + " but the configuration file"
-                                + " being replaced has " + preserved.acl()
-                                + "; the existing file has been left untouched");
+            if (actualAcl == null || !grantsNoMoreThan(actualAcl, preserved.acl())) {
+                throw new IOException("The replacement's access-control list grants access the configuration file being"
+                        + " replaced does not: it is " + actualAcl + " where that file has "
+                        + preserved.acl() + "; the existing file has been left untouched");
+            }
+            if (!grantsNoMoreThan(preserved.acl(), actualAcl)) {
+                // Narrower than the file it replaces. Nobody gains anything, so this is not the disclosure
+                // the check is here for -- but someone who could read the configuration no longer can, and
+                // that is not something to find out later.
+                log.warn(
+                        "The replacement for the configuration file has a narrower access-control list than the"
+                                + " file it replaces: {} where that file has {}. Nobody gains access, but"
+                                + " principals that could read the configuration may no longer be able to.",
+                        actualAcl,
+                        preserved.acl());
             }
         }
     }

--- a/hivemq-edge/src/main/java/com/hivemq/configuration/reader/ConfigFileReaderWriter.java
+++ b/hivemq-edge/src/main/java/com/hivemq/configuration/reader/ConfigFileReaderWriter.java
@@ -65,14 +65,18 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.BasicFileAttributeView;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -444,17 +448,31 @@ public class ConfigFileReaderWriter {
             final Path target = Files.exists(configured) ? configured.toRealPath() : configured;
             final Path partial = target.resolveSibling(target.getFileName() + ".partial");
             try {
+                // The replacement's mode is settled before a single byte of it is written, not after.
+                //
+                // The rendered document holds bridge passwords, keystore and truststore passwords and
+                // adapter credentials. A file created by FileWriter takes this process's umask, so on a
+                // 022 umask the first version of this change created a world-readable 0644 file,
+                // populated it with every secret in the configuration, closed it, and only then narrowed
+                // it to the mode of the file it was about to replace. Any local principal reading the
+                // directory during that window got the lot -- on every REST write to any subsystem.
+                //
+                // That window did not exist before this branch: writing in place reused config.xml's own
+                // inode and therefore its own mode, so the secrets never touched a wider file. It is a
+                // disclosure this change would have introduced, which is why it fails closed rather than
+                // best-effort (EDG-882 review v03, R3-07).
+                final Set<PosixFilePermission> targetPermissions = posixPermissionsOf(target);
+                createPartialFile(partial, targetPermissions);
                 try (final FileWriter writer = new FileWriter(partial.toFile(), StandardCharsets.UTF_8)) {
                     writer.write(rendered.toString());
                     writer.flush();
                 }
-                // The replacement is a new file, so it carries this process's umask rather than the mode
-                // of the file it replaces -- and config.xml holds bridge passwords, keystore passwords
-                // and client secrets. Writing in place preserved whatever the operator had set; the
-                // first REST write after this change would otherwise widen a deliberately restricted
-                // file, silently. Best effort: a file store without POSIX permissions has nothing to
-                // carry over, and failing the whole write over the mode would be the worse outcome.
-                copyPermissions(target, partial);
+                // Widened to exactly the target's mode only once the content is on disk, so the file is
+                // never wider than its eventual self while it is being filled. A failure here aborts the
+                // replacement: moving a file whose protections could not be reproduced would either
+                // widen a deliberately restricted config.xml or narrow one an operator shares
+                // deliberately, and the original on disk is still valid and still correct.
+                applyPermissions(partial, targetPermissions);
                 try {
                     Files.move(partial, target, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
                 } catch (final AtomicMoveNotSupportedException atomicNotSupported) {
@@ -476,23 +494,82 @@ public class ConfigFileReaderWriter {
     }
 
     /**
-     * Gives {@code replacement} the POSIX permissions of {@code existing}, so that replacing a file
-     * does not change who can read it.
+     * Owner read/write and nothing else: what the replacement is created as, before it is written.
      * <p>
-     * Best effort by design. A file store with no POSIX view has nothing to carry over, and a
-     * permission that cannot be set is not a reason to fail a configuration write that has already been
-     * rendered successfully — the previous behaviour, writing into the original file, simply left the
-     * mode alone. Reported at debug rather than warn for the same reason: on the platforms where this
-     * does nothing, it does nothing on every write.
+     * Unmodifiable because it is shared static state handed to callers that have no reason to expect a
+     * mutable set — an {@code EnumSet} on its own would let one of them widen it for the whole process.
      */
-    private static void copyPermissions(final @NotNull Path existing, final @NotNull Path replacement) {
-        if (!Files.exists(existing)) {
+    private static final @NotNull Set<PosixFilePermission> OWNER_ONLY =
+            Collections.unmodifiableSet(EnumSet.of(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE));
+
+    /**
+     * The POSIX permissions of the file about to be replaced, or {@code null} when there are none to
+     * reproduce — the file does not exist yet, or its file store has no POSIX view.
+     * <p>
+     * {@code null} is the "nothing to preserve" answer, not a failure: a configuration file being
+     * created for the first time has no mode of its own to carry, and on a store without POSIX
+     * permissions there is nothing a replacement could get wrong.
+     */
+    @VisibleForTesting
+    static @Nullable Set<PosixFilePermission> posixPermissionsOf(final @NotNull Path path) {
+        if (!Files.exists(path)) {
+            return null;
+        }
+        try {
+            return Files.getPosixFilePermissions(path);
+        } catch (final UnsupportedOperationException | IOException | SecurityException e) {
+            log.debug("No POSIX permissions to carry over from {}", path, e);
+            return null;
+        }
+    }
+
+    /**
+     * Creates the file the configuration is rendered into, narrow from the moment it exists.
+     * <p>
+     * When there is a mode to reproduce, the file is created owner-only and widened to the target's
+     * mode after it has been written — the permissions are an attribute of the {@code createFile} call
+     * rather than a {@code chmod} after the fact, so there is no instant at which the file exists and is
+     * readable by anyone else. With nothing to reproduce, it is created normally and takes the umask,
+     * which is what a first-time configuration file would have had anyway.
+     * <p>
+     * A partial file left behind by a killed process is deleted rather than reused: reopening it would
+     * inherit whatever mode <em>it</em> was left with.
+     */
+    @VisibleForTesting
+    static void createPartialFile(
+            final @NotNull Path partial, final @Nullable Set<PosixFilePermission> targetPermissions)
+            throws IOException {
+        Files.deleteIfExists(partial);
+        if (targetPermissions == null) {
+            Files.createFile(partial);
+        } else {
+            Files.createFile(partial, PosixFilePermissions.asFileAttribute(OWNER_ONLY));
+        }
+    }
+
+    /**
+     * Gives the written replacement exactly the mode of the file it is about to replace.
+     * <p>
+     * Throws rather than warns. The alternative — carry the mode if you can, move it either way — is
+     * what {@code R3-07} reported: a failure there leaves the umask's mode on a file full of
+     * credentials, permanently, announced at debug level. Refusing the replacement keeps the previous
+     * configuration file, which is intact, correctly permissioned and still the one the running node
+     * matches.
+     */
+    @VisibleForTesting
+    static void applyPermissions(
+            final @NotNull Path partial, final @Nullable Set<PosixFilePermission> targetPermissions)
+            throws IOException {
+        if (targetPermissions == null) {
             return;
         }
         try {
-            Files.setPosixFilePermissions(replacement, Files.getPosixFilePermissions(existing));
-        } catch (final UnsupportedOperationException | IOException | SecurityException e) {
-            log.debug("Could not carry the permissions of {} over to the replacement file", existing, e);
+            Files.setPosixFilePermissions(partial, targetPermissions);
+        } catch (final UnsupportedOperationException | SecurityException e) {
+            throw new IOException(
+                    "Could not reproduce the permissions of the configuration file being replaced; "
+                            + "the existing file has been left untouched",
+                    e);
         }
     }
 

--- a/hivemq-edge/src/main/java/com/hivemq/configuration/reader/ConfigFileReaderWriter.java
+++ b/hivemq-edge/src/main/java/com/hivemq/configuration/reader/ConfigFileReaderWriter.java
@@ -68,7 +68,6 @@ import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.AclEntry;
-import java.nio.file.attribute.AclEntryFlag;
 import java.nio.file.attribute.AclEntryPermission;
 import java.nio.file.attribute.AclEntryType;
 import java.nio.file.attribute.AclFileAttributeView;
@@ -781,11 +780,18 @@ public class ConfigFileReaderWriter {
      * normalises a permission mask, or hands back an inherited entry alongside the one just written would
      * have failed that comparison and refused every configuration write — on the only kind of store this
      * code path exists for, and in a way nothing off that platform can reproduce (EDG-882 review v04).
-     * The list is compared by what it decides instead, which is order- and flag-aware where those change
-     * the decision and indifferent to them where they do not. What has to be true is that nobody
-     * else can read the file while the credentials go into it: owner-only if the store took it, and
-     * otherwise no wider than the file about to be replaced, which the replacement is entitled to be
-     * because that is what it is about to become.
+     * {@link AclComparison} answers what the lists grant instead, over every token that could be presented
+     * to them, so a store may return the narrowing in whatever shape it likes and is held only to what it
+     * decided.
+     * <p>
+     * <b>Two acceptable outcomes, in order of preference.</b> Owner-only, when the store took the list it
+     * was given; otherwise no wider than the file about to be replaced, which the replacement is entitled
+     * to be because that is exactly what it is about to become. The second is not a weakening: a Windows
+     * directory that propagates entries to what is created inside it — {@code ProgramData} and most
+     * installation trees do — hands every new file an inherited list, and {@code setAcl} cannot mark a
+     * DACL protected through this API, so demanding owner-only would refuse every configuration write on
+     * an ordinary node. That is review v04's finding 2.1 in the other direction, and it is a fault, not a
+     * safeguard.
      */
     private static void narrowToItsOwner(final @NotNull Path partial, final @NotNull List<AclEntry> targetAcl)
             throws IOException {
@@ -809,10 +815,10 @@ public class ConfigFileReaderWriter {
                     e);
         }
         final List<AclEntry> actual = view.getAcl();
-        if (grantsNoMoreThan(actual, ownerOnly)) {
+        if (AclComparison.grantsNoMoreThan(actual, ownerOnly)) {
             return;
         }
-        if (grantsNoMoreThan(actual, targetAcl)) {
+        if (AclComparison.grantsNoMoreThan(actual, targetAcl)) {
             // Not owner-only, but no wider than the file it is about to replace -- which is the property
             // that matters: the replacement is never readable by anyone the configuration it replaces is
             // not, at any point while it holds the configuration. Worth saying out loud, because it means
@@ -828,84 +834,6 @@ public class ConfigFileReaderWriter {
         throw new IOException("The replacement for the configuration file is readable by principals the"
                 + " configuration file being replaced is not, so the configuration cannot be written into it;"
                 + " the existing file has been left untouched");
-    }
-
-    /**
-     * Whether an access-control list grants nobody anything that another one does not.
-     * <p>
-     * The question every check on this path actually wants to ask, and the only one that can be answered
-     * without knowing how a particular file store chooses to represent a list. It is asked of what each
-     * list <em>decides</em>, not of how it is written down: two lists that decide the same access are the
-     * same answer here whatever order their entries are in and however their permissions are split across
-     * entries.
-     * <p>
-     * Deciding is where order lives. A list is evaluated in sequence and the first entry that names a
-     * principal and mentions a permission settles that permission for that principal, so
-     * {@code DENY Alice READ} followed by {@code ALLOW Alice READ} keeps Alice out while the same two
-     * entries the other way round let her in — the same entries, opposite access (EDG-882 review v05,
-     * finding 1). {@link #effective} is that evaluation; the comparison then runs over its result.
-     * <p>
-     * Flags are read the same way. {@code FILE_INHERIT} and {@code DIRECTORY_INHERIT} govern what a
-     * <em>directory</em> propagates to what is created inside it, and the file being written propagates to
-     * nothing, so they change no answer here. {@code INHERIT_ONLY} is not one of those: it says the entry
-     * does not apply to the object carrying it, so such an entry decides nothing about this file and
-     * dropping it grants access the reference did not.
-     * <p>
-     * Conservative in both directions that can widen access: an {@code ALLOW} in effect that the reference
-     * does not have widens, and so does losing a {@code DENY} the reference has in effect, because a denial
-     * can be the only thing keeping a member of an allowed group out. Entries that are neither — audit and
-     * alarm entries — grant no access and are ignored.
-     */
-    @VisibleForTesting
-    static boolean grantsNoMoreThan(final @NotNull List<AclEntry> candidate, final @NotNull List<AclEntry> reference) {
-        return contains(effective(reference, AclEntryType.ALLOW), effective(candidate, AclEntryType.ALLOW))
-                && contains(effective(candidate, AclEntryType.DENY), effective(reference, AclEntryType.DENY));
-    }
-
-    /**
-     * The permissions each principal is actually left with by the entries of one type, once the list has
-     * been evaluated in order.
-     * <p>
-     * A permission belongs to the first entry that names the principal and mentions it; every later entry
-     * for that principal and permission has already been settled and cannot change it. Entries that do not
-     * apply to the object itself, and entries that grant nothing, take no part.
-     */
-    private static @NotNull Map<UserPrincipal, Set<AclEntryPermission>> effective(
-            final @NotNull List<AclEntry> acl, final @NotNull AclEntryType type) {
-        final Map<UserPrincipal, Set<AclEntryPermission>> settled = new HashMap<>();
-        final Map<UserPrincipal, Set<AclEntryPermission>> ofThisType = new HashMap<>();
-        for (final AclEntry entry : acl) {
-            if (entry.type() != AclEntryType.ALLOW && entry.type() != AclEntryType.DENY) {
-                continue;
-            }
-            if (entry.flags().contains(AclEntryFlag.INHERIT_ONLY)) {
-                continue;
-            }
-            final Set<AclEntryPermission> alreadySettled =
-                    settled.computeIfAbsent(entry.principal(), principal -> EnumSet.noneOf(AclEntryPermission.class));
-            final Set<AclEntryPermission> decidedHere = EnumSet.noneOf(AclEntryPermission.class);
-            decidedHere.addAll(entry.permissions());
-            decidedHere.removeAll(alreadySettled);
-            if (entry.type() == type) {
-                ofThisType
-                        .computeIfAbsent(entry.principal(), principal -> EnumSet.noneOf(AclEntryPermission.class))
-                        .addAll(decidedHere);
-            }
-            alreadySettled.addAll(decidedHere);
-        }
-        return ofThisType;
-    }
-
-    /** Whether every principal in {@code subset} is given no more there than {@code superset} gives it. */
-    private static boolean contains(
-            final @NotNull Map<UserPrincipal, Set<AclEntryPermission>> superset,
-            final @NotNull Map<UserPrincipal, Set<AclEntryPermission>> subset) {
-        for (final Map.Entry<UserPrincipal, Set<AclEntryPermission>> granted : subset.entrySet()) {
-            if (!superset.getOrDefault(granted.getKey(), Set.of()).containsAll(granted.getValue())) {
-                return false;
-            }
-        }
-        return true;
     }
 
     /**
@@ -1059,12 +987,12 @@ public class ConfigFileReaderWriter {
         if (preserved.acl() != null) {
             final AclFileAttributeView aclView = Files.getFileAttributeView(partial, AclFileAttributeView.class);
             final List<AclEntry> actualAcl = aclView == null ? null : aclView.getAcl();
-            if (actualAcl == null || !grantsNoMoreThan(actualAcl, preserved.acl())) {
+            if (actualAcl == null || !AclComparison.grantsNoMoreThan(actualAcl, preserved.acl())) {
                 throw new IOException("The replacement's access-control list grants access the configuration file being"
                         + " replaced does not: it is " + actualAcl + " where that file has "
                         + preserved.acl() + "; the existing file has been left untouched");
             }
-            if (!grantsNoMoreThan(preserved.acl(), actualAcl)) {
+            if (!AclComparison.grantsNoMoreThan(preserved.acl(), actualAcl)) {
                 // Narrower than the file it replaces. Nobody gains anything, so this is not the disclosure
                 // the check is here for -- but someone who could read the configuration no longer can, and
                 // that is not something to find out later.

--- a/hivemq-edge/src/main/java/com/hivemq/configuration/reader/ConfigFileReaderWriter.java
+++ b/hivemq-edge/src/main/java/com/hivemq/configuration/reader/ConfigFileReaderWriter.java
@@ -376,6 +376,21 @@ public class ConfigFileReaderWriter {
             if (entity.getGatewayConfig().isMutableConfigurationEnabled()) {
                 writeConfigToXML();
             }
+        } catch (final UnrecoverableException refused) {
+            // A deliberate refusal: something on the write path would have had to put a credential on disk,
+            // or replace a good configuration file with one whose protections it could not reproduce, and
+            // stopped instead. The reason is in the error logged immediately above this one by whichever
+            // check made the decision; what is added here is the consequence, because nothing else says it.
+            //
+            // The caller is not told. A REST change that cannot be persisted still answers success, and
+            // this log line is the only place an operator can learn that config.xml no longer matches the
+            // node. Telling the caller instead means deciding what every configuration endpoint should
+            // return when the file cannot be written, which is a larger change than this one (EDG-882
+            // review v04).
+            log.error("The configuration was not written to config.xml -- the reason is the error logged just"
+                    + " above. This node keeps running on the configuration it already holds and is correct,"
+                    + " but config.xml no longer matches it: a restart would come up on the older"
+                    + " configuration, and the change that triggered this write would be lost.");
         } catch (final Exception e) {
             log.error("Configuration file sync failed: ", e);
         } finally {

--- a/hivemq-edge/src/main/java/com/hivemq/configuration/reader/ConfigFileReaderWriter.java
+++ b/hivemq-edge/src/main/java/com/hivemq/configuration/reader/ConfigFileReaderWriter.java
@@ -455,7 +455,6 @@ public class ConfigFileReaderWriter {
             final StringWriter rendered = new StringWriter();
             writeConfigToXML(rendered);
 
-            backupConfig(file, doBackup); // write the backup of the file before rewriting
             // The real path, not the configured one: replacing a path is replacing whatever the last
             // component *is*, so when config.xml is a symbolic link -- a mounted configuration
             // directory, an operator's link into a versioned tree -- the move would delete the link and
@@ -464,6 +463,21 @@ public class ConfigFileReaderWriter {
             // which is what ATOMIC_MOVE needs.
             final Path configured = file.toPath();
             final Path target = Files.exists(configured) ? configured.toRealPath() : configured;
+            // Only a file this process could have written in place. Replacing by move needs permission on
+            // the directory, not on the file, so without this a configuration an operator write-protected
+            // -- root-owned, or read-only on purpose -- would be replaced anyway, and quietly change owner
+            // in the process. Writing in place refused it, and so does this (EDG-882 review v04).
+            if (Files.exists(target) && !Files.isWritable(target)) {
+                log.error(
+                        "The configuration file {} is not writable by this node, so the configuration has not"
+                                + " been persisted. The replacement is written beside it and moved onto it, which"
+                                + " needs no permission on the file itself -- overwriting one this node may not"
+                                + " change is not something to do quietly. This node keeps running on the"
+                                + " configuration it already holds.",
+                        target);
+                throw new UnrecoverableException(false);
+            }
+            backupConfig(file, doBackup); // write the backup of the file before rewriting
             replaceCarryingProtections(target, preservedAttributesOf(target), partial -> {
                 try (final FileWriter writer = new FileWriter(partial.toFile(), StandardCharsets.UTF_8)) {
                     writer.write(rendered.toString());
@@ -615,6 +629,12 @@ public class ConfigFileReaderWriter {
 
         boolean nothingToReproduce() {
             return permissions == null && owner == null && group == null && acl == null;
+        }
+
+        /** The same protections, minus a claim to have reproduced the owner. */
+        @NotNull
+        PreservedAttributes withoutOwner() {
+            return new PreservedAttributes(permissions, null, group, acl);
         }
     }
 
@@ -789,11 +809,19 @@ public class ConfigFileReaderWriter {
      * mode last. Setting the mode first would open a window in which the file is already group- or
      * world-readable but still owned by the wrong principals.
      * <p>
-     * Throws rather than warns, at every step. The alternative — carry what you can, move it either way —
-     * is what R3-07 and R3-09 reported between them: a failure leaves a file full of credentials with the
-     * umask's mode and the creating process's group, permanently, announced at debug level. Refusing the
-     * replacement keeps the previous configuration file, which is intact, correctly permissioned and
-     * still the one the running node matches.
+     * Throws rather than warns, at every step but one. The alternative — carry what you can, move it
+     * either way — is what R3-07 and R3-09 reported between them: a failure leaves a file full of
+     * credentials with the umask's mode and the creating process's group, permanently, announced at debug
+     * level. Refusing the replacement keeps the previous configuration file, which is intact, correctly
+     * permissioned and still the one the running node matches.
+     * <p>
+     * The exception is the owner, which is not the node's to set: changing it is privileged everywhere
+     * this runs, so refusing on it meant a configuration installed by one account and served by another
+     * could never be written at all. It falls back to this node's own account with a warning, because the
+     * account that just rendered the document already holds every credential in it — while the mode, the
+     * group and the access-control list, which are what decide who <em>else</em> can read the file, keep
+     * refusing. A file this node may not write in the first place never gets here: {@code writeConfigToXML}
+     * turns that away before anything is written.
      */
     @VisibleForTesting
     static void applyPreservedAttributes(final @NotNull Path partial, final @NotNull PreservedAttributes preserved)
@@ -801,6 +829,9 @@ public class ConfigFileReaderWriter {
         if (preserved.nothingToReproduce()) {
             return;
         }
+        // What the verification below is entitled to insist on: everything, unless the owner turned out
+        // not to be this node's to set.
+        PreservedAttributes proven = preserved;
         try {
             // Owner through the owner view, not the POSIX one: an ACL-only store has an owner and no
             // mode, and reading it through the POSIX view meant it was never restored there at all
@@ -817,7 +848,28 @@ public class ConfigFileReaderWriter {
                     throw new IOException("The replacement cannot carry an owner on this file store");
                 }
                 if (!preserved.owner().equals(partialOwner.getOwner())) {
-                    partialOwner.setOwner(preserved.owner());
+                    try {
+                        partialOwner.setOwner(preserved.owner());
+                    } catch (final UnsupportedOperationException | SecurityException | IOException notPermitted) {
+                        // The one protection that is not the node's to reproduce. Changing a file's owner
+                        // is privileged on every platform this runs on, so a configuration installed by
+                        // one account and served by another -- root-owned config.xml, service user running
+                        // Edge -- made every write fail, and the node silently stopped persisting anything
+                        // (EDG-882 review v04). The mode, the group and any access-control list are still
+                        // reproduced exactly or the write is refused, and those are what decide who else
+                        // can read the file; the owner it falls back to is the account that just rendered
+                        // the configuration and therefore already holds every credential in it.
+                        log.warn(
+                                "The replacement for {} could not be given the owner of the file it replaces"
+                                        + " ('{}'), so it is owned by this node's own account instead. Its mode,"
+                                        + " group and access-control list are unchanged, so no one else gains"
+                                        + " access -- but if the owner matters here, set it back and check what"
+                                        + " installed the file.",
+                                partial,
+                                preserved.owner().getName(),
+                                notPermitted);
+                        proven = preserved.withoutOwner();
+                    }
                 }
             }
             if (preserved.group() != null) {
@@ -848,7 +900,7 @@ public class ConfigFileReaderWriter {
                             + "the existing file has been left untouched",
                     e);
         }
-        verifyPreservedAttributes(partial, preserved);
+        verifyPreservedAttributes(partial, proven);
     }
 
     /**

--- a/hivemq-edge/src/main/java/com/hivemq/configuration/reader/ConfigFileReaderWriter.java
+++ b/hivemq-edge/src/main/java/com/hivemq/configuration/reader/ConfigFileReaderWriter.java
@@ -539,11 +539,12 @@ public class ConfigFileReaderWriter {
         try {
             createPartialFile(partial, preserved);
             content.writeTo(partial);
-            // Widened to exactly the target's protections only once the content is on disk, so the file is
-            // never wider than its eventual self while it is being filled. A failure here aborts the
-            // replacement: moving a file whose protections could not be reproduced would either widen a
-            // deliberately restricted config.xml or narrow one an operator shares deliberately, and the
-            // original on disk is still valid and still correct.
+            // Widened to the target's protections only once the content is on disk, so the file is never
+            // wider than its eventual self while it is being filled. Never wider than the target either:
+            // a protection this node cannot set -- the owner, or a group it is not in -- narrows the
+            // replacement instead of widening it, and anything else aborts, because moving a file whose
+            // protections could not be reproduced would open a deliberately restricted config.xml while
+            // the original on disk is still valid and still correct.
             applyPreservedAttributes(partial, preserved);
             try {
                 Files.move(partial, target, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
@@ -602,6 +603,14 @@ public class ConfigFileReaderWriter {
             Collections.unmodifiableSet(EnumSet.of(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE));
 
     /**
+     * Everything a mode can grant to the file's group: what comes off it when the replacement could not be
+     * given the group of the file it replaces, so that the mode never grants to this node's own group what
+     * it was meant to grant to that one.
+     */
+    private static final @NotNull Set<PosixFilePermission> GROUP_PERMISSIONS = Collections.unmodifiableSet(EnumSet.of(
+            PosixFilePermission.GROUP_READ, PosixFilePermission.GROUP_WRITE, PosixFilePermission.GROUP_EXECUTE));
+
+    /**
      * Everything about the file being replaced that decides who can read it.
      * <p>
      * The mode alone is not that. {@code 0640} names a group without naming <em>which</em> group, and a
@@ -636,6 +645,38 @@ public class ConfigFileReaderWriter {
         PreservedAttributes withoutOwner() {
             return new PreservedAttributes(permissions, null, group, acl);
         }
+
+        /**
+         * The same protections, minus a claim to have reproduced the group <em>and</em> minus everything
+         * the mode would have granted through it.
+         * <p>
+         * The two are one protection. {@code 0640} says "the group may read" without saying which group,
+         * so dropping the group while keeping the mode is precisely R3-09: group-read of a file full of
+         * credentials, granted to whichever group this node happens to belong to instead of the one the
+         * operator chose. Dropping both leaves the replacement granting the group nothing, which is
+         * narrower than the file it replaces rather than wider.
+         * <p>
+         * Only the group's own bits come off. The owner's are this node's either way, and what the mode
+         * grants to others is granted to the same others on the file being replaced, so removing those
+         * would take away access the operator deliberately gave.
+         */
+        @NotNull
+        PreservedAttributes withoutGroupAccess() {
+            if (permissions == null) {
+                return new PreservedAttributes(null, owner, null, acl);
+            }
+            // Built empty and added to, rather than EnumSet.copyOf, which throws on an empty collection
+            // that is not itself an EnumSet -- and the mode of a file nobody may read is exactly that.
+            final EnumSet<PosixFilePermission> withoutTheGroups = EnumSet.noneOf(PosixFilePermission.class);
+            withoutTheGroups.addAll(permissions);
+            withoutTheGroups.removeAll(GROUP_PERMISSIONS);
+            return new PreservedAttributes(Collections.unmodifiableSet(withoutTheGroups), owner, null, acl);
+        }
+    }
+
+    /** Whether a mode grants the file's group anything at all. */
+    private static boolean grantsAnythingToGroup(final @Nullable Set<PosixFilePermission> permissions) {
+        return permissions != null && !Collections.disjoint(permissions, GROUP_PERMISSIONS);
     }
 
     /**
@@ -844,19 +885,38 @@ public class ConfigFileReaderWriter {
      * mode last. Setting the mode first would open a window in which the file is already group- or
      * world-readable but still owned by the wrong principals.
      * <p>
-     * Throws rather than warns, at every step but one. The alternative — carry what you can, move it
-     * either way — is what R3-07 and R3-09 reported between them: a failure leaves a file full of
-     * credentials with the umask's mode and the creating process's group, permanently, announced at debug
-     * level. Refusing the replacement keeps the previous configuration file, which is intact, correctly
-     * permissioned and still the one the running node matches.
+     * <b>What is guaranteed is that the replacement is never more accessible than the file it replaces —
+     * not that every protection is reproduced exactly.</b> Both extremes are defects and both have been
+     * shipped here. Carrying what you can and moving it either way is R3-07 and R3-09 between them: a
+     * failure left a file full of credentials with the umask's mode and the creating process's group,
+     * permanently, announced at debug level. Refusing the replacement outright is the other, and it is not
+     * free — it is the <em>write</em> that is refused, so the configuration the operator just asked for is
+     * not persisted, and the node goes on running correctly until a restart brings back the older file
+     * without it. Where a protection cannot be reproduced, this narrows instead: the replacement is given
+     * less than the file it replaces rather than more, and the write goes on.
      * <p>
-     * The exception is the owner, which is not the node's to set: changing it is privileged everywhere
-     * this runs, so refusing on it meant a configuration installed by one account and served by another
-     * could never be written at all. It falls back to this node's own account with a warning, because the
-     * account that just rendered the document already holds every credential in it — while the mode, the
-     * group and the access-control list, which are what decide who <em>else</em> can read the file, keep
-     * refusing. A file this node may not write in the first place never gets here: {@code writeConfigToXML}
-     * turns that away before anything is written.
+     * Two protections are not this node's to set, and each narrows in its own way.
+     * <ul>
+     * <li><b>The owner.</b> Changing it is privileged everywhere this runs, so refusing on it meant a
+     * configuration installed by one account and served by another could never be written at all
+     * (EDG-882 review v04). It falls back to this node's own account, which discloses nothing: the account
+     * that just rendered the document already holds every credential in it.</li>
+     * <li><b>The group.</b> Setting it requires membership of it, so the ordinary container case — a
+     * {@code config.xml} installed under one group, Edge running under another — failed here and stopped
+     * the node persisting anything at all, found in QA on this branch. Keeping the mode while the group
+     * falls back to this process's own is exactly R3-09's disclosure, so the group's permissions come off
+     * the mode with it: the replacement grants the group nothing rather than granting it to the wrong
+     * principals. Nobody gains, someone may lose, and that is said out loud.</li>
+     * </ul>
+     * <p>
+     * The mode and the access-control list keep refusing. Neither can fail the way those two do — both are
+     * set on a file this process created and owns, which is all either call asks for — so a failure there
+     * is the store saying something is wrong, not a privilege this node was never going to have.
+     * <p>
+     * What is applied is taken from what has been proved rather than from what was asked for, so a
+     * protection that could not be reproduced cannot be granted back through another one. A file this node
+     * may not write in the first place never gets here: {@code writeConfigToXML} turns that away before
+     * anything is written.
      */
     @VisibleForTesting
     static void applyPreservedAttributes(final @NotNull Path partial, final @NotNull PreservedAttributes preserved)
@@ -864,8 +924,8 @@ public class ConfigFileReaderWriter {
         if (preserved.nothingToReproduce()) {
             return;
         }
-        // What the verification below is entitled to insist on: everything, unless the owner turned out
-        // not to be this node's to set.
+        // What the verification below is entitled to insist on, and what the mode at the end is taken
+        // from: everything, less whatever turned out not to be this node's to set.
         PreservedAttributes proven = preserved;
         try {
             // Owner through the owner view, not the POSIX one: an ACL-only store has an owner and no
@@ -903,7 +963,7 @@ public class ConfigFileReaderWriter {
                                 partial,
                                 preserved.owner().getName(),
                                 notPermitted);
-                        proven = preserved.withoutOwner();
+                        proven = proven.withoutOwner();
                     }
                 }
             }
@@ -914,7 +974,44 @@ public class ConfigFileReaderWriter {
                     throw new IOException("The replacement cannot carry a group on this file store");
                 }
                 if (!preserved.group().equals(partialPosix.readAttributes().group())) {
-                    partialPosix.setGroup(preserved.group());
+                    try {
+                        partialPosix.setGroup(preserved.group());
+                    } catch (final UnsupportedOperationException | SecurityException | IOException notPermitted) {
+                        // Setting a file's group requires membership of it, so the ordinary container case
+                        // -- config.xml installed under one group, Edge running under another -- refused
+                        // the whole write here. The node then went on running correctly while persisting
+                        // nothing at all, and every REST change since the last restart was lost on the
+                        // next one (found in QA on this branch).
+                        //
+                        // Dropping the group takes the mode's group permissions with it. Keeping them
+                        // would grant group-read of every credential in the configuration to whichever
+                        // group this node belongs to, which is R3-09 in the one place it still could
+                        // happen. The verification below is told not to insist on either.
+                        proven = proven.withoutGroupAccess();
+                        if (grantsAnythingToGroup(preserved.permissions())) {
+                            log.warn(
+                                    "The replacement for {} could not be given the group of the file it replaces"
+                                            + " ('{}'), so the permissions that mode grants to the group have been"
+                                            + " removed from it rather than handed to this node's own group. The"
+                                            + " configuration is still written and nobody gains access, but"
+                                            + " principals that could read it through that group no longer can."
+                                            + " Add this node's account to that group, or give the file a group it"
+                                            + " is already in, to keep it readable.",
+                                    partial,
+                                    preserved.group().getName(),
+                                    notPermitted);
+                        } else {
+                            // The mode grants the group nothing, so which group it names decides nobody's
+                            // access and dropping it costs nothing. Not worth a warning on every write.
+                            log.debug(
+                                    "The replacement for {} could not be given the group of the file it replaces"
+                                            + " ('{}'). That file's mode grants its group nothing, so no principal"
+                                            + " gains or loses access.",
+                                    partial,
+                                    preserved.group().getName(),
+                                    notPermitted);
+                        }
+                    }
                 }
             }
             if (preserved.acl() != null) {
@@ -926,8 +1023,10 @@ public class ConfigFileReaderWriter {
                     partialAcl.setAcl(preserved.acl());
                 }
             }
-            if (preserved.permissions() != null) {
-                Files.setPosixFilePermissions(partial, preserved.permissions());
+            // From what was proved, not from what was asked for: if the group could not be reproduced, the
+            // permissions it would have had are no longer in here to grant.
+            if (proven.permissions() != null) {
+                Files.setPosixFilePermissions(partial, proven.permissions());
             }
         } catch (final UnsupportedOperationException | SecurityException | IOException e) {
             throw new IOException(

--- a/hivemq-edge/src/main/java/com/hivemq/configuration/reader/ConfigFileReaderWriter.java
+++ b/hivemq-edge/src/main/java/com/hivemq/configuration/reader/ConfigFileReaderWriter.java
@@ -66,8 +66,11 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.AclEntry;
+import java.nio.file.attribute.AclEntryPermission;
+import java.nio.file.attribute.AclEntryType;
 import java.nio.file.attribute.AclFileAttributeView;
 import java.nio.file.attribute.BasicFileAttributeView;
+import java.nio.file.attribute.FileOwnerAttributeView;
 import java.nio.file.attribute.GroupPrincipal;
 import java.nio.file.attribute.PosixFileAttributeView;
 import java.nio.file.attribute.PosixFileAttributes;
@@ -522,7 +525,9 @@ public class ConfigFileReaderWriter {
      * @param permissions the POSIX mode, or {@code null} on a store with no POSIX view
      * @param owner       the owning principal, or {@code null} when the store exposes none
      * @param group       the owning group, or {@code null} on a store with no POSIX view
-     * @param acl         the access-control list, or {@code null} on a store that has no ACL view
+     * @param acl         the access-control list -- empty when the file has one that grants nobody
+     *                    anything, which is a protection in its own right -- or {@code null} on a store
+     *                    that has no ACL view
      */
     @VisibleForTesting
     record PreservedAttributes(
@@ -580,15 +585,14 @@ public class ConfigFileReaderWriter {
         final AclFileAttributeView aclView = Files.getFileAttributeView(path, AclFileAttributeView.class);
         if (aclView != null) {
             try {
-                final List<AclEntry> entries = aclView.getAcl();
-                // Only a non-empty list is worth carrying. Several stores expose an ACL view for every
-                // file and answer with an empty list when none is set; reproducing that would mean an
-                // otherwise pointless setAcl on the ordinary path, which can fail for its own reasons and
-                // would then refuse a write that had nothing to preserve in the first place.
-                acl = entries.isEmpty() ? null : entries;
-                if (owner == null) {
-                    owner = aclView.getOwner();
-                }
+                // An empty list is a value, not an absence. An access-control list that grants nobody
+                // anything is exactly what is on a file only its owner may read, and the previous version
+                // discarded it as "nothing to carry" -- which left the replacement with whatever the
+                // containing directory's inheritance produced, on the one file where that matters most
+                // (EDG-882 review v04). Reproducing it costs nothing on stores that answer empty for every
+                // file, because applyPreservedAttributes only calls setAcl when the replacement's own list
+                // differs.
+                acl = List.copyOf(aclView.getAcl());
             } catch (final NoSuchFileException absent) {
                 return PreservedAttributes.NONE;
             } catch (final IOException | SecurityException e) {
@@ -600,12 +604,30 @@ public class ConfigFileReaderWriter {
             }
         }
 
-        if (posixView == null && aclView == null) {
+        // Through the owner view rather than the POSIX one, because a store can have an owner without
+        // having a mode: on an ACL-only store the owner was previously read only as a side effect of the
+        // ACL block, and never restored at all (EDG-882 review v04).
+        final FileOwnerAttributeView ownerView = Files.getFileAttributeView(path, FileOwnerAttributeView.class);
+        if (owner == null && ownerView != null) {
+            try {
+                owner = ownerView.getOwner();
+            } catch (final NoSuchFileException absent) {
+                return PreservedAttributes.NONE;
+            } catch (final IOException | SecurityException e) {
+                throw new IOException(
+                        "Could not read the owner of the configuration file being replaced, so a replacement"
+                                + " carrying the same protections cannot be produced; the existing file has been"
+                                + " left untouched",
+                        e);
+            }
+        }
+
+        if (posixView == null && aclView == null && ownerView == null) {
             // A store that exposes neither view has no protections a replacement could get wrong.
             if (!Files.exists(path)) {
                 return PreservedAttributes.NONE;
             }
-            log.debug("{} is on a file store with no POSIX or ACL view; nothing to reproduce", path);
+            log.debug("{} is on a file store with no POSIX, ACL or owner view; nothing to reproduce", path);
             return PreservedAttributes.NONE;
         }
         return new PreservedAttributes(permissions, owner, group, acl);
@@ -620,6 +642,19 @@ public class ConfigFileReaderWriter {
      * the file exists and is readable by anyone else. With nothing to reproduce, it is created normally
      * and takes the umask, which is what a first-time configuration file would have had anyway.
      * <p>
+     * On a store with no mode at all — Windows and any other ACL-only file system — there is no such
+     * attribute to create it with, and the previous version simply created the file with whatever the
+     * containing directory's inheritance grants and wrote every credential in the configuration into it
+     * (EDG-882 review v04). It is instead narrowed to its own owner, in a file that is still empty,
+     * before any caller can write a byte of the configuration into it; the narrowing is proved before
+     * this returns, so a store that accepts the call and does something else does not get the secrets
+     * either.
+     * <p>
+     * That narrowing is not the target's own list: an access-control list naming a principal this
+     * process is not would either lock the writer out of the file it just created, or — where the target
+     * is readable by others — leave the replacement open to them for the whole write, which is the defect
+     * itself. The window that remains holds an empty file.
+     * <p>
      * A partial file left behind by a killed process is deleted rather than reused: reopening it would
      * inherit whatever mode <em>it</em> was left with.
      */
@@ -627,10 +662,48 @@ public class ConfigFileReaderWriter {
     static void createPartialFile(final @NotNull Path partial, final @NotNull PreservedAttributes preserved)
             throws IOException {
         Files.deleteIfExists(partial);
-        if (preserved.nothingToReproduce() || preserved.permissions() == null) {
-            Files.createFile(partial);
-        } else {
+        if (preserved.permissions() != null) {
             Files.createFile(partial, PosixFilePermissions.asFileAttribute(OWNER_ONLY));
+        } else {
+            // Nothing to reproduce, or a store that has no mode. The file takes the store's own default,
+            // exactly as a first-time configuration file would -- and is narrowed below when the store
+            // expresses protection as a list instead.
+            Files.createFile(partial);
+        }
+        if (preserved.acl() != null) {
+            narrowToItsOwner(partial);
+        }
+    }
+
+    /**
+     * Replaces the inherited access-control list of the just-created, still-empty replacement with one
+     * that grants its own owner everything and everyone else nothing, and refuses to go on if that did
+     * not take.
+     */
+    private static void narrowToItsOwner(final @NotNull Path partial) throws IOException {
+        final AclFileAttributeView view = Files.getFileAttributeView(partial, AclFileAttributeView.class);
+        if (view == null) {
+            throw new IOException("The replacement for the configuration file cannot be given an access-control"
+                    + " list on this file store, so it cannot be written without disclosing the configuration;"
+                    + " the existing file has been left untouched");
+        }
+        final List<AclEntry> ownerOnly = List.of(AclEntry.newBuilder()
+                .setType(AclEntryType.ALLOW)
+                .setPrincipal(view.getOwner())
+                .setPermissions(EnumSet.allOf(AclEntryPermission.class))
+                .build());
+        try {
+            view.setAcl(ownerOnly);
+        } catch (final UnsupportedOperationException | SecurityException | IOException e) {
+            throw new IOException(
+                    "The replacement for the configuration file could not be restricted to its owner before"
+                            + " being written; the existing file has been left untouched",
+                    e);
+        }
+        if (!ownerOnly.equals(view.getAcl())) {
+            throw new IOException("The replacement for the configuration file did not keep the access-control"
+                    + " list restricting it to its owner, so the configuration cannot be written into it;"
+                    + " the existing file has been left untouched");
         }
     }
 
@@ -655,18 +728,31 @@ public class ConfigFileReaderWriter {
             return;
         }
         try {
-            final PosixFileAttributeView partialPosix =
-                    Files.getFileAttributeView(partial, PosixFileAttributeView.class);
-            if (partialPosix != null) {
-                // Only when they differ. Changing owner is a privileged operation on every platform this
-                // runs on, and changing group requires membership; asking for a change that is already
-                // true would fail for no reason on the ordinary path, where the node replaces a file it
-                // owns.
-                final PosixFileAttributes current = partialPosix.readAttributes();
-                if (preserved.owner() != null && !preserved.owner().equals(current.owner())) {
-                    partialPosix.setOwner(preserved.owner());
+            // Owner through the owner view, not the POSIX one: an ACL-only store has an owner and no
+            // mode, and reading it through the POSIX view meant it was never restored there at all
+            // (EDG-882 review v04).
+            //
+            // Only when they differ, here and below. Changing owner is a privileged operation on every
+            // platform this runs on, and changing group requires membership; asking for a change that is
+            // already true would fail for no reason on the ordinary path, where the node replaces a file
+            // it owns.
+            if (preserved.owner() != null) {
+                final FileOwnerAttributeView partialOwner =
+                        Files.getFileAttributeView(partial, FileOwnerAttributeView.class);
+                if (partialOwner == null) {
+                    throw new IOException("The replacement cannot carry an owner on this file store");
                 }
-                if (preserved.group() != null && !preserved.group().equals(current.group())) {
+                if (!preserved.owner().equals(partialOwner.getOwner())) {
+                    partialOwner.setOwner(preserved.owner());
+                }
+            }
+            if (preserved.group() != null) {
+                final PosixFileAttributeView partialPosix =
+                        Files.getFileAttributeView(partial, PosixFileAttributeView.class);
+                if (partialPosix == null) {
+                    throw new IOException("The replacement cannot carry a group on this file store");
+                }
+                if (!preserved.group().equals(partialPosix.readAttributes().group())) {
                     partialPosix.setGroup(preserved.group());
                 }
             }
@@ -675,7 +761,9 @@ public class ConfigFileReaderWriter {
                 if (partialAcl == null) {
                     throw new IOException("The replacement cannot carry an access-control list on this file store");
                 }
-                partialAcl.setAcl(preserved.acl());
+                if (!preserved.acl().equals(partialAcl.getAcl())) {
+                    partialAcl.setAcl(preserved.acl());
+                }
             }
             if (preserved.permissions() != null) {
                 Files.setPosixFilePermissions(partial, preserved.permissions());
@@ -698,33 +786,52 @@ public class ConfigFileReaderWriter {
      * worth checking rather than assuming, because the cost of it being wrong is every credential in the
      * configuration.
      */
-    private static void verifyPreservedAttributes(
-            final @NotNull Path partial, final @NotNull PreservedAttributes preserved) throws IOException {
-        final PosixFileAttributeView view = Files.getFileAttributeView(partial, PosixFileAttributeView.class);
-        if (view == null) {
-            return;
+    @VisibleForTesting
+    static void verifyPreservedAttributes(final @NotNull Path partial, final @NotNull PreservedAttributes preserved)
+            throws IOException {
+        // Every attribute that was carried, whichever view expresses it. The previous version read the
+        // POSIX view and returned when there was none, so on an ACL-only store it verified nothing at all
+        // (EDG-882 review v04). The access-control list is checked here rather than where it is applied
+        // because the mode is set after it: on a store that has both, a chmod can rewrite the mask of the
+        // list that was just applied, and the file's protection is whatever survives that.
+        final PosixFileAttributeView posixView = Files.getFileAttributeView(partial, PosixFileAttributeView.class);
+        if (posixView != null) {
+            final PosixFileAttributes actual = posixView.readAttributes();
+            if (preserved.permissions() != null && !preserved.permissions().equals(actual.permissions())) {
+                throw new IOException("The replacement's permissions are "
+                        + PosixFilePermissions.toString(actual.permissions())
+                        + " but the configuration file being replaced has "
+                        + PosixFilePermissions.toString(preserved.permissions())
+                        + "; the existing file has been left untouched");
+            }
+            if (preserved.group() != null && !preserved.group().equals(actual.group())) {
+                throw new IOException(
+                        "The replacement's group is '" + actual.group().getName() + "' but the"
+                                + " configuration file being replaced has group '"
+                                + preserved.group().getName()
+                                + "'; the existing file has been left untouched");
+            }
         }
-        final PosixFileAttributes actual = view.readAttributes();
-        if (preserved.permissions() != null && !preserved.permissions().equals(actual.permissions())) {
-            throw new IOException("The replacement's permissions are "
-                    + PosixFilePermissions.toString(actual.permissions())
-                    + " but the configuration file being replaced has "
-                    + PosixFilePermissions.toString(preserved.permissions())
-                    + "; the existing file has been left untouched");
+        if (preserved.owner() != null) {
+            final FileOwnerAttributeView ownerView = Files.getFileAttributeView(partial, FileOwnerAttributeView.class);
+            final UserPrincipal actualOwner = ownerView == null ? null : ownerView.getOwner();
+            if (!preserved.owner().equals(actualOwner)) {
+                throw new IOException(
+                        "The replacement is owned by '" + (actualOwner == null ? "nobody" : actualOwner.getName())
+                                + "' but the configuration file being replaced is owned by '"
+                                + preserved.owner().getName()
+                                + "'; the existing file has been left untouched");
+            }
         }
-        if (preserved.owner() != null && !preserved.owner().equals(actual.owner())) {
-            throw new IOException(
-                    "The replacement is owned by '" + actual.owner().getName() + "' but the"
-                            + " configuration file being replaced is owned by '"
-                            + preserved.owner().getName()
-                            + "'; the existing file has been left untouched");
-        }
-        if (preserved.group() != null && !preserved.group().equals(actual.group())) {
-            throw new IOException(
-                    "The replacement's group is '" + actual.group().getName() + "' but the"
-                            + " configuration file being replaced has group '"
-                            + preserved.group().getName()
-                            + "'; the existing file has been left untouched");
+        if (preserved.acl() != null) {
+            final AclFileAttributeView aclView = Files.getFileAttributeView(partial, AclFileAttributeView.class);
+            final List<AclEntry> actualAcl = aclView == null ? null : aclView.getAcl();
+            if (!preserved.acl().equals(actualAcl)) {
+                throw new IOException(
+                        "The replacement's access-control list is " + actualAcl + " but the configuration file"
+                                + " being replaced has " + preserved.acl()
+                                + "; the existing file has been left untouched");
+            }
         }
     }
 

--- a/hivemq-edge/src/main/java/com/hivemq/configuration/reader/ConfigFileReaderWriter.java
+++ b/hivemq-edge/src/main/java/com/hivemq/configuration/reader/ConfigFileReaderWriter.java
@@ -53,6 +53,7 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.io.StringWriter;
 import java.io.Writer;
 import java.net.URL;
@@ -65,6 +66,7 @@ import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.AclEntry;
 import java.nio.file.attribute.AclEntryPermission;
 import java.nio.file.attribute.AclEntryType;
@@ -103,7 +105,6 @@ import javax.xml.XMLConstants;
 import javax.xml.transform.stream.StreamSource;
 import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
-import org.apache.commons.io.FileUtils;
 import org.glassfish.jaxb.runtime.v2.runtime.IllegalAnnotationsException;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -440,15 +441,6 @@ public class ConfigFileReaderWriter {
             writeConfigToXML(rendered);
 
             backupConfig(file, doBackup); // write the backup of the file before rewriting
-            // Written beside the target and moved onto it, rather than opened and written in place.
-            // Rendering first closed the "schema validation fails half way" case; opening the real file
-            // still truncates it, so a crash, a full disk or a killed process between open and close left
-            // a config.xml cut off mid-element. There is a backup, but nothing restores it on its own and
-            // the node does not start (EDG-882 review v02, R2-08).
-            //
-            // Same directory on purpose: ATOMIC_MOVE is only guaranteed within a file store, and the
-            // temporary file has to be one the configuration watcher will not try to parse.
-            //
             // The real path, not the configured one: replacing a path is replacing whatever the last
             // component *is*, so when config.xml is a symbolic link -- a mounted configuration
             // directory, an operator's link into a versioned tree -- the move would delete the link and
@@ -457,51 +449,118 @@ public class ConfigFileReaderWriter {
             // which is what ATOMIC_MOVE needs.
             final Path configured = file.toPath();
             final Path target = Files.exists(configured) ? configured.toRealPath() : configured;
-            final Path partial = target.resolveSibling(target.getFileName() + ".partial");
-            try {
-                // The replacement's mode is settled before a single byte of it is written, not after.
-                //
-                // The rendered document holds bridge passwords, keystore and truststore passwords and
-                // adapter credentials. A file created by FileWriter takes this process's umask, so on a
-                // 022 umask the first version of this change created a world-readable 0644 file,
-                // populated it with every secret in the configuration, closed it, and only then narrowed
-                // it to the mode of the file it was about to replace. Any local principal reading the
-                // directory during that window got the lot -- on every REST write to any subsystem.
-                //
-                // That window did not exist before this branch: writing in place reused config.xml's own
-                // inode and therefore its own mode, so the secrets never touched a wider file. It is a
-                // disclosure this change would have introduced, which is why it fails closed rather than
-                // best-effort (EDG-882 review v03, R3-07).
-                final PreservedAttributes preserved = preservedAttributesOf(target);
-                createPartialFile(partial, preserved);
+            replaceCarryingProtections(target, preservedAttributesOf(target), partial -> {
                 try (final FileWriter writer = new FileWriter(partial.toFile(), StandardCharsets.UTF_8)) {
                     writer.write(rendered.toString());
                     writer.flush();
                 }
-                // Widened to exactly the target's protections only once the content is on disk, so the
-                // file is never wider than its eventual self while it is being filled. A failure here
-                // aborts the replacement: moving a file whose protections could not be reproduced would
-                // either widen a deliberately restricted config.xml or narrow one an operator shares
-                // deliberately, and the original on disk is still valid and still correct.
-                applyPreservedAttributes(partial, preserved);
-                try {
-                    Files.move(partial, target, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
-                } catch (final AtomicMoveNotSupportedException atomicNotSupported) {
-                    // Some network and container file systems cannot do it. A non-atomic replace is still
-                    // better than truncating the original and writing into it, because the content being
-                    // moved is already complete on disk.
-                    log.debug("Atomic replace of {} is not supported here, falling back", file.getAbsolutePath());
-                    Files.move(partial, target, StandardCopyOption.REPLACE_EXISTING);
-                }
-            } finally {
-                Files.deleteIfExists(partial);
-            }
+            });
         } catch (final IOException e) {
             log.error("Error writing file:", e);
             throw new UnrecoverableException(false);
         } finally {
             lock.unlock();
         }
+    }
+
+    /** The bytes of one replacement, written into the narrow file that has just been created for them. */
+    @FunctionalInterface
+    @VisibleForTesting
+    interface ContentWriter {
+
+        void writeTo(@NotNull Path partial) throws IOException;
+    }
+
+    /**
+     * Replaces a file with content written beside it, under the protections it is given, and never wider
+     * than those while it holds the content.
+     * <p>
+     * <b>Written beside the target and moved onto it, rather than opened and written in place.</b>
+     * Rendering the document first closed the "schema validation fails half way" case; opening the real
+     * file still truncates it, so a crash, a full disk or a killed process between open and close left a
+     * config.xml cut off mid-element. There is a backup, but nothing restores it on its own and the node
+     * does not start (EDG-882 review v02, R2-08). Same directory on purpose: ATOMIC_MOVE is only
+     * guaranteed within a file store, and the temporary file has to be one the configuration watcher will
+     * not try to parse.
+     * <p>
+     * <b>The protections are settled before a single byte is written, not after.</b> The content holds
+     * bridge passwords, keystore and truststore passwords and adapter credentials. A file created by
+     * {@code FileWriter} takes this process's umask, so on a 022 umask the first version of this change
+     * created a world-readable 0644 file, populated it with every secret in the configuration, closed it,
+     * and only then narrowed it to the mode of the file it was about to replace. Any local principal
+     * reading the directory during that window got the lot -- on every REST write to any subsystem. That
+     * window did not exist before this branch: writing in place reused config.xml's own inode and
+     * therefore its own mode, so the secrets never touched a wider file. It is a disclosure this change
+     * would have introduced, which is why it fails closed rather than best-effort (EDG-882 review v03,
+     * R3-07).
+     * <p>
+     * <b>One sequence, both files.</b> The rolling backup goes through this too. It is a copy of the same
+     * document, made by the same write, and it used to be produced by a plain file copy that carried the
+     * mode and left the group to the process -- so a 0640 config.xml owned by one group was backed up
+     * into a 0640 file readable by another (EDG-882 review v04). Two paths that must not differ are one
+     * path.
+     */
+    @VisibleForTesting
+    static void replaceCarryingProtections(
+            final @NotNull Path target,
+            final @NotNull PreservedAttributes preserved,
+            final @NotNull ContentWriter content)
+            throws IOException {
+        final Path partial = target.resolveSibling(target.getFileName() + ".partial");
+        try {
+            createPartialFile(partial, preserved);
+            content.writeTo(partial);
+            // Widened to exactly the target's protections only once the content is on disk, so the file is
+            // never wider than its eventual self while it is being filled. A failure here aborts the
+            // replacement: moving a file whose protections could not be reproduced would either widen a
+            // deliberately restricted config.xml or narrow one an operator shares deliberately, and the
+            // original on disk is still valid and still correct.
+            applyPreservedAttributes(partial, preserved);
+            try {
+                Files.move(partial, target, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+            } catch (final AtomicMoveNotSupportedException atomicNotSupported) {
+                // Some network and container file systems cannot do it. A non-atomic replace is still
+                // better than truncating the original and writing into it, because the content being moved
+                // is already complete on disk.
+                log.debug("Atomic replace of {} is not supported here, falling back", target);
+                Files.move(partial, target, StandardCopyOption.REPLACE_EXISTING);
+            }
+        } finally {
+            Files.deleteIfExists(partial);
+        }
+    }
+
+    /**
+     * Copies the configuration file to its rolling backup, under the protections of the file it copies.
+     * <p>
+     * <b>The source's protections, not the destination's.</b> The backup holds the source's content, so it
+     * is the source that decides who may read it; the file being overwritten is a previous backup whose
+     * protections are of no interest, and on the first rotation there is no destination at all -- which is
+     * how the plain copy this replaces ended up handing the backup to the process's own group.
+     *
+     * @throws IOException when the backup cannot be given the protections of the file it copies, which
+     *         aborts the write that asked for it: a backup of a configuration file is a second copy of
+     *         every credential in it.
+     */
+    private static void copyCarryingProtections(final @NotNull Path source, final @NotNull Path configured)
+            throws IOException {
+        final Path destination = Files.exists(configured) ? configured.toRealPath() : configured;
+        if (Files.exists(destination) && Files.isSameFile(source, destination)) {
+            // The rotation picked the configuration file itself, which would copy it onto itself through a
+            // temporary file. The copy this replaces refused that outright and so does this.
+            throw new IOException("The rolling backup of " + source + " resolves to the configuration file"
+                    + " itself, so taking it would overwrite the configuration being backed up");
+        }
+        final PreservedAttributes preserved = preservedAttributesOf(source);
+        replaceCarryingProtections(destination, preserved, partial -> {
+            try (final InputStream in = Files.newInputStream(source);
+                    final OutputStream out = Files.newOutputStream(
+                            partial, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING)) {
+                in.transferTo(out);
+            }
+            // Carried because the rotation picks the backup to overwrite by modification time.
+            Files.setLastModifiedTime(partial, Files.getLastModifiedTime(source));
+        });
     }
 
     /**
@@ -1018,7 +1077,7 @@ public class ConfigFileReaderWriter {
             if (log.isDebugEnabled()) {
                 log.debug("Rolling backup of configuration file to {}", copyFile.getName());
             }
-            FileUtils.copyFile(configFile, copyFile);
+            copyCarryingProtections(configFile.toPath(), copyFile.toPath());
         } else {
             log.error("Configuration folder {} does not exist or is not a directory", copyPath.getAbsolutePath());
             throw new UnrecoverableException(false);

--- a/hivemq-edge/src/main/java/com/hivemq/configuration/reader/ConfigFileReaderWriter.java
+++ b/hivemq-edge/src/main/java/com/hivemq/configuration/reader/ConfigFileReaderWriter.java
@@ -58,10 +58,12 @@ import java.io.Writer;
 import java.net.URL;
 import java.net.URLConnection;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.BasicFileAttributeView;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -423,8 +425,32 @@ public class ConfigFileReaderWriter {
             writeConfigToXML(rendered);
 
             backupConfig(file, doBackup); // write the backup of the file before rewriting
-            try (final FileWriter writer = new FileWriter(file, StandardCharsets.UTF_8)) {
-                writer.write(rendered.toString());
+            // Written beside the target and moved onto it, rather than opened and written in place.
+            // Rendering first closed the "schema validation fails half way" case; opening the real file
+            // still truncates it, so a crash, a full disk or a killed process between open and close left
+            // a config.xml cut off mid-element. There is a backup, but nothing restores it on its own and
+            // the node does not start (EDG-882 review v02, R2-08).
+            //
+            // Same directory on purpose: ATOMIC_MOVE is only guaranteed within a file store, and the
+            // temporary file has to be one the configuration watcher will not try to parse.
+            final Path target = file.toPath();
+            final Path partial = target.resolveSibling(file.getName() + ".partial");
+            try {
+                try (final FileWriter writer = new FileWriter(partial.toFile(), StandardCharsets.UTF_8)) {
+                    writer.write(rendered.toString());
+                    writer.flush();
+                }
+                try {
+                    Files.move(partial, target, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+                } catch (final AtomicMoveNotSupportedException atomicNotSupported) {
+                    // Some network and container file systems cannot do it. A non-atomic replace is still
+                    // better than truncating the original and writing into it, because the content being
+                    // moved is already complete on disk.
+                    log.debug("Atomic replace of {} is not supported here, falling back", file.getAbsolutePath());
+                    Files.move(partial, target, StandardCopyOption.REPLACE_EXISTING);
+                }
+            } finally {
+                Files.deleteIfExists(partial);
             }
         } catch (final IOException e) {
             log.error("Error writing file:", e);

--- a/hivemq-edge/src/main/java/com/hivemq/configuration/reader/ConfigFileReaderWriter.java
+++ b/hivemq-edge/src/main/java/com/hivemq/configuration/reader/ConfigFileReaderWriter.java
@@ -168,13 +168,12 @@ public class ConfigFileReaderWriter {
     private final @NotNull AtomicReference<HiveMQConfigEntity> configEntity;
 
     /**
-     * The {@code ${ENV:...}} placeholders of the configuration file as it was written, and the file's
-     * text at the point they were still in it. Both are needed to put them back when the configuration
-     * is written out again; see {@link EnvVarUtil#restorePlaceholders}.
+     * The {@code ${ENV:...}} placeholders of the configuration file as it was written, so that writing
+     * the configuration back out restores them instead of the values they stand for; see
+     * {@link EnvVarUtil#restorePlaceholders}. Replaced only when a configuration is actually accepted.
      */
-    private final @NotNull AtomicReference<Map<String, String>> envPlaceholders;
+    private final @NotNull AtomicReference<List<EnvVarUtil.ElementPlaceholder>> envPlaceholders;
 
-    private final @NotNull AtomicReference<String> renderedText;
     private final @NotNull Lock lock;
     private final @NotNull AtomicReference<ScheduledExecutorService> executorService;
     private boolean defaultBackupConfig;
@@ -202,8 +201,7 @@ public class ConfigFileReaderWriter {
         this.postApplyCallbacks = new CopyOnWriteArrayList<>();
         this.fragmentToModificationTime = new ConcurrentHashMap<>();
         this.configEntity = new AtomicReference<>();
-        this.envPlaceholders = new AtomicReference<>(Map.of());
-        this.renderedText = new AtomicReference<>("");
+        this.envPlaceholders = new AtomicReference<>(List.of());
         this.lastWrite = new AtomicLong();
         this.lock = new ReentrantLock();
         this.executorService = new AtomicReference<>();
@@ -383,9 +381,7 @@ public class ConfigFileReaderWriter {
             final StringWriter marshalled = new StringWriter();
             createMarshaller().marshal(configEntity.get(), marshalled);
             writer.write(EnvVarUtil.restorePlaceholders(
-                    marshalled.toString(),
-                    Objects.requireNonNullElse(envPlaceholders.get(), Map.of()),
-                    Objects.requireNonNullElse(renderedText.get(), "")));
+                    marshalled.toString(), Objects.requireNonNullElse(envPlaceholders.get(), List.of())));
             writer.flush();
         } catch (final Throwable e) {
             log.error("Original error message:", e);
@@ -417,9 +413,18 @@ public class ConfigFileReaderWriter {
                 throw new UnrecoverableException(false);
             }
 
+            // Rendered in full before the file is opened, because opening it truncates it and the
+            // marshaller validates against the schema as it writes. Anything it rejects -- a value that
+            // does not fit its element, a constraint a REST call did not enforce -- used to leave the
+            // operator with a config.xml emptied or cut off mid-element, while the REST call that
+            // triggered the write answered 200 and the node kept running on the configuration it still
+            // had in memory. The next restart is where they would find out (EDG-882 QA round 3).
+            final StringWriter rendered = new StringWriter();
+            writeConfigToXML(rendered);
+
             backupConfig(file, doBackup); // write the backup of the file before rewriting
             try (final FileWriter writer = new FileWriter(file, StandardCharsets.UTF_8)) {
-                writeConfigToXML(writer);
+                writer.write(rendered.toString());
             }
         } catch (final IOException e) {
             log.error("Error writing file:", e);
@@ -449,11 +454,13 @@ public class ConfigFileReaderWriter {
             final var fragment = replaceFragmentPlaceHolders(content, sysInfo.isConfigFragmentBase64Zip());
             content = fragment.getRenderResult(); // must happen before env rendering so templates can be used with envs
             content = IfUtil.replaceIfPlaceHolders(content);
-            // Remembered before rendering, so that writing the configuration back out restores the
+            // Collected before rendering, so that writing the configuration back out restores the
             // operator's placeholders instead of the secrets they stand for -- see
-            // EnvVarUtil.restorePlaceholders.
-            renderedText.set(content);
-            envPlaceholders.set(EnvVarUtil.collectPlaceholders(content));
+            // EnvVarUtil.restorePlaceholders. Held locally until the configuration has actually been
+            // accepted: a file that fails to parse must not replace the placeholders of the
+            // configuration still running, or the next write would marshal that older configuration --
+            // with its resolved secrets -- against a map that no longer describes it.
+            final List<EnvVarUtil.ElementPlaceholder> placeholders = EnvVarUtil.collectPlaceholders(content);
             content = EnvVarUtil.replaceEnvironmentVariablePlaceholders(content);
 
             fragmentToModificationTime.putAll(fragment.getFragmentToModificationTime());
@@ -475,6 +482,9 @@ public class ConfigFileReaderWriter {
                 }
 
                 configEntity.set(entity);
+                // Only now: this configuration is the one that will be written back out, so these are
+                // the placeholders that describe it.
+                envPlaceholders.set(placeholders);
                 return internalApplyConfig(entity);
             }
         } catch (final JAXBException | IOException e) {

--- a/hivemq-edge/src/main/java/com/hivemq/mqtt/handler/subscribe/IncomingSubscribeService.java
+++ b/hivemq-edge/src/main/java/com/hivemq/mqtt/handler/subscribe/IncomingSubscribeService.java
@@ -24,6 +24,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.*;
 import com.hivemq.bootstrap.ClientConnection;
+import com.hivemq.bridge.MessageForwarder;
 import com.hivemq.configuration.service.MqttConfigurationService;
 import com.hivemq.configuration.service.RestrictionsConfigurationService;
 import com.hivemq.extension.sdk.api.packets.auth.DefaultAuthorizationBehaviour;
@@ -45,9 +46,11 @@ import com.hivemq.persistence.clientsession.SharedSubscriptionService;
 import com.hivemq.persistence.clientsession.SharedSubscriptionServiceImpl.SharedSubscription;
 import com.hivemq.persistence.clientsession.callback.SubscriptionResult;
 import com.hivemq.persistence.retained.RetainedMessagePersistence;
+import com.hivemq.sampling.SamplingService;
 import com.hivemq.util.Exceptions;
 import com.hivemq.util.ReasonStrings;
 import com.hivemq.util.Topics;
+import dagger.Lazy;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 import jakarta.inject.Inject;
@@ -84,6 +87,8 @@ public class IncomingSubscribeService {
     private final @NotNull MqttConfigurationService mqttConfigurationService;
     private final @NotNull RestrictionsConfigurationService restrictionsConfigurationService;
     private final @NotNull MqttServerDisconnector mqttServerDisconnector;
+    private final @NotNull Lazy<MessageForwarder> messageForwarder;
+    private final @NotNull Lazy<SamplingService> samplingService;
 
     @Inject
     protected IncomingSubscribeService(
@@ -93,8 +98,12 @@ public class IncomingSubscribeService {
             final @NotNull RetainedMessagesSender retainedMessagesSender,
             final @NotNull MqttConfigurationService mqttConfigurationService,
             final @NotNull RestrictionsConfigurationService restrictionsConfigurationService,
-            final @NotNull MqttServerDisconnector mqttServerDisconnector) {
+            final @NotNull MqttServerDisconnector mqttServerDisconnector,
+            final @NotNull Lazy<MessageForwarder> messageForwarder,
+            final @NotNull Lazy<SamplingService> samplingService) {
 
+        this.messageForwarder = messageForwarder;
+        this.samplingService = samplingService;
         this.clientSessionSubscriptionPersistence = clientSessionSubscriptionPersistence;
         this.retainedMessagePersistence = retainedMessagePersistence;
         this.sharedSubscriptionService = sharedSubscriptionService;
@@ -183,6 +192,31 @@ public class IncomingSubscribeService {
     }
 
     /**
+     * Whether this subscription would land the client in the same shared-subscription group as a live
+     * internal queue — a bridge forwarder's or a sampler's.
+     * <p>
+     * Shared subscribers of one group take turns, so a client that joins a bridge forwarder's group
+     * receives the bridge's messages instead of the bridge, and they are never forwarded to the remote
+     * broker. The group name embeds a digest a client can compute from the bridge's own configuration,
+     * which makes it reachable rather than theoretical (EDG-882 QA round 2).
+     * <p>
+     * Asked of the registries, and deliberately <b>not</b> a reserved-namespace rule: the
+     * {@code $SAMPLER::} and {@code $FORWARDER::} namespaces stay open, because a share name is the
+     * client's to choose and {@code $share/$SAMPLER::customer/alerts} is a legal subscription that no
+     * part of Edge owns — EDG-882 F-05 settled that, and {@code SamplerNamedSharedSubscriptionIT} pins
+     * it. Only an actual collision with a queue Edge is using right now is refused.
+     */
+    private boolean collidesWithAnInternalQueue(final @NotNull String topic) {
+        final SharedSubscription sharedSubscription = Topics.checkForSharedSubscription(topic);
+        if (sharedSubscription == null) {
+            return false;
+        }
+        final String queueId = sharedSubscription.getShareName() + "/" + sharedSubscription.getTopicFilter();
+        return messageForwarder.get().isForwarderQueue(queueId)
+                || samplingService.get().isSamplerQueue(queueId);
+    }
+
+    /**
      * Checks if the SUBSCRIBE message contains only valid topic subscriptions
      *
      * @param ctx The ChannelHandlerContext
@@ -204,6 +238,17 @@ public class IncomingSubscribeService {
                         ctx.channel(),
                         logMessage,
                         "Invalid subscription topic " + topic.getTopic(),
+                        Mqtt5DisconnectReasonCode.TOPIC_FILTER_INVALID,
+                        ReasonStrings.DISCONNECT_SUBSCRIBE_TOPIC_FILTER_INVALID);
+                return false;
+            } else if (collidesWithAnInternalQueue(topicString)) {
+                final String logMessage = "Disconnecting client '" + clientConnection.getClientId()
+                        + "'  (IP: {}) because it subscribed to a shared subscription group that is in use"
+                        + " by an internal Edge component: '" + topic.getTopic() + "'";
+                mqttServerDisconnector.disconnect(
+                        ctx.channel(),
+                        logMessage,
+                        "Shared subscription group in use by Edge in " + topic.getTopic(),
                         Mqtt5DisconnectReasonCode.TOPIC_FILTER_INVALID,
                         ReasonStrings.DISCONNECT_SUBSCRIBE_TOPIC_FILTER_INVALID);
                 return false;

--- a/hivemq-edge/src/main/java/com/hivemq/mqtt/handler/subscribe/IncomingSubscribeService.java
+++ b/hivemq-edge/src/main/java/com/hivemq/mqtt/handler/subscribe/IncomingSubscribeService.java
@@ -242,6 +242,14 @@ public class IncomingSubscribeService {
                         ReasonStrings.DISCONNECT_SUBSCRIBE_TOPIC_FILTER_INVALID);
                 return false;
             } else if (collidesWithAnInternalQueue(topicString)) {
+                // Answered with a DISCONNECT rather than a per-subscription SUBACK reason code, which
+                // takes the client's other, valid subscriptions in the same packet down with it. Kept
+                // deliberately (EDG-882 review v02, R2-11): every other refusal in this method
+                // disconnects, and a SUBSCRIBE that is refused for one filter and accepted for another
+                // would be the only mixed outcome here. The filter is syntactically valid and normally
+                // legal — it collides only while an internal queue is live — so MQTT 5's per-subscription
+                // answer would be the friendlier one, and if that is ever wanted it is a product decision
+                // about this whole method rather than about this branch.
                 final String logMessage = "Disconnecting client '" + clientConnection.getClientId()
                         + "'  (IP: {}) because it subscribed to a shared subscription group that is in use"
                         + " by an internal Edge component: '" + topic.getTopic() + "'";

--- a/hivemq-edge/src/main/java/com/hivemq/mqtt/handler/subscribe/retained/RetainedMessagesSender.java
+++ b/hivemq-edge/src/main/java/com/hivemq/mqtt/handler/subscribe/retained/RetainedMessagesSender.java
@@ -31,6 +31,7 @@ import com.hivemq.mqtt.message.publish.PublishWithFuture;
 import com.hivemq.mqtt.message.subscribe.Topic;
 import com.hivemq.persistence.RetainedMessage;
 import com.hivemq.persistence.clientqueue.ClientQueuePersistence;
+import com.hivemq.persistence.clientqueue.QueuePolicy;
 import com.hivemq.persistence.payload.PublishPayloadPersistence;
 import com.hivemq.persistence.retained.RetainedMessagePersistence;
 import com.hivemq.persistence.util.FutureUtils;
@@ -242,7 +243,10 @@ public class RetainedMessagesSender {
                     false,
                     qos1and2Messages,
                     true,
-                    Objects.requireNonNullElseGet(queueLimit, mqttConfigurationService::maxQueuedMessages)));
+                    Objects.requireNonNullElseGet(queueLimit, mqttConfigurationService::maxQueuedMessages),
+                    // retained messages go to an ordinary client queue: the session's configured limit
+                    // and overflow strategy, nothing sampler-shaped
+                    QueuePolicy.DEFAULT));
             resultFuture.setFuture(FutureUtils.voidFutureFromList(futures.build()));
         }
 

--- a/hivemq-edge/src/main/java/com/hivemq/mqtt/services/PublishDistributorImpl.java
+++ b/hivemq-edge/src/main/java/com/hivemq/mqtt/services/PublishDistributorImpl.java
@@ -31,6 +31,7 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.SettableFuture;
+import com.hivemq.bridge.MessageForwarder;
 import com.hivemq.bridge.config.LocalSubscription;
 import com.hivemq.bridge.config.MqttBridge;
 import com.hivemq.configuration.reader.BridgeExtractor;
@@ -93,17 +94,26 @@ public class PublishDistributorImpl implements PublishDistributor {
     @NotNull
     private final Lazy<SamplingService> samplingService;
 
+    /**
+     * Lazy for the same reason as {@link #samplingService}: the message forwarder is built on the queue
+     * persistence this class also uses.
+     */
+    @NotNull
+    private final Lazy<MessageForwarder> messageForwarder;
+
     @Inject
     public PublishDistributorImpl(
             final @NotNull ClientQueuePersistence clientQueuePersistence,
             final @NotNull Lazy<ClientSessionPersistence> clientSessionPersistence,
             final @NotNull ConfigurationService configurationService,
-            final @NotNull Lazy<SamplingService> samplingService) {
+            final @NotNull Lazy<SamplingService> samplingService,
+            final @NotNull Lazy<MessageForwarder> messageForwarder) {
         this.clientQueuePersistence = clientQueuePersistence;
         this.clientSessionPersistence = clientSessionPersistence;
         this.mqttConfigurationService = configurationService.mqttConfiguration();
         this.bridgeConfiguration = configurationService.bridgeExtractor();
         this.samplingService = samplingService;
+        this.messageForwarder = messageForwarder;
     }
 
     @NotNull
@@ -183,8 +193,13 @@ public class PublishDistributorImpl implements PublishDistributor {
             final @Nullable ImmutableIntArray subscriptionIdentifier) {
 
         if (sharedSubscription) {
-            // only do the bridge iterations for client ids that can even be bridge clients
-            if (client.startsWith(FORWARDER_PREFIX)) {
+            // Asked of the registry that owns forwarder queues, not read off the queue ID -- the same
+            // rule the sampler branch below states, applied to the branch above it. A queue ID is built
+            // from a share name, and a share name is the client's to choose: a subscription to
+            // $share/$FORWARDER::<a live forwarder id>/t took this branch, so an ordinary client had a
+            // bridge's queue limit applied to its own queue and, against a persist=false bridge, its
+            // QoS silently rewritten to 0 (EDG-882 QA round 2).
+            if (messageForwarder.get().isForwarderQueue(client)) {
                 return handlePublishForBridgeForwarder(
                         publish,
                         client,
@@ -329,17 +344,25 @@ public class PublishDistributorImpl implements PublishDistributor {
         return statusFuture;
     }
 
-    private @Nullable CustomBridgeLimitations getBridgeConfig(final @NotNull String clientId) {
+    /**
+     * The limits configured for the bridge subscription that owns this queue, or {@code null}.
+     * <p>
+     * Anchored rather than by substring: a forwarder queue ID is exactly
+     * {@code $FORWARDER::<bridgeId>-<digest>/<topic filter>}, so the prefix up to and including the '/'
+     * identifies the subscription and the rest is the topic. Matching with {@code contains} let one
+     * bridge whose id merely appears inside another's queue ID answer for it, and made the resolution
+     * depend on a string a client can influence (EDG-882 QA round 2).
+     */
+    private @Nullable CustomBridgeLimitations getBridgeConfig(final @NotNull String queueId) {
         for (final MqttBridge bridge : bridgeConfiguration.getBridges()) {
-            final String bridgeClientId = FORWARDER_PREFIX + bridge.getId();
-            if (clientId.contains(bridgeClientId)) {
-                for (final LocalSubscription localSubscription : bridge.getLocalSubscriptions()) {
-                    final String detailedBridgeClientId =
-                            FORWARDER_PREFIX + bridge.getId() + "-" + localSubscription.calculateUniqueId();
-                    // contains as it ends with the topic filter, which we dont know
-                    if (clientId.contains(detailedBridgeClientId)) {
-                        return new CustomBridgeLimitations(bridge.isPersist(), localSubscription.getQueueLimit());
-                    }
+            if (!queueId.startsWith(FORWARDER_PREFIX + bridge.getId() + "-")) {
+                continue;
+            }
+            for (final LocalSubscription localSubscription : bridge.getLocalSubscriptions()) {
+                final String queueIdPrefix =
+                        FORWARDER_PREFIX + bridge.getId() + "-" + localSubscription.calculateUniqueId() + "/";
+                if (queueId.startsWith(queueIdPrefix)) {
+                    return new CustomBridgeLimitations(bridge.isPersist(), localSubscription.getQueueLimit());
                 }
             }
         }

--- a/hivemq-edge/src/main/java/com/hivemq/mqtt/services/PublishDistributorImpl.java
+++ b/hivemq-edge/src/main/java/com/hivemq/mqtt/services/PublishDistributorImpl.java
@@ -42,9 +42,11 @@ import com.hivemq.mqtt.message.publish.PUBLISH;
 import com.hivemq.mqtt.message.publish.PUBLISHFactory;
 import com.hivemq.mqtt.topic.SubscriberWithIdentifiers;
 import com.hivemq.persistence.clientqueue.ClientQueuePersistence;
+import com.hivemq.persistence.clientqueue.QueuePolicy;
 import com.hivemq.persistence.clientsession.ClientSession;
 import com.hivemq.persistence.clientsession.ClientSessionPersistence;
 import com.hivemq.persistence.util.FutureUtils;
+import com.hivemq.sampling.SamplingService;
 import dagger.Lazy;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
@@ -84,15 +86,24 @@ public class PublishDistributorImpl implements PublishDistributor {
     @NotNull
     private final BridgeExtractor bridgeConfiguration;
 
+    /**
+     * Lazy because sampling is built on top of the queue persistence this class also uses: asking for
+     * it eagerly closes a dependency cycle at construction time.
+     */
+    @NotNull
+    private final Lazy<SamplingService> samplingService;
+
     @Inject
     public PublishDistributorImpl(
             final @NotNull ClientQueuePersistence clientQueuePersistence,
             final @NotNull Lazy<ClientSessionPersistence> clientSessionPersistence,
-            final @NotNull ConfigurationService configurationService) {
+            final @NotNull ConfigurationService configurationService,
+            final @NotNull Lazy<SamplingService> samplingService) {
         this.clientQueuePersistence = clientQueuePersistence;
         this.clientSessionPersistence = clientSessionPersistence;
         this.mqttConfigurationService = configurationService.mqttConfiguration();
         this.bridgeConfiguration = configurationService.bridgeExtractor();
+        this.samplingService = samplingService;
     }
 
     @NotNull
@@ -181,7 +192,12 @@ public class PublishDistributorImpl implements PublishDistributor {
                         subscriptionIdentifier,
                         mqttConfigurationService.maxQueuedMessages(),
                         subscriptionQos);
-            } else if (client.startsWith(SAMPLER_PREFIX)) {
+            } else if (samplingService.get().isSamplerQueue(client)) {
+                // Asked of the service that creates samplers rather than read off the queue ID: the ID
+                // is built from a share name, and a share name is the client's to choose. A
+                // subscription to $share/$SAMPLER::customer/alerts is legal and belongs to that client,
+                // so it must keep the configured queue limit and the configured overflow strategy
+                // instead of being turned into a ten-message ring (EDG-882 F-05).
                 return queuePublish(
                         client,
                         publish,
@@ -189,7 +205,8 @@ public class PublishDistributorImpl implements PublishDistributor {
                         true,
                         retainAsPublished,
                         subscriptionIdentifier,
-                        SAMPLER_QUEUE_LIMIT);
+                        SAMPLER_QUEUE_LIMIT,
+                        QueuePolicy.SAMPLE_RING);
             } else {
                 return queuePublish(
                         client,
@@ -261,6 +278,27 @@ public class PublishDistributorImpl implements PublishDistributor {
             final boolean retainAsPublished,
             final @Nullable ImmutableIntArray subscriptionIdentifier,
             final @Nullable Long queueLimit) {
+        return queuePublish(
+                client,
+                publish,
+                subscriptionQos,
+                shared,
+                retainAsPublished,
+                subscriptionIdentifier,
+                queueLimit,
+                QueuePolicy.DEFAULT);
+    }
+
+    @NotNull
+    private SettableFuture<PublishStatus> queuePublish(
+            final @NotNull String client,
+            final @NotNull PUBLISH publish,
+            final int subscriptionQos,
+            final boolean shared,
+            final boolean retainAsPublished,
+            final @Nullable ImmutableIntArray subscriptionIdentifier,
+            final @Nullable Long queueLimit,
+            final @NotNull QueuePolicy policy) {
 
         final Long appliedQueueLimit =
                 Objects.requireNonNullElseGet(queueLimit, mqttConfigurationService::maxQueuedMessages);
@@ -269,7 +307,8 @@ public class PublishDistributorImpl implements PublishDistributor {
                 shared,
                 createPublish(publish, subscriptionQos, retainAsPublished, subscriptionIdentifier),
                 false,
-                appliedQueueLimit);
+                appliedQueueLimit,
+                policy);
 
         final SettableFuture<PublishStatus> statusFuture = SettableFuture.create();
 

--- a/hivemq-edge/src/main/java/com/hivemq/persistence/clientqueue/ClientQueueLocalPersistence.java
+++ b/hivemq-edge/src/main/java/com/hivemq/persistence/clientqueue/ClientQueueLocalPersistence.java
@@ -43,6 +43,13 @@ public interface ClientQueueLocalPersistence extends LocalPersistence {
      * @param publish     to be queued
      * @param max         maximum amount of messages queued for the client
      * @param strategy    how to discard messages in case the queue is full
+     * @param applyMaxToQos0 whether {@code max} also bounds QoS 0 messages. Normally false: QoS 0 queues
+     *                       are held only by the node-wide QoS 0 memory budget, and imposing a count
+     *                       limit on them would change long-standing behaviour for bridges and client
+     *                       queues. Sampler queues pass true — they are ring buffers of the most recent
+     *                       {@code SamplingService.SAMPLE_SIZE} payloads, and without this one sampled
+     *                       QoS 0 topic can consume the whole shared budget and starve every other QoS 0
+     *                       consumer on the node (EDG-885).
      * @param retained    true if this message was sent in response to a subscribe. Retained messages are not dropped
      *                    when the queue reached the maximum queue size.
      * @param bucketIndex provided by the single writer
@@ -54,7 +61,20 @@ public interface ClientQueueLocalPersistence extends LocalPersistence {
             long max,
             @NotNull QueuedMessagesStrategy strategy,
             boolean retained,
+            boolean applyMaxToQos0,
             int bucketIndex);
+
+    /** Equivalent to the overload above with {@code applyMaxToQos0 = false}, which is the historical behaviour. */
+    default void add(
+            final @NotNull String queueId,
+            final boolean shared,
+            final @NotNull PUBLISH publish,
+            final long max,
+            final @NotNull QueuedMessagesStrategy strategy,
+            final boolean retained,
+            final int bucketIndex) {
+        add(queueId, shared, publish, max, strategy, retained, false, bucketIndex);
+    }
 
     /**
      * Adds a list of PUBLISHes to a client or shared subscription queue. If the size exceeds the queue limit, the given
@@ -66,6 +86,13 @@ public interface ClientQueueLocalPersistence extends LocalPersistence {
      * @param publishes   to be queued
      * @param max         maximum amount of messages queued for the client
      * @param strategy    how to discard messages in case the queue is full
+     * @param applyMaxToQos0 whether {@code max} also bounds QoS 0 messages. Normally false: QoS 0 queues
+     *                       are held only by the node-wide QoS 0 memory budget, and imposing a count
+     *                       limit on them would change long-standing behaviour for bridges and client
+     *                       queues. Sampler queues pass true — they are ring buffers of the most recent
+     *                       {@code SamplingService.SAMPLE_SIZE} payloads, and without this one sampled
+     *                       QoS 0 topic can consume the whole shared budget and starve every other QoS 0
+     *                       consumer on the node (EDG-885).
      * @param retained    true if this messages are sent in response to a subscribe. Retained messages are not dropped
      *                    when the queue reached the maximum queue size. It is not necessarily the same as the retain
      *                    flag of the publish.
@@ -78,7 +105,20 @@ public interface ClientQueueLocalPersistence extends LocalPersistence {
             long max,
             @NotNull QueuedMessagesStrategy strategy,
             boolean retained,
+            boolean applyMaxToQos0,
             int bucketIndex);
+
+    /** Equivalent to the overload above with {@code applyMaxToQos0 = false}, which is the historical behaviour. */
+    default void add(
+            final @NotNull String queueId,
+            final boolean shared,
+            final @NotNull List<PUBLISH> publishes,
+            final long max,
+            final @NotNull QueuedMessagesStrategy strategy,
+            final boolean retained,
+            final int bucketIndex) {
+        add(queueId, shared, publishes, max, strategy, retained, false, bucketIndex);
+    }
 
     /**
      * Returns a batch of PUBLISHes and marks them by setting packet identifiers. The size of the batch is limited by 2

--- a/hivemq-edge/src/main/java/com/hivemq/persistence/clientqueue/ClientQueueLocalPersistence.java
+++ b/hivemq-edge/src/main/java/com/hivemq/persistence/clientqueue/ClientQueueLocalPersistence.java
@@ -29,6 +29,27 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /**
+ * <b>Binary compatibility with the file-native module is part of this interface's contract.</b>
+ * <p>
+ * The file-native implementation lives in {@code hivemq-edge-mqtt-persistence}, which is loaded from
+ * {@code HIVEMQ_HOME/modules} at run time. Core and module are compiled separately and meet only at
+ * start-up, so an operator can pair any module jar with any core jar — including by accident, by
+ * replacing the core zip and leaving {@code modules/} alone.
+ * <p>
+ * That makes the direction of every {@code default} here load-bearing. A default method protects
+ * <em>callers</em> of the signature it replaces, and core has no callers of the old signatures left.
+ * What needs protecting is <em>implementors</em>: an older module implements only the signature that
+ * existed when it was built, so the signature core calls must be the one with a default, and the
+ * default must delegate to the older one. Getting this backwards makes a mismatched module fail with
+ * {@code AbstractMethodError} on the first queued publish — on a file-native node, the entire message
+ * path, with a stack trace that names no version (EDG-882 review v02, R2-01).
+ * <p>
+ * So: <b>when a parameter is added here, the old signature stays abstract and the new one gets the
+ * default.</b> Implementations override the new signature and implement the old one as a delegation.
+ * The cost is that a module built before the addition degrades silently to the previous behaviour, so
+ * {@code ClientQueueLocalPersistenceProvider} probes the loaded implementation once at start-up and
+ * says plainly what a stale module gives up.
+ *
  * @author Lukas Brandl
  * @since 4.0.0
  */
@@ -54,17 +75,6 @@ public interface ClientQueueLocalPersistence extends LocalPersistence {
      *                    when the queue reached the maximum queue size.
      * @param bucketIndex provided by the single writer
      */
-    void add(
-            @NotNull String queueId,
-            boolean shared,
-            @NotNull PUBLISH publish,
-            long max,
-            @NotNull QueuedMessagesStrategy strategy,
-            boolean retained,
-            boolean applyMaxToQos0,
-            int bucketIndex);
-
-    /** Equivalent to the overload above with {@code applyMaxToQos0 = false}, which is the historical behaviour. */
     default void add(
             final @NotNull String queueId,
             final boolean shared,
@@ -72,9 +82,26 @@ public interface ClientQueueLocalPersistence extends LocalPersistence {
             final long max,
             final @NotNull QueuedMessagesStrategy strategy,
             final boolean retained,
+            final boolean applyMaxToQos0,
             final int bucketIndex) {
-        add(queueId, shared, publish, max, strategy, retained, false, bucketIndex);
+        // Default, not abstract, so a module built before applyMaxToQos0 existed keeps working; see the
+        // contract note on this interface. It loses the QoS 0 bound, which is the previous behaviour.
+        add(queueId, shared, publish, max, strategy, retained, bucketIndex);
     }
+
+    /**
+     * Equivalent to the overload above with {@code applyMaxToQos0 = false}, which is the historical
+     * behaviour. Abstract, and staying abstract, because it is the signature every module ever built
+     * implements.
+     */
+    void add(
+            @NotNull String queueId,
+            boolean shared,
+            @NotNull PUBLISH publish,
+            long max,
+            @NotNull QueuedMessagesStrategy strategy,
+            boolean retained,
+            int bucketIndex);
 
     /**
      * Adds a list of PUBLISHes to a client or shared subscription queue. If the size exceeds the queue limit, the given
@@ -98,17 +125,6 @@ public interface ClientQueueLocalPersistence extends LocalPersistence {
      *                    flag of the publish.
      * @param bucketIndex provided by the single writer
      */
-    void add(
-            @NotNull String queueId,
-            boolean shared,
-            @NotNull List<PUBLISH> publishes,
-            long max,
-            @NotNull QueuedMessagesStrategy strategy,
-            boolean retained,
-            boolean applyMaxToQos0,
-            int bucketIndex);
-
-    /** Equivalent to the overload above with {@code applyMaxToQos0 = false}, which is the historical behaviour. */
     default void add(
             final @NotNull String queueId,
             final boolean shared,
@@ -116,9 +132,26 @@ public interface ClientQueueLocalPersistence extends LocalPersistence {
             final long max,
             final @NotNull QueuedMessagesStrategy strategy,
             final boolean retained,
+            final boolean applyMaxToQos0,
             final int bucketIndex) {
-        add(queueId, shared, publishes, max, strategy, retained, false, bucketIndex);
+        // Default, not abstract, so a module built before applyMaxToQos0 existed keeps working; see the
+        // contract note on this interface. It loses the QoS 0 bound, which is the previous behaviour.
+        add(queueId, shared, publishes, max, strategy, retained, bucketIndex);
     }
+
+    /**
+     * Equivalent to the overload above with {@code applyMaxToQos0 = false}, which is the historical
+     * behaviour. Abstract, and staying abstract, because it is the signature every module ever built
+     * implements.
+     */
+    void add(
+            @NotNull String queueId,
+            boolean shared,
+            @NotNull List<PUBLISH> publishes,
+            long max,
+            @NotNull QueuedMessagesStrategy strategy,
+            boolean retained,
+            int bucketIndex);
 
     /**
      * Returns a batch of PUBLISHes and marks them by setting packet identifiers. The size of the batch is limited by 2

--- a/hivemq-edge/src/main/java/com/hivemq/persistence/clientqueue/ClientQueuePersistence.java
+++ b/hivemq-edge/src/main/java/com/hivemq/persistence/clientqueue/ClientQueuePersistence.java
@@ -29,6 +29,18 @@ import org.jetbrains.annotations.NotNull;
 public interface ClientQueuePersistence {
 
     /**
+     * Checkpoint visited when the client-queue clean-up has finished a bucket.
+     * <p>
+     * Declared here rather than on the implementation because the integration tests that wait for it
+     * cannot reference the implementation class: reading its class file needs types that are not on
+     * their compile classpath. Tests wait for a number of these instead of sleeping — the sleeps they
+     * replace passed just as green on a node where the clean-up had stopped being scheduled at all
+     * (EDG-882 F-09).
+     */
+    @NotNull
+    String CLIENT_QUEUE_CLEAN_UP_FINISHED = "client-queue-clean-up-finished";
+
+    /**
      * Add a publish to the queue.
      * The publish will be queued without a packet ID
      *

--- a/hivemq-edge/src/main/java/com/hivemq/persistence/clientqueue/ClientQueuePersistence.java
+++ b/hivemq-edge/src/main/java/com/hivemq/persistence/clientqueue/ClientQueuePersistence.java
@@ -38,10 +38,17 @@ public interface ClientQueuePersistence {
      * @param retained   true if this message was sent in response to a subscribe.
      *                   It is not necessarily the same as the retain flag of the publish.
      * @param queueLimit of the client session or the default configuration.
+     * @param policy     what to do when the queue is full, decided by the producer of the messages —
+     *                   see {@link QueuePolicy}, and EDG-882 F-05 for why it is not inferred here.
      */
     @NotNull
     ListenableFuture<Void> add(
-            @NotNull String queueId, boolean shared, @NotNull PUBLISH publish, boolean retained, long queueLimit);
+            @NotNull String queueId,
+            boolean shared,
+            @NotNull PUBLISH publish,
+            boolean retained,
+            long queueLimit,
+            @NotNull QueuePolicy policy);
 
     /**
      * Add a list of publishes to the queue.
@@ -53,6 +60,8 @@ public interface ClientQueuePersistence {
      * @param retained   true if this message was sent in response to a subscribe.
      *                   It is not necessarily the same as the retain flag of the publishes.
      * @param queueLimit of the client session or the default configuration.
+     * @param policy     what to do when the queue is full, decided by the producer of the messages —
+     *                   see {@link QueuePolicy}, and EDG-882 F-05 for why it is not inferred here.
      */
     @NotNull
     ListenableFuture<Void> add(
@@ -60,7 +69,8 @@ public interface ClientQueuePersistence {
             boolean shared,
             @NotNull List<PUBLISH> publishes,
             boolean retained,
-            final long queueLimit);
+            final long queueLimit,
+            @NotNull QueuePolicy policy);
 
     /**
      * Read publishes that are not yet in-flight.

--- a/hivemq-edge/src/main/java/com/hivemq/persistence/clientqueue/ClientQueuePersistenceImpl.java
+++ b/hivemq-edge/src/main/java/com/hivemq/persistence/clientqueue/ClientQueuePersistenceImpl.java
@@ -100,7 +100,8 @@ public class ClientQueuePersistenceImpl extends AbstractPersistence implements C
             final boolean shared,
             final @NotNull PUBLISH publish,
             final boolean retained,
-            final long queueLimit) {
+            final long queueLimit,
+            final @NotNull QueuePolicy policy) {
         try {
             checkNotNull(queueId, "Queue ID must not be null");
             checkNotNull(publish, "Publish must not be null");
@@ -109,17 +110,15 @@ public class ClientQueuePersistenceImpl extends AbstractPersistence implements C
         }
 
         return singleWriter.submit(queueId, (bucketIndex) -> {
-            MqttConfigurationService.QueuedMessagesStrategy queuedMessagesStrategy =
-                    mqttConfigurationService.getQueuedMessagesStrategy();
-            // A sampler queue is a ring buffer of the most recent SamplingService.SAMPLE_SIZE payloads,
-            // so it discards the oldest -- and, unlike every other queue, that bound applies to QoS 0
-            // too. Without it a sampled topic whose publishers use QoS 0 is held only by the node-wide
-            // QoS 0 memory budget and can starve every other QoS 0 consumer on the node (EDG-885).
-            boolean applyMaxToQos0 = false;
-            if (queueId.startsWith(SAMPLER_PREFIX)) {
-                queuedMessagesStrategy = MqttConfigurationService.QueuedMessagesStrategy.DISCARD_OLDEST;
-                applyMaxToQos0 = true;
-            }
+            // What to do when the queue is full comes from the producer (see QueuePolicy). It used to be
+            // read off the queue ID -- a share name a client chooses -- so an ordinary subscription to
+            // $share/$SAMPLER::customer/alerts had its own messages discarded under a policy meant for
+            // diagnostics (EDG-882 F-05).
+            final MqttConfigurationService.QueuedMessagesStrategy queuedMessagesStrategy =
+                    policy == QueuePolicy.SAMPLE_RING
+                            ? MqttConfigurationService.QueuedMessagesStrategy.DISCARD_OLDEST
+                            : mqttConfigurationService.getQueuedMessagesStrategy();
+            final boolean applyMaxToQos0 = policy == QueuePolicy.SAMPLE_RING;
 
             localPersistence.add(
                     queueId,
@@ -149,7 +148,8 @@ public class ClientQueuePersistenceImpl extends AbstractPersistence implements C
             final boolean shared,
             final @NotNull List<PUBLISH> publishes,
             final boolean retained,
-            final long queueLimit) {
+            final long queueLimit,
+            final @NotNull QueuePolicy policy) {
         try {
             checkNotNull(queueId, "Queue ID must not be null");
             checkNotNull(publishes, "Publishes must not be null");
@@ -159,17 +159,15 @@ public class ClientQueuePersistenceImpl extends AbstractPersistence implements C
 
         return singleWriter.submit(queueId, (bucketIndex) -> {
             final boolean queueWasEmpty = localPersistence.size(queueId, shared, bucketIndex) == 0;
-            MqttConfigurationService.QueuedMessagesStrategy queuedMessagesStrategy =
-                    mqttConfigurationService.getQueuedMessagesStrategy();
-            // A sampler queue is a ring buffer of the most recent SamplingService.SAMPLE_SIZE payloads,
-            // so it discards the oldest -- and, unlike every other queue, that bound applies to QoS 0
-            // too. Without it a sampled topic whose publishers use QoS 0 is held only by the node-wide
-            // QoS 0 memory budget and can starve every other QoS 0 consumer on the node (EDG-885).
-            boolean applyMaxToQos0 = false;
-            if (queueId.startsWith(SAMPLER_PREFIX)) {
-                queuedMessagesStrategy = MqttConfigurationService.QueuedMessagesStrategy.DISCARD_OLDEST;
-                applyMaxToQos0 = true;
-            }
+            // What to do when the queue is full comes from the producer (see QueuePolicy). It used to be
+            // read off the queue ID -- a share name a client chooses -- so an ordinary subscription to
+            // $share/$SAMPLER::customer/alerts had its own messages discarded under a policy meant for
+            // diagnostics (EDG-882 F-05).
+            final MqttConfigurationService.QueuedMessagesStrategy queuedMessagesStrategy =
+                    policy == QueuePolicy.SAMPLE_RING
+                            ? MqttConfigurationService.QueuedMessagesStrategy.DISCARD_OLDEST
+                            : mqttConfigurationService.getQueuedMessagesStrategy();
+            final boolean applyMaxToQos0 = policy == QueuePolicy.SAMPLE_RING;
 
             localPersistence.add(
                     queueId,

--- a/hivemq-edge/src/main/java/com/hivemq/persistence/clientqueue/ClientQueuePersistenceImpl.java
+++ b/hivemq-edge/src/main/java/com/hivemq/persistence/clientqueue/ClientQueuePersistenceImpl.java
@@ -392,15 +392,19 @@ public class ClientQueuePersistenceImpl extends AbstractPersistence implements C
             // hasAppliedBridgeConfiguration gate in isOrphaned; this is its missing other half
             // (EDG-882 QA round 1). Nothing leaks: whatever is genuinely abandoned is still there for
             // the next start's first sweep.
-            if (shutdownHooks.isShuttingDown()) {
-                if (log.isDebugEnabled()) {
-                    log.debug("Node is shutting down, skipping reclamation of {} shared queue(s)", sharedQueues.size());
-                }
-            } else {
-                for (final String sharedQueue : sharedQueues) {
-                    if (isOrphaned(sharedQueue)) {
-                        localPersistence.clear(sharedQueue, true, bucketIndex);
+            for (final String sharedQueue : sharedQueues) {
+                // Re-read per queue rather than once for the sweep: a sweep that started while the node
+                // was up can still be inside this loop when the bridge shutdown hook un-registers every
+                // forwarder, and each remaining iteration would then clear a live bridge queue. One
+                // volatile read per queue narrows that to a single iteration.
+                if (shutdownHooks.isShuttingDown()) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Node is shutting down, stopping the reclamation of shared queues");
                     }
+                    break;
+                }
+                if (isOrphaned(sharedQueue)) {
+                    localPersistence.clear(sharedQueue, true, bucketIndex);
                 }
             }
             // Visited once per bucket, after the sweep has finished, so that a test can wait for the

--- a/hivemq-edge/src/main/java/com/hivemq/persistence/clientqueue/ClientQueuePersistenceImpl.java
+++ b/hivemq-edge/src/main/java/com/hivemq/persistence/clientqueue/ClientQueuePersistenceImpl.java
@@ -111,11 +111,25 @@ public class ClientQueuePersistenceImpl extends AbstractPersistence implements C
         return singleWriter.submit(queueId, (bucketIndex) -> {
             MqttConfigurationService.QueuedMessagesStrategy queuedMessagesStrategy =
                     mqttConfigurationService.getQueuedMessagesStrategy();
+            // A sampler queue is a ring buffer of the most recent SamplingService.SAMPLE_SIZE payloads,
+            // so it discards the oldest -- and, unlike every other queue, that bound applies to QoS 0
+            // too. Without it a sampled topic whose publishers use QoS 0 is held only by the node-wide
+            // QoS 0 memory budget and can starve every other QoS 0 consumer on the node (EDG-885).
+            boolean applyMaxToQos0 = false;
             if (queueId.startsWith(SAMPLER_PREFIX)) {
                 queuedMessagesStrategy = MqttConfigurationService.QueuedMessagesStrategy.DISCARD_OLDEST;
+                applyMaxToQos0 = true;
             }
 
-            localPersistence.add(queueId, shared, publish, queueLimit, queuedMessagesStrategy, retained, bucketIndex);
+            localPersistence.add(
+                    queueId,
+                    shared,
+                    publish,
+                    queueLimit,
+                    queuedMessagesStrategy,
+                    retained,
+                    applyMaxToQos0,
+                    bucketIndex);
             final int queueSize = localPersistence.size(queueId, shared, bucketIndex);
             if (queueSize == 1) {
                 if (shared) {
@@ -147,11 +161,25 @@ public class ClientQueuePersistenceImpl extends AbstractPersistence implements C
             final boolean queueWasEmpty = localPersistence.size(queueId, shared, bucketIndex) == 0;
             MqttConfigurationService.QueuedMessagesStrategy queuedMessagesStrategy =
                     mqttConfigurationService.getQueuedMessagesStrategy();
+            // A sampler queue is a ring buffer of the most recent SamplingService.SAMPLE_SIZE payloads,
+            // so it discards the oldest -- and, unlike every other queue, that bound applies to QoS 0
+            // too. Without it a sampled topic whose publishers use QoS 0 is held only by the node-wide
+            // QoS 0 memory budget and can starve every other QoS 0 consumer on the node (EDG-885).
+            boolean applyMaxToQos0 = false;
             if (queueId.startsWith(SAMPLER_PREFIX)) {
                 queuedMessagesStrategy = MqttConfigurationService.QueuedMessagesStrategy.DISCARD_OLDEST;
+                applyMaxToQos0 = true;
             }
 
-            localPersistence.add(queueId, shared, publishes, queueLimit, queuedMessagesStrategy, retained, bucketIndex);
+            localPersistence.add(
+                    queueId,
+                    shared,
+                    publishes,
+                    queueLimit,
+                    queuedMessagesStrategy,
+                    retained,
+                    applyMaxToQos0,
+                    bucketIndex);
             if (queueWasEmpty) {
                 if (shared) {
                     sharedPublishAvailable(queueId);

--- a/hivemq-edge/src/main/java/com/hivemq/persistence/clientqueue/ClientQueuePersistenceImpl.java
+++ b/hivemq-edge/src/main/java/com/hivemq/persistence/clientqueue/ClientQueuePersistenceImpl.java
@@ -403,7 +403,12 @@ public class ClientQueuePersistenceImpl extends AbstractPersistence implements C
                     }
                     break;
                 }
-                if (isOrphaned(sharedQueue)) {
+                // Re-read after resolving ownership, immediately before the clear. The bridge shutdown
+                // hook can un-register every forwarder while isOrphaned is running, which turns a live
+                // queue into an apparently orphaned one between the guard above and the clear below --
+                // so the guard has to be the last thing that happens before the destructive call, not
+                // the first thing in the iteration (EDG-882 QA round 4).
+                if (isOrphaned(sharedQueue) && !shutdownHooks.isShuttingDown()) {
                     localPersistence.clear(sharedQueue, true, bucketIndex);
                 }
             }

--- a/hivemq-edge/src/main/java/com/hivemq/persistence/clientqueue/ClientQueuePersistenceImpl.java
+++ b/hivemq-edge/src/main/java/com/hivemq/persistence/clientqueue/ClientQueuePersistenceImpl.java
@@ -33,7 +33,6 @@ import com.hivemq.mqtt.message.dropping.MessageDroppedService;
 import com.hivemq.mqtt.message.publish.PUBLISH;
 import com.hivemq.mqtt.message.pubrel.PUBREL;
 import com.hivemq.mqtt.services.PublishPollService;
-import com.hivemq.mqtt.topic.SubscriberWithQoS;
 import com.hivemq.mqtt.topic.tree.LocalTopicTree;
 import com.hivemq.persistence.AbstractPersistence;
 import com.hivemq.persistence.ProducerQueues;
@@ -43,6 +42,7 @@ import com.hivemq.persistence.clientsession.SharedSubscriptionServiceImpl;
 import com.hivemq.persistence.connection.ConnectionPersistence;
 import com.hivemq.persistence.local.ClientSessionLocalPersistence;
 import com.hivemq.persistence.payload.PayloadPersistenceException;
+import com.hivemq.sampling.SamplingService;
 import dagger.Lazy;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
@@ -344,16 +344,37 @@ public class ClientQueuePersistenceImpl extends AbstractPersistence implements C
         return singleWriter.submit(bucketIndex, (bucketIndex1) -> {
             final ImmutableSet<String> sharedQueues = localPersistence.cleanUp(bucketIndex1);
             for (final String sharedQueue : sharedQueues) {
-                final SharedSubscription sharedSubscription =
-                        SharedSubscriptionServiceImpl.splitTopicAndGroup(sharedQueue);
-                final ImmutableSet<SubscriberWithQoS> sharedSubscriber = topicTree.getSharedSubscriber(
-                        sharedSubscription.getShareName(), sharedSubscription.getTopicFilter());
-                if (sharedSubscriber.isEmpty()) {
+                if (isOrphaned(sharedQueue)) {
                     localPersistence.clear(sharedQueue, true, bucketIndex);
                 }
             }
             return null;
         });
+    }
+
+    /**
+     * A shared queue is orphaned when no subscriber holds it any more. Queue IDs are
+     * {@code <share name>/<topic filter>}, but two internal producers put a '/' inside the share name
+     * itself — bridge forwarders through the Base64 subscription hash, samplers through the sampled
+     * topic — so splitting at the first '/' resolves an owner that never existed and would clear a
+     * live queue. Both shapes are therefore resolved by their own convention, and a queue is only
+     * declared orphaned when no reading of it finds an owner.
+     */
+    private boolean isOrphaned(final @NotNull String queueId) {
+        if (queueId.startsWith(MessageForwarderImpl.FORWARDER_PREFIX) && messageForwarder.isForwarderQueue(queueId)) {
+            return false;
+        }
+        final SharedSubscription sharedSubscription = SharedSubscriptionServiceImpl.splitTopicAndGroup(queueId);
+        if (!topicTree
+                .getSharedSubscriber(sharedSubscription.getShareName(), sharedSubscription.getTopicFilter())
+                .isEmpty()) {
+            return false;
+        }
+        final String sampledTopic = SamplingService.extractSampledTopic(queueId);
+        return sampledTopic == null
+                || topicTree
+                        .getSharedSubscriber(SAMPLER_PREFIX + sampledTopic, sampledTopic)
+                        .isEmpty();
     }
 
     @Override

--- a/hivemq-edge/src/main/java/com/hivemq/persistence/clientqueue/ClientQueuePersistenceImpl.java
+++ b/hivemq-edge/src/main/java/com/hivemq/persistence/clientqueue/ClientQueuePersistenceImpl.java
@@ -43,6 +43,7 @@ import com.hivemq.persistence.connection.ConnectionPersistence;
 import com.hivemq.persistence.local.ClientSessionLocalPersistence;
 import com.hivemq.persistence.payload.PayloadPersistenceException;
 import com.hivemq.sampling.SamplingService;
+import com.hivemq.util.Checkpoints;
 import dagger.Lazy;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
@@ -374,6 +375,12 @@ public class ClientQueuePersistenceImpl extends AbstractPersistence implements C
                     localPersistence.clear(sharedQueue, true, bucketIndex);
                 }
             }
+            // Visited once per bucket, after the sweep has finished, so that a test can wait for the
+            // thing it means to observe. Regressions for the queues this clean-up used to delete had to
+            // sleep for long enough that a pass had "probably" happened, which passes just as green on a
+            // node where the job stopped being scheduled at all -- the one failure the sleep was there
+            // to catch (EDG-882 F-09). A checkpoint is inert unless a test enables it.
+            Checkpoints.checkpoint(ClientQueuePersistence.CLIENT_QUEUE_CLEAN_UP_FINISHED);
             return null;
         });
     }

--- a/hivemq-edge/src/main/java/com/hivemq/persistence/clientqueue/ClientQueuePersistenceImpl.java
+++ b/hivemq-edge/src/main/java/com/hivemq/persistence/clientqueue/ClientQueuePersistenceImpl.java
@@ -27,6 +27,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.hivemq.bootstrap.ClientConnection;
 import com.hivemq.bridge.MessageForwarder;
 import com.hivemq.bridge.MessageForwarderImpl;
+import com.hivemq.common.shutdown.ShutdownHooks;
 import com.hivemq.configuration.service.MqttConfigurationService;
 import com.hivemq.mqtt.message.MessageWithID;
 import com.hivemq.mqtt.message.dropping.MessageDroppedService;
@@ -53,10 +54,14 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Singleton
 @SuppressWarnings("FutureReturnValueIgnored")
 public class ClientQueuePersistenceImpl extends AbstractPersistence implements ClientQueuePersistence {
+
+    private static final @NotNull Logger log = LoggerFactory.getLogger(ClientQueuePersistenceImpl.class);
 
     public static final int SHARED_IN_FLIGHT_MARKER = 1;
 
@@ -69,6 +74,7 @@ public class ClientQueuePersistenceImpl extends AbstractPersistence implements C
     private final @NotNull ConnectionPersistence connectionPersistence;
     private final @NotNull Lazy<PublishPollService> publishPollService;
     private final @NotNull MessageForwarder messageForwarder;
+    private final @NotNull ShutdownHooks shutdownHooks;
     private final @NotNull Map<String, PublishAvailableCallback> queueidCallbackMap;
 
     @Inject
@@ -81,7 +87,9 @@ public class ClientQueuePersistenceImpl extends AbstractPersistence implements C
             final @NotNull LocalTopicTree topicTree,
             final @NotNull ConnectionPersistence connectionPersistence,
             final @NotNull Lazy<PublishPollService> publishPollService,
-            final @NotNull MessageForwarder messageForwarder) {
+            final @NotNull MessageForwarder messageForwarder,
+            final @NotNull ShutdownHooks shutdownHooks) {
+        this.shutdownHooks = shutdownHooks;
         this.localPersistence = localPersistence;
         this.mqttConfigurationService = mqttConfigurationService;
         this.clientSessionLocalPersistence = clientSessionLocalPersistence;
@@ -218,7 +226,13 @@ public class ClientQueuePersistenceImpl extends AbstractPersistence implements C
 
     @Override
     public void sharedPublishAvailable(final @NotNull String queueId) {
-        if (queueId.startsWith(MessageForwarderImpl.FORWARDER_PREFIX)) {
+        // Asked of the forwarder registry rather than read off the queue ID, for the same reason the
+        // producer side asks (EDG-882 F-05): a queue ID is built from a share name, and a share name is
+        // the client's to choose. A client subscribing to $share/$FORWARDER::anything/t used to have its
+        // notification handed to the message forwarder, which owns no such queue -- so the client was
+        // never told to poll, and the ID stayed in the forwarder's notEmptyQueues set for the life of
+        // the node, once per distinct share name the client cared to invent.
+        if (messageForwarder.isForwarderQueue(queueId)) {
             messageForwarder.messageAvailable(queueId);
         } else {
             final PublishAvailableCallback availableCallback = queueidCallbackMap.get(queueId);
@@ -370,9 +384,23 @@ public class ClientQueuePersistenceImpl extends AbstractPersistence implements C
     public ListenableFuture<Void> cleanUp(final int bucketIndex) {
         return singleWriter.submit(bucketIndex, (bucketIndex1) -> {
             final ImmutableSet<String> sharedQueues = localPersistence.cleanUp(bucketIndex1);
-            for (final String sharedQueue : sharedQueues) {
-                if (isOrphaned(sharedQueue)) {
-                    localPersistence.clear(sharedQueue, true, bucketIndex);
+            // Expiry above still runs; reclaiming abandoned queues does not, once the node is going
+            // down. The bridge shutdown hook has priority HIGH and runs early, and it un-registers every
+            // forwarder -- so from that moment until the process exits, every live bridge queue reads as
+            // unowned while this job is still scheduled, and a sweep landing there clears the backlog
+            // the shutdown was careful not to clear. The start-up side of exactly this window is the
+            // hasAppliedBridgeConfiguration gate in isOrphaned; this is its missing other half
+            // (EDG-882 QA round 1). Nothing leaks: whatever is genuinely abandoned is still there for
+            // the next start's first sweep.
+            if (shutdownHooks.isShuttingDown()) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Node is shutting down, skipping reclamation of {} shared queue(s)", sharedQueues.size());
+                }
+            } else {
+                for (final String sharedQueue : sharedQueues) {
+                    if (isOrphaned(sharedQueue)) {
+                        localPersistence.clear(sharedQueue, true, bucketIndex);
+                    }
                 }
             }
             // Visited once per bucket, after the sweep has finished, so that a test can wait for the

--- a/hivemq-edge/src/main/java/com/hivemq/persistence/clientqueue/ClientQueuePersistenceImpl.java
+++ b/hivemq-edge/src/main/java/com/hivemq/persistence/clientqueue/ClientQueuePersistenceImpl.java
@@ -394,8 +394,17 @@ public class ClientQueuePersistenceImpl extends AbstractPersistence implements C
      * declared orphaned when no reading of it finds an owner.
      */
     private boolean isOrphaned(final @NotNull String queueId) {
-        if (queueId.startsWith(MessageForwarderImpl.FORWARDER_PREFIX) && messageForwarder.isForwarderQueue(queueId)) {
-            return false;
+        if (queueId.startsWith(MessageForwarderImpl.FORWARDER_PREFIX)) {
+            // Before any bridge configuration has been applied, "no forwarder owns this" means the
+            // bridges have not started yet rather than that the queue is abandoned. This service is
+            // scheduled during persistence bootstrap and the bridge subsystem is built after it, so a
+            // sweep in between would delete the queues of every bridge on the node.
+            if (!messageForwarder.hasAppliedBridgeConfiguration()) {
+                return false;
+            }
+            if (messageForwarder.isForwarderQueue(queueId)) {
+                return false;
+            }
         }
         final SharedSubscription sharedSubscription = SharedSubscriptionServiceImpl.splitTopicAndGroup(queueId);
         if (!topicTree

--- a/hivemq-edge/src/main/java/com/hivemq/persistence/clientqueue/QueuePolicy.java
+++ b/hivemq-edge/src/main/java/com/hivemq/persistence/clientqueue/QueuePolicy.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.persistence.clientqueue;
+
+/**
+ * How a queue behaves when it is full — chosen by the component that produces the messages, and
+ * carried into the persistence rather than guessed there.
+ * <p>
+ * EDG-882, F-05. The persistence used to decide this from the queue ID: a queue whose ID started with
+ * {@code $SAMPLER::} was treated as a sampler and had its oldest messages discarded, QoS 0 included.
+ * But a queue ID is built from a share name, and a share name is chosen by the client — {@code
+ * $share/$SAMPLER::customer/alerts} is a legal subscription that no part of Edge owns. Inferring a
+ * destructive eviction policy from it meant an ordinary client could lose its own messages by naming a
+ * subscription group unluckily. The same class of mistake as parsing an owner out of a queue ID, which
+ * is what this ticket is about.
+ * <p>
+ * Deliberately named for the behaviour rather than the owner ({@code CLIENT}, {@code BRIDGE},
+ * {@code SAMPLER}): the persistence has no use for who owns a queue, only for what to do when it
+ * overflows, and owner values whose behaviour is identical would be a distinction the code cannot
+ * honour. If a future owner needs its own behaviour, it gets its own policy here.
+ */
+public enum QueuePolicy {
+
+    /**
+     * The ordinary queue: the configured {@code QueuedMessagesStrategy} applies to QoS 1 and 2, and
+     * QoS 0 is held only by the node-wide QoS 0 memory budget. Everything except sampling — client
+     * queues, shared subscriptions, and bridge forwarders, whose outage buffer must not be silently
+     * shortened.
+     */
+    DEFAULT,
+
+    /**
+     * A ring buffer of the most recent messages: the oldest are discarded to make room, and the count
+     * bound applies to QoS 0 as well. Used by payload sampling, which exists to show the last few
+     * messages on a topic and would otherwise be held only by the node-wide QoS 0 budget — a sampled
+     * QoS 0 topic could then starve every other QoS 0 consumer on the node (EDG-885).
+     */
+    SAMPLE_RING
+}

--- a/hivemq-edge/src/main/java/com/hivemq/persistence/local/memory/ClientQueueMemoryLocalPersistence.java
+++ b/hivemq-edge/src/main/java/com/hivemq/persistence/local/memory/ClientQueueMemoryLocalPersistence.java
@@ -145,6 +145,7 @@ public class ClientQueueMemoryLocalPersistence implements ClientQueueLocalPersis
             final long max,
             final @NotNull QueuedMessagesStrategy strategy,
             final boolean retained,
+            final boolean applyMaxToQos0,
             final int bucketIndex) {
 
         checkNotNull(queueId, "Queue ID must not be null");
@@ -152,7 +153,7 @@ public class ClientQueueMemoryLocalPersistence implements ClientQueueLocalPersis
         checkNotNull(strategy, "Strategy must not be null");
         ThreadPreConditions.startsWith(SINGLE_WRITER_THREAD_PREFIX);
 
-        add(queueId, shared, List.of(publish), max, strategy, retained, bucketIndex);
+        add(queueId, shared, List.of(publish), max, strategy, retained, applyMaxToQos0, bucketIndex);
     }
 
     /**
@@ -167,6 +168,7 @@ public class ClientQueueMemoryLocalPersistence implements ClientQueueLocalPersis
             final long max,
             final @NotNull QueuedMessagesStrategy strategy,
             final boolean retained,
+            final boolean applyMaxToQos0,
             final int bucketIndex) {
 
         checkNotNull(queueId, "Queue ID must not be null");
@@ -180,7 +182,7 @@ public class ClientQueueMemoryLocalPersistence implements ClientQueueLocalPersis
         for (final PUBLISH publish : publishes) {
             final PublishWithRetained publishWithRetained = new PublishWithRetained(publish, retained);
             if (publish.getQoS() == QoS.AT_MOST_ONCE) {
-                addQos0Publish(queueId, shared, messages, publishWithRetained);
+                addQos0Publish(queueId, shared, messages, publishWithRetained, max, applyMaxToQos0);
             } else {
                 final int qos1And2QueueSize = messages.qos1Or2Messages.size() - messages.retainedQos1Or2Messages;
                 if ((qos1And2QueueSize >= max) && !retained) {
@@ -224,7 +226,31 @@ public class ClientQueueMemoryLocalPersistence implements ClientQueueLocalPersis
             final @NotNull String queueId,
             final boolean shared,
             final @NotNull Messages messages,
-            final @NotNull PublishWithRetained publishWithRetained) {
+            final @NotNull PublishWithRetained publishWithRetained,
+            final long max,
+            final boolean applyMaxToQos0) {
+
+        // Only callers that asked for it (sampler queues today) bound QoS 0 by count. Everything else
+        // keeps the historical behaviour of being held solely by the node-wide QoS 0 memory budget --
+        // imposing a count limit here would silently shrink the outage buffer of every persist=false
+        // bridge, which is a separate decision from EDG-885.
+        //
+        // Trimming before the memory guards below is deliberate: it releases the space the incoming
+        // message needs, so a ring buffer keeps rotating even on a node already at the QoS 0 ceiling
+        // rather than freezing at whatever it happened to hold when the ceiling was reached.
+        if (applyMaxToQos0) {
+            while (max > 0 && messages.qos0Messages.size() >= max) {
+                final PublishWithRetained oldest = messages.qos0Messages.pollFirst();
+                if (oldest == null) {
+                    break;
+                }
+                final int freed = -oldest.getEstimatedSize();
+                increaseQos0MessagesMemory(freed);
+                increaseClientQos0MessagesMemory(messages, freed);
+                increaseMessagesMemory(freed);
+                logAndDecrementPayloadReference(oldest, shared, queueId);
+            }
+        }
 
         final long currentQos0MessagesMemory = qos0MessagesMemory.get();
         if (currentQos0MessagesMemory >= qos0MemoryLimit) {

--- a/hivemq-edge/src/main/java/com/hivemq/persistence/local/memory/ClientQueueMemoryLocalPersistence.java
+++ b/hivemq-edge/src/main/java/com/hivemq/persistence/local/memory/ClientQueueMemoryLocalPersistence.java
@@ -164,6 +164,38 @@ public class ClientQueueMemoryLocalPersistence implements ClientQueueLocalPersis
     public void add(
             final @NotNull String queueId,
             final boolean shared,
+            final @NotNull PUBLISH publish,
+            final long max,
+            final @NotNull QueuedMessagesStrategy strategy,
+            final boolean retained,
+            final int bucketIndex) {
+        add(queueId, shared, publish, max, strategy, retained, false, bucketIndex);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @ExecuteInSingleWriter
+    public void add(
+            final @NotNull String queueId,
+            final boolean shared,
+            final @NotNull List<PUBLISH> publishes,
+            final long max,
+            final @NotNull QueuedMessagesStrategy strategy,
+            final boolean retained,
+            final int bucketIndex) {
+        add(queueId, shared, publishes, max, strategy, retained, false, bucketIndex);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @ExecuteInSingleWriter
+    public void add(
+            final @NotNull String queueId,
+            final boolean shared,
             final @NotNull List<PUBLISH> publishes,
             final long max,
             final @NotNull QueuedMessagesStrategy strategy,

--- a/hivemq-edge/src/main/java/com/hivemq/persistence/local/memory/ClientQueueMemoryLocalPersistence.java
+++ b/hivemq-edge/src/main/java/com/hivemq/persistence/local/memory/ClientQueueMemoryLocalPersistence.java
@@ -267,34 +267,34 @@ public class ClientQueueMemoryLocalPersistence implements ClientQueueLocalPersis
         // imposing a count limit here would silently shrink the outage buffer of every persist=false
         // bridge, which is a separate decision from EDG-885.
         //
-        // Trimming before the memory guards below is deliberate: it releases the space the incoming
-        // message needs, so a ring buffer keeps rotating even on a node already at the QoS 0 ceiling
-        // rather than freezing at whatever it happened to hold when the ceiling was reached.
-        if (applyMaxToQos0) {
-            while (max > 0 && messages.qos0Messages.size() >= max) {
-                final PublishWithRetained oldest = messages.qos0Messages.pollFirst();
-                if (oldest == null) {
+        // Admission and eviction are ONE decision, and nothing is mutated until it has been made.
+        //
+        // The count bound used to trim first and check the memory guards afterwards, which reads
+        // correctly for the case it was written for -- the evicted sample releases the space its
+        // replacement needs, so a ring keeps rotating at the node-wide ceiling. It is wrong for the case
+        // where the pressure belongs to somebody else: unrelated QoS 0 traffic holds the node over the
+        // ceiling, the incoming sample is rejected *after* the old one has already been destroyed, and a
+        // ring of one empties itself. Every sample after it repeats the trade, so the diagnostic this
+        // bound exists to protect ends up showing nothing at all (EDG-882 review v03, R3-05).
+        //
+        // So: work out what the trim would evict and what that would free, decide admission against the
+        // post-trim figures, and only then touch the deque.
+        int victimCount = 0;
+        long freedByTrim = 0;
+        if (applyMaxToQos0 && max > 0) {
+            for (final PublishWithRetained candidate : messages.qos0Messages) {
+                if (messages.qos0Messages.size() - victimCount < max) {
                     break;
                 }
-                final int freed = -oldest.getEstimatedSize();
-                increaseQos0MessagesMemory(freed);
-                increaseClientQos0MessagesMemory(messages, freed);
-                increaseMessagesMemory(freed);
-                // Rotation, not a drop. Reporting it through the dropped-message service put every
-                // sample a UI topic preview replaces on the node-wide dropped-message counter and wrote
-                // an event.log line per publish -- so opening a topic in the UI made the node look like
-                // it was losing customer messages (EDG-882 QA round 1). Nothing to dereference either:
-                // QoS 0 payloads are never reference-counted.
-                if (log.isTraceEnabled()) {
-                    log.trace(
-                            "Rotated the oldest QoS 0 message out of bounded queue '{}' to make room for a new one",
-                            queueId);
-                }
+                victimCount++;
+                freedByTrim += candidate.getEstimatedSize();
             }
         }
 
         final long currentQos0MessagesMemory = qos0MessagesMemory.get();
-        if (currentQos0MessagesMemory >= qos0MemoryLimit) {
+        if (currentQos0MessagesMemory - freedByTrim >= qos0MemoryLimit) {
+            // Reported against the memory the node actually holds, not the hypothetical post-trim
+            // figure: nothing was evicted, and the counter the operator can observe is this one.
             if (shared) {
                 messageDroppedService.qos0MemoryExceededShared(
                         queueId, publishWithRetained.getTopic(), 0, currentQos0MessagesMemory, qos0MemoryLimit);
@@ -306,10 +306,32 @@ public class ClientQueueMemoryLocalPersistence implements ClientQueueLocalPersis
         }
 
         if (!shared) {
-            if (messages.qos0Memory >= qos0ClientMemoryLimit) {
+            if (messages.qos0Memory - freedByTrim >= qos0ClientMemoryLimit) {
                 messageDroppedService.qos0MemoryExceeded(
                         queueId, publishWithRetained.getTopic(), 0, messages.qos0Memory, qos0ClientMemoryLimit);
                 return;
+            }
+        }
+
+        // Admitted. Now, and only now, the ring gives up what it has to.
+        for (int evicted = 0; evicted < victimCount; evicted++) {
+            final PublishWithRetained oldest = messages.qos0Messages.pollFirst();
+            if (oldest == null) {
+                break;
+            }
+            final int freed = -oldest.getEstimatedSize();
+            increaseQos0MessagesMemory(freed);
+            increaseClientQos0MessagesMemory(messages, freed);
+            increaseMessagesMemory(freed);
+            // Rotation, not a drop. Reporting it through the dropped-message service put every
+            // sample a UI topic preview replaces on the node-wide dropped-message counter and wrote
+            // an event.log line per publish -- so opening a topic in the UI made the node look like
+            // it was losing customer messages (EDG-882 QA round 1). Nothing to dereference either:
+            // QoS 0 payloads are never reference-counted.
+            if (log.isTraceEnabled()) {
+                log.trace(
+                        "Rotated the oldest QoS 0 message out of bounded queue '{}' to make room for a new one",
+                        queueId);
             }
         }
 

--- a/hivemq-edge/src/main/java/com/hivemq/persistence/local/memory/ClientQueueMemoryLocalPersistence.java
+++ b/hivemq-edge/src/main/java/com/hivemq/persistence/local/memory/ClientQueueMemoryLocalPersistence.java
@@ -248,7 +248,16 @@ public class ClientQueueMemoryLocalPersistence implements ClientQueueLocalPersis
                 increaseQos0MessagesMemory(freed);
                 increaseClientQos0MessagesMemory(messages, freed);
                 increaseMessagesMemory(freed);
-                logAndDecrementPayloadReference(oldest, shared, queueId);
+                // Rotation, not a drop. Reporting it through the dropped-message service put every
+                // sample a UI topic preview replaces on the node-wide dropped-message counter and wrote
+                // an event.log line per publish -- so opening a topic in the UI made the node look like
+                // it was losing customer messages (EDG-882 QA round 1). Nothing to dereference either:
+                // QoS 0 payloads are never reference-counted.
+                if (log.isTraceEnabled()) {
+                    log.trace(
+                            "Rotated the oldest QoS 0 message out of bounded queue '{}' to make room for a new one",
+                            queueId);
+                }
             }
         }
 

--- a/hivemq-edge/src/main/java/com/hivemq/sampling/SamplingService.java
+++ b/hivemq-edge/src/main/java/com/hivemq/sampling/SamplingService.java
@@ -15,6 +15,7 @@
  */
 package com.hivemq.sampling;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.hivemq.mqtt.message.QoS;
@@ -26,6 +27,8 @@ import com.hivemq.persistence.clientqueue.ClientQueuePersistence;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 import org.jetbrains.annotations.NotNull;
@@ -47,6 +50,16 @@ public class SamplingService {
     private final @NotNull LocalTopicTree localTopicTree;
     private final @NotNull ClientQueuePersistence clientQueuePersistence;
 
+    /**
+     * How many callers currently want samples for each topic.
+     * <p>
+     * Sampling is a diagnostic collection started so the mapping editor can infer a schema, not a
+     * durable subscription: several clients may ask for the same topic at once, and the subscription
+     * must live exactly as long as the last of them. Counting watchers is what makes one client
+     * closing its panel harmless to another that is still looking.
+     */
+    private final @NotNull Map<String, Integer> watchers = new ConcurrentHashMap<>(0);
+
     @Inject
     public SamplingService(
             final @NotNull LocalTopicTree localTopicTree,
@@ -55,7 +68,63 @@ public class SamplingService {
         this.clientQueuePersistence = clientQueuePersistence;
     }
 
+    /**
+     * Registers interest in samples for a topic, subscribing on the first watcher.
+     * <p>
+     * Every call must be paired with exactly one {@link #stopSampling(String)}, or the subscription
+     * outlives its last watcher and its queue is never reclaimed.
+     * <p>
+     * The subscribe happens <b>inside</b> the map update rather than after it. {@code compute} is
+     * atomic for a key, so a concurrent {@link #stopSampling(String)} cannot interleave between the
+     * count reaching zero and the subscriber being removed. Without that, a release that had decided
+     * to stop could remove the subscriber an acquire had just added, leaving the count saying
+     * "watched" while the topic tree says "not subscribed" — no samples would ever arrive, the
+     * clean-up would rightly reclaim the queue, and nothing would re-register until the topic changed.
+     * Silent, sticky, and invisible to any single-threaded test.
+     */
     public void startSampling(final @NotNull String topic) {
+        watchers.compute(topic, (sampledTopic, count) -> {
+            if (count == null) {
+                subscribe(sampledTopic);
+                return 1;
+            }
+            return count + 1;
+        });
+    }
+
+    /**
+     * Releases one watcher's interest, unsubscribing when the last one lets go.
+     * <p>
+     * A release for a topic nobody is watching is a no-op: the count never goes negative, so a
+     * duplicate stop cannot make a later {@link #startSampling(String)} fail to subscribe.
+     * <p>
+     * Once the subscriber is gone the periodic clean-up reclaims the queue on its next sweep with no
+     * further help — {@code ClientQueuePersistenceImpl.isOrphaned} stops finding an owner for it. If a
+     * new watcher arrives after that, it starts from an empty queue and waits a moment for fresh
+     * samples. That is the intended behaviour and not a race worth defending against: samples are
+     * ephemeral diagnostics that regenerate in seconds, unlike a bridge queue, whose loss is
+     * unbounded and unrecoverable.
+     */
+    public void stopSampling(final @NotNull String topic) {
+        watchers.computeIfPresent(topic, (sampledTopic, count) -> {
+            if (count > 1) {
+                return count - 1;
+            }
+            unsubscribe(sampledTopic);
+            return null;
+        });
+    }
+
+    /**
+     * Whether any caller is currently watching this topic. Exposed for tests and diagnostics; the
+     * authoritative record of a live sampler remains the topic tree.
+     */
+    @VisibleForTesting
+    public boolean isSampling(final @NotNull String topic) {
+        return watchers.containsKey(topic);
+    }
+
+    private void subscribe(final @NotNull String topic) {
         log.debug("Starting sampling for topic: '{}'", topic);
         final String clientId = SAMPLER_PREFIX + topic;
         localTopicTree.addTopic(
@@ -65,10 +134,15 @@ public class SamplingService {
                 clientId);
     }
 
-    public void stopSampling(final @NotNull String topic) {
+    private void unsubscribe(final @NotNull String topic) {
         log.debug("Stopping sampling for topic: '{}'", topic);
         final String clientId = SAMPLER_PREFIX + topic;
-        localTopicTree.removeSubscriber(clientId, topic, null);
+        // The share name must be the one subscribe() registered under. Passing null here sends
+        // MatchingNodeSubscriptions.removeSubscriberFromStructures down its non-shared branch, which
+        // searches a map this subscription was never in -- so the removal silently does nothing and
+        // the sampler lives forever. MessageForwarderImpl.removeForwarder passes its share name for
+        // the same reason.
+        localTopicTree.removeSubscriber(clientId, topic, clientId);
     }
 
     /**
@@ -113,7 +187,7 @@ public class SamplingService {
                 clientQueuePersistence.peek(queueId, true, BYTE_LIMIT_SAMPLES, SAMPLE_SIZE);
         try {
             return publishes.get().stream().map(PUBLISH::getPayload).collect(Collectors.toList());
-        } catch (InterruptedException | ExecutionException e) {
+        } catch (final @NotNull InterruptedException | ExecutionException e) {
             log.warn("Exception while retrieval of sample payloads for topic '{}'", topic);
             throw new RuntimeException(e);
         }

--- a/hivemq-edge/src/main/java/com/hivemq/sampling/SamplingService.java
+++ b/hivemq-edge/src/main/java/com/hivemq/sampling/SamplingService.java
@@ -51,14 +51,23 @@ public class SamplingService {
     private final @NotNull ClientQueuePersistence clientQueuePersistence;
 
     /**
-     * How many callers currently want samples for each topic.
+     * The topics currently sampled. A set, not a count of watchers.
      * <p>
-     * Sampling is a diagnostic collection started so the mapping editor can infer a schema, not a
-     * durable subscription: several clients may ask for the same topic at once, and the subscription
-     * must live exactly as long as the last of them. Counting watchers is what makes one client
-     * closing its panel harmless to another that is still looking.
+     * Counting was the wrong shape while nothing releases: {@link #startSampling(String)} is reached
+     * from an HTTP POST that carries no watcher identity, so retries, a remounted panel and a second
+     * browser tab are indistinguishable and each one incremented a count that nothing ever decremented.
+     * A count like that cannot be balanced by any release added later — it would have no way to know
+     * which acquire it was balancing — and it read as a lifecycle that was being managed when it was
+     * not (EDG-882 F-06).
+     * <p>
+     * <b>What this does not fix:</b> nothing in production stops sampling, so a sampled topic keeps its
+     * subscription, and its ten-message queue, for the life of the node. Making that finite needs
+     * either a release the caller can be identified by — a DELETE endpoint with a watcher token — or a
+     * lease that expires unless refreshed, and the second changes what an idle-but-open editor panel
+     * sees. Both are decisions about the product's API surface rather than repairs to this class, and
+     * they belong to EDG-885.
      */
-    private final @NotNull Map<String, Integer> watchers = new ConcurrentHashMap<>(0);
+    private final @NotNull Map<String, Boolean> sampledTopics = new ConcurrentHashMap<>(0);
 
     @Inject
     public SamplingService(
@@ -69,59 +78,55 @@ public class SamplingService {
     }
 
     /**
-     * Registers interest in samples for a topic, subscribing on the first watcher.
+     * Starts sampling a topic, subscribing the first time it is asked for.
      * <p>
-     * Every call must be paired with exactly one {@link #stopSampling(String)}, or the subscription
-     * outlives its last watcher and its queue is never reclaimed.
+     * Idempotent: asking again while the topic is already sampled changes nothing. That is the honest
+     * shape for a call reached from a POST with no watcher identity — retries, a remounted panel and a
+     * second tab all mean the same thing here, "somebody wants samples of this topic".
      * <p>
-     * The subscribe happens <b>inside</b> the map update rather than after it. {@code compute} is
-     * atomic for a key, so a concurrent {@link #stopSampling(String)} cannot interleave between the
-     * count reaching zero and the subscriber being removed. Without that, a release that had decided
-     * to stop could remove the subscriber an acquire had just added, leaving the count saying
-     * "watched" while the topic tree says "not subscribed" — no samples would ever arrive, the
-     * clean-up would rightly reclaim the queue, and nothing would re-register until the topic changed.
-     * Silent, sticky, and invisible to any single-threaded test.
+     * The subscribe happens <b>inside</b> the map update rather than after it. {@code computeIfAbsent}
+     * is atomic for a key, so a concurrent {@link #stopSampling(String)} cannot interleave between the
+     * entry appearing and the subscriber being added. Without that, a stop could remove the subscriber
+     * a start had just added, leaving this map saying "sampled" while the topic tree says "not
+     * subscribed" — no samples would ever arrive, the clean-up would rightly reclaim the queue, and
+     * nothing would re-register until the topic changed. Silent, sticky, and invisible to any
+     * single-threaded test.
      */
     public void startSampling(final @NotNull String topic) {
-        watchers.compute(topic, (sampledTopic, count) -> {
-            if (count == null) {
-                subscribe(sampledTopic);
-                return 1;
-            }
-            return count + 1;
+        sampledTopics.computeIfAbsent(topic, sampledTopic -> {
+            subscribe(sampledTopic);
+            return Boolean.TRUE;
         });
     }
 
     /**
-     * Releases one watcher's interest, unsubscribing when the last one lets go.
+     * Stops sampling a topic and unsubscribes.
      * <p>
-     * A release for a topic nobody is watching is a no-op: the count never goes negative, so a
-     * duplicate stop cannot make a later {@link #startSampling(String)} fail to subscribe.
+     * <b>Nothing in production calls this yet</b>; it is the entry point a release path will use, and
+     * what the tests drive. Stopping a topic nobody is sampling is a no-op, so a duplicate stop cannot
+     * make a later {@link #startSampling(String)} fail to subscribe.
      * <p>
      * Once the subscriber is gone the periodic clean-up reclaims the queue on its next sweep with no
-     * further help — {@code ClientQueuePersistenceImpl.isOrphaned} stops finding an owner for it. If a
-     * new watcher arrives after that, it starts from an empty queue and waits a moment for fresh
+     * further help — {@code ClientQueuePersistenceImpl.isOrphaned} stops finding an owner for it. If
+     * sampling starts again after that, it starts from an empty queue and waits a moment for fresh
      * samples. That is the intended behaviour and not a race worth defending against: samples are
-     * ephemeral diagnostics that regenerate in seconds, unlike a bridge queue, whose loss is
-     * unbounded and unrecoverable.
+     * ephemeral diagnostics that regenerate in seconds, unlike a bridge queue, whose loss is unbounded
+     * and unrecoverable.
      */
     public void stopSampling(final @NotNull String topic) {
-        watchers.computeIfPresent(topic, (sampledTopic, count) -> {
-            if (count > 1) {
-                return count - 1;
-            }
+        sampledTopics.computeIfPresent(topic, (sampledTopic, sampling) -> {
             unsubscribe(sampledTopic);
             return null;
         });
     }
 
     /**
-     * Whether any caller is currently watching this topic. Exposed for tests and diagnostics; the
-     * authoritative record of a live sampler remains the topic tree.
+     * Whether this topic is currently sampled. Exposed for tests and diagnostics; the authoritative
+     * record of a live sampler remains the topic tree.
      */
     @VisibleForTesting
     public boolean isSampling(final @NotNull String topic) {
-        return watchers.containsKey(topic);
+        return sampledTopics.containsKey(topic);
     }
 
     /**
@@ -135,13 +140,13 @@ public class SamplingService {
      * contrives the doubled shape fails the second, so neither has an eviction policy applied to its
      * messages that it did not ask for (EDG-882 F-05).
      * <p>
-     * The watchers map, not the topic tree: it is the record of who asked for samples, and it is the
-     * same map {@link #startSampling(String)} maintains, so this cannot disagree with whether a
+     * The sampled-topics map, not the topic tree: it is the record of what was asked for, and it is
+     * the same map {@link #startSampling(String)} maintains, so this cannot disagree with whether a
      * subscription exists.
      */
     public boolean isSamplerQueue(final @NotNull String queueId) {
         final String sampledTopic = extractSampledTopic(queueId);
-        return sampledTopic != null && watchers.containsKey(sampledTopic);
+        return sampledTopic != null && sampledTopics.containsKey(sampledTopic);
     }
 
     private void subscribe(final @NotNull String topic) {

--- a/hivemq-edge/src/main/java/com/hivemq/sampling/SamplingService.java
+++ b/hivemq-edge/src/main/java/com/hivemq/sampling/SamplingService.java
@@ -124,6 +124,26 @@ public class SamplingService {
         return watchers.containsKey(topic);
     }
 
+    /**
+     * Whether this queue belongs to a sampling subscription this service created.
+     * <p>
+     * Asked by the publish path to decide whether the queue is a sample ring — a policy that discards
+     * the oldest messages — so the answer has to be about what Edge owns, not about how the ID is
+     * spelled. Two things have to hold: the ID must have the shape {@link #createQueueId(String)}
+     * produces, and the topic it decodes to must actually be sampled right now. A client subscribing
+     * to {@code $share/$SAMPLER::customer/alerts} fails the first (the two halves differ) and one that
+     * contrives the doubled shape fails the second, so neither has an eviction policy applied to its
+     * messages that it did not ask for (EDG-882 F-05).
+     * <p>
+     * The watchers map, not the topic tree: it is the record of who asked for samples, and it is the
+     * same map {@link #startSampling(String)} maintains, so this cannot disagree with whether a
+     * subscription exists.
+     */
+    public boolean isSamplerQueue(final @NotNull String queueId) {
+        final String sampledTopic = extractSampledTopic(queueId);
+        return sampledTopic != null && watchers.containsKey(sampledTopic);
+    }
+
     private void subscribe(final @NotNull String topic) {
         log.debug("Starting sampling for topic: '{}'", topic);
         final String clientId = SAMPLER_PREFIX + topic;

--- a/hivemq-edge/src/main/java/com/hivemq/sampling/SamplingService.java
+++ b/hivemq-edge/src/main/java/com/hivemq/sampling/SamplingService.java
@@ -225,8 +225,14 @@ public class SamplingService {
                 clientQueuePersistence.peek(queueId, true, BYTE_LIMIT_SAMPLES, SAMPLE_SIZE);
         try {
             return publishes.get().stream().map(PUBLISH::getPayload).collect(Collectors.toList());
-        } catch (final @NotNull InterruptedException | ExecutionException e) {
-            log.warn("Exception while retrieval of sample payloads for topic '{}'", topic);
+        } catch (final InterruptedException | ExecutionException e) {
+            // The flag is restored before the throw: this runs on the REST request thread, which the
+            // container reuses, and swallowing the interrupt leaves the next request on that thread
+            // unable to see that it was asked to stop.
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            log.warn("Exception while retrieval of sample payloads for topic '{}'", topic, e);
             throw new RuntimeException(e);
         }
     }

--- a/hivemq-edge/src/main/java/com/hivemq/sampling/SamplingService.java
+++ b/hivemq-edge/src/main/java/com/hivemq/sampling/SamplingService.java
@@ -88,13 +88,23 @@ public class SamplingService {
         if (!queueId.startsWith(SAMPLER_PREFIX)) {
             return null;
         }
-        final String topicTwice = queueId.substring(SAMPLER_PREFIX.length());
-        final int separator = topicTwice.length() / 2;
-        if (topicTwice.length() % 2 == 0 || topicTwice.charAt(separator) != '/') {
+        // What follows the prefix must be the topic, a '/', then the same topic again. Both halves
+        // have the same length, so the separator can only be at the exact midpoint -- which makes the
+        // shape decidable by three checks and no searching.
+        final int topicStart = SAMPLER_PREFIX.length();
+        final int remainingLength = queueId.length() - topicStart;
+        if (remainingLength % 2 == 0) {
+            return null; // topic + '/' + topic always has odd length
+        }
+        final int topicLength = remainingLength / 2;
+        final int separator = topicStart + topicLength;
+        if (queueId.charAt(separator) != '/') {
             return null;
         }
-        final String topic = topicTwice.substring(0, separator);
-        return topic.equals(topicTwice.substring(separator + 1)) ? topic : null;
+        if (!queueId.regionMatches(topicStart, queueId, separator + 1, topicLength)) {
+            return null; // the two halves differ, so this is not a sampler queue
+        }
+        return queueId.substring(topicStart, separator);
     }
 
     public @NotNull List<byte[]> getSamples(final @NotNull String topic) {

--- a/hivemq-edge/src/main/java/com/hivemq/sampling/SamplingService.java
+++ b/hivemq-edge/src/main/java/com/hivemq/sampling/SamplingService.java
@@ -43,7 +43,20 @@ public class SamplingService {
 
     public static final @NotNull String SAMPLER_PREFIX = "$SAMPLER::";
 
+    /**
+     * How many samples {@link #getSamples} asks the persistence for.
+     * <p>
+     * <b>The ring is bounded per QoS class, not per queue</b> (EDG-882 review v02, R2-12). The limit is
+     * applied on the QoS 0 path and on the QoS 1/2 path independently, so a topic whose publishers use
+     * both can hold up to {@code 2 × SAMPLE_SIZE} messages while this peek takes {@code SAMPLE_SIZE} of
+     * them — and which ones is the persistence's read order, not recency. Acceptable for a diagnostic
+     * that exists to show an operator what a topic looks like, and written down because EDG-885's "at
+     * most ten samples" is true per class rather than per topic. Counting across both classes would mean
+     * one shared counter on a path where the two are stored separately, which is a bigger change than
+     * the imprecision costs.
+     */
     public static final int SAMPLE_SIZE = 10;
+
     public static final long SAMPLER_QUEUE_LIMIT = SAMPLE_SIZE;
     public static final int BYTE_LIMIT_SAMPLES = 100_000;
 

--- a/hivemq-edge/src/main/java/com/hivemq/sampling/SamplingService.java
+++ b/hivemq-edge/src/main/java/com/hivemq/sampling/SamplingService.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -70,9 +71,34 @@ public class SamplingService {
         localTopicTree.removeSubscriber(clientId, topic, null);
     }
 
+    /**
+     * The queue backing a sampled topic. The share name is {@code $SAMPLER::<topic>}, so the topic
+     * appears twice and, when it contains a '/', the share-name boundary is not the first slash.
+     */
+    public static @NotNull String createQueueId(final @NotNull String topic) {
+        return SAMPLER_PREFIX + topic + "/" + topic;
+    }
+
+    /**
+     * Recovers the sampled topic from a queue ID built by {@link #createQueueId(String)}, or null if
+     * the ID does not have that shape. Splitting at the first '/' would yield the wrong share name
+     * for any sampled topic containing a '/'.
+     */
+    public static @Nullable String extractSampledTopic(final @NotNull String queueId) {
+        if (!queueId.startsWith(SAMPLER_PREFIX)) {
+            return null;
+        }
+        final String topicTwice = queueId.substring(SAMPLER_PREFIX.length());
+        final int separator = topicTwice.length() / 2;
+        if (topicTwice.length() % 2 == 0 || topicTwice.charAt(separator) != '/') {
+            return null;
+        }
+        final String topic = topicTwice.substring(0, separator);
+        return topic.equals(topicTwice.substring(separator + 1)) ? topic : null;
+    }
+
     public @NotNull List<byte[]> getSamples(final @NotNull String topic) {
-        final String clientId = SAMPLER_PREFIX + topic;
-        final String queueId = clientId + "/" + topic;
+        final String queueId = createQueueId(topic);
         final ListenableFuture<ImmutableList<PUBLISH>> publishes =
                 clientQueuePersistence.peek(queueId, true, BYTE_LIMIT_SAMPLES, SAMPLE_SIZE);
         try {

--- a/hivemq-edge/src/main/java/com/hivemq/util/render/EnvVarUtil.java
+++ b/hivemq-edge/src/main/java/com/hivemq/util/render/EnvVarUtil.java
@@ -319,7 +319,7 @@ public class EnvVarUtil {
                 "The '<{}>' element holds a credential and its placeholder cannot be restored, because {}."
                         + " Rather than write the credential to config.xml it is written as '{}', which no"
                         + " variable sets: this node keeps running on the value it already holds, and the next"
-                        + " start will stop and name that variable. Restore the intended '${{ENV:...}}'"
+                        + " start will stop and name that variable. Restore the intended '${ENV:...}'"
                         + " reference in config.xml -- the previous file is in the rolling backup beside it.",
                 placeholder.element(),
                 reason,

--- a/hivemq-edge/src/main/java/com/hivemq/util/render/EnvVarUtil.java
+++ b/hivemq-edge/src/main/java/com/hivemq/util/render/EnvVarUtil.java
@@ -22,6 +22,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -101,39 +102,72 @@ public class EnvVarUtil {
     }
 
     /**
-     * A {@code ${ENV:...}} placeholder that is the entire text of one element, and the value it renders
-     * to: the element's name, the placeholder as written, and that value.
+     * One span of the configuration file that contained at least one {@code ${ENV:...}} placeholder, and
+     * the text it renders to.
+     * <p>
+     * {@code name} is the element name, or the attribute name when {@code attribute} is set. {@code
+     * literal} is the span exactly as the operator wrote it, placeholders and all; {@code value} is what
+     * that span renders to, which is what the marshaller will have written.
+     * <p>
+     * The span is the <em>whole</em> text of the element or attribute, not the placeholder alone. That is
+     * what makes a concatenation restorable: {@code <host>edge-${ENV:SITE}</host>} is one span whose
+     * literal is {@code edge-${ENV:SITE}} and whose value is {@code edge-berlin}, and putting the literal
+     * back where the value is found needs no knowledge of where inside it the placeholder sat (EDG-882
+     * review v03, R3-01).
      */
     public record ElementPlaceholder(
-            @NotNull String element,
+            @NotNull String name,
             @NotNull String literal,
-            @NotNull String value) {}
+            @NotNull String value,
+            boolean attribute) {
+
+        /** An element span, which is what the great majority of placeholders are. */
+        public ElementPlaceholder(
+                final @NotNull String name, final @NotNull String literal, final @NotNull String value) {
+            this(name, literal, value, false);
+        }
+    }
 
     /**
-     * Matches a placeholder that is the whole text of an element, capturing the element name and any
-     * whitespace the operator wrote around it.
+     * Matches an element whose text contains at least one placeholder, capturing the name and the entire
+     * text between the tags.
      * <p>
-     * The padding is captured rather than skipped because the element's text is what the document ends up
-     * holding: the file is rendered before it is parsed, so {@code <password>\n  ${ENV:PW}\n</password>}
-     * becomes an element whose text is the value <em>with</em> that padding, and the marshaller writes it
-     * back the same way. A search string built from the bare value then matches nothing, the restore gives
-     * up, and the credential is written out — which is what this looked like before
-     * {@code whenThePlaceholderIsWrittenWithSurroundingWhitespace_thenItIsStillRestored} was written
-     * (EDG-882 review v02, R2-20).
+     * The whole text, rather than the placeholder alone, so that any whitespace the operator wrote and
+     * any literal text they concatenated it with are both carried. The file is rendered before it is
+     * parsed, so {@code <password>\n  ${ENV:PW}\n</password>} becomes an element whose text is the value
+     * <em>with</em> that padding and the marshaller writes it back the same way; a search string built
+     * from the bare value matches nothing, the restore gives up, and the credential goes out (EDG-882
+     * review v02, R2-20). Concatenation is the same problem one step further out (R3-01).
+     * <p>
+     * {@code [^<>]} keeps a match inside one element: without it the text could run across a closing tag
+     * and swallow a sibling.
      */
     private static final @NotNull Pattern ELEMENT_PLACEHOLDER =
-            Pattern.compile("<([A-Za-z_][\\w.:-]*)>(\\s*)(\\$\\{ENV:(.*?)})(\\s*)</\\1>");
+            Pattern.compile("<([A-Za-z_][\\w.:-]*)>([^<>]*\\$\\{ENV:[^}]*}[^<>]*)</\\1>");
+
+    /**
+     * Matches an attribute whose value contains at least one placeholder.
+     * <p>
+     * Attributes were a documented blind spot until R3-01: a placeholder in one was resolved on the way
+     * in and written out resolved, with nothing reported at all. There is nothing about an attribute that
+     * makes it harder than an element — it is a named span with a value — so it is collected the same way
+     * and restored the same way.
+     */
+    private static final @NotNull Pattern ATTRIBUTE_PLACEHOLDER =
+            Pattern.compile("([A-Za-z_][\\w.:-]*)=\"([^\"]*\\$\\{ENV:[^}]*}[^\"]*)\"");
 
     private static final @NotNull Pattern XML_COMMENT = Pattern.compile("(?s)<!--.*?-->");
+
+    private static final @NotNull Pattern ENV_PLACEHOLDER = Pattern.compile(ENV_VAR_PATTERN);
 
     /**
      * The {@code ${ENV:...}} placeholders of the file as it was written that
      * {@link #restorePlaceholders} is able to put back.
      * <p>
-     * Only placeholders that are an element's entire text are collected, because those are the only ones
-     * that can be located again in a document the marshaller rebuilt from the configuration model: a
-     * placeholder in an attribute, or one concatenated with other text, has no anchor to return to. Such
-     * a placeholder is reported by {@code restorePlaceholders} rather than silently resolved.
+     * Every element text and every attribute value that contains a placeholder is collected, whether the
+     * placeholder is the whole of it or concatenated with literal text. What is <em>not</em> collectable
+     * is a span whose rendered form the marshaller will not reproduce verbatim; {@code restorePlaceholders}
+     * decides that when it looks, and refuses to write a credential it cannot put back.
      * <p>
      * Comments are stripped first. A commented-out block is not part of the configuration and never
      * reaches the marshalled document, but its placeholders would otherwise be counted and make every
@@ -142,19 +176,47 @@ public class EnvVarUtil {
     public static @NotNull List<ElementPlaceholder> collectPlaceholders(final @NotNull String text) {
         final String withoutComments = XML_COMMENT.matcher(text).replaceAll("");
         final List<ElementPlaceholder> placeholders = new ArrayList<>();
-        final var matcher = ELEMENT_PLACEHOLDER.matcher(withoutComments);
+        collectInto(placeholders, ELEMENT_PLACEHOLDER.matcher(withoutComments), false);
+        collectInto(placeholders, ATTRIBUTE_PLACEHOLDER.matcher(withoutComments), true);
+        return placeholders;
+    }
+
+    private static void collectInto(
+            final @NotNull List<ElementPlaceholder> placeholders,
+            final @NotNull Matcher matcher,
+            final boolean attribute) {
         while (matcher.find()) {
-            final var value = getValue(matcher.group(4));
+            final String literal = matcher.group(2);
+            final String value = renderOrNull(literal);
+            // An empty rendered span gives the restore nothing to search for, and a span with an unset
+            // variable never reaches the marshalled document at all -- the render of the whole file
+            // throws first, which is the behaviour this must not change.
             if (value != null && !value.isEmpty()) {
-                // Both sides carry the operator's padding, so the search string is what the marshaller
-                // wrote and the replacement is what they typed, character for character.
-                final String leading = matcher.group(2);
-                final String trailing = matcher.group(5);
-                placeholders.add(new ElementPlaceholder(
-                        matcher.group(1), leading + matcher.group(3) + trailing, leading + value + trailing));
+                placeholders.add(new ElementPlaceholder(matcher.group(1), literal, value, attribute));
             }
         }
-        return placeholders;
+    }
+
+    /**
+     * Renders one span the way {@link #replaceEnvironmentVariablePlaceholders} renders the whole file, or
+     * {@code null} when a variable it uses is unset.
+     * <p>
+     * Null rather than a throw: the whole-file render runs immediately after collection and throws on the
+     * same variable with the message the operator needs. Throwing here would only move that failure
+     * earlier and describe it worse.
+     */
+    private static @Nullable String renderOrNull(final @NotNull String span) {
+        final StringBuilder rendered = new StringBuilder();
+        final var matcher = ENV_PLACEHOLDER.matcher(span);
+        while (matcher.find()) {
+            final String replacement = getValue(matcher.group(1));
+            if (replacement == null) {
+                return null;
+            }
+            matcher.appendReplacement(rendered, escapeReplacement(replacement));
+        }
+        matcher.appendTail(rendered);
+        return rendered.toString();
     }
 
     /**
@@ -178,68 +240,108 @@ public class EnvVarUtil {
      * the value so that no secret reaches the disk unannounced (EDG-882 review v02, R2-04). It used to be
      * a warning and the value.
      * <p>
-     * <b>Known blind spots</b>, all of them cases {@link #collectPlaceholders} never sees, so they are
-     * resolved on the way in and stay resolved on the way out with nothing reported at all:
-     * <ul>
-     *   <li>a placeholder in an <em>attribute</em> rather than in element text;</li>
-     *   <li>a placeholder <em>concatenated</em> with other text, as in
-     *       {@code <host>edge-${ENV:SITE}</host>} — there is no anchor to return it to;</li>
-     *   <li>a placeholder inside a <em>configuration fragment</em> or an {@code <if>} block, which are
-     *       flattened into the document before this runs.</li>
-     * </ul>
-     * A credential written through any of these is materialised into {@code config.xml} exactly as it was
-     * before this method existed. Closing them means restoring at the level the operator wrote at rather
-     * than at the element, which is a larger change than this one.
+     * <b>Concatenation and attributes are covered</b> (EDG-882 review v03, R3-01). The unit collected is
+     * the whole text of an element or the whole value of an attribute, so
+     * {@code <host>edge-${ENV:SITE}</host>} and {@code path="${ENV:DIR}/certs"} are located and restored
+     * the same way a bare placeholder is; there is no need to know where inside the span it sat.
+     * <p>
+     * <b>What remains genuinely undecidable</b> is a span the marshaller does not reproduce verbatim: it
+     * normalises a typed field, or the element leaves the configuration. That is the {@code inDocument ==
+     * 0} case below, and it no longer returns quietly. If the value is still somewhere in the document
+     * and it is a credential, the write is <b>refused</b> rather than completed with the secret in it.
+     * <p>
+     * A placeholder inside a configuration fragment or an {@code <if>} block is collected, because both
+     * are flattened into the text before this runs; the write-back cannot reproduce the fragment
+     * structure itself, which is a separate and pre-existing limitation of the round trip.
      *
      * @param placeholders what {@link #collectPlaceholders(String)} found in the file as it was written
+     * @throws UnrecoverableException when a credential cannot be kept out of the document being written
      */
     public static @NotNull String restorePlaceholders(
             final @NotNull String renderedXml, final @NotNull List<ElementPlaceholder> placeholders) {
         if (placeholders.isEmpty()) {
             return renderedXml;
         }
-        // Grouped by the element the placeholder occupied and the value it renders to. Two placeholders
-        // that share both are indistinguishable in the marshalled document; a group whose literal is not
+        // Grouped by the span the placeholder occupied and the value it renders to. Two placeholders that
+        // share both are indistinguishable in the marshalled document; a group whose literal is not
         // unique is left alone rather than guessed at.
-        final Map<String, List<ElementPlaceholder>> byElementAndValue = new LinkedHashMap<>();
+        final Map<String, List<ElementPlaceholder>> bySpanAndValue = new LinkedHashMap<>();
         for (final ElementPlaceholder placeholder : placeholders) {
-            byElementAndValue
-                    .computeIfAbsent(placeholder.element() + ' ' + placeholder.value(), key -> new ArrayList<>())
+            bySpanAndValue
+                    .computeIfAbsent(
+                            // NUL, as the original key did -- it cannot occur in an XML name or in text
+                            // the parser accepted, so the three parts can never run together ambiguously.
+                            // Written as the escape rather than as a raw byte: the byte was in the source
+                            // literally, which made file(1) and grep treat this whole file as binary and
+                            // silently skip it (EDG-882 review v03, R3-01).
+                            placeholder.attribute() + "@" + placeholder.name() + '\0' + placeholder.value(),
+                            key -> new ArrayList<>())
                     .add(placeholder);
         }
 
         var result = renderedXml;
-        for (final List<ElementPlaceholder> group : byElementAndValue.values()) {
+        for (final List<ElementPlaceholder> group : bySpanAndValue.values()) {
             final ElementPlaceholder first = group.get(0);
             final String literal = first.literal();
-            final String element =
-                    "<" + first.element() + ">" + escapeXmlText(first.value()) + "</" + first.element() + ">";
-            final int inDocument = countOccurrences(result, element);
+            final String rendered = renderedSpan(first);
+            final int inDocument = countOccurrences(result, rendered);
 
             if (group.stream().anyMatch(placeholder -> !placeholder.literal().equals(literal))) {
                 result = giveUpOn(
                         result,
                         first,
-                        element,
+                        rendered,
                         "two different placeholders fill it with the same value, so neither of them can be told"
                                 + " from the other");
                 continue;
             }
             if (inDocument == 0) {
-                // Nothing to replace: the element the placeholder filled is not in the document as this
-                // expects it. Either it left the configuration, or the marshaller wrote its text
-                // differently -- normalising a typed field (TRUE -> true, 01883 -> 1883), or anything else
-                // that makes the element's text not what was collected.
+                // The span is not in the document as this expects it. Either it left the configuration --
+                // nothing to restore, and nothing to leak -- or the marshaller wrote it differently,
+                // normalising a typed field (TRUE to true, 01883 to 1883) or anything else not predicted
+                // here.
                 //
-                // This branch can leak: if the element is still there under a text this did not predict,
-                // the value is on disk and nothing here can find it to take it out. That is why the
-                // collection side has to record the text exactly as the document will hold it -- the
-                // whitespace case (R2-20) was precisely this, and it was a credential written in plain.
+                // Telling those two apart is the whole point, because the second is a leak: the value is in
+                // the document and the anchor cannot find it to take it out. So ask the one question that
+                // separates them, which is whether the value is still there at all. If it is, and it is a
+                // credential, refuse the write. Returning a document known to contain a secret the operator
+                // chose to keep out of it is not a decision this method gets to make (R3-01).
+                // Both forms, because the question is "is the secret in this document", not "is this exact
+                // string": a value the marshaller escaped is the same disclosure spelled differently. It is
+                // not reachable through ${ENV:...} today -- a value carrying an XML metacharacter is
+                // spliced in raw and makes the file unparseable long before this -- but a security check
+                // that only looks for one spelling is the kind that stops being true quietly.
+                if (result.contains(first.value()) || result.contains(escapeXmlText(first.value()))) {
+                    if (isSecretElement(first.name())) {
+                        log.error(
+                                "The '{}' {} holds a credential supplied through '{}', and that value is in the"
+                                        + " configuration being written in a form this cannot locate, so the"
+                                        + " placeholder cannot be put back. The write has been refused: config.xml is"
+                                        + " unchanged, and this node keeps running on the value it already holds.",
+                                first.name(),
+                                first.attribute() ? "attribute" : "element",
+                                literal);
+                        throw new UnrecoverableException(false);
+                    }
+                    log.error(
+                            "The '{}' {} that '{}' filled is in the configuration being written in a form this cannot"
+                                    + " locate, so its value is written out and the variable reference is lost; put it"
+                                    + " back by hand.",
+                            first.name(),
+                            first.attribute() ? "attribute" : "element",
+                            literal);
+                    continue;
+                }
+                // The value is nowhere in the document, so nothing leaked. Still an error, because the two
+                // readings of that are "the element left the configuration", which costs nothing, and "the
+                // marshaller normalised it", which silently costs the operator their variable reference --
+                // and this cannot tell them apart.
                 log.error(
-                        "The '<{}>' element that '{}' filled is not in the configuration being written, so the"
-                                + " placeholder cannot be restored. If the element was not removed, check the file"
-                                + " for a value that should have stayed a variable reference.",
-                        first.element(),
+                        "The '{}' {} that '{}' filled is not in the configuration being written, so the placeholder"
+                                + " cannot be restored. If it was not removed, check the file for a value that should"
+                                + " have stayed a variable reference.",
+                        first.name(),
+                        first.attribute() ? "attribute" : "element",
                         literal);
                 continue;
             }
@@ -247,12 +349,12 @@ public class EnvVarUtil {
                 result = giveUpOn(
                         result,
                         first,
-                        element,
+                        rendered,
                         "'" + literal + "' fills " + group.size() + " of them but the configuration being written"
                                 + " has " + inDocument + ", so which ones came from the variable cannot be told");
                 continue;
             }
-            result = result.replace(element, "<" + first.element() + ">" + literal + "</" + first.element() + ">");
+            result = result.replace(rendered, literalSpan(first));
         }
         return result;
     }
@@ -304,14 +406,14 @@ public class EnvVarUtil {
     private static @NotNull String giveUpOn(
             final @NotNull String document,
             final @NotNull ElementPlaceholder placeholder,
-            final @NotNull String element,
+            final @NotNull String rendered,
             final @NotNull String reason) {
-        if (!isSecretElement(placeholder.element())) {
+        if (!isSecretElement(placeholder.name())) {
             log.error(
                     "The '<{}>' placeholder cannot be restored when the configuration file is written, because"
                             + " {}. Its value is written out instead and the variable reference is lost; put it"
                             + " back by hand once the ambiguity is resolved.",
-                    placeholder.element(),
+                    placeholder.name(),
                     reason);
             return document;
         }
@@ -321,11 +423,39 @@ public class EnvVarUtil {
                         + " variable sets: this node keeps running on the value it already holds, and the next"
                         + " start will stop and name that variable. Restore the intended '${ENV:...}'"
                         + " reference in config.xml -- the previous file is in the rolling backup beside it.",
-                placeholder.element(),
+                placeholder.name(),
                 reason,
                 UNRESTORED_SECRET);
-        return document.replace(
-                element, "<" + placeholder.element() + ">" + UNRESTORED_SECRET + "</" + placeholder.element() + ">");
+        return document.replace(rendered, poisonedSpan(placeholder));
+    }
+
+    /** The span as the marshaller will have written it: what the restore searches the document for. */
+    private static @NotNull String renderedSpan(final @NotNull ElementPlaceholder placeholder) {
+        return placeholder.attribute()
+                ? placeholder.name() + "=\"" + escapeXmlAttribute(placeholder.value()) + "\""
+                : "<" + placeholder.name() + ">" + escapeXmlText(placeholder.value()) + "</" + placeholder.name() + ">";
+    }
+
+    /** The same span with the operator's placeholders back in it: what the restore writes. */
+    private static @NotNull String literalSpan(final @NotNull ElementPlaceholder placeholder) {
+        return placeholder.attribute()
+                ? placeholder.name() + "=\"" + placeholder.literal() + "\""
+                : "<" + placeholder.name() + ">" + placeholder.literal() + "</" + placeholder.name() + ">";
+    }
+
+    /** The same span with {@link #UNRESTORED_SECRET} in place of a credential that cannot be restored. */
+    private static @NotNull String poisonedSpan(final @NotNull ElementPlaceholder placeholder) {
+        return placeholder.attribute()
+                ? placeholder.name() + "=\"" + UNRESTORED_SECRET + "\""
+                : "<" + placeholder.name() + ">" + UNRESTORED_SECRET + "</" + placeholder.name() + ">";
+    }
+
+    /**
+     * The characters a marshaller escapes inside an attribute value. Differs from element text by the
+     * quote, which would otherwise close the attribute.
+     */
+    private static @NotNull String escapeXmlAttribute(final @NotNull String text) {
+        return text.replace("&", "&amp;").replace("<", "&lt;").replace("\"", "&quot;");
     }
 
     private static int countOccurrences(final @NotNull String text, final @NotNull String needle) {

--- a/hivemq-edge/src/main/java/com/hivemq/util/render/EnvVarUtil.java
+++ b/hivemq-edge/src/main/java/com/hivemq/util/render/EnvVarUtil.java
@@ -577,20 +577,38 @@ public class EnvVarUtil {
     }
 
     /**
-     * Whether one element text or attribute value of the finished document carries {@code value}.
+     * Whether one element text or attribute value of the finished document carries {@code value} — the
+     * broad question, asked when the span the restore was anchored to has gone missing.
      * <p>
-     * Equal, or containing it where the span is a credential-bearing one. A value that <em>is</em> the
-     * secret is the secret written out wherever it sits; a value that merely contains it is a disclosure
-     * only where the credential belongs — {@code <password>prefix-s3cr3t</password>}, the concatenation
-     * case — because anywhere else it is the operator's own text with the secret inside it, and refusing
-     * on that is how {@code <port>1883</port>} came to reject a password of {@code 1}.
+     * Equal, or inside a credential-bearing span. A value that <em>is</em> the secret is the secret
+     * written out wherever it sits, and when the anchor has vanished there is no telling where the
+     * marshaller put it; a value that merely contains it is a disclosure only where the credential
+     * belongs, because anywhere else it is the operator's own text with the secret inside it, and
+     * refusing on that is how {@code <port>1883</port>} came to reject a password of {@code 1}.
      */
     private static boolean holdsValue(
             final @NotNull String spanName, final @NotNull String spanValue, final @NotNull String value) {
-        if (spanValue.isEmpty()) {
-            return false;
-        }
-        return spanValue.equals(value) || (isSecretElement(spanName) && spanValue.contains(value));
+        return !spanValue.isEmpty() && (spanValue.equals(value) || isInACredentialSpan(spanName, spanValue, value));
+    }
+
+    /**
+     * Whether a credential-bearing span is still holding a credential — the narrow question, and the only
+     * shape a restore that believes it succeeded can actually have left behind.
+     * <p>
+     * The restore replaces a span with its own literal; it cannot move a value into a span it never
+     * touched. So a credential appearing in some other element of the finished document is the operator's
+     * own text — a username that happens to equal the password, a host name a credential variable resolves
+     * to — and refusing the write over it means that configuration can never be persisted again while the
+     * coincidence lasts (EDG-882 review v04). What is left is the span where the credential belongs, still
+     * holding the value instead of the placeholder, whole or concatenated.
+     * <p>
+     * The residual is an operator who writes the same credential literally in a second credential element.
+     * That one is refused, the message names both spans, and the remedy — stop writing the credential in
+     * plain text — is the one worth having.
+     */
+    private static boolean isInACredentialSpan(
+            final @NotNull String spanName, final @NotNull String spanValue, final @NotNull String value) {
+        return !spanValue.isEmpty() && isSecretElement(spanName) && spanValue.contains(value);
     }
 
     /**
@@ -612,16 +630,19 @@ public class EnvVarUtil {
      * parsed and only element text and attribute values are examined, which is where a credential would
      * have to be to be disclosed (EDG-882 review v04).
      * <p>
-     * <b>Whole values, except inside a credential-bearing span.</b> A value that <em>is</em> the secret is
-     * the secret written out, wherever it sits. A value that merely contains it is only a disclosure where
-     * the credential belongs — {@code <password>prefix-s3cr3t</password>}, the concatenation case — because
-     * anywhere else it is the operator's own text that happens to have the secret inside it, and refusing
-     * on that is how {@code <port>1883</port>} came to reject a password of {@code 1}.
+     * <b>Of the spans where a credential belongs, not of every value in the file.</b> The restore replaces
+     * a span with its own literal and cannot move a value into a span it never touched, so a credential
+     * still sitting in {@code <password>} is a bug in the restore and the same string sitting in
+     * {@code <username>} or {@code <host>} is the operator's own text. Asking the broad question refused
+     * every write for a bridge whose password happened to equal its own host name, which is an ordinary
+     * enough coincidence and left that node unable to persist a configuration change ever again (EDG-882
+     * review v04). Inside a credential-bearing span the question stays broad — containment, not equality —
+     * because {@code <password>prefix-s3cr3t</password>} is the concatenation case and is exactly what a
+     * half-done restore looks like.
      * <p>
-     * The false positive it can still have is an operator who wrote the same string that a credential
-     * variable resolves to as the whole value of another element. Refusing that write is the right side of
-     * the trade: the remedy is to stop writing the credential in plain text, and the message names the
-     * element.
+     * The false positive it can still have is an operator who writes the same credential literally in a
+     * second credential element. Refusing that write is the right side of the trade: the remedy is to stop
+     * writing the credential in plain text, and the message names both spans.
      */
     private static @NotNull String refuseIfACredentialSurvived(
             final @NotNull String document, final @NotNull List<ElementPlaceholder> placeholders) {
@@ -644,7 +665,7 @@ public class EnvVarUtil {
                 parsed,
                 (name, value, attribute) -> {
                     for (final ElementPlaceholder secret : secrets) {
-                        if (holdsValue(name, value, secret.value())) {
+                        if (isInACredentialSpan(name, value, secret.value())) {
                             log.error(
                                     "The value supplied to the '{}' {} through '{}' is still present in the"
                                             + " configuration being written, in the '{}' {}, after its placeholder"

--- a/hivemq-edge/src/main/java/com/hivemq/util/render/EnvVarUtil.java
+++ b/hivemq-edge/src/main/java/com/hivemq/util/render/EnvVarUtil.java
@@ -15,10 +15,12 @@
  */
 package com.hivemq.util.render;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.hivemq.exceptions.UnrecoverableException;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.regex.Pattern;
 import org.jetbrains.annotations.NotNull;
@@ -153,8 +155,25 @@ public class EnvVarUtil {
      * the document holds exactly as many such elements as the original file did. Matching on the value
      * alone was not enough: a variable that resolves to a string the operator also wrote somewhere else
      * — {@code ${ENV:NODE_NAME}} rendering to a bridge's own id, say — would have rewritten that other
-     * element into a variable reference nobody asked for. Anything ambiguous is left rendered and
-     * reported, which is rare and visible; the alternative is silent and permanent.
+     * element into a variable reference nobody asked for.
+     * <p>
+     * <b>What happens when it cannot decide</b> is {@link #giveUpOn}: an error naming the element and the
+     * reason, and, for an element that holds a credential, {@link #UNRESTORED_SECRET} written in place of
+     * the value so that no secret reaches the disk unannounced (EDG-882 review v02, R2-04). It used to be
+     * a warning and the value.
+     * <p>
+     * <b>Known blind spots</b>, all of them cases {@link #collectPlaceholders} never sees, so they are
+     * resolved on the way in and stay resolved on the way out with nothing reported at all:
+     * <ul>
+     *   <li>a placeholder in an <em>attribute</em> rather than in element text;</li>
+     *   <li>a placeholder <em>concatenated</em> with other text, as in
+     *       {@code <host>edge-${ENV:SITE}</host>} — there is no anchor to return it to;</li>
+     *   <li>a placeholder inside a <em>configuration fragment</em> or an {@code <if>} block, which are
+     *       flattened into the document before this runs.</li>
+     * </ul>
+     * A credential written through any of these is materialised into {@code config.xml} exactly as it was
+     * before this method existed. Closing them means restoring at the level the operator wrote at rather
+     * than at the element, which is a larger change than this one.
      *
      * @param placeholders what {@link #collectPlaceholders(String)} found in the file as it was written
      */
@@ -177,39 +196,115 @@ public class EnvVarUtil {
         for (final List<ElementPlaceholder> group : byElementAndValue.values()) {
             final ElementPlaceholder first = group.get(0);
             final String literal = first.literal();
-            if (group.stream().anyMatch(placeholder -> !placeholder.literal().equals(literal))) {
-                log.warn(
-                        "Two different placeholders fill a '<{}>' element with the same value, so neither can be"
-                                + " restored when the configuration file is written; the value will be written out"
-                                + " instead.",
-                        first.element());
-                continue;
-            }
             final String element =
                     "<" + first.element() + ">" + escapeXmlText(first.value()) + "</" + first.element() + ">";
             final int inDocument = countOccurrences(result, element);
+
+            if (group.stream().anyMatch(placeholder -> !placeholder.literal().equals(literal))) {
+                result = giveUpOn(
+                        result,
+                        first,
+                        element,
+                        "two different placeholders fill it with the same value, so neither of them can be told"
+                                + " from the other");
+                continue;
+            }
             if (inDocument == 0) {
-                log.warn(
+                // Nothing to write out and nothing to replace: the element the placeholder filled is not
+                // in the document at all. Either it left the configuration, or the marshaller normalised
+                // its value on the way out (TRUE -> true, 01883 -> 1883), which only happens to a typed
+                // field and so never to a secret -- those are xs:string and are written verbatim.
+                log.error(
                         "The '<{}>' element that '{}' filled is not in the configuration being written, so the"
-                                + " placeholder cannot be restored. Check the file for a value that should have"
-                                + " stayed a variable reference.",
+                                + " placeholder cannot be restored. If the element was not removed, check the file"
+                                + " for a value that should have stayed a variable reference.",
                         first.element(),
                         literal);
                 continue;
             }
             if (inDocument != group.size()) {
-                log.warn(
-                        "'{}' fills {} '<{}>' element(s) but the configuration being written has {}, so the"
-                                + " placeholder cannot be restored; its value will be written out instead.",
-                        literal,
-                        group.size(),
-                        first.element(),
-                        inDocument);
+                result = giveUpOn(
+                        result,
+                        first,
+                        element,
+                        "'" + literal + "' fills " + group.size() + " of them but the configuration being written"
+                                + " has " + inDocument + ", so which ones came from the variable cannot be told");
                 continue;
             }
             result = result.replace(element, "<" + first.element() + ">" + literal + "</" + first.element() + ">");
         }
         return result;
+    }
+
+    /**
+     * What is written in place of a secret whose placeholder could not be restored.
+     * <p>
+     * Not the value, which is the whole point; not an empty element either, because some secret-bearing
+     * elements are {@code nonEmptyString} in the schema and an empty one would make the file unparseable
+     * on the next start — a worse failure than the one being avoided, and one that names the schema
+     * rather than the cause. This is a placeholder for a variable nobody sets, so the next start stops
+     * with {@code Environment Variable EDGE_UNRESTORED_SECRET for HiveMQ config.xml is not set} and the
+     * operator is told exactly where to look, while the node they are running now carries on with the
+     * secret it already holds in memory.
+     */
+    @VisibleForTesting
+    static final @NotNull String UNRESTORED_SECRET = "${ENV:EDGE_UNRESTORED_SECRET}";
+
+    /**
+     * Element names whose text is a credential. Matched as a suffix so that the adapter configurations —
+     * {@code xs:any} in the schema, so their element names are not knowable here — are covered by the
+     * same rule as {@code <password>}, {@code <client-secret>}, {@code <private-key-password>} and
+     * {@code <truststore-password>}.
+     */
+    private static final @NotNull List<String> SECRET_ELEMENT_SUFFIXES =
+            List.of("password", "secret", "passphrase", "token", "credentials");
+
+    private static boolean isSecretElement(final @NotNull String element) {
+        final String name = element.toLowerCase(Locale.ROOT);
+        return SECRET_ELEMENT_SUFFIXES.stream().anyMatch(name::endsWith);
+    }
+
+    /**
+     * Reports a placeholder that cannot be put back, and keeps its value off the disk when that value is
+     * a credential.
+     * <p>
+     * The restore is anchored to an element name and count-checked, which is sound when the counts line
+     * up and ambiguous when they do not; there is no reading of an ambiguous case that is right, because
+     * an element holding the value and an element holding a literal that happens to equal it are the same
+     * bytes by the time the document is marshalled. So the ambiguous case is decided by which mistake can
+     * be undone. Writing a credential out cannot be: it is on disk, usually under version control, and
+     * rotating it is the only remedy. Replacing one the operator had written literally can be — the write
+     * takes a rolling backup of {@code config.xml} first, and the element is named in the error below.
+     * <p>
+     * A non-secret takes the other side of that trade and keeps its value: losing the indirection is
+     * permanent and worth an error, but poisoning a {@code <port>} would stop a node from starting over
+     * something that is not a disclosure.
+     */
+    private static @NotNull String giveUpOn(
+            final @NotNull String document,
+            final @NotNull ElementPlaceholder placeholder,
+            final @NotNull String element,
+            final @NotNull String reason) {
+        if (!isSecretElement(placeholder.element())) {
+            log.error(
+                    "The '<{}>' placeholder cannot be restored when the configuration file is written, because"
+                            + " {}. Its value is written out instead and the variable reference is lost; put it"
+                            + " back by hand once the ambiguity is resolved.",
+                    placeholder.element(),
+                    reason);
+            return document;
+        }
+        log.error(
+                "The '<{}>' element holds a credential and its placeholder cannot be restored, because {}."
+                        + " Rather than write the credential to config.xml it is written as '{}', which no"
+                        + " variable sets: this node keeps running on the value it already holds, and the next"
+                        + " start will stop and name that variable. Restore the intended '${{ENV:...}}'"
+                        + " reference in config.xml -- the previous file is in the rolling backup beside it.",
+                placeholder.element(),
+                reason,
+                UNRESTORED_SECRET);
+        return document.replace(
+                element, "<" + placeholder.element() + ">" + UNRESTORED_SECRET + "</" + placeholder.element() + ">");
     }
 
     private static int countOccurrences(final @NotNull String text, final @NotNull String needle) {
@@ -222,7 +317,15 @@ public class EnvVarUtil {
         return count;
     }
 
-    /** The three characters a marshaller escapes inside element text. */
+    /**
+     * The three characters a marshaller escapes inside element text.
+     * <p>
+     * Defensive only, and unreachable through {@code ${ENV:...}}:
+     * {@link #replaceEnvironmentVariablePlaceholders} splices a value into the document as raw text
+     * before it is parsed, escaping only the regex metacharacters, so a value carrying one of these
+     * makes the file malformed and the configuration fails to read. Kept because the search string has
+     * to be what the marshaller wrote for any value that reaches here by another route.
+     */
     private static @NotNull String escapeXmlText(final @NotNull String text) {
         return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;");
     }

--- a/hivemq-edge/src/main/java/com/hivemq/util/render/EnvVarUtil.java
+++ b/hivemq-edge/src/main/java/com/hivemq/util/render/EnvVarUtil.java
@@ -496,6 +496,7 @@ public class EnvVarUtil {
         }
 
         var result = renderedXml;
+        final ParsedOnce parses = new ParsedOnce();
         for (final List<ElementPlaceholder> group : bySpanAndValue.values()) {
             final ElementPlaceholder first = group.get(0);
             final String literal = first.literal();
@@ -526,7 +527,7 @@ public class EnvVarUtil {
                 // secret is still here" for a password of 'admin' in any file with an <admin-api> element,
                 // and refused every write from then on (EDG-882 review v04). Parsing also settles the
                 // escaping question the previous version handled by searching for two spellings.
-                if (isInTheDocumentAsAValue(result, first.value())) {
+                if (isInTheDocumentAsAValue(parses, result, first.value())) {
                     if (isSecretElement(first.name())) {
                         log.error(
                                 "The '{}' {} holds a credential supplied through '{}', and that value is in the"
@@ -571,7 +572,7 @@ public class EnvVarUtil {
             }
             result = rendered.matcher(result).replaceAll(literalSpan(first));
         }
-        return refuseIfACredentialSurvived(result, placeholders);
+        return refuseIfACredentialSurvived(result, placeholders, parses);
     }
 
     /**
@@ -603,14 +604,46 @@ public class EnvVarUtil {
     }
 
     /**
+     * The parsed form of the document being restored, kept for as long as the document has not changed.
+     * <p>
+     * Two questions on the write path are asked of the document's values rather than its text — whether a
+     * span the restore could not locate is still in it, and the final sweep for a surviving credential —
+     * and each one parsed the whole document again. A configuration whose spans the marshaller normalises
+     * therefore paid one parse per span, on every write (EDG-882 review v04). They are the same document
+     * and the same parse; only the questions differ.
+     * <p>
+     * Invalidated by identity, deliberately. Every rewrite in the loop produces a new {@code String}, so
+     * {@code !=} is exactly "the document has changed"; two equal instances would only cost a parse that
+     * was not needed, never return an answer about a document that no longer exists.
+     * <p>
+     * What it is not is a cheaper test. Deciding from the text — "the value does not appear anywhere, so
+     * skip the parse" — is the shortcut that let a numeric character reference carry a credential past
+     * this check once already, and no amount of it being faster makes it true.
+     */
+    private static final class ParsedOnce {
+
+        private @Nullable String source;
+        private @Nullable Document parsed;
+
+        private @Nullable Document of(final @NotNull String document) {
+            if (source != document) {
+                source = document;
+                parsed = parseOrNull(document);
+            }
+            return parsed;
+        }
+    }
+
+    /**
      * Whether a value is in the document as data rather than as markup — the question both the
      * unlocatable-span branch and {@link #refuseIfACredentialSurvived} ask of a finished document.
      * <p>
      * A document that cannot be parsed answers yes: this cannot see into it, and the caller's safe
      * reading of "cannot tell" is the same as "it is in there".
      */
-    private static boolean isInTheDocumentAsAValue(final @NotNull String document, final @NotNull String value) {
-        final Document parsed = parseOrNull(document);
+    private static boolean isInTheDocumentAsAValue(
+            final @NotNull ParsedOnce parses, final @NotNull String document, final @NotNull String value) {
+        final Document parsed = parses.of(document);
         if (parsed == null) {
             return true;
         }
@@ -688,14 +721,16 @@ public class EnvVarUtil {
      * writing the credential in plain text, and the message names both spans.
      */
     private static @NotNull String refuseIfACredentialSurvived(
-            final @NotNull String document, final @NotNull List<ElementPlaceholder> placeholders) {
+            final @NotNull String document,
+            final @NotNull List<ElementPlaceholder> placeholders,
+            final @NotNull ParsedOnce parses) {
         final List<ElementPlaceholder> secrets = placeholders.stream()
                 .filter(placeholder -> isSecretElement(placeholder.name()))
                 .toList();
         if (secrets.isEmpty()) {
             return document;
         }
-        final Document parsed = parseOrNull(document);
+        final Document parsed = parses.of(document);
         if (parsed == null) {
             // The document about to be written cannot be read back, so this cannot say whether a credential
             // is in it. Refusing keeps the previous config.xml, which parses.

--- a/hivemq-edge/src/main/java/com/hivemq/util/render/EnvVarUtil.java
+++ b/hivemq-edge/src/main/java/com/hivemq/util/render/EnvVarUtil.java
@@ -214,7 +214,7 @@ public class EnvVarUtil {
         }
         final List<ElementPlaceholder> placeholders = new ArrayList<>();
         final int[] seen = {0};
-        walk(document, placeholders, seen);
+        visitValues(document, (name, value, attribute) -> collect(placeholders, seen, name, value, attribute), seen);
         return new CollectedPlaceholders(placeholders, inFile - seen[0]);
     }
 
@@ -254,24 +254,32 @@ public class EnvVarUtil {
         }
     }
 
+    /** What one element text or attribute value of a parsed document is, to the two passes that read them. */
+    private interface ValueVisitor {
+
+        void visit(@NotNull String name, @NotNull String value, boolean attribute);
+    }
+
     /**
-     * Visits every node, collecting the restorable spans and counting every placeholder token the
-     * document holds anywhere — including in comments and processing instructions, which are counted as
-     * seen but never restored.
+     * Visits every element text and attribute value of a parsed document.
      * <p>
-     * Counting them is what makes {@code unaccountedTokens} mean "somewhere this walk cannot reach"
-     * rather than "somewhere this walk chose not to restore".
+     * Values, never markup. Both readers of a configuration document want the same thing — what the
+     * unmarshaller would see — and neither wants element names, which is the whole of
+     * {@link #refuseIfACredentialSurvived}'s defect: a document containing {@code <admin-api>} read as a
+     * document containing the password {@code admin} (EDG-882 review v04).
+     * <p>
+     * {@code seenInComments} counts the placeholder tokens held in comments and processing instructions,
+     * for the collector, which needs {@code unaccountedTokens} to mean "somewhere this walk cannot reach"
+     * rather than "somewhere this walk chose not to restore". Null for callers that only want the values.
      */
-    private static void walk(
-            final @NotNull Node node,
-            final @NotNull List<ElementPlaceholder> placeholders,
-            final int @NotNull [] seen) {
+    private static void visitValues(
+            final @NotNull Node node, final @NotNull ValueVisitor visitor, final int @Nullable [] seenInComments) {
         if (node.getNodeType() == Node.ELEMENT_NODE) {
             final Element element = (Element) node;
             final NamedNodeMap attributes = element.getAttributes();
             for (int i = 0; i < attributes.getLength(); i++) {
                 final Node attribute = attributes.item(i);
-                collect(placeholders, seen, attribute.getNodeName(), attribute.getNodeValue(), true);
+                visitor.visit(attribute.getNodeName(), attribute.getNodeValue(), true);
             }
             // Only the direct text children, joined: that is what the element's value is to the
             // unmarshaller, and what the marshaller writes back for it.
@@ -283,14 +291,16 @@ public class EnvVarUtil {
                     text.append(child.getNodeValue());
                 }
             }
-            collect(placeholders, seen, element.getTagName(), text.toString(), false);
-        } else if (node.getNodeType() == Node.COMMENT_NODE || node.getNodeType() == Node.PROCESSING_INSTRUCTION_NODE) {
+            visitor.visit(element.getTagName(), text.toString(), false);
+        } else if (seenInComments != null
+                && (node.getNodeType() == Node.COMMENT_NODE
+                        || node.getNodeType() == Node.PROCESSING_INSTRUCTION_NODE)) {
             // Seen, deliberately not restorable: neither reaches the marshalled document.
-            seen[0] += countOccurrences(requireNonNullElse(node.getNodeValue(), ""), ENV_TOKEN);
+            seenInComments[0] += countOccurrences(requireNonNullElse(node.getNodeValue(), ""), ENV_TOKEN);
         }
         final NodeList children = node.getChildNodes();
         for (int i = 0; i < children.getLength(); i++) {
-            walk(children.item(i), placeholders, seen);
+            visitValues(children.item(i), visitor, seenInComments);
         }
     }
 
@@ -424,12 +434,11 @@ public class EnvVarUtil {
                 // separates them, which is whether the value is still there at all. If it is, and it is a
                 // credential, refuse the write. Returning a document known to contain a secret the operator
                 // chose to keep out of it is not a decision this method gets to make (R3-01).
-                // Both forms, because the question is "is the secret in this document", not "is this exact
-                // string": a value the marshaller escaped is the same disclosure spelled differently. It is
-                // not reachable through ${ENV:...} today -- a value carrying an XML metacharacter is
-                // spliced in raw and makes the file unparseable long before this -- but a security check
-                // that only looks for one spelling is the kind that stops being true quietly.
-                if (result.contains(first.value()) || result.contains(escapeXmlText(first.value()))) {
+                // Of the document's values, not of its text: searching the serialised XML answered "the
+                // secret is still here" for a password of 'admin' in any file with an <admin-api> element,
+                // and refused every write from then on (EDG-882 review v04). Parsing also settles the
+                // escaping question the previous version handled by searching for two spellings.
+                if (isInTheDocumentAsAValue(result, first.value())) {
                     if (isSecretElement(first.name())) {
                         log.error(
                                 "The '{}' {} holds a credential supplied through '{}', and that value is in the"
@@ -506,6 +515,40 @@ public class EnvVarUtil {
     }
 
     /**
+     * Whether a value is in the document as data rather than as markup — the question both the
+     * unlocatable-span branch and {@link #refuseIfACredentialSurvived} ask of a finished document.
+     * <p>
+     * A document that cannot be parsed answers yes: this cannot see into it, and the caller's safe
+     * reading of "cannot tell" is the same as "it is in there".
+     */
+    private static boolean isInTheDocumentAsAValue(final @NotNull String document, final @NotNull String value) {
+        final Document parsed = parseOrNull(document);
+        if (parsed == null) {
+            return true;
+        }
+        final boolean[] found = {false};
+        visitValues(parsed, (name, spanValue, attribute) -> found[0] |= holdsValue(name, spanValue, value), null);
+        return found[0];
+    }
+
+    /**
+     * Whether one element text or attribute value of the finished document carries {@code value}.
+     * <p>
+     * Equal, or containing it where the span is a credential-bearing one. A value that <em>is</em> the
+     * secret is the secret written out wherever it sits; a value that merely contains it is a disclosure
+     * only where the credential belongs — {@code <password>prefix-s3cr3t</password>}, the concatenation
+     * case — because anywhere else it is the operator's own text with the secret inside it, and refusing
+     * on that is how {@code <port>1883</port>} came to reject a password of {@code 1}.
+     */
+    private static boolean holdsValue(
+            final @NotNull String spanName, final @NotNull String spanValue, final @NotNull String value) {
+        if (spanValue.isEmpty()) {
+            return false;
+        }
+        return spanValue.equals(value) || (isSecretElement(spanName) && spanValue.contains(value));
+    }
+
+    /**
      * The last word on whether a credential is going to disk, asked of the finished document rather than
      * of the branch that produced it.
      * <p>
@@ -516,33 +559,64 @@ public class EnvVarUtil {
      * believes it is finished is a bug in the restore, and shipping the document anyway would make it a
      * disclosure instead (EDG-882 review v03, R3-08).
      * <p>
-     * The one false positive it can have is an operator who wrote the same string that a credential
-     * variable resolves to somewhere else in the file, literally. Refusing that write is the right side of
+     * <b>Asked of the document's values, not of its text.</b> The first version searched the serialised
+     * XML with {@code String.contains}, which reads markup as content: a password of {@code admin} was
+     * "still present" because the file has an {@code <admin-api>} element, and every configuration write
+     * was refused from then on — the node stayed up and silently stopped being able to persist anything.
+     * Short values ({@code a}, {@code 1}, {@code true}) made it near-certain. So the finished document is
+     * parsed and only element text and attribute values are examined, which is where a credential would
+     * have to be to be disclosed (EDG-882 review v04).
+     * <p>
+     * <b>Whole values, except inside a credential-bearing span.</b> A value that <em>is</em> the secret is
+     * the secret written out, wherever it sits. A value that merely contains it is only a disclosure where
+     * the credential belongs — {@code <password>prefix-s3cr3t</password>}, the concatenation case — because
+     * anywhere else it is the operator's own text that happens to have the secret inside it, and refusing
+     * on that is how {@code <port>1883</port>} came to reject a password of {@code 1}.
+     * <p>
+     * The false positive it can still have is an operator who wrote the same string that a credential
+     * variable resolves to as the whole value of another element. Refusing that write is the right side of
      * the trade: the remedy is to stop writing the credential in plain text, and the message names the
      * element.
      */
     private static @NotNull String refuseIfACredentialSurvived(
             final @NotNull String document, final @NotNull List<ElementPlaceholder> placeholders) {
-        for (final ElementPlaceholder placeholder : placeholders) {
-            if (!isSecretElement(placeholder.name())) {
-                continue;
-            }
-            final String value = placeholder.value();
-            if (document.contains(value)
-                    || document.contains(escapeXmlText(value))
-                    || document.contains(escapeXmlAttribute(value))) {
-                log.error(
-                        "The value supplied to the '{}' {} through '{}' is still present in the configuration"
-                                + " being written after its placeholder was restored, so writing it would put a"
-                                + " credential on disk. The write has been refused: config.xml is unchanged, and"
-                                + " this node keeps running on the value it already holds. If that value is also"
-                                + " written literally somewhere else in the file, remove it there.",
-                        placeholder.name(),
-                        placeholder.attribute() ? "attribute" : "element",
-                        placeholder.literal());
-                throw new UnrecoverableException(false);
-            }
+        final List<ElementPlaceholder> secrets = placeholders.stream()
+                .filter(placeholder -> isSecretElement(placeholder.name()))
+                .toList();
+        if (secrets.isEmpty()) {
+            return document;
         }
+        final Document parsed = parseOrNull(document);
+        if (parsed == null) {
+            // The document about to be written cannot be read back, so this cannot say whether a credential
+            // is in it. Refusing keeps the previous config.xml, which parses.
+            log.error("The configuration being written could not be parsed to check that no credential"
+                    + " survived in it, so the write has been refused: config.xml is unchanged, and this node"
+                    + " keeps running on the configuration it already holds.");
+            throw new UnrecoverableException(false);
+        }
+        visitValues(
+                parsed,
+                (name, value, attribute) -> {
+                    for (final ElementPlaceholder secret : secrets) {
+                        if (holdsValue(name, value, secret.value())) {
+                            log.error(
+                                    "The value supplied to the '{}' {} through '{}' is still present in the"
+                                            + " configuration being written, in the '{}' {}, after its placeholder"
+                                            + " was restored -- so writing it would put a credential on disk. The"
+                                            + " write has been refused: config.xml is unchanged, and this node keeps"
+                                            + " running on the value it already holds. If that value is also written"
+                                            + " literally somewhere else in the file, remove it there.",
+                                    secret.name(),
+                                    secret.attribute() ? "attribute" : "element",
+                                    secret.literal(),
+                                    name,
+                                    attribute ? "attribute" : "element");
+                            throw new UnrecoverableException(false);
+                        }
+                    }
+                },
+                null);
         return document;
     }
 

--- a/hivemq-edge/src/main/java/com/hivemq/util/render/EnvVarUtil.java
+++ b/hivemq-edge/src/main/java/com/hivemq/util/render/EnvVarUtil.java
@@ -109,9 +109,20 @@ public class EnvVarUtil {
             @NotNull String literal,
             @NotNull String value) {}
 
-    /** Matches a placeholder that is the whole text of an element, capturing the element name. */
+    /**
+     * Matches a placeholder that is the whole text of an element, capturing the element name and any
+     * whitespace the operator wrote around it.
+     * <p>
+     * The padding is captured rather than skipped because the element's text is what the document ends up
+     * holding: the file is rendered before it is parsed, so {@code <password>\n  ${ENV:PW}\n</password>}
+     * becomes an element whose text is the value <em>with</em> that padding, and the marshaller writes it
+     * back the same way. A search string built from the bare value then matches nothing, the restore gives
+     * up, and the credential is written out — which is what this looked like before
+     * {@code whenThePlaceholderIsWrittenWithSurroundingWhitespace_thenItIsStillRestored} was written
+     * (EDG-882 review v02, R2-20).
+     */
     private static final @NotNull Pattern ELEMENT_PLACEHOLDER =
-            Pattern.compile("<([A-Za-z_][\\w.:-]*)>\\s*(\\$\\{ENV:(.*?)})\\s*</\\1>");
+            Pattern.compile("<([A-Za-z_][\\w.:-]*)>(\\s*)(\\$\\{ENV:(.*?)})(\\s*)</\\1>");
 
     private static final @NotNull Pattern XML_COMMENT = Pattern.compile("(?s)<!--.*?-->");
 
@@ -133,9 +144,14 @@ public class EnvVarUtil {
         final List<ElementPlaceholder> placeholders = new ArrayList<>();
         final var matcher = ELEMENT_PLACEHOLDER.matcher(withoutComments);
         while (matcher.find()) {
-            final var value = getValue(matcher.group(3));
+            final var value = getValue(matcher.group(4));
             if (value != null && !value.isEmpty()) {
-                placeholders.add(new ElementPlaceholder(matcher.group(1), matcher.group(2), value));
+                // Both sides carry the operator's padding, so the search string is what the marshaller
+                // wrote and the replacement is what they typed, character for character.
+                final String leading = matcher.group(2);
+                final String trailing = matcher.group(5);
+                placeholders.add(new ElementPlaceholder(
+                        matcher.group(1), leading + matcher.group(3) + trailing, leading + value + trailing));
             }
         }
         return placeholders;
@@ -210,10 +226,15 @@ public class EnvVarUtil {
                 continue;
             }
             if (inDocument == 0) {
-                // Nothing to write out and nothing to replace: the element the placeholder filled is not
-                // in the document at all. Either it left the configuration, or the marshaller normalised
-                // its value on the way out (TRUE -> true, 01883 -> 1883), which only happens to a typed
-                // field and so never to a secret -- those are xs:string and are written verbatim.
+                // Nothing to replace: the element the placeholder filled is not in the document as this
+                // expects it. Either it left the configuration, or the marshaller wrote its text
+                // differently -- normalising a typed field (TRUE -> true, 01883 -> 1883), or anything else
+                // that makes the element's text not what was collected.
+                //
+                // This branch can leak: if the element is still there under a text this did not predict,
+                // the value is on disk and nothing here can find it to take it out. That is why the
+                // collection side has to record the text exactly as the document will hold it -- the
+                // whitespace case (R2-20) was precisely this, and it was a credential written in plain.
                 log.error(
                         "The '<{}>' element that '{}' filled is not in the configuration being written, so the"
                                 + " placeholder cannot be restored. If the element was not removed, check the file"

--- a/hivemq-edge/src/main/java/com/hivemq/util/render/EnvVarUtil.java
+++ b/hivemq-edge/src/main/java/com/hivemq/util/render/EnvVarUtil.java
@@ -15,19 +15,33 @@
  */
 package com.hivemq.util.render;
 
+import static java.util.Objects.requireNonNullElse;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.hivemq.exceptions.UnrecoverableException;
+import java.io.IOException;
+import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
 
 /**
  * Util for handling system environment variables
@@ -128,72 +142,176 @@ public class EnvVarUtil {
         }
     }
 
-    /**
-     * Matches an element whose text contains at least one placeholder, capturing the name and the entire
-     * text between the tags.
-     * <p>
-     * The whole text, rather than the placeholder alone, so that any whitespace the operator wrote and
-     * any literal text they concatenated it with are both carried. The file is rendered before it is
-     * parsed, so {@code <password>\n  ${ENV:PW}\n</password>} becomes an element whose text is the value
-     * <em>with</em> that padding and the marshaller writes it back the same way; a search string built
-     * from the bare value matches nothing, the restore gives up, and the credential goes out (EDG-882
-     * review v02, R2-20). Concatenation is the same problem one step further out (R3-01).
-     * <p>
-     * {@code [^<>]} keeps a match inside one element: without it the text could run across a closing tag
-     * and swallow a sibling.
-     */
-    private static final @NotNull Pattern ELEMENT_PLACEHOLDER =
-            Pattern.compile("<([A-Za-z_][\\w.:-]*)>([^<>]*\\$\\{ENV:[^}]*}[^<>]*)</\\1>");
-
-    /**
-     * Matches an attribute whose value contains at least one placeholder.
-     * <p>
-     * Attributes were a documented blind spot until R3-01: a placeholder in one was resolved on the way
-     * in and written out resolved, with nothing reported at all. There is nothing about an attribute that
-     * makes it harder than an element — it is a named span with a value — so it is collected the same way
-     * and restored the same way.
-     */
-    private static final @NotNull Pattern ATTRIBUTE_PLACEHOLDER =
-            Pattern.compile("([A-Za-z_][\\w.:-]*)=\"([^\"]*\\$\\{ENV:[^}]*}[^\"]*)\"");
-
-    private static final @NotNull Pattern XML_COMMENT = Pattern.compile("(?s)<!--.*?-->");
-
     private static final @NotNull Pattern ENV_PLACEHOLDER = Pattern.compile(ENV_VAR_PATTERN);
+
+    /** The token every placeholder starts with, used for the cheap "is there one in here at all" test. */
+    private static final @NotNull String ENV_TOKEN = "${ENV:";
+
+    /**
+     * What {@link #collectPlaceholders(String)} found: the spans that can be restored, and whether it was
+     * able to account for every placeholder in the file.
+     *
+     * @param placeholders      one entry per element text or attribute value that holds a placeholder
+     * @param unaccountedTokens placeholders present in the file that the walk below never saw. Always
+     *                          zero for a well-formed configuration; anything else means the file holds a
+     *                          placeholder somewhere this cannot reason about, and
+     *                          {@link #restorePlaceholders} refuses the write rather than guess whether a
+     *                          credential is about to go out with it (EDG-882 review v03, R3-08).
+     */
+    public record CollectedPlaceholders(@NotNull List<ElementPlaceholder> placeholders, int unaccountedTokens) {
+
+        public static final @NotNull CollectedPlaceholders NONE = new CollectedPlaceholders(List.of(), 0);
+    }
 
     /**
      * The {@code ${ENV:...}} placeholders of the file as it was written that
      * {@link #restorePlaceholders} is able to put back.
      * <p>
-     * Every element text and every attribute value that contains a placeholder is collected, whether the
-     * placeholder is the whole of it or concatenated with literal text. What is <em>not</em> collectable
-     * is a span whose rendered form the marshaller will not reproduce verbatim; {@code restorePlaceholders}
-     * decides that when it looks, and refuses to write a credential it cannot put back.
+     * <b>Collected from a parsed document, not from the file's bytes.</b> The earlier version of this
+     * matched elements and attributes with a regular expression and stored the source span exactly as the
+     * operator typed it. That span is not what the marshaller writes, because the parser normalises text
+     * on the way in and the restore compares against post-marshal output: a numeric character reference
+     * standing in for an ordinary character, CRLF padding, or a value inside a CDATA section all
+     * rendered to something the restore then failed to find, took the "not in the document" branch, and
+     * let the credential through. CDATA was worse still — the pattern excluded angle brackets, so it
+     * could not match one and nothing was collected at all. Parsing the file the same way the
+     * configuration loader is about to parse it makes the collected value equal to the value JAXB will
+     * hold, which is the only thing the restore can honestly anchor on (EDG-882 review v03, R3-08).
      * <p>
-     * Comments are stripped first. A commented-out block is not part of the configuration and never
-     * reaches the marshalled document, but its placeholders would otherwise be counted and make every
-     * occurrence look ambiguous — commenting a bridge out is an ordinary thing for an operator to do.
+     * The literal kept is therefore the <em>parsed</em> text with the placeholders still in it, not the
+     * original bytes: a character reference comes back as the character it denotes, and a CDATA section
+     * comes back as its content. Both mean the same thing to the next parse, and {@link #literalSpan}
+     * escapes whatever needs escaping on the way out.
+     * <p>
+     * Comments are skipped, because the walk only visits element text and attribute values. A
+     * commented-out block is not part of the configuration and never reaches the marshalled document, but
+     * its placeholders would otherwise make every occurrence look ambiguous — commenting a bridge out is
+     * an ordinary thing for an operator to do. Their tokens are counted as seen, so they do not show up
+     * as unaccounted either.
      */
-    public static @NotNull List<ElementPlaceholder> collectPlaceholders(final @NotNull String text) {
-        final String withoutComments = XML_COMMENT.matcher(text).replaceAll("");
+    public static @NotNull CollectedPlaceholders collectPlaceholders(final @NotNull String text) {
+        final int inFile = countOccurrences(text, ENV_TOKEN);
+        if (inFile == 0) {
+            return CollectedPlaceholders.NONE;
+        }
+        final Document document = parseOrNull(text);
+        if (document == null) {
+            // Every token is unaccounted for, which refuses the next write-back rather than performing
+            // one with no restoration at all.
+            //
+            // Usually this never matters: the content handed here is what the configuration loader is
+            // about to unmarshal, so content this cannot parse fails there a moment later with the
+            // parser's own message, and the placeholders of a configuration that was never accepted are
+            // never used. What it does cover is the case where the two parsers disagree -- this one
+            // refuses a DOCTYPE and turns off external access, so a file the loader would accept can
+            // still be rejected here. Returning "no placeholders" for that would write every resolved
+            // secret to disk in silence, which is the failure this whole mechanism exists to prevent.
+            log.error("The configuration could not be parsed while locating its environment-variable"
+                    + " placeholders, so writing the configuration back out will be refused until it can be."
+                    + " Until then a REST change to any subsystem applies to the running node but cannot be"
+                    + " persisted to config.xml.");
+            return new CollectedPlaceholders(List.of(), inFile);
+        }
         final List<ElementPlaceholder> placeholders = new ArrayList<>();
-        collectInto(placeholders, ELEMENT_PLACEHOLDER.matcher(withoutComments), false);
-        collectInto(placeholders, ATTRIBUTE_PLACEHOLDER.matcher(withoutComments), true);
-        return placeholders;
+        final int[] seen = {0};
+        walk(document, placeholders, seen);
+        return new CollectedPlaceholders(placeholders, inFile - seen[0]);
     }
 
-    private static void collectInto(
+    /**
+     * Parses the configuration content with external access turned off, or {@code null} when it is not
+     * well formed.
+     * <p>
+     * This runs on a file that is about to be unmarshalled by the loader anyway, so it resolves nothing
+     * the loader would not; the restrictions are here because a parser that reaches the network or the
+     * file system on someone else's say-so is never wanted, not because this particular content is
+     * suspect.
+     */
+    private static @Nullable Document parseOrNull(final @NotNull String text) {
+        try {
+            final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+            setFeatureQuietly(factory, "http://apache.org/xml/features/disallow-doctype-decl", true);
+            setFeatureQuietly(factory, "http://xml.org/sax/features/external-general-entities", false);
+            setFeatureQuietly(factory, "http://xml.org/sax/features/external-parameter-entities", false);
+            factory.setXIncludeAware(false);
+            factory.setExpandEntityReferences(false);
+            factory.setNamespaceAware(false);
+            final DocumentBuilder builder = factory.newDocumentBuilder();
+            builder.setErrorHandler(null);
+            return builder.parse(new InputSource(new StringReader(text)));
+        } catch (final ParserConfigurationException | SAXException | IOException e) {
+            return null;
+        }
+    }
+
+    private static void setFeatureQuietly(
+            final @NotNull DocumentBuilderFactory factory, final @NotNull String feature, final boolean value) {
+        try {
+            factory.setFeature(feature, value);
+        } catch (final ParserConfigurationException ignored) {
+            // Not every parser implementation knows every feature name; secure processing is already on.
+        }
+    }
+
+    /**
+     * Visits every node, collecting the restorable spans and counting every placeholder token the
+     * document holds anywhere — including in comments and processing instructions, which are counted as
+     * seen but never restored.
+     * <p>
+     * Counting them is what makes {@code unaccountedTokens} mean "somewhere this walk cannot reach"
+     * rather than "somewhere this walk chose not to restore".
+     */
+    private static void walk(
+            final @NotNull Node node,
             final @NotNull List<ElementPlaceholder> placeholders,
-            final @NotNull Matcher matcher,
-            final boolean attribute) {
-        while (matcher.find()) {
-            final String literal = matcher.group(2);
-            final String value = renderOrNull(literal);
-            // An empty rendered span gives the restore nothing to search for, and a span with an unset
-            // variable never reaches the marshalled document at all -- the render of the whole file
-            // throws first, which is the behaviour this must not change.
-            if (value != null && !value.isEmpty()) {
-                placeholders.add(new ElementPlaceholder(matcher.group(1), literal, value, attribute));
+            final int @NotNull [] seen) {
+        if (node.getNodeType() == Node.ELEMENT_NODE) {
+            final Element element = (Element) node;
+            final NamedNodeMap attributes = element.getAttributes();
+            for (int i = 0; i < attributes.getLength(); i++) {
+                final Node attribute = attributes.item(i);
+                collect(placeholders, seen, attribute.getNodeName(), attribute.getNodeValue(), true);
             }
+            // Only the direct text children, joined: that is what the element's value is to the
+            // unmarshaller, and what the marshaller writes back for it.
+            final StringBuilder text = new StringBuilder();
+            final NodeList children = element.getChildNodes();
+            for (int i = 0; i < children.getLength(); i++) {
+                final Node child = children.item(i);
+                if (child.getNodeType() == Node.TEXT_NODE || child.getNodeType() == Node.CDATA_SECTION_NODE) {
+                    text.append(child.getNodeValue());
+                }
+            }
+            collect(placeholders, seen, element.getTagName(), text.toString(), false);
+        } else if (node.getNodeType() == Node.COMMENT_NODE || node.getNodeType() == Node.PROCESSING_INSTRUCTION_NODE) {
+            // Seen, deliberately not restorable: neither reaches the marshalled document.
+            seen[0] += countOccurrences(requireNonNullElse(node.getNodeValue(), ""), ENV_TOKEN);
+        }
+        final NodeList children = node.getChildNodes();
+        for (int i = 0; i < children.getLength(); i++) {
+            walk(children.item(i), placeholders, seen);
+        }
+    }
+
+    private static void collect(
+            final @NotNull List<ElementPlaceholder> placeholders,
+            final int @NotNull [] seen,
+            final @NotNull String name,
+            final @NotNull String literal,
+            final boolean attribute) {
+        final int tokens = countOccurrences(literal, ENV_TOKEN);
+        if (tokens == 0) {
+            return;
+        }
+        seen[0] += tokens;
+        final String value = renderOrNull(literal);
+        // An empty rendered span gives the restore nothing to search for, and a span with an unset
+        // variable never reaches the marshalled document at all -- the render of the whole file
+        // throws first, which is the behaviour this must not change. Both are still accounted for
+        // above: they were found, they are simply not restorable, which is not the same as unseen.
+        if (value != null && !value.isEmpty()) {
+            placeholders.add(new ElementPlaceholder(name, literal, value, attribute));
         }
     }
 
@@ -356,7 +474,76 @@ public class EnvVarUtil {
             }
             result = result.replace(rendered, literalSpan(first));
         }
-        return result;
+        return refuseIfACredentialSurvived(result, placeholders);
+    }
+
+    /**
+     * Restores the placeholders of a whole configuration file, refusing the write when the collector
+     * could not account for every one of them.
+     * <p>
+     * The branch-by-branch reasoning in {@link #restorePlaceholders(String, List)} can only speak for the
+     * spans it was given. A token the collector never saw has no branch at all — and "no branch" was
+     * exactly how the character-reference, CRLF and CDATA cases got a credential onto disk before the
+     * collector was rewritten. So the count is checked here rather than trusted: if the file held a
+     * placeholder the walk did not reach, this cannot say whether the value it stands for is in the
+     * document, and it refuses instead of assuming (EDG-882 review v03, R3-08).
+     *
+     * @throws UnrecoverableException when a credential cannot be kept out of the document being written
+     */
+    public static @NotNull String restorePlaceholders(
+            final @NotNull String renderedXml, final @NotNull CollectedPlaceholders collected) {
+        if (collected.unaccountedTokens() != 0) {
+            log.error(
+                    "The configuration file holds {} '{}...' placeholder(s) that could not be located in its"
+                            + " structure, so this cannot tell whether writing the configuration back out would"
+                            + " put the value of one on disk. The write has been refused: config.xml is"
+                            + " unchanged, and this node keeps running on the configuration it already holds.",
+                    collected.unaccountedTokens(),
+                    ENV_TOKEN);
+            throw new UnrecoverableException(false);
+        }
+        return restorePlaceholders(renderedXml, collected.placeholders());
+    }
+
+    /**
+     * The last word on whether a credential is going to disk, asked of the finished document rather than
+     * of the branch that produced it.
+     * <p>
+     * Every branch above that can end with a secret still in the document refuses on its own, and each of
+     * those refusals is tested. This exists because the branch that gets it wrong is by definition the one
+     * nobody thought of: it does not reason about how the document was built, it just looks for the values
+     * that were supposed to have been taken out of it. A secret that is still there when the restore
+     * believes it is finished is a bug in the restore, and shipping the document anyway would make it a
+     * disclosure instead (EDG-882 review v03, R3-08).
+     * <p>
+     * The one false positive it can have is an operator who wrote the same string that a credential
+     * variable resolves to somewhere else in the file, literally. Refusing that write is the right side of
+     * the trade: the remedy is to stop writing the credential in plain text, and the message names the
+     * element.
+     */
+    private static @NotNull String refuseIfACredentialSurvived(
+            final @NotNull String document, final @NotNull List<ElementPlaceholder> placeholders) {
+        for (final ElementPlaceholder placeholder : placeholders) {
+            if (!isSecretElement(placeholder.name())) {
+                continue;
+            }
+            final String value = placeholder.value();
+            if (document.contains(value)
+                    || document.contains(escapeXmlText(value))
+                    || document.contains(escapeXmlAttribute(value))) {
+                log.error(
+                        "The value supplied to the '{}' {} through '{}' is still present in the configuration"
+                                + " being written after its placeholder was restored, so writing it would put a"
+                                + " credential on disk. The write has been refused: config.xml is unchanged, and"
+                                + " this node keeps running on the value it already holds. If that value is also"
+                                + " written literally somewhere else in the file, remove it there.",
+                        placeholder.name(),
+                        placeholder.attribute() ? "attribute" : "element",
+                        placeholder.literal());
+                throw new UnrecoverableException(false);
+            }
+        }
+        return document;
     }
 
     /**
@@ -436,11 +623,19 @@ public class EnvVarUtil {
                 : "<" + placeholder.name() + ">" + escapeXmlText(placeholder.value()) + "</" + placeholder.name() + ">";
     }
 
-    /** The same span with the operator's placeholders back in it: what the restore writes. */
+    /**
+     * The same span with the operator's placeholders back in it: what the restore writes.
+     * <p>
+     * Escaped on the way out, because the literal is now the <em>parsed</em> text rather than the
+     * original bytes: an operator who wrote an escaped ampersand has a literal holding a bare one, and
+     * putting that back raw would produce a config.xml that does not parse on the next start. A
+     * placeholder itself carries none of the escaped characters, so it passes through untouched.
+     */
     private static @NotNull String literalSpan(final @NotNull ElementPlaceholder placeholder) {
         return placeholder.attribute()
-                ? placeholder.name() + "=\"" + placeholder.literal() + "\""
-                : "<" + placeholder.name() + ">" + placeholder.literal() + "</" + placeholder.name() + ">";
+                ? placeholder.name() + "=\"" + escapeXmlAttribute(placeholder.literal()) + "\""
+                : "<" + placeholder.name() + ">" + escapeXmlText(placeholder.literal()) + "</" + placeholder.name()
+                        + ">";
     }
 
     /** The same span with {@link #UNRESTORED_SECRET} in place of a credential that cannot be restored. */

--- a/hivemq-edge/src/main/java/com/hivemq/util/render/EnvVarUtil.java
+++ b/hivemq-edge/src/main/java/com/hivemq/util/render/EnvVarUtil.java
@@ -22,6 +22,7 @@ import com.hivemq.exceptions.UnrecoverableException;
 import java.io.IOException;
 import java.io.StringReader;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
@@ -157,7 +158,8 @@ public class EnvVarUtil {
      *                          zero for a well-formed configuration; anything else means the file holds a
      *                          placeholder somewhere this cannot reason about, and
      *                          {@link #restorePlaceholders} refuses the write rather than guess whether a
-     *                          credential is about to go out with it (EDG-882 review v03, R3-08).
+     *                          credential is about to go out with it (EDG-882 review v03, R3-08). Counted
+     *                          per variable and never negative -- see {@link #collectPlaceholders}.
      */
     public record CollectedPlaceholders(@NotNull List<ElementPlaceholder> placeholders, int unaccountedTokens) {
 
@@ -189,12 +191,29 @@ public class EnvVarUtil {
      * its placeholders would otherwise make every occurrence look ambiguous — commenting a bridge out is
      * an ordinary thing for an operator to do. Their tokens are counted as seen, so they do not show up
      * as unaccounted either.
+     * <p>
+     * <b>Accounted for by variable, not by total.</b> The two counts measure different populations: the
+     * file's own bytes are what the whole-file render resolves, and the parsed document is what this walk
+     * can reach. A placeholder spelled with a character reference — {@code $&#123;ENV:PW}} — exists only
+     * in the second, so subtracting one total from the other went <em>negative</em>, and a negative count
+     * is not zero: it refused every subsequent write of a configuration that had nothing wrong with it
+     * (EDG-882 review v04). Comparing per variable and keeping only the shortfall says what the guard
+     * always meant — a placeholder the render resolved and this walk could not find — and it no longer
+     * lets two different oddities cancel each other out into a clean bill of health.
+     * <p>
+     * A token visible only after parsing is not a disclosure risk in the first place: the render works on
+     * the file's bytes, so it never resolves one, and the value it stands for never enters the document.
      */
     public static @NotNull CollectedPlaceholders collectPlaceholders(final @NotNull String text) {
-        final int inFile = countOccurrences(text, ENV_TOKEN);
-        if (inFile == 0) {
+        final int tokensInFile = countOccurrences(text, ENV_TOKEN);
+        if (tokensInFile == 0) {
             return CollectedPlaceholders.NONE;
         }
+        final Map<String, Integer> namedInFile = tokenCounts(text);
+        // A token whose braces never close names no variable, so nothing can account for it. It is not
+        // rendered either -- the whole-file render matches the same pattern this does -- but it is exactly
+        // the shape this guard exists to be suspicious of, so it stays unaccounted rather than ignored.
+        final int unnamedInFile = tokensInFile - total(namedInFile);
         final Document document = parseOrNull(text);
         if (document == null) {
             // Every token is unaccounted for, which refuses the next write-back rather than performing
@@ -211,12 +230,34 @@ public class EnvVarUtil {
                     + " placeholders, so writing the configuration back out will be refused until it can be."
                     + " Until then a REST change to any subsystem applies to the running node but cannot be"
                     + " persisted to config.xml.");
-            return new CollectedPlaceholders(List.of(), inFile);
+            return new CollectedPlaceholders(List.of(), tokensInFile);
         }
         final List<ElementPlaceholder> placeholders = new ArrayList<>();
-        final int[] seen = {0};
+        final Map<String, Integer> seen = new HashMap<>();
         visitValues(document, (name, value, attribute) -> collect(placeholders, seen, name, value, attribute), seen);
-        return new CollectedPlaceholders(placeholders, inFile - seen[0]);
+        int unaccounted = unnamedInFile;
+        for (final Map.Entry<String, Integer> token : namedInFile.entrySet()) {
+            unaccounted += Math.max(0, token.getValue() - seen.getOrDefault(token.getKey(), 0));
+        }
+        return new CollectedPlaceholders(placeholders, unaccounted);
+    }
+
+    /** How many times each variable is named by a placeholder in the given text. */
+    private static @NotNull Map<String, Integer> tokenCounts(final @NotNull String text) {
+        final Map<String, Integer> counts = new HashMap<>();
+        final var matcher = ENV_PLACEHOLDER.matcher(text);
+        while (matcher.find()) {
+            counts.merge(matcher.group(1), 1, Integer::sum);
+        }
+        return counts;
+    }
+
+    private static int total(final @NotNull Map<String, Integer> counts) {
+        int total = 0;
+        for (final int count : counts.values()) {
+            total += count;
+        }
+        return total;
     }
 
     /**
@@ -274,7 +315,9 @@ public class EnvVarUtil {
      * rather than "somewhere this walk chose not to restore". Null for callers that only want the values.
      */
     private static void visitValues(
-            final @NotNull Node node, final @NotNull ValueVisitor visitor, final int @Nullable [] seenInComments) {
+            final @NotNull Node node,
+            final @NotNull ValueVisitor visitor,
+            final @Nullable Map<String, Integer> seenInComments) {
         if (node.getNodeType() == Node.ELEMENT_NODE) {
             final Element element = (Element) node;
             final NamedNodeMap attributes = element.getAttributes();
@@ -297,7 +340,8 @@ public class EnvVarUtil {
                 && (node.getNodeType() == Node.COMMENT_NODE
                         || node.getNodeType() == Node.PROCESSING_INSTRUCTION_NODE)) {
             // Seen, deliberately not restorable: neither reaches the marshalled document.
-            seenInComments[0] += countOccurrences(requireNonNullElse(node.getNodeValue(), ""), ENV_TOKEN);
+            tokenCounts(requireNonNullElse(node.getNodeValue(), ""))
+                    .forEach((name, count) -> seenInComments.merge(name, count, Integer::sum));
         }
         final NodeList children = node.getChildNodes();
         for (int i = 0; i < children.getLength(); i++) {
@@ -307,15 +351,15 @@ public class EnvVarUtil {
 
     private static void collect(
             final @NotNull List<ElementPlaceholder> placeholders,
-            final int @NotNull [] seen,
+            final @NotNull Map<String, Integer> seen,
             final @NotNull String name,
             final @NotNull String literal,
             final boolean attribute) {
-        final int tokens = countOccurrences(literal, ENV_TOKEN);
-        if (tokens == 0) {
+        final Map<String, Integer> tokens = tokenCounts(literal);
+        if (tokens.isEmpty()) {
             return;
         }
-        seen[0] += tokens;
+        tokens.forEach((variable, count) -> seen.merge(variable, count, Integer::sum));
         final String value = renderOrNull(literal);
         // An empty rendered span gives the restore nothing to search for, and a span with an unset
         // variable never reaches the marshalled document at all -- the render of the whole file

--- a/hivemq-edge/src/main/java/com/hivemq/util/render/EnvVarUtil.java
+++ b/hivemq-edge/src/main/java/com/hivemq/util/render/EnvVarUtil.java
@@ -26,6 +26,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
@@ -411,8 +412,8 @@ public class EnvVarUtil {
         for (final List<ElementPlaceholder> group : bySpanAndValue.values()) {
             final ElementPlaceholder first = group.get(0);
             final String literal = first.literal();
-            final String rendered = renderedSpan(first);
-            final int inDocument = countOccurrences(result, rendered);
+            final Pattern rendered = renderedSpan(first);
+            final int inDocument = countMatches(result, rendered);
 
             if (group.stream().anyMatch(placeholder -> !placeholder.literal().equals(literal))) {
                 result = giveUpOn(
@@ -481,7 +482,7 @@ public class EnvVarUtil {
                                 + " has " + inDocument + ", so which ones came from the variable cannot be told");
                 continue;
             }
-            result = result.replace(rendered, literalSpan(first));
+            result = rendered.matcher(result).replaceAll(literalSpan(first));
         }
         return refuseIfACredentialSurvived(result, placeholders);
     }
@@ -667,7 +668,7 @@ public class EnvVarUtil {
     private static @NotNull String giveUpOn(
             final @NotNull String document,
             final @NotNull ElementPlaceholder placeholder,
-            final @NotNull String rendered,
+            final @NotNull Pattern rendered,
             final @NotNull String reason) {
         if (!isSecretElement(placeholder.name())) {
             log.error(
@@ -687,14 +688,50 @@ public class EnvVarUtil {
                 placeholder.name(),
                 reason,
                 UNRESTORED_SECRET);
-        return document.replace(rendered, poisonedSpan(placeholder));
+        return rendered.matcher(document).replaceAll(poisonedSpan(placeholder));
     }
 
-    /** The span as the marshaller will have written it: what the restore searches the document for. */
-    private static @NotNull String renderedSpan(final @NotNull ElementPlaceholder placeholder) {
-        return placeholder.attribute()
-                ? placeholder.name() + "=\"" + escapeXmlAttribute(placeholder.value()) + "\""
-                : "<" + placeholder.name() + ">" + escapeXmlText(placeholder.value()) + "</" + placeholder.name() + ">";
+    /**
+     * Whatever the marshaller may have written between an element's name and the {@code >} that ends its
+     * start tag: nothing, or attributes.
+     * <p>
+     * Quoted values are stepped over rather than excluded, so an attribute holding a {@code >} does not
+     * end the tag early. Everything outside the quotes must be free of angle brackets, which is what keeps
+     * the pattern inside one start tag.
+     */
+    private static final @NotNull String START_TAG_REST = "(\\s(?:[^<>\"]|\"[^\"]*\")*)?";
+
+    /**
+     * The span as the marshaller will have written it: what the restore searches the document for.
+     * <p>
+     * <b>A pattern rather than a string, because an element may carry attributes.</b> The span was built
+     * as {@code <name>value</name>} and compared literally, so an element written as
+     * {@code <name attr="x">value</name>} was never found: the restore took the "not in the document"
+     * branch, which refuses the write outright when the element holds a credential and writes the value
+     * out when it does not. Nothing in today's schema puts an attribute on an element that also holds
+     * text -- the adapter and module configurations, which are the only arbitrary XML in the file, are
+     * unmarshalled into maps and lose their attributes long before this -- so it is a trap rather than a
+     * live defect, and it is one the next attribute added to a text-bearing element would spring silently
+     * (EDG-882 review v04). The attributes are matched, kept in a group, and written back unchanged.
+     */
+    private static @NotNull Pattern renderedSpan(final @NotNull ElementPlaceholder placeholder) {
+        if (placeholder.attribute()) {
+            return Pattern.compile(
+                    Pattern.quote(placeholder.name() + "=\"" + escapeXmlAttribute(placeholder.value()) + "\""));
+        }
+        return Pattern.compile("<" + Pattern.quote(placeholder.name()) + START_TAG_REST + ">"
+                + Pattern.quote(escapeXmlText(placeholder.value()))
+                + "</" + Pattern.quote(placeholder.name()) + ">");
+    }
+
+    /** How many spans of that shape the document holds. */
+    private static int countMatches(final @NotNull String text, final @NotNull Pattern pattern) {
+        final var matcher = pattern.matcher(text);
+        int count = 0;
+        while (matcher.find()) {
+            count++;
+        }
+        return count;
     }
 
     /**
@@ -706,17 +743,24 @@ public class EnvVarUtil {
      * placeholder itself carries none of the escaped characters, so it passes through untouched.
      */
     private static @NotNull String literalSpan(final @NotNull ElementPlaceholder placeholder) {
-        return placeholder.attribute()
-                ? placeholder.name() + "=\"" + escapeXmlAttribute(placeholder.literal()) + "\""
-                : "<" + placeholder.name() + ">" + escapeXmlText(placeholder.literal()) + "</" + placeholder.name()
-                        + ">";
+        if (placeholder.attribute()) {
+            return Matcher.quoteReplacement(
+                    placeholder.name() + "=\"" + escapeXmlAttribute(placeholder.literal()) + "\"");
+        }
+        // $1 is whatever stood between the element's name and the end of its start tag, put back as it
+        // was: the restore replaces the value an element holds, not the element.
+        return "<" + placeholder.name() + "$1>"
+                + Matcher.quoteReplacement(escapeXmlText(placeholder.literal()))
+                + "</" + placeholder.name() + ">";
     }
 
     /** The same span with {@link #UNRESTORED_SECRET} in place of a credential that cannot be restored. */
     private static @NotNull String poisonedSpan(final @NotNull ElementPlaceholder placeholder) {
-        return placeholder.attribute()
-                ? placeholder.name() + "=\"" + UNRESTORED_SECRET + "\""
-                : "<" + placeholder.name() + ">" + UNRESTORED_SECRET + "</" + placeholder.name() + ">";
+        if (placeholder.attribute()) {
+            return Matcher.quoteReplacement(placeholder.name() + "=\"" + UNRESTORED_SECRET + "\"");
+        }
+        return "<" + placeholder.name() + "$1>" + Matcher.quoteReplacement(UNRESTORED_SECRET) + "</"
+                + placeholder.name() + ">";
     }
 
     /**

--- a/hivemq-edge/src/main/java/com/hivemq/util/render/EnvVarUtil.java
+++ b/hivemq-edge/src/main/java/com/hivemq/util/render/EnvVarUtil.java
@@ -46,7 +46,46 @@ import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
 /**
- * Util for handling system environment variables
+ * The two directions of {@code ${ENV:...}} in {@code config.xml}: resolving a placeholder when the file is
+ * read, and putting it back when the file is written.
+ * <p>
+ * <b>Why the second direction exists.</b> Rendering happens once, on the whole file, before it is parsed,
+ * so the configuration Edge holds in memory contains the <em>values</em>. Marshalling that back out — which
+ * any REST change to any subsystem does — used to write those values into {@code config.xml}, so a bridge
+ * password supplied through an environment variable ended up on disk in plain text and the indirection the
+ * operator chose was gone for good (EDG-882 QA round 2). Everything below the render exists to prevent
+ * that, and the rest of this note is what a reader needs to trust it.
+ * <p>
+ * <b>Three phases, in this order.</b>
+ * <ol>
+ *   <li><b>Render</b> — {@link #replaceEnvironmentVariablePlaceholders} substitutes each placeholder into
+ *       the file's text before anything parses it. Values go in as raw XML, which is what lets a fragment
+ *       bring in markup and what makes a value containing {@code <} or {@code &} unusable
+ *       ({@link #variablesWhoseValueIsNotText} explains that failure when it happens).</li>
+ *   <li><b>Collect</b> — {@link #collectPlaceholders} parses the file <em>before</em> the render and
+ *       records one span per element text or attribute value that holds a placeholder: the literal the
+ *       operator wrote, and what it resolves to. Parsed rather than pattern-matched, because the restore
+ *       compares against post-marshal output and the parser is what decides what a value <em>is</em>.</li>
+ *   <li><b>Restore</b> — {@link #restorePlaceholders} finds each span in the marshalled document and puts
+ *       the literal back, then checks the finished document for a credential that survived.</li>
+ * </ol>
+ * <p>
+ * <b>What it promises.</b> A credential supplied through a variable does not reach the disk. Where that
+ * cannot be guaranteed, the write is refused and the previous {@code config.xml} — intact, and still the
+ * one the running node matches — stays where it is. Nothing here decides to write a credential out except
+ * {@link #giveUpOn} for an element that holds no credential, which trades a lost indirection for a node
+ * that still starts.
+ * <p>
+ * <b>Where it can be wrong, deliberately.</b> The restore is anchored to an element or attribute name and
+ * count-checked; ambiguity is refused rather than guessed at. Two questions are asked of the parsed
+ * document's values rather than of its text, because markup is not content and a password of {@code admin}
+ * is not "still present" because the file has an {@code <admin-api>} element. A credential still sitting in
+ * a credential-bearing span is a bug in the restore; the same string in {@code <username>} is the
+ * operator's own text and is left alone.
+ * <p>
+ * <b>Reading it.</b> Every method is static and holds no state between calls; the one piece of mutable
+ * state, {@link ParsedOnce}, lives for a single restore. A {@code null} document from
+ * {@link #parseOrNull} means "cannot tell", and every caller of it treats that as the unsafe answer.
  *
  * @author Christoph Schäbel
  */
@@ -55,6 +94,44 @@ public class EnvVarUtil {
     private static final Logger log = LoggerFactory.getLogger(EnvVarUtil.class);
 
     private static final @NotNull String ENV_VAR_PATTERN = "\\$\\{ENV:(.*?)}";
+
+    private static final @NotNull Pattern ENV_PLACEHOLDER = Pattern.compile(ENV_VAR_PATTERN);
+
+    /** The token every placeholder starts with, used for the cheap "is there one in here at all" test. */
+    private static final @NotNull String ENV_TOKEN = "${ENV:";
+
+    /**
+     * What is written in place of a secret whose placeholder could not be restored.
+     * <p>
+     * Not the value, which is the whole point; not an empty element either, because some secret-bearing
+     * elements are {@code nonEmptyString} in the schema and an empty one would make the file unparseable
+     * on the next start — a worse failure than the one being avoided, and one that names the schema
+     * rather than the cause. This is a placeholder for a variable nobody sets, so the next start stops
+     * with {@code Environment Variable EDGE_UNRESTORED_SECRET for HiveMQ config.xml is not set} and the
+     * operator is told exactly where to look, while the node they are running now carries on with the
+     * secret it already holds in memory.
+     */
+    @VisibleForTesting
+    static final @NotNull String UNRESTORED_SECRET = "${ENV:EDGE_UNRESTORED_SECRET}";
+
+    /**
+     * Element names whose text is a credential. Matched as a suffix so that the adapter configurations —
+     * {@code xs:any} in the schema, so their element names are not knowable here — are covered by the
+     * same rule as {@code <password>}, {@code <client-secret>}, {@code <private-key-password>} and
+     * {@code <truststore-password>}.
+     */
+    private static final @NotNull List<String> SECRET_ELEMENT_SUFFIXES =
+            List.of("password", "secret", "passphrase", "token", "credentials");
+
+    /**
+     * Whatever the marshaller may have written between an element's name and the {@code >} that ends its
+     * start tag: nothing, or attributes.
+     * <p>
+     * Quoted values are stepped over rather than excluded, so an attribute holding a {@code >} does not
+     * end the tag early. Everything outside the quotes must be free of angle brackets, which is what keeps
+     * the pattern inside one start tag.
+     */
+    private static final @NotNull String START_TAG_REST = "(\\s(?:[^<>\"]|\"[^\"]*\")*)?";
 
     /**
      * Get a Java system property or system environment variable with the specified name.
@@ -83,17 +160,9 @@ public class EnvVarUtil {
     public static @NotNull String replaceEnvironmentVariablePlaceholders(final @NotNull String text) {
         final var resultString = new StringBuilder();
 
-        final var matcher = Pattern.compile(ENV_VAR_PATTERN).matcher(text);
+        final var matcher = ENV_PLACEHOLDER.matcher(text);
 
         while (matcher.find()) {
-
-            if (matcher.groupCount() < 1) {
-                // this should never happen as we declared 1 groups in the ENV_VAR_PATTERN
-                log.warn("Found unexpected environment variable placeholder in config.xml");
-                matcher.appendReplacement(resultString, "");
-                continue;
-            }
-
             final var varName = matcher.group(1);
 
             final var replacement = getValue(varName);
@@ -143,11 +212,6 @@ public class EnvVarUtil {
             this(name, literal, value, false);
         }
     }
-
-    private static final @NotNull Pattern ENV_PLACEHOLDER = Pattern.compile(ENV_VAR_PATTERN);
-
-    /** The token every placeholder starts with, used for the cheap "is there one in here at all" test. */
-    private static final @NotNull String ENV_TOKEN = "${ENV:";
 
     /**
      * What {@link #collectPlaceholders(String)} found: the spans that can be restored, and whether it was
@@ -306,9 +370,8 @@ public class EnvVarUtil {
      * Visits every element text and attribute value of a parsed document.
      * <p>
      * Values, never markup. Both readers of a configuration document want the same thing — what the
-     * unmarshaller would see — and neither wants element names, which is the whole of
-     * {@link #refuseIfACredentialSurvived}'s defect: a document containing {@code <admin-api>} read as a
-     * document containing the password {@code admin} (EDG-882 review v04).
+     * unmarshaller would see — and neither wants element names; {@link #refuseIfACredentialSurvived} is
+     * where that distinction is paid for.
      * <p>
      * {@code seenInComments} counts the placeholder tokens held in comments and processing instructions,
      * for the collector, which needs {@code unaccountedTokens} to mean "somewhere this walk cannot reach"
@@ -378,9 +441,9 @@ public class EnvVarUtil {
                             + " configuration write will leave that {} empty and the variable reference will be"
                             + " lost. Set the variable to a value if the reference is meant to survive.",
                     name,
-                    attribute ? "attribute" : "element",
+                    describe(attribute),
                     literal,
-                    attribute ? "attribute" : "element");
+                    describe(attribute));
             return;
         }
         // Accounted for either way: they were found, they are simply not restorable, which is not the same
@@ -535,7 +598,7 @@ public class EnvVarUtil {
                                         + " placeholder cannot be put back. The write has been refused: config.xml is"
                                         + " unchanged, and this node keeps running on the value it already holds.",
                                 first.name(),
-                                first.attribute() ? "attribute" : "element",
+                                describe(first.attribute()),
                                 literal);
                         throw new UnrecoverableException(false);
                     }
@@ -544,7 +607,7 @@ public class EnvVarUtil {
                                     + " locate, so its value is written out and the variable reference is lost; put it"
                                     + " back by hand.",
                             first.name(),
-                            first.attribute() ? "attribute" : "element",
+                            describe(first.attribute()),
                             literal);
                     continue;
                 }
@@ -557,7 +620,7 @@ public class EnvVarUtil {
                                 + " cannot be restored. If it was not removed, check the file for a value that should"
                                 + " have stayed a variable reference.",
                         first.name(),
-                        first.attribute() ? "attribute" : "element",
+                        describe(first.attribute()),
                         literal);
                 continue;
             }
@@ -648,7 +711,11 @@ public class EnvVarUtil {
             return true;
         }
         final boolean[] found = {false};
-        visitValues(parsed, (name, spanValue, attribute) -> found[0] |= holdsValue(name, spanValue, value), null);
+        // No early exit from the walk itself; the flag is what stops it doing any more work than reading.
+        visitValues(
+                parsed,
+                (name, spanValue, attribute) -> found[0] = found[0] || holdsValue(name, spanValue, value),
+                null);
         return found[0];
     }
 
@@ -656,11 +723,9 @@ public class EnvVarUtil {
      * Whether one element text or attribute value of the finished document carries {@code value} — the
      * broad question, asked when the span the restore was anchored to has gone missing.
      * <p>
-     * Equal, or inside a credential-bearing span. A value that <em>is</em> the secret is the secret
-     * written out wherever it sits, and when the anchor has vanished there is no telling where the
-     * marshaller put it; a value that merely contains it is a disclosure only where the credential
-     * belongs, because anywhere else it is the operator's own text with the secret inside it, and
-     * refusing on that is how {@code <port>1883</port>} came to reject a password of {@code 1}.
+     * Equal, or inside a credential-bearing span. When the anchor has vanished there is no telling where
+     * the marshaller put the value, so a value that <em>is</em> the secret counts wherever it sits. Mere
+     * containment counts only where a credential belongs — see {@link #isInACredentialSpan}.
      */
     private static boolean holdsValue(
             final @NotNull String spanName, final @NotNull String spanValue, final @NotNull String value) {
@@ -671,16 +736,11 @@ public class EnvVarUtil {
      * Whether a credential-bearing span is still holding a credential — the narrow question, and the only
      * shape a restore that believes it succeeded can actually have left behind.
      * <p>
-     * The restore replaces a span with its own literal; it cannot move a value into a span it never
-     * touched. So a credential appearing in some other element of the finished document is the operator's
-     * own text — a username that happens to equal the password, a host name a credential variable resolves
-     * to — and refusing the write over it means that configuration can never be persisted again while the
-     * coincidence lasts (EDG-882 review v04). What is left is the span where the credential belongs, still
-     * holding the value instead of the placeholder, whole or concatenated.
-     * <p>
-     * The residual is an operator who writes the same credential literally in a second credential element.
-     * That one is refused, the message names both spans, and the remedy — stop writing the credential in
-     * plain text — is the one worth having.
+     * The load-bearing argument: the restore replaces a span with its own literal and cannot move a value
+     * into a span it never touched. A credential appearing anywhere else in the finished document is
+     * therefore the operator's own text, and what is left to look for is the span where the credential
+     * belongs, still holding the value instead of the placeholder, whole or concatenated
+     * ({@link #refuseIfACredentialSurvived} has the reasoning and the residual case).
      */
     private static boolean isInACredentialSpan(
             final @NotNull String spanName, final @NotNull String spanValue, final @NotNull String value) {
@@ -752,10 +812,10 @@ public class EnvVarUtil {
                                             + " running on the value it already holds. If that value is also written"
                                             + " literally somewhere else in the file, remove it there.",
                                     secret.name(),
-                                    secret.attribute() ? "attribute" : "element",
+                                    describe(secret.attribute()),
                                     secret.literal(),
                                     name,
-                                    attribute ? "attribute" : "element");
+                                    describe(attribute));
                             throw new UnrecoverableException(false);
                         }
                     }
@@ -763,29 +823,6 @@ public class EnvVarUtil {
                 null);
         return document;
     }
-
-    /**
-     * What is written in place of a secret whose placeholder could not be restored.
-     * <p>
-     * Not the value, which is the whole point; not an empty element either, because some secret-bearing
-     * elements are {@code nonEmptyString} in the schema and an empty one would make the file unparseable
-     * on the next start — a worse failure than the one being avoided, and one that names the schema
-     * rather than the cause. This is a placeholder for a variable nobody sets, so the next start stops
-     * with {@code Environment Variable EDGE_UNRESTORED_SECRET for HiveMQ config.xml is not set} and the
-     * operator is told exactly where to look, while the node they are running now carries on with the
-     * secret it already holds in memory.
-     */
-    @VisibleForTesting
-    static final @NotNull String UNRESTORED_SECRET = "${ENV:EDGE_UNRESTORED_SECRET}";
-
-    /**
-     * Element names whose text is a credential. Matched as a suffix so that the adapter configurations —
-     * {@code xs:any} in the schema, so their element names are not knowable here — are covered by the
-     * same rule as {@code <password>}, {@code <client-secret>}, {@code <private-key-password>} and
-     * {@code <truststore-password>}.
-     */
-    private static final @NotNull List<String> SECRET_ELEMENT_SUFFIXES =
-            List.of("password", "secret", "passphrase", "token", "credentials");
 
     private static boolean isSecretElement(final @NotNull String element) {
         final String name = element.toLowerCase(Locale.ROOT);
@@ -833,16 +870,6 @@ public class EnvVarUtil {
                 UNRESTORED_SECRET);
         return rendered.matcher(document).replaceAll(poisonedSpan(placeholder));
     }
-
-    /**
-     * Whatever the marshaller may have written between an element's name and the {@code >} that ends its
-     * start tag: nothing, or attributes.
-     * <p>
-     * Quoted values are stepped over rather than excluded, so an attribute holding a {@code >} does not
-     * end the tag early. Everything outside the quotes must be free of angle brackets, which is what keeps
-     * the pattern inside one start tag.
-     */
-    private static final @NotNull String START_TAG_REST = "(\\s(?:[^<>\"]|\"[^\"]*\")*)?";
 
     /**
      * The span as the marshaller will have written it: what the restore searches the document for.
@@ -910,6 +937,11 @@ public class EnvVarUtil {
      * The characters a marshaller escapes inside an attribute value. Differs from element text by the
      * quote, which would otherwise close the attribute.
      */
+    /** What a span is called in a message: the two kinds this works on, spelled once. */
+    private static @NotNull String describe(final boolean attribute) {
+        return attribute ? "attribute" : "element";
+    }
+
     private static @NotNull String escapeXmlAttribute(final @NotNull String text) {
         return text.replace("&", "&amp;").replace("<", "&lt;").replace("\"", "&quot;");
     }

--- a/hivemq-edge/src/main/java/com/hivemq/util/render/EnvVarUtil.java
+++ b/hivemq-edge/src/main/java/com/hivemq/util/render/EnvVarUtil.java
@@ -16,6 +16,10 @@
 package com.hivemq.util.render;
 
 import com.hivemq.exceptions.UnrecoverableException;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
 import java.util.regex.Pattern;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -92,5 +96,104 @@ public class EnvVarUtil {
 
     private static @NotNull String escapeReplacement(final @NotNull String replacement) {
         return replacement.replace("\\", "\\\\").replace("$", "\\$");
+    }
+
+    /**
+     * Every {@code ${ENV:...}} placeholder in the given text, mapped to the value it renders to.
+     * <p>
+     * Taken from the file as it was written, before rendering, so that
+     * {@link #restorePlaceholders(String, Map)} can put the placeholders back when the configuration is
+     * written out again.
+     */
+    public static @NotNull Map<String, String> collectPlaceholders(final @NotNull String text) {
+        final Map<String, String> placeholders = new LinkedHashMap<>();
+        final var matcher = Pattern.compile(ENV_VAR_PATTERN).matcher(text);
+        while (matcher.find()) {
+            final var value = getValue(matcher.group(1));
+            if (value != null && !value.isEmpty()) {
+                placeholders.put(matcher.group(), value);
+            }
+        }
+        return placeholders;
+    }
+
+    /**
+     * Puts {@code ${ENV:...}} placeholders back into a rendered document before it is written to disk.
+     * <p>
+     * Rendering happens once, on the whole file, before it is parsed, so the configuration Edge holds in
+     * memory contains the <em>values</em>. Writing that back out — which any REST change to any subsystem
+     * does — replaced the operator's placeholders with what they resolved to, so a bridge password
+     * supplied through an environment variable ended up in {@code config.xml} in plain text, and the
+     * indirection the operator chose was gone for good (EDG-882 QA round 2).
+     * <p>
+     * <b>Anchored and count-checked, because the reverse direction is ambiguous by nature.</b> A value
+     * is only put back where it is the <em>entire</em> text of an element, and only when the document
+     * contains exactly as many such elements as the original file had occurrences of that placeholder.
+     * Anything else — a value that also appears somewhere the operator wrote literally, or two variables
+     * that happen to resolve to the same string — is left rendered and reported, because rewriting an
+     * element into a variable reference the operator did not ask for would be its own defect. That case
+     * is rare and visible; the alternative is silent and permanent.
+     *
+     * @param placeholders the mapping from {@link #collectPlaceholders(String)}, taken from the file as
+     *     it was written
+     * @param originalText the file as it was written, used to count the placeholder's occurrences
+     */
+    public static @NotNull String restorePlaceholders(
+            final @NotNull String renderedXml,
+            final @NotNull Map<String, String> placeholders,
+            final @NotNull String originalText) {
+        if (placeholders.isEmpty()) {
+            return renderedXml;
+        }
+        final Set<String> ambiguousValues = new HashSet<>();
+        final Set<String> seenValues = new HashSet<>();
+        for (final String value : placeholders.values()) {
+            if (!seenValues.add(value)) {
+                ambiguousValues.add(value);
+            }
+        }
+
+        var result = renderedXml;
+        for (final var placeholder : placeholders.entrySet()) {
+            final String literal = placeholder.getKey();
+            final String value = placeholder.getValue();
+            if (ambiguousValues.contains(value)) {
+                log.warn(
+                        "Two placeholders in the configuration file resolve to the same value, so '{}' cannot be"
+                                + " restored when the file is written; its value will be written out instead.",
+                        literal);
+                continue;
+            }
+            final String element = ">" + escapeXmlText(value) + "<";
+            final int inDocument = countOccurrences(result, element);
+            if (inDocument == 0) {
+                continue;
+            }
+            if (inDocument != countOccurrences(originalText, literal)) {
+                log.warn(
+                        "The value of '{}' also appears in the configuration where it was not written as a"
+                                + " placeholder, so the placeholder cannot be restored when the file is written;"
+                                + " its value will be written out instead.",
+                        literal);
+                continue;
+            }
+            result = result.replace(element, ">" + literal + "<");
+        }
+        return result;
+    }
+
+    private static int countOccurrences(final @NotNull String text, final @NotNull String needle) {
+        int count = 0;
+        int index = text.indexOf(needle);
+        while (index >= 0) {
+            count++;
+            index = text.indexOf(needle, index + needle.length());
+        }
+        return count;
+    }
+
+    /** The three characters a marshaller escapes inside element text. */
+    private static @NotNull String escapeXmlText(final @NotNull String text) {
+        return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;");
     }
 }

--- a/hivemq-edge/src/main/java/com/hivemq/util/render/EnvVarUtil.java
+++ b/hivemq-edge/src/main/java/com/hivemq/util/render/EnvVarUtil.java
@@ -16,10 +16,10 @@
 package com.hivemq.util.render;
 
 import com.hivemq.exceptions.UnrecoverableException;
-import java.util.HashSet;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.regex.Pattern;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -99,19 +99,41 @@ public class EnvVarUtil {
     }
 
     /**
-     * Every {@code ${ENV:...}} placeholder in the given text, mapped to the value it renders to.
-     * <p>
-     * Taken from the file as it was written, before rendering, so that
-     * {@link #restorePlaceholders(String, Map)} can put the placeholders back when the configuration is
-     * written out again.
+     * A {@code ${ENV:...}} placeholder that is the entire text of one element, and the value it renders
+     * to: the element's name, the placeholder as written, and that value.
      */
-    public static @NotNull Map<String, String> collectPlaceholders(final @NotNull String text) {
-        final Map<String, String> placeholders = new LinkedHashMap<>();
-        final var matcher = Pattern.compile(ENV_VAR_PATTERN).matcher(text);
+    public record ElementPlaceholder(
+            @NotNull String element,
+            @NotNull String literal,
+            @NotNull String value) {}
+
+    /** Matches a placeholder that is the whole text of an element, capturing the element name. */
+    private static final @NotNull Pattern ELEMENT_PLACEHOLDER =
+            Pattern.compile("<([A-Za-z_][\\w.:-]*)>\\s*(\\$\\{ENV:(.*?)})\\s*</\\1>");
+
+    private static final @NotNull Pattern XML_COMMENT = Pattern.compile("(?s)<!--.*?-->");
+
+    /**
+     * The {@code ${ENV:...}} placeholders of the file as it was written that
+     * {@link #restorePlaceholders} is able to put back.
+     * <p>
+     * Only placeholders that are an element's entire text are collected, because those are the only ones
+     * that can be located again in a document the marshaller rebuilt from the configuration model: a
+     * placeholder in an attribute, or one concatenated with other text, has no anchor to return to. Such
+     * a placeholder is reported by {@code restorePlaceholders} rather than silently resolved.
+     * <p>
+     * Comments are stripped first. A commented-out block is not part of the configuration and never
+     * reaches the marshalled document, but its placeholders would otherwise be counted and make every
+     * occurrence look ambiguous — commenting a bridge out is an ordinary thing for an operator to do.
+     */
+    public static @NotNull List<ElementPlaceholder> collectPlaceholders(final @NotNull String text) {
+        final String withoutComments = XML_COMMENT.matcher(text).replaceAll("");
+        final List<ElementPlaceholder> placeholders = new ArrayList<>();
+        final var matcher = ELEMENT_PLACEHOLDER.matcher(withoutComments);
         while (matcher.find()) {
-            final var value = getValue(matcher.group(1));
+            final var value = getValue(matcher.group(3));
             if (value != null && !value.isEmpty()) {
-                placeholders.put(matcher.group(), value);
+                placeholders.add(new ElementPlaceholder(matcher.group(1), matcher.group(2), value));
             }
         }
         return placeholders;
@@ -126,58 +148,66 @@ public class EnvVarUtil {
      * supplied through an environment variable ended up in {@code config.xml} in plain text, and the
      * indirection the operator chose was gone for good (EDG-882 QA round 2).
      * <p>
-     * <b>Anchored and count-checked, because the reverse direction is ambiguous by nature.</b> A value
-     * is only put back where it is the <em>entire</em> text of an element, and only when the document
-     * contains exactly as many such elements as the original file had occurrences of that placeholder.
-     * Anything else — a value that also appears somewhere the operator wrote literally, or two variables
-     * that happen to resolve to the same string — is left rendered and reported, because rewriting an
-     * element into a variable reference the operator did not ask for would be its own defect. That case
-     * is rare and visible; the alternative is silent and permanent.
+     * <b>Anchored to the element, and count-checked, because the reverse direction is ambiguous by
+     * nature.</b> A placeholder is only put back into the same element name it came from, and only when
+     * the document holds exactly as many such elements as the original file did. Matching on the value
+     * alone was not enough: a variable that resolves to a string the operator also wrote somewhere else
+     * — {@code ${ENV:NODE_NAME}} rendering to a bridge's own id, say — would have rewritten that other
+     * element into a variable reference nobody asked for. Anything ambiguous is left rendered and
+     * reported, which is rare and visible; the alternative is silent and permanent.
      *
-     * @param placeholders the mapping from {@link #collectPlaceholders(String)}, taken from the file as
-     *     it was written
-     * @param originalText the file as it was written, used to count the placeholder's occurrences
+     * @param placeholders what {@link #collectPlaceholders(String)} found in the file as it was written
      */
     public static @NotNull String restorePlaceholders(
-            final @NotNull String renderedXml,
-            final @NotNull Map<String, String> placeholders,
-            final @NotNull String originalText) {
+            final @NotNull String renderedXml, final @NotNull List<ElementPlaceholder> placeholders) {
         if (placeholders.isEmpty()) {
             return renderedXml;
         }
-        final Set<String> ambiguousValues = new HashSet<>();
-        final Set<String> seenValues = new HashSet<>();
-        for (final String value : placeholders.values()) {
-            if (!seenValues.add(value)) {
-                ambiguousValues.add(value);
-            }
+        // Grouped by the element the placeholder occupied and the value it renders to. Two placeholders
+        // that share both are indistinguishable in the marshalled document; a group whose literal is not
+        // unique is left alone rather than guessed at.
+        final Map<String, List<ElementPlaceholder>> byElementAndValue = new LinkedHashMap<>();
+        for (final ElementPlaceholder placeholder : placeholders) {
+            byElementAndValue
+                    .computeIfAbsent(placeholder.element() + ' ' + placeholder.value(), key -> new ArrayList<>())
+                    .add(placeholder);
         }
 
         var result = renderedXml;
-        for (final var placeholder : placeholders.entrySet()) {
-            final String literal = placeholder.getKey();
-            final String value = placeholder.getValue();
-            if (ambiguousValues.contains(value)) {
+        for (final List<ElementPlaceholder> group : byElementAndValue.values()) {
+            final ElementPlaceholder first = group.get(0);
+            final String literal = first.literal();
+            if (group.stream().anyMatch(placeholder -> !placeholder.literal().equals(literal))) {
                 log.warn(
-                        "Two placeholders in the configuration file resolve to the same value, so '{}' cannot be"
-                                + " restored when the file is written; its value will be written out instead.",
-                        literal);
+                        "Two different placeholders fill a '<{}>' element with the same value, so neither can be"
+                                + " restored when the configuration file is written; the value will be written out"
+                                + " instead.",
+                        first.element());
                 continue;
             }
-            final String element = ">" + escapeXmlText(value) + "<";
+            final String element =
+                    "<" + first.element() + ">" + escapeXmlText(first.value()) + "</" + first.element() + ">";
             final int inDocument = countOccurrences(result, element);
             if (inDocument == 0) {
-                continue;
-            }
-            if (inDocument != countOccurrences(originalText, literal)) {
                 log.warn(
-                        "The value of '{}' also appears in the configuration where it was not written as a"
-                                + " placeholder, so the placeholder cannot be restored when the file is written;"
-                                + " its value will be written out instead.",
+                        "The '<{}>' element that '{}' filled is not in the configuration being written, so the"
+                                + " placeholder cannot be restored. Check the file for a value that should have"
+                                + " stayed a variable reference.",
+                        first.element(),
                         literal);
                 continue;
             }
-            result = result.replace(element, ">" + literal + "<");
+            if (inDocument != group.size()) {
+                log.warn(
+                        "'{}' fills {} '<{}>' element(s) but the configuration being written has {}, so the"
+                                + " placeholder cannot be restored; its value will be written out instead.",
+                        literal,
+                        group.size(),
+                        first.element(),
+                        inDocument);
+                continue;
+            }
+            result = result.replace(element, "<" + first.element() + ">" + literal + "</" + first.element() + ">");
         }
         return result;
     }

--- a/hivemq-edge/src/main/java/com/hivemq/util/render/EnvVarUtil.java
+++ b/hivemq-edge/src/main/java/com/hivemq/util/render/EnvVarUtil.java
@@ -361,13 +361,56 @@ public class EnvVarUtil {
         }
         tokens.forEach((variable, count) -> seen.merge(variable, count, Integer::sum));
         final String value = renderOrNull(literal);
-        // An empty rendered span gives the restore nothing to search for, and a span with an unset
-        // variable never reaches the marshalled document at all -- the render of the whole file
-        // throws first, which is the behaviour this must not change. Both are still accounted for
-        // above: they were found, they are simply not restorable, which is not the same as unseen.
-        if (value != null && !value.isEmpty()) {
-            placeholders.add(new ElementPlaceholder(name, literal, value, attribute));
+        if (value == null) {
+            // A span with an unset variable never reaches the marshalled document at all: the render of
+            // the whole file throws on the same variable moments from now, with the message the operator
+            // needs. Saying anything here would only precede it and describe it worse.
+            return;
         }
+        if (value.isEmpty()) {
+            // An empty rendered span gives the restore nothing to search for, so the placeholder is lost
+            // the next time the configuration is written -- silently, until now. Every other way of losing
+            // one is reported; this one was the exception, and it is the only one the operator can still
+            // do something about before it happens (EDG-882 review v04).
+            log.warn(
+                    "The '{}' {} is filled by '{}', which resolves to an empty value. There is nothing in the"
+                            + " written configuration for the placeholder to be put back into, so the next"
+                            + " configuration write will leave that {} empty and the variable reference will be"
+                            + " lost. Set the variable to a value if the reference is meant to survive.",
+                    name,
+                    attribute ? "attribute" : "element",
+                    literal,
+                    attribute ? "attribute" : "element");
+            return;
+        }
+        // Accounted for either way: they were found, they are simply not restorable, which is not the same
+        // as unseen.
+        placeholders.add(new ElementPlaceholder(name, literal, value, attribute));
+    }
+
+    /**
+     * The variables in the given configuration text whose value cannot be put into it as text.
+     * <p>
+     * {@link #replaceEnvironmentVariablePlaceholders} splices a value into the file before anything parses
+     * it, escaping only what the regular expression needs, so a value carrying {@code <} or {@code &}
+     * produces a document that is not well formed and the node stops at a parser error about a line the
+     * operator did not write -- a password of {@code p@ss&word} cannot be supplied this way at all, and
+     * nothing said so. Splicing is also what makes a fragment able to bring in whole elements, so the
+     * behaviour is not changed here; the failure is explained instead, on the path where it happens.
+     * <p>
+     * Names only. The values are the reason this exists and never go anywhere near a log.
+     */
+    public static @NotNull List<String> variablesWhoseValueIsNotText(final @NotNull String text) {
+        final List<String> names = new ArrayList<>();
+        final var matcher = ENV_PLACEHOLDER.matcher(text);
+        while (matcher.find()) {
+            final String name = matcher.group(1);
+            final String value = getValue(name);
+            if (value != null && (value.contains("<") || value.contains("&")) && !names.contains(name)) {
+                names.add(name);
+            }
+        }
+        return names;
     }
 
     /**

--- a/hivemq-edge/src/test/java/com/hivemq/api/resources/impl/BridgeResourceImplConcurrencyTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/api/resources/impl/BridgeResourceImplConcurrencyTest.java
@@ -100,6 +100,14 @@ class BridgeResourceImplConcurrencyTest {
                 .when(bridgeExtractor)
                 .removeBridge(anyString());
 
+        // An update is one transition, not remove-then-add: the removal half was seen by the bridge
+        // subsystem as "this bridge is gone" and cleared every queue it owned (EDG-882 QA round 1).
+        when(bridgeExtractor.replaceBridge(anyString(), any(MqttBridge.class))).thenAnswer(invocation -> {
+            final String bridgeId = invocation.getArgument(0);
+            final MqttBridge bridge = invocation.getArgument(1);
+            return bridgeStore.replace(bridgeId, bridge) != null;
+        });
+
         bridgeResource = new BridgeResourceImpl(configurationService, bridgeService, systemInformation);
     }
 

--- a/hivemq-edge/src/test/java/com/hivemq/api/resources/impl/BridgeResourceImplTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/api/resources/impl/BridgeResourceImplTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.api.resources.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.hivemq.bridge.BridgeService;
+import com.hivemq.bridge.config.MqttBridge;
+import com.hivemq.configuration.info.SystemInformation;
+import com.hivemq.configuration.reader.BridgeExtractor;
+import com.hivemq.configuration.service.ConfigurationService;
+import com.hivemq.edge.api.model.Bridge;
+import jakarta.ws.rs.core.Response;
+import java.util.List;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+/**
+ * The two branches {@code updateBridge} grew on this branch, asserted deterministically (EDG-882 review
+ * v02, R2-21).
+ * <p>
+ * {@code BridgeResourceImplConcurrencyTest} is the only other test of this class, and it races threads
+ * against each other to prove they serialise — which cannot pin what a single call does. Both branches
+ * here decide something the ticket is about: whether an update is one transition or a removal, and
+ * whether it leaves the bridge running.
+ */
+class BridgeResourceImplTest {
+
+    private static final @NotNull String BRIDGE_ID = "edg-882-rest-bridge";
+
+    private final @NotNull BridgeExtractor bridgeExtractor = mock(BridgeExtractor.class);
+    private final @NotNull BridgeService bridgeService = mock(BridgeService.class);
+
+    private @NotNull BridgeResourceImpl bridgeResource;
+
+    private static @NotNull Bridge apiBridge() {
+        return new Bridge().id(BRIDGE_ID).host("remote.example.com").port(1883).clientId(BRIDGE_ID + "-client");
+    }
+
+    private static @NotNull MqttBridge configured() {
+        return new MqttBridge.Builder()
+                .withId(BRIDGE_ID)
+                .withHost("remote.example.com")
+                .withPort(1883)
+                .withClientId(BRIDGE_ID + "-client")
+                .withLocalSubscriptions(List.of())
+                .withRemoteSubscriptions(List.of())
+                .build();
+    }
+
+    @BeforeEach
+    void setUp() {
+        final ConfigurationService configurationService = mock(ConfigurationService.class);
+        final SystemInformation systemInformation = mock(SystemInformation.class);
+        when(systemInformation.isConfigWriteable()).thenReturn(true);
+        when(configurationService.bridgeExtractor()).thenReturn(bridgeExtractor);
+        when(bridgeExtractor.getBridges()).thenReturn(List.of(configured()));
+        bridgeResource = new BridgeResourceImpl(configurationService, bridgeService, systemInformation);
+    }
+
+    /**
+     * A bridge that vanished between the existence check and the replacement is a 404, not a silent 200.
+     * {@code replaceBridge} returning {@code false} is the only signal the resource gets, and treating it
+     * as success would answer OK for a configuration that was never written.
+     */
+    @Test
+    @Timeout(5)
+    void updateBridge_whenTheReplacementFindsNoSuchBridge_thenNotFound() {
+        when(bridgeExtractor.replaceBridge(anyString(), any(MqttBridge.class))).thenReturn(false);
+
+        final Response response = bridgeResource.updateBridge(BRIDGE_ID, apiBridge());
+
+        assertEquals(404, response.getStatus());
+        verify(bridgeService, never()).startBridge(anyString());
+    }
+
+    /**
+     * A bridge the operator had stopped is started again by an update, which is what this endpoint has
+     * always done: an update leaves the bridge running.
+     */
+    @Test
+    @Timeout(5)
+    void updateBridge_whenTheBridgeIsNotRunning_thenItIsStarted() {
+        when(bridgeExtractor.replaceBridge(anyString(), any(MqttBridge.class))).thenReturn(true);
+        when(bridgeService.isRunning(BRIDGE_ID)).thenReturn(false);
+
+        final Response response = bridgeResource.updateBridge(BRIDGE_ID, apiBridge());
+
+        assertEquals(200, response.getStatus());
+        verify(bridgeService).startBridge(BRIDGE_ID);
+    }
+
+    /**
+     * And a running one is left alone: {@code updateBridges} has already restarted it as part of the
+     * configuration transition, and starting it again here would be a second restart — which is another
+     * hand-over of its queues for no reason.
+     */
+    @Test
+    @Timeout(5)
+    void updateBridge_whenTheBridgeIsRunning_thenItIsNotStartedAgain() {
+        when(bridgeExtractor.replaceBridge(anyString(), any(MqttBridge.class))).thenReturn(true);
+        when(bridgeService.isRunning(BRIDGE_ID)).thenReturn(true);
+
+        final Response response = bridgeResource.updateBridge(BRIDGE_ID, apiBridge());
+
+        assertEquals(200, response.getStatus());
+        verify(bridgeService, never()).startBridge(anyString());
+    }
+
+    /**
+     * The update goes through {@code replaceBridge} and never through remove-then-add. Each half of that
+     * pair notifies the bridge subsystem separately, and the removal half is read as "this bridge is gone
+     * from the configuration" — answered by clearing every queue it owns, including the subscriptions the
+     * request never mentioned (EDG-882 QA round 1).
+     */
+    @Test
+    @Timeout(5)
+    void updateBridge_isOneTransition_notARemovalFollowedByAnAddition() {
+        when(bridgeExtractor.replaceBridge(anyString(), any(MqttBridge.class))).thenReturn(true);
+
+        bridgeResource.updateBridge(BRIDGE_ID, apiBridge());
+
+        verify(bridgeExtractor).replaceBridge(eq(BRIDGE_ID), any(MqttBridge.class));
+        verify(bridgeExtractor, never()).removeBridge(anyString());
+        verify(bridgeExtractor, never()).addBridge(any(MqttBridge.class));
+    }
+}

--- a/hivemq-edge/src/test/java/com/hivemq/bootstrap/HiveMQEdgeNettyBootstrapTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/bootstrap/HiveMQEdgeNettyBootstrapTest.java
@@ -34,7 +34,9 @@ import com.hivemq.persistence.connection.ConnectionPersistence;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.nio.NioDatagramChannel;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -147,13 +149,32 @@ public class HiveMQEdgeNettyBootstrapTest {
         assertTrue(listenableFuture.get().get(0).isSuccessful());
     }
 
+    /**
+     * Four ports, each checked free on its own.
+     * <p>
+     * The test below used to take one checked port and assume the three above it were free as well. Those
+     * three were never checked, and on a build agent running several test JVMs at once one of them
+     * regularly is not free: netty's bind fails, the listener comes back through
+     * {@code failedListenerStartup}, and the assertion reports {@code expected: <true> but was: <false>}
+     * against a listener whose port the test never chose. Nothing about the failure says "port", which is
+     * why it reads as an unrelated flake.
+     */
+    private static int[] fourFreePorts() {
+        final Set<Integer> ports = new LinkedHashSet<>();
+        while (ports.size() < 4) {
+            ports.add(RandomPortGenerator.get());
+        }
+        return ports.stream().mapToInt(Integer::intValue).toArray();
+    }
+
     @Test
     public void bootstrapServer_whenDifferentListenersProvided_thenSuccessfulBootstrap() throws Exception {
 
-        setupTcpListener(randomPort);
-        setupTlsTcpListener(randomPort + 1);
-        setupWebsocketListener(randomPort + 2);
-        setupTlsWebsocketListener(randomPort + 3);
+        final int[] ports = fourFreePorts();
+        setupTcpListener(ports[0]);
+        setupTlsTcpListener(ports[1]);
+        setupWebsocketListener(ports[2]);
+        setupTlsWebsocketListener(ports[3]);
 
         final ListenableFuture<List<ListenerStartupInformation>> listenableFuture =
                 hiveMQNettyBootstrap.bootstrapServer();

--- a/hivemq-edge/src/test/java/com/hivemq/bootstrap/provider/ClientQueueModuleCompatibilityTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/bootstrap/provider/ClientQueueModuleCompatibilityTest.java
@@ -225,6 +225,28 @@ public class ClientQueueModuleCompatibilityTest {
         }
     }
 
+    /**
+     * A module that took half the contract: it overrides the single-publish form and leaves the batch
+     * form on the interface default. Nothing stops one being built — the two overloads carry separate
+     * defaults — and the batch form is the one the poll path uses, so a probe that looked only at the
+     * single-publish form would call this module current and say nothing.
+     */
+    private static class HalfMigratedModulePersistence extends LegacyModulePersistence {
+
+        @Override
+        public void add(
+                final @NotNull String queueId,
+                final boolean shared,
+                final @NotNull PUBLISH publish,
+                final long max,
+                final @NotNull QueuedMessagesStrategy strategy,
+                final boolean retained,
+                final boolean applyMaxToQos0,
+                final int bucketIndex) {
+            calls().add("single-with-policy:" + queueId + ":" + applyMaxToQos0);
+        }
+    }
+
     private static @NotNull PUBLISH publish() {
         return new PUBLISHFactory.Mqtt5Builder()
                 .withTopic("plant/a")
@@ -285,6 +307,17 @@ public class ClientQueueModuleCompatibilityTest {
     public void test_the_probe_tells_a_stale_module_from_a_current_one() {
         assertFalse(ClientQueueLocalPersistenceProvider.implementsQueuePolicyAdd(LegacyModulePersistence.class));
         assertTrue(ClientQueueLocalPersistenceProvider.implementsQueuePolicyAdd(CurrentModulePersistence.class));
+    }
+
+    /**
+     * Both overloads are the contract, so overriding one of them is not it. The probe reports on "the
+     * queue-policy contract", and answering that from the single-publish form alone would call a module
+     * current on the strength of the half that was migrated (EDG-882 QA, 2026-08-25).
+     */
+    @Test
+    @Timeout(5)
+    public void test_the_probe_is_not_satisfied_by_half_the_contract() {
+        assertFalse(ClientQueueLocalPersistenceProvider.implementsQueuePolicyAdd(HalfMigratedModulePersistence.class));
     }
 
     /**

--- a/hivemq-edge/src/test/java/com/hivemq/bootstrap/provider/ClientQueueModuleCompatibilityTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/bootstrap/provider/ClientQueueModuleCompatibilityTest.java
@@ -1,0 +1,300 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.bootstrap.provider;
+
+import static com.hivemq.configuration.service.MqttConfigurationService.QueuedMessagesStrategy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.primitives.ImmutableIntArray;
+import com.hivemq.mqtt.message.MessageWithID;
+import com.hivemq.mqtt.message.QoS;
+import com.hivemq.mqtt.message.publish.PUBLISH;
+import com.hivemq.mqtt.message.publish.PUBLISHFactory;
+import com.hivemq.mqtt.message.pubrel.PUBREL;
+import com.hivemq.persistence.clientqueue.ClientQueueLocalPersistence;
+import com.hivemq.persistence.local.memory.ClientQueueMemoryLocalPersistence;
+import java.util.ArrayList;
+import java.util.List;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+/**
+ * The cross-repository delivery contract of {@link ClientQueueLocalPersistence} (EDG-882 review v02,
+ * R2-01; v01 F-04).
+ * <p>
+ * The file-native implementation ships in {@code hivemq-edge-mqtt-persistence} and is loaded from
+ * {@code HIVEMQ_HOME/modules} at run time, so core and module are compiled separately and an operator
+ * can pair any two — including by accident, by replacing the core zip and leaving {@code modules/}
+ * alone. When {@code applyMaxToQos0} was added, the new signature was made abstract and the old one a
+ * default; that is the direction that <b>guarantees</b> {@code AbstractMethodError} on the first queued
+ * publish against an older module, because a default protects callers of the signature it replaces and
+ * core has no callers of the old one left. What needs protecting is implementors.
+ * <p>
+ * {@link LegacyModulePersistence} below is a module built before the addition: it implements exactly
+ * the method set such a module has, and nothing else. Every call in these tests goes through a variable
+ * typed as the interface, so the dispatch is the same {@code invokeinterface} core performs.
+ * <p>
+ * <b>What this does not cover.</b> It proves method resolution, which is where the defect lives. It
+ * does not boot a node against a released module jar, so it says nothing about module loading,
+ * licensing or the classloader those go through.
+ */
+public class ClientQueueModuleCompatibilityTest {
+
+    private static final @NotNull String QUEUE_ID = "$FORWARDER::bridge-1/plant/a";
+
+    /**
+     * A module compiled before {@code applyMaxToQos0} existed: it implements the seven-argument
+     * {@code add} and has never heard of the eight-argument one.
+     */
+    private static class LegacyModulePersistence implements ClientQueueLocalPersistence {
+
+        private final @NotNull List<String> calls = new ArrayList<>();
+
+        @NotNull
+        List<String> calls() {
+            return calls;
+        }
+
+        @Override
+        public void add(
+                final @NotNull String queueId,
+                final boolean shared,
+                final @NotNull PUBLISH publish,
+                final long max,
+                final @NotNull QueuedMessagesStrategy strategy,
+                final boolean retained,
+                final int bucketIndex) {
+            calls.add("single:" + queueId + ":" + max);
+        }
+
+        @Override
+        public void add(
+                final @NotNull String queueId,
+                final boolean shared,
+                final @NotNull List<PUBLISH> publishes,
+                final long max,
+                final @NotNull QueuedMessagesStrategy strategy,
+                final boolean retained,
+                final int bucketIndex) {
+            calls.add("batch:" + queueId + ":" + publishes.size());
+        }
+
+        // Everything below is irrelevant to the contract under test; a module implements it, this does
+        // not need to. Throwing rather than returning a plausible value keeps an accidental dependency
+        // on one of them from passing silently.
+
+        @Override
+        public @NotNull ImmutableList<PUBLISH> readNew(
+                final @NotNull String queueId,
+                final boolean shared,
+                final @NotNull ImmutableIntArray packetIds,
+                final long bytesLimit,
+                final int bucketIndex) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public @NotNull ImmutableList<PUBLISH> peek(
+                final @NotNull String queueId,
+                final boolean shared,
+                final long bytesLimit,
+                final int maxMessages,
+                final int bucketIndex) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public @NotNull ImmutableList<MessageWithID> readInflight(
+                final @NotNull String client,
+                final boolean shared,
+                final int batchSize,
+                final long bytesLimit,
+                final int bucketIndex) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public @Nullable String replace(
+                final @NotNull String client, final @NotNull PUBREL pubrel, final int bucketIndex) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public @Nullable String remove(final @NotNull String client, final int packetId, final int bucketIndex) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public @Nullable String remove(
+                final @NotNull String client,
+                final int packetId,
+                final @Nullable String uniqueId,
+                final int bucketIndex) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public int size(final @NotNull String queueId, final boolean shared, final int bucketIndex) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void clear(final @NotNull String queueId, final boolean shared, final int bucketIndex) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void removeAllQos0Messages(final @NotNull String queueId, final boolean shared, final int bucketIndex) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public @NotNull ImmutableSet<String> cleanUp(final int bucketIndex) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void removeShared(
+                final @NotNull String sharedSubscription, final @NotNull String uniqueId, final int bucketIndex) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void removeInFlightMarker(
+                final @NotNull String queueId, final @NotNull String uniqueId, final int bucketIndex) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void removeAllInFlightMarkers(final @NotNull String queueId, final int bucketIndex) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void closeDB(final int bucketIndex) {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    /** A module built against the current contract: it answers the call core actually makes. */
+    private static class CurrentModulePersistence extends LegacyModulePersistence {
+
+        @Override
+        public void add(
+                final @NotNull String queueId,
+                final boolean shared,
+                final @NotNull PUBLISH publish,
+                final long max,
+                final @NotNull QueuedMessagesStrategy strategy,
+                final boolean retained,
+                final boolean applyMaxToQos0,
+                final int bucketIndex) {
+            calls().add("single-with-policy:" + queueId + ":" + applyMaxToQos0);
+        }
+
+        @Override
+        public void add(
+                final @NotNull String queueId,
+                final boolean shared,
+                final @NotNull List<PUBLISH> publishes,
+                final long max,
+                final @NotNull QueuedMessagesStrategy strategy,
+                final boolean retained,
+                final boolean applyMaxToQos0,
+                final int bucketIndex) {
+            calls().add("batch-with-policy:" + queueId + ":" + applyMaxToQos0);
+        }
+    }
+
+    private static @NotNull PUBLISH publish() {
+        return new PUBLISHFactory.Mqtt5Builder()
+                .withTopic("plant/a")
+                .withQoS(QoS.AT_MOST_ONCE)
+                .withOnwardQos(QoS.AT_MOST_ONCE)
+                .withPayload("payload".getBytes())
+                .withHivemqId("hivemqId")
+                .build();
+    }
+
+    /**
+     * The whole point. This call is the one {@code ClientQueuePersistenceImpl} makes on every queued
+     * publish; against a module that predates the parameter it must land on the historical method
+     * rather than throw {@link AbstractMethodError}. On a file-native node that error is the entire
+     * message path, with a stack trace that names no version.
+     */
+    @Test
+    @Timeout(5)
+    public void test_a_module_predating_the_queue_policy_answers_the_call_core_makes() {
+        final LegacyModulePersistence legacy = new LegacyModulePersistence();
+        final ClientQueueLocalPersistence persistence = legacy;
+
+        persistence.add(QUEUE_ID, true, publish(), 10, QueuedMessagesStrategy.DISCARD_OLDEST, false, true, 0);
+        persistence.add(
+                QUEUE_ID,
+                true,
+                List.of(publish(), publish()),
+                10,
+                QueuedMessagesStrategy.DISCARD_OLDEST,
+                false,
+                true,
+                0);
+
+        assertEquals(List.of("single:" + QUEUE_ID + ":10", "batch:" + QUEUE_ID + ":2"), legacy.calls());
+    }
+
+    /** And a module that does implement it is called directly, with the flag intact. */
+    @Test
+    @Timeout(5)
+    public void test_a_current_module_receives_the_queue_policy_flag() {
+        final CurrentModulePersistence current = new CurrentModulePersistence();
+        final ClientQueueLocalPersistence persistence = current;
+
+        persistence.add(QUEUE_ID, true, publish(), 10, QueuedMessagesStrategy.DISCARD_OLDEST, false, true, 0);
+        persistence.add(QUEUE_ID, true, List.of(publish()), 10, QueuedMessagesStrategy.DISCARD_OLDEST, false, false, 0);
+
+        assertEquals(
+                List.of("single-with-policy:" + QUEUE_ID + ":true", "batch-with-policy:" + QUEUE_ID + ":false"),
+                current.calls());
+    }
+
+    /**
+     * The degradation above is safe but silent, so the provider says it out loud once at start-up. This
+     * pins the predicate that decides whether it does.
+     */
+    @Test
+    @Timeout(5)
+    public void test_the_probe_tells_a_stale_module_from_a_current_one() {
+        assertFalse(ClientQueueLocalPersistenceProvider.implementsQueuePolicyAdd(LegacyModulePersistence.class));
+        assertTrue(ClientQueueLocalPersistenceProvider.implementsQueuePolicyAdd(CurrentModulePersistence.class));
+    }
+
+    /**
+     * And the implementation that ships inside core must never be the one the probe warns about — it is
+     * compiled against this very interface, so a warning here would mean the override was dropped.
+     */
+    @Test
+    @Timeout(5)
+    public void test_the_in_memory_persistence_carries_the_current_contract() {
+        assertTrue(
+                ClientQueueLocalPersistenceProvider.implementsQueuePolicyAdd(ClientQueueMemoryLocalPersistence.class));
+    }
+}

--- a/hivemq-edge/src/test/java/com/hivemq/bridge/BridgeServiceConfigUpdateTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/bridge/BridgeServiceConfigUpdateTest.java
@@ -260,6 +260,39 @@ class BridgeServiceConfigUpdateTest {
         verify(messageForwarder).markBridgeConfigurationApplied();
     }
 
+    /**
+     * EDG-882 review v02, R2-07. A bridge the operator stopped by hand must stay stopped.
+     * <p>
+     * {@code bridgeNameToLastError} is written by two different things: a bridge that could not be
+     * <em>started</em>, and a bridge that started fine but could not <em>connect</em>. Only a later
+     * successful connect cleared it. The reload path reads it as "this bridge failed and its
+     * configuration has just been corrected, so try again" — which for the second kind, after the
+     * operator had deliberately stopped it, means the next unrelated edit to the file starts a bridge
+     * they turned off.
+     */
+    @Test
+    void updateBridges_whenAStoppedBridgeHadAConnectFailure_thenAReloadDoesNotStartItAgain() {
+        final MqttBridge before = bridge(List.of(KEPT));
+        final MqttBridge after = bridge(List.of(KEPT, EDITED_AFTER));
+        final BridgeMqttClient clientBefore = client(before, List.of(forwarder(KEPT)));
+        // it starts, and then fails to reach the remote -- which is what writes the error
+        when(clientBefore.start())
+                .thenReturn(Futures.immediateFailedFuture(new RuntimeException("remote unreachable")));
+        when(clientFactory.createRemoteClient(any())).thenReturn(clientBefore);
+
+        bridgeService.updateBridges(List.of(before));
+        assertNotNull(bridgeService.getLastError(BRIDGE_ID), "the connect failure must have been recorded");
+
+        bridgeService.stopBridge(BRIDGE_ID, false, List.of());
+        bridgeService.updateBridges(List.of(after));
+
+        assertFalse(
+                bridgeService.isRunning(BRIDGE_ID),
+                "a reload restarted a bridge the operator had stopped, because its old connect error was"
+                        + " still on record");
+        verify(clientFactory, times(1)).createRemoteClient(any());
+    }
+
     /** Thrown where {@code internalStartBridge}'s {@code catch (Exception)} cannot see it. */
     private static final class SynchronizationError extends Error {
         private SynchronizationError() {

--- a/hivemq-edge/src/test/java/com/hivemq/bridge/BridgeServiceConfigUpdateTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/bridge/BridgeServiceConfigUpdateTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.bridge;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.hivemq.bridge.config.LocalSubscription;
+import com.hivemq.bridge.config.MqttBridge;
+import com.hivemq.bridge.mqtt.BridgeMqttClient;
+import com.hivemq.common.shutdown.ShutdownHooks;
+import com.hivemq.configuration.reader.BridgeExtractor;
+import com.hivemq.edge.HiveMQEdgeRemoteService;
+import java.util.List;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * EDG-882 F-07: what a configuration change costs the subscriptions it did not touch.
+ * <p>
+ * The reload path answered any change to a bridge by stopping it with an empty retain list, which
+ * clears every queue the bridge owns. Editing one subscription's filter therefore threw away the
+ * messages queued for all the others — a bridge with one busy subscription and one being tuned lost
+ * the busy one's backlog on every save, with nothing logged and nothing the operator could do.
+ */
+class BridgeServiceConfigUpdateTest {
+
+    private static final @NotNull String BRIDGE_ID = "edg-882-update-bridge";
+    private static final @NotNull String DESTINATION = "{#}";
+
+    private static final @NotNull LocalSubscription KEPT =
+            new LocalSubscription(List.of("plant/a", "plant/b"), DESTINATION);
+    private static final @NotNull LocalSubscription EDITED_BEFORE =
+            new LocalSubscription(List.of("other/x"), DESTINATION);
+    private static final @NotNull LocalSubscription EDITED_AFTER =
+            new LocalSubscription(List.of("other/y"), DESTINATION);
+
+    private @NotNull BridgeService bridgeService;
+    private @NotNull BridgeMqttClientFactory clientFactory;
+    private @NotNull MessageForwarder messageForwarder;
+
+    private static @NotNull MqttBridge bridge(final @NotNull List<LocalSubscription> subscriptions) {
+        return new MqttBridge.Builder()
+                .withId(BRIDGE_ID)
+                .withHost("remote.example.com")
+                .withPort(1883)
+                .withClientId(BRIDGE_ID + "-client")
+                .withLocalSubscriptions(subscriptions)
+                .withRemoteSubscriptions(List.of())
+                .build();
+    }
+
+    private static @NotNull MqttForwarder forwarder(final @NotNull LocalSubscription subscription) {
+        final MqttForwarder forwarder = mock(MqttForwarder.class);
+        when(forwarder.getId()).thenReturn(BridgeMqttClient.createForwarderId(BRIDGE_ID, subscription));
+        when(forwarder.getTopics()).thenReturn(subscription.getFilters());
+        return forwarder;
+    }
+
+    private @NotNull BridgeMqttClient client(
+            final @NotNull MqttBridge bridge, final @NotNull List<MqttForwarder> forwarders) {
+        final BridgeMqttClient client = mock(BridgeMqttClient.class);
+        when(client.getBridge()).thenReturn(bridge);
+        when(client.start()).thenReturn(Futures.immediateFuture(null));
+        when(client.stop()).thenReturn(Futures.immediateFuture(null));
+        when(client.createForwarders()).thenReturn(forwarders);
+        when(client.getActiveForwarders()).thenReturn(forwarders);
+        return client;
+    }
+
+    @BeforeEach
+    void setUp() {
+        clientFactory = mock(BridgeMqttClientFactory.class);
+        messageForwarder = mock(MessageForwarder.class);
+        bridgeService = new BridgeService(
+                mock(BridgeExtractor.class),
+                messageForwarder,
+                clientFactory,
+                MoreExecutors.newDirectExecutorService(),
+                mock(HiveMQEdgeRemoteService.class),
+                new ShutdownHooks(),
+                new MetricRegistry());
+    }
+
+    @Test
+    void updateBridges_whenOneSubscriptionChanges_thenOnlyItsQueueIsCleared() {
+        final MqttForwarder keptForwarder = forwarder(KEPT);
+        final MqttForwarder editedForwarder = forwarder(EDITED_BEFORE);
+        final MqttBridge before = bridge(List.of(KEPT, EDITED_BEFORE));
+        final MqttBridge after = bridge(List.of(KEPT, EDITED_AFTER));
+        // the clients are built outside the stubbing call: creating a mock inside when(...) leaves
+        // Mockito with an unfinished stubbing
+        final BridgeMqttClient clientBefore = client(before, List.of(keptForwarder, editedForwarder));
+        final BridgeMqttClient clientAfter = client(after, List.of(forwarder(KEPT), forwarder(EDITED_AFTER)));
+        when(clientFactory.createRemoteClient(any())).thenReturn(clientBefore).thenReturn(clientAfter);
+        bridgeService.updateBridges(List.of(before));
+
+        bridgeService.updateBridges(List.of(after));
+
+        verify(messageForwarder).removeForwarder(keptForwarder, false); // survives the change: its messages stay
+        verify(messageForwarder).removeForwarder(editedForwarder, true); // gone from the configuration: cleared
+    }
+
+    /**
+     * The other half of F-07, at this level: a reorder-only edit is not a change at all, so the bridge
+     * must not even be stopped. Restarting it drops the connection to the remote broker and
+     * re-subscribes, which is not what writing the same filters in another order should cost.
+     */
+    @Test
+    void updateBridges_whenOnlyTheFilterOrderChanges_thenTheBridgeIsNotRestarted() {
+        final MqttForwarder keptForwarder = forwarder(KEPT);
+        final MqttBridge before = bridge(List.of(KEPT));
+        final MqttBridge reordered = bridge(List.of(new LocalSubscription(List.of("plant/b", "plant/a"), DESTINATION)));
+        final BridgeMqttClient clientBefore = client(before, List.of(keptForwarder));
+        when(clientFactory.createRemoteClient(any())).thenReturn(clientBefore);
+        bridgeService.updateBridges(List.of(before));
+
+        bridgeService.updateBridges(List.of(reordered));
+
+        verify(messageForwarder, never()).removeForwarder(any(), anyBoolean());
+        verify(messageForwarder, times(1)).addForwarder(keptForwarder);
+    }
+}

--- a/hivemq-edge/src/test/java/com/hivemq/bridge/BridgeServiceConfigUpdateTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/bridge/BridgeServiceConfigUpdateTest.java
@@ -17,6 +17,7 @@ package com.hivemq.bridge;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
@@ -35,8 +36,12 @@ import com.hivemq.bridge.config.LocalSubscription;
 import com.hivemq.bridge.config.MqttBridge;
 import com.hivemq.bridge.mqtt.BridgeMqttClient;
 import com.hivemq.common.shutdown.ShutdownHooks;
+import com.hivemq.configuration.HivemqId;
 import com.hivemq.configuration.reader.BridgeExtractor;
 import com.hivemq.edge.HiveMQEdgeRemoteService;
+import com.hivemq.mqtt.topic.tree.LocalTopicTree;
+import com.hivemq.persistence.SingleWriterService;
+import com.hivemq.persistence.clientsession.ClientSessionSubscriptionPersistence;
 import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
@@ -229,11 +234,6 @@ class BridgeServiceConfigUpdateTest {
     }
 
     /**
-     * And the reaping gate opens even then. It is what tells the periodic clean-up that a forwarder
-     * queue nobody owns is genuinely abandoned; left closed, forwarder queues are never reclaimed again
-     * for the life of the node — a storage leak in place of a message loss, and silent either way.
-     */
-    /**
      * And on a node with no bridges at all. The gate is what tells the periodic clean-up that a
      * forwarder queue nobody owns is genuinely abandoned; if it only opened when a bridge started, a
      * node whose bridges were all removed would never reclaim the queues they left behind.
@@ -245,6 +245,11 @@ class BridgeServiceConfigUpdateTest {
         verify(messageForwarder).markBridgeConfigurationApplied();
     }
 
+    /**
+     * And the reaping gate opens even when a bridge fails. Left closed, forwarder queues are never
+     * reclaimed again for the life of the node — a storage leak in place of a message loss, and silent
+     * either way.
+     */
     @Test
     void updateBridges_whenABridgeThrows_thenTheReapingGateIsStillOpened() {
         final MqttBridge broken = bridge("edg-882-broken", List.of(KEPT));
@@ -253,6 +258,66 @@ class BridgeServiceConfigUpdateTest {
         bridgeService.updateBridges(List.of(broken));
 
         verify(messageForwarder).markBridgeConfigurationApplied();
+    }
+
+    /** Thrown where {@code internalStartBridge}'s {@code catch (Exception)} cannot see it. */
+    private static final class SynchronizationError extends Error {
+        private SynchronizationError() {
+            super("out of stack reading the keystore");
+        }
+    }
+
+    /**
+     * EDG-882 review v02, R2-03. The gate opens in a {@code finally}, so it opens whether or not every
+     * bridge got its turn — and each bridge claims its own queues only when its turn comes, inside
+     * {@code internalStartBridge}. Anything escaping the synchronization part way therefore used to open
+     * the gate with the bridges after it neither registered nor held, and the periodic clean-up reclaims
+     * a forwarder queue nobody holds. On the first call at boot that is every configured bridge, and
+     * what it reclaims is the backlog they accumulated before the restart.
+     * <p>
+     * Asserted against a real {@link MessageForwarderImpl}, because the reading that decides whether a
+     * queue is deleted is {@code isForwarderQueue}, and a mock would answer whatever the test wanted.
+     * Both halves are asserted: the gate must open <em>and</em> the queues must be held. Either one
+     * alone passes for the wrong reason — a gate that stayed shut would also leave the queues intact.
+     */
+    @Test
+    void updateBridges_whenTheSynchronizationThrows_thenTheUnstartedBridgesStillHoldTheirQueues() {
+        final MessageForwarder realForwarder = new MessageForwarderImpl(
+                mock(LocalTopicTree.class),
+                new HivemqId(),
+                () -> null,
+                () -> mock(ClientSessionSubscriptionPersistence.class),
+                mock(SingleWriterService.class),
+                new ShutdownHooks());
+        final BridgeService service = new BridgeService(
+                mock(BridgeExtractor.class),
+                realForwarder,
+                clientFactory,
+                MoreExecutors.newDirectExecutorService(),
+                mock(HiveMQEdgeRemoteService.class),
+                new ShutdownHooks(),
+                new MetricRegistry());
+        final List<MqttBridge> bridges = List.of(
+                bridge("edg-882-one", List.of(KEPT)),
+                bridge("edg-882-two", List.of(KEPT)),
+                bridge("edg-882-three", List.of(KEPT)));
+        // On the very first invocation, so no bridge has been through internalStartBridge. Which bridge
+        // draws it does not matter and must not: toAdd is a HashSet, so the iteration order is the hash
+        // order, and a test that named a position would be pinning that instead of the behaviour.
+        when(clientFactory.createRemoteClient(any())).thenThrow(new SynchronizationError());
+
+        assertThrows(SynchronizationError.class, () -> service.updateBridges(bridges));
+
+        assertTrue(realForwarder.hasAppliedBridgeConfiguration(), "the reaping gate never opened");
+        for (final MqttBridge configured : bridges) {
+            for (final String filter : KEPT.getFilters()) {
+                final String queueId = MessageForwarderImpl.FORWARDER_PREFIX
+                        + BridgeMqttClient.createForwarderId(configured.getId(), KEPT) + "/" + filter;
+                assertTrue(
+                        realForwarder.isForwarderQueue(queueId),
+                        "queue '" + queueId + "' reads as orphaned, so the clean-up will delete it");
+            }
+        }
     }
 
     /**

--- a/hivemq-edge/src/test/java/com/hivemq/bridge/BridgeServiceConfigUpdateTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/bridge/BridgeServiceConfigUpdateTest.java
@@ -15,8 +15,13 @@
  */
 package com.hivemq.bridge;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -141,5 +146,158 @@ class BridgeServiceConfigUpdateTest {
 
         verify(messageForwarder, never()).removeForwarder(any(), anyBoolean());
         verify(messageForwarder, times(1)).addForwarder(keptForwarder);
+    }
+
+    /**
+     * F-07 one level up (EDG-882 QA round 1). Canonicalising the filters inside a subscription made a
+     * reorder of the filters harmless; the order of the {@code <forwarded-topic>} blocks themselves was
+     * still compared positionally, so moving one block above another was a "changed" bridge — restarted,
+     * with the queues of everything the new configuration could not match cleared.
+     */
+    @Test
+    void updateBridges_whenOnlyTheSubscriptionOrderChanges_thenTheBridgeIsNotRestarted() {
+        final MqttForwarder keptForwarder = forwarder(KEPT);
+        final MqttForwarder editedForwarder = forwarder(EDITED_BEFORE);
+        final MqttBridge before = bridge(List.of(KEPT, EDITED_BEFORE));
+        final MqttBridge reordered = bridge(List.of(EDITED_BEFORE, KEPT));
+        final BridgeMqttClient clientBefore = client(before, List.of(keptForwarder, editedForwarder));
+        when(clientFactory.createRemoteClient(any())).thenReturn(clientBefore);
+        bridgeService.updateBridges(List.of(before));
+
+        bridgeService.updateBridges(List.of(reordered));
+
+        verify(messageForwarder, never()).removeForwarder(any(), anyBoolean());
+    }
+
+    /** But a repeated block is a different configuration from a single one, and must still restart. */
+    @Test
+    void updateBridges_whenASubscriptionIsDuplicated_thenTheBridgeIsRestarted() {
+        final MqttForwarder keptForwarder = forwarder(KEPT);
+        final MqttBridge before = bridge(List.of(KEPT));
+        final MqttBridge duplicated = bridge(List.of(KEPT, KEPT));
+        final BridgeMqttClient clientBefore = client(before, List.of(keptForwarder));
+        final BridgeMqttClient clientAfter = client(duplicated, List.of(forwarder(KEPT)));
+        when(clientFactory.createRemoteClient(any())).thenReturn(clientBefore).thenReturn(clientAfter);
+        bridgeService.updateBridges(List.of(before));
+
+        bridgeService.updateBridges(List.of(duplicated));
+
+        verify(messageForwarder).removeForwarder(keptForwarder, false);
+    }
+
+    /**
+     * EDG-882 QA round 1: only restartBridge used to write allKnownBridgeConfigs, so a bridge that had
+     * been stopped through the API kept the configuration it was stopped with. A later start ran a
+     * stale subscription set — and the next reload then read the difference as a change and cleared the
+     * queues of the subscriptions that had "disappeared".
+     */
+    @Test
+    void updateBridges_whenTheBridgeIsNotRunning_thenTheNewConfigurationIsUsedByTheNextStart() {
+        final MqttBridge before = bridge(List.of(EDITED_BEFORE));
+        final MqttBridge after = bridge(List.of(EDITED_AFTER));
+        final BridgeMqttClient clientBefore = client(before, List.of(forwarder(EDITED_BEFORE)));
+        final BridgeMqttClient clientAfter = client(after, List.of(forwarder(EDITED_AFTER)));
+        when(clientFactory.createRemoteClient(any())).thenReturn(clientBefore).thenReturn(clientAfter);
+        bridgeService.updateBridges(List.of(before));
+        bridgeService.stopBridge(BRIDGE_ID, false, List.of());
+
+        bridgeService.updateBridges(List.of(after));
+        bridgeService.startBridge(BRIDGE_ID);
+
+        verify(clientFactory).createRemoteClient(after);
+    }
+
+    /**
+     * EDG-882 QA round 1: constructing the client reads the TLS material, and that statement sat one
+     * short of the try that is there precisely so one bad bridge cannot take the synchronization down
+     * with it. A mistyped keystore path left every bridge after it in the iteration unstarted.
+     */
+    @Test
+    void updateBridges_whenOneBridgeCannotBeConstructed_thenTheOthersStillStart() {
+        final MqttBridge broken = bridge("edg-882-broken", List.of(KEPT));
+        final MqttBridge healthy = bridge("edg-882-healthy", List.of(KEPT));
+        final BridgeMqttClient healthyClient = client(healthy, List.of(forwarder("edg-882-healthy", KEPT)));
+        when(clientFactory.createRemoteClient(broken)).thenThrow(new RuntimeException("unreadable keystore"));
+        when(clientFactory.createRemoteClient(healthy)).thenReturn(healthyClient);
+
+        bridgeService.updateBridges(List.of(broken, healthy));
+
+        verify(clientFactory).createRemoteClient(healthy);
+        assertNotNull(bridgeService.getLastError("edg-882-broken"));
+        assertTrue(bridgeService.isRunning("edg-882-healthy"));
+        assertFalse(bridgeService.isRunning("edg-882-broken"));
+    }
+
+    /**
+     * And the reaping gate opens even then. It is what tells the periodic clean-up that a forwarder
+     * queue nobody owns is genuinely abandoned; left closed, forwarder queues are never reclaimed again
+     * for the life of the node — a storage leak in place of a message loss, and silent either way.
+     */
+    /**
+     * And on a node with no bridges at all. The gate is what tells the periodic clean-up that a
+     * forwarder queue nobody owns is genuinely abandoned; if it only opened when a bridge started, a
+     * node whose bridges were all removed would never reclaim the queues they left behind.
+     */
+    @Test
+    void updateBridges_whenThereAreNoBridgesAtAll_thenTheReapingGateIsStillOpened() {
+        bridgeService.updateBridges(List.of());
+
+        verify(messageForwarder).markBridgeConfigurationApplied();
+    }
+
+    @Test
+    void updateBridges_whenABridgeThrows_thenTheReapingGateIsStillOpened() {
+        final MqttBridge broken = bridge("edg-882-broken", List.of(KEPT));
+        when(clientFactory.createRemoteClient(any())).thenThrow(new RuntimeException("unreadable keystore"));
+
+        bridgeService.updateBridges(List.of(broken));
+
+        verify(messageForwarder).markBridgeConfigurationApplied();
+    }
+
+    /**
+     * EDG-882 QA round 2: a start that failed part way left the forwarders it had already registered
+     * live and polling, draining persisted messages into a client that was never started and would
+     * never reconnect. Nothing is cleared on the way out — the queues stay, held by the reservation.
+     */
+    @Test
+    void internalStartBridge_whenTheSecondForwarderFailsToRegister_thenTheFirstIsUnregistered() {
+        final MqttForwarder first = forwarder(KEPT);
+        final MqttForwarder second = forwarder(EDITED_BEFORE);
+        final MqttBridge bridge = bridge(List.of(KEPT, EDITED_BEFORE));
+        // built outside the stubbing call: a mock created inside when(...) leaves Mockito with an
+        // unfinished stubbing
+        final BridgeMqttClient bridgeClient = client(bridge, List.of(first, second));
+        when(clientFactory.createRemoteClient(any())).thenReturn(bridgeClient);
+        doThrow(new IllegalStateException("already registered"))
+                .when(messageForwarder)
+                .addForwarder(second);
+
+        bridgeService.updateBridges(List.of(bridge));
+
+        verify(messageForwarder).removeForwarder(first, false);
+        verify(messageForwarder, never()).removeForwarder(eq(first), eq(true));
+        verify(messageForwarder, never()).releaseReservedQueues(BRIDGE_ID);
+        assertNotNull(bridgeService.getLastError(BRIDGE_ID));
+    }
+
+    private static @NotNull MqttBridge bridge(
+            final @NotNull String bridgeId, final @NotNull List<LocalSubscription> subscriptions) {
+        return new MqttBridge.Builder()
+                .withId(bridgeId)
+                .withHost("remote.example.com")
+                .withPort(1883)
+                .withClientId(bridgeId + "-client")
+                .withLocalSubscriptions(subscriptions)
+                .withRemoteSubscriptions(List.of())
+                .build();
+    }
+
+    private static @NotNull MqttForwarder forwarder(
+            final @NotNull String bridgeId, final @NotNull LocalSubscription subscription) {
+        final MqttForwarder forwarder = mock(MqttForwarder.class);
+        when(forwarder.getId()).thenReturn(BridgeMqttClient.createForwarderId(bridgeId, subscription));
+        when(forwarder.getTopics()).thenReturn(subscription.getFilters());
+        return forwarder;
     }
 }

--- a/hivemq-edge/src/test/java/com/hivemq/bridge/BridgeServiceForwarderRegistrationFailureTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/bridge/BridgeServiceForwarderRegistrationFailureTest.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -280,5 +281,47 @@ class BridgeServiceForwarderRegistrationFailureTest {
         // the restart path clears the queues of the forwarders it removes; the rejected bridge has none,
         // so what accumulated while the configuration was broken is still there to be forwarded
         verify(messageForwarder, never()).removeForwarder(any(), anyBoolean());
+    }
+
+    /**
+     * EDG-882 review v03, R3-04. The removal loop used to sit inside one {@code try}, so the first
+     * forwarder whose teardown threw took every forwarder behind it with it: they were never removed,
+     * their queue IDs stayed in the ownership index, and the periodic clean-up read them as owned for
+     * the life of the node — while {@code addForwarder} refused to re-register any of them, so the
+     * bridge could not be restarted either.
+     * <p>
+     * {@code removeForwarder} now completes its own teardown before reporting, so what reaches this loop
+     * is a forwarder that has already been released. Continuing is what lets the rest of the bridge be
+     * released too.
+     */
+    @Test
+    void stopBridge_whenOneForwardersTeardownThrows_thenTheRemainingForwardersAreStillRemoved() {
+        final LocalSubscription first = new LocalSubscription(List.of("plant/line1"), "remote/one");
+        final LocalSubscription second = new LocalSubscription(List.of("plant/line2"), "remote/two");
+        final MqttBridge bridge = bridge("two-forwarder-bridge", List.of(first, second));
+        final MqttForwarder failing = mock(MqttForwarder.class);
+        when(failing.getId()).thenReturn("two-forwarder-bridge-" + first.calculateUniqueId());
+        when(failing.getTopics()).thenReturn(List.of("plant/line1"));
+        final MqttForwarder survivor = mock(MqttForwarder.class);
+        when(survivor.getId()).thenReturn("two-forwarder-bridge-" + second.calculateUniqueId());
+        when(survivor.getTopics()).thenReturn(List.of("plant/line2"));
+
+        final BridgeMqttClient client = healthyClient(bridge);
+        when(client.createForwarders()).thenReturn(List.of(failing, survivor));
+        when(client.getActiveForwarders()).thenReturn(List.of(failing, survivor));
+        when(clientFactory.createRemoteClient(any())).thenReturn(client);
+        bridgeService.updateBridges(List.of(bridge));
+
+        doThrow(new IllegalStateException("teardown did not complete cleanly"))
+                .when(messageForwarder)
+                .removeForwarder(eq(failing), anyBoolean());
+
+        // the bridge leaves the configuration, so every forwarder must be torn down
+        assertDoesNotThrow(() -> bridgeService.updateBridges(List.of()));
+
+        verify(messageForwarder).removeForwarder(eq(failing), anyBoolean());
+        verify(messageForwarder)
+                .removeForwarder(
+                        eq(survivor), anyBoolean()); // the one behind the failure -- never reached before the fix
     }
 }

--- a/hivemq-edge/src/test/java/com/hivemq/bridge/BridgeServiceForwarderRegistrationFailureTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/bridge/BridgeServiceForwarderRegistrationFailureTest.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -45,6 +46,7 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
 
 /**
  * EDG-882 F-01, at the level that has to survive the rejection.
@@ -159,17 +161,32 @@ class BridgeServiceForwarderRegistrationFailureTest {
                 "a queue of either subscription that is not held is a queue the clean-up will delete");
     }
 
-    /** A bridge that starts owns its queues through its forwarders; the hold must not outlive that. */
+    /**
+     * Even a bridge that starts normally has a window to cover. The clean-up service is scheduled
+     * during persistence bootstrap, before any bridge has registered a forwarder, so at node start a
+     * persisted bridge queue is visible and unowned — and the clean-up deletes forwarder queues nobody
+     * owns. The hold is therefore taken for every start and dropped the moment the forwarders take
+     * over: before the registration it would not cover the window, after it there would be an instant
+     * with no owner at all, and never dropping it would strand the queues for the life of the node.
+     */
     @Test
-    void updateBridges_whenTheBridgeStarts_thenNoQueuesAreHeldForIt() {
-        final MqttBridge healthy = bridge("healthy-bridge");
+    void updateBridges_whenTheBridgeStarts_thenItsQueuesAreHeldOnlyUntilTheForwardersOwnThem() {
+        final LocalSubscription subscription = new LocalSubscription(List.of("plant/line1"), "remote/dest");
+        final MqttBridge healthy = bridge("healthy-bridge", List.of(subscription));
         final BridgeMqttClient client = healthyClient(healthy);
+        final MqttForwarder forwarder = mock(MqttForwarder.class);
+        when(forwarder.getId()).thenReturn("healthy-bridge-" + subscription.calculateUniqueId());
+        when(forwarder.getTopics()).thenReturn(List.of("plant/line1"));
+        when(client.createForwarders()).thenReturn(List.of(forwarder));
+        when(client.getActiveForwarders()).thenReturn(List.of(forwarder));
         when(clientFactory.createRemoteClient(any())).thenReturn(client);
 
         bridgeService.updateBridges(List.of(healthy));
 
-        verify(messageForwarder, never()).reserveQueues(any(), any());
-        verify(messageForwarder).releaseReservedQueues("healthy-bridge");
+        final InOrder handover = inOrder(messageForwarder);
+        handover.verify(messageForwarder).reserveQueues(eq("healthy-bridge"), any());
+        handover.verify(messageForwarder).addForwarder(forwarder);
+        handover.verify(messageForwarder).releaseReservedQueues("healthy-bridge");
     }
 
     /**

--- a/hivemq-edge/src/test/java/com/hivemq/bridge/BridgeServiceForwarderRegistrationFailureTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/bridge/BridgeServiceForwarderRegistrationFailureTest.java
@@ -1,0 +1,254 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.bridge;
+
+import static java.util.Objects.requireNonNull;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.hivemq.bridge.config.LocalSubscription;
+import com.hivemq.bridge.config.MqttBridge;
+import com.hivemq.bridge.mqtt.BridgeMqttClient;
+import com.hivemq.common.shutdown.ShutdownHooks;
+import com.hivemq.configuration.reader.BridgeExtractor;
+import com.hivemq.edge.HiveMQEdgeRemoteService;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+/**
+ * EDG-882 F-01, at the level that has to survive the rejection.
+ * <p>
+ * A bridge whose local subscriptions collide on a forwarder id cannot start. What the service must do
+ * with that is report it and carry on: {@code updateBridges} walks every configured bridge, so an
+ * exception escaping the start of one would leave every bridge after it in the iteration unstarted —
+ * turning one unusable bridge into an outage of all of them.
+ * <p>
+ * The rejected bridge must also be left strictly alone: nothing registered, nothing started, and — the
+ * point of the whole ticket — no queue cleared, so its messages are still there once the configuration
+ * is corrected.
+ */
+class BridgeServiceForwarderRegistrationFailureTest {
+
+    private @NotNull BridgeService bridgeService;
+    private @NotNull BridgeMqttClientFactory clientFactory;
+    private @NotNull MessageForwarder messageForwarder;
+
+    private static @NotNull MqttBridge bridge(final @NotNull String bridgeId) {
+        return bridge(bridgeId, List.of());
+    }
+
+    private static @NotNull MqttBridge bridge(
+            final @NotNull String bridgeId, final @NotNull List<LocalSubscription> localSubscriptions) {
+        return new MqttBridge.Builder()
+                .withId(bridgeId)
+                .withHost("remote.example.com")
+                .withPort(1883)
+                .withClientId(bridgeId + "-client")
+                .withLocalSubscriptions(localSubscriptions)
+                .withRemoteSubscriptions(List.of())
+                .build();
+    }
+
+    private static @NotNull BridgeMqttClient healthyClient(final @NotNull MqttBridge bridge) {
+        final BridgeMqttClient client = mock(BridgeMqttClient.class);
+        when(client.getBridge()).thenReturn(bridge);
+        when(client.start()).thenReturn(Futures.immediateFuture(null));
+        when(client.stop()).thenReturn(Futures.immediateFuture(null));
+        when(client.getActiveForwarders()).thenReturn(List.of());
+        when(client.createForwarders()).thenReturn(List.of());
+        return client;
+    }
+
+    private static @NotNull BridgeMqttClient rejectingClient(
+            final @NotNull MqttBridge bridge, final @NotNull IllegalStateException rejection) {
+        final BridgeMqttClient client = healthyClient(bridge);
+        when(client.createForwarders()).thenThrow(rejection);
+        return client;
+    }
+
+    @BeforeEach
+    void setUp() {
+        clientFactory = mock(BridgeMqttClientFactory.class);
+        messageForwarder = mock(MessageForwarder.class);
+        bridgeService = new BridgeService(
+                mock(BridgeExtractor.class),
+                messageForwarder,
+                clientFactory,
+                MoreExecutors.newDirectExecutorService(),
+                mock(HiveMQEdgeRemoteService.class),
+                new ShutdownHooks(),
+                new MetricRegistry());
+    }
+
+    @Test
+    void updateBridges_whenForwarderRegistrationIsRejected_thenReportedAndNothingIsRegisteredOrStarted() {
+        final MqttBridge colliding = bridge("colliding-bridge");
+        final IllegalStateException rejection = new IllegalStateException("two subscriptions share a forwarder id");
+        final BridgeMqttClient client = rejectingClient(colliding, rejection);
+        when(clientFactory.createRemoteClient(any())).thenReturn(client);
+
+        assertDoesNotThrow(() -> bridgeService.updateBridges(List.of(colliding)));
+
+        assertSame(rejection, bridgeService.getLastError("colliding-bridge"), "the rejection must be reported");
+        verify(messageForwarder, never()).addForwarder(any());
+        verify(client, never()).start();
+        // and above all: nothing was cleared, so the queues survive until the configuration is fixed
+        verify(messageForwarder, never()).removeForwarder(any(), anyBoolean());
+    }
+
+    /**
+     * The half of the refusal that the customer feels. A bridge that cannot start registers no
+     * forwarder, so its persisted queues read as unowned — and the periodic clean-up deletes unowned
+     * forwarder queues within seconds of the node coming up. Refusing without holding them would only
+     * change which line of code destroys the messages.
+     * <p>
+     * The hold covers both colliding subscriptions. Their forwarder id is the same by construction, so
+     * a hold built by keying on it must merge the two filter lists rather than keep whichever came
+     * last — otherwise half the queues are left to the clean-up.
+     */
+    @Test
+    void updateBridges_whenForwarderRegistrationIsRejected_thenTheQueuesOfEverySubscriptionAreHeld() {
+        final LocalSubscription split = new LocalSubscription(List.of("ab", "c"), "remote/dest");
+        final LocalSubscription joined = new LocalSubscription(List.of("a", "bc"), "remote/dest");
+        assertEquals(split.calculateUniqueId(), joined.calculateUniqueId(), "the premise: one id, two queue sets");
+
+        final MqttBridge colliding = bridge("colliding-bridge", List.of(split, joined));
+        final BridgeMqttClient client = rejectingClient(colliding, new IllegalStateException("colliding ids"));
+        when(clientFactory.createRemoteClient(any())).thenReturn(client);
+
+        bridgeService.updateBridges(List.of(colliding));
+
+        final ArgumentCaptor<Map<String, List<String>>> held = ArgumentCaptor.captor();
+        verify(messageForwarder).reserveQueues(eq("colliding-bridge"), held.capture());
+        final String forwarderId = "colliding-bridge-" + split.calculateUniqueId();
+        assertEquals(Set.of(forwarderId), held.getValue().keySet());
+        assertEquals(
+                List.of("ab", "c", "a", "bc"),
+                held.getValue().get(forwarderId),
+                "a queue of either subscription that is not held is a queue the clean-up will delete");
+    }
+
+    /** A bridge that starts owns its queues through its forwarders; the hold must not outlive that. */
+    @Test
+    void updateBridges_whenTheBridgeStarts_thenNoQueuesAreHeldForIt() {
+        final MqttBridge healthy = bridge("healthy-bridge");
+        final BridgeMqttClient client = healthyClient(healthy);
+        when(clientFactory.createRemoteClient(any())).thenReturn(client);
+
+        bridgeService.updateBridges(List.of(healthy));
+
+        verify(messageForwarder, never()).reserveQueues(any(), any());
+        verify(messageForwarder).releaseReservedQueues("healthy-bridge");
+    }
+
+    /**
+     * Held queues are reclaimable once the bridge is gone from the configuration — and only then.
+     * Releasing on any stop would drop the hold as a node shuts down, letting a last clean-up pass
+     * delete the messages the operator is coming back for.
+     */
+    @Test
+    void updateBridges_whenTheRefusedBridgeIsRemoved_thenTheHoldIsReleased() {
+        final MqttBridge colliding = bridge("colliding-bridge");
+        final BridgeMqttClient client = rejectingClient(colliding, new IllegalStateException("colliding ids"));
+        when(clientFactory.createRemoteClient(any())).thenReturn(client);
+        bridgeService.updateBridges(List.of(colliding));
+        verify(messageForwarder, never()).releaseReservedQueues("colliding-bridge");
+
+        bridgeService.updateBridges(List.of());
+
+        verify(messageForwarder).releaseReservedQueues("colliding-bridge");
+    }
+
+    /**
+     * The reason the rejection is caught rather than allowed to propagate. {@code toAdd} is iterated in
+     * hash order, so an escaping exception would take down an arbitrary subset of the other bridges —
+     * a failure that would reproduce differently on every run.
+     */
+    @Test
+    void updateBridges_whenOneBridgeIsRejected_thenTheOthersStillStart() {
+        final MqttBridge colliding = bridge("colliding-bridge");
+        final MqttBridge healthy = bridge("healthy-bridge");
+        final MqttBridge alsoHealthy = bridge("also-healthy-bridge");
+        final BridgeMqttClient collidingClient =
+                rejectingClient(colliding, new IllegalStateException("two subscriptions share a forwarder id"));
+        final BridgeMqttClient healthyClient = healthyClient(healthy);
+        final BridgeMqttClient alsoHealthyClient = healthyClient(alsoHealthy);
+        when(clientFactory.createRemoteClient(any())).thenAnswer(invocation -> {
+            final MqttBridge requested = invocation.getArgument(0);
+            return switch (requested.getId()) {
+                case "colliding-bridge" -> collidingClient;
+                case "healthy-bridge" -> healthyClient;
+                default -> alsoHealthyClient;
+            };
+        });
+
+        bridgeService.updateBridges(List.of(healthy, colliding, alsoHealthy));
+
+        verify(healthyClient, times(1)).start();
+        verify(alsoHealthyClient, times(1)).start();
+        assertNull(bridgeService.getLastError("healthy-bridge"));
+        assertNull(bridgeService.getLastError("also-healthy-bridge"));
+    }
+
+    @Test
+    void updateBridges_whenTheConfigurationIsCorrected_thenTheBridgeStartsAndTheErrorClears() {
+        final MqttBridge colliding = bridge("bridge");
+        // built outside the stubbing call: creating a mock inside when(...) confuses Mockito
+        final BridgeMqttClient collidingClient =
+                rejectingClient(colliding, new IllegalStateException("two subscriptions share an id"));
+        when(clientFactory.createRemoteClient(any())).thenReturn(collidingClient);
+        bridgeService.updateBridges(List.of(colliding));
+        requireNonNull(bridgeService.getLastError("bridge"), "the rejection must have been recorded");
+
+        // the operator edits the offending filter: same bridge id, a configuration that now resolves
+        final MqttBridge corrected = new MqttBridge.Builder()
+                .withId("bridge")
+                .withHost("remote.example.com")
+                .withPort(8883)
+                .withClientId("bridge-client")
+                .withLocalSubscriptions(List.of())
+                .withRemoteSubscriptions(List.of())
+                .build();
+        final BridgeMqttClient correctedClient = healthyClient(corrected);
+        when(clientFactory.createRemoteClient(any())).thenReturn(correctedClient);
+
+        bridgeService.updateBridges(List.of(corrected));
+
+        verify(correctedClient, times(1)).start();
+        assertNull(bridgeService.getLastError("bridge"), "the recorded rejection must not outlive the fix");
+        // the restart path clears the queues of the forwarders it removes; the rejected bridge has none,
+        // so what accumulated while the configuration was broken is still there to be forwarded
+        verify(messageForwarder, never()).removeForwarder(any(), anyBoolean());
+    }
+}

--- a/hivemq-edge/src/test/java/com/hivemq/bridge/BridgeServiceForwarderRegistrationFailureTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/bridge/BridgeServiceForwarderRegistrationFailureTest.java
@@ -138,6 +138,12 @@ class BridgeServiceForwarderRegistrationFailureTest {
      * The hold covers both colliding subscriptions. Their forwarder id is the same by construction, so
      * a hold built by keying on it must merge the two filter lists rather than keep whichever came
      * last — otherwise half the queues are left to the clean-up.
+     * <p>
+     * Two holds are taken, and every one of them is checked: {@code updateBridges} pre-reserves each
+     * bridge it is about to add before the reaping gate can open (R2-03), and {@code internalStartBridge}
+     * takes its own when the bridge's turn comes. They supersede rather than accumulate, but a
+     * pre-reservation that built the map differently would leave exactly the queues this test is about
+     * uncovered for the part of the window it exists to cover.
      */
     @Test
     void updateBridges_whenForwarderRegistrationIsRejected_thenTheQueuesOfEverySubscriptionAreHeld() {
@@ -152,13 +158,15 @@ class BridgeServiceForwarderRegistrationFailureTest {
         bridgeService.updateBridges(List.of(colliding));
 
         final ArgumentCaptor<Map<String, List<String>>> held = ArgumentCaptor.captor();
-        verify(messageForwarder).reserveQueues(eq("colliding-bridge"), held.capture());
+        verify(messageForwarder, times(2)).reserveQueues(eq("colliding-bridge"), held.capture());
         final String forwarderId = "colliding-bridge-" + split.calculateUniqueId();
-        assertEquals(Set.of(forwarderId), held.getValue().keySet());
-        assertEquals(
-                List.of("ab", "c", "a", "bc"),
-                held.getValue().get(forwarderId),
-                "a queue of either subscription that is not held is a queue the clean-up will delete");
+        for (final Map<String, List<String>> reservation : held.getAllValues()) {
+            assertEquals(Set.of(forwarderId), reservation.keySet());
+            assertEquals(
+                    List.of("ab", "c", "a", "bc"),
+                    reservation.get(forwarderId),
+                    "a queue of either subscription that is not held is a queue the clean-up will delete");
+        }
     }
 
     /**
@@ -168,6 +176,11 @@ class BridgeServiceForwarderRegistrationFailureTest {
      * owns. The hold is therefore taken for every start and dropped the moment the forwarders take
      * over: before the registration it would not cover the window, after it there would be an instant
      * with no owner at all, and never dropping it would strand the queues for the life of the node.
+     * <p>
+     * Both holds are expected before the registration: {@code updateBridges} pre-reserves every bridge
+     * it is about to add before the reaping gate can open (R2-03), and {@code internalStartBridge} takes
+     * its own when the bridge's turn comes. What this pins is the order — every hold ahead of the
+     * registration, the release behind it — not how many there are.
      */
     @Test
     void updateBridges_whenTheBridgeStarts_thenItsQueuesAreHeldOnlyUntilTheForwardersOwnThem() {
@@ -184,7 +197,7 @@ class BridgeServiceForwarderRegistrationFailureTest {
         bridgeService.updateBridges(List.of(healthy));
 
         final InOrder handover = inOrder(messageForwarder);
-        handover.verify(messageForwarder).reserveQueues(eq("healthy-bridge"), any());
+        handover.verify(messageForwarder, times(2)).reserveQueues(eq("healthy-bridge"), any());
         handover.verify(messageForwarder).addForwarder(forwarder);
         handover.verify(messageForwarder).releaseReservedQueues("healthy-bridge");
     }

--- a/hivemq-edge/src/test/java/com/hivemq/bridge/BridgeServiceRestartHandoverTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/bridge/BridgeServiceRestartHandoverTest.java
@@ -16,12 +16,14 @@
 package com.hivemq.bridge;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import ch.qos.logback.classic.Level;
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.Futures;
@@ -42,6 +44,8 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.slf4j.LoggerFactory;
+import util.LogbackCapturingAppender;
 
 /**
  * EDG-882 F-02: a bridge queue that a restart keeps must never read as unowned while it is being
@@ -210,5 +214,46 @@ class BridgeServiceRestartHandoverTest {
         assertFalse(
                 messageForwarder.isForwarderQueue(queueId(FILTER)),
                 "the queue of a subscription that was removed and cleared must be reclaimable");
+    }
+
+    /**
+     * A cancelled start is this generation being stopped on purpose, not a bridge that failed.
+     * <p>
+     * {@code BridgeMqttClient.stop()} cancels the pending start future, and the callback attached to it
+     * then runs asynchronously — after {@code stopBridge} has cleared {@code bridgeNameToLastError}. So
+     * a restart of a bridge whose remote is down recorded a failure for the generation that had just
+     * been retired, and the bridge that went on to connect normally reported an error through the API
+     * under an {@code ERROR - Unable to start bridge} line saying it could not be started. Seen on a
+     * real node during the 2026-08-25 smoke test; reachable on every update of a disconnected bridge,
+     * because an update is now one transition through {@code restartBridge}.
+     */
+    @Test
+    @Timeout(10)
+    void internalStartBridge_whenTheStartIsCancelledByAStop_thenNoFailureIsRecordedOrLogged() {
+        final LogbackCapturingAppender logCapture =
+                LogbackCapturingAppender.Factory.weaveInto(LoggerFactory.getLogger(BridgeService.class));
+        try {
+            final MqttBridge configured = bridge(FILTER);
+            when(clientFactory.createRemoteClient(any())).thenAnswer(invocation -> {
+                final BridgeMqttClient client = client(configured, FILTER);
+                // exactly what stop() leaves behind for a start that was still in flight
+                when(client.start()).thenReturn(Futures.immediateCancelledFuture());
+                return client;
+            });
+
+            bridgeService.updateBridges(List.of(configured));
+
+            assertNull(
+                    bridgeService.getLastError(BRIDGE_ID),
+                    "a start cancelled by a deliberate stop was recorded as the bridge's last error, so the API "
+                            + "reports a failure for a bridge that is about to connect normally");
+            assertFalse(
+                    logCapture.getCapturedLogs().stream()
+                            .anyMatch(event -> event.getLevel() == Level.ERROR
+                                    && event.getFormattedMessage().contains("Unable to start bridge")),
+                    "an operator was told the bridge could not be started, when it was only stopped");
+        } finally {
+            LogbackCapturingAppender.Factory.cleanUp();
+        }
     }
 }

--- a/hivemq-edge/src/test/java/com/hivemq/bridge/BridgeServiceRestartHandoverTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/bridge/BridgeServiceRestartHandoverTest.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.bridge;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.hivemq.bridge.config.LocalSubscription;
+import com.hivemq.bridge.config.MqttBridge;
+import com.hivemq.bridge.mqtt.BridgeMqttClient;
+import com.hivemq.common.shutdown.ShutdownHooks;
+import com.hivemq.configuration.HivemqId;
+import com.hivemq.configuration.reader.BridgeExtractor;
+import com.hivemq.edge.HiveMQEdgeRemoteService;
+import com.hivemq.mqtt.topic.tree.LocalTopicTree;
+import com.hivemq.persistence.SingleWriterService;
+import java.util.ArrayList;
+import java.util.List;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+/**
+ * EDG-882 F-02: a bridge queue that a restart keeps must never read as unowned while it is being
+ * handed from one generation of forwarders to the next.
+ * <p>
+ * {@code restartBridge} deliberately does not clear the queues of forwarders that survive into the new
+ * configuration. Between the two generations, though, the old forwarders have been removed and
+ * released and the replacements are not registered yet — and the periodic clean-up, which runs on its
+ * own schedule and clears every forwarder queue no registered forwarder owns, does not know that a
+ * restart is in progress. A sweep landing in that gap deletes exactly the messages the restart was
+ * careful to keep, and the bridge comes back to an empty queue with nothing logged.
+ * <p>
+ * The gap cannot be observed from outside {@link BridgeService}, so it is observed from inside: the
+ * real {@link MessageForwarderImpl} is wired in, and the mocked client answers at each point of the
+ * hand-over by recording what {@code isForwarderQueue} says at that instant. Every recording must be
+ * {@code true} — that is what the clean-up would have read.
+ */
+class BridgeServiceRestartHandoverTest {
+
+    private static final @NotNull String BRIDGE_ID = "edg-882-restart-bridge";
+    private static final @NotNull String FILTER = "plant/line1/from-plc";
+    private static final @NotNull String DESTINATION = "{#}";
+
+    private @NotNull BridgeService bridgeService;
+    private @NotNull BridgeMqttClientFactory clientFactory;
+    private @NotNull MessageForwarderImpl messageForwarder;
+
+    /** Every answer to "does a registered forwarder own this queue?" taken during a hand-over. */
+    private final @NotNull List<Boolean> ownershipDuringHandover = new ArrayList<>();
+
+    private static @NotNull MqttBridge bridge(final @NotNull String filter) {
+        return new MqttBridge.Builder()
+                .withId(BRIDGE_ID)
+                .withHost("remote.example.com")
+                .withPort(1883)
+                .withClientId(BRIDGE_ID + "-client")
+                .withLocalSubscriptions(List.of(new LocalSubscription(List.of(filter), DESTINATION)))
+                .withRemoteSubscriptions(List.of())
+                .build();
+    }
+
+    private static @NotNull String forwarderId(final @NotNull String filter) {
+        return BridgeMqttClient.createForwarderId(BRIDGE_ID, new LocalSubscription(List.of(filter), DESTINATION));
+    }
+
+    private static @NotNull String queueId(final @NotNull String filter) {
+        return MessageForwarderImpl.FORWARDER_PREFIX + forwarderId(filter) + "/" + filter;
+    }
+
+    private @NotNull MqttForwarder forwarder(final @NotNull String filter) {
+        final MqttForwarder forwarder = mock(MqttForwarder.class);
+        when(forwarder.getId()).thenReturn(forwarderId(filter));
+        when(forwarder.getTopics()).thenReturn(List.of(filter));
+        // the moment the old generation lets go
+        org.mockito.Mockito.doAnswer(invocation -> {
+                    ownershipDuringHandover.add(messageForwarder.isForwarderQueue(queueId(FILTER)));
+                    return null;
+                })
+                .when(forwarder)
+                .stop();
+        return forwarder;
+    }
+
+    private @NotNull BridgeMqttClient client(final @NotNull MqttBridge bridge, final @NotNull String filter) {
+        final BridgeMqttClient client = mock(BridgeMqttClient.class);
+        final MqttForwarder forwarder = forwarder(filter);
+        when(client.getBridge()).thenReturn(bridge);
+        when(client.start()).thenReturn(Futures.immediateFuture(null));
+        when(client.stop()).thenReturn(Futures.immediateFuture(null));
+        when(client.getActiveForwarders()).thenReturn(List.of(forwarder));
+        // the widest point of the gap: the old generation is gone, the new one not registered yet
+        when(client.createForwarders()).thenAnswer(invocation -> {
+            ownershipDuringHandover.add(messageForwarder.isForwarderQueue(queueId(FILTER)));
+            return List.of(forwarder);
+        });
+        return client;
+    }
+
+    @BeforeEach
+    void setUp() {
+        clientFactory = mock(BridgeMqttClientFactory.class);
+        messageForwarder = new MessageForwarderImpl(
+                mock(LocalTopicTree.class),
+                new HivemqId(),
+                () -> null,
+                mock(SingleWriterService.class),
+                mock(ShutdownHooks.class));
+        bridgeService = new BridgeService(
+                mock(BridgeExtractor.class),
+                messageForwarder,
+                clientFactory,
+                MoreExecutors.newDirectExecutorService(),
+                mock(HiveMQEdgeRemoteService.class),
+                new ShutdownHooks(),
+                new MetricRegistry());
+    }
+
+    @Test
+    @Timeout(10)
+    void restartBridge_whenTheSubscriptionSurvives_thenItsQueueIsOwnedThroughout() {
+        final MqttBridge configured = bridge(FILTER);
+        when(clientFactory.createRemoteClient(any())).thenAnswer(invocation -> client(configured, FILTER));
+        bridgeService.updateBridges(List.of(configured));
+        assertTrue(messageForwarder.isForwarderQueue(queueId(FILTER)), "the bridge did not register its queue");
+        ownershipDuringHandover.clear();
+
+        bridgeService.restartBridge(BRIDGE_ID, configured);
+
+        assertFalse(ownershipDuringHandover.isEmpty(), "the hand-over was never observed; this run proves nothing");
+        assertFalse(
+                ownershipDuringHandover.contains(false),
+                "a retained queue read as unowned during the restart; a clean-up sweep there deletes its messages "
+                        + "and the bridge comes back empty. Readings in order: " + ownershipDuringHandover);
+        assertTrue(messageForwarder.isForwarderQueue(queueId(FILTER)), "the replacement must own it afterwards");
+    }
+
+    /**
+     * The hold is not a leak. Once the replacement forwarders own the queues the hold is dropped, so a
+     * later removal of the bridge still makes them reclaimable — otherwise a restarted bridge could
+     * never have its queues cleaned up again, and every restart would strand another set for the life
+     * of the node.
+     */
+    @Test
+    @Timeout(10)
+    void restartBridge_whenTheBridgeIsAfterwardsRemoved_thenItsQueuesBecomeReclaimable() {
+        final MqttBridge configured = bridge(FILTER);
+        when(clientFactory.createRemoteClient(any())).thenAnswer(invocation -> client(configured, FILTER));
+        bridgeService.updateBridges(List.of(configured));
+        bridgeService.restartBridge(BRIDGE_ID, configured);
+        assertTrue(messageForwarder.isForwarderQueue(queueId(FILTER)));
+
+        bridgeService.updateBridges(List.of());
+
+        assertFalse(
+                messageForwarder.isForwarderQueue(queueId(FILTER)),
+                "the restart hold outlived the bridge; the queue can now never be reclaimed");
+    }
+
+    /**
+     * A subscription that does not survive the restart is a different matter: its queue is cleared by
+     * the stop, and nothing must go on holding it afterwards.
+     */
+    @Test
+    @Timeout(10)
+    void restartBridge_whenTheSubscriptionChanges_thenTheOldQueueIsNotHeld() {
+        final String newFilter = "plant/line2/from-plc";
+        final MqttBridge configured = bridge(FILTER);
+        final MqttBridge updated = bridge(newFilter);
+        when(clientFactory.createRemoteClient(any())).thenAnswer(invocation -> {
+            final MqttBridge requested = invocation.getArgument(0);
+            return client(
+                    requested,
+                    requested.getLocalSubscriptions().getFirst().getFilters().getFirst());
+        });
+        bridgeService.updateBridges(List.of(configured));
+
+        bridgeService.restartBridge(BRIDGE_ID, updated);
+
+        assertTrue(messageForwarder.isForwarderQueue(queueId(newFilter)), "the new subscription must own its queue");
+        assertFalse(
+                messageForwarder.isForwarderQueue(queueId(FILTER)),
+                "the queue of a subscription that was removed and cleared must be reclaimable");
+    }
+}

--- a/hivemq-edge/src/test/java/com/hivemq/bridge/BridgeServiceRestartHandoverTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/bridge/BridgeServiceRestartHandoverTest.java
@@ -18,10 +18,12 @@ package com.hivemq.bridge;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.codahale.metrics.MetricRegistry;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.hivemq.bridge.config.LocalSubscription;
@@ -33,6 +35,7 @@ import com.hivemq.configuration.reader.BridgeExtractor;
 import com.hivemq.edge.HiveMQEdgeRemoteService;
 import com.hivemq.mqtt.topic.tree.LocalTopicTree;
 import com.hivemq.persistence.SingleWriterService;
+import com.hivemq.persistence.clientsession.ClientSessionSubscriptionPersistence;
 import java.util.ArrayList;
 import java.util.List;
 import org.jetbrains.annotations.NotNull;
@@ -117,13 +120,19 @@ class BridgeServiceRestartHandoverTest {
         return client;
     }
 
+    private final @NotNull ClientSessionSubscriptionPersistence subscriptionPersistence =
+            mock(ClientSessionSubscriptionPersistence.class);
+
     @BeforeEach
     void setUp() {
         clientFactory = mock(BridgeMqttClientFactory.class);
+        final LocalTopicTree topicTree = mock(LocalTopicTree.class);
+        when(topicTree.getSharedSubscriber(anyString(), anyString())).thenReturn(ImmutableSet.of());
         messageForwarder = new MessageForwarderImpl(
-                mock(LocalTopicTree.class),
+                topicTree,
                 new HivemqId(),
                 () -> null,
+                () -> subscriptionPersistence,
                 mock(SingleWriterService.class),
                 mock(ShutdownHooks.class));
         bridgeService = new BridgeService(

--- a/hivemq-edge/src/test/java/com/hivemq/bridge/MessageForwarderImplTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/bridge/MessageForwarderImplTest.java
@@ -17,6 +17,8 @@ package com.hivemq.bridge;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -31,14 +33,21 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.codahale.metrics.MetricRegistry;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.Futures;
 import com.hivemq.common.shutdown.ShutdownHooks;
 import com.hivemq.configuration.HivemqId;
+import com.hivemq.metrics.MetricsHolder;
+import com.hivemq.mqtt.message.QoS;
+import com.hivemq.mqtt.message.subscribe.Topic;
 import com.hivemq.mqtt.topic.SubscriberWithQoS;
+import com.hivemq.mqtt.topic.SubscriptionFlag;
 import com.hivemq.mqtt.topic.tree.LocalTopicTree;
 import com.hivemq.persistence.SingleWriterService;
 import com.hivemq.persistence.clientsession.ClientSessionSubscriptionPersistence;
+import com.hivemq.persistence.clientsession.SharedSubscriptionServiceImpl.SharedSubscription;
+import com.hivemq.util.Topics;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -121,6 +130,55 @@ public class MessageForwarderImplTest {
         // restore the subscription on its next reconnect and take the group straight back
         verify(subscriptionPersistence)
                 .remove("squatter", "$share/" + MessageForwarderImpl.FORWARDER_PREFIX + FORWARDER_ID + "/" + TOPIC);
+    }
+
+    /**
+     * EDG-882 review v02, R2-02. The test above stubs the tree under the forwarder's <em>own</em> split,
+     * which is the only split a forwarder itself ever registers — it passes the group and the filter to
+     * the tree directly. A client cannot: it sends one string and the broker splits it at the first '/'
+     * after {@code $share/}, which for this ticket's slash-bearing digest falls inside the digest. That
+     * puts the intruder on a different node entirely, so an eviction that looks only under the
+     * forwarder's own split finds nothing — while the queue the client polls is keyed off the
+     * concatenated string and is byte-identical to the bridge's.
+     * <p>
+     * A real {@link LocalTopicTree} and the real {@link Topics} split, because the whole defect lives in
+     * the disagreement between the two decompositions; a mock would only replay whichever one the test
+     * author had in mind.
+     */
+    @Test
+    @Timeout(5)
+    public void test_addForwarder_removes_a_squatter_stored_under_the_alternative_split() {
+        final LocalTopicTree realTree = new LocalTopicTree(new MetricsHolder(new MetricRegistry()));
+        final MessageForwarderImpl forwarderOverRealTree = new MessageForwarderImpl(
+                realTree,
+                new HivemqId(),
+                () -> null,
+                () -> subscriptionPersistence,
+                mock(SingleWriterService.class),
+                mock(ShutdownHooks.class));
+        when(subscriptionPersistence.remove(anyString(), anyString())).thenReturn(Futures.immediateFuture(null));
+
+        // exactly what a client's SUBSCRIBE goes through
+        final SharedSubscription asStored = Topics.checkForSharedSubscription("$share/" + QUEUE_ID);
+        assertNotNull(asStored);
+        // the premise, pinned: were the digest slash-free this would equal the forwarder's own split and
+        // the test would pass without exercising anything
+        assertNotEquals(MessageForwarderImpl.FORWARDER_PREFIX + FORWARDER_ID, asStored.getShareName());
+        realTree.addTopic(
+                "squatter",
+                new Topic(asStored.getTopicFilter(), QoS.AT_LEAST_ONCE, false, true),
+                SubscriptionFlag.getDefaultFlags(true, true, false),
+                asStored.getShareName());
+        assertFalse(
+                realTree.getSharedSubscriber(asStored.getShareName(), asStored.getTopicFilter())
+                        .isEmpty(),
+                "fixture is vacuous: the squatter is not in the tree");
+
+        forwarderOverRealTree.addForwarder(mqttForwarder);
+
+        // the removal string does not depend on which split found the client: group + '/' + filter is
+        // the queue ID however it was cut, and '$share/' + that is what the client's session stores
+        verify(subscriptionPersistence).remove("squatter", "$share/" + QUEUE_ID);
     }
 
     /** An internal component's own entry is not an intruder, including a previous generation of it. */

--- a/hivemq-edge/src/test/java/com/hivemq/bridge/MessageForwarderImplTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/bridge/MessageForwarderImplTest.java
@@ -44,6 +44,7 @@ import com.hivemq.mqtt.message.subscribe.Topic;
 import com.hivemq.mqtt.topic.SubscriberWithQoS;
 import com.hivemq.mqtt.topic.SubscriptionFlag;
 import com.hivemq.mqtt.topic.tree.LocalTopicTree;
+import com.hivemq.persistence.ProducerQueues;
 import com.hivemq.persistence.SingleWriterService;
 import com.hivemq.persistence.clientsession.ClientSessionSubscriptionPersistence;
 import com.hivemq.persistence.clientsession.SharedSubscriptionServiceImpl.SharedSubscription;
@@ -564,6 +565,132 @@ public class MessageForwarderImplTest {
         assertFalse(
                 messageForwarder.isForwarderQueue(QUEUE_ID),
                 "the originally registered queue leaked a reference and can never be reclaimed");
+    }
+
+    /**
+     * A notification that lands after the forwarder is gone must not put its queue back into the poll
+     * set (EDG-882 review v02, R2-06).
+     * <p>
+     * {@code messageAvailable} does not touch the set directly: it submits the add to the single writer,
+     * so the add runs at a moment {@code removeForwarder} does not control. Pruning "after the stop" was
+     * not enough, because a task submitted before the stop can still run after the prune, and the entry
+     * it leaves is one nothing else removes — one string per retired subscription, for the life of the
+     * node. The guard reads the ownership at the moment the task runs, and {@code removeForwarder}
+     * releases ownership before it prunes, so a late add is impossible rather than merely unlikely.
+     * <p>
+     * The writer here runs tasks inline, which is a faithful stand-in: what the guard depends on is the
+     * state when the task runs, not how long it waited.
+     */
+    @Test
+    @Timeout(5)
+    public void test_a_notification_arriving_after_removal_does_not_re_add_the_queue() {
+        final MessageForwarderImpl forwarderOverInlineWriter = new MessageForwarderImpl(
+                topicTree,
+                new HivemqId(),
+                () -> null,
+                () -> subscriptionPersistence,
+                inlineSingleWriter(),
+                mock(ShutdownHooks.class));
+        final MqttForwarder registered = forwarder(FORWARDER_ID, TOPIC);
+        forwarderOverInlineWriter.addForwarder(registered);
+
+        // the control: while it is registered, a notification does put the queue in the poll set
+        forwarderOverInlineWriter.messageAvailable(QUEUE_ID);
+        assertTrue(forwarderOverInlineWriter.notEmptyQueues().contains(QUEUE_ID));
+
+        forwarderOverInlineWriter.removeForwarder(registered, false);
+        forwarderOverInlineWriter.messageAvailable(QUEUE_ID); // the straggler
+
+        assertFalse(
+                forwarderOverInlineWriter.notEmptyQueues().contains(QUEUE_ID),
+                "a queue nobody owns was put back into the poll set, and nothing ever takes it out again");
+    }
+
+    /**
+     * The poll set is pruned against what was registered, not against what the forwarder object says its
+     * topics are now (EDG-882 review v02, R2-05).
+     * <p>
+     * The sibling test asserts the same thing for ownership. This is the other map the two can disagree
+     * about, and the entry the disagreement leaves behind is one nothing else removes: the forwarder is
+     * gone, so nothing polls it and nothing ever prunes it again.
+     */
+    @Test
+    @Timeout(5)
+    public void test_removal_prunes_the_poll_set_against_the_registered_set() {
+        messageForwarder.addForwarder(forwarder(FORWARDER_ID, TOPIC));
+        assertTrue(messageForwarder.notEmptyQueues().contains(QUEUE_ID));
+
+        // same id, different topics — as if the forwarder object had been rebuilt in the meantime
+        messageForwarder.removeForwarder(forwarder(FORWARDER_ID, OTHER_TOPIC), false);
+
+        assertFalse(
+                messageForwarder.notEmptyQueues().contains(QUEUE_ID),
+                "the registered queue stayed in the poll set, and nothing polls or prunes it again");
+    }
+
+    /** A single writer that runs what it is given, so a submitted task's ordering can be asserted. */
+    private static SingleWriterService inlineSingleWriter() {
+        final ProducerQueues queues = mock(ProducerQueues.class);
+        when(queues.submit(anyString(), any())).thenAnswer(invocation -> {
+            final SingleWriterService.Task<?> task = invocation.getArgument(1);
+            task.doTask(0);
+            return Futures.immediateFuture(null);
+        });
+        final SingleWriterService singleWriter = mock(SingleWriterService.class);
+        when(singleWriter.getQueuedMessagesQueue()).thenReturn(queues);
+        return singleWriter;
+    }
+
+    /**
+     * Why removal is by id and not conditional on the instance (EDG-882 review v02, R2-05).
+     * <p>
+     * The review asked for {@code forwarders.remove(id, instance)}, so that a caller holding a stale
+     * object cannot tear down a successor that has taken the same id. That defence is unnecessary and
+     * not free: it would break {@link #test_removal_releases_the_registered_set_not_the_current_topics},
+     * where the caller holds a rebuilt object and the removal must still release — otherwise the queue
+     * is claimed for the life of the node with nothing able to free it.
+     * <p>
+     * It is unnecessary because a successor cannot coexist with an incumbent: {@code addForwarder}
+     * refuses a second registration under a live id. This pins that, so the argument the decision rests
+     * on fails here rather than in review if it ever stops being true.
+     */
+    @Test
+    @Timeout(5)
+    public void test_a_successor_cannot_register_while_the_incumbent_is_live() {
+        final MqttForwarder incumbent = forwarder(FORWARDER_ID, TOPIC);
+        final MqttForwarder successor = forwarder(FORWARDER_ID, TOPIC);
+        messageForwarder.addForwarder(incumbent);
+
+        assertThrows(IllegalStateException.class, () -> messageForwarder.addForwarder(successor));
+
+        // and the incumbent is untouched by the refusal
+        assertTrue(messageForwarder.isForwarderQueue(QUEUE_ID));
+        verify(successor, never()).start();
+    }
+
+    /**
+     * The other half of the same argument: once the incumbent has been removed, a successor may take the
+     * id, and a second (stale) removal of the incumbent must not take the successor's queues with it.
+     * <p>
+     * It does not, because the stale removal finds nothing left of the incumbent to remove — the maps
+     * were emptied by the first one and the successor re-populated them. This is the sequence the review
+     * asked for; it passes with removal by id.
+     */
+    @Test
+    @Timeout(5)
+    public void test_a_stale_removal_after_a_successor_registered_leaves_the_successor_alone() {
+        final MqttForwarder incumbent = forwarder(FORWARDER_ID, TOPIC);
+        final MqttForwarder successor = forwarder(FORWARDER_ID, TOPIC);
+        messageForwarder.addForwarder(incumbent);
+        messageForwarder.removeForwarder(incumbent, false);
+        messageForwarder.addForwarder(successor);
+
+        messageForwarder.removeForwarder(incumbent, false); // the stale one
+
+        assertFalse(
+                messageForwarder.isForwarderQueue(QUEUE_ID),
+                "a stale removal must not leave the successor's queue owned by nobody either");
+        verify(successor).stop();
     }
 
     /**

--- a/hivemq-edge/src/test/java/com/hivemq/bridge/MessageForwarderImplTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/bridge/MessageForwarderImplTest.java
@@ -15,6 +15,7 @@
  */
 package com.hivemq.bridge;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -24,7 +25,14 @@ import com.hivemq.common.shutdown.ShutdownHooks;
 import com.hivemq.configuration.HivemqId;
 import com.hivemq.mqtt.topic.tree.LocalTopicTree;
 import com.hivemq.persistence.SingleWriterService;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -58,11 +66,15 @@ public class MessageForwarderImplTest {
         otherMqttForwarder = forwarder(OTHER_FORWARDER_ID, OTHER_TOPIC);
     }
 
-    private static MqttForwarder forwarder(final String id, final String topic) {
+    private static MqttForwarder forwarder(final String id, final String... topics) {
         final MqttForwarder forwarder = mock(MqttForwarder.class);
         when(forwarder.getId()).thenReturn(id);
-        when(forwarder.getTopics()).thenReturn(List.of(topic));
+        when(forwarder.getTopics()).thenReturn(List.of(topics));
         return forwarder;
+    }
+
+    private static String queueId(final String forwarderId, final String topic) {
+        return MessageForwarderImpl.FORWARDER_PREFIX + forwarderId + "/" + topic;
     }
 
     @Test
@@ -87,8 +99,7 @@ public class MessageForwarderImplTest {
         assertTrue(messageForwarder.isForwarderQueue(QUEUE_ID));
         assertTrue(messageForwarder.isForwarderQueue(OTHER_QUEUE_ID));
         // a queue may not be claimed by the wrong forwarder's registration
-        assertFalse(messageForwarder.isForwarderQueue(
-                MessageForwarderImpl.FORWARDER_PREFIX + FORWARDER_ID + "/" + OTHER_TOPIC));
+        assertFalse(messageForwarder.isForwarderQueue(queueId(FORWARDER_ID, OTHER_TOPIC)));
 
         // removing one forwarder must not deregister the other's queue
         messageForwarder.removeForwarder(mqttForwarder, false);
@@ -99,14 +110,303 @@ public class MessageForwarderImplTest {
     @Test
     @Timeout(5)
     public void test_isForwarderQueue_covers_every_topic_of_a_multi_topic_forwarder() {
-        final MqttForwarder multiTopic = mock(MqttForwarder.class);
-        when(multiTopic.getId()).thenReturn(FORWARDER_ID);
-        when(multiTopic.getTopics()).thenReturn(List.of(TOPIC, OTHER_TOPIC));
-
-        messageForwarder.addForwarder(multiTopic);
+        messageForwarder.addForwarder(forwarder(FORWARDER_ID, TOPIC, OTHER_TOPIC));
 
         assertTrue(messageForwarder.isForwarderQueue(QUEUE_ID));
-        assertTrue(messageForwarder.isForwarderQueue(
-                MessageForwarderImpl.FORWARDER_PREFIX + FORWARDER_ID + "/" + OTHER_TOPIC));
+        assertTrue(messageForwarder.isForwarderQueue(queueId(FORWARDER_ID, OTHER_TOPIC)));
+    }
+
+    /**
+     * EDG-882, the case that rules out a plain {@code Map<queueId, ownerId>} index. A share name may
+     * contain '/', so two different forwarders can mint byte-identical queue IDs: {@code ("a", "b/c")}
+     * and {@code ("a/b", "c")} both produce {@code $FORWARDER::a/b/c}. A map keyed by queue ID drops the
+     * entry when the first of them unregisters, and the periodic clean-up then clears a queue the
+     * second still owns. Counting owners survives it.
+     * <p>
+     * Only constructible at unit level, where forwarder IDs are unconstrained; in production the bridge
+     * ID regex and the fixed digest shape make it unreachable. It is here to pin the guarantee
+     * unconditionally, so the index cannot later be "simplified" into the unsafe form.
+     */
+    @Test
+    @Timeout(5)
+    public void test_a_queue_claimed_by_two_forwarders_survives_the_first_unregistering() {
+        final MqttForwarder first = forwarder("a", "b/c");
+        final MqttForwarder second = forwarder("a/b", "c");
+        final String collidingQueueId = queueId("a", "b/c");
+        assertEquals(collidingQueueId, queueId("a/b", "c"), "the two registrations must collide");
+
+        messageForwarder.addForwarder(first);
+        messageForwarder.addForwarder(second);
+        assertTrue(messageForwarder.isForwarderQueue(collidingQueueId));
+
+        messageForwarder.removeForwarder(first, false);
+        assertTrue(
+                messageForwarder.isForwarderQueue(collidingQueueId),
+                "the second forwarder still owns this queue; clearing it would destroy its messages");
+
+        messageForwarder.removeForwarder(second, false);
+        assertFalse(messageForwarder.isForwarderQueue(collidingQueueId));
+    }
+
+    /**
+     * EDG-882, the case that rules out an {@code if (put(...) == null)} skip guard. A forwarder ID does
+     * not determine its queue set: the ID embeds a digest over the filters joined with an <em>empty</em>
+     * separator, so {@code {"ab","c"}} and {@code {"a","bc"}} share an ID with different queue sets. A
+     * guard that skipped the re-registration would leave the index stale in the message-losing
+     * direction — reporting the new queue as unowned.
+     */
+    @Test
+    @Timeout(5)
+    public void test_reregistration_with_a_changed_topic_set_updates_ownership() {
+        messageForwarder.addForwarder(forwarder(FORWARDER_ID, "ab", "c"));
+        assertTrue(messageForwarder.isForwarderQueue(queueId(FORWARDER_ID, "ab")));
+        assertTrue(messageForwarder.isForwarderQueue(queueId(FORWARDER_ID, "c")));
+
+        messageForwarder.addForwarder(forwarder(FORWARDER_ID, "a", "bc"));
+
+        assertTrue(messageForwarder.isForwarderQueue(queueId(FORWARDER_ID, "a")));
+        assertTrue(messageForwarder.isForwarderQueue(queueId(FORWARDER_ID, "bc")));
+        assertFalse(messageForwarder.isForwarderQueue(queueId(FORWARDER_ID, "ab")));
+        assertFalse(messageForwarder.isForwarderQueue(queueId(FORWARDER_ID, "c")));
+    }
+
+    /** A topic kept across a re-registration must never read as unowned, before or after. */
+    @Test
+    @Timeout(5)
+    public void test_reregistration_keeps_ownership_of_an_unchanged_topic() {
+        messageForwarder.addForwarder(forwarder(FORWARDER_ID, TOPIC, OTHER_TOPIC));
+        messageForwarder.addForwarder(forwarder(FORWARDER_ID, TOPIC));
+
+        assertTrue(messageForwarder.isForwarderQueue(QUEUE_ID));
+        assertFalse(messageForwarder.isForwarderQueue(queueId(FORWARDER_ID, OTHER_TOPIC)));
+    }
+
+    @Test
+    @Timeout(5)
+    public void test_repeated_registration_of_the_same_forwarder_is_idempotent() {
+        messageForwarder.addForwarder(mqttForwarder);
+        messageForwarder.addForwarder(mqttForwarder);
+        messageForwarder.addForwarder(mqttForwarder);
+        assertTrue(messageForwarder.isForwarderQueue(QUEUE_ID));
+
+        // a single removal must fully deregister: the repeated adds must not have stacked references
+        messageForwarder.removeForwarder(mqttForwarder, false);
+        assertFalse(messageForwarder.isForwarderQueue(QUEUE_ID));
+    }
+
+    @Test
+    @Timeout(5)
+    public void test_repeated_removal_of_the_same_forwarder_is_idempotent() {
+        messageForwarder.addForwarder(mqttForwarder);
+        messageForwarder.removeForwarder(mqttForwarder, false);
+        messageForwarder.removeForwarder(mqttForwarder, false);
+        assertFalse(messageForwarder.isForwarderQueue(QUEUE_ID));
+
+        // the counts must not have gone negative: a fresh registration still works
+        messageForwarder.addForwarder(mqttForwarder);
+        assertTrue(messageForwarder.isForwarderQueue(QUEUE_ID));
+    }
+
+    @Test
+    @Timeout(5)
+    public void test_removing_a_forwarder_that_was_never_added_is_a_no_op() {
+        messageForwarder.removeForwarder(mqttForwarder, false);
+        assertFalse(messageForwarder.isForwarderQueue(QUEUE_ID));
+
+        messageForwarder.addForwarder(mqttForwarder);
+        assertTrue(messageForwarder.isForwarderQueue(QUEUE_ID));
+    }
+
+    @Test
+    @Timeout(5)
+    public void test_a_forwarder_without_topics_owns_nothing() {
+        final MqttForwarder empty = forwarder(FORWARDER_ID);
+        messageForwarder.addForwarder(empty);
+
+        assertFalse(messageForwarder.isForwarderQueue(QUEUE_ID));
+        assertFalse(messageForwarder.isForwarderQueue(MessageForwarderImpl.FORWARDER_PREFIX + FORWARDER_ID + "/"));
+
+        messageForwarder.removeForwarder(empty, false);
+        assertFalse(messageForwarder.isForwarderQueue(QUEUE_ID));
+    }
+
+    /**
+     * Three forwarders colliding on one queue name. The queue must survive until the <em>last</em>
+     * owner unregisters — a design that merely handled the two-owner case (a boolean "shared" flag,
+     * say) would release it on the second removal.
+     */
+    @Test
+    @Timeout(5)
+    public void test_a_queue_claimed_by_three_forwarders_survives_until_the_last_one_leaves() {
+        final MqttForwarder first = forwarder("a", "b/c/d");
+        final MqttForwarder second = forwarder("a/b", "c/d");
+        final MqttForwarder third = forwarder("a/b/c", "d");
+        final String queue = queueId("a", "b/c/d");
+        assertEquals(queue, queueId("a/b", "c/d"));
+        assertEquals(queue, queueId("a/b/c", "d"));
+
+        messageForwarder.addForwarder(first);
+        messageForwarder.addForwarder(second);
+        messageForwarder.addForwarder(third);
+
+        messageForwarder.removeForwarder(first, false);
+        assertTrue(messageForwarder.isForwarderQueue(queue), "two owners remain");
+        messageForwarder.removeForwarder(second, false);
+        assertTrue(messageForwarder.isForwarderQueue(queue), "one owner remains");
+        messageForwarder.removeForwarder(third, false);
+        assertFalse(messageForwarder.isForwarderQueue(queue));
+    }
+
+    /**
+     * {@code getTopics()} is a {@code List} and may repeat a topic. The queue IDs are collected into a
+     * set, so a duplicate must claim exactly one reference — otherwise a single removal would leave the
+     * queue permanently claimed and the clean-up could never reclaim it.
+     */
+    @Test
+    @Timeout(5)
+    public void test_a_duplicated_topic_claims_only_one_reference() {
+        final MqttForwarder duplicated = forwarder(FORWARDER_ID, TOPIC, TOPIC, TOPIC);
+        messageForwarder.addForwarder(duplicated);
+        assertTrue(messageForwarder.isForwarderQueue(QUEUE_ID));
+
+        messageForwarder.removeForwarder(duplicated, false);
+        assertFalse(messageForwarder.isForwarderQueue(QUEUE_ID), "duplicate topics leaked a reference");
+    }
+
+    /** Degenerate identifiers must not be treated specially by the index. */
+    @Test
+    @Timeout(5)
+    public void test_empty_forwarder_id_and_empty_topic_are_handled_like_any_other() {
+        final MqttForwarder emptyId = forwarder("", "");
+        messageForwarder.addForwarder(emptyId);
+        assertTrue(messageForwarder.isForwarderQueue(MessageForwarderImpl.FORWARDER_PREFIX + "/"));
+
+        messageForwarder.removeForwarder(emptyId, false);
+        assertFalse(messageForwarder.isForwarderQueue(MessageForwarderImpl.FORWARDER_PREFIX + "/"));
+    }
+
+    /** A forwarder id that itself contains the forwarder prefix must not confuse ownership. */
+    @Test
+    @Timeout(5)
+    public void test_a_forwarder_id_containing_the_prefix_is_resolved_normally() {
+        final String nestedId = MessageForwarderImpl.FORWARDER_PREFIX + "inner-Ab/cd==";
+        final MqttForwarder nested = forwarder(nestedId, TOPIC);
+        messageForwarder.addForwarder(nested);
+
+        assertTrue(messageForwarder.isForwarderQueue(queueId(nestedId, TOPIC)));
+        messageForwarder.removeForwarder(nested, false);
+        assertFalse(messageForwarder.isForwarderQueue(queueId(nestedId, TOPIC)));
+    }
+
+    /** Topics with leading, trailing and repeated separators are ordinary inputs here. */
+    @Test
+    @Timeout(5)
+    public void test_topics_full_of_separators_are_resolved_normally() {
+        final List<String> awkward = List.of("/", "//", "/leading", "trailing/", "a//b", "///");
+        final MqttForwarder awkwardForwarder = forwarder(FORWARDER_ID, awkward.toArray(new String[0]));
+        messageForwarder.addForwarder(awkwardForwarder);
+
+        for (final String topic : awkward) {
+            assertTrue(messageForwarder.isForwarderQueue(queueId(FORWARDER_ID, topic)), topic);
+        }
+        messageForwarder.removeForwarder(awkwardForwarder, false);
+        for (final String topic : awkward) {
+            assertFalse(messageForwarder.isForwarderQueue(queueId(FORWARDER_ID, topic)), topic);
+        }
+    }
+
+    /**
+     * {@code removeForwarder(_, true)} additionally clears the persisted queues. Ownership must be
+     * dropped exactly as it is on the non-clearing path — the two must not diverge.
+     */
+    @Test
+    @Timeout(5)
+    public void test_removal_with_queue_clearing_deregisters_identically() {
+        messageForwarder.addForwarder(mqttForwarder);
+        assertTrue(messageForwarder.isForwarderQueue(QUEUE_ID));
+
+        messageForwarder.removeForwarder(mqttForwarder, true);
+        assertFalse(messageForwarder.isForwarderQueue(QUEUE_ID));
+    }
+
+    /**
+     * Ownership is released against the set that was actually registered, not against whatever
+     * {@code getTopics()} happens to return at removal time. A forwarder object whose topics changed
+     * after registration must still fully deregister — otherwise the stale queue is claimed forever.
+     */
+    @Test
+    @Timeout(5)
+    public void test_removal_releases_the_registered_set_not_the_current_topics() {
+        messageForwarder.addForwarder(forwarder(FORWARDER_ID, TOPIC));
+        assertTrue(messageForwarder.isForwarderQueue(QUEUE_ID));
+
+        // same id, different topics — as if the forwarder object had been rebuilt in the meantime
+        messageForwarder.removeForwarder(forwarder(FORWARDER_ID, OTHER_TOPIC), false);
+
+        assertFalse(
+                messageForwarder.isForwarderQueue(QUEUE_ID),
+                "the originally registered queue leaked a reference and can never be reclaimed");
+    }
+
+    /**
+     * The equivalence property: for every queue ID, at every step of an arbitrary registration
+     * sequence, the index must answer exactly what a full scan over the registered sets would answer.
+     * The ID and topic pools are chosen so that colliding queue IDs and shared topics occur often.
+     * <p>
+     * Deterministic by construction — a fixed seed, so a failure is reproducible from the report alone.
+     */
+    @Test
+    @Timeout(30)
+    public void test_isForwarderQueue_matches_a_full_scan_over_random_registration_sequences() {
+        final List<String> ids = List.of("a", "a/b", "bridge-Ab/cd==", "bridge-Abcd==", "x");
+        final List<String> topics = List.of("b/c", "c", "cd==/t", "t", "a/b/c");
+
+        final Set<String> universe = new LinkedHashSet<>();
+        for (final String id : ids) {
+            for (final String topic : topics) {
+                universe.add(queueId(id, topic));
+            }
+        }
+
+        final Map<String, Set<String>> oracle = new HashMap<>();
+        final Random random = new Random(882L);
+
+        for (int step = 0; step < 400; step++) {
+            final String id = ids.get(random.nextInt(ids.size()));
+            if (random.nextInt(3) == 0) {
+                messageForwarder.removeForwarder(forwarder(id), false);
+                oracle.remove(id);
+            } else {
+                final List<String> chosen = new ArrayList<>();
+                for (final String topic : topics) {
+                    if (random.nextBoolean()) {
+                        chosen.add(topic);
+                    }
+                }
+                messageForwarder.addForwarder(forwarder(id, chosen.toArray(new String[0])));
+                final Set<String> registered = new HashSet<>();
+                for (final String topic : chosen) {
+                    registered.add(queueId(id, topic));
+                }
+                oracle.put(id, registered);
+            }
+
+            for (final String candidate : universe) {
+                assertEquals(
+                        scan(oracle, candidate),
+                        messageForwarder.isForwarderQueue(candidate),
+                        "step " + step + ", queue " + candidate);
+            }
+        }
+    }
+
+    /** The pre-fix implementation, kept as the oracle the reference-counted index must match. */
+    private static boolean scan(final Map<String, Set<String>> registry, final String queueId) {
+        for (final Set<String> queueIds : registry.values()) {
+            if (queueIds.contains(queueId)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/hivemq-edge/src/test/java/com/hivemq/bridge/MessageForwarderImplTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/bridge/MessageForwarderImplTest.java
@@ -22,7 +22,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyByte;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -550,6 +552,80 @@ public class MessageForwarderImplTest {
         assertTrue(messageForwarder.isForwarderQueue(QUEUE_ID));
         messageForwarder.removeForwarder(mqttForwarder, false);
         assertFalse(messageForwarder.isForwarderQueue(QUEUE_ID));
+    }
+
+    /**
+     * EDG-882 F-10. A registration that throws part way must leave nothing behind. Ownership is what
+     * the periodic clean-up reads, so a claim held by an object that never ran preserves a queue
+     * nobody will ever drain — for the life of the node, since the ID cannot be registered again
+     * either.
+     */
+    @Test
+    @Timeout(5)
+    public void test_a_registration_that_fails_in_the_topic_tree_leaves_nothing_behind() {
+        final MqttForwarder failing = forwarder(FORWARDER_ID, TOPIC, OTHER_TOPIC);
+        doThrow(new IllegalStateException("topic tree said no"))
+                .when(topicTree)
+                .addTopic(any(), argThat(topic -> topic.getTopic().equals(OTHER_TOPIC)), anyByte(), any());
+
+        assertThrows(IllegalStateException.class, () -> messageForwarder.addForwarder(failing));
+
+        assertFalse(messageForwarder.isForwarderQueue(QUEUE_ID), "ownership survived a failed registration");
+        assertFalse(messageForwarder.isForwarderQueue(queueId(FORWARDER_ID, OTHER_TOPIC)));
+        // the subscription that did get added must have been taken back out again
+        verify(topicTree).removeSubscriber(any(), eq(TOPIC), any());
+        verify(failing, never()).start();
+    }
+
+    /** The same, one step later: the object was published and started before it threw. */
+    @Test
+    @Timeout(5)
+    public void test_a_registration_that_fails_on_start_leaves_nothing_behind() {
+        final MqttForwarder failing = forwarder(FORWARDER_ID, TOPIC);
+        doThrow(new IllegalStateException("start said no")).when(failing).start();
+
+        assertThrows(IllegalStateException.class, () -> messageForwarder.addForwarder(failing));
+
+        assertFalse(messageForwarder.isForwarderQueue(QUEUE_ID), "ownership survived a failed start");
+        verify(failing).stop();
+        verify(topicTree).removeSubscriber(any(), eq(TOPIC), any());
+    }
+
+    /** And the ID is free afterwards: a failed registration must not block the retry. */
+    @Test
+    @Timeout(5)
+    public void test_the_id_is_registerable_again_after_a_failed_registration() {
+        final MqttForwarder failing = forwarder(FORWARDER_ID, TOPIC);
+        doThrow(new IllegalStateException("start said no")).when(failing).start();
+        assertThrows(IllegalStateException.class, () -> messageForwarder.addForwarder(failing));
+
+        messageForwarder.addForwarder(forwarder(FORWARDER_ID, TOPIC));
+
+        assertTrue(messageForwarder.isForwarderQueue(QUEUE_ID));
+    }
+
+    /**
+     * The rollback must undo its own claim and nothing else. Another forwarder holding the same queue
+     * ID — reachable because a share name may contain '/' — must still own it afterwards, or one
+     * forwarder's failure deletes another's messages.
+     */
+    @Test
+    @Timeout(5)
+    public void test_a_failed_registration_does_not_disturb_another_owner_of_the_same_queue() {
+        final MqttForwarder incumbent = forwarder("a/b", "c");
+        messageForwarder.addForwarder(incumbent);
+        final String sharedQueue = queueId("a/b", "c");
+        assertEquals(sharedQueue, queueId("a", "b/c"), "the two registrations must collide");
+
+        final MqttForwarder failing = forwarder("a", "b/c");
+        doThrow(new IllegalStateException("start said no")).when(failing).start();
+        assertThrows(IllegalStateException.class, () -> messageForwarder.addForwarder(failing));
+
+        assertTrue(
+                messageForwarder.isForwarderQueue(sharedQueue),
+                "the incumbent still owns this queue; clearing it would destroy its messages");
+        messageForwarder.removeForwarder(incumbent, false);
+        assertFalse(messageForwarder.isForwarderQueue(sharedQueue), "the failed registration leaked a reference");
     }
 
     /**

--- a/hivemq-edge/src/test/java/com/hivemq/bridge/MessageForwarderImplTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/bridge/MessageForwarderImplTest.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyByte;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -39,6 +40,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -435,6 +437,33 @@ public class MessageForwarderImplTest {
         assertFalse(
                 messageForwarder.isForwarderQueue(QUEUE_ID),
                 "the originally registered queue leaked a reference and can never be reclaimed");
+    }
+
+    /**
+     * EDG-882 F-02, the half of the hand-over that lives in this class. Ownership is what the periodic
+     * clean-up reads, so it may not be dropped while the forwarder is still published and still
+     * polling: a sweep landing in that window clears a queue that is being filled and drained as it
+     * does so. The queue must therefore still read as owned at the moment the forwarder is stopped.
+     */
+    @Test
+    @Timeout(5)
+    public void test_ownership_outlives_the_forwarder_it_belongs_to() {
+        final AtomicBoolean ownedWhenStopped = new AtomicBoolean();
+        doAnswer(invocation -> {
+                    ownedWhenStopped.set(messageForwarder.isForwarderQueue(QUEUE_ID));
+                    return null;
+                })
+                .when(mqttForwarder)
+                .stop();
+
+        messageForwarder.addForwarder(mqttForwarder);
+        messageForwarder.removeForwarder(mqttForwarder, false);
+
+        assertTrue(
+                ownedWhenStopped.get(),
+                "the queue read as unowned while its forwarder was still running; a sweep here clears a live queue");
+        assertFalse(
+                messageForwarder.isForwarderQueue(QUEUE_ID), "and it must be reclaimable once the forwarder is gone");
     }
 
     /**

--- a/hivemq-edge/src/test/java/com/hivemq/bridge/MessageForwarderImplTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/bridge/MessageForwarderImplTest.java
@@ -17,8 +17,14 @@ package com.hivemq.bridge;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyByte;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.hivemq.common.shutdown.ShutdownHooks;
@@ -51,17 +57,15 @@ public class MessageForwarderImplTest {
             MessageForwarderImpl.FORWARDER_PREFIX + OTHER_FORWARDER_ID + "/" + OTHER_TOPIC;
 
     private MessageForwarderImpl messageForwarder;
+    private LocalTopicTree topicTree;
     private MqttForwarder mqttForwarder;
     private MqttForwarder otherMqttForwarder;
 
     @BeforeEach
     public void setUp() {
+        topicTree = mock(LocalTopicTree.class);
         messageForwarder = new MessageForwarderImpl(
-                mock(LocalTopicTree.class),
-                new HivemqId(),
-                () -> null,
-                mock(SingleWriterService.class),
-                mock(ShutdownHooks.class));
+                topicTree, new HivemqId(), () -> null, mock(SingleWriterService.class), mock(ShutdownHooks.class));
         mqttForwarder = forwarder(FORWARDER_ID, TOPIC);
         otherMqttForwarder = forwarder(OTHER_FORWARDER_ID, OTHER_TOPIC);
     }
@@ -149,20 +153,85 @@ public class MessageForwarderImplTest {
     }
 
     /**
-     * EDG-882, the case that rules out an {@code if (put(...) == null)} skip guard. A forwarder ID does
-     * not determine its queue set: the ID embeds a digest over the filters joined with an <em>empty</em>
-     * separator, so {@code {"ab","c"}} and {@code {"a","bc"}} share an ID with different queue sets. A
-     * guard that skipped the re-registration would leave the index stale in the message-losing
-     * direction — reporting the new queue as unowned.
+     * EDG-882 F-01, the defect itself, at the level where it is decided.
+     * <p>
+     * A forwarder ID does not determine its queue set: the ID embeds a digest over the filters joined
+     * with an <em>empty</em> separator, so the subscriptions {@code {"ab","c"}} and {@code {"a","bc"}}
+     * — with the same destination — share an ID while owning different queues. Both are live at the
+     * same time, because a bridge builds and registers one forwarder per local subscription.
+     * <p>
+     * Letting the second registration displace the first is what loses messages: the first
+     * forwarder's queues stop reading as owned while it is still running and still filling them, and
+     * the next clean-up sweep deletes their contents. So the second registration is refused and the
+     * first keeps everything.
      */
     @Test
     @Timeout(5)
-    public void test_reregistration_with_a_changed_topic_set_updates_ownership() {
-        messageForwarder.addForwarder(forwarder(FORWARDER_ID, "ab", "c"));
-        assertTrue(messageForwarder.isForwarderQueue(queueId(FORWARDER_ID, "ab")));
-        assertTrue(messageForwarder.isForwarderQueue(queueId(FORWARDER_ID, "c")));
+    public void test_a_colliding_registration_is_refused_and_the_incumbent_keeps_its_queues() {
+        final MqttForwarder incumbent = forwarder(FORWARDER_ID, "ab", "c");
+        final MqttForwarder colliding = forwarder(FORWARDER_ID, "a", "bc");
+        messageForwarder.addForwarder(incumbent);
 
-        messageForwarder.addForwarder(forwarder(FORWARDER_ID, "a", "bc"));
+        assertThrows(IllegalStateException.class, () -> messageForwarder.addForwarder(colliding));
+
+        assertTrue(
+                messageForwarder.isForwarderQueue(queueId(FORWARDER_ID, "ab")),
+                "the incumbent is still live; un-owning its queue lets the clean-up delete its messages");
+        assertTrue(messageForwarder.isForwarderQueue(queueId(FORWARDER_ID, "c")));
+        // and the refused registration claimed nothing of its own
+        assertFalse(messageForwarder.isForwarderQueue(queueId(FORWARDER_ID, "a")));
+        assertFalse(messageForwarder.isForwarderQueue(queueId(FORWARDER_ID, "bc")));
+    }
+
+    /** A refused registration must not have been started or subscribed — it was never registered. */
+    @Test
+    @Timeout(5)
+    public void test_a_refused_registration_is_never_started() {
+        final MqttForwarder colliding = forwarder(FORWARDER_ID, "a", "bc");
+        messageForwarder.addForwarder(forwarder(FORWARDER_ID, "ab", "c"));
+
+        assertThrows(IllegalStateException.class, () -> messageForwarder.addForwarder(colliding));
+
+        verify(colliding, never()).start();
+        verify(topicTree, never())
+                .addTopic(any(), argThat(topic -> topic.getTopic().equals("bc")), anyByte(), any());
+    }
+
+    /**
+     * The refusal must leave the reference counts exactly as it found them. A queue the two
+     * registrations have in common is the case that breaks a naive undo: releasing the incumbent's
+     * reference along with the refused one drops the count to zero for a queue that is still owned.
+     */
+    @Test
+    @Timeout(5)
+    public void test_a_refused_registration_leaves_the_reference_counts_untouched() {
+        final MqttForwarder incumbent = forwarder(FORWARDER_ID, TOPIC, "ab", "c");
+        messageForwarder.addForwarder(incumbent);
+
+        // overlaps the incumbent on TOPIC and differs elsewhere
+        assertThrows(
+                IllegalStateException.class,
+                () -> messageForwarder.addForwarder(forwarder(FORWARDER_ID, TOPIC, "a", "bc")));
+
+        assertTrue(messageForwarder.isForwarderQueue(QUEUE_ID), "the shared queue lost its owner");
+
+        // one removal must still fully deregister: the refusal may not have leaked or stacked a reference
+        messageForwarder.removeForwarder(incumbent, false);
+        assertFalse(messageForwarder.isForwarderQueue(QUEUE_ID), "the refusal leaked a reference on the shared queue");
+        assertFalse(messageForwarder.isForwarderQueue(queueId(FORWARDER_ID, "ab")));
+    }
+
+    /** Refusing is not poisoning: once the incumbent is gone, the same ID registers normally. */
+    @Test
+    @Timeout(5)
+    public void test_the_id_is_reusable_after_the_incumbent_is_removed() {
+        final MqttForwarder incumbent = forwarder(FORWARDER_ID, "ab", "c");
+        final MqttForwarder replacement = forwarder(FORWARDER_ID, "a", "bc");
+        messageForwarder.addForwarder(incumbent);
+        assertThrows(IllegalStateException.class, () -> messageForwarder.addForwarder(replacement));
+
+        messageForwarder.removeForwarder(incumbent, false);
+        messageForwarder.addForwarder(replacement);
 
         assertTrue(messageForwarder.isForwarderQueue(queueId(FORWARDER_ID, "a")));
         assertTrue(messageForwarder.isForwarderQueue(queueId(FORWARDER_ID, "bc")));
@@ -170,27 +239,47 @@ public class MessageForwarderImplTest {
         assertFalse(messageForwarder.isForwarderQueue(queueId(FORWARDER_ID, "c")));
     }
 
-    /** A topic kept across a re-registration must never read as unowned, before or after. */
+    /** A topic kept across a remove-then-add must be owned before and after. */
     @Test
     @Timeout(5)
-    public void test_reregistration_keeps_ownership_of_an_unchanged_topic() {
-        messageForwarder.addForwarder(forwarder(FORWARDER_ID, TOPIC, OTHER_TOPIC));
+    public void test_reregistration_after_removal_keeps_ownership_of_an_unchanged_topic() {
+        final MqttForwarder first = forwarder(FORWARDER_ID, TOPIC, OTHER_TOPIC);
+        messageForwarder.addForwarder(first);
+        messageForwarder.removeForwarder(first, false);
         messageForwarder.addForwarder(forwarder(FORWARDER_ID, TOPIC));
 
         assertTrue(messageForwarder.isForwarderQueue(QUEUE_ID));
         assertFalse(messageForwarder.isForwarderQueue(queueId(FORWARDER_ID, OTHER_TOPIC)));
     }
 
+    /**
+     * Even the same object twice is refused. Nothing in production does this — a bridge registers each
+     * forwarder once, and a restart removes before it adds — so tolerating it would only hide the case
+     * the refusal exists for: an ID that is registered twice while both owners are live.
+     */
     @Test
     @Timeout(5)
-    public void test_repeated_registration_of_the_same_forwarder_is_idempotent() {
+    public void test_registering_the_same_forwarder_object_twice_is_refused() {
         messageForwarder.addForwarder(mqttForwarder);
-        messageForwarder.addForwarder(mqttForwarder);
-        messageForwarder.addForwarder(mqttForwarder);
-        assertTrue(messageForwarder.isForwarderQueue(QUEUE_ID));
 
-        // a single removal must fully deregister: the repeated adds must not have stacked references
+        assertThrows(IllegalStateException.class, () -> messageForwarder.addForwarder(mqttForwarder));
+
+        assertTrue(messageForwarder.isForwarderQueue(QUEUE_ID));
+        // a single removal must fully deregister: the refused add must not have stacked a reference
         messageForwarder.removeForwarder(mqttForwarder, false);
+        assertFalse(messageForwarder.isForwarderQueue(QUEUE_ID));
+    }
+
+    /**
+     * A forwarder without topics owns no queues, so its registration leaves no trace in the reference
+     * counts — the ID must still be taken, or the collision it exists to catch goes unnoticed.
+     */
+    @Test
+    @Timeout(5)
+    public void test_a_topicless_registration_still_takes_the_id() {
+        messageForwarder.addForwarder(forwarder(FORWARDER_ID));
+
+        assertThrows(IllegalStateException.class, () -> messageForwarder.addForwarder(forwarder(FORWARDER_ID, TOPIC)));
         assertFalse(messageForwarder.isForwarderQueue(QUEUE_ID));
     }
 
@@ -349,9 +438,97 @@ public class MessageForwarderImplTest {
     }
 
     /**
+     * A reservation is ownership without a forwarder: it exists so that the periodic clean-up, which
+     * deletes every forwarder queue no registered forwarder owns, leaves the queues of a bridge that
+     * could not start alone until it can be corrected or removed.
+     */
+    @Test
+    @Timeout(5)
+    public void test_reserved_queues_read_as_owned_until_released() {
+        assertFalse(messageForwarder.isForwarderQueue(QUEUE_ID));
+
+        messageForwarder.reserveQueues("bridge", Map.of(FORWARDER_ID, List.of(TOPIC, OTHER_TOPIC)));
+        assertTrue(messageForwarder.isForwarderQueue(QUEUE_ID));
+        assertTrue(messageForwarder.isForwarderQueue(queueId(FORWARDER_ID, OTHER_TOPIC)));
+        assertFalse(messageForwarder.isForwarderQueue(OTHER_QUEUE_ID), "only what was reserved is held");
+
+        messageForwarder.releaseReservedQueues("bridge");
+        assertFalse(messageForwarder.isForwarderQueue(QUEUE_ID));
+        assertFalse(messageForwarder.isForwarderQueue(queueId(FORWARDER_ID, OTHER_TOPIC)));
+    }
+
+    /**
+     * The hand-over a corrected configuration makes: the forwarder registers, and only then is the
+     * reservation dropped. The queue is owned throughout — its count goes 1 → 2 → 1 and never reaches
+     * zero, because a single sweep landing on zero is all it takes to lose the messages.
+     */
+    @Test
+    @Timeout(5)
+    public void test_a_reserved_queue_stays_owned_across_the_hand_over_to_its_forwarder() {
+        messageForwarder.reserveQueues("bridge", Map.of(FORWARDER_ID, List.of(TOPIC)));
+
+        messageForwarder.addForwarder(mqttForwarder);
+        assertTrue(messageForwarder.isForwarderQueue(QUEUE_ID));
+        messageForwarder.releaseReservedQueues("bridge");
+        assertTrue(messageForwarder.isForwarderQueue(QUEUE_ID), "the forwarder owns it now");
+
+        // and the reservation left no residual reference behind: one removal fully deregisters
+        messageForwarder.removeForwarder(mqttForwarder, false);
+        assertFalse(messageForwarder.isForwarderQueue(QUEUE_ID), "the reservation leaked a reference");
+    }
+
+    /** Re-reserving under the same id replaces the held set rather than stacking references on it. */
+    @Test
+    @Timeout(5)
+    public void test_reserving_twice_replaces_the_held_set() {
+        messageForwarder.reserveQueues("bridge", Map.of(FORWARDER_ID, List.of(TOPIC, OTHER_TOPIC)));
+        messageForwarder.reserveQueues("bridge", Map.of(FORWARDER_ID, List.of(TOPIC)));
+
+        assertTrue(messageForwarder.isForwarderQueue(QUEUE_ID));
+        assertFalse(
+                messageForwarder.isForwarderQueue(queueId(FORWARDER_ID, OTHER_TOPIC)),
+                "a queue dropped from the configuration must stop being held");
+
+        messageForwarder.releaseReservedQueues("bridge");
+        assertFalse(messageForwarder.isForwarderQueue(QUEUE_ID), "re-reserving stacked a reference");
+    }
+
+    /** Two bridges may hold the same queue id; it is reclaimable only once both have let go. */
+    @Test
+    @Timeout(5)
+    public void test_queues_held_by_two_reservations_survive_the_first_release() {
+        messageForwarder.reserveQueues("bridge-a", Map.of(FORWARDER_ID, List.of(TOPIC)));
+        messageForwarder.reserveQueues("bridge-b", Map.of(FORWARDER_ID, List.of(TOPIC)));
+
+        messageForwarder.releaseReservedQueues("bridge-a");
+        assertTrue(messageForwarder.isForwarderQueue(QUEUE_ID), "the second reservation still holds it");
+        messageForwarder.releaseReservedQueues("bridge-b");
+        assertFalse(messageForwarder.isForwarderQueue(QUEUE_ID));
+    }
+
+    /** Degenerate inputs must not corrupt the counts: releasing an unknown id, or reserving nothing. */
+    @Test
+    @Timeout(5)
+    public void test_reserving_nothing_and_releasing_an_unknown_reservation_are_no_ops() {
+        messageForwarder.releaseReservedQueues("never-reserved");
+        messageForwarder.reserveQueues("empty", Map.of());
+        messageForwarder.reserveQueues("no-topics", Map.of(FORWARDER_ID, List.of()));
+        messageForwarder.releaseReservedQueues("empty");
+        messageForwarder.releaseReservedQueues("no-topics");
+
+        // the index must still work afterwards
+        messageForwarder.addForwarder(mqttForwarder);
+        assertTrue(messageForwarder.isForwarderQueue(QUEUE_ID));
+        messageForwarder.removeForwarder(mqttForwarder, false);
+        assertFalse(messageForwarder.isForwarderQueue(QUEUE_ID));
+    }
+
+    /**
      * The equivalence property: for every queue ID, at every step of an arbitrary registration
      * sequence, the index must answer exactly what a full scan over the registered sets would answer.
-     * The ID and topic pools are chosen so that colliding queue IDs and shared topics occur often.
+     * The ID and topic pools are chosen so that colliding queue IDs and shared topics occur often, and
+     * the sequence deliberately attempts registrations under IDs that are already taken — each of
+     * those must be refused and must leave the index byte-for-byte as it was.
      * <p>
      * Deterministic by construction — a fixed seed, so a failure is reproducible from the report alone.
      */
@@ -370,6 +547,7 @@ public class MessageForwarderImplTest {
 
         final Map<String, Set<String>> oracle = new HashMap<>();
         final Random random = new Random(882L);
+        int refusals = 0;
 
         for (int step = 0; step < 400; step++) {
             final String id = ids.get(random.nextInt(ids.size()));
@@ -383,12 +561,19 @@ public class MessageForwarderImplTest {
                         chosen.add(topic);
                     }
                 }
-                messageForwarder.addForwarder(forwarder(id, chosen.toArray(new String[0])));
-                final Set<String> registered = new HashSet<>();
-                for (final String topic : chosen) {
-                    registered.add(queueId(id, topic));
+                final MqttForwarder candidate = forwarder(id, chosen.toArray(new String[0]));
+                if (oracle.containsKey(id)) {
+                    // the ID is taken: refused, and the index must be unchanged by the attempt
+                    assertThrows(IllegalStateException.class, () -> messageForwarder.addForwarder(candidate));
+                    refusals++;
+                } else {
+                    messageForwarder.addForwarder(candidate);
+                    final Set<String> registered = new HashSet<>();
+                    for (final String topic : chosen) {
+                        registered.add(queueId(id, topic));
+                    }
+                    oracle.put(id, registered);
                 }
-                oracle.put(id, registered);
             }
 
             for (final String candidate : universe) {
@@ -398,6 +583,8 @@ public class MessageForwarderImplTest {
                         "step " + step + ", queue " + candidate);
             }
         }
+
+        assertTrue(refusals > 0, "the sequence never attempted a registration under a taken ID");
     }
 
     /** The pre-fix implementation, kept as the oracle the reference-counted index must match. */

--- a/hivemq-edge/src/test/java/com/hivemq/bridge/MessageForwarderImplTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/bridge/MessageForwarderImplTest.java
@@ -22,7 +22,10 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyByte;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
@@ -34,6 +37,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.codahale.metrics.MetricRegistry;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.Futures;
 import com.hivemq.common.shutdown.ShutdownHooks;
@@ -46,10 +50,12 @@ import com.hivemq.mqtt.topic.SubscriptionFlag;
 import com.hivemq.mqtt.topic.tree.LocalTopicTree;
 import com.hivemq.persistence.ProducerQueues;
 import com.hivemq.persistence.SingleWriterService;
+import com.hivemq.persistence.clientqueue.ClientQueuePersistence;
 import com.hivemq.persistence.clientsession.ClientSessionSubscriptionPersistence;
 import com.hivemq.persistence.clientsession.SharedSubscriptionServiceImpl.SharedSubscription;
 import com.hivemq.util.Topics;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -952,5 +958,144 @@ public class MessageForwarderImplTest {
             }
         }
         return false;
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // EDG-882 review v03, R3-04 — the teardown must reach a deliberate final state whatever throws.
+    //
+    // removeForwarder used to stop the forwarder before dropping its ownership, and a stop() that threw
+    // took the rest of the method with it: the queue IDs stayed in the index, so the periodic clean-up
+    // read them as owned for the life of the node and never reclaimed them, and addForwarder refused a
+    // replacement under the same id because putIfAbsent still found the abandoned claim. One transient
+    // persistence failure, and the bridge could not be restarted and its storage could not be freed.
+    //
+    // RemoteMqttForwarder.stop() drains its buffers through reset callbacks that wait on persistence
+    // futures and rethrow an ExecutionException as a RuntimeException, so this is an ordinary
+    // consequence of a persistence hiccup rather than a contrived mock.
+    // ---------------------------------------------------------------------------------------------
+
+    @Test
+    @Timeout(5)
+    public void test_aStopThatThrowsStillReleasesQueueOwnership() {
+        messageForwarder.addForwarder(mqttForwarder);
+        assertTrue(messageForwarder.isForwarderQueue(QUEUE_ID));
+        doThrow(new RuntimeException("persistence future failed while draining"))
+                .when(mqttForwarder)
+                .stop();
+
+        assertThrows(RuntimeException.class, () -> messageForwarder.removeForwarder(mqttForwarder, false));
+
+        assertFalse(
+                messageForwarder.isForwarderQueue(QUEUE_ID),
+                "the queue is owned by a forwarder that no longer exists, so the clean-up can never reclaim it");
+    }
+
+    /**
+     * And the id must be reusable afterwards. A claim left behind is not only a storage leak: {@code
+     * addForwarder} refuses a second registration while one is live, so the bridge cannot be restarted.
+     */
+    @Test
+    @Timeout(5)
+    public void test_aStopThatThrowsLeavesTheForwarderIdReusable() {
+        messageForwarder.addForwarder(mqttForwarder);
+        doThrow(new RuntimeException("persistence future failed while draining"))
+                .when(mqttForwarder)
+                .stop();
+        assertThrows(RuntimeException.class, () -> messageForwarder.removeForwarder(mqttForwarder, false));
+
+        final MqttForwarder replacement = forwarder(FORWARDER_ID, TOPIC);
+        messageForwarder.addForwarder(replacement);
+
+        assertTrue(
+                messageForwarder.isForwarderQueue(QUEUE_ID),
+                "the replacement could not claim the id its predecessor abandoned");
+    }
+
+    /** The failure still has to reach the caller — released, but not silently. */
+    @Test
+    @Timeout(5)
+    public void test_aStopThatThrowsIsReportedToTheCaller() {
+        messageForwarder.addForwarder(mqttForwarder);
+        final RuntimeException stopFailure = new RuntimeException("persistence future failed while draining");
+        doThrow(stopFailure).when(mqttForwarder).stop();
+
+        final RuntimeException thrown =
+                assertThrows(RuntimeException.class, () -> messageForwarder.removeForwarder(mqttForwarder, false));
+
+        assertTrue(
+                Arrays.asList(thrown.getSuppressed()).contains(stopFailure),
+                "the teardown swallowed the reason it did not complete cleanly");
+    }
+
+    /**
+     * The topic-tree removal runs before the stop, and it can throw too — a forwarder left subscribed to
+     * a topic it can no longer serve is the same class of half-finished teardown.
+     */
+    @Test
+    @Timeout(5)
+    public void test_aTopicTreeRemovalThatThrowsStillReleasesQueueOwnership() {
+        messageForwarder.addForwarder(mqttForwarder);
+        doThrow(new RuntimeException("topic tree unavailable"))
+                .when(topicTree)
+                .removeSubscriber(anyString(), anyString(), anyString());
+
+        assertThrows(RuntimeException.class, () -> messageForwarder.removeForwarder(mqttForwarder, false));
+
+        assertFalse(
+                messageForwarder.isForwarderQueue(QUEUE_ID),
+                "a topic-tree failure stranded the queue ownership behind it");
+    }
+
+    /**
+     * A stop that throws must not take the other forwarders' teardown with it either. This is the
+     * per-forwarder guarantee {@code BridgeService.internalStopBridge} relies on when it continues to the
+     * next forwarder after one reports a failure.
+     */
+    @Test
+    @Timeout(5)
+    public void test_aStopThatThrowsDoesNotStrandTheOtherForwardersQueues() {
+        messageForwarder.addForwarder(mqttForwarder);
+        messageForwarder.addForwarder(otherMqttForwarder);
+        doThrow(new RuntimeException("persistence future failed while draining"))
+                .when(mqttForwarder)
+                .stop();
+
+        assertThrows(RuntimeException.class, () -> messageForwarder.removeForwarder(mqttForwarder, false));
+        messageForwarder.removeForwarder(otherMqttForwarder, false);
+
+        assertFalse(messageForwarder.isForwarderQueue(QUEUE_ID), "the failing forwarder's queue stayed claimed");
+        assertFalse(messageForwarder.isForwarderQueue(OTHER_QUEUE_ID), "the second forwarder's queue stayed claimed");
+    }
+
+    /**
+     * Clearing a queue is fallible too — the persistence it calls is the same one whose failures make
+     * {@code stop()} throw.
+     */
+    @Test
+    @Timeout(5)
+    public void test_aQueueClearThatThrowsStillReleasesQueueOwnership() {
+        final ClientQueuePersistence queuePersistence = mock(ClientQueuePersistence.class);
+        // registration polls the queue as soon as the forwarder is added; an empty read is all this
+        // test needs from that path, and without it the poll fails before the removal under test runs
+        when(queuePersistence.readShared(anyString(), anyInt(), anyLong()))
+                .thenReturn(Futures.immediateFuture(ImmutableList.of()));
+        doThrow(new RuntimeException("queue persistence unavailable"))
+                .when(queuePersistence)
+                .clear(anyString(), anyBoolean());
+        final MessageForwarderImpl forwarderWithPersistence = new MessageForwarderImpl(
+                topicTree,
+                new HivemqId(),
+                () -> queuePersistence,
+                () -> subscriptionPersistence,
+                mock(SingleWriterService.class),
+                mock(ShutdownHooks.class));
+        final MqttForwarder toRemove = forwarder(FORWARDER_ID, TOPIC);
+        forwarderWithPersistence.addForwarder(toRemove);
+
+        assertThrows(RuntimeException.class, () -> forwarderWithPersistence.removeForwarder(toRemove, true));
+
+        assertFalse(
+                forwarderWithPersistence.isForwarderQueue(QUEUE_ID),
+                "a queue-clear failure stranded the ownership behind it");
     }
 }

--- a/hivemq-edge/src/test/java/com/hivemq/bridge/MessageForwarderImplTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/bridge/MessageForwarderImplTest.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyByte;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
@@ -30,10 +31,14 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.google.common.collect.ImmutableSet;
+import com.google.common.util.concurrent.Futures;
 import com.hivemq.common.shutdown.ShutdownHooks;
 import com.hivemq.configuration.HivemqId;
+import com.hivemq.mqtt.topic.SubscriberWithQoS;
 import com.hivemq.mqtt.topic.tree.LocalTopicTree;
 import com.hivemq.persistence.SingleWriterService;
+import com.hivemq.persistence.clientsession.ClientSessionSubscriptionPersistence;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -65,11 +70,21 @@ public class MessageForwarderImplTest {
     private MqttForwarder mqttForwarder;
     private MqttForwarder otherMqttForwarder;
 
+    private final ClientSessionSubscriptionPersistence subscriptionPersistence =
+            mock(ClientSessionSubscriptionPersistence.class);
+
     @BeforeEach
     public void setUp() {
         topicTree = mock(LocalTopicTree.class);
+        // production returns an empty set, never null; the eviction pass reads it on every registration
+        when(topicTree.getSharedSubscriber(anyString(), anyString())).thenReturn(ImmutableSet.of());
         messageForwarder = new MessageForwarderImpl(
-                topicTree, new HivemqId(), () -> null, mock(SingleWriterService.class), mock(ShutdownHooks.class));
+                topicTree,
+                new HivemqId(),
+                () -> null,
+                () -> subscriptionPersistence,
+                mock(SingleWriterService.class),
+                mock(ShutdownHooks.class));
         mqttForwarder = forwarder(FORWARDER_ID, TOPIC);
         otherMqttForwarder = forwarder(OTHER_FORWARDER_ID, OTHER_TOPIC);
     }
@@ -83,6 +98,58 @@ public class MessageForwarderImplTest {
 
     private static String queueId(final String forwarderId, final String topic) {
         return MessageForwarderImpl.FORWARDER_PREFIX + forwarderId + "/" + topic;
+    }
+
+    /**
+     * EDG-882 QA round 2. Shared subscribers of one group take turns, so a client that holds this
+     * forwarder's group receives the messages the bridge is there to forward and they never reach the
+     * remote broker. A SUBSCRIBE is refused while the queue is claimed, and BridgeService claims it from
+     * the top of every start and restart — so the one window left is a client subscribing to the group
+     * of a bridge that does not exist yet, which becomes a collision when the operator creates it. That
+     * window is closed here, at the moment the forwarder registers.
+     */
+    @Test
+    @Timeout(5)
+    public void test_addForwarder_removes_a_client_squatting_on_the_forwarders_group() {
+        when(topicTree.getSharedSubscriber(MessageForwarderImpl.FORWARDER_PREFIX + FORWARDER_ID, TOPIC))
+                .thenReturn(ImmutableSet.of(new SubscriberWithQoS("squatter", 1, (byte) 0, null)));
+        when(subscriptionPersistence.remove(anyString(), anyString())).thenReturn(Futures.immediateFuture(null));
+
+        messageForwarder.addForwarder(mqttForwarder);
+
+        // through the persistence, not the topic tree alone: the client's session would otherwise
+        // restore the subscription on its next reconnect and take the group straight back
+        verify(subscriptionPersistence)
+                .remove("squatter", "$share/" + MessageForwarderImpl.FORWARDER_PREFIX + FORWARDER_ID + "/" + TOPIC);
+    }
+
+    /** An internal component's own entry is not an intruder, including a previous generation of it. */
+    @Test
+    @Timeout(5)
+    public void test_addForwarder_leaves_internal_subscribers_alone() {
+        final String ownClientId = MessageForwarderImpl.FORWARDER_PREFIX + FORWARDER_ID + "#node-1";
+        when(topicTree.getSharedSubscriber(MessageForwarderImpl.FORWARDER_PREFIX + FORWARDER_ID, TOPIC))
+                .thenReturn(ImmutableSet.of(new SubscriberWithQoS(ownClientId, 1, (byte) 0, null)));
+
+        messageForwarder.addForwarder(mqttForwarder);
+
+        verify(subscriptionPersistence, never()).remove(anyString(), anyString());
+    }
+
+    /**
+     * The claim the subscribe-side check rests on: a queue held only by a reservation — which is what
+     * every start, restart and node bootstrap takes before anything is registered — already reads as a
+     * forwarder queue, so a client cannot slip into the group during the hand-over.
+     */
+    @Test
+    @Timeout(5)
+    public void test_isForwarderQueue_is_true_while_only_a_reservation_holds_the_queue() {
+        messageForwarder.reserveQueues("bridge", Map.of(FORWARDER_ID, List.of(TOPIC)));
+
+        assertTrue(messageForwarder.isForwarderQueue(QUEUE_ID));
+
+        messageForwarder.releaseReservedQueues("bridge");
+        assertFalse(messageForwarder.isForwarderQueue(QUEUE_ID));
     }
 
     @Test

--- a/hivemq-edge/src/test/java/com/hivemq/bridge/MessageForwarderImplTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/bridge/MessageForwarderImplTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.bridge;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.hivemq.common.shutdown.ShutdownHooks;
+import com.hivemq.configuration.HivemqId;
+import com.hivemq.mqtt.topic.tree.LocalTopicTree;
+import com.hivemq.persistence.SingleWriterService;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+public class MessageForwarderImplTest {
+
+    // EDG-882: the Base64 subscription hash may contain '/'
+    private static final String FORWARDER_ID = "bridge-Bt80p78iNo/w7W1W7bGwcg==";
+    private static final String TOPIC = "miele/v1/production/sapdm/dev/+/+/from-plc-to-dm";
+    private static final String QUEUE_ID = MessageForwarderImpl.FORWARDER_PREFIX + FORWARDER_ID + "/" + TOPIC;
+
+    // a second bridge whose hash also carries a '/', to pin cross-forwarder isolation
+    private static final String OTHER_FORWARDER_ID = "other-LHHqscdwUV/C1PCBYfZ6Bg==";
+    private static final String OTHER_TOPIC = "other/topic/+";
+    private static final String OTHER_QUEUE_ID =
+            MessageForwarderImpl.FORWARDER_PREFIX + OTHER_FORWARDER_ID + "/" + OTHER_TOPIC;
+
+    private MessageForwarderImpl messageForwarder;
+    private MqttForwarder mqttForwarder;
+    private MqttForwarder otherMqttForwarder;
+
+    @BeforeEach
+    public void setUp() {
+        messageForwarder = new MessageForwarderImpl(
+                mock(LocalTopicTree.class),
+                new HivemqId(),
+                () -> null,
+                mock(SingleWriterService.class),
+                mock(ShutdownHooks.class));
+        mqttForwarder = forwarder(FORWARDER_ID, TOPIC);
+        otherMqttForwarder = forwarder(OTHER_FORWARDER_ID, OTHER_TOPIC);
+    }
+
+    private static MqttForwarder forwarder(final String id, final String topic) {
+        final MqttForwarder forwarder = mock(MqttForwarder.class);
+        when(forwarder.getId()).thenReturn(id);
+        when(forwarder.getTopics()).thenReturn(List.of(topic));
+        return forwarder;
+    }
+
+    @Test
+    @Timeout(5)
+    public void test_isForwarderQueue_follows_forwarder_registration() {
+        assertFalse(messageForwarder.isForwarderQueue(QUEUE_ID));
+
+        messageForwarder.addForwarder(mqttForwarder);
+        assertTrue(messageForwarder.isForwarderQueue(QUEUE_ID));
+        assertFalse(messageForwarder.isForwarderQueue(MessageForwarderImpl.FORWARDER_PREFIX + "other/" + TOPIC));
+
+        messageForwarder.removeForwarder(mqttForwarder, false);
+        assertFalse(messageForwarder.isForwarderQueue(QUEUE_ID));
+    }
+
+    @Test
+    @Timeout(5)
+    public void test_isForwarderQueue_resolves_each_forwarder_independently() {
+        messageForwarder.addForwarder(mqttForwarder);
+        messageForwarder.addForwarder(otherMqttForwarder);
+
+        assertTrue(messageForwarder.isForwarderQueue(QUEUE_ID));
+        assertTrue(messageForwarder.isForwarderQueue(OTHER_QUEUE_ID));
+        // a queue may not be claimed by the wrong forwarder's registration
+        assertFalse(messageForwarder.isForwarderQueue(
+                MessageForwarderImpl.FORWARDER_PREFIX + FORWARDER_ID + "/" + OTHER_TOPIC));
+
+        // removing one forwarder must not deregister the other's queue
+        messageForwarder.removeForwarder(mqttForwarder, false);
+        assertFalse(messageForwarder.isForwarderQueue(QUEUE_ID));
+        assertTrue(messageForwarder.isForwarderQueue(OTHER_QUEUE_ID));
+    }
+
+    @Test
+    @Timeout(5)
+    public void test_isForwarderQueue_covers_every_topic_of_a_multi_topic_forwarder() {
+        final MqttForwarder multiTopic = mock(MqttForwarder.class);
+        when(multiTopic.getId()).thenReturn(FORWARDER_ID);
+        when(multiTopic.getTopics()).thenReturn(List.of(TOPIC, OTHER_TOPIC));
+
+        messageForwarder.addForwarder(multiTopic);
+
+        assertTrue(messageForwarder.isForwarderQueue(QUEUE_ID));
+        assertTrue(messageForwarder.isForwarderQueue(
+                MessageForwarderImpl.FORWARDER_PREFIX + FORWARDER_ID + "/" + OTHER_TOPIC));
+    }
+}

--- a/hivemq-edge/src/test/java/com/hivemq/bridge/MessageForwarderQueueOwnershipConcurrencyTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/bridge/MessageForwarderQueueOwnershipConcurrencyTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
 
+import ch.qos.logback.classic.Level;
 import com.hivemq.common.shutdown.ShutdownHooks;
 import com.hivemq.configuration.HivemqId;
 import com.hivemq.mqtt.topic.tree.LocalTopicTree;
@@ -35,10 +36,13 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.slf4j.LoggerFactory;
 
 /**
  * Concurrency coverage for the reference-counted queue-ownership index (EDG-882).
@@ -63,6 +67,31 @@ public class MessageForwarderQueueOwnershipConcurrencyTest {
 
     private MessageForwarderImpl messageForwarder;
     private ExecutorService executor;
+    private static Level previousForwarderLogLevel;
+
+    /**
+     * Silences {@link MessageForwarderImpl}'s own logging for the duration of this class.
+     * <p>
+     * Not cosmetic. {@code addForwarder} and {@code removeForwarder} each log at INFO or WARN on every
+     * call, and these tests make hundreds of thousands of calls. Gradle captures that output into the
+     * JUnit XML, which produced a <b>155 MB result file</b> whose CDATA section exceeded libxml2's size
+     * limit — CI's test-result reporter could not parse it and failed the build even though every test
+     * passed. Leave this in place, or restore it if the logging here ever changes.
+     */
+    @BeforeAll
+    public static void silenceForwarderLogging() {
+        final ch.qos.logback.classic.Logger logger =
+                (ch.qos.logback.classic.Logger) LoggerFactory.getLogger(MessageForwarderImpl.class);
+        previousForwarderLogLevel = logger.getLevel();
+        logger.setLevel(Level.OFF);
+    }
+
+    /** Restores the level so this class cannot affect others sharing the JVM. */
+    @AfterAll
+    public static void restoreForwarderLogging() {
+        ((ch.qos.logback.classic.Logger) LoggerFactory.getLogger(MessageForwarderImpl.class))
+                .setLevel(previousForwarderLogLevel);
+    }
 
     @BeforeEach
     public void setUp() {

--- a/hivemq-edge/src/test/java/com/hivemq/bridge/MessageForwarderQueueOwnershipConcurrencyTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/bridge/MessageForwarderQueueOwnershipConcurrencyTest.java
@@ -1,0 +1,361 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.bridge;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
+
+import com.hivemq.common.shutdown.ShutdownHooks;
+import com.hivemq.configuration.HivemqId;
+import com.hivemq.mqtt.topic.tree.LocalTopicTree;
+import com.hivemq.persistence.SingleWriterService;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+/**
+ * Concurrency coverage for the reference-counted queue-ownership index (EDG-882).
+ * <p>
+ * Every test here is deliberately <b>one-sided</b>: it asserts a safety property that a correct
+ * implementation can never violate, so it cannot fail spuriously on green code. What it cannot do is
+ * guarantee detection — a race window a few instructions wide may simply not be hit on a given run.
+ * The quiescent-state assertions (after all threads have joined) are fully deterministic; the
+ * assertions made by the hammering reader threads are probabilistic detectors. Each test says which
+ * of the two it is.
+ * <p>
+ * The property under test throughout is the one that matters to the customer: {@code
+ * isForwarderQueue} must never answer {@code false} for a queue that a live forwarder owns, because
+ * the periodic clean-up deletes what it believes to be unowned, irreversibly and without logging.
+ * Answering {@code true} for a queue that has just become unowned is harmless — it is reclaimed on
+ * the next sweep.
+ */
+public class MessageForwarderQueueOwnershipConcurrencyTest {
+
+    private static final int WRITER_ITERATIONS = 20_000;
+    private static final int CHURN_THREADS = 4;
+
+    private MessageForwarderImpl messageForwarder;
+    private ExecutorService executor;
+
+    @BeforeEach
+    public void setUp() {
+        messageForwarder = new MessageForwarderImpl(
+                mock(LocalTopicTree.class, withSettings().stubOnly()),
+                new HivemqId(),
+                () -> null,
+                mock(SingleWriterService.class, withSettings().stubOnly()),
+                mock(ShutdownHooks.class, withSettings().stubOnly()));
+        executor = Executors.newCachedThreadPool();
+    }
+
+    @AfterEach
+    public void tearDown() throws InterruptedException {
+        executor.shutdownNow();
+        executor.awaitTermination(10, TimeUnit.SECONDS);
+    }
+
+    /**
+     * Stub-only so that hammering a mock several hundred thousand times does not accumulate recorded
+     * invocations (which would exhaust the heap) and does not contend on Mockito's invocation
+     * container across threads.
+     */
+    private static MqttForwarder forwarder(final @NotNull String id, final String... topics) {
+        final MqttForwarder forwarder = mock(MqttForwarder.class, withSettings().stubOnly());
+        when(forwarder.getId()).thenReturn(id);
+        when(forwarder.getTopics()).thenReturn(List.of(topics));
+        return forwarder;
+    }
+
+    private static String queueId(final @NotNull String forwarderId, final @NotNull String topic) {
+        return MessageForwarderImpl.FORWARDER_PREFIX + forwarderId + "/" + topic;
+    }
+
+    /**
+     * Runs {@code reader} continuously on its own thread while {@code writers} run, then joins
+     * everything and rethrows the first failure any thread saw.
+     */
+    private void runConcurrently(final @NotNull Runnable reader, final @NotNull List<Runnable> writers)
+            throws Exception {
+        final AtomicBoolean writersDone = new AtomicBoolean(false);
+        final CountDownLatch start = new CountDownLatch(1);
+        final CountDownLatch finished = new CountDownLatch(writers.size() + 1);
+        final List<Throwable> failures = java.util.Collections.synchronizedList(new ArrayList<>());
+
+        executor.submit(() -> {
+            try {
+                start.await();
+                while (!writersDone.get()) {
+                    reader.run();
+                }
+                reader.run(); // one last look after the writers have stopped
+            } catch (final Throwable t) {
+                failures.add(t);
+            } finally {
+                finished.countDown();
+            }
+        });
+
+        for (final Runnable writer : writers) {
+            executor.submit(() -> {
+                try {
+                    start.await();
+                    writer.run();
+                } catch (final Throwable t) {
+                    failures.add(t);
+                } finally {
+                    finished.countDown();
+                }
+            });
+        }
+
+        start.countDown();
+        // writers finish on their own; flip the flag once all but the reader have counted down
+        while (finished.getCount() > 1) {
+            Thread.onSpinWait();
+        }
+        writersDone.set(true);
+        assertTrue(finished.await(120, TimeUnit.SECONDS), "threads did not finish in time");
+
+        if (!failures.isEmpty()) {
+            final Throwable first = failures.get(0);
+            if (first instanceof Error) {
+                throw (Error) first;
+            }
+            throw new AssertionError("concurrent failure: " + first, first);
+        }
+    }
+
+    /**
+     * O2 under contention, and the single most valuable test in this class.
+     * <p>
+     * A forwarder is re-registered over and over with two topic sets that <b>overlap</b> in one topic.
+     * The overlapping queue is continuously owned throughout — its reference count goes 1 → 2 → 1 and
+     * must never reach zero. Reversing {@code retain(new)} and {@code release(superseded)} makes it dip
+     * to zero for an instant, and a clean-up sweep landing in that instant would clear a live queue.
+     * <p>
+     * Probabilistic detector for the reader assertion; the post-join assertion is deterministic.
+     */
+    @Test
+    @Timeout(120)
+    public void test_reregistration_never_exposes_a_topic_present_in_both_sets() throws Exception {
+        final String id = "bridge-Bt80p78iNo/w7W1W7bGwcg==";
+        final String keptTopic = "plant/line1/from-plc";
+        final String queue = queueId(id, keptTopic);
+
+        final MqttForwarder registrationA = forwarder(id, keptTopic, "plant/line1/alpha");
+        final MqttForwarder registrationB = forwarder(id, keptTopic, "plant/line1/beta");
+        messageForwarder.addForwarder(registrationA);
+
+        final AtomicLong reads = new AtomicLong();
+        final Runnable reader = () -> {
+            reads.incrementAndGet();
+            assertTrue(
+                    messageForwarder.isForwarderQueue(queue),
+                    "a topic kept across a re-registration read as unowned; a sweep here deletes live messages");
+        };
+        final Runnable writer = () -> {
+            for (int i = 0; i < WRITER_ITERATIONS; i++) {
+                messageForwarder.addForwarder(i % 2 == 0 ? registrationB : registrationA);
+            }
+        };
+
+        runConcurrently(reader, List.of(writer));
+
+        assertTrue(reads.get() > 0, "the reader never ran");
+        assertTrue(messageForwarder.isForwarderQueue(queue));
+    }
+
+    /**
+     * A queue owned by two <b>different</b> forwarders — reachable because a share name may contain
+     * '/' — must stay owned while either of them is registered, no matter how hard the other churns.
+     * <p>
+     * Probabilistic detector for the reader assertion; the post-join assertion is deterministic.
+     */
+    @Test
+    @Timeout(120)
+    public void test_a_colliding_queue_stays_owned_while_one_owner_churns() throws Exception {
+        final MqttForwarder stable = forwarder("a/b", "c");
+        final MqttForwarder churning = forwarder("a", "b/c");
+        final String collidingQueue = queueId("a", "b/c");
+        assertEquals(collidingQueue, queueId("a/b", "c"), "the two registrations must collide");
+
+        messageForwarder.addForwarder(stable);
+
+        final Runnable reader = () -> assertTrue(
+                messageForwarder.isForwarderQueue(collidingQueue),
+                "a queue still owned by the stable forwarder read as unowned");
+        final Runnable writer = () -> {
+            for (int i = 0; i < WRITER_ITERATIONS; i++) {
+                messageForwarder.addForwarder(churning);
+                messageForwarder.removeForwarder(churning, false);
+            }
+        };
+
+        runConcurrently(reader, List.of(writer));
+
+        assertTrue(messageForwarder.isForwarderQueue(collidingQueue));
+        messageForwarder.removeForwarder(stable, false);
+        assertFalse(messageForwarder.isForwarderQueue(collidingQueue));
+    }
+
+    /**
+     * A forwarder that is registered once and never removed must never read as unowned, whatever else
+     * is being registered and unregistered around it.
+     * <p>
+     * Probabilistic detector for the reader assertion; the post-join assertion is deterministic.
+     */
+    @Test
+    @Timeout(120)
+    public void test_an_untouched_forwarder_is_unaffected_by_churn_on_others() throws Exception {
+        final MqttForwarder stable = forwarder("stable-AbCd/EfGh==", "stable/topic");
+        final String stableQueue = queueId("stable-AbCd/EfGh==", "stable/topic");
+        messageForwarder.addForwarder(stable);
+
+        final Runnable reader = () -> assertTrue(
+                messageForwarder.isForwarderQueue(stableQueue), "a forwarder that was never removed read as unowned");
+
+        final List<Runnable> writers = new ArrayList<>();
+        for (int t = 0; t < CHURN_THREADS; t++) {
+            final MqttForwarder churn = forwarder("churn-" + t + "-Xy/Zw==", "churn/" + t);
+            writers.add(() -> {
+                for (int i = 0; i < WRITER_ITERATIONS; i++) {
+                    messageForwarder.addForwarder(churn);
+                    messageForwarder.removeForwarder(churn, false);
+                }
+            });
+        }
+
+        runConcurrently(reader, writers);
+
+        assertTrue(messageForwarder.isForwarderQueue(stableQueue));
+    }
+
+    /**
+     * Reference-count pairing under contention: many threads register the <b>same</b> forwarder
+     * concurrently, so many {@code retain}s race a single winning {@code put}. Each must still be
+     * paired with exactly one {@code release}, or a single removal leaves the queue permanently
+     * claimed and it is never reclaimed.
+     * <p>
+     * Fully deterministic — the assertion is made after every thread has joined.
+     */
+    @Test
+    @Timeout(120)
+    public void test_concurrent_registrations_of_one_forwarder_leave_no_residual_references() throws Exception {
+        final String id = "bridge-Zz99/Yy88==";
+        final String topic = "shared/topic";
+        final String queue = queueId(id, topic);
+        final MqttForwarder subject = forwarder(id, topic);
+
+        final CountDownLatch start = new CountDownLatch(1);
+        final CountDownLatch done = new CountDownLatch(CHURN_THREADS);
+        for (int t = 0; t < CHURN_THREADS; t++) {
+            executor.submit(() -> {
+                try {
+                    start.await();
+                    for (int i = 0; i < WRITER_ITERATIONS; i++) {
+                        messageForwarder.addForwarder(subject);
+                    }
+                } catch (final InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    done.countDown();
+                }
+            });
+        }
+        start.countDown();
+        assertTrue(done.await(120, TimeUnit.SECONDS), "registration threads did not finish");
+
+        assertTrue(messageForwarder.isForwarderQueue(queue), "the forwarder is registered");
+
+        // one removal must fully deregister, however many concurrent adds preceded it
+        messageForwarder.removeForwarder(subject, false);
+        assertFalse(
+                messageForwarder.isForwarderQueue(queue),
+                "references leaked: the queue can now never be reclaimed by the clean-up");
+    }
+
+    /**
+     * The whole index must return to empty once every forwarder is unregistered, after arbitrary
+     * concurrent add/remove interleavings — no leaked references (a queue that can never be reclaimed)
+     * and no lost ones (re-registration must still work afterwards).
+     * <p>
+     * Fully deterministic — asserted at quiescence.
+     */
+    @Test
+    @Timeout(120)
+    public void test_index_returns_to_empty_after_concurrent_add_remove_storms() throws Exception {
+        final List<String> ids = List.of("a", "a/b", "bridge-Ab/cd==", "bridge-Abcd==");
+        final List<String> topics = List.of("b/c", "c", "t");
+
+        final List<MqttForwarder> forwarders = new ArrayList<>();
+        final List<String> universe = new ArrayList<>();
+        for (final String id : ids) {
+            forwarders.add(forwarder(id, topics.toArray(new String[0])));
+            for (final String topic : topics) {
+                universe.add(queueId(id, topic));
+            }
+        }
+
+        final CountDownLatch start = new CountDownLatch(1);
+        final CountDownLatch done = new CountDownLatch(forwarders.size());
+        for (final MqttForwarder subject : forwarders) {
+            executor.submit(() -> {
+                try {
+                    start.await();
+                    for (int i = 0; i < WRITER_ITERATIONS / 2; i++) {
+                        messageForwarder.addForwarder(subject);
+                        messageForwarder.removeForwarder(subject, false);
+                    }
+                } catch (final InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    done.countDown();
+                }
+            });
+        }
+        start.countDown();
+        assertTrue(done.await(120, TimeUnit.SECONDS), "storm threads did not finish");
+
+        // every forwarder ended on a removal, so nothing may remain claimed
+        for (final String queue : universe) {
+            assertFalse(
+                    messageForwarder.isForwarderQueue(queue),
+                    "reference leaked for " + queue + "; this queue would never be reclaimed");
+        }
+
+        // and the index must still be usable: counts must not have gone negative or been corrupted
+        for (final MqttForwarder subject : forwarders) {
+            messageForwarder.addForwarder(subject);
+        }
+        for (final String queue : universe) {
+            assertTrue(messageForwarder.isForwarderQueue(queue), "re-registration failed for " + queue);
+        }
+    }
+}

--- a/hivemq-edge/src/test/java/com/hivemq/bridge/MessageForwarderQueueOwnershipConcurrencyTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/bridge/MessageForwarderQueueOwnershipConcurrencyTest.java
@@ -60,6 +60,7 @@ import org.slf4j.LoggerFactory;
  * Answering {@code true} for a queue that has just become unowned is harmless — it is reclaimed on
  * the next sweep.
  */
+@SuppressWarnings("FutureReturnValueIgnored") // submitted work reports failures through the shared list
 public class MessageForwarderQueueOwnershipConcurrencyTest {
 
     private static final int WRITER_ITERATIONS = 20_000;
@@ -174,8 +175,8 @@ public class MessageForwarderQueueOwnershipConcurrencyTest {
 
         if (!failures.isEmpty()) {
             final Throwable first = failures.get(0);
-            if (first instanceof Error) {
-                throw (Error) first;
+            if (first instanceof Error error) {
+                throw error;
             }
             throw new AssertionError("concurrent failure: " + first, first);
         }

--- a/hivemq-edge/src/test/java/com/hivemq/bridge/MessageForwarderQueueOwnershipConcurrencyTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/bridge/MessageForwarderQueueOwnershipConcurrencyTest.java
@@ -18,15 +18,18 @@ package com.hivemq.bridge;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
 
 import ch.qos.logback.classic.Level;
+import com.google.common.collect.ImmutableSet;
 import com.hivemq.common.shutdown.ShutdownHooks;
 import com.hivemq.configuration.HivemqId;
 import com.hivemq.mqtt.topic.tree.LocalTopicTree;
 import com.hivemq.persistence.SingleWriterService;
+import com.hivemq.persistence.clientsession.ClientSessionSubscriptionPersistence;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -96,10 +99,16 @@ public class MessageForwarderQueueOwnershipConcurrencyTest {
 
     @BeforeEach
     public void setUp() {
+        final LocalTopicTree topicTree =
+                mock(LocalTopicTree.class, withSettings().stubOnly());
+        when(topicTree.getSharedSubscriber(anyString(), anyString())).thenReturn(ImmutableSet.of());
         messageForwarder = new MessageForwarderImpl(
-                mock(LocalTopicTree.class, withSettings().stubOnly()),
+                topicTree,
                 new HivemqId(),
                 () -> null,
+                () -> mock(
+                        ClientSessionSubscriptionPersistence.class,
+                        withSettings().stubOnly()),
                 mock(SingleWriterService.class, withSettings().stubOnly()),
                 mock(ShutdownHooks.class, withSettings().stubOnly()));
         executor = Executors.newCachedThreadPool();

--- a/hivemq-edge/src/test/java/com/hivemq/bridge/MessageForwarderQueueOwnershipConcurrencyTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/bridge/MessageForwarderQueueOwnershipConcurrencyTest.java
@@ -185,41 +185,55 @@ public class MessageForwarderQueueOwnershipConcurrencyTest {
     /**
      * O2 under contention, and the single most valuable test in this class.
      * <p>
-     * A forwarder is re-registered over and over with two topic sets that <b>overlap</b> in one topic.
-     * The overlapping queue is continuously owned throughout — its reference count goes 1 → 2 → 1 and
-     * must never reach zero. Reversing {@code retain(new)} and {@code release(superseded)} makes it dip
-     * to zero for an instant, and a clean-up sweep landing in that instant would clear a live queue.
+     * A registration is attempted over and over under an ID that is already taken (EDG-882 F-01: two
+     * local subscriptions of one bridge can derive the same ID while owning different queues), with a
+     * topic set that <b>overlaps</b> the incumbent's in one topic. Every attempt is refused, and the
+     * overlapping queue is continuously owned throughout — its reference count goes 1 → 2 → 1 and must
+     * never reach zero. Undoing the refused claim by releasing the incumbent's set instead of the one
+     * just taken makes it dip to zero for an instant, and a clean-up sweep landing in that instant
+     * clears a live queue.
      * <p>
      * Probabilistic detector for the reader assertion; the post-join assertion is deterministic.
      */
     @Test
     @Timeout(120)
-    public void test_reregistration_never_exposes_a_topic_present_in_both_sets() throws Exception {
+    public void test_refused_registrations_never_expose_a_topic_present_in_both_sets() throws Exception {
         final String id = "bridge-Bt80p78iNo/w7W1W7bGwcg==";
         final String keptTopic = "plant/line1/from-plc";
         final String queue = queueId(id, keptTopic);
 
-        final MqttForwarder registrationA = forwarder(id, keptTopic, "plant/line1/alpha");
-        final MqttForwarder registrationB = forwarder(id, keptTopic, "plant/line1/beta");
-        messageForwarder.addForwarder(registrationA);
+        final MqttForwarder incumbent = forwarder(id, keptTopic, "plant/line1/alpha");
+        final MqttForwarder refused = forwarder(id, keptTopic, "plant/line1/beta");
+        messageForwarder.addForwarder(incumbent);
 
         final AtomicLong reads = new AtomicLong();
+        final AtomicLong refusals = new AtomicLong();
         final Runnable reader = () -> {
             reads.incrementAndGet();
             assertTrue(
                     messageForwarder.isForwarderQueue(queue),
-                    "a topic kept across a re-registration read as unowned; a sweep here deletes live messages");
+                    "a topic held by the incumbent read as unowned; a sweep here deletes live messages");
         };
         final Runnable writer = () -> {
             for (int i = 0; i < WRITER_ITERATIONS; i++) {
-                messageForwarder.addForwarder(i % 2 == 0 ? registrationB : registrationA);
+                try {
+                    messageForwarder.addForwarder(refused);
+                    throw new AssertionError("a registration under a taken ID was accepted");
+                } catch (final IllegalStateException expected) {
+                    refusals.incrementAndGet();
+                }
             }
         };
 
         runConcurrently(reader, List.of(writer));
 
         assertTrue(reads.get() > 0, "the reader never ran");
+        assertEquals(WRITER_ITERATIONS, refusals.get(), "not every attempt was refused");
         assertTrue(messageForwarder.isForwarderQueue(queue));
+        // the incumbent's own queues are intact, and the refusals leaked nothing
+        messageForwarder.removeForwarder(incumbent, false);
+        assertFalse(messageForwarder.isForwarderQueue(queue), "the refusals leaked references on the shared queue");
+        assertFalse(messageForwarder.isForwarderQueue(queueId(id, "plant/line1/beta")));
     }
 
     /**
@@ -289,11 +303,11 @@ public class MessageForwarderQueueOwnershipConcurrencyTest {
 
     /**
      * Reference-count pairing under contention: many threads register the <b>same</b> forwarder
-     * concurrently, so many {@code retain}s race a single winning {@code put}. Each must still be
-     * paired with exactly one {@code release}, or a single removal leaves the queue permanently
-     * claimed and it is never reclaimed.
+     * concurrently, so many {@code retain}s race a single winning {@code putIfAbsent}. Exactly one
+     * may win; every loser must undo precisely the references it took, or a single removal leaves the
+     * queue permanently claimed and it is never reclaimed.
      * <p>
-     * Fully deterministic — the assertion is made after every thread has joined.
+     * Fully deterministic — the assertions are made after every thread has joined.
      */
     @Test
     @Timeout(120)
@@ -302,6 +316,7 @@ public class MessageForwarderQueueOwnershipConcurrencyTest {
         final String topic = "shared/topic";
         final String queue = queueId(id, topic);
         final MqttForwarder subject = forwarder(id, topic);
+        final AtomicLong accepted = new AtomicLong();
 
         final CountDownLatch start = new CountDownLatch(1);
         final CountDownLatch done = new CountDownLatch(CHURN_THREADS);
@@ -310,7 +325,12 @@ public class MessageForwarderQueueOwnershipConcurrencyTest {
                 try {
                     start.await();
                     for (int i = 0; i < WRITER_ITERATIONS; i++) {
-                        messageForwarder.addForwarder(subject);
+                        try {
+                            messageForwarder.addForwarder(subject);
+                            accepted.incrementAndGet();
+                        } catch (final IllegalStateException alreadyRegistered) {
+                            // exactly what every attempt but the first must do
+                        }
                     }
                 } catch (final InterruptedException e) {
                     Thread.currentThread().interrupt();
@@ -322,6 +342,7 @@ public class MessageForwarderQueueOwnershipConcurrencyTest {
         start.countDown();
         assertTrue(done.await(120, TimeUnit.SECONDS), "registration threads did not finish");
 
+        assertEquals(1L, accepted.get(), "an ID was registered more than once");
         assertTrue(messageForwarder.isForwarderQueue(queue), "the forwarder is registered");
 
         // one removal must fully deregister, however many concurrent adds preceded it

--- a/hivemq-edge/src/test/java/com/hivemq/bridge/config/LocalSubscriptionTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/bridge/config/LocalSubscriptionTest.java
@@ -164,4 +164,99 @@ class LocalSubscriptionTest {
                 1000L);
         assertNotEquals(localSubscription.calculateUniqueId(), otherSubscription.calculateUniqueId());
     }
+
+    private static LocalSubscription subscription(final String filter, final String destination) {
+        return new LocalSubscription(
+                List.of(filter),
+                destination,
+                List.of("excluded/topic"),
+                List.of(CustomUserProperty.of("key1", "value1")),
+                true,
+                2,
+                1000L);
+    }
+
+    /**
+     * EDG-884. The fingerprint is computed lazily, so a running bridge's subscription has it cached
+     * while one freshly read from the configuration file does not. If equality compared it, the two
+     * would differ even for a byte-identical configuration — and the reload path reads that as "the
+     * bridge changed", restarts it with {@code clearQueue = true} and destroys every queued message.
+     */
+    @Test
+    void equals_whenOneSideHasMemoisedItsUniqueId_thenStillEqual() {
+        final LocalSubscription running = subscription("topicA/+", "destinationTopic");
+        final LocalSubscription freshlyParsed = subscription("topicA/+", "destinationTopic");
+
+        assertEquals(running, freshlyParsed, "identical configurations must start out equal");
+
+        // what a running bridge does: BridgeMqttClient.createForwarderId asks for the fingerprint
+        running.calculateUniqueId();
+
+        assertEquals(
+                running,
+                freshlyParsed,
+                "memoising the derived fingerprint must not make an unchanged configuration look changed");
+        assertEquals(freshlyParsed, running, "equality must stay symmetric regardless of which side memoised first");
+    }
+
+    /**
+     * The hash must not change over an object's lifetime — a config object whose hash moves the first
+     * time a derived field is computed is a trap for any future map keyed on it, and it would break
+     * {@code MqttBridge.hashCode}, which folds this one in.
+     */
+    @Test
+    void hashCode_whenUniqueIdIsMemoised_thenUnchanged() {
+        final LocalSubscription subscription = subscription("topicA/+", "destinationTopic");
+        final int before = subscription.hashCode();
+
+        subscription.calculateUniqueId();
+
+        assertEquals(before, subscription.hashCode(), "hashCode changed once the fingerprint was cached");
+        assertEquals(
+                subscription("topicA/+", "destinationTopic").hashCode(),
+                subscription.hashCode(),
+                "equal objects must still agree on hashCode after one of them memoised");
+    }
+
+    /** A genuine configuration change must still be detected — the fix must not blind the reload path. */
+    @Test
+    void equals_whenTheConfigurationGenuinelyChanges_thenNotEqual() {
+        final LocalSubscription original = subscription("topicA/+", "destinationTopic");
+        original.calculateUniqueId();
+
+        assertNotEquals(original, subscription("topicB/+", "destinationTopic"), "a changed filter must be detected");
+        assertNotEquals(
+                original, subscription("topicA/+", "otherDestination"), "a changed destination must be detected");
+    }
+
+    /**
+     * The whole point of EDG-884, one level up: {@code BridgeService.updateBridges} compares
+     * {@link MqttBridge} objects, and that comparison walks into the subscription list. An unchanged
+     * bridge must compare equal even after it has been running.
+     */
+    @Test
+    void mqttBridgeEquals_whenARunningBridgeIsComparedToItsReparsedConfig_thenEqual() {
+        final LocalSubscription runningSubscription = subscription("topicA/+", "destinationTopic");
+        final MqttBridge running = bridge(runningSubscription);
+        final MqttBridge freshlyParsed = bridge(subscription("topicA/+", "destinationTopic"));
+
+        runningSubscription.calculateUniqueId(); // the bridge has been up; something asked for the id
+
+        assertEquals(
+                running,
+                freshlyParsed,
+                "an unchanged bridge compared as changed; the reload path would clear its live queue");
+        assertEquals(running.hashCode(), freshlyParsed.hashCode());
+    }
+
+    private static MqttBridge bridge(final LocalSubscription subscription) {
+        return new MqttBridge.Builder()
+                .withId("edg-884-bridge")
+                .withHost("localhost")
+                .withPort(1883)
+                .withClientId("client")
+                .withLocalSubscriptions(List.of(subscription))
+                .withRemoteSubscriptions(List.of())
+                .build();
+    }
 }

--- a/hivemq-edge/src/test/java/com/hivemq/bridge/config/LocalSubscriptionTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/bridge/config/LocalSubscriptionTest.java
@@ -421,6 +421,36 @@ class LocalSubscriptionTest {
         assertEquals(asWritten.hashCode(), reordered.hashCode());
     }
 
+    /**
+     * EDG-882 QA round 4. {@code persist} was in {@code hashCode} and not in {@code equals}, which was
+     * unobservable while a REST update was expressed as remove-then-add — every PUT restarted the bridge
+     * whatever equality said. Once an update became one transition, this comparison is what decides
+     * whether the bridge restarts, so toggling only this flag was silently ignored: the bridge kept
+     * forwarding under the old setting, which is what decides whether a local subscription's publishes
+     * are downgraded to QoS 0 and therefore whether they are persisted at all.
+     */
+    @Test
+    void mqttBridgeEquals_whenOnlyPersistDiffers_thenNotEqual() {
+        final LocalSubscription subscription = subscription("topicA/+", "destinationTopic");
+        final MqttBridge persisting = bridgeWithPersist(subscription, true);
+        final MqttBridge notPersisting = bridgeWithPersist(subscription, false);
+
+        assertNotEquals(persisting, notPersisting, "toggling persist must be a configuration change");
+        assertNotEquals(persisting.hashCode(), notPersisting.hashCode());
+    }
+
+    private static MqttBridge bridgeWithPersist(final LocalSubscription subscription, final boolean persist) {
+        return new MqttBridge.Builder()
+                .withId("edg-884-bridge")
+                .withHost("localhost")
+                .withPort(1883)
+                .withClientId("client")
+                .withLocalSubscriptions(List.of(subscription))
+                .withRemoteSubscriptions(List.of())
+                .persist(persist)
+                .build();
+    }
+
     /** But a repeated block is a different configuration, and a multiset keeps them apart. */
     @Test
     void mqttBridgeEquals_whenASubscriptionIsRepeated_thenNotEqual() {

--- a/hivemq-edge/src/test/java/com/hivemq/bridge/config/LocalSubscriptionTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/bridge/config/LocalSubscriptionTest.java
@@ -457,9 +457,8 @@ class LocalSubscriptionTest {
      * {@code MqttBridge.equals} compares both subscription lists as multisets. Only the local half was
      * covered, so a change that made the remote half positional again would restart the bridge on a
      * reorder — and a restart is what clears the queues of everything the new configuration cannot
-     * match. Note that this is about the order of the {@code <remote-subscription>} blocks; the filters
-     * <em>inside</em> a remote subscription are still compared positionally, which is the open item in
-     * the AUG-20 list.
+     * match. The order of the filters <em>inside</em> a remote subscription is covered separately,
+     * below.
      */
     @Test
     void mqttBridgeEquals_whenTheRemoteSubscriptionBlocksAreReordered_thenEqual() {
@@ -480,6 +479,51 @@ class LocalSubscriptionTest {
         assertNotEquals(
                 bridgeWithRemote(List.of(only)),
                 bridgeWithRemote(List.of(only, new RemoteSubscription(List.of("remoteA/+"), "destinationTopic"))));
+    }
+
+    /**
+     * And the filters <em>inside</em> a remote subscription, which is the half F-07 left behind.
+     * <p>
+     * {@code RemoteSubscription.equals} compared them positionally, so reordering a
+     * {@code <mqtt-topic-filter>} inside one {@code <remote-subscription>} made the bridge compare as
+     * changed and the reload path restarted it — EDG-884's yardstick failing on the remote side, with
+     * no message loss (the retain list comes from the local subscriptions) but a reconnect nobody asked
+     * for (EDG-882 QA, 2026-08-25).
+     */
+    @Test
+    void remoteSubscriptionEquals_whenTheFiltersAreReordered_thenEqual() {
+        final RemoteSubscription asWritten =
+                new RemoteSubscription(List.of("remoteB/+", "remoteA/+"), "destinationTopic");
+        final RemoteSubscription reordered =
+                new RemoteSubscription(List.of("remoteA/+", "remoteB/+"), "destinationTopic");
+
+        assertEquals(asWritten, reordered, "the same filters in another order are the same subscription");
+        assertEquals(asWritten.hashCode(), reordered.hashCode());
+        assertEquals(
+                bridgeWithRemote(List.of(asWritten)),
+                bridgeWithRemote(List.of(reordered)),
+                "so the bridge is unchanged, and the reload must not restart it");
+    }
+
+    /** A repeated filter is still a different subscription: canonical means sorted, not de-duplicated. */
+    @Test
+    void remoteSubscriptionEquals_whenAFilterIsRepeated_thenNotEqual() {
+        assertNotEquals(
+                new RemoteSubscription(List.of("remoteA/+"), "destinationTopic"),
+                new RemoteSubscription(List.of("remoteA/+", "remoteA/+"), "destinationTopic"));
+    }
+
+    /**
+     * And the operator's order survives for the write-back, or canonicalisation would rewrite the
+     * elements of a file it was only ever meant to stop reacting to.
+     */
+    @Test
+    void remoteSubscription_keepsTheConfiguredFilterOrderForTheWriteBack() {
+        final RemoteSubscription asWritten =
+                new RemoteSubscription(List.of("remoteB/+", "remoteA/+"), "destinationTopic");
+
+        assertEquals(List.of("remoteB/+", "remoteA/+"), asWritten.getConfiguredFilters());
+        assertEquals(List.of("remoteA/+", "remoteB/+"), asWritten.getFilters(), "identity is the sorted order");
     }
 
     private static MqttBridge bridgeWithRemote(final List<RemoteSubscription> remoteSubscriptions) {

--- a/hivemq-edge/src/test/java/com/hivemq/bridge/config/LocalSubscriptionTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/bridge/config/LocalSubscriptionTest.java
@@ -372,6 +372,74 @@ class LocalSubscriptionTest {
         assertEquals(running.hashCode(), freshlyParsed.hashCode());
     }
 
+    /**
+     * The configured order is kept for writing the file back out, and is invisible to identity: two
+     * subscriptions that differ only in the order they were written in are one subscription, or F-07's
+     * fix would be undone by the field that exists to protect the operator's file (EDG-882 QA round 2).
+     */
+    @Test
+    void configuredOrder_isKeptButDoesNotAffectIdentity() {
+        final LocalSubscription asWritten = new LocalSubscription(List.of("zone-b/#", "alarms/#"), "destinationTopic");
+        final LocalSubscription reordered = new LocalSubscription(List.of("alarms/#", "zone-b/#"), "destinationTopic");
+
+        assertEquals(List.of("zone-b/#", "alarms/#"), asWritten.getConfiguredFilters());
+        assertEquals(List.of("alarms/#", "zone-b/#"), reordered.getConfiguredFilters());
+        assertEquals(List.of("alarms/#", "zone-b/#"), asWritten.getFilters());
+        assertEquals(asWritten, reordered);
+        assertEquals(asWritten.hashCode(), reordered.hashCode());
+        assertEquals(asWritten.calculateUniqueId(), reordered.calculateUniqueId());
+    }
+
+    @Test
+    void configuredExcludes_areKeptInTheOrderTheyWereWritten() {
+        final LocalSubscription subscription = new LocalSubscription(
+                List.of("topicA/+"),
+                "destinationTopic",
+                List.of("zone-b/private/#", "alarms/private/#"),
+                List.of(),
+                false,
+                1,
+                null);
+
+        assertEquals(List.of("zone-b/private/#", "alarms/private/#"), subscription.getConfiguredExcludes());
+        assertEquals(List.of("alarms/private/#", "zone-b/private/#"), subscription.getExcludes());
+    }
+
+    /**
+     * EDG-882 QA round 1: the order of the {@code <forwarded-topic>} blocks was compared positionally,
+     * so moving one above another was a configuration change — and a configuration change restarts the
+     * bridge and clears the queues of everything the new configuration cannot match.
+     */
+    @Test
+    void mqttBridgeEquals_whenTheSubscriptionBlocksAreReordered_thenEqual() {
+        final LocalSubscription first = subscription("topicA/+", "destinationTopic");
+        final LocalSubscription second = subscription("topicB/+", "destinationTopic");
+        final MqttBridge asWritten = bridge(List.of(first, second));
+        final MqttBridge reordered = bridge(List.of(second, first));
+
+        assertEquals(asWritten, reordered, "a reordered subscription list is the same configuration");
+        assertEquals(asWritten.hashCode(), reordered.hashCode());
+    }
+
+    /** But a repeated block is a different configuration, and a multiset keeps them apart. */
+    @Test
+    void mqttBridgeEquals_whenASubscriptionIsRepeated_thenNotEqual() {
+        final LocalSubscription only = subscription("topicA/+", "destinationTopic");
+
+        assertNotEquals(bridge(List.of(only)), bridge(List.of(only, subscription("topicA/+", "destinationTopic"))));
+    }
+
+    private static MqttBridge bridge(final List<LocalSubscription> subscriptions) {
+        return new MqttBridge.Builder()
+                .withId("edg-884-bridge")
+                .withHost("localhost")
+                .withPort(1883)
+                .withClientId("client")
+                .withLocalSubscriptions(subscriptions)
+                .withRemoteSubscriptions(List.of())
+                .build();
+    }
+
     private static MqttBridge bridge(final LocalSubscription subscription) {
         return new MqttBridge.Builder()
                 .withId("edg-884-bridge")

--- a/hivemq-edge/src/test/java/com/hivemq/bridge/config/LocalSubscriptionTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/bridge/config/LocalSubscriptionTest.java
@@ -230,6 +230,34 @@ class LocalSubscriptionTest {
     }
 
     /**
+     * EDG-882 F-01, pinned as known and deliberate. The filters are joined with an <b>empty</b>
+     * separator before being digested, so any two filter lists with the same sorted concatenation
+     * produce the same fingerprint — and the fingerprint names every persisted queue the subscription
+     * owns.
+     * <p>
+     * This is not fixed here: changing the encoding changes the fingerprint of every configuration,
+     * renaming every persisted bridge queue on upgrade and stranding the messages in them, which is
+     * why EDG-882 rejected re-encoding. The ambiguity is contained instead by
+     * {@code BridgeMqttClient.verifyForwarderIdsAreUnique}, which refuses to start a bridge carrying
+     * two subscriptions that collide. This test exists so that anyone who "fixes" the join here sees
+     * that the collision is load-bearing and reads why.
+     */
+    @Test
+    void calculateUniqueId_whenFilterConcatenationsAreEqual_thenIdsCollide() {
+        final LocalSubscription first = new LocalSubscription(List.of("ab", "c"), "destinationTopic");
+        final LocalSubscription second = new LocalSubscription(List.of("a", "bc"), "destinationTopic");
+
+        assertEquals(
+                first.calculateUniqueId(),
+                second.calculateUniqueId(),
+                "the ambiguity documented on calculateUniqueId(); bridge startup is what rejects it");
+        assertNotEquals(first, second, "the two configurations are genuinely different");
+
+        // and the digest itself commonly carries a '/', which is what made the collision fatal
+        assertEquals("kAFQmDzST7DWlj99KOF/cg==", new LocalSubscription(List.of("abc"), null).calculateUniqueId());
+    }
+
+    /**
      * The whole point of EDG-884, one level up: {@code BridgeService.updateBridges} compares
      * {@link MqttBridge} objects, and that comparison walks into the subscription list. An unchanged
      * bridge must compare equal even after it has been running.

--- a/hivemq-edge/src/test/java/com/hivemq/bridge/config/LocalSubscriptionTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/bridge/config/LocalSubscriptionTest.java
@@ -451,6 +451,48 @@ class LocalSubscriptionTest {
                 .build();
     }
 
+    /**
+     * The same, for the other half of the comparison (EDG-882 review v02, R2-21).
+     * <p>
+     * {@code MqttBridge.equals} compares both subscription lists as multisets. Only the local half was
+     * covered, so a change that made the remote half positional again would restart the bridge on a
+     * reorder — and a restart is what clears the queues of everything the new configuration cannot
+     * match. Note that this is about the order of the {@code <remote-subscription>} blocks; the filters
+     * <em>inside</em> a remote subscription are still compared positionally, which is the open item in
+     * the AUG-20 list.
+     */
+    @Test
+    void mqttBridgeEquals_whenTheRemoteSubscriptionBlocksAreReordered_thenEqual() {
+        final RemoteSubscription first = new RemoteSubscription(List.of("remoteA/+"), "destinationTopic");
+        final RemoteSubscription second = new RemoteSubscription(List.of("remoteB/+"), "destinationTopic");
+        final MqttBridge asWritten = bridgeWithRemote(List.of(first, second));
+        final MqttBridge reordered = bridgeWithRemote(List.of(second, first));
+
+        assertEquals(asWritten, reordered, "a reordered remote subscription list is the same configuration");
+        assertEquals(asWritten.hashCode(), reordered.hashCode());
+    }
+
+    /** And a repeated remote block is a different configuration, exactly as for the local ones. */
+    @Test
+    void mqttBridgeEquals_whenARemoteSubscriptionIsRepeated_thenNotEqual() {
+        final RemoteSubscription only = new RemoteSubscription(List.of("remoteA/+"), "destinationTopic");
+
+        assertNotEquals(
+                bridgeWithRemote(List.of(only)),
+                bridgeWithRemote(List.of(only, new RemoteSubscription(List.of("remoteA/+"), "destinationTopic"))));
+    }
+
+    private static MqttBridge bridgeWithRemote(final List<RemoteSubscription> remoteSubscriptions) {
+        return new MqttBridge.Builder()
+                .withId("edg-884-bridge")
+                .withHost("localhost")
+                .withPort(1883)
+                .withClientId("client")
+                .withLocalSubscriptions(List.of())
+                .withRemoteSubscriptions(remoteSubscriptions)
+                .build();
+    }
+
     /** But a repeated block is a different configuration, and a multiset keeps them apart. */
     @Test
     void mqttBridgeEquals_whenASubscriptionIsRepeated_thenNotEqual() {

--- a/hivemq-edge/src/test/java/com/hivemq/bridge/config/LocalSubscriptionTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/bridge/config/LocalSubscriptionTest.java
@@ -230,6 +230,101 @@ class LocalSubscriptionTest {
     }
 
     /**
+     * EDG-882 F-07. Order is not part of a subscription's identity: the filters are what the forwarder
+     * subscribes to and the excludes are a match-any test, so a configuration edited only to reorder
+     * them is the same configuration. It did not compare that way — {@code equals} was positional while
+     * the fingerprint sorted — so a formatting change read as "the bridge changed", and the reload path
+     * answers that by restarting the bridge in the mode that clears its queues.
+     */
+    @Test
+    void equals_whenOnlyTheOrderOfFiltersOrExcludesDiffers_thenEqual() {
+        final LocalSubscription written = new LocalSubscription(
+                List.of("factory/+/temperature", "factory/+/pressure"),
+                "destinationTopic",
+                List.of("factory/ignored/temperature", "factory/ignored/pressure"),
+                List.of(),
+                false,
+                1,
+                null);
+        final LocalSubscription reordered = new LocalSubscription(
+                List.of("factory/+/pressure", "factory/+/temperature"),
+                "destinationTopic",
+                List.of("factory/ignored/pressure", "factory/ignored/temperature"),
+                List.of(),
+                false,
+                1,
+                null);
+
+        assertEquals(written, reordered, "a reorder-only edit compared as a changed bridge");
+        assertEquals(written.hashCode(), reordered.hashCode());
+        assertEquals(written.calculateUniqueId(), reordered.calculateUniqueId(), "and it always owned the same queues");
+    }
+
+    /**
+     * The bridge-level comparison is what {@code updateBridges} actually asks, so the property has to
+     * survive being folded into {@link MqttBridge}: an unchanged bridge whose filters were reordered
+     * must not be restarted at all.
+     */
+    @Test
+    void mqttBridgeEquals_whenFiltersAreReordered_thenEqual() {
+        assertEquals(
+                bridge(new LocalSubscription(List.of("a/1", "b/2"), "destinationTopic")),
+                bridge(new LocalSubscription(List.of("b/2", "a/1"), "destinationTopic")));
+    }
+
+    /**
+     * Sorted, not de-duplicated. The fingerprint is taken over the sorted filters including repeats and
+     * it names every persisted queue, so collapsing a repeat would rename that queue on upgrade and
+     * strand the messages in it — the trade this ticket refused for the encoding itself.
+     */
+    @Test
+    void calculateUniqueId_whenAFilterIsRepeated_thenStillItsOwnIdentity() {
+        final LocalSubscription repeated = new LocalSubscription(List.of("a/1", "a/1"), "destinationTopic");
+        final LocalSubscription once = new LocalSubscription(List.of("a/1"), "destinationTopic");
+
+        assertNotEquals(once, repeated, "a repeated filter is a different configuration");
+        assertNotEquals(
+                once.calculateUniqueId(),
+                repeated.calculateUniqueId(),
+                "de-duplicating would rename this subscription's queues on upgrade");
+        assertEquals(List.of("a/1", "a/1"), repeated.getFilters(), "and the repeat survives canonicalisation");
+    }
+
+    /**
+     * User properties are left ordered on purpose: MQTT user properties are an ordered list and two
+     * entries may share a key, so their order is configuration rather than formatting.
+     */
+    @Test
+    void equals_whenOnlyTheOrderOfUserPropertiesDiffers_thenNotEqual() {
+        final LocalSubscription first = new LocalSubscription(
+                List.of("a/1"),
+                "destinationTopic",
+                List.of(),
+                List.of(CustomUserProperty.of("k1", "v1"), CustomUserProperty.of("k2", "v2")),
+                false,
+                1,
+                null);
+        final LocalSubscription swapped = new LocalSubscription(
+                List.of("a/1"),
+                "destinationTopic",
+                List.of(),
+                List.of(CustomUserProperty.of("k2", "v2"), CustomUserProperty.of("k1", "v1")),
+                false,
+                1,
+                null);
+
+        assertNotEquals(first, swapped);
+    }
+
+    /** Canonicalisation must not lose or invent filters, whatever it is handed. */
+    @Test
+    void getFilters_returnsTheSameFiltersInCanonicalOrder() {
+        assertEquals(List.of("a", "b", "c"), new LocalSubscription(List.of("c", "a", "b"), "d").getFilters());
+        assertEquals(List.of(), new LocalSubscription(List.of(), "d").getFilters());
+        assertEquals(List.of("only"), new LocalSubscription(List.of("only"), "d").getFilters());
+    }
+
+    /**
      * EDG-882 F-01, pinned as known and deliberate. The filters are joined with an <b>empty</b>
      * separator before being digested, so any two filter lists with the same sorted concatenation
      * produce the same fingerprint — and the fingerprint names every persisted queue the subscription

--- a/hivemq-edge/src/test/java/com/hivemq/bridge/mqtt/BridgeMqttClientForwarderIdTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/bridge/mqtt/BridgeMqttClientForwarderIdTest.java
@@ -1,0 +1,270 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.bridge.mqtt;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import com.codahale.metrics.MetricRegistry;
+import com.hivemq.adapter.sdk.api.events.EventService;
+import com.hivemq.bridge.MqttForwarder;
+import com.hivemq.bridge.config.CustomUserProperty;
+import com.hivemq.bridge.config.LocalSubscription;
+import com.hivemq.bridge.config.MqttBridge;
+import com.hivemq.configuration.HivemqId;
+import com.hivemq.configuration.info.SystemInformation;
+import java.util.List;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.junit.jupiter.api.Test;
+
+/**
+ * EDG-882 F-01. A bridge whose local subscriptions do not resolve to distinct forwarder ids must not
+ * start.
+ * <p>
+ * The id is a digest over the sorted topic filters joined with an <b>empty</b> separator and the
+ * destination, so {@code ["ab","c"]} and {@code ["a","bc"]} produce the same one. It names every
+ * persisted queue the subscription owns, so two subscriptions sharing an id share their queues: the
+ * second registration takes the first's queues out of the ownership index, and the periodic clean-up
+ * deletes what it finds unowned. The id cannot be disambiguated without renaming every persisted
+ * queue on upgrade, so the configuration is rejected instead — loudly, naming both subscriptions,
+ * with nothing cleared.
+ */
+class BridgeMqttClientForwarderIdTest {
+
+    private static final @NotNull String BRIDGE_ID = "plant-bridge";
+
+    private static @NotNull LocalSubscription subscription(
+            final @NotNull List<String> filters, final @Nullable String destination) {
+        return new LocalSubscription(filters, destination);
+    }
+
+    private static @NotNull MqttBridge bridge(final @NotNull List<LocalSubscription> localSubscriptions) {
+        return new MqttBridge.Builder()
+                .withId(BRIDGE_ID)
+                .withHost("remote.example.com")
+                .withPort(1883)
+                .withClientId(BRIDGE_ID + "-client")
+                .withLocalSubscriptions(localSubscriptions)
+                .withRemoteSubscriptions(List.of())
+                .build();
+    }
+
+    private static @NotNull BridgeMqttClient client(final @NotNull MqttBridge bridge) {
+        return new BridgeMqttClient(
+                mock(SystemInformation.class),
+                bridge,
+                mock(BridgeInterceptorHandler.class),
+                new HivemqId(),
+                new MetricRegistry(),
+                mock(EventService.class));
+    }
+
+    /** The customer-shaped case: distinct subscriptions, one of them hashing to an id with a '/'. */
+    @Test
+    void verifyForwarderIdsAreUnique_whenSubscriptionsAreDistinct_thenAccepted() {
+        final MqttBridge bridge = bridge(List.of(
+                subscription(List.of("miele/v1/production/sapdm/dev/+/+/from-plc-to-dm"), "remote/from-plc"),
+                subscription(List.of("plant/+/pressure", "plant/+/temperature"), "remote/readings"),
+                subscription(List.of("plant/+/alarms"), "remote/alarms")));
+
+        assertDoesNotThrow(() -> BridgeMqttClient.verifyForwarderIdsAreUnique(bridge));
+        assertEquals(3, client(bridge).createForwarders().size());
+    }
+
+    /**
+     * The collision itself. Both subscriptions are live at once — a bridge builds one forwarder per
+     * local subscription — so this is not a re-registration, and neither of the two can be dropped in
+     * favour of the other.
+     */
+    @Test
+    void verifyForwarderIdsAreUnique_whenFilterConcatenationsCollide_thenRejected() {
+        final LocalSubscription first = subscription(List.of("ab", "c"), "remote/dest");
+        final LocalSubscription second = subscription(List.of("a", "bc"), "remote/dest");
+        assertEquals(
+                first.calculateUniqueId(),
+                second.calculateUniqueId(),
+                "the premise of this test: the two subscriptions collide");
+
+        final IllegalStateException rejected = assertThrows(
+                IllegalStateException.class,
+                () -> BridgeMqttClient.verifyForwarderIdsAreUnique(bridge(List.of(first, second))));
+
+        // the operator has to be able to find both offending subscriptions from the message alone
+        final String message = rejected.getMessage();
+        assertTrue(message.contains(BRIDGE_ID), message);
+        assertTrue(message.contains("[ab, c]"), message);
+        assertTrue(message.contains("[a, bc]"), message);
+        assertTrue(message.contains(BRIDGE_ID + "-" + first.calculateUniqueId()), message);
+    }
+
+    /** The rejection has to happen before any forwarder is built, registered or started. */
+    @Test
+    void createForwarders_whenFilterConcatenationsCollide_thenRejectedAndNothingIsCreated() {
+        final BridgeMqttClient client = client(bridge(List.of(
+                subscription(List.of("ab", "c"), "remote/dest"), subscription(List.of("a", "bc"), "remote/dest"))));
+
+        assertThrows(IllegalStateException.class, client::createForwarders);
+        assertEquals(List.of(), client.getActiveForwarders(), "a rejected bridge must hold no forwarders");
+    }
+
+    /**
+     * A subscription duplicated in the configuration. The two own exactly the same queues, so today
+     * both forwarders poll them and every message is forwarded twice; removing either stops both.
+     * Rejecting is the same answer as for any other collision, and the fix is to delete one block.
+     */
+    @Test
+    void verifyForwarderIdsAreUnique_whenASubscriptionIsDuplicated_thenRejected() {
+        final LocalSubscription sub = subscription(List.of("plant/+/temperature"), "remote/readings");
+
+        assertThrows(
+                IllegalStateException.class,
+                () -> BridgeMqttClient.verifyForwarderIdsAreUnique(
+                        bridge(List.of(sub, subscription(List.of("plant/+/temperature"), "remote/readings")))));
+    }
+
+    /**
+     * The id sorts the filters before digesting them, so a subscription repeated with its filters in
+     * another order is the same subscription as far as queue ownership is concerned — and collides.
+     * (It compares unequal under {@code LocalSubscription.equals}, which is EDG-884's remaining
+     * order-sensitivity, tracked as F-07; it does not change the answer here.)
+     */
+    @Test
+    void verifyForwarderIdsAreUnique_whenFiltersAreOnlyReordered_thenRejected() {
+        assertThrows(
+                IllegalStateException.class,
+                () -> BridgeMqttClient.verifyForwarderIdsAreUnique(bridge(List.of(
+                        subscription(List.of("plant/+/pressure", "plant/+/temperature"), "remote/readings"),
+                        subscription(List.of("plant/+/temperature", "plant/+/pressure"), "remote/readings")))));
+    }
+
+    /**
+     * The destination is part of the digest, so filter sets that would otherwise collide do not when
+     * they forward somewhere else. Rejecting these too would fail configurations that are perfectly
+     * unambiguous.
+     */
+    @Test
+    void verifyForwarderIdsAreUnique_whenCollidingFiltersHaveDifferentDestinations_thenAccepted() {
+        assertDoesNotThrow(() -> BridgeMqttClient.verifyForwarderIdsAreUnique(bridge(List.of(
+                subscription(List.of("ab", "c"), "remote/one"), subscription(List.of("a", "bc"), "remote/two")))));
+    }
+
+    /**
+     * Subscriptions that differ only in a field outside the digest — excludes, user properties, QoS,
+     * retain handling, queue limit — still collide, because the id is what names the queues. They
+     * would forward the same messages under two different rule sets from one set of queues.
+     */
+    @Test
+    void verifyForwarderIdsAreUnique_whenOnlyNonIdentityFieldsDiffer_thenRejected() {
+        final List<String> filters = List.of("plant/+/temperature");
+        assertThrows(
+                IllegalStateException.class,
+                () -> BridgeMqttClient.verifyForwarderIdsAreUnique(bridge(List.of(
+                        new LocalSubscription(filters, "remote/readings", List.of(), List.of(), false, 1, null),
+                        new LocalSubscription(
+                                filters,
+                                "remote/readings",
+                                List.of("plant/ignored/temperature"),
+                                List.of(CustomUserProperty.of("k", "v")),
+                                true,
+                                2,
+                                1000L)))));
+    }
+
+    /** A null destination is a legal configuration and must not collide with a named one. */
+    @Test
+    void verifyForwarderIdsAreUnique_whenDestinationIsNull_thenTreatedAsAnyOther() {
+        assertDoesNotThrow(() -> BridgeMqttClient.verifyForwarderIdsAreUnique(bridge(List.of(
+                subscription(List.of("plant/+/temperature"), null),
+                subscription(List.of("plant/+/temperature"), "remote/readings")))));
+
+        assertThrows(
+                IllegalStateException.class,
+                () -> BridgeMqttClient.verifyForwarderIdsAreUnique(bridge(List.of(
+                        subscription(List.of("plant/+/temperature"), null),
+                        subscription(List.of("plant/+/temperature"), null)))));
+    }
+
+    /**
+     * A subscription without filters digests the destination alone, so two of them collide. Degenerate
+     * but reachable through the API, and it must not slip through for want of anything to hash.
+     */
+    @Test
+    void verifyForwarderIdsAreUnique_whenSubscriptionsHaveNoFilters_thenStillChecked() {
+        assertDoesNotThrow(() -> BridgeMqttClient.verifyForwarderIdsAreUnique(
+                bridge(List.of(subscription(List.of(), "remote/one"), subscription(List.of(), "remote/two")))));
+
+        assertThrows(
+                IllegalStateException.class,
+                () -> BridgeMqttClient.verifyForwarderIdsAreUnique(
+                        bridge(List.of(subscription(List.of(), "remote/one"), subscription(List.of(), "remote/one")))));
+    }
+
+    /** Nothing to compare: the empty and single-subscription cases must not be made to fail. */
+    @Test
+    void verifyForwarderIdsAreUnique_whenFewerThanTwoSubscriptions_thenAccepted() {
+        assertDoesNotThrow(() -> BridgeMqttClient.verifyForwarderIdsAreUnique(bridge(List.of())));
+        assertDoesNotThrow(() -> BridgeMqttClient.verifyForwarderIdsAreUnique(
+                bridge(List.of(subscription(List.of("plant/+/temperature"), "remote/readings")))));
+    }
+
+    /**
+     * Uniqueness is required within a bridge, not across bridges. The bridge id prefixes the digest,
+     * so the same subscription on two bridges owns two distinct sets of queues; failing that
+     * configuration would break every deployment that fans one topic out to two remotes.
+     */
+    @Test
+    void verifyForwarderIdsAreUnique_whenTheSameSubscriptionIsOnTwoBridges_thenAccepted() {
+        final LocalSubscription sub = subscription(List.of("plant/+/temperature"), "remote/readings");
+        final MqttBridge other = new MqttBridge.Builder()
+                .withId("other-bridge")
+                .withHost("other.example.com")
+                .withPort(1883)
+                .withClientId("other-bridge-client")
+                .withLocalSubscriptions(List.of(sub))
+                .withRemoteSubscriptions(List.of())
+                .build();
+
+        assertDoesNotThrow(() -> BridgeMqttClient.verifyForwarderIdsAreUnique(bridge(List.of(sub))));
+        assertDoesNotThrow(() -> BridgeMqttClient.verifyForwarderIdsAreUnique(other));
+        assertEquals(
+                1,
+                client(other).createForwarders().stream()
+                        .map(MqttForwarder::getId)
+                        .filter(id -> id.startsWith("other-bridge-"))
+                        .count());
+    }
+
+    /**
+     * The three subscriptions collide pairwise; the first two are enough to reject, and the message
+     * must name the pair it found rather than a summary the operator cannot act on.
+     */
+    @Test
+    void verifyForwarderIdsAreUnique_whenMoreThanTwoCollide_thenRejectedNamingAPair() {
+        final IllegalStateException rejected = assertThrows(
+                IllegalStateException.class,
+                () -> BridgeMqttClient.verifyForwarderIdsAreUnique(bridge(List.of(
+                        subscription(List.of("ab", "c"), "remote/dest"),
+                        subscription(List.of("a", "bc"), "remote/dest"),
+                        subscription(List.of("abc"), "remote/dest")))));
+
+        assertTrue(rejected.getMessage().contains("[ab, c]"), rejected.getMessage());
+        assertTrue(rejected.getMessage().contains("[a, bc]"), rejected.getMessage());
+    }
+}

--- a/hivemq-edge/src/test/java/com/hivemq/configuration/reader/AclComparisonFixture.java
+++ b/hivemq-edge/src/test/java/com/hivemq/configuration/reader/AclComparisonFixture.java
@@ -1,0 +1,228 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.configuration.reader;
+
+import java.nio.file.attribute.AclEntry;
+import java.nio.file.attribute.AclEntryFlag;
+import java.nio.file.attribute.AclEntryPermission;
+import java.nio.file.attribute.AclEntryType;
+import java.nio.file.attribute.UserPrincipal;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * The principals, permissions and entry shapes the ACL comparison tests are written in terms of, and the
+ * generator the exhaustive pass draws its universe from.
+ * <p>
+ * Three principals is not an arbitrary size. A witness that one list grants more than another needs at most
+ * two — the principal whose entry decided it one way and the principal whose entry decided it the other —
+ * so a universe of three carries every witness shape plus one principal that takes no part, which is what
+ * catches a rule that accidentally depends on a principal being named at all.
+ */
+final class AclComparisonFixture {
+
+    private AclComparisonFixture() {}
+
+    /** The account the node runs as: the owner of the file being written, in every test here. */
+    static final @NotNull UserPrincipal EDGE = new Principal("edge");
+
+    /** A user who is a member of {@link #ADMINISTRATORS} — asserted nowhere, because it cannot be. */
+    static final @NotNull UserPrincipal ALICE = new Principal("alice");
+
+    /** A group. Indistinguishable from a user through this API, which is the point of review v06. */
+    static final @NotNull UserPrincipal ADMINISTRATORS = new Principal("Administrators");
+
+    /** A fourth identity, named by nothing in most tests: the one that must change no answer. */
+    static final @NotNull UserPrincipal SYSTEM = new Principal("SYSTEM");
+
+    static final @NotNull List<UserPrincipal> PRINCIPALS = List.of(EDGE, ALICE, ADMINISTRATORS);
+
+    /**
+     * Four identities, for the pass that tests the claim the whole implementation rests on. A witness needs
+     * at most two principals; with four in play and every subset of them presented as a token, an
+     * implementation that needed three would be caught here and nowhere else.
+     */
+    static final @NotNull List<UserPrincipal> FOUR_PRINCIPALS = List.of(EDGE, ALICE, ADMINISTRATORS, SYSTEM);
+
+    static final @NotNull Set<AclEntryPermission> READ = Set.of(AclEntryPermission.READ_DATA);
+    static final @NotNull Set<AclEntryPermission> WRITE = Set.of(AclEntryPermission.WRITE_DATA);
+    static final @NotNull Set<AclEntryPermission> READ_WRITE =
+            Set.of(AclEntryPermission.READ_DATA, AclEntryPermission.WRITE_DATA);
+
+    /** The permission bits an access check is run for. Every entry below is built out of these two. */
+    static final @NotNull List<AclEntryPermission> BITS =
+            List.of(AclEntryPermission.READ_DATA, AclEntryPermission.WRITE_DATA);
+
+    static @NotNull AclEntry allow(
+            final @NotNull UserPrincipal principal, final @NotNull Set<AclEntryPermission> permissions) {
+        return entry(AclEntryType.ALLOW, principal, permissions);
+    }
+
+    static @NotNull AclEntry deny(
+            final @NotNull UserPrincipal principal, final @NotNull Set<AclEntryPermission> permissions) {
+        return entry(AclEntryType.DENY, principal, permissions);
+    }
+
+    static @NotNull AclEntry entry(
+            final @NotNull AclEntryType type,
+            final @NotNull UserPrincipal principal,
+            final @NotNull Set<AclEntryPermission> permissions) {
+        return AclEntry.newBuilder()
+                .setType(type)
+                .setPrincipal(principal)
+                .setPermissions(permissions)
+                .build();
+    }
+
+    /** The same entry, marked as not applying to the object that carries it. */
+    static @NotNull AclEntry inheritOnly(final @NotNull AclEntry entry) {
+        return AclEntry.newBuilder(entry)
+                .setFlags(AclEntryFlag.INHERIT_ONLY, AclEntryFlag.FILE_INHERIT)
+                .build();
+    }
+
+    /** The entry types that decide access. */
+    static final @NotNull List<AclEntryType> DECIDING_TYPES = List.of(AclEntryType.ALLOW, AclEntryType.DENY);
+
+    /**
+     * Every entry type there is. The two that grant nothing are not decoration in a generated universe:
+     * an audit entry read as a decision would sit in front of the allow behind it and hide it, so a list
+     * that grants access would look like one that grants none.
+     */
+    static final @NotNull List<AclEntryType> ALL_TYPES =
+            List.of(AclEntryType.ALLOW, AclEntryType.DENY, AclEntryType.AUDIT, AclEntryType.ALARM);
+
+    /**
+     * Every entry that can be built from the given principals, types, permission sets and the two states of
+     * {@code INHERIT_ONLY}: the alphabet the exhaustive pass forms its lists over.
+     */
+    static @NotNull List<AclEntry> alphabet(
+            final @NotNull List<UserPrincipal> principals,
+            final @NotNull List<Set<AclEntryPermission>> permissionSets) {
+        return alphabet(principals, DECIDING_TYPES, permissionSets);
+    }
+
+    static @NotNull List<AclEntry> alphabet(
+            final @NotNull List<UserPrincipal> principals,
+            final @NotNull List<AclEntryType> types,
+            final @NotNull List<Set<AclEntryPermission>> permissionSets) {
+        final List<AclEntry> alphabet = new ArrayList<>();
+        for (final UserPrincipal principal : principals) {
+            for (final AclEntryType type : types) {
+                for (final Set<AclEntryPermission> permissions : permissionSets) {
+                    final AclEntry plain = entry(type, principal, permissions);
+                    alphabet.add(plain);
+                    alphabet.add(inheritOnly(plain));
+                }
+            }
+        }
+        return List.copyOf(alphabet);
+    }
+
+    /** Every list of up to {@code maxLength} entries drawn from an alphabet, the empty list included. */
+    static @NotNull List<List<AclEntry>> listsUpTo(final @NotNull List<AclEntry> alphabet, final int maxLength) {
+        final List<List<AclEntry>> lists = new ArrayList<>();
+        lists.add(List.of());
+        List<List<AclEntry>> previous = List.of(List.of());
+        for (int length = 1; length <= maxLength; length++) {
+            final List<List<AclEntry>> current = new ArrayList<>(previous.size() * alphabet.size());
+            for (final List<AclEntry> prefix : previous) {
+                for (final AclEntry entry : alphabet) {
+                    final List<AclEntry> extended = new ArrayList<>(prefix.size() + 1);
+                    extended.addAll(prefix);
+                    extended.add(entry);
+                    current.add(List.copyOf(extended));
+                }
+            }
+            lists.addAll(current);
+            previous = current;
+        }
+        return lists;
+    }
+
+    /**
+     * The same list with every principal renamed through a bijection. Who the principals are carries no
+     * meaning to a comparison that cannot look any of them up, so the answer has to survive this.
+     */
+    static @NotNull List<AclEntry> renamePrincipals(
+            final @NotNull List<AclEntry> acl, final @NotNull Map<UserPrincipal, UserPrincipal> renaming) {
+        return acl.stream()
+                .map(entry -> AclEntry.newBuilder(entry)
+                        .setPrincipal(renaming.getOrDefault(entry.principal(), entry.principal()))
+                        .build())
+                .toList();
+    }
+
+    /**
+     * The same list with every permission bit swapped for another through a bijection. No bit is special —
+     * a read is compared the same way as a change of owner — so the answer has to survive this too.
+     */
+    static @NotNull List<AclEntry> renamePermissions(
+            final @NotNull List<AclEntry> acl, final @NotNull Map<AclEntryPermission, AclEntryPermission> renaming) {
+        return acl.stream()
+                .map(entry -> {
+                    final Set<AclEntryPermission> renamed = entry.permissions().stream()
+                            .map(permission -> renaming.getOrDefault(permission, permission))
+                            .collect(Collectors.toCollection(() -> EnumSet.noneOf(AclEntryPermission.class)));
+                    return AclEntry.newBuilder(entry).setPermissions(renamed).build();
+                })
+                .toList();
+    }
+
+    /**
+     * The list as it looks to an access check for one permission: the entries that mention that bit, in
+     * order, with everything else about them left alone.
+     */
+    static @NotNull List<AclEntry> project(final @NotNull List<AclEntry> acl, final @NotNull AclEntryPermission bit) {
+        return acl.stream()
+                .filter(entry -> entry.permissions().contains(bit))
+                .map(entry ->
+                        AclEntry.newBuilder(entry).setPermissions(Set.of(bit)).build())
+                .toList();
+    }
+
+    /** A handful of lists of every shape the tests talk about, for properties that hold of all of them. */
+    static @NotNull List<List<AclEntry>> assortedLists() {
+        return List.of(
+                List.of(),
+                List.of(allow(EDGE, READ_WRITE)),
+                List.of(allow(EDGE, READ), allow(EDGE, WRITE)),
+                List.of(deny(ALICE, READ), allow(ADMINISTRATORS, READ)),
+                List.of(allow(ADMINISTRATORS, READ), deny(ALICE, READ)),
+                List.of(inheritOnly(allow(ALICE, READ_WRITE))),
+                List.of(allow(EDGE, READ_WRITE), inheritOnly(allow(ADMINISTRATORS, READ)), deny(ALICE, WRITE)),
+                List.of(deny(EDGE, READ), allow(EDGE, READ_WRITE), allow(ALICE, READ)));
+    }
+
+    /** A principal whose identity is its name, which is all the comparison treats it as. */
+    private record Principal(@NotNull String name) implements UserPrincipal {
+
+        @Override
+        public @NotNull String getName() {
+            return name;
+        }
+
+        @Override
+        public @NotNull String toString() {
+            return name;
+        }
+    }
+}

--- a/hivemq-edge/src/test/java/com/hivemq/configuration/reader/AclComparisonOracleTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/configuration/reader/AclComparisonOracleTest.java
@@ -1,0 +1,499 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.configuration.reader;
+
+import static com.hivemq.configuration.reader.AclComparisonFixture.ADMINISTRATORS;
+import static com.hivemq.configuration.reader.AclComparisonFixture.ALICE;
+import static com.hivemq.configuration.reader.AclComparisonFixture.BITS;
+import static com.hivemq.configuration.reader.AclComparisonFixture.EDGE;
+import static com.hivemq.configuration.reader.AclComparisonFixture.PRINCIPALS;
+import static com.hivemq.configuration.reader.AclComparisonFixture.READ;
+import static com.hivemq.configuration.reader.AclComparisonFixture.READ_WRITE;
+import static com.hivemq.configuration.reader.AclComparisonFixture.WRITE;
+import static com.hivemq.configuration.reader.AclComparisonFixture.allow;
+import static com.hivemq.configuration.reader.AclComparisonFixture.alphabet;
+import static com.hivemq.configuration.reader.AclComparisonFixture.deny;
+import static com.hivemq.configuration.reader.AclComparisonFixture.inheritOnly;
+import static com.hivemq.configuration.reader.AclComparisonFixture.listsUpTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.nio.file.attribute.AclEntry;
+import java.nio.file.attribute.AclEntryFlag;
+import java.nio.file.attribute.AclEntryPermission;
+import java.nio.file.attribute.AclEntryType;
+import java.nio.file.attribute.UserPrincipal;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+
+/**
+ * EDG-882 — the part that closes the class of defect rather than the three instances of it.
+ * <p>
+ * Reviews v04, v05 and v06 each supplied one more clause of the access-check specification, and each had to
+ * arrive from outside, because nothing here could produce the next one. The code path exists for NTFS and
+ * for Solaris ZFS, {@code AclFileAttributeView} is not provided on Linux or macOS, and every workflow in
+ * this repository runs on Ubuntu — so no test that goes near a real file can be the thing that catches it.
+ * <p>
+ * This is the thing that catches it. {@link #grantedBy} is the access check itself, written straight from
+ * MS-DTYP §2.5.3.2 and RFC 7530 §6.2.1: walk the list in order, and the first entry that applies to the
+ * object, names an identity the requester holds and mentions the permission being asked for settles it.
+ * A requester's identities are given to it explicitly as a token, so <em>every</em> arrangement of users and
+ * groups is covered by enumerating every token — which is exactly the thing {@code java.nio} refuses to tell
+ * us, and the reason the previous implementation had to guess at it.
+ * <p>
+ * {@link AclComparison#grantsNoMoreThan} is then asserted to agree with that oracle <b>exactly</b>, over an
+ * exhaustively generated universe of lists: not merely to be safe where the oracle is safe, but to accept
+ * precisely what the oracle accepts. Soundness would leave room for a v07 that reports a widening we let
+ * through; exactness leaves none, and the other direction — refusing a write that discloses nothing — is
+ * what review v04's finding 2.1 was, so it is worth pinning too.
+ * <p>
+ * The two algorithms are unrelated: the oracle quantifies over tokens, the implementation over pairs of
+ * principals. They agree because a witness never needs more than two identities, which is the observation
+ * the implementation is built on and this is the proof of.
+ */
+public class AclComparisonOracleTest {
+
+    /**
+     * The access check, for one requester and one permission bit.
+     * <p>
+     * The requester is a token: the set of identities they hold, their own and every group they belong to,
+     * which is what both specifications match entries against. Entries that do not decide access to this
+     * object take no part — audit and alarm entries grant nothing, and {@code INHERIT_ONLY} says the entry
+     * does not apply to the object carrying it. A list with no entry that applies grants nothing.
+     */
+    private static boolean grantedBy(
+            final @NotNull List<AclEntry> acl,
+            final @NotNull Set<UserPrincipal> token,
+            final @NotNull AclEntryPermission bit) {
+        for (final AclEntry entry : acl) {
+            if (entry.type() != AclEntryType.ALLOW && entry.type() != AclEntryType.DENY) {
+                continue;
+            }
+            if (entry.flags().contains(AclEntryFlag.INHERIT_ONLY)) {
+                continue;
+            }
+            if (!token.contains(entry.principal())) {
+                continue;
+            }
+            if (!entry.permissions().contains(bit)) {
+                continue;
+            }
+            return entry.type() == AclEntryType.ALLOW;
+        }
+        return false;
+    }
+
+    /** Every token that can be formed from the principals in play — every membership arrangement at once. */
+    private static @NotNull List<Set<UserPrincipal>> everyToken(final @NotNull List<UserPrincipal> principals) {
+        final List<Set<UserPrincipal>> tokens = new ArrayList<>(1 << principals.size());
+        for (int bits = 0; bits < (1 << principals.size()); bits++) {
+            final Set<UserPrincipal> token = new LinkedHashSet<>();
+            for (int index = 0; index < principals.size(); index++) {
+                if ((bits & (1 << index)) != 0) {
+                    token.add(principals.get(index));
+                }
+            }
+            tokens.add(Set.copyOf(token));
+        }
+        return tokens;
+    }
+
+    /**
+     * What a list grants, as one bit per (token, permission) pair — everything about a list that an access
+     * check can observe, in a {@code long}.
+     * <p>
+     * With this, "grants no more than" is one machine instruction: {@code candidate} grants nothing
+     * {@code reference} does not exactly when {@code candidate & ~reference} is zero.
+     */
+    private static long profile(
+            final @NotNull List<AclEntry> acl,
+            final @NotNull List<Set<UserPrincipal>> tokens,
+            final @NotNull List<AclEntryPermission> bits) {
+        long profile = 0;
+        int position = 0;
+        for (final Set<UserPrincipal> token : tokens) {
+            for (final AclEntryPermission bit : bits) {
+                if (grantedBy(acl, token, bit)) {
+                    profile |= 1L << position;
+                }
+                position++;
+            }
+        }
+        return profile;
+    }
+
+    // -------------------------------------------------------------------- the oracle, checked by hand first
+
+    /**
+     * The oracle is the yardstick for everything below, so it is worth a handful of cases whose answer can
+     * be read off the specification without running anything.
+     */
+    @Test
+    public void theOracleImplementsTheAccessCheck() {
+        final List<AclEntry> denyThenAllow = List.of(deny(ALICE, READ), allow(ADMINISTRATORS, READ));
+        final List<AclEntry> allowThenDeny = List.of(allow(ADMINISTRATORS, READ), deny(ALICE, READ));
+        final Set<UserPrincipal> aliceTheAdministrator = Set.of(ALICE, ADMINISTRATORS);
+
+        assertFalse(
+                grantedBy(denyThenAllow, aliceTheAdministrator, AclEntryPermission.READ_DATA),
+                "her own denial comes first and settles the read");
+        assertTrue(
+                grantedBy(allowThenDeny, aliceTheAdministrator, AclEntryPermission.READ_DATA),
+                "the group's allow comes first and settles it the other way");
+        assertFalse(
+                grantedBy(allowThenDeny, Set.of(ALICE), AclEntryPermission.READ_DATA),
+                "someone who is not an administrator meets only the denial");
+        assertFalse(
+                grantedBy(List.of(allow(EDGE, READ_WRITE)), Set.of(ALICE), AclEntryPermission.READ_DATA),
+                "a list that names nobody in the token grants nothing");
+        assertFalse(
+                grantedBy(List.of(inheritOnly(allow(ALICE, READ))), Set.of(ALICE), AclEntryPermission.READ_DATA),
+                "an entry that does not apply to the object decides nothing about it");
+        assertFalse(
+                grantedBy(List.of(allow(ALICE, READ)), Set.of(ALICE), AclEntryPermission.WRITE_DATA),
+                "an entry that does not mention the permission decides nothing about it");
+    }
+
+    // --------------------------------------------------------------------------------- exhaustive agreement
+
+    /**
+     * Every list of up to two entries over the full alphabet — three principals, both types, all three
+     * non-empty permission masks, both states of {@code INHERIT_ONLY} — against every other, which is a
+     * little under two million pairs.
+     */
+    @Test
+    public void agreesWithTheOracleOnEveryShortListOverTheFullAlphabet() {
+        assertAgreementOver(listsUpTo(alphabet(PRINCIPALS, List.of(READ, WRITE, READ_WRITE)), 2));
+    }
+
+    /**
+     * The same, traded the other way: one permission bit, so that lists can be a third longer without the
+     * universe exploding. Order and shadowing need length to go wrong, and this is where three entries deep
+     * gets covered.
+     */
+    @Test
+    public void agreesWithTheOracleOnEveryLongerSinglePermissionList() {
+        assertAgreementOver(listsUpTo(alphabet(PRINCIPALS, List.of(READ)), 3));
+    }
+
+    /**
+     * Every list of up to two entries over an alphabet that also contains the two types which grant nothing.
+     * <p>
+     * They are not decoration. An audit entry mistaken for a decision sits in front of the allow behind it
+     * and hides it, so a replacement that grants a principal access looks like one that grants none and the
+     * write is let through — a widening accepted, not merely a safe write refused. The permission alphabet
+     * is one bit here to pay for the extra types.
+     */
+    @Test
+    public void agreesWithTheOracleOnListsThatGrantNothing() {
+        assertAgreementOver(listsUpTo(alphabet(PRINCIPALS, AclComparisonFixture.ALL_TYPES, List.of(READ)), 2));
+    }
+
+    /**
+     * And beyond what can be enumerated: lists of up to eight entries over every type and every mask, drawn
+     * deterministically so a failure is reproducible from the seed alone. Nothing here is expected to fail
+     * that the exhaustive passes would not have caught, which is the claim being tested — that the small
+     * universes above are not small enough to be hiding anything.
+     */
+    @Test
+    public void agreesWithTheOracleOnDeeperRandomLists() {
+        final List<AclEntry> alphabet =
+                alphabet(PRINCIPALS, AclComparisonFixture.ALL_TYPES, List.of(READ, WRITE, READ_WRITE));
+        final List<Set<UserPrincipal>> tokens = everyToken(PRINCIPALS);
+        final Random random = new Random(882L);
+
+        for (int iteration = 0; iteration < 200_000; iteration++) {
+            final List<AclEntry> candidate = randomList(alphabet, random);
+            final List<AclEntry> reference = randomList(alphabet, random);
+            assertAgreement(candidate, reference, profile(candidate, tokens, BITS), profile(reference, tokens, BITS));
+        }
+    }
+
+    /**
+     * The claim the whole implementation rests on, tested where it could actually fail.
+     * <p>
+     * A witness needs at most two principals, so the implementation tries pairs and never triples. With
+     * three identities in play that is nearly vacuous — a pair is most of a triple. This pass puts four in
+     * play and presents all sixteen subsets of them as tokens, so an implementation that in fact needed
+     * three identities to see a widening would be caught here, and here only.
+     */
+    @Test
+    public void agreesWithTheOracleWithAFourthIdentityInPlay() {
+        assertAgreementOver(
+                listsUpTo(alphabet(AclComparisonFixture.FOUR_PRINCIPALS, List.of(READ, WRITE, READ_WRITE)), 2),
+                AclComparisonFixture.FOUR_PRINCIPALS);
+    }
+
+    private static @NotNull List<AclEntry> randomList(
+            final @NotNull List<AclEntry> alphabet, final @NotNull Random random) {
+        final int length = random.nextInt(9);
+        final List<AclEntry> acl = new ArrayList<>(length);
+        for (int index = 0; index < length; index++) {
+            acl.add(alphabet.get(random.nextInt(alphabet.size())));
+        }
+        return List.copyOf(acl);
+    }
+
+    // ------------------------------------------------------------------------------ algebraic properties
+
+    /**
+     * Who the principals are carries no meaning to a comparison that cannot look any of them up, so renaming
+     * every one of them through a bijection must change no answer.
+     * <p>
+     * What this catches is an accidental dependence on identity rather than on structure — a set iterated in
+     * hash order deciding which pair is tried first, a principal treated specially because it happens to be
+     * the one the tests call the owner.
+     */
+    @Test
+    public void theAnswerDoesNotDependOnWhoThePrincipalsAre() {
+        final Map<UserPrincipal, UserPrincipal> rotated =
+                Map.of(EDGE, ALICE, ALICE, ADMINISTRATORS, ADMINISTRATORS, AclComparisonFixture.SYSTEM);
+
+        forRandomPairs((candidate, reference) -> assertEquals(
+                AclComparison.grantsNoMoreThan(candidate, reference),
+                AclComparison.grantsNoMoreThan(
+                        AclComparisonFixture.renamePrincipals(candidate, rotated),
+                        AclComparisonFixture.renamePrincipals(reference, rotated)),
+                () -> "renaming the principals changed the answer for " + render(candidate) + " against "
+                        + render(reference)));
+    }
+
+    /**
+     * And no permission bit is special either. The two the tests are written in terms of are a read and a
+     * write because those are what a configuration file discloses, but the comparison never mentions them:
+     * swapping them for the two bits that decide who may take the file over must change no answer.
+     */
+    @Test
+    public void theAnswerDoesNotDependOnWhichPermissionBitsAreUsed() {
+        final Map<AclEntryPermission, AclEntryPermission> swapped = Map.of(
+                AclEntryPermission.READ_DATA, AclEntryPermission.WRITE_OWNER,
+                AclEntryPermission.WRITE_DATA, AclEntryPermission.WRITE_ACL);
+
+        forRandomPairs((candidate, reference) -> assertEquals(
+                AclComparison.grantsNoMoreThan(candidate, reference),
+                AclComparison.grantsNoMoreThan(
+                        AclComparisonFixture.renamePermissions(candidate, swapped),
+                        AclComparisonFixture.renamePermissions(reference, swapped)),
+                () -> "renaming the permissions changed the answer for " + render(candidate) + " against "
+                        + render(reference)));
+    }
+
+    /**
+     * Both specifications settle one permission bit at a time, and the implementation says so in its shape.
+     * This is that claim on its own: judging two lists whole gives the same answer as judging each bit's
+     * slice of them separately and taking every answer together.
+     */
+    @Test
+    public void oneBitAtATimeIsTheSameAsAllBitsAtOnce() {
+        forRandomPairs((candidate, reference) -> {
+            boolean bitByBit = true;
+            for (final AclEntryPermission bit : BITS) {
+                bitByBit &= AclComparison.grantsNoMoreThan(
+                        AclComparisonFixture.project(candidate, bit), AclComparisonFixture.project(reference, bit));
+            }
+            assertEquals(
+                    AclComparison.grantsNoMoreThan(candidate, reference),
+                    bitByBit,
+                    () -> "the bits do not decide independently for " + render(candidate) + " against "
+                            + render(reference));
+        });
+    }
+
+    /**
+     * "Grants no more than" orders lists, so it has to be transitive: a replacement no wider than the file it
+     * replaces, which is itself no wider than what an operator set, is no wider than what the operator set.
+     * <p>
+     * The write path leans on this without saying so — the partial file is judged against the target, then
+     * the written file is judged again — and a comparison that was merely nearly right would be free to
+     * break it.
+     */
+    @Test
+    public void theRelationIsTransitive() {
+        final List<AclEntry> alphabet =
+                alphabet(PRINCIPALS, AclComparisonFixture.ALL_TYPES, List.of(READ, WRITE, READ_WRITE));
+        final Random random = new Random(884L);
+        final List<List<AclEntry>> sample = new ArrayList<>(150);
+        for (int index = 0; index < 150; index++) {
+            sample.add(randomList(alphabet, random));
+        }
+
+        final boolean[][] noWiderThan = new boolean[sample.size()][sample.size()];
+        for (int one = 0; one < sample.size(); one++) {
+            for (int other = 0; other < sample.size(); other++) {
+                noWiderThan[one][other] = AclComparison.grantsNoMoreThan(sample.get(one), sample.get(other));
+            }
+        }
+        for (int a = 0; a < sample.size(); a++) {
+            assertTrue(noWiderThan[a][a], () -> "not reflexive");
+            for (int b = 0; b < sample.size(); b++) {
+                if (!noWiderThan[a][b]) {
+                    continue;
+                }
+                for (int c = 0; c < sample.size(); c++) {
+                    if (noWiderThan[b][c] && !noWiderThan[a][c]) {
+                        final int first = a;
+                        final int second = b;
+                        final int third = c;
+                        fail(() -> "not transitive: " + render(sample.get(first)) + " is no wider than "
+                                + render(sample.get(second)) + ", which is no wider than "
+                                + render(sample.get(third)) + ", but the first is judged wider than the third");
+                    }
+                }
+            }
+        }
+    }
+
+    /** A deterministic sweep of list pairs, for the properties that hold whatever two lists are given. */
+    private static void forRandomPairs(final @NotNull PairAssertion assertion) {
+        final List<AclEntry> alphabet =
+                alphabet(PRINCIPALS, AclComparisonFixture.ALL_TYPES, List.of(READ, WRITE, READ_WRITE));
+        final Random random = new Random(883L);
+        for (int iteration = 0; iteration < 100_000; iteration++) {
+            assertion.check(randomList(alphabet, random), randomList(alphabet, random));
+        }
+    }
+
+    @FunctionalInterface
+    private interface PairAssertion {
+
+        void check(@NotNull List<AclEntry> candidate, @NotNull List<AclEntry> reference);
+    }
+
+    private static void assertAgreementOver(final @NotNull List<List<AclEntry>> lists) {
+        assertAgreementOver(lists, PRINCIPALS);
+    }
+
+    private static void assertAgreementOver(
+            final @NotNull List<List<AclEntry>> lists, final @NotNull List<UserPrincipal> principals) {
+        final List<Set<UserPrincipal>> tokens = everyToken(principals);
+        final long[] profiles = new long[lists.size()];
+        for (int index = 0; index < lists.size(); index++) {
+            profiles[index] = profile(lists.get(index), tokens, BITS);
+        }
+        for (int candidate = 0; candidate < lists.size(); candidate++) {
+            for (int reference = 0; reference < lists.size(); reference++) {
+                assertAgreement(lists.get(candidate), lists.get(reference), profiles[candidate], profiles[reference]);
+            }
+        }
+    }
+
+    private static void assertAgreement(
+            final @NotNull List<AclEntry> candidate,
+            final @NotNull List<AclEntry> reference,
+            final long candidateProfile,
+            final long referenceProfile) {
+        final boolean expected = (candidateProfile & ~referenceProfile) == 0;
+        if (AclComparison.grantsNoMoreThan(candidate, reference) != expected) {
+            fail((expected
+                            ? "refused a replacement that grants nobody anything the file it replaces does not"
+                            : "accepted a replacement that grants access the file it replaces does not")
+                    + "\n  candidate: " + render(candidate) + "\n  reference: " + render(reference));
+        }
+    }
+
+    private static @NotNull String render(final @NotNull List<AclEntry> acl) {
+        if (acl.isEmpty()) {
+            return "[]";
+        }
+        return acl.stream()
+                .map(entry -> entry.type()
+                        + " " + entry.principal().getName()
+                        + " "
+                        + entry.permissions().stream().map(Enum::name).sorted().collect(Collectors.joining("+"))
+                        + (entry.flags().contains(AclEntryFlag.INHERIT_ONLY) ? " (inherit-only)" : ""))
+                .collect(Collectors.joining(", ", "[", "]"));
+    }
+
+    // ------------------------------------------------- the reported findings, rediscovered rather than recited
+
+    /**
+     * A named regression test proves a fix. It does not prove the search that has to find the next one is
+     * wide enough to have found this one — so the shapes reviews v05 and v06 reported are asserted to be
+     * inside the exhaustively enumerated universe, and therefore to have been judged there against the
+     * oracle rather than only here against a hand-written expectation.
+     * <p>
+     * If a future change narrows the alphabet or the lengths, this is what says so.
+     */
+    @Test
+    public void theReportedFindingsAreInsideTheExhaustedUniverse() {
+        final List<List<AclEntry>> universe = listsUpTo(alphabet(PRINCIPALS, List.of(READ, WRITE, READ_WRITE)), 2);
+
+        final List<AclEntry> v06Candidate = List.of(allow(ADMINISTRATORS, READ), deny(ALICE, READ));
+        final List<AclEntry> v06Reference = List.of(deny(ALICE, READ), allow(ADMINISTRATORS, READ));
+        final List<AclEntry> v05Candidate = List.of(allow(ALICE, READ), deny(ALICE, READ));
+        final List<AclEntry> v05Reference = List.of(deny(ALICE, READ), allow(ALICE, READ));
+        final List<AclEntry> inheritOnlyCandidate = List.of(allow(ALICE, READ));
+        final List<AclEntry> inheritOnlyReference = List.of(inheritOnly(allow(ALICE, READ)));
+
+        assertTrue(universe.contains(v06Candidate), "review v06's replacement is not among the lists enumerated");
+        assertTrue(universe.contains(v06Reference), "review v06's target is not among the lists enumerated");
+        assertTrue(universe.contains(v05Candidate), "review v05's replacement is not among the lists enumerated");
+        assertTrue(universe.contains(v05Reference), "review v05's target is not among the lists enumerated");
+        assertTrue(universe.contains(inheritOnlyCandidate), "the INHERIT_ONLY replacement is not enumerated");
+        assertTrue(universe.contains(inheritOnlyReference), "the INHERIT_ONLY target is not enumerated");
+
+        // And that the oracle, independently of the implementation, calls them widenings.
+        final List<Set<UserPrincipal>> tokens = everyToken(PRINCIPALS);
+        assertFalse(
+                (profile(v06Candidate, tokens, BITS) & ~profile(v06Reference, tokens, BITS)) == 0,
+                "the oracle should see review v06's reorder as a widening");
+        assertFalse(
+                (profile(v05Candidate, tokens, BITS) & ~profile(v05Reference, tokens, BITS)) == 0,
+                "the oracle should see review v05's reorder as a widening");
+        assertFalse(
+                (profile(inheritOnlyCandidate, tokens, BITS) & ~profile(inheritOnlyReference, tokens, BITS)) == 0,
+                "the oracle should see a dropped INHERIT_ONLY as a widening");
+    }
+
+    /**
+     * The measurement review v04's finding 2.1 asks for: how often the comparison refuses a replacement that
+     * would in fact have disclosed nothing. A rule that refuses every write on a store that normalises is
+     * not a safeguard, and this is the number that says whether we have one.
+     * <p>
+     * It is zero, because the implementation is exact rather than conservative — but it is asserted here as
+     * a count over the whole universe rather than inferred from the agreement tests, so that a future change
+     * trading exactness for simplicity has to state what it cost.
+     */
+    @Test
+    public void nothingSafeIsRefused() {
+        final List<List<AclEntry>> lists = listsUpTo(alphabet(PRINCIPALS, List.of(READ, WRITE, READ_WRITE)), 2);
+        final List<Set<UserPrincipal>> tokens = everyToken(PRINCIPALS);
+        final long[] profiles = new long[lists.size()];
+        for (int index = 0; index < lists.size(); index++) {
+            profiles[index] = profile(lists.get(index), tokens, BITS);
+        }
+
+        long refusedButSafe = 0;
+        for (int candidate = 0; candidate < lists.size(); candidate++) {
+            for (int reference = 0; reference < lists.size(); reference++) {
+                if ((profiles[candidate] & ~profiles[reference]) == 0
+                        && !AclComparison.grantsNoMoreThan(lists.get(candidate), lists.get(reference))) {
+                    refusedButSafe++;
+                }
+            }
+        }
+        assertEquals(0L, refusedButSafe, "configuration writes refused that would have disclosed nothing");
+    }
+}

--- a/hivemq-edge/src/test/java/com/hivemq/configuration/reader/AclComparisonTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/configuration/reader/AclComparisonTest.java
@@ -29,8 +29,8 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 
 /**
- * EDG-882 review v04, finding 2.1 — the decision the ACL-only write path makes, taken apart from the file
- * store that provokes it.
+ * EDG-882 review v04 finding 2.1 and review v05 finding 1 — the decision the ACL-only write path makes,
+ * taken apart from the file store that provokes it.
  * <p>
  * Both ACL checks used to demand that the list read back be <em>equal</em> to the list set. That is a claim
  * about how a store represents an access-control list, not about who can read the file, and it is the
@@ -43,6 +43,11 @@ import org.junit.jupiter.api.Test;
  * all. This class is that answer: every shape a store might plausibly hand back, judged directly. What
  * remains untested off Windows is only what NTFS actually returns — and under this rule, any answer that
  * does not widen access is accepted.
+ * <p>
+ * The first version of that question was asked of the entries rather than of what they decide, which threw
+ * away the two things about an access-control list that are not decoration: the order the entries are
+ * evaluated in, and {@code INHERIT_ONLY}, which says an entry does not apply to the object carrying it.
+ * Both are exercised below, in both directions.
  */
 public class AclComparisonTest {
 
@@ -69,6 +74,13 @@ public class AclComparisonTest {
                 .setType(AclEntryType.DENY)
                 .setPrincipal(principal)
                 .setPermissions(permissions)
+                .build();
+    }
+
+    /** The same entry, marked as not applying to the object that carries it. */
+    private static @NotNull AclEntry inheritOnly(final @NotNull AclEntry entry) {
+        return AclEntry.newBuilder(entry)
+                .setFlags(AclEntryFlag.INHERIT_ONLY, AclEntryFlag.FILE_INHERIT)
                 .build();
     }
 
@@ -104,8 +116,9 @@ public class AclComparisonTest {
     }
 
     /**
-     * Nor are inheritance flags: they decide what a <em>directory</em> propagates to what is created inside
-     * it, and the file being written propagates to nothing.
+     * Nor are the propagation flags: they decide what a <em>directory</em> propagates to what is created
+     * inside it, and the file being written propagates to nothing. {@code INHERIT_ONLY} is not one of them
+     * — see below.
      */
     @Test
     public void inheritanceFlagsGrantNoMore() {
@@ -117,6 +130,75 @@ public class AclComparisonTest {
                 .build();
 
         assertTrue(grantsNoMoreThan(List.of(flagged), List.of(allow(EDGE, READ_WRITE))));
+    }
+
+    /**
+     * A denial the list can never reach, because an earlier entry has already allowed the permission, is
+     * worth nothing — so a list that puts the same denial where it does decide something is narrower, not
+     * wider.
+     */
+    @Test
+    public void movingADenialAheadOfItsAllowGrantsNoMore() {
+        assertTrue(grantsNoMoreThan(
+                List.of(deny(ALICE, READ), allow(ALICE, READ)), List.of(allow(ALICE, READ), deny(ALICE, READ))));
+    }
+
+    /** Which entry decides is settled one permission at a time, not one principal at a time. */
+    @Test
+    public void aDenialOfOnePermissionLeavesTheOthersToTheNextEntry() {
+        assertTrue(grantsNoMoreThan(
+                List.of(deny(ALICE, READ), allow(ALICE, READ_WRITE)),
+                List.of(deny(ALICE, READ), allow(ALICE, READ_WRITE))));
+        assertFalse(
+                grantsNoMoreThan(
+                        List.of(allow(ALICE, READ_WRITE)), List.of(deny(ALICE, READ), allow(ALICE, READ_WRITE))),
+                "the write survives the denial, the read does not");
+    }
+
+    /**
+     * An entry that does not apply to the file grants nothing on the file, so a list carrying one is no
+     * wider than the same list without it.
+     */
+    @Test
+    public void anInheritOnlyEntryGrantsNoMore() {
+        assertTrue(grantsNoMoreThan(
+                List.of(allow(EDGE, READ_WRITE), inheritOnly(allow(ALICE, READ))), List.of(allow(EDGE, READ_WRITE))));
+    }
+
+    /** And adding the flag to an entry that did apply narrows it to nothing. */
+    @Test
+    public void addingInheritOnlyGrantsNoMore() {
+        assertTrue(grantsNoMoreThan(List.of(inheritOnly(allow(ALICE, READ))), List.of(allow(ALICE, READ))));
+    }
+
+    // ------------------------------------------------- what order and INHERIT_ONLY must still refuse
+
+    /**
+     * The first of the two shapes review v05 named. A list is evaluated in order, so the entry that comes
+     * first settles the permission: {@code DENY} then {@code ALLOW} keeps Alice out, and the same two
+     * entries the other way round let her in. Nothing about the entries themselves changed.
+     */
+    @Test
+    public void movingAnAllowAheadOfItsDenialGrantsMore() {
+        assertFalse(grantsNoMoreThan(
+                List.of(allow(ALICE, READ), deny(ALICE, READ)), List.of(deny(ALICE, READ), allow(ALICE, READ))));
+    }
+
+    /**
+     * The second. {@code INHERIT_ONLY} says the entry does not apply to the object carrying it, so taking
+     * the flag off an entry hands its principal access to the file that the reference never gave.
+     */
+    @Test
+    public void removingInheritOnlyGrantsMore() {
+        assertFalse(grantsNoMoreThan(List.of(allow(ALICE, READ)), List.of(inheritOnly(allow(ALICE, READ)))));
+    }
+
+    /** The same, where the flag is the only thing keeping the principal off an otherwise owner-only file. */
+    @Test
+    public void removingInheritOnlyFromAnOwnerOnlyListGrantsMore() {
+        assertFalse(grantsNoMoreThan(
+                List.of(allow(EDGE, READ_WRITE), allow(ADMINISTRATORS, READ)),
+                List.of(allow(EDGE, READ_WRITE), inheritOnly(allow(ADMINISTRATORS, READ)))));
     }
 
     /** An audit entry grants nothing, so a store that adds one has not widened anything. */

--- a/hivemq-edge/src/test/java/com/hivemq/configuration/reader/AclComparisonTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/configuration/reader/AclComparisonTest.java
@@ -15,78 +15,57 @@
  */
 package com.hivemq.configuration.reader;
 
+import static com.hivemq.configuration.reader.AclComparisonFixture.ADMINISTRATORS;
+import static com.hivemq.configuration.reader.AclComparisonFixture.ALICE;
+import static com.hivemq.configuration.reader.AclComparisonFixture.EDGE;
+import static com.hivemq.configuration.reader.AclComparisonFixture.READ;
+import static com.hivemq.configuration.reader.AclComparisonFixture.READ_WRITE;
+import static com.hivemq.configuration.reader.AclComparisonFixture.WRITE;
+import static com.hivemq.configuration.reader.AclComparisonFixture.allow;
+import static com.hivemq.configuration.reader.AclComparisonFixture.deny;
+import static com.hivemq.configuration.reader.AclComparisonFixture.inheritOnly;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.attribute.AclEntry;
 import java.nio.file.attribute.AclEntryFlag;
 import java.nio.file.attribute.AclEntryPermission;
 import java.nio.file.attribute.AclEntryType;
-import java.nio.file.attribute.UserPrincipal;
+import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 
 /**
- * EDG-882 review v04 finding 2.1 and review v05 finding 1 — the decision the ACL-only write path makes,
- * taken apart from the file store that provokes it.
+ * EDG-882 reviews v04, v05 and v06 — the decision the ACL-only configuration write path makes, taken apart
+ * from the file store that provokes it.
  * <p>
- * Both ACL checks used to demand that the list read back be <em>equal</em> to the list set. That is a claim
- * about how a store represents an access-control list, not about who can read the file, and it is the
+ * Both ACL checks originally demanded that the list read back be <em>equal</em> to the list set. That is a
+ * claim about how a store represents an access-control list, not about who can read the file, and it is the
  * claim nothing outside Windows can test: jimfs hands back exactly what it was given, so those tests passed
  * by construction while a real NTFS volume that reordered entries, merged a permission mask or returned an
  * inherited entry alongside the one just written would have refused every configuration write — on the only
  * platform the code path exists for.
  * <p>
- * The question is now "does this grant anyone more than that does", which is answerable without a store at
- * all. This class is that answer: every shape a store might plausibly hand back, judged directly. What
- * remains untested off Windows is only what NTFS actually returns — and under this rule, any answer that
- * does not widen access is accepted.
+ * Three rounds then found three ways the replacement was wrong about what a list means: it ignored the order
+ * entries are evaluated in (v05), it read {@code INHERIT_ONLY} as a propagation flag (v05), and it settled
+ * permissions per principal, so an entry naming a group could not settle a permission for a user who belongs
+ * to it (v06). Each round arrived from outside, because nothing here was capable of producing the next one.
  * <p>
- * The first version of that question was asked of the entries rather than of what they decide, which threw
- * away the two things about an access-control list that are not decoration: the order the entries are
- * evaluated in, and {@code INHERIT_ONLY}, which says an entry does not apply to the object carrying it.
- * Both are exercised below, in both directions.
+ * {@link AclComparison} answers the question over every token that could be presented to the two lists
+ * rather than modelling any particular directory's groups, which makes it exact. This class pins the rules
+ * one shape at a time and every case the three rounds raised; {@link AclComparisonOracleTest} is the part
+ * that closes the class rather than the instance, by agreeing with a direct implementation of the
+ * access-check algorithm over an exhaustively generated universe of lists.
  */
 public class AclComparisonTest {
 
-    private static final @NotNull UserPrincipal EDGE = new Principal("edge");
-    private static final @NotNull UserPrincipal ALICE = new Principal("alice");
-    private static final @NotNull UserPrincipal ADMINISTRATORS = new Principal("Administrators");
-
-    private static final @NotNull Set<AclEntryPermission> READ = Set.of(AclEntryPermission.READ_DATA);
-    private static final @NotNull Set<AclEntryPermission> READ_WRITE =
-            Set.of(AclEntryPermission.READ_DATA, AclEntryPermission.WRITE_DATA);
-
-    private static @NotNull AclEntry allow(
-            final @NotNull UserPrincipal principal, final @NotNull Set<AclEntryPermission> permissions) {
-        return AclEntry.newBuilder()
-                .setType(AclEntryType.ALLOW)
-                .setPrincipal(principal)
-                .setPermissions(permissions)
-                .build();
-    }
-
-    private static @NotNull AclEntry deny(
-            final @NotNull UserPrincipal principal, final @NotNull Set<AclEntryPermission> permissions) {
-        return AclEntry.newBuilder()
-                .setType(AclEntryType.DENY)
-                .setPrincipal(principal)
-                .setPermissions(permissions)
-                .build();
-    }
-
-    /** The same entry, marked as not applying to the object that carries it. */
-    private static @NotNull AclEntry inheritOnly(final @NotNull AclEntry entry) {
-        return AclEntry.newBuilder(entry)
-                .setFlags(AclEntryFlag.INHERIT_ONLY, AclEntryFlag.FILE_INHERIT)
-                .build();
-    }
-
     private static boolean grantsNoMoreThan(
             final @NotNull List<AclEntry> candidate, final @NotNull List<AclEntry> reference) {
-        return ConfigFileReaderWriter.grantsNoMoreThan(candidate, reference);
+        return AclComparison.grantsNoMoreThan(candidate, reference);
     }
 
     // ------------------------------------------------------------- what a store may change and still pass
@@ -110,9 +89,7 @@ public class AclComparisonTest {
     /** Nor is how the permissions are split across entries for the same principal. */
     @Test
     public void permissionsSplitAcrossEntriesGrantNoMore() {
-        assertTrue(grantsNoMoreThan(
-                List.of(allow(EDGE, READ), allow(EDGE, Set.of(AclEntryPermission.WRITE_DATA))),
-                List.of(allow(EDGE, READ_WRITE))));
+        assertTrue(grantsNoMoreThan(List.of(allow(EDGE, READ), allow(EDGE, WRITE)), List.of(allow(EDGE, READ_WRITE))));
     }
 
     /**
@@ -171,7 +148,106 @@ public class AclComparisonTest {
         assertTrue(grantsNoMoreThan(List.of(inheritOnly(allow(ALICE, READ))), List.of(allow(ALICE, READ))));
     }
 
-    // ------------------------------------------------- what order and INHERIT_ONLY must still refuse
+    /** An audit entry grants nothing, so a store that adds one has not widened anything. */
+    @Test
+    public void anAuditEntryGrantsNoMore() {
+        final AclEntry audit = AclEntry.newBuilder()
+                .setType(AclEntryType.AUDIT)
+                .setPrincipal(ALICE)
+                .setPermissions(READ)
+                .setFlags(AclEntryFlag.FILE_INHERIT)
+                .build();
+
+        assertTrue(grantsNoMoreThan(List.of(allow(EDGE, READ_WRITE), audit), List.of(allow(EDGE, READ_WRITE))));
+    }
+
+    /**
+     * An audit entry grants nothing, so it also takes nothing away: it does not stand in front of the entry
+     * behind it and hide what that one grants.
+     * <p>
+     * Both directions matter and they fail differently. Read as a decision, an audit entry ahead of an allow
+     * makes a replacement that grants access look like one that grants none — a widening waved through,
+     * which is the whole disclosure this path exists to prevent. Read as a decision in the file being
+     * replaced, it makes that file look narrower than it is and refuses a write that discloses nothing.
+     */
+    @Test
+    public void anAuditEntryDoesNotHideTheEntryBehindIt() {
+        final AclEntry audit = AclEntry.newBuilder()
+                .setType(AclEntryType.AUDIT)
+                .setPrincipal(ALICE)
+                .setPermissions(READ)
+                .build();
+
+        assertFalse(
+                grantsNoMoreThan(List.of(audit, allow(ALICE, READ)), List.of()),
+                "the allow behind the audit entry grants Alice a read the file being replaced does not");
+        assertTrue(
+                grantsNoMoreThan(List.of(allow(ALICE, READ)), List.of(audit, allow(ALICE, READ))),
+                "the file being replaced grants that read too, whatever is recorded in front of it");
+    }
+
+    /** Granting less is not granting more. */
+    @Test
+    public void aNarrowerListGrantsNoMore() {
+        assertTrue(grantsNoMoreThan(List.of(allow(EDGE, READ)), List.of(allow(EDGE, READ_WRITE), allow(ALICE, READ))));
+    }
+
+    /** And granting nothing at all is the narrowest there is. */
+    @Test
+    public void anEmptyListGrantsNoMore() {
+        assertTrue(grantsNoMoreThan(List.of(), List.of(allow(EDGE, READ_WRITE))));
+    }
+
+    /** Adding a denial is a narrowing whatever else the list says. */
+    @Test
+    public void addingADenialGrantsNoMore() {
+        assertTrue(grantsNoMoreThan(
+                List.of(allow(EDGE, READ_WRITE), deny(ALICE, READ)), List.of(allow(EDGE, READ_WRITE))));
+    }
+
+    // ---------------------------------------------------------------------- what must still be refused
+
+    /** A principal the file being replaced does not name at all. */
+    @Test
+    public void anExtraPrincipalGrantsMore() {
+        assertFalse(grantsNoMoreThan(
+                List.of(allow(EDGE, READ_WRITE), allow(ADMINISTRATORS, READ)), List.of(allow(EDGE, READ_WRITE))));
+    }
+
+    /** A permission the file being replaced does not grant that principal. */
+    @Test
+    public void anExtraPermissionGrantsMore() {
+        assertFalse(grantsNoMoreThan(List.of(allow(EDGE, READ_WRITE)), List.of(allow(EDGE, READ))));
+    }
+
+    /** Anything at all, where the file being replaced grants nobody anything. */
+    @Test
+    public void anythingGrantsMoreThanAnEmptyList() {
+        assertFalse(grantsNoMoreThan(List.of(allow(EDGE, READ)), List.of()));
+    }
+
+    /**
+     * The shape the whole change is about, end to end: the list a store might return after being asked for
+     * owner-only — reordered, flagged, and with the permissions merged differently — is accepted, while the
+     * same list with the directory's inherited entry still in it is not.
+     */
+    @Test
+    public void whatAStoreMayReturnAfterBeingAskedForOwnerOnly() {
+        final List<AclEntry> ownerOnly = List.of(allow(EDGE, READ_WRITE));
+        final AclEntry rewritten = AclEntry.newBuilder()
+                .setType(AclEntryType.ALLOW)
+                .setPrincipal(EDGE)
+                .setPermissions(READ_WRITE)
+                .setFlags(AclEntryFlag.NO_PROPAGATE_INHERIT)
+                .build();
+
+        assertTrue(grantsNoMoreThan(List.of(rewritten), ownerOnly), "a store that rewrote the entry did not widen it");
+        assertFalse(
+                grantsNoMoreThan(List.of(rewritten, allow(ADMINISTRATORS, READ)), ownerOnly),
+                "an inherited entry the store kept is exactly what the narrowing is for");
+    }
+
+    // ------------------------------------------------------- review v05: order is part of what a list says
 
     /**
      * The first of the two shapes review v05 named. A list is evaluated in order, so the entry that comes
@@ -201,97 +277,212 @@ public class AclComparisonTest {
                 List.of(allow(EDGE, READ_WRITE), inheritOnly(allow(ADMINISTRATORS, READ)))));
     }
 
-    /** An audit entry grants nothing, so a store that adds one has not widened anything. */
-    @Test
-    public void anAuditEntryGrantsNoMore() {
-        final AclEntry audit = AclEntry.newBuilder()
-                .setType(AclEntryType.AUDIT)
-                .setPrincipal(ALICE)
-                .setPermissions(READ)
-                .setFlags(AclEntryFlag.FILE_INHERIT)
-                .build();
+    // ------------------------------- review v06: an entry naming a group settles a permission for its members
 
-        assertTrue(grantsNoMoreThan(List.of(allow(EDGE, READ_WRITE), audit), List.of(allow(EDGE, READ_WRITE))));
+    /**
+     * Review v06, exactly as reported. A token carries the user's own identity <em>and</em> every group they
+     * belong to, so entries naming different principals settle the same person's access and the order
+     * between them decides who wins.
+     * <p>
+     * The reference denies Alice and then allows the administrators; a request from Alice, who is one, meets
+     * her denial first and is refused. The candidate has the same two entries the other way round, so the
+     * group's allow is reached first and she is let in. Every per-principal summary of these two lists is
+     * identical, which is why the previous implementation called them equivalent.
+     */
+    @Test
+    public void reorderingAGroupAllowAheadOfAUserDenialGrantsMore() {
+        assertFalse(
+                grantsNoMoreThan(
+                        List.of(allow(ADMINISTRATORS, READ), deny(ALICE, READ)),
+                        List.of(deny(ALICE, READ), allow(ADMINISTRATORS, READ))),
+                "Alice is an administrator: the group's allow now settles the read her own denial used to");
     }
 
-    /** Granting less is not granting more. */
+    /** The same pair the other way round, which is a narrowing and has to stay accepted. */
     @Test
-    public void aNarrowerListGrantsNoMore() {
-        assertTrue(grantsNoMoreThan(List.of(allow(EDGE, READ)), List.of(allow(EDGE, READ_WRITE), allow(ALICE, READ))));
-    }
-
-    /** And granting nothing at all is the narrowest there is. */
-    @Test
-    public void anEmptyListGrantsNoMore() {
-        assertTrue(grantsNoMoreThan(List.of(), List.of(allow(EDGE, READ_WRITE))));
-    }
-
-    // ---------------------------------------------------------------------- what must still be refused
-
-    /** A principal the file being replaced does not name at all. */
-    @Test
-    public void anExtraPrincipalGrantsMore() {
-        assertFalse(grantsNoMoreThan(
-                List.of(allow(EDGE, READ_WRITE), allow(ADMINISTRATORS, READ)), List.of(allow(EDGE, READ_WRITE))));
-    }
-
-    /** A permission the file being replaced does not grant that principal. */
-    @Test
-    public void anExtraPermissionGrantsMore() {
-        assertFalse(grantsNoMoreThan(List.of(allow(EDGE, READ_WRITE)), List.of(allow(EDGE, READ))));
-    }
-
-    /** Anything at all, where the file being replaced grants nobody anything. */
-    @Test
-    public void anythingGrantsMoreThanAnEmptyList() {
-        assertFalse(grantsNoMoreThan(List.of(allow(EDGE, READ)), List.of()));
+    public void reorderingAUserDenialAheadOfAGroupAllowGrantsNoMore() {
+        assertTrue(grantsNoMoreThan(
+                List.of(deny(ALICE, READ), allow(ADMINISTRATORS, READ)),
+                List.of(allow(ADMINISTRATORS, READ), deny(ALICE, READ))));
     }
 
     /**
-     * A denial that was dropped. It reads like a narrowing and is the opposite: a DENY can be the only
-     * thing keeping a member of an allowed group out of the file, so losing one widens access even though
-     * no ALLOW changed.
+     * The membership is never asserted anywhere, because it cannot be: {@code java.nio} will not say who
+     * belongs to what. The comparison assumes any principals may appear in one token, so a group allow that
+     * the reference does not have is refused whether or not anybody is actually in the group.
      */
     @Test
-    public void losingADenialGrantsMore() {
-        assertFalse(grantsNoMoreThan(
+    public void aGroupAllowIsJudgedWithoutKnowingWhoIsInTheGroup() {
+        assertFalse(
+                grantsNoMoreThan(List.of(deny(ALICE, READ), allow(ADMINISTRATORS, READ)), List.of(deny(ALICE, READ))));
+    }
+
+    // ------------------------------------------------- a denial is worth what its position makes it worth
+
+    /**
+     * A denial sitting behind an allow that already settles the permission for anyone who can reach it
+     * decides nothing, so dropping it takes nothing away.
+     * <p>
+     * This is the one case whose answer changed with review v06's fix, from refuse to accept, and it is
+     * the same reasoning in the opposite direction: whoever holds Alice's identity alone is denied by both
+     * lists, and whoever also holds Edge's is allowed by both, at the entry that comes first. There is no
+     * token that can tell them apart. The previous implementation refused it on the blanket rule that
+     * losing any {@code DENY} widens access, which is over-conservative rather than unsafe — it refused
+     * configuration writes that disclose nothing. {@link AclComparisonOracleTest} is what makes changing it
+     * a measurement instead of an opinion.
+     */
+    @Test
+    public void losingADenialNothingCanReachGrantsNoMore() {
+        assertTrue(grantsNoMoreThan(
                 List.of(allow(EDGE, READ_WRITE)), List.of(allow(EDGE, READ_WRITE), deny(ALICE, READ))));
     }
 
-    /** Adding one is the other direction, and allowed. */
+    /** And losing one that does decide something is the widening the rule is there to catch. */
     @Test
-    public void addingADenialGrantsNoMore() {
-        assertTrue(grantsNoMoreThan(
-                List.of(allow(EDGE, READ_WRITE), deny(ALICE, READ)), List.of(allow(EDGE, READ_WRITE))));
+    public void losingADenialThatDecidesGrantsMore() {
+        assertFalse(
+                grantsNoMoreThan(List.of(allow(EDGE, READ_WRITE)), List.of(deny(ALICE, READ), allow(EDGE, READ_WRITE))),
+                "a token holding both identities meets the denial first in the reference and nothing in the"
+                        + " candidate");
+    }
+
+    // ----------------------------------------------------------------------------- structural properties
+
+    /** Whatever a store returns, it is never wider than itself. */
+    @Test
+    public void everyListGrantsNoMoreThanItself() {
+        for (final List<AclEntry> acl : AclComparisonFixture.assortedLists()) {
+            assertTrue(grantsNoMoreThan(acl, acl), () -> "not reflexive for " + acl);
+        }
     }
 
     /**
-     * The shape the whole change is about, end to end: the list a store might return after being asked for
-     * owner-only — reordered, flagged, and with the permissions merged differently — is accepted, while the
-     * same list with the directory's inherited entry still in it is not.
+     * A list of entries that mention no permission at all decides nothing. {@code AclEntry} allows an empty
+     * mask and a store is free to hand one back; it grants nothing and shadows nothing.
      */
     @Test
-    public void whatAStoreMayReturnAfterBeingAskedForOwnerOnly() {
-        final List<AclEntry> ownerOnly = List.of(allow(EDGE, READ_WRITE));
-        final AclEntry rewritten = AclEntry.newBuilder()
-                .setType(AclEntryType.ALLOW)
-                .setPrincipal(EDGE)
-                .setPermissions(READ_WRITE)
-                .setFlags(AclEntryFlag.NO_PROPAGATE_INHERIT)
-                .build();
+    public void anEntryMentioningNoPermissionDecidesNothing() {
+        final AclEntry nothing = AclComparisonFixture.entry(AclEntryType.ALLOW, ALICE, Set.of());
+        final AclEntry denyNothing = AclComparisonFixture.entry(AclEntryType.DENY, ALICE, Set.of());
 
-        assertTrue(grantsNoMoreThan(List.of(rewritten), ownerOnly), "a store that rewrote the entry did not widen it");
+        assertTrue(grantsNoMoreThan(List.of(nothing), List.of()), "an empty mask grants nothing");
         assertFalse(
-                grantsNoMoreThan(List.of(rewritten, allow(ADMINISTRATORS, READ)), ownerOnly),
-                "an inherited entry the store kept is exactly what the narrowing is for");
+                grantsNoMoreThan(List.of(denyNothing, allow(ALICE, READ)), List.of()),
+                "and takes nothing away from the entry behind it");
+        assertTrue(grantsNoMoreThan(List.of(nothing, allow(ALICE, READ)), List.of(allow(ALICE, READ))));
     }
 
-    /** A principal whose identity is its name, which is all the comparison treats it as. */
-    private record Principal(@NotNull String name) implements UserPrincipal {
+    /** The same entry twice is the same list: the second one was settled before it was reached. */
+    @Test
+    public void aRepeatedEntryChangesNothing() {
+        final List<AclEntry> once = List.of(allow(EDGE, READ_WRITE), deny(ALICE, READ));
+        final List<AclEntry> twice =
+                List.of(allow(EDGE, READ_WRITE), deny(ALICE, READ), allow(EDGE, READ_WRITE), deny(ALICE, READ));
 
-        @Override
-        public @NotNull String getName() {
-            return name;
+        assertTrue(grantsNoMoreThan(twice, once));
+        assertTrue(grantsNoMoreThan(once, twice));
+    }
+
+    /** A list that contradicts itself is not undefined: the entry that comes first is the one that counts. */
+    @Test
+    public void aListThatContradictsItselfIsSettledByItsFirstEntry() {
+        assertTrue(
+                grantsNoMoreThan(List.of(deny(ALICE, READ), allow(ALICE, READ)), List.of()),
+                "the denial comes first, so the list grants nothing and is no wider than an empty one");
+        assertFalse(
+                grantsNoMoreThan(List.of(allow(ALICE, READ), deny(ALICE, READ)), List.of()),
+                "the allow comes first, so it grants a read an empty list does not");
+    }
+
+    /** A list made only of entries that do not apply to the file grants nothing, whatever they say. */
+    @Test
+    public void aListOfEntriesThatDoNotApplyGrantsNothing() {
+        assertTrue(grantsNoMoreThan(
+                List.of(inheritOnly(allow(ALICE, READ_WRITE)), inheritOnly(allow(ADMINISTRATORS, READ_WRITE))),
+                List.of()));
+    }
+
+    /**
+     * No permission bit is special. The comparison is written in terms of {@code AclEntryPermission} and
+     * never in terms of a particular one, and the cases that matter give the same answers when the read and
+     * the write are swapped for the two bits that decide who may take the file over.
+     */
+    @Test
+    public void noPermissionBitIsTreatedDifferentlyFromAnother() {
+        final Set<AclEntryPermission> takeOwnership = Set.of(AclEntryPermission.WRITE_OWNER);
+        final Set<AclEntryPermission> changeTheList = Set.of(AclEntryPermission.WRITE_ACL);
+
+        assertFalse(
+                grantsNoMoreThan(
+                        List.of(allow(ADMINISTRATORS, takeOwnership), deny(ALICE, takeOwnership)),
+                        List.of(deny(ALICE, takeOwnership), allow(ADMINISTRATORS, takeOwnership))),
+                "review v06's shape, in a bit nothing else in these tests uses");
+        assertTrue(grantsNoMoreThan(
+                List.of(allow(EDGE, changeTheList)), List.of(allow(EDGE, changeTheList), allow(ALICE, READ))));
+        assertFalse(grantsNoMoreThan(List.of(allow(EDGE, changeTheList)), List.of(allow(EDGE, takeOwnership))));
+    }
+
+    /** The list the write path actually sets on a replacement: its owner, everything, and nobody else. */
+    @Test
+    public void theOwnerOnlyListTheWritePathSetsIsAcceptedAgainstItself() {
+        final List<AclEntry> ownerOnly = List.of(allow(EDGE, EnumSet.allOf(AclEntryPermission.class)));
+
+        assertTrue(grantsNoMoreThan(ownerOnly, ownerOnly));
+        assertFalse(
+                grantsNoMoreThan(
+                        List.of(allow(EDGE, EnumSet.allOf(AclEntryPermission.class)), allow(ALICE, READ)), ownerOnly),
+                "every bit granted to the owner still grants none of them to anybody else");
+    }
+
+    /**
+     * Length is not a special case. An inherited list on a long-lived installation tree can carry dozens of
+     * entries, and the one that decides is still the first one that applies.
+     */
+    @Test
+    public void aLongListIsStillDecidedByTheFirstEntryThatApplies() {
+        final List<AclEntry> padded = new ArrayList<>();
+        padded.add(deny(ALICE, READ));
+        for (int index = 0; index < 64; index++) {
+            padded.add(inheritOnly(allow(ALICE, READ_WRITE)));
+            padded.add(allow(ADMINISTRATORS, READ));
         }
+        padded.add(allow(ALICE, READ_WRITE));
+
+        assertTrue(
+                grantsNoMoreThan(padded, List.of(deny(ALICE, READ), allow(ADMINISTRATORS, READ), allow(ALICE, WRITE))),
+                "Alice's read was settled by the denial at the front, sixty-four entries ago");
+        assertFalse(
+                grantsNoMoreThan(padded, List.of(deny(ALICE, READ), allow(ALICE, WRITE))),
+                "the administrators' read is granted all the same");
+    }
+
+    /**
+     * A list that is not there is not a list that grants nothing. The caller has failed to read one, and the
+     * write it was about to authorise must not proceed on a cheerful answer.
+     */
+    @Test
+    public void aMissingListIsNotQuietlyAccepted() {
+        assertThrows(
+                NullPointerException.class, () -> AclComparison.grantsNoMoreThan(null, List.of(allow(EDGE, READ))));
+        assertThrows(
+                NullPointerException.class, () -> AclComparison.grantsNoMoreThan(List.of(allow(EDGE, READ)), null));
+    }
+
+    /**
+     * The property the write path relies on when it accepts the strong outcome: a list every one of whose
+     * deciding allows names the owner cannot let anyone else in, in any order, under any token. It is not a
+     * branch in the implementation — the general rule already decides it — but it is the invariant
+     * {@code narrowToItsOwner} is asserting when it asks whether the store took the owner-only list.
+     */
+    @Test
+    public void aListWhoseAllowsAllNameTheOwnerIsOwnerOnly() {
+        final List<AclEntry> ownerOnly = List.of(allow(EDGE, READ_WRITE));
+
+        assertTrue(grantsNoMoreThan(
+                List.of(deny(ALICE, READ_WRITE), allow(EDGE, READ), allow(EDGE, WRITE), deny(ADMINISTRATORS, READ)),
+                ownerOnly));
+        assertFalse(
+                grantsNoMoreThan(List.of(allow(EDGE, READ_WRITE), allow(ADMINISTRATORS, READ)), ownerOnly),
+                "one allow naming anyone else is the whole difference");
     }
 }

--- a/hivemq-edge/src/test/java/com/hivemq/configuration/reader/AclComparisonTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/configuration/reader/AclComparisonTest.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.configuration.reader;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.attribute.AclEntry;
+import java.nio.file.attribute.AclEntryFlag;
+import java.nio.file.attribute.AclEntryPermission;
+import java.nio.file.attribute.AclEntryType;
+import java.nio.file.attribute.UserPrincipal;
+import java.util.List;
+import java.util.Set;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+
+/**
+ * EDG-882 review v04, finding 2.1 — the decision the ACL-only write path makes, taken apart from the file
+ * store that provokes it.
+ * <p>
+ * Both ACL checks used to demand that the list read back be <em>equal</em> to the list set. That is a claim
+ * about how a store represents an access-control list, not about who can read the file, and it is the
+ * claim nothing outside Windows can test: jimfs hands back exactly what it was given, so those tests passed
+ * by construction while a real NTFS volume that reordered entries, merged a permission mask or returned an
+ * inherited entry alongside the one just written would have refused every configuration write — on the only
+ * platform the code path exists for.
+ * <p>
+ * The question is now "does this grant anyone more than that does", which is answerable without a store at
+ * all. This class is that answer: every shape a store might plausibly hand back, judged directly. What
+ * remains untested off Windows is only what NTFS actually returns — and under this rule, any answer that
+ * does not widen access is accepted.
+ */
+public class AclComparisonTest {
+
+    private static final @NotNull UserPrincipal EDGE = new Principal("edge");
+    private static final @NotNull UserPrincipal ALICE = new Principal("alice");
+    private static final @NotNull UserPrincipal ADMINISTRATORS = new Principal("Administrators");
+
+    private static final @NotNull Set<AclEntryPermission> READ = Set.of(AclEntryPermission.READ_DATA);
+    private static final @NotNull Set<AclEntryPermission> READ_WRITE =
+            Set.of(AclEntryPermission.READ_DATA, AclEntryPermission.WRITE_DATA);
+
+    private static @NotNull AclEntry allow(
+            final @NotNull UserPrincipal principal, final @NotNull Set<AclEntryPermission> permissions) {
+        return AclEntry.newBuilder()
+                .setType(AclEntryType.ALLOW)
+                .setPrincipal(principal)
+                .setPermissions(permissions)
+                .build();
+    }
+
+    private static @NotNull AclEntry deny(
+            final @NotNull UserPrincipal principal, final @NotNull Set<AclEntryPermission> permissions) {
+        return AclEntry.newBuilder()
+                .setType(AclEntryType.DENY)
+                .setPrincipal(principal)
+                .setPermissions(permissions)
+                .build();
+    }
+
+    private static boolean grantsNoMoreThan(
+            final @NotNull List<AclEntry> candidate, final @NotNull List<AclEntry> reference) {
+        return ConfigFileReaderWriter.grantsNoMoreThan(candidate, reference);
+    }
+
+    // ------------------------------------------------------------- what a store may change and still pass
+
+    /** The same list, which is what a store that changes nothing hands back. */
+    @Test
+    public void anIdenticalListGrantsNoMore() {
+        final List<AclEntry> acl = List.of(allow(EDGE, READ_WRITE), allow(ALICE, READ));
+
+        assertTrue(grantsNoMoreThan(acl, acl));
+    }
+
+    /** Order is not access. A store that canonicalises the list still grants exactly what it was given. */
+    @Test
+    public void aReorderedListGrantsNoMore() {
+        assertTrue(grantsNoMoreThan(
+                List.of(allow(ALICE, READ), allow(EDGE, READ_WRITE)),
+                List.of(allow(EDGE, READ_WRITE), allow(ALICE, READ))));
+    }
+
+    /** Nor is how the permissions are split across entries for the same principal. */
+    @Test
+    public void permissionsSplitAcrossEntriesGrantNoMore() {
+        assertTrue(grantsNoMoreThan(
+                List.of(allow(EDGE, READ), allow(EDGE, Set.of(AclEntryPermission.WRITE_DATA))),
+                List.of(allow(EDGE, READ_WRITE))));
+    }
+
+    /**
+     * Nor are inheritance flags: they decide what a <em>directory</em> propagates to what is created inside
+     * it, and the file being written propagates to nothing.
+     */
+    @Test
+    public void inheritanceFlagsGrantNoMore() {
+        final AclEntry flagged = AclEntry.newBuilder()
+                .setType(AclEntryType.ALLOW)
+                .setPrincipal(EDGE)
+                .setPermissions(READ_WRITE)
+                .setFlags(AclEntryFlag.FILE_INHERIT, AclEntryFlag.DIRECTORY_INHERIT)
+                .build();
+
+        assertTrue(grantsNoMoreThan(List.of(flagged), List.of(allow(EDGE, READ_WRITE))));
+    }
+
+    /** An audit entry grants nothing, so a store that adds one has not widened anything. */
+    @Test
+    public void anAuditEntryGrantsNoMore() {
+        final AclEntry audit = AclEntry.newBuilder()
+                .setType(AclEntryType.AUDIT)
+                .setPrincipal(ALICE)
+                .setPermissions(READ)
+                .setFlags(AclEntryFlag.FILE_INHERIT)
+                .build();
+
+        assertTrue(grantsNoMoreThan(List.of(allow(EDGE, READ_WRITE), audit), List.of(allow(EDGE, READ_WRITE))));
+    }
+
+    /** Granting less is not granting more. */
+    @Test
+    public void aNarrowerListGrantsNoMore() {
+        assertTrue(grantsNoMoreThan(List.of(allow(EDGE, READ)), List.of(allow(EDGE, READ_WRITE), allow(ALICE, READ))));
+    }
+
+    /** And granting nothing at all is the narrowest there is. */
+    @Test
+    public void anEmptyListGrantsNoMore() {
+        assertTrue(grantsNoMoreThan(List.of(), List.of(allow(EDGE, READ_WRITE))));
+    }
+
+    // ---------------------------------------------------------------------- what must still be refused
+
+    /** A principal the file being replaced does not name at all. */
+    @Test
+    public void anExtraPrincipalGrantsMore() {
+        assertFalse(grantsNoMoreThan(
+                List.of(allow(EDGE, READ_WRITE), allow(ADMINISTRATORS, READ)), List.of(allow(EDGE, READ_WRITE))));
+    }
+
+    /** A permission the file being replaced does not grant that principal. */
+    @Test
+    public void anExtraPermissionGrantsMore() {
+        assertFalse(grantsNoMoreThan(List.of(allow(EDGE, READ_WRITE)), List.of(allow(EDGE, READ))));
+    }
+
+    /** Anything at all, where the file being replaced grants nobody anything. */
+    @Test
+    public void anythingGrantsMoreThanAnEmptyList() {
+        assertFalse(grantsNoMoreThan(List.of(allow(EDGE, READ)), List.of()));
+    }
+
+    /**
+     * A denial that was dropped. It reads like a narrowing and is the opposite: a DENY can be the only
+     * thing keeping a member of an allowed group out of the file, so losing one widens access even though
+     * no ALLOW changed.
+     */
+    @Test
+    public void losingADenialGrantsMore() {
+        assertFalse(grantsNoMoreThan(
+                List.of(allow(EDGE, READ_WRITE)), List.of(allow(EDGE, READ_WRITE), deny(ALICE, READ))));
+    }
+
+    /** Adding one is the other direction, and allowed. */
+    @Test
+    public void addingADenialGrantsNoMore() {
+        assertTrue(grantsNoMoreThan(
+                List.of(allow(EDGE, READ_WRITE), deny(ALICE, READ)), List.of(allow(EDGE, READ_WRITE))));
+    }
+
+    /**
+     * The shape the whole change is about, end to end: the list a store might return after being asked for
+     * owner-only — reordered, flagged, and with the permissions merged differently — is accepted, while the
+     * same list with the directory's inherited entry still in it is not.
+     */
+    @Test
+    public void whatAStoreMayReturnAfterBeingAskedForOwnerOnly() {
+        final List<AclEntry> ownerOnly = List.of(allow(EDGE, READ_WRITE));
+        final AclEntry rewritten = AclEntry.newBuilder()
+                .setType(AclEntryType.ALLOW)
+                .setPrincipal(EDGE)
+                .setPermissions(READ_WRITE)
+                .setFlags(AclEntryFlag.NO_PROPAGATE_INHERIT)
+                .build();
+
+        assertTrue(grantsNoMoreThan(List.of(rewritten), ownerOnly), "a store that rewrote the entry did not widen it");
+        assertFalse(
+                grantsNoMoreThan(List.of(rewritten, allow(ADMINISTRATORS, READ)), ownerOnly),
+                "an inherited entry the store kept is exactly what the narrowing is for");
+    }
+
+    /** A principal whose identity is its name, which is all the comparison treats it as. */
+    private record Principal(@NotNull String name) implements UserPrincipal {
+
+        @Override
+        public @NotNull String getName() {
+            return name;
+        }
+    }
+}

--- a/hivemq-edge/src/test/java/com/hivemq/configuration/reader/AclNativeStoreTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/configuration/reader/AclNativeStoreTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.configuration.reader;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.AclEntry;
+import java.nio.file.attribute.AclEntryPermission;
+import java.nio.file.attribute.AclEntryType;
+import java.nio.file.attribute.AclFileAttributeView;
+import java.util.EnumSet;
+import java.util.List;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * EDG-882 / EDG-947 — the ACL write path against a file store that actually has access-control lists.
+ * <p>
+ * <b>This class does not run on the machines that develop Edge, and it does not run in CI.</b>
+ * {@code AclFileAttributeView} is provided by the Windows file system provider and by the Solaris one for
+ * ZFS; on Linux and macOS {@code Files.getFileAttributeView(path, AclFileAttributeView.class)} returns
+ * {@code null}, and every workflow in this repository runs on {@code ubuntu-latest}. So it skips, and it is
+ * written to be found and to pass or fail honestly on the day a Windows job exists — which is EDG-947, and
+ * is the difference between this path being tested and being modelled.
+ * <p>
+ * Everything else about the comparison is decided without a store at all, in {@link AclComparisonTest} and
+ * {@link AclComparisonOracleTest}. What is left over, and only reachable here, is what a real store
+ * <em>returns</em>: whether it hands back the list it was given, whether it maps a permission mask into a
+ * different one, whether inheritance from the containing directory survives a {@code setAcl}, and therefore
+ * whether the narrowing the write path asks for is achievable at all. Review v04's finding 2.1 was a rule
+ * that would have refused every configuration write on exactly that behaviour, and nothing off Windows could
+ * have reproduced it.
+ * <p>
+ * The assertions are consequently about what the store <em>decided</em>, never about the shape it returned.
+ * A store is free to reorder, split, merge or annotate; it is not free to change who can read a file full of
+ * credentials.
+ */
+public class AclNativeStoreTest {
+
+    @TempDir
+    private @NotNull Path directory;
+
+    private @NotNull Path target;
+
+    @BeforeEach
+    public void requireAnAclStore() throws IOException {
+        target = directory.resolve("config.xml");
+        Files.writeString(target, "<hivemq/>", StandardCharsets.UTF_8);
+        assumeTrue(
+                Files.getFileAttributeView(target, AclFileAttributeView.class) != null,
+                "this file store has no access-control lists, so there is no ACL write path to exercise");
+    }
+
+    private static @NotNull List<AclEntry> aclOf(final @NotNull Path path) throws IOException {
+        final AclFileAttributeView view = Files.getFileAttributeView(path, AclFileAttributeView.class);
+        assertNotNull(view, "the store lost its ACL view between the assumption and here");
+        return List.copyOf(view.getAcl());
+    }
+
+    /**
+     * The round trip the whole comparison exists to tolerate: whatever the store does to a list on the way
+     * in and out, it must not change what the list grants. A failure here is the store telling us that
+     * {@code setAcl} does not mean what the caller thinks, and it is the only way to find that out.
+     */
+    @Test
+    public void aListSurvivesBeingWrittenAndReadBack() throws IOException {
+        final AclFileAttributeView view = Files.getFileAttributeView(target, AclFileAttributeView.class);
+        assertNotNull(view);
+        final List<AclEntry> ownerOnly = List.of(AclEntry.newBuilder()
+                .setType(AclEntryType.ALLOW)
+                .setPrincipal(view.getOwner())
+                .setPermissions(EnumSet.allOf(AclEntryPermission.class))
+                .build());
+
+        view.setAcl(ownerOnly);
+        final List<AclEntry> readBack = aclOf(target);
+
+        assertTrue(
+                AclComparison.grantsNoMoreThan(readBack, ownerOnly),
+                () -> "the store returned a list granting more than the one it was given: " + readBack);
+    }
+
+    /**
+     * The property {@code createPartialFile} promises: the file the configuration is about to be rendered
+     * into is never readable by anyone the file it replaces is not, from the moment it exists.
+     * <p>
+     * On this store that is done by writing an owner-only list rather than by a creation mode, and it is
+     * proved before the caller may write a byte — so if the store keeps an inherited entry the replacement
+     * is refused outright. Either outcome is correct and both are asserted: what may not happen is a partial
+     * file that exists, is wider than the target, and is handed back to be filled with credentials.
+     */
+    @Test
+    public void theReplacementIsNeverWiderThanTheFileItReplaces() throws IOException {
+        final Path partial = directory.resolve("config.xml.partial");
+        final List<AclEntry> targetAcl = aclOf(target);
+
+        try {
+            ConfigFileReaderWriter.createPartialFile(partial, ConfigFileReaderWriter.preservedAttributesOf(target));
+        } catch (final IOException refused) {
+            assertTrue(
+                    Files.notExists(partial) || aclOf(partial).isEmpty(),
+                    "the narrowing was refused but a partial file was left behind anyway");
+            return;
+        }
+        final List<AclEntry> partialAcl = aclOf(partial);
+        assertTrue(
+                AclComparison.grantsNoMoreThan(partialAcl, targetAcl),
+                () -> "the replacement is readable by principals the configuration file is not: " + partialAcl
+                        + " where the configuration has " + targetAcl);
+    }
+
+    /**
+     * And the whole replacement, end to end: the file that lands carries what the file it replaced granted,
+     * in both directions. Narrower would lock out an operator who could read the configuration before;
+     * wider is the disclosure everything here is for.
+     */
+    @Test
+    public void aReplacedFileGrantsWhatTheFileItReplacedGranted() throws IOException {
+        final List<AclEntry> before = aclOf(target);
+
+        ConfigFileReaderWriter.replaceCarryingProtections(
+                target,
+                ConfigFileReaderWriter.preservedAttributesOf(target),
+                partial -> Files.writeString(partial, "<hivemq><replaced/></hivemq>", StandardCharsets.UTF_8));
+
+        final List<AclEntry> after = aclOf(target);
+        assertEquals("<hivemq><replaced/></hivemq>", Files.readString(target, StandardCharsets.UTF_8));
+        assertTrue(
+                AclComparison.grantsNoMoreThan(after, before),
+                () -> "the replacement grants more than the file it replaced: " + after + " where it had " + before);
+        assertTrue(
+                AclComparison.grantsNoMoreThan(before, after),
+                () -> "the replacement grants less than the file it replaced: " + after + " where it had " + before);
+    }
+}

--- a/hivemq-edge/src/test/java/com/hivemq/configuration/reader/BridgeConfigWriteBackTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/configuration/reader/BridgeConfigWriteBackTest.java
@@ -17,6 +17,7 @@ package com.hivemq.configuration.reader;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.common.io.Files;
 import com.hivemq.bridge.config.LocalSubscription;
@@ -166,7 +167,11 @@ public class BridgeConfigWriteBackTest extends AbstractConfigurationTest {
                 bridges -> notified.add(bridges.stream().map(MqttBridge::getId).toList()));
         notified.clear();
 
-        final boolean replaced = bridgeConfiguration.replaceBridge("no-such-bridge", updatedCopy(before));
+        // The body carries the id being replaced: replaceBridge requires the two to agree, because a
+        // mismatch turns an update into a remove + add and clears the queues of the bridge it was meant
+        // to update (EDG-882 review v02, R2-09).
+        final boolean replaced =
+                bridgeConfiguration.replaceBridge("no-such-bridge", copyWithId(updatedCopy(before), "no-such-bridge"));
 
         assertThat(replaced).isFalse();
         assertThat(notified).isEmpty();
@@ -186,6 +191,33 @@ public class BridgeConfigWriteBackTest extends AbstractConfigurationTest {
 
         assertThat(bridgeConfiguration.getBridges().stream().map(MqttBridge::getId))
                 .containsExactly("edg-882-writeback", "edg-882-second", "edg-882-third");
+    }
+
+    /**
+     * The id in the body has to be the id being replaced (EDG-882 review v02, R2-09).
+     * <p>
+     * This method exists to keep a bridge <em>present</em> across an update, because a bridge that
+     * disappears from the configuration is stopped with an empty retain list and loses every queue it
+     * owns. A body carrying a different id defeats exactly that: the list comes out without the old id
+     * and with a new one, which {@code updateBridges} reads as a removal followed by an addition. The
+     * REST layer rejects an id change, so today no caller does it — the precondition is here so that the
+     * next one cannot either, silently.
+     */
+    @Test
+    public void whenTheBodyCarriesADifferentId_thenTheReplacementIsRefused() throws IOException {
+        Files.write(CONFIG.getBytes(UTF_8), xmlFile);
+        reader.applyConfig();
+        final MqttBridge before = bridgeConfiguration.getBridges().get(0);
+
+        assertThatThrownBy(
+                        () -> bridgeConfiguration.replaceBridge(before.getId(), copyWithId(before, "a-different-id")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(before.getId())
+                .hasMessageContaining("a-different-id");
+
+        assertThat(bridgeConfiguration.getBridges().stream().map(MqttBridge::getId))
+                .as("a refused replacement must not have changed the configuration")
+                .containsExactly(before.getId());
     }
 
     /**

--- a/hivemq-edge/src/test/java/com/hivemq/configuration/reader/BridgeConfigWriteBackTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/configuration/reader/BridgeConfigWriteBackTest.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.configuration.reader;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.io.Files;
+import com.hivemq.bridge.config.LocalSubscription;
+import com.hivemq.bridge.config.MqttBridge;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+
+/**
+ * What writing {@code config.xml} back out does to a bridge the operator did not touch (EDG-882 QA
+ * round 2).
+ * <p>
+ * {@code sync} rebuilds every bridge entity from the runtime objects, and <b>any</b> REST write of
+ * <b>any</b> subsystem triggers a write — creating a protocol adapter rewrites the bridges. So
+ * anything the round trip loses is lost from the operator's file, and anything it changes is a
+ * configuration change: the reload that follows sees a different bridge, restarts it, and clears the
+ * queues of whatever the new configuration cannot match.
+ */
+public class BridgeConfigWriteBackTest extends AbstractConfigurationTest {
+
+    /** Filters written deliberately out of alphabetical order, with a queue limit. */
+    private static final @NotNull String CONFIG = "" + "<hivemq>\n"
+            + "<mqtt-bridges>\n"
+            + "    <mqtt-bridge>\n"
+            + "        <id>edg-882-writeback</id>\n"
+            + "        <remote-broker>\n"
+            + "            <host>testhost</host>\n"
+            + "        </remote-broker>\n"
+            + "        <forwarded-topics>\n"
+            + "            <forwarded-topic>\n"
+            + "                <filters>\n"
+            + "                    <mqtt-topic-filter>zone-b/#</mqtt-topic-filter>\n"
+            + "                    <mqtt-topic-filter>alarms/#</mqtt-topic-filter>\n"
+            + "                </filters>\n"
+            + "                <excludes>\n"
+            + "                    <mqtt-topic-filter>zone-b/private/#</mqtt-topic-filter>\n"
+            + "                    <mqtt-topic-filter>alarms/private/#</mqtt-topic-filter>\n"
+            + "                </excludes>\n"
+            + "                <destination>{#}</destination>\n"
+            + "                <max-qos>1</max-qos>\n"
+            + "                <queue-limit>500</queue-limit>\n"
+            + "            </forwarded-topic>\n"
+            + "        </forwarded-topics>\n"
+            + "    </mqtt-bridge>\n"
+            + "</mqtt-bridges>"
+            + "</hivemq>";
+
+    private @NotNull MqttBridge loadAndWriteBack() throws IOException {
+        Files.write(CONFIG.getBytes(UTF_8), xmlFile);
+        reader.applyConfig();
+        final MqttBridge asRead = bridgeConfiguration.getBridges().get(0);
+
+        // the production write path, not writeConfigToXML: only this one runs the extractors' sync,
+        // which is where the bridge entities are rebuilt
+        reader.writeConfigWithSync();
+
+        reader.applyConfig();
+        final MqttBridge afterRoundTrip = bridgeConfiguration.getBridges().get(0);
+        assertThat(afterRoundTrip)
+                .as("a write-back the operator did not ask for must not change the bridge")
+                .isEqualTo(asRead);
+        return afterRoundTrip;
+    }
+
+    @Test
+    public void whenTheConfigurationIsWrittenBack_thenTheQueueLimitSurvives() throws IOException {
+        final MqttBridge bridge = loadAndWriteBack();
+
+        assertThat(bridge.getLocalSubscriptions().get(0).getQueueLimit()).isEqualTo(500L);
+    }
+
+    @Test
+    public void whenTheConfigurationIsWrittenBack_thenTheOperatorsFilterOrderIsKept() throws IOException {
+        loadAndWriteBack();
+
+        final String written = java.nio.file.Files.readString(xmlFile.toPath());
+        assertThat(written.indexOf("zone-b/#"))
+                .as("the filters were written as zone-b then alarms and must stay that way")
+                .isLessThan(written.indexOf("alarms/#"));
+        assertThat(written.indexOf("zone-b/private/#")).isLessThan(written.indexOf("alarms/private/#"));
+    }
+
+    @Test
+    public void whenTheConfigurationIsWrittenBack_thenTheQueueLimitElementIsStillThere() throws IOException {
+        loadAndWriteBack();
+
+        assertThat(java.nio.file.Files.readString(xmlFile.toPath())).contains("<queue-limit>500</queue-limit>");
+    }
+
+    /**
+     * Canonicalisation is for identity, not for the file: the subscription the runtime works with is
+     * still sorted, whatever order it was written in.
+     */
+    @Test
+    public void whenFiltersAreOutOfOrder_thenTheRuntimeStillSeesThemCanonically() throws IOException {
+        Files.write(CONFIG.getBytes(UTF_8), xmlFile);
+        reader.applyConfig();
+
+        final LocalSubscription subscription =
+                bridgeConfiguration.getBridges().get(0).getLocalSubscriptions().get(0);
+
+        assertThat(subscription.getFilters()).containsExactly("alarms/#", "zone-b/#");
+        assertThat(subscription.getConfiguredFilters()).containsExactly("zone-b/#", "alarms/#");
+        assertThat(subscription.getExcludes()).containsExactly("alarms/private/#", "zone-b/private/#");
+        assertThat(subscription.getConfiguredExcludes()).containsExactly("zone-b/private/#", "alarms/private/#");
+    }
+
+    /**
+     * EDG-882 QA round 1: an update expressed as remove-then-add notified the bridge subsystem twice,
+     * and the first notification said the bridge was gone from the configuration — which is answered by
+     * stopping it and clearing every queue it owns, whatever the second notification then says.
+     */
+    @Test
+    public void whenABridgeIsReplaced_thenTheConsumerNeverSeesItAbsent() throws IOException {
+        Files.write(CONFIG.getBytes(UTF_8), xmlFile);
+        reader.applyConfig();
+        final List<List<String>> notifiedBridgeIds = new ArrayList<>();
+        bridgeConfiguration.registerConsumer(bridges ->
+                notifiedBridgeIds.add(bridges.stream().map(MqttBridge::getId).toList()));
+        notifiedBridgeIds.clear();
+
+        final boolean replaced = bridgeConfiguration.replaceBridge(
+                "edg-882-writeback",
+                updatedCopy(bridgeConfiguration.getBridges().get(0)));
+
+        assertThat(replaced).isTrue();
+        assertThat(notifiedBridgeIds).containsExactly(List.of("edg-882-writeback"));
+        assertThat(bridgeConfiguration.getBridges()).hasSize(1);
+        assertThat(bridgeConfiguration
+                        .getBridges()
+                        .get(0)
+                        .getLocalSubscriptions()
+                        .get(0)
+                        .getFilters())
+                .containsExactly("changed/#");
+    }
+
+    @Test
+    public void whenAnUnknownBridgeIsReplaced_thenNothingChanges() throws IOException {
+        Files.write(CONFIG.getBytes(UTF_8), xmlFile);
+        reader.applyConfig();
+        final MqttBridge before = bridgeConfiguration.getBridges().get(0);
+        final List<List<String>> notified = new ArrayList<>();
+        bridgeConfiguration.registerConsumer(
+                bridges -> notified.add(bridges.stream().map(MqttBridge::getId).toList()));
+        notified.clear();
+
+        final boolean replaced = bridgeConfiguration.replaceBridge("no-such-bridge", updatedCopy(before));
+
+        assertThat(replaced).isFalse();
+        assertThat(notified).isEmpty();
+        assertThat(bridgeConfiguration.getBridges()).containsExactly(before);
+    }
+
+    /** The replacement keeps its position among the other bridges. */
+    @Test
+    public void whenABridgeIsReplaced_thenTheOrderOfTheOthersIsKept() throws IOException {
+        Files.write(CONFIG.getBytes(UTF_8), xmlFile);
+        reader.applyConfig();
+        final MqttBridge first = bridgeConfiguration.getBridges().get(0);
+        bridgeConfiguration.addBridge(copyWithId(first, "edg-882-second"));
+        bridgeConfiguration.addBridge(copyWithId(first, "edg-882-third"));
+
+        bridgeConfiguration.replaceBridge("edg-882-second", updatedCopy(copyWithId(first, "edg-882-second")));
+
+        assertThat(bridgeConfiguration.getBridges().stream().map(MqttBridge::getId))
+                .containsExactly("edg-882-writeback", "edg-882-second", "edg-882-third");
+    }
+
+    private static @NotNull MqttBridge updatedCopy(final @NotNull MqttBridge bridge) {
+        return builderOf(bridge)
+                .withLocalSubscriptions(List.of(new LocalSubscription(List.of("changed/#"), "{#}")))
+                .build();
+    }
+
+    private static @NotNull MqttBridge copyWithId(final @NotNull MqttBridge bridge, final @NotNull String id) {
+        return builderOf(bridge).withId(id).withClientId(id).build();
+    }
+
+    private static MqttBridge.@NotNull Builder builderOf(final @NotNull MqttBridge bridge) {
+        return new MqttBridge.Builder()
+                .withId(bridge.getId())
+                .withHost(bridge.getHost())
+                .withPort(bridge.getPort())
+                .withClientId(bridge.getClientId())
+                .withLocalSubscriptions(bridge.getLocalSubscriptions())
+                .withRemoteSubscriptions(bridge.getRemoteSubscriptions());
+    }
+}

--- a/hivemq-edge/src/test/java/com/hivemq/configuration/reader/BridgeConfigWriteBackTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/configuration/reader/BridgeConfigWriteBackTest.java
@@ -66,6 +66,16 @@ public class BridgeConfigWriteBackTest extends AbstractConfigurationTest {
             + "                <queue-limit>500</queue-limit>\n"
             + "            </forwarded-topic>\n"
             + "        </forwarded-topics>\n"
+            + "        <remote-subscriptions>\n"
+            + "            <remote-subscription>\n"
+            + "                <filters>\n"
+            + "                    <mqtt-topic-filter>remote-z/#</mqtt-topic-filter>\n"
+            + "                    <mqtt-topic-filter>remote-a/#</mqtt-topic-filter>\n"
+            + "                </filters>\n"
+            + "                <destination>{#}</destination>\n"
+            + "                <max-qos>1</max-qos>\n"
+            + "            </remote-subscription>\n"
+            + "        </remote-subscriptions>\n"
             + "    </mqtt-bridge>\n"
             + "</mqtt-bridges>"
             + "</hivemq>";
@@ -166,6 +176,21 @@ public class BridgeConfigWriteBackTest extends AbstractConfigurationTest {
         final MqttBridge bridge = loadAndWriteBack();
 
         assertThat(bridge.getLocalSubscriptions().get(0).getQueueLimit()).isEqualTo(500L);
+    }
+
+    /**
+     * The remote half of the same rule. Canonicalisation makes a reorder stop counting as a change; it
+     * must not make the write-back reorder the operator's elements, which would be the churn F-07
+     * removed from the local half arriving through the other door (EDG-882 QA, 2026-08-25).
+     */
+    @Test
+    public void whenTheConfigurationIsWrittenBack_thenTheRemoteFilterOrderIsKept() throws IOException {
+        loadAndWriteBack();
+
+        final String written = java.nio.file.Files.readString(xmlFile.toPath());
+        assertThat(written.indexOf("remote-z/#"))
+                .as("the remote filters were written as remote-z then remote-a and must stay that way")
+                .isLessThan(written.indexOf("remote-a/#"));
     }
 
     @Test

--- a/hivemq-edge/src/test/java/com/hivemq/configuration/reader/BridgeConfigWriteBackTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/configuration/reader/BridgeConfigWriteBackTest.java
@@ -19,6 +19,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import ch.qos.logback.classic.Level;
 import com.google.common.io.Files;
 import com.hivemq.bridge.config.LocalSubscription;
 import com.hivemq.bridge.config.MqttBridge;
@@ -27,6 +28,8 @@ import java.util.ArrayList;
 import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import util.LogbackCapturingAppender;
 
 /**
  * What writing {@code config.xml} back out does to a bridge the operator did not touch (EDG-882 QA
@@ -82,6 +85,80 @@ public class BridgeConfigWriteBackTest extends AbstractConfigurationTest {
                 .as("a write-back the operator did not ask for must not change the bridge")
                 .isEqualTo(asRead);
         return afterRoundTrip;
+    }
+
+    /** A credential written the way an operator naturally writes a placeholder: indented, on its own line. */
+    private static final @NotNull String PADDED_CREDENTIAL_CONFIG = "" + "<hivemq>\n"
+            + "<mqtt-bridges>\n"
+            + "    <mqtt-bridge>\n"
+            + "        <id>edg-882-padded</id>\n"
+            + "        <remote-broker>\n"
+            + "            <host>testhost</host>\n"
+            + "            <authentication>\n"
+            + "                <mqtt-simple-authentication>\n"
+            + "                    <username>bridge-user</username>\n"
+            + "                    <password>\n"
+            + "                        s3cret\n"
+            + "                    </password>\n"
+            + "                </mqtt-simple-authentication>\n"
+            + "            </authentication>\n"
+            + "        </remote-broker>\n"
+            + "        <forwarded-topics>\n"
+            + "            <forwarded-topic>\n"
+            + "                <filters>\n"
+            + "                    <mqtt-topic-filter>alarms/#</mqtt-topic-filter>\n"
+            + "                </filters>\n"
+            + "                <destination>{#}</destination>\n"
+            + "                <max-qos>1</max-qos>\n"
+            + "            </forwarded-topic>\n"
+            + "        </forwarded-topics>\n"
+            + "    </mqtt-bridge>\n"
+            + "</mqtt-bridges>"
+            + "</hivemq>";
+
+    /**
+     * The element's text is the credential, indentation included, so the bridge sends a password with
+     * newlines in it and the remote refuses the connection — with nothing in the configuration looking
+     * wrong. It is not trimmed (whitespace is legal in a password, and trimming would break the
+     * placeholder restore that keeps the secret off disk), so the only defence is saying so.
+     */
+    @Test
+    public void whenACredentialIsIndentedOnItsOwnLine_thenTheWhitespaceIsPartOfItAndIsReported() throws IOException {
+        final LogbackCapturingAppender logCapture =
+                LogbackCapturingAppender.Factory.weaveInto(LoggerFactory.getLogger(BridgeExtractor.class));
+        try {
+            Files.write(PADDED_CREDENTIAL_CONFIG.getBytes(UTF_8), xmlFile);
+            reader.applyConfig();
+
+            final MqttBridge bridge = bridgeConfiguration.getBridges().get(0);
+            assertThat(bridge.getPassword())
+                    .as("the premise: the padding really is part of the value the bridge will send")
+                    .isNotNull()
+                    .isNotEqualTo("s3cret")
+                    .contains("s3cret");
+
+            assertThat(logCapture.getCapturedLogs())
+                    .as("an operator has no other way to find out")
+                    .anySatisfy(event -> {
+                        assertThat(event.getLevel()).isEqualTo(Level.WARN);
+                        assertThat(event.getFormattedMessage())
+                                .contains("<password>")
+                                .contains("edg-882-padded")
+                                .contains("whitespace")
+                                // The advice names the syntax the operator has to correct, so it has to
+                                // be the syntax: SLF4J substitutes '{}' and passes anything else through,
+                                // so a brace doubled to "escape" it is simply printed. Caught on a real
+                                // node during the 2026-08-25 smoke test, where it read '${{ENV:...}}'.
+                                .contains("${ENV:...}")
+                                .doesNotContain("{{");
+                    });
+            assertThat(logCapture.getCapturedLogs())
+                    .as("the username is unpadded here, so nothing should be said about it")
+                    .noneSatisfy(
+                            event -> assertThat(event.getFormattedMessage()).contains("<username>"));
+        } finally {
+            LogbackCapturingAppender.Factory.cleanUp();
+        }
     }
 
     @Test

--- a/hivemq-edge/src/test/java/com/hivemq/configuration/reader/BridgeConfigWriteBackTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/configuration/reader/BridgeConfigWriteBackTest.java
@@ -188,6 +188,49 @@ public class BridgeConfigWriteBackTest extends AbstractConfigurationTest {
                 .containsExactly("edg-882-writeback", "edg-882-second", "edg-882-third");
     }
 
+    /**
+     * A {@code <forwarded-topic>} with no {@code <max-qos>} forwards at QoS <b>0</b>, not at the
+     * schema's documented default of 2 (EDG-882 review v02, R2-17).
+     * <p>
+     * {@code ForwardedTopicEntity.maxQoS} is a bare {@code int} with no initialiser and the element is
+     * {@code minOccurs="0"}; the "Default: 2" in {@code config.xsd} is an {@code xs:annotation}, which is
+     * documentation and not an XSD {@code default}, so JAXB leaves the field at the Java default and
+     * {@code RemoteMqttForwarder.convertQos} then downgrades every forwarded message to fire-and-forget.
+     * <p>
+     * Pinned here because it is silent: a configuration or a test fixture that omits the element looks
+     * like it asks for QoS 2 and delivers at QoS 0, and the only symptom is messages that occasionally
+     * are not there. Three fixtures on this branch had exactly that.
+     */
+    @Test
+    public void whenMaxQosIsOmitted_thenTheSubscriptionForwardsAtQosZero() throws IOException {
+        Files.write(CONFIG.replace("<max-qos>1</max-qos>", "").getBytes(UTF_8), xmlFile);
+        reader.applyConfig();
+
+        assertThat(bridgeConfiguration
+                        .getBridges()
+                        .get(0)
+                        .getLocalSubscriptions()
+                        .get(0)
+                        .getMaxQoS())
+                .as("an absent <max-qos> is QoS 0, whatever the schema documentation says")
+                .isZero();
+    }
+
+    /** And the value is honoured when it is written, which is what the fixtures must do. */
+    @Test
+    public void whenMaxQosIsGiven_thenTheSubscriptionForwardsAtThatQos() throws IOException {
+        Files.write(CONFIG.getBytes(UTF_8), xmlFile);
+        reader.applyConfig();
+
+        assertThat(bridgeConfiguration
+                        .getBridges()
+                        .get(0)
+                        .getLocalSubscriptions()
+                        .get(0)
+                        .getMaxQoS())
+                .isEqualTo(1);
+    }
+
     private static @NotNull MqttBridge updatedCopy(final @NotNull MqttBridge bridge) {
         return builderOf(bridge)
                 .withLocalSubscriptions(List.of(new LocalSubscription(List.of("changed/#"), "{#}")))

--- a/hivemq-edge/src/test/java/com/hivemq/configuration/reader/ConfigBackupPermissionsTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/configuration/reader/ConfigBackupPermissionsTest.java
@@ -1,0 +1,247 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.configuration.reader;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
+import java.nio.file.attribute.GroupPrincipal;
+import java.nio.file.attribute.PosixFileAttributeView;
+import java.nio.file.attribute.PosixFileAttributes;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.List;
+import java.util.Set;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * EDG-882 review v04 — the rolling backup is a second copy of every credential in {@code config.xml}, so
+ * it is protected like the file it copies.
+ * <p>
+ * {@link ConfigWritePermissionsTest} pins that property for the replacement written over {@code
+ * config.xml}. The same write produces {@code config_1.xml} beside it, holding the same passwords, and
+ * that one was produced by a plain file copy: it carried the mode and left the group to whatever the
+ * process happened to have. A {@code 0640} configuration owned by group {@code operators} was therefore
+ * backed up into a {@code 0640} file readable by group {@code staff} — R3-09 exactly, in the sibling file
+ * of the path R3-09 was raised against.
+ * <p>
+ * The backup now goes through the same replace-by-move as the configuration file itself, so the two
+ * cannot drift apart again.
+ */
+public class ConfigBackupPermissionsTest extends AbstractConfigurationTest {
+
+    private static final @NotNull Set<PosixFilePermission> OWNER_ONLY = PosixFilePermissions.fromString("rw-------");
+    private static final @NotNull Set<PosixFilePermission> GROUP_READABLE =
+            PosixFilePermissions.fromString("rw-r-----");
+    private static final @NotNull Set<PosixFilePermission> WORLD_WRITABLE =
+            PosixFilePermissions.fromString("rw-rw-rw-");
+
+    private @NotNull Path config;
+    private @NotNull Path backup;
+
+    @BeforeEach
+    public void requirePosix() {
+        config = Path.of(xmlFile.getPath());
+        backup = config.resolveSibling("config_1.xml");
+        assumeTrue(
+                config.getFileSystem().supportedFileAttributeViews().contains("posix"),
+                "no POSIX permissions on this file system, so there is nothing to protect");
+    }
+
+    /** A configuration with a credential in it, so that what the backup holds is what the finding is about. */
+    private static @NotNull String config(final @NotNull String password) {
+        return "<hivemq>\n<mqtt-bridges>\n    <mqtt-bridge>\n        <id>edg-882-backup-bridge</id>\n"
+                + "        <remote-broker>\n            <host>testhost</host>\n            <authentication>\n"
+                + "                <mqtt-simple-authentication>\n"
+                + "                    <username>hivemq-edge</username>\n"
+                + "                    <password>" + password + "</password>\n"
+                + "                </mqtt-simple-authentication>\n            </authentication>\n"
+                + "        </remote-broker>\n        <forwarded-topics>\n            <forwarded-topic>\n"
+                + "                <filters>\n                    <mqtt-topic-filter>plant/#</mqtt-topic-filter>\n"
+                + "                </filters>\n                <destination>{#}</destination>\n"
+                + "                <max-qos>1</max-qos>\n            </forwarded-topic>\n"
+                + "        </forwarded-topics>\n    </mqtt-bridge>\n</mqtt-bridges></hivemq>";
+    }
+
+    private void writeConfigurationWithBackup(final @NotNull Set<PosixFilePermission> mode) throws IOException {
+        Files.writeString(config, config("s3cr3t-do-not-write-me"));
+        Files.setPosixFilePermissions(config, mode);
+        reader.applyConfig();
+        reader.writeConfigToXML(xmlFile, true, true);
+    }
+
+    private static @NotNull PosixFileAttributes attributesOf(final @NotNull Path path) throws IOException {
+        return Files.readAttributes(path, PosixFileAttributes.class);
+    }
+
+    /**
+     * The finding. The backup of a {@code 0640} configuration must grant group-read to the same group the
+     * configuration does, not to whichever group the writing process belongs to — a mode names a group
+     * without naming which one.
+     * <p>
+     * Skipped where the account running the build belongs to only one group, or may not set the group of a
+     * file it owns: there is then no second principal for the assertion to tell apart.
+     */
+    @Test
+    public void theBackupCarriesTheConfigurationsGroupNotTheProcessDefault() throws IOException {
+        Files.writeString(config, config("s3cr3t-do-not-write-me"));
+        Files.setPosixFilePermissions(config, GROUP_READABLE);
+        final GroupPrincipal defaultGroup = attributesOf(config).group();
+        final GroupPrincipal other = ConfigWritePermissionsTest.aDifferentGroupOfThisUser(config, defaultGroup);
+        assumeTrue(other != null, "this account has no second group, so there is nothing to tell apart");
+        Files.getFileAttributeView(config, PosixFileAttributeView.class).setGroup(other);
+
+        reader.applyConfig();
+        reader.writeConfigToXML(xmlFile, true, true);
+
+        assertTrue(Files.exists(backup), "the rolling backup must still be taken");
+        final PosixFileAttributes actual = attributesOf(backup);
+        assertEquals(
+                other,
+                actual.group(),
+                "the backup kept the mode but granted group-read to a different group than the configuration it"
+                        + " copies");
+        assertEquals(GROUP_READABLE, actual.permissions(), "the mode must be reproduced as well as the group");
+    }
+
+    /** And the mode itself: a configuration only its owner may read is backed up into a file only its owner may read. */
+    @Test
+    public void theBackupCarriesTheConfigurationsMode() throws IOException {
+        writeConfigurationWithBackup(OWNER_ONLY);
+
+        assertEquals(
+                OWNER_ONLY,
+                Files.getPosixFilePermissions(backup),
+                "the backup of a 0600 configuration is readable by someone the configuration is not");
+    }
+
+    /** The owner travels with it too, on the one platform where this can be asserted without a second account. */
+    @Test
+    public void theBackupCarriesTheConfigurationsOwner() throws IOException {
+        writeConfigurationWithBackup(OWNER_ONLY);
+
+        assertEquals(attributesOf(config).owner(), attributesOf(backup).owner());
+    }
+
+    /**
+     * The protections come from the file being copied, not from the file being overwritten. Once all five
+     * slots exist the rotation recycles the oldest, and a slot left wide by an earlier release — or by an
+     * operator — must not decide how the next backup of a restricted configuration is protected.
+     * <p>
+     * The modification times are set rather than assumed, because "oldest" is what selects the slot and
+     * the configuration file itself is in the set the rotation looks at.
+     */
+    @Test
+    public void theRecycledBackupSlotIsNotWidenedByWhatItHeld() throws IOException {
+        final long now = 1_700_000_000_000L;
+        Files.writeString(config, config("s3cr3t-do-not-write-me"));
+        Files.setPosixFilePermissions(config, OWNER_ONLY);
+        Files.setLastModifiedTime(config, FileTime.fromMillis(now));
+        for (int slot = 1; slot <= 4; slot++) {
+            final Path used = config.resolveSibling("config_" + slot + ".xml");
+            Files.writeString(used, "an earlier backup left readable by everyone");
+            Files.setPosixFilePermissions(used, WORLD_WRITABLE);
+            Files.setLastModifiedTime(used, FileTime.fromMillis(now - (5L - slot) * 60_000L));
+        }
+
+        reader.applyConfig();
+        reader.writeConfigToXML(xmlFile, true, true);
+
+        assertTrue(
+                Files.readString(backup).contains("edg-882-backup-bridge"),
+                "the oldest slot is the one the rotation should have recycled");
+        assertEquals(
+                OWNER_ONLY,
+                Files.getPosixFilePermissions(backup),
+                "the backup took the protections of the file it overwrote instead of the one it copies");
+    }
+
+    /** What it is for: the backup holds the configuration as it was before the write. */
+    @Test
+    public void theBackupHoldsTheConfigurationThatWasReplaced() throws IOException {
+        final String before = config("s3cr3t-do-not-write-me");
+        Files.writeString(config, before);
+        Files.setPosixFilePermissions(config, OWNER_ONLY);
+        reader.applyConfig();
+
+        reader.writeConfigToXML(xmlFile, true, true);
+
+        assertEquals(before, Files.readString(backup), "the backup is not the configuration it replaced");
+        assertFalse(
+                Files.readString(config).equals(before),
+                "the configuration file should have been rewritten by the marshaller");
+    }
+
+    /**
+     * The modification time is carried because the rotation picks which backup to overwrite by it. Losing
+     * it would not lose a credential, but it would quietly change which of the five slots is recycled.
+     */
+    @Test
+    public void theBackupKeepsTheConfigurationsModificationTime() throws IOException {
+        Files.writeString(config, config("s3cr3t-do-not-write-me"));
+        Files.setPosixFilePermissions(config, OWNER_ONLY);
+        final FileTime stamped = FileTime.fromMillis(1_600_000_000_000L);
+        Files.setLastModifiedTime(config, stamped);
+        reader.applyConfig();
+
+        reader.writeConfigToXML(xmlFile, true, true);
+
+        assertEquals(stamped, Files.getLastModifiedTime(backup), "the rotation orders the slots by this");
+    }
+
+    /** Written beside the backup and moved onto it, so nothing half-written is left behind either. */
+    @Test
+    public void noPartialFileSurvivesTheWrite() throws IOException {
+        writeConfigurationWithBackup(OWNER_ONLY);
+
+        try (var listing = Files.list(config.getParent())) {
+            final List<String> left = listing.map(path -> path.getFileName().toString())
+                    .filter(name -> name.endsWith(".partial"))
+                    .toList();
+            assertEquals(List.of(), left, "a partial file was left in the configuration directory");
+        }
+    }
+
+    /** Every backup taken by the same write is protected, not only the first slot. */
+    @Test
+    public void everyRotatedBackupCarriesTheConfigurationsProtections() throws IOException {
+        for (int i = 0; i < 3; i++) {
+            Files.writeString(config, config("s3cr3t-do-not-write-me"));
+            Files.setPosixFilePermissions(config, OWNER_ONLY);
+            reader.applyConfig();
+            reader.writeConfigToXML(xmlFile, true, true);
+        }
+
+        try (var listing = Files.list(config.getParent())) {
+            for (final Path file : listing.toList()) {
+                if (file.getFileName().toString().startsWith("config_")) {
+                    assertEquals(
+                            OWNER_ONLY,
+                            Files.getPosixFilePermissions(file),
+                            file.getFileName() + " is readable by someone the configuration is not");
+                }
+            }
+        }
+    }
+}

--- a/hivemq-edge/src/test/java/com/hivemq/configuration/reader/ConfigWriteAclPermissionsTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/configuration/reader/ConfigWriteAclPermissionsTest.java
@@ -1,0 +1,380 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.configuration.reader;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.google.common.jimfs.Configuration;
+import com.google.common.jimfs.Jimfs;
+import com.hivemq.configuration.reader.ConfigFileReaderWriter.PreservedAttributes;
+import java.io.IOException;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.AclEntry;
+import java.nio.file.attribute.AclEntryPermission;
+import java.nio.file.attribute.AclEntryType;
+import java.nio.file.attribute.AclFileAttributeView;
+import java.nio.file.attribute.PosixFileAttributeView;
+import java.nio.file.attribute.UserPrincipal;
+import java.util.EnumSet;
+import java.util.List;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * EDG-882 review v04, finding 1 — the same guarantee as {@link ConfigWritePermissionsTest}, on a file
+ * store that has no mode at all.
+ * <p>
+ * Windows and every other ACL-only store answers {@code null} for the POSIX view, and the previous
+ * version of the replace-by-move read that as "there is nothing here to protect": the replacement was
+ * created with whatever the containing directory's inheritance grants, every credential in the
+ * configuration was written into it, the target's owner was never restored because it was only ever read
+ * through the POSIX view, an access-control list that grants nobody anything was discarded as absent, and
+ * the verification step returned without checking anything. Five ways for the replacement of a protected
+ * {@code config.xml} to end up readable by principals the original was not.
+ * <p>
+ * It cannot be pinned on the build machine's own file system — neither Linux nor macOS exposes an ACL
+ * view through the JDK, so the whole path is dead code there and would stay untested until it ran on a
+ * customer's Windows node. Jimfs provides the store instead: owner and ACL views, no POSIX view, which is
+ * exactly the shape of the store this is about.
+ */
+public class ConfigWriteAclPermissionsTest {
+
+    private @NotNull FileSystem fileSystem;
+    private @NotNull Path directory;
+    private @NotNull Path partial;
+    private @NotNull UserPrincipal alice;
+    private @NotNull UserPrincipal bob;
+
+    @BeforeEach
+    public void anAclOnlyStore() throws IOException {
+        fileSystem = Jimfs.newFileSystem(Configuration.windows().toBuilder()
+                .setAttributeViews("basic", "owner", "acl")
+                .build());
+        directory = fileSystem.getPath("C:\\hivemq\\conf");
+        Files.createDirectories(directory);
+        partial = directory.resolve("config.xml.partial");
+        alice = fileSystem.getUserPrincipalLookupService().lookupPrincipalByName("alice");
+        bob = fileSystem.getUserPrincipalLookupService().lookupPrincipalByName("bob");
+    }
+
+    @AfterEach
+    public void close() throws IOException {
+        fileSystem.close();
+    }
+
+    /** The premise of every test here: no mode, so nothing the POSIX half of the writer can act on. */
+    @Test
+    public void theStoreUnderTestHasAnAclAndNoMode() throws IOException {
+        final Path target = targetReadableBy(bob);
+
+        assertNotNull(Files.getFileAttributeView(target, AclFileAttributeView.class));
+        assertNull(
+                Files.getFileAttributeView(target, PosixFileAttributeView.class),
+                "this store must have no POSIX view, or it does not exercise the path under test");
+    }
+
+    // ------------------------------------------------- the replacement is narrowed before it is written
+
+    /**
+     * The defect. A replacement created with the store's default access control and then filled with the
+     * configuration is readable, for the duration of the write, by whoever the containing directory
+     * grants — on every REST write to any subsystem. It is restricted to its own owner instead, while it
+     * is still empty.
+     */
+    @Test
+    public void createPartialFile_restrictsTheReplacementToItsOwnerBeforeItIsWritten() throws IOException {
+        final PreservedAttributes preserved = ConfigFileReaderWriter.preservedAttributesOf(targetReadableBy(bob));
+
+        ConfigFileReaderWriter.createPartialFile(partial, preserved);
+
+        final List<AclEntry> actual = aclOf(partial);
+        assertEquals(1, actual.size(), "the replacement is open to someone other than its owner");
+        final AclEntry only = actual.get(0);
+        assertEquals(Files.getOwner(partial), only.principal(), "the one entry must name the file's own owner");
+        assertEquals(AclEntryType.ALLOW, only.type());
+        assertEquals(EnumSet.allOf(AclEntryPermission.class), only.permissions());
+    }
+
+    /**
+     * And restricted to its owner rather than given the target's list. The creation-time list is not "the
+     * target's protection" but "the narrowest protection that can become it": a replacement created
+     * readable by bob is disclosed to bob for the whole write, which is the defect, and one created
+     * granting only a principal this process is not would leave nobody able to write the configuration
+     * into it.
+     */
+    @Test
+    public void createPartialFile_doesNotGiveTheReplacementTheTargetsOwnAcl() throws IOException {
+        final Path target = targetReadableBy(bob);
+        final PreservedAttributes preserved = ConfigFileReaderWriter.preservedAttributesOf(target);
+
+        ConfigFileReaderWriter.createPartialFile(partial, preserved);
+
+        assertNotEquals(aclOf(target), aclOf(partial), "the replacement was created as open as its target");
+        assertFalse(
+                namesPrincipal(aclOf(partial), bob),
+                "the replacement was created readable by a principal other than its owner");
+    }
+
+    /**
+     * A partial file left behind by a killed write must not be reused: it carries whatever access control
+     * <em>it</em> was left with, which on this store is whatever the directory granted at the time.
+     */
+    @Test
+    public void createPartialFile_replacesAStalePartialRatherThanReusingIt() throws IOException {
+        Files.createFile(partial);
+        aclViewOf(partial).setAcl(readWriteFor(bob));
+        Files.writeString(partial, "left behind by a killed write");
+
+        ConfigFileReaderWriter.createPartialFile(
+                partial, ConfigFileReaderWriter.preservedAttributesOf(targetReadableBy(bob)));
+
+        assertFalse(namesPrincipal(aclOf(partial), bob), "a stale partial was reopened and kept its access control");
+        assertEquals("", Files.readString(partial), "the stale content survived into the new write");
+    }
+
+    /**
+     * With nothing to reproduce — a configuration file being created for the first time — the replacement
+     * is created as the store creates any file. Narrowing it here would silently change the protection of
+     * every newly created configuration, which is a different decision than this one and not one a defect
+     * report asked for.
+     */
+    @Test
+    public void createPartialFile_withNothingToReproduce_createsTheFileNormally() throws IOException {
+        ConfigFileReaderWriter.createPartialFile(partial, PreservedAttributes.NONE);
+
+        assertTrue(Files.exists(partial), "the replacement must still be created");
+    }
+
+    // ------------------------------------------------------------------ what is carried, and put back
+
+    /**
+     * The owner is part of the answer to "who can read this", and on this store it was previously read
+     * only through the POSIX view — which does not exist here, so it was neither carried nor restored.
+     */
+    @Test
+    public void preservedAttributesOf_carriesTheOwnerAndTheAclWithNoMode() throws IOException {
+        final Path target = targetReadableBy(bob);
+        Files.getFileAttributeView(target, AclFileAttributeView.class).setOwner(alice);
+
+        final PreservedAttributes preserved = ConfigFileReaderWriter.preservedAttributesOf(target);
+
+        assertEquals(alice, preserved.owner(), "the owner of an ACL-only file was not carried");
+        assertEquals(aclOf(target), preserved.acl(), "the access-control list was not carried");
+        assertNull(preserved.permissions(), "there is no mode on this store to carry");
+        assertFalse(preserved.nothingToReproduce());
+    }
+
+    /**
+     * An access-control list that grants nobody anything is a protection, not an absence. The previous
+     * version discarded the empty list as "nothing to carry", which left the replacement of the most
+     * tightly protected configuration file possible with whatever the directory's inheritance produces.
+     */
+    @Test
+    public void preservedAttributesOf_keepsAnAclThatGrantsNobodyAnything() throws IOException {
+        final Path target = directory.resolve("config.xml");
+        Files.createFile(target);
+        aclViewOf(target).setAcl(List.of());
+
+        final PreservedAttributes preserved = ConfigFileReaderWriter.preservedAttributesOf(target);
+
+        assertEquals(List.of(), preserved.acl(), "an empty access-control list was read as 'there is none'");
+        assertFalse(
+                preserved.nothingToReproduce(),
+                "a file only its owner may read must not be replaced by one with the store's defaults");
+    }
+
+    /** And it is put back: the replacement ends up granting nobody anything either. */
+    @Test
+    public void applyPreservedAttributes_reproducesAnAclThatGrantsNobodyAnything() throws IOException {
+        final Path target = directory.resolve("config.xml");
+        Files.createFile(target);
+        aclViewOf(target).setAcl(List.of());
+        final PreservedAttributes preserved = ConfigFileReaderWriter.preservedAttributesOf(target);
+        ConfigFileReaderWriter.createPartialFile(partial, preserved);
+
+        ConfigFileReaderWriter.applyPreservedAttributes(partial, preserved);
+
+        assertEquals(List.of(), aclOf(partial), "the replacement is readable by someone the target was not");
+    }
+
+    /** The ordinary case: the target's own list and owner, exactly, on the replacement. */
+    @Test
+    public void applyPreservedAttributes_reproducesTheTargetsAclAndOwner() throws IOException {
+        final Path target = targetReadableBy(bob);
+        aclViewOf(target).setOwner(alice);
+        final PreservedAttributes preserved = ConfigFileReaderWriter.preservedAttributesOf(target);
+        ConfigFileReaderWriter.createPartialFile(partial, preserved);
+        Files.writeString(partial, "<hivemq><bridge><password>s3cr3t</password></bridge></hivemq>");
+
+        ConfigFileReaderWriter.applyPreservedAttributes(partial, preserved);
+
+        assertEquals(aclOf(target), aclOf(partial), "the target's access-control list was not reproduced");
+        assertEquals(alice, Files.getOwner(partial), "the target's owner was not reproduced");
+    }
+
+    /**
+     * The whole sequence in the order the writer runs it, with the assertion in the middle that the
+     * end-to-end test cannot make: the configuration is only ever written into a file nobody but its
+     * owner can read, and the target's protection is applied afterwards.
+     */
+    @Test
+    public void theReplacementIsNeverWiderThanItsTargetWhileItHoldsTheConfiguration() throws IOException {
+        final Path target = targetReadableBy(bob);
+        final PreservedAttributes preserved = ConfigFileReaderWriter.preservedAttributesOf(target);
+
+        ConfigFileReaderWriter.createPartialFile(partial, preserved);
+        assertFalse(namesPrincipal(aclOf(partial), bob), "the secrets are written into a file bob can read");
+        Files.writeString(partial, "<hivemq><bridge><password>s3cr3t</password></bridge></hivemq>");
+        assertFalse(namesPrincipal(aclOf(partial), bob), "the file was widened while it still held the secrets");
+
+        ConfigFileReaderWriter.applyPreservedAttributes(partial, preserved);
+
+        assertEquals(aclOf(target), aclOf(partial), "the target's access-control list was not reproduced");
+    }
+
+    // ------------------------------------------------------------------------------- and it is proved
+
+    /**
+     * The verification step, which on this store used to return without checking anything. A store can
+     * accept {@code setAcl} and hold something else — a share that rewrites entries, a mask applied on the
+     * way in, and on a store with both a mode and a list, the {@code chmod} this runs afterwards. The
+     * replacement is only moved onto the configuration file if what is actually on it is what was on the
+     * file it replaces.
+     */
+    @Test
+    public void verifyPreservedAttributes_whenTheAclOnTheReplacementIsNotTheTargetsThenTheWriteIsAborted()
+            throws IOException {
+        Files.createFile(partial);
+        aclViewOf(partial).setAcl(readWriteFor(alice));
+
+        final IOException refused = assertThrows(
+                IOException.class,
+                () -> ConfigFileReaderWriter.verifyPreservedAttributes(
+                        partial, new PreservedAttributes(null, null, null, readWriteFor(bob))),
+                "an access-control list that did not take must abort the replacement, not be assumed");
+        assertTrue(refused.getMessage().contains("access-control list"), refused.getMessage());
+    }
+
+    /** And it passes what it is meant to pass: the list the replacement actually carries. */
+    @Test
+    public void verifyPreservedAttributes_whenTheAclOnTheReplacementIsTheTargetsThenTheWriteGoesOn()
+            throws IOException {
+        Files.createFile(partial);
+        aclViewOf(partial).setAcl(readWriteFor(bob));
+
+        ConfigFileReaderWriter.verifyPreservedAttributes(
+                partial, new PreservedAttributes(null, null, null, readWriteFor(bob)));
+    }
+
+    /** The same for the owner, which is half of what an access-control list means. */
+    @Test
+    public void applyPreservedAttributes_whenTheOwnerDoesNotTake_thenTheWriteIsAborted() throws IOException {
+        final PreservedAttributes preserved = new PreservedAttributes(null, new NeverTheSame("alice"), null, null);
+        ConfigFileReaderWriter.createPartialFile(partial, preserved);
+
+        final IOException refused = assertThrows(
+                IOException.class,
+                () -> ConfigFileReaderWriter.applyPreservedAttributes(partial, preserved),
+                "an owner that did not take must abort the replacement, not be assumed");
+        assertTrue(refused.getMessage().contains("owned by"), refused.getMessage());
+    }
+
+    /**
+     * Fail closed at the other end too: protections that cannot be applied at all keep the previous
+     * configuration file, which is intact and correctly protected.
+     */
+    @Test
+    public void applyPreservedAttributes_whenTheAclCannotBeApplied_thenTheWriteIsAborted() throws IOException {
+        final PreservedAttributes preserved = ConfigFileReaderWriter.preservedAttributesOf(targetReadableBy(bob));
+        ConfigFileReaderWriter.createPartialFile(partial, preserved);
+        Files.delete(partial); // the replacement is gone, so its protections cannot be set
+
+        assertThrows(
+                IOException.class,
+                () -> ConfigFileReaderWriter.applyPreservedAttributes(partial, preserved),
+                "protections that cannot be reproduced must abort the replacement, not be logged and ignored");
+    }
+
+    /** A file that does not exist yet has no protections to carry, which is an answer rather than a throw. */
+    @Test
+    public void preservedAttributesOf_aMissingFile_hasNothingToReproduce() throws IOException {
+        final PreservedAttributes preserved =
+                ConfigFileReaderWriter.preservedAttributesOf(directory.resolve("not-written-yet.xml"));
+
+        assertTrue(preserved.nothingToReproduce(), "a first-time configuration file has nothing to preserve");
+    }
+
+    // ------------------------------------------------------------------------------------------ helpers
+
+    private @NotNull Path targetReadableBy(final @NotNull UserPrincipal principal) throws IOException {
+        final Path target = directory.resolve("config.xml");
+        Files.createFile(target);
+        aclViewOf(target).setAcl(readWriteFor(principal));
+        return target;
+    }
+
+    private @NotNull AclFileAttributeView aclViewOf(final @NotNull Path path) {
+        return Files.getFileAttributeView(path, AclFileAttributeView.class);
+    }
+
+    private @NotNull List<AclEntry> aclOf(final @NotNull Path path) throws IOException {
+        return aclViewOf(path).getAcl();
+    }
+
+    private static @NotNull List<AclEntry> readWriteFor(final @NotNull UserPrincipal principal) {
+        return List.of(AclEntry.newBuilder()
+                .setType(AclEntryType.ALLOW)
+                .setPrincipal(principal)
+                .setPermissions(EnumSet.of(AclEntryPermission.READ_DATA, AclEntryPermission.WRITE_DATA))
+                .build());
+    }
+
+    private static boolean namesPrincipal(final @NotNull List<AclEntry> acl, final @NotNull UserPrincipal principal) {
+        return acl.stream().anyMatch(entry -> entry.principal().equals(principal));
+    }
+
+    /**
+     * A principal that is never equal to itself: a file store that stores something other than what it
+     * was handed, seen from the only side this code has.
+     */
+    private record NeverTheSame(@NotNull String name) implements UserPrincipal {
+
+        @Override
+        public @NotNull String getName() {
+            return name;
+        }
+
+        @Override
+        public boolean equals(final Object other) {
+            return false;
+        }
+
+        @Override
+        public int hashCode() {
+            return name.hashCode();
+        }
+    }
+}

--- a/hivemq-edge/src/test/java/com/hivemq/configuration/reader/ConfigWriteAclPermissionsTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/configuration/reader/ConfigWriteAclPermissionsTest.java
@@ -278,6 +278,42 @@ public class ConfigWriteAclPermissionsTest {
         assertTrue(refused.getMessage().contains("access-control list"), refused.getMessage());
     }
 
+    /**
+     * EDG-882 review v04, finding 2.1. A replacement that grants <em>less</em> than the file it replaces is
+     * not the disclosure this check exists for, so it is reported rather than refused — demanding an
+     * identical list is what would have refused every write on a store that hands back an equivalent one.
+     */
+    @Test
+    public void verifyPreservedAttributes_whenTheReplacementIsNarrowerThanTheTarget_thenTheWriteGoesOn()
+            throws IOException {
+        Files.createFile(partial);
+        aclViewOf(partial).setAcl(List.of());
+
+        ConfigFileReaderWriter.verifyPreservedAttributes(
+                partial, new PreservedAttributes(null, null, null, readWriteFor(bob)));
+    }
+
+    /** And a list that merely says the same thing differently is not a failure either. */
+    @Test
+    public void verifyPreservedAttributes_whenTheStoreSplitTheEntries_thenTheWriteGoesOn() throws IOException {
+        Files.createFile(partial);
+        aclViewOf(partial)
+                .setAcl(List.of(
+                        AclEntry.newBuilder()
+                                .setType(AclEntryType.ALLOW)
+                                .setPrincipal(bob)
+                                .setPermissions(EnumSet.of(AclEntryPermission.READ_DATA))
+                                .build(),
+                        AclEntry.newBuilder()
+                                .setType(AclEntryType.ALLOW)
+                                .setPrincipal(bob)
+                                .setPermissions(EnumSet.of(AclEntryPermission.WRITE_DATA))
+                                .build()));
+
+        ConfigFileReaderWriter.verifyPreservedAttributes(
+                partial, new PreservedAttributes(null, null, null, readWriteFor(bob)));
+    }
+
     /** And it passes what it is meant to pass: the list the replacement actually carries. */
     @Test
     public void verifyPreservedAttributes_whenTheAclOnTheReplacementIsTheTargetsThenTheWriteGoesOn()

--- a/hivemq-edge/src/test/java/com/hivemq/configuration/reader/ConfigWriteAclPermissionsTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/configuration/reader/ConfigWriteAclPermissionsTest.java
@@ -318,6 +318,31 @@ public class ConfigWriteAclPermissionsTest {
                 "protections that cannot be reproduced must abort the replacement, not be logged and ignored");
     }
 
+    /**
+     * The sequence both the configuration file and its rolling backup now go through, end to end on this
+     * store: created restricted to its own owner, filled, given the target's protections, moved onto the
+     * target, nothing left beside it.
+     */
+    @Test
+    public void replaceCarryingProtections_writesUnderTheTargetsProtectionsAndLeavesNothingBehind() throws IOException {
+        final Path target = targetReadableBy(bob);
+        final PreservedAttributes preserved = ConfigFileReaderWriter.preservedAttributesOf(target);
+
+        ConfigFileReaderWriter.replaceCarryingProtections(target, preserved, written -> {
+            assertFalse(namesPrincipal(aclOf(written), bob), "the configuration is written into a file bob can read");
+            Files.writeString(written, "<hivemq><bridge><password>s3cr3t</password></bridge></hivemq>");
+        });
+
+        assertEquals(
+                "<hivemq><bridge><password>s3cr3t</password></bridge></hivemq>",
+                Files.readString(target),
+                "the content did not reach the target");
+        assertEquals(aclOf(target), preserved.acl(), "the target's access-control list was not reproduced");
+        assertFalse(
+                Files.exists(target.resolveSibling(target.getFileName() + ".partial")),
+                "a partial file was left beside the target");
+    }
+
     /** A file that does not exist yet has no protections to carry, which is an answer rather than a throw. */
     @Test
     public void preservedAttributesOf_aMissingFile_hasNothingToReproduce() throws IOException {

--- a/hivemq-edge/src/test/java/com/hivemq/configuration/reader/ConfigWriteBackEnvVarTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/configuration/reader/ConfigWriteBackEnvVarTest.java
@@ -439,4 +439,31 @@ public class ConfigWriteBackEnvVarTest extends AbstractConfigurationTest {
                 .as("the bridge that wrote the value literally must keep it")
                 .contains("<host>testhost</host>");
     }
+
+    /**
+     * EDG-882 review v04, finding 1.4. The survivor sweep used to ask whether the credential was anywhere
+     * in the finished document, so a bridge whose password variable resolved to its own host name could
+     * never be written again -- and the REST call that triggered the write still answered success. The
+     * question is asked of the elements where a credential belongs now, so this configuration writes.
+     */
+    @Test
+    public void whenThePasswordEqualsAnotherElementsValue_thenTheWriteStillHappens() throws IOException {
+        System.setProperty(PASSWORD_VAR, "testhost"); // the <host> of the bridge in this fixture
+        final String loaded = config("${ENV:" + PASSWORD_VAR + "}");
+
+        final String written = loadAndWriteBack(loaded);
+
+        // A refusal leaves the file exactly as it was loaded -- and it is swallowed by writeConfigWithSync,
+        // so the file is the only place the outcome shows. Comparing against the loaded text is what tells
+        // "the marshaller wrote this" from "nothing happened"; the placeholder survives either way.
+        assertThat(written).as("the configuration was not rewritten at all").isNotEqualTo(loaded);
+        assertThat(written).contains("${ENV:" + PASSWORD_VAR + "}");
+        assertThat(written).contains("<host>testhost</host>");
+        assertThat(logCapture.getCapturedLogs().stream()
+                        .filter(event -> event.getLevel() == Level.ERROR)
+                        .map(ILoggingEvent::getFormattedMessage)
+                        .toList())
+                .as("nothing about this configuration should have been refused")
+                .isEmpty();
+    }
 }

--- a/hivemq-edge/src/test/java/com/hivemq/configuration/reader/ConfigWriteBackEnvVarTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/configuration/reader/ConfigWriteBackEnvVarTest.java
@@ -319,6 +319,24 @@ public class ConfigWriteBackEnvVarTest extends AbstractConfigurationTest {
                 .anySatisfy(message -> assertThat(message).contains("variable reference is lost"));
     }
 
+    /**
+     * A placeholder written with whitespace around it (EDG-882 review v02, R2-20).
+     * <p>
+     * {@code collectPlaceholders} allows it — {@code <password>\s*${ENV:X}\s*</password>} — because an
+     * operator formatting their file that way is ordinary. The value the element resolves to is the
+     * trimmed one either way, so the restore has to put back the placeholder and not the padding, and the
+     * credential still has to stay off the disk.
+     */
+    @Test
+    public void whenThePlaceholderIsWrittenWithSurroundingWhitespace_thenItIsStillRestored() throws IOException {
+        System.setProperty(PASSWORD_VAR, SECRET);
+
+        final String written = loadAndWriteBack(config("\n            ${ENV:" + PASSWORD_VAR + "}\n        "));
+
+        assertThat(written).as("the credential must not reach the disk").doesNotContain(SECRET);
+        assertThat(written).contains("${ENV:" + PASSWORD_VAR + "}");
+    }
+
     private @NotNull List<String> errorsFromTheRestore() {
         return logCapture.getCapturedLogs().stream()
                 .filter(event -> event.getLevel() == Level.ERROR)

--- a/hivemq-edge/src/test/java/com/hivemq/configuration/reader/ConfigWriteBackEnvVarTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/configuration/reader/ConfigWriteBackEnvVarTest.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.configuration.reader;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.io.Files;
+import java.io.IOException;
+import java.nio.file.Path;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * What writing the configuration back out does to the operator's {@code ${ENV:...}} placeholders
+ * (EDG-882 QA round 2).
+ * <p>
+ * Rendering happens once, on the whole file, before it is parsed, so the configuration Edge holds in
+ * memory contains the values. Marshalling that back out — which any REST change to any subsystem does,
+ * including one to an unrelated subsystem — replaced the placeholders with what they resolved to. A
+ * bridge password supplied through an environment variable therefore ended up in {@code config.xml} in
+ * plain text, and the indirection the operator chose was gone for good.
+ * <p>
+ * {@link com.hivemq.util.render.EnvVarUtil#getValue} reads Java system properties before the
+ * environment, which is how these tests supply the values.
+ */
+public class ConfigWriteBackEnvVarTest extends AbstractConfigurationTest {
+
+    private static final @NotNull String PASSWORD_VAR = "EDG882_BRIDGE_PW";
+    private static final @NotNull String SECRET = "s3cr3t-do-not-write-me";
+
+    @AfterEach
+    public void clearProperties() {
+        System.clearProperty(PASSWORD_VAR);
+        System.clearProperty("EDG882_OTHER");
+    }
+
+    private static @NotNull String config(final @NotNull String password) {
+        return "" + "<hivemq>\n"
+                + "<mqtt-bridges>\n"
+                + "    <mqtt-bridge>\n"
+                + "        <id>edg-882-env-bridge</id>\n"
+                + "        <remote-broker>\n"
+                + "            <host>testhost</host>\n"
+                + "            <authentication>\n"
+                + "                <mqtt-simple-authentication>\n"
+                + "                    <username>hivemq-edge</username>\n"
+                + "                    <password>"
+                + password
+                + "</password>\n"
+                + "                </mqtt-simple-authentication>\n"
+                + "            </authentication>\n"
+                + "        </remote-broker>\n"
+                + "        <forwarded-topics>\n"
+                + "            <forwarded-topic>\n"
+                + "                <filters>\n"
+                + "                    <mqtt-topic-filter>plant/#</mqtt-topic-filter>\n"
+                + "                </filters>\n"
+                + "                <destination>{#}</destination>\n"
+                + "                <max-qos>1</max-qos>\n"
+                + "            </forwarded-topic>\n"
+                + "        </forwarded-topics>\n"
+                + "    </mqtt-bridge>\n"
+                + "</mqtt-bridges>"
+                + "</hivemq>";
+    }
+
+    private @NotNull String loadAndWriteBack(final @NotNull String configXml) throws IOException {
+        Files.write(configXml.getBytes(UTF_8), xmlFile);
+        reader.applyConfig();
+
+        reader.writeConfigWithSync();
+
+        return java.nio.file.Files.readString(Path.of(xmlFile.getPath()));
+    }
+
+    @Test
+    public void whenAPasswordComesFromAnEnvironmentVariable_thenItIsNotWrittenToTheFile() throws IOException {
+        System.setProperty(PASSWORD_VAR, SECRET);
+
+        final String written = loadAndWriteBack(config("${ENV:" + PASSWORD_VAR + "}"));
+
+        assertThat(written).doesNotContain(SECRET);
+        assertThat(written).contains("${ENV:" + PASSWORD_VAR + "}");
+    }
+
+    /** And the configuration still means the same thing after the round trip. */
+    @Test
+    public void whenTheFileIsWrittenBack_thenTheRenderedConfigurationIsUnchanged() throws IOException {
+        System.setProperty(PASSWORD_VAR, SECRET);
+        Files.write(config("${ENV:" + PASSWORD_VAR + "}").getBytes(UTF_8), xmlFile);
+        reader.applyConfig();
+        final String passwordAsRead = bridgeConfiguration.getBridges().get(0).getPassword();
+
+        reader.writeConfigWithSync();
+        reader.applyConfig();
+
+        assertThat(passwordAsRead).isEqualTo(SECRET);
+        assertThat(bridgeConfiguration.getBridges().get(0).getPassword()).isEqualTo(SECRET);
+    }
+
+    /** A value the operator wrote literally is not turned into a variable reference. */
+    @Test
+    public void whenAValueWasNotAPlaceholder_thenItIsWrittenOutUnchanged() throws IOException {
+        final String written = loadAndWriteBack(config("literal-password"));
+
+        assertThat(written).contains("literal-password");
+        assertThat(written).doesNotContain("${ENV:");
+    }
+
+    /**
+     * The conservative half of the rule. When the same value also appears where the operator wrote it
+     * literally, there is no way to tell the two apart in the rendered document, and rewriting the
+     * literal one into a variable reference would be a defect of its own — so the placeholder is left
+     * resolved instead, and the operator is told.
+     */
+    @Test
+    public void whenTheValueAlsoAppearsLiterally_thenNothingIsRewrittenBlindly() throws IOException {
+        System.setProperty(PASSWORD_VAR, "hivemq-edge"); // the same string the username uses
+
+        final String written = loadAndWriteBack(config("${ENV:" + PASSWORD_VAR + "}"));
+
+        assertThat(written)
+                .as("the username the operator wrote literally must not become a variable reference")
+                .contains("<username>hivemq-edge</username>");
+        assertThat(written).doesNotContain("${ENV:" + PASSWORD_VAR + "}");
+    }
+
+    /** Two elements fed by the same variable are both restored — the count matches. */
+    @Test
+    public void whenOneVariableFeedsTwoElements_thenBothArePutBack() throws IOException {
+        System.setProperty(PASSWORD_VAR, SECRET);
+        final String placeholder = "${ENV:" + PASSWORD_VAR + "}";
+        final String configXml =
+                config(placeholder).replace("<host>testhost</host>", "<host>" + placeholder + "</host>");
+
+        Files.write(configXml.getBytes(UTF_8), xmlFile);
+        reader.applyConfig();
+        reader.writeConfigWithSync();
+        final String written = java.nio.file.Files.readString(Path.of(xmlFile.getPath()));
+
+        assertThat(written).doesNotContain(SECRET);
+        assertThat(written).contains("<host>" + placeholder + "</host>");
+        assertThat(written).contains("<password>" + placeholder + "</password>");
+    }
+}

--- a/hivemq-edge/src/test/java/com/hivemq/configuration/reader/ConfigWriteBackEnvVarTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/configuration/reader/ConfigWriteBackEnvVarTest.java
@@ -17,13 +17,21 @@ package com.hivemq.configuration.reader;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
 import com.google.common.io.Files;
+import com.hivemq.exceptions.UnrecoverableException;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import util.LogbackCapturingAppender;
 
 /**
  * What writing the configuration back out does to the operator's {@code ${ENV:...}} placeholders
@@ -41,12 +49,25 @@ import org.junit.jupiter.api.Test;
 public class ConfigWriteBackEnvVarTest extends AbstractConfigurationTest {
 
     private static final @NotNull String PASSWORD_VAR = "EDG882_BRIDGE_PW";
+    private static final @NotNull String OTHER_VAR = "EDG882_OTHER";
     private static final @NotNull String SECRET = "s3cr3t-do-not-write-me";
+
+    /** What is written in place of a credential whose placeholder could not be restored. */
+    private static final @NotNull String UNRESTORED = "${ENV:EDGE_UNRESTORED_SECRET}";
+
+    private @NotNull LogbackCapturingAppender logCapture;
+
+    @BeforeEach
+    public void captureTheRestoreLog() {
+        logCapture = LogbackCapturingAppender.Factory.weaveInto(
+                LoggerFactory.getLogger(com.hivemq.util.render.EnvVarUtil.class));
+    }
 
     @AfterEach
     public void clearProperties() {
+        LogbackCapturingAppender.Factory.cleanUp();
         System.clearProperty(PASSWORD_VAR);
-        System.clearProperty("EDG882_OTHER");
+        System.clearProperty(OTHER_VAR);
     }
 
     private static @NotNull String config(final @NotNull String password) {
@@ -182,5 +203,140 @@ public class ConfigWriteBackEnvVarTest extends AbstractConfigurationTest {
         assertThat(written).doesNotContain(SECRET);
         assertThat(written).contains("<host>" + placeholder + "</host>");
         assertThat(written).contains("<password>" + placeholder + "</password>");
+    }
+
+    /**
+     * The escaping path, and what it turns out to be worth (EDG-882 review v02, R2-20).
+     * <p>
+     * The review asked for a value carrying the three characters a marshaller escapes in element text,
+     * on the reasoning that restoration finds the element by rebuilding the string JAXB wrote and so
+     * has to escape it the same way — and that "finds nothing" means the credential is written out.
+     * Writing the test showed the case cannot arise from an environment variable at all:
+     * {@code replaceEnvironmentVariablePlaceholders} splices the value into the document as raw text
+     * before it is parsed, escaping only the regex metacharacters {@code \} and {@code $}. A value
+     * carrying {@code &}, {@code <} or {@code >} therefore produces XML that is not well formed, and
+     * the configuration fails to <em>read</em> — long before any of this.
+     * <p>
+     * So {@code EnvVarUtil.escapeXmlText} is unreachable through this path and defensive only. This is
+     * pinned rather than left implicit: it is a pre-existing defect on the inbound side, out of scope
+     * here, and whoever fixes it should come back to the write-back side at the same time — at which
+     * point this test fails and says so.
+     */
+    @Test
+    public void whenAnEnvironmentValueCarriesXmlSpecialCharacters_thenTheConfigurationCannotEvenBeRead()
+            throws IOException {
+        System.setProperty(PASSWORD_VAR, "p&ss<w>rd");
+        Files.write(config("${ENV:" + PASSWORD_VAR + "}").getBytes(UTF_8), xmlFile);
+
+        assertThatThrownBy(reader::applyConfig)
+                .as("an env value with XML special characters is spliced in unescaped, so the file is malformed")
+                .isInstanceOf(UnrecoverableException.class);
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // The three ways the restore gives up, and what each one does with the value (R2-04).
+    //
+    // Anchoring to an element name and checking counts is sound when the counts line up and ambiguous
+    // when they do not, and no reading of an ambiguous case is right: by the time the document is
+    // marshalled, an element holding a resolved variable and one holding a literal that happens to
+    // equal it are the same bytes. So the ambiguous case is decided by which mistake can be undone.
+    // Writing a credential to disk cannot be undone; replacing one the operator wrote literally can,
+    // from the rolling backup the write takes first.
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Bail-out 1: two variables resolving to the same value in the same element name. Neither can be
+     * told from the other, so neither is restored — and because the element holds a credential, neither
+     * is written out either.
+     */
+    @Test
+    public void whenTwoVariablesFillTheSameElementWithTheSameValue_thenNeitherSecretIsWritten() throws IOException {
+        System.setProperty(PASSWORD_VAR, SECRET);
+        System.setProperty(OTHER_VAR, SECRET); // a different variable, the same resolved value
+
+        final String written = loadAndWriteBack(twoBridges("${ENV:" + PASSWORD_VAR + "}", "${ENV:" + OTHER_VAR + "}"));
+
+        assertThat(written).as("the credential must not reach the disk").doesNotContain(SECRET);
+        assertThat(written).contains("<password>" + UNRESTORED + "</password>");
+        assertThat(errorsFromTheRestore())
+                .as("giving up on a credential must be an error, not a warning")
+                .anySatisfy(message -> assertThat(message).contains("holds a credential"));
+    }
+
+    /**
+     * Bail-out 3: the counts disagree, because one bridge takes the value from a variable and the other
+     * has the same string written literally. Which occurrence came from the variable cannot be told, so
+     * both are poisoned. That does cost the operator the literal they wrote — deliberately, and it is
+     * the one direction that is recoverable: the previous file is in the rolling backup, whereas a
+     * credential written to config.xml is only fixed by rotating it.
+     */
+    @Test
+    public void whenAnotherElementHoldsTheSameValueLiterally_thenTheSecretIsStillNotWritten() throws IOException {
+        System.setProperty(PASSWORD_VAR, SECRET);
+
+        final String written = loadAndWriteBack(twoBridges("${ENV:" + PASSWORD_VAR + "}", SECRET));
+
+        assertThat(written).as("the credential must not reach the disk").doesNotContain(SECRET);
+        assertThat(written).contains("<password>" + UNRESTORED + "</password>");
+    }
+
+    /**
+     * Bail-out 2: the element the placeholder filled is not in the document as written, because the
+     * marshaller normalised the value on the way out. Only a typed field does that, so it is never a
+     * credential — nothing is poisoned, and the point of the case is that it is reported.
+     */
+    @Test
+    public void whenTheMarshallerNormalisesTheValue_thenItIsReportedAndNothingIsPoisoned() throws IOException {
+        System.setProperty(OTHER_VAR, "01883"); // <port> is an int in the schema: JAXB writes 1883
+
+        final String written = loadAndWriteBack(config("literal-password")
+                .replace("<host>testhost</host>", "<host>testhost</host><port>${ENV:" + OTHER_VAR + "}</port>"));
+
+        assertThat(written).contains("<port>1883</port>");
+        assertThat(written)
+                .as("a port is not a credential and must not be poisoned")
+                .doesNotContain(UNRESTORED);
+        assertThat(errorsFromTheRestore())
+                .anySatisfy(message -> assertThat(message).contains("is not in the configuration being written"));
+    }
+
+    /**
+     * And a non-credential that cannot be restored keeps its value. Losing the indirection is worth an
+     * error, but stopping a node from starting over a {@code <host>} would be answering a disclosure
+     * that did not happen.
+     */
+    @Test
+    public void whenANonSecretCannotBeRestored_thenItsValueIsWrittenOut() throws IOException {
+        System.setProperty(OTHER_VAR, "shared.example.com");
+
+        final String written = loadAndWriteBack(twoBridges("literal-password", "literal-password")
+                .replace("<host>testhost</host>", "<host>${ENV:" + OTHER_VAR + "}</host>")
+                .replace("<host>testhost2</host>", "<host>shared.example.com</host>"));
+
+        assertThat(written).contains("<host>shared.example.com</host>");
+        assertThat(written).doesNotContain(UNRESTORED);
+        assertThat(errorsFromTheRestore())
+                .anySatisfy(message -> assertThat(message).contains("variable reference is lost"));
+    }
+
+    private @NotNull List<String> errorsFromTheRestore() {
+        return logCapture.getCapturedLogs().stream()
+                .filter(event -> event.getLevel() == Level.ERROR)
+                .map(ILoggingEvent::getFormattedMessage)
+                .toList();
+    }
+
+    /** Two bridges, so that one element name can carry two values or two variables. */
+    private static @NotNull String twoBridges(final @NotNull String first, final @NotNull String second) {
+        return config(first).replace("</mqtt-bridges>", secondBridge(second) + "</mqtt-bridges>");
+    }
+
+    private static @NotNull String secondBridge(final @NotNull String password) {
+        return config(password)
+                .replace("<hivemq>\n<mqtt-bridges>\n", "")
+                .replace("</mqtt-bridges></hivemq>", "")
+                .replace("edg-882-env-bridge", "edg-882-env-bridge-2")
+                .replace("testhost", "testhost2")
+                .replace("plant/#", "plant2/#");
     }
 }

--- a/hivemq-edge/src/test/java/com/hivemq/configuration/reader/ConfigWriteBackEnvVarTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/configuration/reader/ConfigWriteBackEnvVarTest.java
@@ -466,4 +466,49 @@ public class ConfigWriteBackEnvVarTest extends AbstractConfigurationTest {
                 .as("nothing about this configuration should have been refused")
                 .isEmpty();
     }
+
+    /**
+     * EDG-882 review v04, finding 1.7. A credential containing an ampersand cannot be supplied through an
+     * environment variable at all: the value is spliced into the file as raw text before it is parsed, so
+     * the document is malformed and the node stops. That is not changed here -- the same splice is what
+     * lets a fragment bring in whole elements -- but the parser's complaint about a line the operator never
+     * wrote is now followed by the name of the variable responsible.
+     */
+    @Test
+    public void whenAPasswordContainsAnAmpersand_thenTheParseFailureNamesTheVariable() throws IOException {
+        final var readerLog =
+                LogbackCapturingAppender.Factory.weaveInto(LoggerFactory.getLogger(ConfigFileReaderWriter.class));
+        System.setProperty(PASSWORD_VAR, "p@ss&word");
+        Files.write(config("${ENV:" + PASSWORD_VAR + "}").getBytes(UTF_8), xmlFile);
+
+        assertThatThrownBy(() -> reader.applyConfig()).isInstanceOf(UnrecoverableException.class);
+
+        final List<String> errors = readerLog.getCapturedLogs().stream()
+                .filter(event -> event.getLevel() == Level.ERROR)
+                .map(ILoggingEvent::getFormattedMessage)
+                .toList();
+        assertThat(errors)
+                .as("the parse error alone points at content the operator cannot see")
+                .anySatisfy(
+                        message -> assertThat(message).contains(PASSWORD_VAR).contains("raw XML"));
+        assertThat(errors).as("the value itself must never be logged").noneSatisfy(message -> assertThat(message)
+                .contains("p@ss&word"));
+    }
+
+    /** A configuration that parses says nothing of the sort, whatever its values contain. */
+    @Test
+    public void whenTheConfigurationParses_thenNoSuchDiagnosticIsLogged() throws IOException {
+        final var readerLog =
+                LogbackCapturingAppender.Factory.weaveInto(LoggerFactory.getLogger(ConfigFileReaderWriter.class));
+        System.setProperty(PASSWORD_VAR, SECRET);
+        Files.write(config("${ENV:" + PASSWORD_VAR + "}").getBytes(UTF_8), xmlFile);
+
+        reader.applyConfig();
+
+        assertThat(readerLog.getCapturedLogs().stream()
+                        .filter(event -> event.getLevel() == Level.ERROR)
+                        .map(ILoggingEvent::getFormattedMessage)
+                        .toList())
+                .isEmpty();
+    }
 }

--- a/hivemq-edge/src/test/java/com/hivemq/configuration/reader/ConfigWriteBackEnvVarTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/configuration/reader/ConfigWriteBackEnvVarTest.java
@@ -364,4 +364,79 @@ public class ConfigWriteBackEnvVarTest extends AbstractConfigurationTest {
                 .replace("testhost", "testhost2")
                 .replace("plant/#", "plant2/#");
     }
+
+    // ---------------------------------------------------------------------------------------------
+    // EDG-882 review v03, R3-01 -- the collector recorded only placeholders that were an element's
+    // entire text, so a placeholder concatenated with other text, or one in an attribute, was resolved
+    // on the way in and written out resolved with nothing reported at all. The unit collected is now the
+    // whole span, which makes both restorable by the same anchoring the bare case already used.
+    // ---------------------------------------------------------------------------------------------
+
+    /** Sam's reproducer, verbatim: a password that is a prefix plus a variable. */
+    @Test
+    public void whenAPasswordIsConcatenatedWithText_thenTheSecretIsNotWrittenToTheFile() throws IOException {
+        System.setProperty(PASSWORD_VAR, SECRET);
+
+        final String written = loadAndWriteBack(config("prefix-${ENV:" + PASSWORD_VAR + "}"));
+
+        assertThat(written).as("the credential must not reach the disk").doesNotContain(SECRET);
+        assertThat(written)
+                .as("the operator's span must come back exactly as they wrote it")
+                .contains("<password>prefix-${ENV:" + PASSWORD_VAR + "}</password>");
+    }
+
+    /** The variable in the middle, so the restore cannot be a prefix or suffix trick. */
+    @Test
+    public void whenAPasswordSurroundsTheVariableOnBothSides_thenTheSecretIsNotWrittenToTheFile() throws IOException {
+        System.setProperty(PASSWORD_VAR, SECRET);
+
+        final String written = loadAndWriteBack(config("pre-${ENV:" + PASSWORD_VAR + "}-post"));
+
+        assertThat(written).doesNotContain(SECRET);
+        assertThat(written).contains("<password>pre-${ENV:" + PASSWORD_VAR + "}-post</password>");
+    }
+
+    /** Two variables in one span: the whole span is the unit, so the count does not matter. */
+    @Test
+    public void whenAPasswordUsesTwoVariables_thenNeitherValueIsWritten() throws IOException {
+        System.setProperty(PASSWORD_VAR, SECRET);
+        System.setProperty(OTHER_VAR, "second-half");
+
+        final String written = loadAndWriteBack(config("${ENV:" + PASSWORD_VAR + "}:${ENV:" + OTHER_VAR + "}"));
+
+        assertThat(written).doesNotContain(SECRET);
+        assertThat(written).doesNotContain("second-half");
+        assertThat(written).contains("<password>${ENV:" + PASSWORD_VAR + "}:${ENV:" + OTHER_VAR + "}</password>");
+    }
+
+    /** A concatenated non-secret keeps working too, and keeps its indirection. */
+    @Test
+    public void whenANonSecretIsConcatenated_thenItsPlaceholderIsAlsoRestored() throws IOException {
+        System.setProperty(OTHER_VAR, "berlin");
+
+        final String written = loadAndWriteBack(config("literal-password")
+                .replace("<host>testhost</host>", "<host>edge-${ENV:" + OTHER_VAR + "}</host>"));
+
+        assertThat(written)
+                .as("the indirection must survive for ordinary settings, not just credentials")
+                .contains("<host>edge-${ENV:" + OTHER_VAR + "}</host>");
+        assertThat(written).doesNotContain("<host>edge-berlin</host>");
+    }
+
+    /**
+     * The value being a substring of the rendered span must not confuse the anchor: the search is for the
+     * whole span between the tags, so a bare-value match elsewhere is not a candidate.
+     */
+    @Test
+    public void whenTheConcatenatedValueAlsoAppearsBare_thenOnlyTheSpanIsRestored() throws IOException {
+        System.setProperty(OTHER_VAR, "testhost");
+
+        final String written = loadAndWriteBack(twoBridges("literal-password", "literal-password")
+                .replace("<host>testhost2</host>", "<host>edge-${ENV:" + OTHER_VAR + "}</host>"));
+
+        assertThat(written).contains("<host>edge-${ENV:" + OTHER_VAR + "}</host>");
+        assertThat(written)
+                .as("the bridge that wrote the value literally must keep it")
+                .contains("<host>testhost</host>");
+    }
 }

--- a/hivemq-edge/src/test/java/com/hivemq/configuration/reader/ConfigWriteBackEnvVarTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/configuration/reader/ConfigWriteBackEnvVarTest.java
@@ -338,10 +338,17 @@ public class ConfigWriteBackEnvVarTest extends AbstractConfigurationTest {
     }
 
     private @NotNull List<String> errorsFromTheRestore() {
-        return logCapture.getCapturedLogs().stream()
+        final List<String> errors = logCapture.getCapturedLogs().stream()
                 .filter(event -> event.getLevel() == Level.ERROR)
                 .map(ILoggingEvent::getFormattedMessage)
                 .toList();
+        // These messages tell the operator to restore a '${ENV:...}' reference by hand, so they have to
+        // spell it the way it is written in the file. SLF4J substitutes '{}' and prints everything else
+        // verbatim, so a brace doubled to "escape" it survives into the log and the advice names syntax
+        // that does not exist. Caught on a real node during the 2026-08-25 smoke test.
+        assertThat(errors).as("an operator is being told to type this").allSatisfy(message -> assertThat(message)
+                .doesNotContain("{{"));
+        return errors;
     }
 
     /** Two bridges, so that one element name can carry two values or two variables. */

--- a/hivemq-edge/src/test/java/com/hivemq/configuration/reader/ConfigWriteBackEnvVarTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/configuration/reader/ConfigWriteBackEnvVarTest.java
@@ -123,13 +123,16 @@ public class ConfigWriteBackEnvVarTest extends AbstractConfigurationTest {
     }
 
     /**
-     * The conservative half of the rule. When the same value also appears where the operator wrote it
-     * literally, there is no way to tell the two apart in the rendered document, and rewriting the
-     * literal one into a variable reference would be a defect of its own — so the placeholder is left
-     * resolved instead, and the operator is told.
+     * A value that also appears where the operator wrote it literally, in a different element.
+     * <p>
+     * Restoration is anchored to the element the placeholder occupied, so the two are distinguishable
+     * and both are handled correctly: the password goes back to being a variable reference and the
+     * username stays exactly as the operator wrote it. Matching on the value alone could not tell them
+     * apart — it either left the secret in the file or rewrote the username into a variable reference
+     * nobody asked for (EDG-882 QA round 3).
      */
     @Test
-    public void whenTheValueAlsoAppearsLiterally_thenNothingIsRewrittenBlindly() throws IOException {
+    public void whenTheValueAlsoAppearsInAnotherElement_thenOnlyThePlaceholdersElementIsRestored() throws IOException {
         System.setProperty(PASSWORD_VAR, "hivemq-edge"); // the same string the username uses
 
         final String written = loadAndWriteBack(config("${ENV:" + PASSWORD_VAR + "}"));
@@ -137,7 +140,30 @@ public class ConfigWriteBackEnvVarTest extends AbstractConfigurationTest {
         assertThat(written)
                 .as("the username the operator wrote literally must not become a variable reference")
                 .contains("<username>hivemq-edge</username>");
-        assertThat(written).doesNotContain("${ENV:" + PASSWORD_VAR + "}");
+        assertThat(written)
+                .as("the password came from a variable and must go back to being one")
+                .contains("<password>${ENV:" + PASSWORD_VAR + "}</password>");
+    }
+
+    /**
+     * A placeholder in a commented-out block is not part of the configuration and never reaches the
+     * marshalled document; it must not make the live one look ambiguous. Commenting a bridge out is an
+     * ordinary thing for an operator to do (EDG-882 QA round 3).
+     */
+    @Test
+    public void whenACommentedOutBlockRepeatsThePlaceholder_thenTheLiveOneIsStillRestored() throws IOException {
+        System.setProperty(PASSWORD_VAR, SECRET);
+        final String placeholder = "${ENV:" + PASSWORD_VAR + "}";
+        final String configXml = config(placeholder)
+                .replace("<mqtt-bridges>", "<mqtt-bridges>\n<!-- <password>" + placeholder + "</password> -->");
+
+        Files.write(configXml.getBytes(UTF_8), xmlFile);
+        reader.applyConfig();
+        reader.writeConfigWithSync();
+
+        final String written = java.nio.file.Files.readString(Path.of(xmlFile.getPath()));
+        assertThat(written).doesNotContain(SECRET);
+        assertThat(written).contains("<password>" + placeholder + "</password>");
     }
 
     /** Two elements fed by the same variable are both restored — the count matches. */

--- a/hivemq-edge/src/test/java/com/hivemq/configuration/reader/ConfigWriteConcurrencyTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/configuration/reader/ConfigWriteConcurrencyTest.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.configuration.reader;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.AclEntry;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * EDG-882 — the configuration write path with more than one thread in it.
+ * <p>
+ * Two claims are worth holding down rather than assuming. The first is that {@link AclComparison} is a pure
+ * function: it decides whether a file full of credentials may be written, it is reached from whatever thread
+ * a REST request landed on, and the moment anyone gives it a cache or a reusable buffer it stops being safe
+ * to call that way. Nothing about its current shape needs protecting — which is exactly why the property
+ * should be a test rather than a reading of the source.
+ * <p>
+ * The second is that two configuration writes in flight at once do not interfere. Within a node they cannot:
+ * {@code writeConfigToXML} holds a lock for the whole render-and-replace, and the rolling backup is taken
+ * inside it. But the replacement itself is a static helper that works through a file named beside its target,
+ * so what has to be true is that <em>different</em> targets in one directory never touch each other's
+ * working file — which is the case that is not serialised by anything, and the case a backup and a
+ * configuration write in the same directory actually are.
+ */
+public class ConfigWriteConcurrencyTest {
+
+    private static final int THREADS = 16;
+
+    @TempDir
+    private @NotNull Path directory;
+
+    // ------------------------------------------------------------------ the comparison is a pure function
+
+    /**
+     * Every pair judged on every thread at once, against the answers the same pairs give on one thread.
+     * <p>
+     * The pairs are the assorted lists crossed with themselves, so the work is identical on every thread and
+     * a shared mutable structure would have to survive being written by all of them. A start gate keeps the
+     * threads from finishing before the last one has begun, which is what makes the overlap real rather than
+     * incidental.
+     */
+    @Test
+    public void theComparisonGivesTheSameAnswersUnderEveryThreadAtOnce() throws Exception {
+        final List<List<AclEntry>> lists = AclComparisonFixture.assortedLists();
+        final boolean[] sequential = judgeAll(lists);
+        final CountDownLatch ready = new CountDownLatch(THREADS);
+        final CountDownLatch go = new CountDownLatch(1);
+
+        try (final ExecutorService threads = Executors.newFixedThreadPool(THREADS)) {
+            final List<Future<boolean[]>> answers = new ArrayList<>(THREADS);
+            for (int thread = 0; thread < THREADS; thread++) {
+                answers.add(threads.submit((Callable<boolean[]>) () -> {
+                    ready.countDown();
+                    if (!go.await(30, TimeUnit.SECONDS)) {
+                        throw new IllegalStateException("the start gate never opened");
+                    }
+                    boolean[] answer = null;
+                    for (int repeat = 0; repeat < 200; repeat++) {
+                        answer = judgeAll(lists);
+                    }
+                    return answer;
+                }));
+            }
+            assertTrue(ready.await(30, TimeUnit.SECONDS), "not every thread started");
+            go.countDown();
+            for (final Future<boolean[]> answer : answers) {
+                assertArrayEquals(
+                        sequential,
+                        answer.get(60, TimeUnit.SECONDS),
+                        "the comparison answered differently on a thread of its own");
+            }
+        }
+    }
+
+    private static boolean[] judgeAll(final @NotNull List<List<AclEntry>> lists) {
+        final boolean[] answers = new boolean[lists.size() * lists.size()];
+        int position = 0;
+        for (final List<AclEntry> candidate : lists) {
+            for (final List<AclEntry> reference : lists) {
+                answers[position++] = AclComparison.grantsNoMoreThan(candidate, reference);
+            }
+        }
+        return answers;
+    }
+
+    // ------------------------------------------------------- concurrent replacements do not cross-talk
+
+    /**
+     * Sixteen files in one directory, each replaced from its own thread at the same moment. Each has to end
+     * up holding its own content and nobody else's, and the directory has to be left with nothing but the
+     * files themselves — a working file surviving a replacement is a copy of a configuration sitting in a
+     * directory under a name nothing will ever clean up.
+     */
+    @Test
+    public void concurrentReplacementsOfDifferentFilesDoNotInterfere() throws Exception {
+        final List<Path> targets = new ArrayList<>(THREADS);
+        for (int index = 0; index < THREADS; index++) {
+            final Path target = directory.resolve("config-" + index + ".xml");
+            Files.writeString(target, "<before-" + index + "/>", StandardCharsets.UTF_8);
+            targets.add(target);
+        }
+        final CountDownLatch ready = new CountDownLatch(THREADS);
+        final CountDownLatch go = new CountDownLatch(1);
+
+        try (final ExecutorService threads = Executors.newVirtualThreadPerTaskExecutor()) {
+            final List<Future<?>> replacements = new ArrayList<>(THREADS);
+            for (int index = 0; index < THREADS; index++) {
+                final Path target = targets.get(index);
+                final String content = "<after-" + index + "/>";
+                replacements.add(threads.submit(() -> {
+                    ready.countDown();
+                    if (!go.await(30, TimeUnit.SECONDS)) {
+                        throw new IllegalStateException("the start gate never opened");
+                    }
+                    ConfigFileReaderWriter.replaceCarryingProtections(
+                            target,
+                            ConfigFileReaderWriter.preservedAttributesOf(target),
+                            partial -> Files.writeString(partial, content, StandardCharsets.UTF_8));
+                    return null;
+                }));
+            }
+            assertTrue(ready.await(30, TimeUnit.SECONDS), "not every thread started");
+            go.countDown();
+            for (final Future<?> replacement : replacements) {
+                replacement.get(60, TimeUnit.SECONDS);
+            }
+        }
+
+        for (int index = 0; index < THREADS; index++) {
+            assertEquals(
+                    "<after-" + index + "/>",
+                    Files.readString(targets.get(index), StandardCharsets.UTF_8),
+                    "a replacement landed in the wrong file, or was overwritten by another one");
+        }
+        assertNoWorkingFilesLeftBehind();
+    }
+
+    /**
+     * The same directory, the same instant, but every thread replacing the file with the content it already
+     * has — the shape a configuration write and its rolling backup make when both are in flight. Whatever
+     * interleaving happens, no file may be left truncated or half written, because the content is complete
+     * on disk before anything is moved onto anything.
+     */
+    @Test
+    public void aReplacementNeverLeavesAFileHalfWritten() throws Exception {
+        final Path target = directory.resolve("config.xml");
+        final String content = "<configuration>" + "x".repeat(64 * 1024) + "</configuration>";
+        Files.writeString(target, content, StandardCharsets.UTF_8);
+
+        try (final ExecutorService threads = Executors.newVirtualThreadPerTaskExecutor()) {
+            final List<Future<?>> work = new ArrayList<>();
+            for (int index = 0; index < THREADS; index++) {
+                // Every thread reads the file while one of them replaces it. Reading a file that is being
+                // replaced by a move sees either the old content or the new one, never a prefix of either.
+                work.add(threads.submit(() -> {
+                    for (int repeat = 0; repeat < 20; repeat++) {
+                        assertEquals(content, Files.readString(target, StandardCharsets.UTF_8));
+                    }
+                    return null;
+                }));
+            }
+            work.add(threads.submit(() -> {
+                for (int repeat = 0; repeat < 20; repeat++) {
+                    ConfigFileReaderWriter.replaceCarryingProtections(
+                            target,
+                            ConfigFileReaderWriter.preservedAttributesOf(target),
+                            partial -> Files.writeString(partial, content, StandardCharsets.UTF_8));
+                }
+                return null;
+            }));
+            for (final Future<?> item : work) {
+                item.get(120, TimeUnit.SECONDS);
+            }
+        }
+
+        assertEquals(content, Files.readString(target, StandardCharsets.UTF_8));
+        assertNoWorkingFilesLeftBehind();
+    }
+
+    private void assertNoWorkingFilesLeftBehind() throws IOException {
+        try (final Stream<Path> entries = Files.list(directory)) {
+            final List<String> leftBehind = entries.map(
+                            path -> path.getFileName().toString())
+                    .filter(name -> name.endsWith(".partial"))
+                    .toList();
+            assertTrue(leftBehind.isEmpty(), "working files left in the configuration directory: " + leftBehind);
+        }
+    }
+}

--- a/hivemq-edge/src/test/java/com/hivemq/configuration/reader/ConfigWriteFailureReportingTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/configuration/reader/ConfigWriteFailureReportingTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.configuration.reader;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import ch.qos.logback.classic.Level;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.List;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import util.LogbackCapturingAppender;
+
+/**
+ * EDG-882 review v04, finding 1.5 — what an operator is told when the configuration cannot be written.
+ * <p>
+ * {@code writeConfigWithSync} catches everything and carries on, deliberately: the running node is
+ * correct and unchanged, and throwing here would decide, for every configuration endpoint at once, what a
+ * REST call should answer when the file cannot be persisted. That decision is not this ticket's to make.
+ * What is this ticket's is that the outcome used to be a message-less {@code UnrecoverableException}
+ * stack trace under a generic "sync failed" line, which reads like a crash and says nothing about the
+ * consequence — while the REST call that triggered it answered success.
+ * <p>
+ * Every deliberate refusal on the write path — a credential that cannot be kept out of the file,
+ * protections that cannot be reproduced — arrives here. The reason is logged by whichever check made the
+ * decision; this pins the line that states what it means for the file on disk.
+ */
+public class ConfigWriteFailureReportingTest extends AbstractConfigurationTest {
+
+    private static final @NotNull String CONFIG =
+            "<hivemq>\n<mqtt-bridges>\n    <mqtt-bridge>\n        <id>edg-882-reporting-bridge</id>\n"
+                    + "        <remote-broker>\n            <host>testhost</host>\n"
+                    + "        </remote-broker>\n        <forwarded-topics>\n            <forwarded-topic>\n"
+                    + "                <filters>\n                    <mqtt-topic-filter>plant/#</mqtt-topic-filter>\n"
+                    + "                </filters>\n                <destination>{#}</destination>\n"
+                    + "                <max-qos>1</max-qos>\n            </forwarded-topic>\n"
+                    + "        </forwarded-topics>\n    </mqtt-bridge>\n</mqtt-bridges></hivemq>";
+
+    private @NotNull LogbackCapturingAppender logCapture;
+    private @NotNull Path config;
+
+    @BeforeEach
+    public void captureTheWriterLog() {
+        logCapture = LogbackCapturingAppender.Factory.weaveInto(LoggerFactory.getLogger(ConfigFileReaderWriter.class));
+        config = Path.of(xmlFile.getPath());
+        assumeTrue(
+                config.getFileSystem().supportedFileAttributeViews().contains("posix"),
+                "the write is made to fail through directory permissions");
+        assumeTrue(!"root".equals(System.getProperty("user.name")), "a superuser is not refused by mode bits");
+    }
+
+    @AfterEach
+    public void restoreTheDirectory() throws IOException {
+        Files.setPosixFilePermissions(config.getParent(), PosixFilePermissions.fromString("rwx------"));
+        LogbackCapturingAppender.Factory.cleanUp();
+    }
+
+    private @NotNull List<String> errorsLogged() {
+        return logCapture.getCapturedLogs().stream()
+                .filter(event -> event.getLevel() == Level.ERROR)
+                .map(event -> event.getFormattedMessage())
+                .toList();
+    }
+
+    /**
+     * The write fails, the caller is not told, and the log says so: the node is correct, the file is not,
+     * and a restart would lose the change. Provoked by taking write permission off the configuration
+     * directory, which is the same path every deliberate refusal takes to get here.
+     */
+    @Test
+    public void whenTheConfigurationCannotBeWritten_thenTheLogSaysTheFileNoLongerMatchesTheNode() throws IOException {
+        Files.writeString(config, CONFIG);
+        reader.applyConfig();
+        Files.setPosixFilePermissions(config.getParent(), PosixFilePermissions.fromString("r-x------"));
+
+        assertThatCode(() -> reader.writeConfigWithSync())
+                .as("the caller must not see the failure, which is exactly why the log has to carry it")
+                .doesNotThrowAnyException();
+
+        assertThat(errorsLogged())
+                .as("the operator is told the file is now stale, not only that something failed")
+                .anySatisfy(message -> assertThat(message)
+                        .contains("config.xml")
+                        .contains("restart")
+                        .contains("keeps running on the configuration it already holds"));
+    }
+
+    /** And the configuration file it could not replace is still the one it was, byte for byte. */
+    @Test
+    public void whenTheConfigurationCannotBeWritten_thenTheFileOnDiskIsUntouched() throws IOException {
+        Files.writeString(config, CONFIG);
+        reader.applyConfig();
+        Files.setPosixFilePermissions(config.getParent(), PosixFilePermissions.fromString("r-x------"));
+
+        reader.writeConfigWithSync();
+
+        Files.setPosixFilePermissions(config.getParent(), PosixFilePermissions.fromString("rwx------"));
+        assertThat(Files.readString(config)).isEqualTo(CONFIG);
+    }
+
+    /** An ordinary write logs none of this. */
+    @Test
+    public void whenTheConfigurationIsWritten_thenNothingIsReported() throws IOException {
+        Files.writeString(config, CONFIG);
+        reader.applyConfig();
+
+        reader.writeConfigWithSync();
+
+        assertThat(errorsLogged()).isEmpty();
+        assertThat(Files.readString(config)).contains("edg-882-reporting-bridge");
+    }
+}

--- a/hivemq-edge/src/test/java/com/hivemq/configuration/reader/ConfigWriteFailureReportingTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/configuration/reader/ConfigWriteFailureReportingTest.java
@@ -130,4 +130,39 @@ public class ConfigWriteFailureReportingTest extends AbstractConfigurationTest {
         assertThat(errorsLogged()).isEmpty();
         assertThat(Files.readString(config)).contains("edg-882-reporting-bridge");
     }
+
+    /**
+     * EDG-882 review v04, finding 2.2's other half. Replacing by move needs permission on the directory,
+     * not on the file, so a configuration an operator write-protected would be replaced anyway — and its
+     * owner quietly changed in the process. Writing in place refused that, and so does this.
+     */
+    @Test
+    public void whenTheConfigurationFileIsNotWritable_thenItIsNotReplaced() throws IOException {
+        Files.writeString(config, CONFIG);
+        reader.applyConfig();
+        Files.setPosixFilePermissions(config, PosixFilePermissions.fromString("r--r--r--"));
+
+        reader.writeConfigWithSync();
+
+        assertThat(Files.readString(config))
+                .as("a write-protected configuration was replaced")
+                .isEqualTo(CONFIG);
+        assertThat(errorsLogged()).anySatisfy(message -> assertThat(message).contains("not writable by this node"));
+    }
+
+    /** And nothing is left behind by the refusal — not even the backup that write would have taken. */
+    @Test
+    public void whenTheConfigurationFileIsNotWritable_thenNoBackupIsTaken() throws IOException {
+        Files.writeString(config, CONFIG);
+        reader.applyConfig();
+        Files.setPosixFilePermissions(config, PosixFilePermissions.fromString("r--r--r--"));
+
+        reader.writeConfigWithSync();
+
+        try (var listing = Files.list(config.getParent())) {
+            assertThat(listing.map(path -> path.getFileName().toString()).toList())
+                    .as("the refusal must come before anything is written")
+                    .containsExactly("config.xml");
+        }
+    }
 }

--- a/hivemq-edge/src/test/java/com/hivemq/configuration/reader/ConfigWritePermissionsTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/configuration/reader/ConfigWritePermissionsTest.java
@@ -16,6 +16,8 @@
 package com.hivemq.configuration.reader;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -60,8 +62,13 @@ import org.junit.jupiter.api.io.TempDir;
  * was treated as "there are none" and the write proceeded on the umask (R3-09).
  * <p>
  * That window did not exist before the branch that introduced it: writing in place reused the file's own
- * inode and therefore its own mode, group and ACL. It is a regression, which is why the behaviour here is
- * fail-closed rather than best-effort.
+ * inode and therefore its own mode, group and ACL. It is a regression, which is why the behaviour here
+ * fails closed rather than best-effort.
+ * <p>
+ * Fails closed on <em>access</em>, which is not the same as refusing the write. A protection this node was
+ * never going to be able to set — an owner it may not assign, a group it is not a member of — narrows the
+ * replacement instead of aborting it, because aborting means the configuration the operator just asked for
+ * is not persisted and comes back missing on the next restart. Both halves are pinned below.
  * <p>
  * The creation-time property is the one that matters and it cannot be observed end to end — the write is
  * synchronous and the temporary file is gone by the time any assertion could run — so it is pinned
@@ -350,13 +357,26 @@ public class ConfigWritePermissionsTest {
         assertEquals(attributes.group(), actual.group(), "and so is the group, which is who else can read it");
     }
 
+    // ------------------------------------------------- EDG-882 QA: a group this node is not a member of
+
     /**
-     * The other half of that trade: the protections that decide who <em>else</em> can read the file keep
-     * refusing. A group this account cannot assign aborts the replacement rather than granting group-read
-     * to whichever group the node happens to belong to.
+     * The regression this closes, and it is the same shape as the owner one above. Setting a file's group
+     * requires membership of it, so a {@code config.xml} installed under one group and served by a node
+     * running under another — the ordinary container case — failed here, and failing here refused the
+     * whole <em>write</em>. Edge went on running correctly on the configuration it already had, so nothing
+     * looked broken until a restart came up on the older file with every REST change since missing.
+     * <p>
+     * The first fix for it aborted rather than granted, because a mode names a group without naming which
+     * one, and reproducing {@code 0640} while the group falls back to this node's own hands group-read of
+     * every credential in the configuration to the wrong principals (R3-09). Narrowing does neither: the
+     * group's permissions come off the mode with the group, so the replacement grants the group nothing.
+     * <p>
+     * Provoked with a group this account is not in, which every POSIX system has and which no ordinary
+     * account may assign. Skipped when the build runs as a superuser, for whom the call succeeds.
      */
     @Test
-    public void applyPreservedAttributes_whenTheGroupCannotBeSet_thenTheWriteIsStillAborted() throws IOException {
+    public void applyPreservedAttributes_whenTheGroupCannotBeSet_thenTheGroupsAccessComesOffTheMode()
+            throws IOException {
         assumeTrue(!"root".equals(System.getProperty("user.name")), "a superuser may set any group");
         final Path target = targetWith(GROUP_READABLE);
         final PosixFileAttributes attributes = Files.readAttributes(target, PosixFileAttributes.class);
@@ -365,11 +385,167 @@ public class ConfigWritePermissionsTest {
         final PreservedAttributes elsewhere =
                 new PreservedAttributes(attributes.permissions(), attributes.owner(), foreign, null);
         ConfigFileReaderWriter.createPartialFile(partial, elsewhere);
+        Files.writeString(partial, "<hivemq><bridge><password>s3cr3t</password></bridge></hivemq>");
+
+        ConfigFileReaderWriter.applyPreservedAttributes(partial, elsewhere);
+
+        final PosixFileAttributes actual = Files.readAttributes(partial, PosixFileAttributes.class);
+        assertEquals(
+                OWNER_ONLY,
+                actual.permissions(),
+                "the group's permissions stayed on a mode whose group is now this node's own, which is R3-09");
+        assertNotEquals(foreign, actual.group(), "the group cannot have been set, or this test proves nothing");
+        assertEquals(attributes.owner(), actual.owner(), "the owner is this account either way and must be unchanged");
+    }
+
+    /**
+     * And only the group's own bits come off. What the mode grants to others is granted to the same others
+     * on the file being replaced, so removing it would take away access the operator deliberately gave —
+     * a narrowing nobody asked for is still a change nobody asked for.
+     */
+    @Test
+    public void applyPreservedAttributes_whenTheGroupCannotBeSet_thenOthersKeepWhatTheModeGaveThem()
+            throws IOException {
+        assumeTrue(!"root".equals(System.getProperty("user.name")), "a superuser may set any group");
+        final Path target = targetWith(WORLD_READABLE);
+        final PosixFileAttributes attributes = Files.readAttributes(target, PosixFileAttributes.class);
+        final GroupPrincipal foreign = aGroupThisUserIsNotIn(target);
+        assumeTrue(foreign != null, "this account can assign every group it can name, so there is nothing to refuse");
+        final PreservedAttributes elsewhere =
+                new PreservedAttributes(attributes.permissions(), attributes.owner(), foreign, null);
+        ConfigFileReaderWriter.createPartialFile(partial, elsewhere);
+
+        ConfigFileReaderWriter.applyPreservedAttributes(partial, elsewhere);
+
+        assertEquals(
+                PosixFilePermissions.fromString("rw----r--"),
+                Files.getPosixFilePermissions(partial),
+                "only the group's permissions come off; the world's are the same world the target grants");
+    }
+
+    /**
+     * A group that decides nobody's access. When the mode grants the group nothing, which group the file
+     * names is decoration, and dropping it must change the mode not at all — the narrowing is of access,
+     * not of bits.
+     */
+    @Test
+    public void applyPreservedAttributes_whenTheGroupCannotBeSetAndGrantsNothing_thenTheModeIsUntouched()
+            throws IOException {
+        assumeTrue(!"root".equals(System.getProperty("user.name")), "a superuser may set any group");
+        final Path target = targetWith(OWNER_ONLY);
+        final PosixFileAttributes attributes = Files.readAttributes(target, PosixFileAttributes.class);
+        final GroupPrincipal foreign = aGroupThisUserIsNotIn(target);
+        assumeTrue(foreign != null, "this account can assign every group it can name, so there is nothing to refuse");
+        final PreservedAttributes elsewhere =
+                new PreservedAttributes(attributes.permissions(), attributes.owner(), foreign, null);
+        ConfigFileReaderWriter.createPartialFile(partial, elsewhere);
+
+        ConfigFileReaderWriter.applyPreservedAttributes(partial, elsewhere);
+
+        assertEquals(
+                OWNER_ONLY,
+                Files.getPosixFilePermissions(partial),
+                "a group that grants nothing must not change the mode when it is dropped");
+    }
+
+    /**
+     * A mode that grants nobody anything is a legal mode, and the set expressing it is empty. Building the
+     * narrowed mode with {@code EnumSet.copyOf} would throw {@code IllegalArgumentException} on exactly
+     * that set — an empty collection that is not itself an {@code EnumSet} — turning a protection this
+     * code is meant to keep into the one input that breaks it.
+     */
+    @Test
+    public void applyPreservedAttributes_whenTheGroupCannotBeSetOnAFileNobodyMayRead_thenItStillGoesOn()
+            throws IOException {
+        assumeTrue(!"root".equals(System.getProperty("user.name")), "a superuser may set any group");
+        final Path target = targetWith(OWNER_ONLY);
+        final GroupPrincipal foreign = aGroupThisUserIsNotIn(target);
+        assumeTrue(foreign != null, "this account can assign every group it can name, so there is nothing to refuse");
+        final PreservedAttributes unreadable = new PreservedAttributes(Set.of(), Files.getOwner(target), foreign, null);
+        ConfigFileReaderWriter.createPartialFile(partial, unreadable);
+
+        ConfigFileReaderWriter.applyPreservedAttributes(partial, unreadable);
+
+        assertEquals(
+                Set.<PosixFilePermission>of(),
+                Files.getPosixFilePermissions(partial),
+                "a file nobody may read must be replaced by one nobody may read");
+    }
+
+    /**
+     * Neither of the two fallbacks may cancel the other. An owner this account cannot set <em>and</em> a
+     * group it is not in is the root-installed configuration served by a service user, which is the
+     * deployment both findings came from; the replacement must end up owned by this account, granting its
+     * group nothing, and written.
+     */
+    @Test
+    public void applyPreservedAttributes_whenNeitherOwnerNorGroupCanBeSet_thenBothNarrowAndTheWriteGoesOn()
+            throws IOException {
+        assumeTrue(!"root".equals(System.getProperty("user.name")), "a superuser may set any owner or group");
+        final Path target = targetWith(GROUP_READABLE);
+        final UserPrincipal root =
+                directory.getFileSystem().getUserPrincipalLookupService().lookupPrincipalByName("root");
+        final GroupPrincipal foreign = aGroupThisUserIsNotIn(target);
+        assumeTrue(foreign != null, "this account can assign every group it can name, so there is nothing to refuse");
+        final PreservedAttributes elsewhere = new PreservedAttributes(GROUP_READABLE, root, foreign, null);
+        ConfigFileReaderWriter.createPartialFile(partial, elsewhere);
+        Files.writeString(partial, "<hivemq><bridge><password>s3cr3t</password></bridge></hivemq>");
+
+        ConfigFileReaderWriter.applyPreservedAttributes(partial, elsewhere);
+
+        final PosixFileAttributes actual = Files.readAttributes(partial, PosixFileAttributes.class);
+        assertEquals(Files.getOwner(target), actual.owner(), "the replacement is owned by the account that wrote it");
+        assertEquals(OWNER_ONLY, actual.permissions(), "the unreproducible group must not keep its permissions");
+    }
+
+    /**
+     * End to end, which is the failure QA actually saw: an adapter created through REST, the node
+     * restarted, the adapter gone. The write must complete and the content must reach the target.
+     */
+    @Test
+    public void replaceCarryingProtections_whenTheGroupCannotBeSet_thenTheConfigurationIsStillWritten()
+            throws IOException {
+        assumeTrue(!"root".equals(System.getProperty("user.name")), "a superuser may set any group");
+        final Path target = targetWith(GROUP_READABLE);
+        final GroupPrincipal foreign = aGroupThisUserIsNotIn(target);
+        assumeTrue(foreign != null, "this account can assign every group it can name, so there is nothing to refuse");
+        final PreservedAttributes elsewhere =
+                new PreservedAttributes(GROUP_READABLE, Files.getOwner(target), foreign, null);
+
+        ConfigFileReaderWriter.replaceCarryingProtections(
+                target,
+                elsewhere,
+                written -> Files.writeString(written, "<hivemq><bridge><password>s3cr3t</password></bridge></hivemq>"));
+
+        assertEquals(
+                "<hivemq><bridge><password>s3cr3t</password></bridge></hivemq>",
+                Files.readString(target),
+                "the configuration was not persisted, which is the defect: a restart would lose the change");
+        assertEquals(
+                OWNER_ONLY,
+                Files.getPosixFilePermissions(target),
+                "the mode kept permissions for a group the replacement could not be given");
+        assertFalse(
+                Files.exists(target.resolveSibling(target.getFileName() + ".partial")),
+                "a partial file was left beside the target");
+    }
+
+    /**
+     * The other half of the trade is unchanged: a protection that fails for any reason other than a
+     * privilege this node was never going to have still aborts. Provoked by removing the replacement, so
+     * that nothing about it can be set or read.
+     */
+    @Test
+    public void applyPreservedAttributes_whenTheReplacementIsGone_thenTheWriteIsStillAborted() throws IOException {
+        final Path target = targetWith(GROUP_READABLE);
+        final PreservedAttributes preserved = ConfigFileReaderWriter.preservedAttributesOf(target);
+        ConfigFileReaderWriter.createPartialFile(partial, preserved);
+        Files.delete(partial);
 
         assertThrows(
                 IOException.class,
-                () -> ConfigFileReaderWriter.applyPreservedAttributes(partial, elsewhere),
-                "a group that cannot be reproduced decides who else can read the file, so it must abort");
+                () -> ConfigFileReaderWriter.applyPreservedAttributes(partial, preserved),
+                "a store failure is not a privilege this node lacks, and must not be narrowed past");
     }
 
     /** A group this account cannot set on a file it owns, or {@code null} when every named group works. */

--- a/hivemq-edge/src/test/java/com/hivemq/configuration/reader/ConfigWritePermissionsTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/configuration/reader/ConfigWritePermissionsTest.java
@@ -322,8 +322,10 @@ public class ConfigWritePermissionsTest {
      * A group this account belongs to that is not {@code current}, and that it may actually set on a file
      * it owns, or {@code null} when there is none. Both conditions matter: membership is what makes the
      * change legal, and some platforms restrict it further.
+     * <p>
+     * Shared with {@link ConfigBackupPermissionsTest}, which asks the same question of the rolling backup.
      */
-    private static @Nullable GroupPrincipal aDifferentGroupOfThisUser(
+    static @Nullable GroupPrincipal aDifferentGroupOfThisUser(
             final @NotNull Path file, final @NotNull GroupPrincipal current) {
         for (final String name : groupNamesOfThisUser()) {
             if (name.equals(current.getName())) {
@@ -343,7 +345,7 @@ public class ConfigWritePermissionsTest {
         return null;
     }
 
-    private static @NotNull List<String> groupNamesOfThisUser() {
+    static @NotNull List<String> groupNamesOfThisUser() {
         final List<String> names = new ArrayList<>();
         try {
             final Process process =

--- a/hivemq-edge/src/test/java/com/hivemq/configuration/reader/ConfigWritePermissionsTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/configuration/reader/ConfigWritePermissionsTest.java
@@ -16,40 +16,55 @@
 package com.hivemq.configuration.reader;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
+import com.hivemq.configuration.reader.ConfigFileReaderWriter.PreservedAttributes;
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.GroupPrincipal;
+import java.nio.file.attribute.PosixFileAttributeView;
+import java.nio.file.attribute.PosixFileAttributes;
 import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 /**
- * EDG-882 review v03, R3-07 — the replacement configuration file must never be readable by anyone the
- * file it replaces was not, at any point while it holds the configuration.
+ * EDG-882 review v03, R3-07 and R3-09 — the replacement configuration file must never be readable by
+ * anyone the file it replaces was not, at any point while it holds the configuration.
  * <p>
  * {@code config.xml} carries bridge passwords, keystore and truststore passwords and adapter
  * credentials. The first version of the replace-by-move wrote the rendered document into a file created
  * by {@code FileWriter}, which takes the process umask — commonly {@code 0644} — and only narrowed it to
  * the target's mode afterwards. Between those two steps a world-readable file held every secret in the
- * configuration, on every REST write to any subsystem.
+ * configuration, on every REST write to any subsystem (R3-07).
+ * <p>
+ * The second version fixed the timing but carried only the mode. A mode names a group without naming
+ * <em>which</em> group, and a newly created file takes its group from the creating process or from the
+ * directory — so a {@code 0640} file could be replaced by a {@code 0640} file whose group-read was
+ * granted to an entirely different set of principals, and a failure to read the original's protections
+ * was treated as "there are none" and the write proceeded on the umask (R3-09).
  * <p>
  * That window did not exist before the branch that introduced it: writing in place reused the file's own
- * inode and therefore its own mode. This is a regression, which is why the behaviour here is fail-closed
- * rather than best-effort.
+ * inode and therefore its own mode, group and ACL. It is a regression, which is why the behaviour here is
+ * fail-closed rather than best-effort.
  * <p>
  * The creation-time property is the one that matters and it cannot be observed end to end — the write is
  * synchronous and the temporary file is gone by the time any assertion could run — so it is pinned
- * directly on the helper that establishes it. {@code ConfigFileWriterTest} covers the end-to-end mode
+ * directly on the helpers that establish it. {@code ConfigFileWriterTest} covers the end-to-end mode
  * preservation and the symbolic-link case.
  */
 public class ConfigWritePermissionsTest {
@@ -59,6 +74,8 @@ public class ConfigWritePermissionsTest {
             PosixFilePermissions.fromString("rw-r--r--");
     private static final @NotNull Set<PosixFilePermission> WORLD_WRITABLE =
             PosixFilePermissions.fromString("rw-rw-rw-");
+    private static final @NotNull Set<PosixFilePermission> GROUP_READABLE =
+            PosixFilePermissions.fromString("rw-r-----");
 
     @TempDir
     private @NotNull Path directory;
@@ -73,6 +90,14 @@ public class ConfigWritePermissionsTest {
         partial = directory.resolve("config.xml.partial");
     }
 
+    private @NotNull Path targetWith(final @NotNull Set<PosixFilePermission> mode) throws IOException {
+        final Path target = directory.resolve("config.xml");
+        Files.createFile(target, PosixFilePermissions.asFileAttribute(mode));
+        return target;
+    }
+
+    // ---------------------------------------------------------------- R3-07: the disclosure window
+
     /**
      * The defect, at the only moment it is observable. A target the operator restricted to {@code 0600}
      * must not produce a replacement that is briefly readable by everyone — so the file is created
@@ -80,7 +105,8 @@ public class ConfigWritePermissionsTest {
      */
     @Test
     public void createPartialFile_createsTheReplacementOwnerOnly() throws IOException {
-        ConfigFileReaderWriter.createPartialFile(partial, OWNER_ONLY);
+        ConfigFileReaderWriter.createPartialFile(
+                partial, ConfigFileReaderWriter.preservedAttributesOf(targetWith(OWNER_ONLY)));
 
         assertEquals(
                 OWNER_ONLY,
@@ -95,7 +121,8 @@ public class ConfigWritePermissionsTest {
      */
     @Test
     public void createPartialFile_isOwnerOnlyEvenWhenTheTargetIsWorldReadable() throws IOException {
-        ConfigFileReaderWriter.createPartialFile(partial, WORLD_READABLE);
+        ConfigFileReaderWriter.createPartialFile(
+                partial, ConfigFileReaderWriter.preservedAttributesOf(targetWith(WORLD_READABLE)));
 
         assertEquals(
                 OWNER_ONLY,
@@ -113,7 +140,8 @@ public class ConfigWritePermissionsTest {
         Files.createFile(partial, PosixFilePermissions.asFileAttribute(WORLD_WRITABLE));
         Files.writeString(partial, "left behind by a killed write");
 
-        ConfigFileReaderWriter.createPartialFile(partial, OWNER_ONLY);
+        ConfigFileReaderWriter.createPartialFile(
+                partial, ConfigFileReaderWriter.preservedAttributesOf(targetWith(OWNER_ONLY)));
 
         assertEquals(
                 OWNER_ONLY,
@@ -123,23 +151,24 @@ public class ConfigWritePermissionsTest {
     }
 
     /**
-     * With no mode to reproduce — a configuration file being created for the first time — the
-     * replacement is created normally and takes the umask, which is what that file would have had
-     * anyway. Narrowing it here would silently change the mode of every newly created configuration.
+     * With nothing to reproduce — a configuration file being created for the first time — the replacement
+     * is created normally and takes the umask, which is what that file would have had anyway. Narrowing
+     * it here would silently change the mode of every newly created configuration.
      */
     @Test
     public void createPartialFile_withNothingToReproduce_createsTheFileNormally() throws IOException {
-        ConfigFileReaderWriter.createPartialFile(partial, null);
+        ConfigFileReaderWriter.createPartialFile(partial, PreservedAttributes.NONE);
 
         assertTrue(Files.exists(partial), "the replacement must still be created");
     }
 
     /** The widening step: the written replacement ends up with exactly the target's mode. */
     @Test
-    public void applyPermissions_givesTheReplacementTheTargetsExactMode() throws IOException {
-        ConfigFileReaderWriter.createPartialFile(partial, WORLD_READABLE);
+    public void applyPreservedAttributes_givesTheReplacementTheTargetsExactMode() throws IOException {
+        final PreservedAttributes preserved = ConfigFileReaderWriter.preservedAttributesOf(targetWith(WORLD_READABLE));
+        ConfigFileReaderWriter.createPartialFile(partial, preserved);
 
-        ConfigFileReaderWriter.applyPermissions(partial, WORLD_READABLE);
+        ConfigFileReaderWriter.applyPreservedAttributes(partial, preserved);
 
         assertEquals(WORLD_READABLE, Files.getPosixFilePermissions(partial), "the target's mode was not reproduced");
     }
@@ -151,52 +180,124 @@ public class ConfigWritePermissionsTest {
      * intact and correctly permissioned.
      */
     @Test
-    public void applyPermissions_whenTheModeCannotBeReproduced_thenTheWriteIsAborted() throws IOException {
-        ConfigFileReaderWriter.createPartialFile(partial, OWNER_ONLY);
-        Files.delete(partial); // the replacement is gone, so its mode cannot be set
+    public void applyPreservedAttributes_whenTheModeCannotBeReproduced_thenTheWriteIsAborted() throws IOException {
+        final PreservedAttributes preserved = ConfigFileReaderWriter.preservedAttributesOf(targetWith(OWNER_ONLY));
+        ConfigFileReaderWriter.createPartialFile(partial, preserved);
+        Files.delete(partial); // the replacement is gone, so its protections cannot be set
 
         assertThrows(
                 IOException.class,
-                () -> ConfigFileReaderWriter.applyPermissions(partial, OWNER_ONLY),
-                "a mode that cannot be reproduced must abort the replacement, not be logged and ignored");
+                () -> ConfigFileReaderWriter.applyPreservedAttributes(partial, preserved),
+                "protections that cannot be reproduced must abort the replacement, not be logged and ignored");
     }
 
     /** Nothing to reproduce is not a failure — it is the answer for a first-time configuration file. */
     @Test
-    public void applyPermissions_withNothingToReproduce_isANoOp() throws IOException {
-        ConfigFileReaderWriter.createPartialFile(partial, null);
+    public void applyPreservedAttributes_withNothingToReproduce_isANoOp() throws IOException {
+        ConfigFileReaderWriter.createPartialFile(partial, PreservedAttributes.NONE);
 
-        ConfigFileReaderWriter.applyPermissions(partial, null);
+        ConfigFileReaderWriter.applyPreservedAttributes(partial, PreservedAttributes.NONE);
 
         assertTrue(Files.exists(partial));
     }
 
-    @Test
-    public void posixPermissionsOf_readsTheModeOfAnExistingFile() throws IOException {
-        final Path target = directory.resolve("config.xml");
-        Files.createFile(target, PosixFilePermissions.asFileAttribute(OWNER_ONLY));
+    // ---------------------------------------------------------- R3-09: who the mode actually refers to
 
-        assertEquals(OWNER_ONLY, ConfigFileReaderWriter.posixPermissionsOf(target));
-    }
-
-    /** A file that does not exist yet has no mode to carry, which is a null answer rather than a throw. */
+    /**
+     * The mode is not the access control. R3-09: the reader captured only {@code Set<PosixFilePermission>},
+     * so owner and group were whatever the newly created replacement happened to get — and {@code 0640}
+     * then granted group-read to a different set of principals than the file it replaced did.
+     */
     @Test
-    public void posixPermissionsOf_aMissingFile_hasNothingToReproduce() {
-        assertNull(ConfigFileReaderWriter.posixPermissionsOf(directory.resolve("not-written-yet.xml")));
+    public void preservedAttributesOf_capturesOwnerAndGroupNotJustTheMode() throws IOException {
+        final Path target = targetWith(GROUP_READABLE);
+        final PosixFileAttributes expected = Files.readAttributes(target, PosixFileAttributes.class);
+
+        final PreservedAttributes preserved = ConfigFileReaderWriter.preservedAttributesOf(target);
+
+        assertEquals(GROUP_READABLE, preserved.permissions(), "the mode must still be carried");
+        assertNotNull(preserved.owner(), "the owner must be carried, or 0640 names a group it cannot name");
+        assertNotNull(preserved.group(), "the group must be carried, or 0640 names a group it cannot name");
+        assertEquals(expected.owner(), preserved.owner());
+        assertEquals(expected.group(), preserved.group());
     }
 
     /**
-     * The two halves together, in the order the writer runs them: created narrow, written, widened to
-     * the target's mode. This is the sequence R3-07 asks for, and the assertion in the middle is the one
-     * the end-to-end test cannot make.
+     * Sam's reproduction, as a test. A {@code 0640} file owned by a group the replacement would not
+     * naturally get must come back out of the replacement owned by that same group — otherwise the mode
+     * survives and the access control does not.
+     * <p>
+     * Skipped where the account running the build belongs to only one group, or where it may not set the
+     * group of a file it owns; there is then no second principal for the assertion to distinguish.
+     */
+    @Test
+    public void applyPreservedAttributes_reproducesTheTargetsGroupNotTheProcessDefault() throws IOException {
+        final Path target = targetWith(GROUP_READABLE);
+        final GroupPrincipal defaultGroup =
+                Files.readAttributes(target, PosixFileAttributes.class).group();
+        final GroupPrincipal other = aDifferentGroupOfThisUser(target, defaultGroup);
+        assumeTrue(other != null, "this account has no second group, so there is nothing to tell apart");
+
+        Files.getFileAttributeView(target, PosixFileAttributeView.class).setGroup(other);
+        final PreservedAttributes preserved = ConfigFileReaderWriter.preservedAttributesOf(target);
+        ConfigFileReaderWriter.createPartialFile(partial, preserved);
+        Files.writeString(partial, "<hivemq><bridge><password>s3cr3t</password></bridge></hivemq>");
+
+        ConfigFileReaderWriter.applyPreservedAttributes(partial, preserved);
+
+        final PosixFileAttributes actual = Files.readAttributes(partial, PosixFileAttributes.class);
+        assertEquals(
+                other,
+                actual.group(),
+                "the replacement kept the mode but granted group-read to a different group than the file it replaces");
+        assertEquals(GROUP_READABLE, actual.permissions(), "the mode must be reproduced as well as the group");
+    }
+
+    /**
+     * R3-09's second half. An {@code IOException} or a {@code SecurityException} reading an existing
+     * file's protections is not the same answer as "this file has no protections", and treating them the
+     * same let the write proceed on the umask. Only a genuinely absent file is "nothing to preserve".
+     * <p>
+     * Provoked by making the containing directory untraversable, which is skipped when the build runs as
+     * a superuser because the permission check does not apply to one.
+     */
+    @Test
+    public void preservedAttributesOf_whenTheProtectionsCannotBeRead_thenTheWriteIsAborted() throws IOException {
+        assumeTrue(!"root".equals(System.getProperty("user.name")), "a superuser is not refused by mode bits");
+        final Path enclosing = Files.createDirectory(directory.resolve("locked"));
+        final Path target = enclosing.resolve("config.xml");
+        Files.createFile(target, PosixFilePermissions.asFileAttribute(GROUP_READABLE));
+        Files.setPosixFilePermissions(enclosing, PosixFilePermissions.fromString("---------"));
+        try {
+            assertThrows(
+                    IOException.class,
+                    () -> ConfigFileReaderWriter.preservedAttributesOf(target),
+                    "a failure to read the target's protections must abort the write, not fall back to the umask");
+        } finally {
+            Files.setPosixFilePermissions(enclosing, PosixFilePermissions.fromString("rwx------"));
+        }
+    }
+
+    /** A file that does not exist yet has no protections to carry, which is an answer rather than a throw. */
+    @Test
+    public void preservedAttributesOf_aMissingFile_hasNothingToReproduce() throws IOException {
+        final PreservedAttributes preserved =
+                ConfigFileReaderWriter.preservedAttributesOf(directory.resolve("not-written-yet.xml"));
+
+        assertTrue(preserved.nothingToReproduce(), "a first-time configuration file has nothing to preserve");
+    }
+
+    /**
+     * The whole sequence, in the order the writer runs them: created narrow, written, widened to the
+     * target's protections. This is what R3-07 and R3-09 ask for together, and the assertion in the
+     * middle is the one the end-to-end test cannot make.
      */
     @Test
     public void theReplacementIsNeverWiderThanItsTargetWhileItHoldsTheConfiguration() throws IOException {
-        final Path target = directory.resolve("config.xml");
-        Files.createFile(target, PosixFilePermissions.asFileAttribute(WORLD_READABLE));
-        final Set<PosixFilePermission> targetMode = ConfigFileReaderWriter.posixPermissionsOf(target);
+        final Path target = targetWith(WORLD_READABLE);
+        final PreservedAttributes preserved = ConfigFileReaderWriter.preservedAttributesOf(target);
 
-        ConfigFileReaderWriter.createPartialFile(partial, targetMode);
+        ConfigFileReaderWriter.createPartialFile(partial, preserved);
         assertEquals(
                 OWNER_ONLY,
                 Files.getPosixFilePermissions(partial),
@@ -207,11 +308,64 @@ public class ConfigWritePermissionsTest {
                 Files.getPosixFilePermissions(partial),
                 "the file was widened while it still held the configuration");
 
-        ConfigFileReaderWriter.applyPermissions(partial, targetMode);
+        ConfigFileReaderWriter.applyPreservedAttributes(partial, preserved);
 
-        assertEquals(WORLD_READABLE, Files.getPosixFilePermissions(partial), "the target's mode must be reproduced");
-        assertFalse(
-                Files.getPosixFilePermissions(partial).isEmpty(),
-                "the replacement must carry a mode, not be left with none");
+        final PosixFileAttributes actual = Files.readAttributes(partial, PosixFileAttributes.class);
+        assertEquals(WORLD_READABLE, actual.permissions(), "the target's mode must be reproduced");
+        assertEquals(
+                Files.readAttributes(target, PosixFileAttributes.class).group(),
+                actual.group(),
+                "the target's group must be reproduced along with its mode");
+    }
+
+    /**
+     * A group this account belongs to that is not {@code current}, and that it may actually set on a file
+     * it owns, or {@code null} when there is none. Both conditions matter: membership is what makes the
+     * change legal, and some platforms restrict it further.
+     */
+    private static @Nullable GroupPrincipal aDifferentGroupOfThisUser(
+            final @NotNull Path file, final @NotNull GroupPrincipal current) {
+        for (final String name : groupNamesOfThisUser()) {
+            if (name.equals(current.getName())) {
+                continue;
+            }
+            try {
+                final GroupPrincipal candidate =
+                        file.getFileSystem().getUserPrincipalLookupService().lookupPrincipalByGroupName(name);
+                final PosixFileAttributeView view = Files.getFileAttributeView(file, PosixFileAttributeView.class);
+                view.setGroup(candidate);
+                view.setGroup(current); // put it back; the test sets it again itself
+                return candidate;
+            } catch (final IOException | UnsupportedOperationException ignored) {
+                // not a group this account can actually assign; try the next one
+            }
+        }
+        return null;
+    }
+
+    private static @NotNull List<String> groupNamesOfThisUser() {
+        final List<String> names = new ArrayList<>();
+        try {
+            final Process process =
+                    new ProcessBuilder("id", "-Gn").redirectErrorStream(true).start();
+            try (final BufferedReader reader =
+                    new BufferedReader(new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))) {
+                final String line = reader.readLine();
+                if (line != null) {
+                    for (final String name : line.trim().split("\\s+")) {
+                        if (!name.isEmpty()) {
+                            names.add(name);
+                        }
+                    }
+                }
+            }
+            process.waitFor();
+        } catch (final IOException e) {
+            return List.of();
+        } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return List.of();
+        }
+        return names;
     }
 }

--- a/hivemq-edge/src/test/java/com/hivemq/configuration/reader/ConfigWritePermissionsTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/configuration/reader/ConfigWritePermissionsTest.java
@@ -33,6 +33,7 @@ import java.nio.file.attribute.PosixFileAttributeView;
 import java.nio.file.attribute.PosixFileAttributes;
 import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
+import java.nio.file.attribute.UserPrincipal;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -316,6 +317,84 @@ public class ConfigWritePermissionsTest {
                 Files.readAttributes(target, PosixFileAttributes.class).group(),
                 actual.group(),
                 "the target's group must be reproduced along with its mode");
+    }
+
+    // ------------------------------------------------- EDG-882 review v04: an owner this node cannot set
+
+    /**
+     * The regression this closes. Changing a file's owner is privileged on every platform this runs on, so
+     * a configuration installed by one account and served by another — root-owned {@code config.xml}, Edge
+     * running as a service user — made {@code setOwner} fail, and failing there refused the whole write.
+     * The node then silently stopped persisting anything at all.
+     * <p>
+     * Provoked by asking for {@code root}, which this account may not assign and which every POSIX system
+     * has. Skipped when the build itself runs as a superuser, for whom the call succeeds.
+     */
+    @Test
+    public void applyPreservedAttributes_whenTheOwnerCannotBeSet_thenTheWriteGoesOnWithoutIt() throws IOException {
+        assumeTrue(!"root".equals(System.getProperty("user.name")), "a superuser may set any owner");
+        final Path target = targetWith(GROUP_READABLE);
+        final PosixFileAttributes attributes = Files.readAttributes(target, PosixFileAttributes.class);
+        final UserPrincipal root =
+                directory.getFileSystem().getUserPrincipalLookupService().lookupPrincipalByName("root");
+        final PreservedAttributes rootOwned =
+                new PreservedAttributes(attributes.permissions(), root, attributes.group(), null);
+        ConfigFileReaderWriter.createPartialFile(partial, rootOwned);
+        Files.writeString(partial, "<hivemq><bridge><password>s3cr3t</password></bridge></hivemq>");
+
+        ConfigFileReaderWriter.applyPreservedAttributes(partial, rootOwned);
+
+        final PosixFileAttributes actual = Files.readAttributes(partial, PosixFileAttributes.class);
+        assertEquals(attributes.owner(), actual.owner(), "the replacement is owned by the account that wrote it");
+        assertEquals(GROUP_READABLE, actual.permissions(), "the mode is still reproduced exactly");
+        assertEquals(attributes.group(), actual.group(), "and so is the group, which is who else can read it");
+    }
+
+    /**
+     * The other half of that trade: the protections that decide who <em>else</em> can read the file keep
+     * refusing. A group this account cannot assign aborts the replacement rather than granting group-read
+     * to whichever group the node happens to belong to.
+     */
+    @Test
+    public void applyPreservedAttributes_whenTheGroupCannotBeSet_thenTheWriteIsStillAborted() throws IOException {
+        assumeTrue(!"root".equals(System.getProperty("user.name")), "a superuser may set any group");
+        final Path target = targetWith(GROUP_READABLE);
+        final PosixFileAttributes attributes = Files.readAttributes(target, PosixFileAttributes.class);
+        final GroupPrincipal foreign = aGroupThisUserIsNotIn(target);
+        assumeTrue(foreign != null, "this account can assign every group it can name, so there is nothing to refuse");
+        final PreservedAttributes elsewhere =
+                new PreservedAttributes(attributes.permissions(), attributes.owner(), foreign, null);
+        ConfigFileReaderWriter.createPartialFile(partial, elsewhere);
+
+        assertThrows(
+                IOException.class,
+                () -> ConfigFileReaderWriter.applyPreservedAttributes(partial, elsewhere),
+                "a group that cannot be reproduced decides who else can read the file, so it must abort");
+    }
+
+    /** A group this account cannot set on a file it owns, or {@code null} when every named group works. */
+    private static @Nullable GroupPrincipal aGroupThisUserIsNotIn(final @NotNull Path file) {
+        final List<String> mine = groupNamesOfThisUser();
+        for (final String name : new String[] {"daemon", "wheel", "operator", "sys", "tty", "bin"}) {
+            if (mine.contains(name)) {
+                continue;
+            }
+            try {
+                final GroupPrincipal candidate =
+                        file.getFileSystem().getUserPrincipalLookupService().lookupPrincipalByGroupName(name);
+                final PosixFileAttributeView view = Files.getFileAttributeView(file, PosixFileAttributeView.class);
+                final GroupPrincipal current = view.readAttributes().group();
+                try {
+                    view.setGroup(candidate);
+                    view.setGroup(current); // it worked after all; not a group this can refuse on
+                } catch (final IOException notPermitted) {
+                    return candidate;
+                }
+            } catch (final IOException | UnsupportedOperationException ignored) {
+                // not a group this system knows; try the next one
+            }
+        }
+        return null;
     }
 
     /**

--- a/hivemq-edge/src/test/java/com/hivemq/configuration/reader/ConfigWritePermissionsTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/configuration/reader/ConfigWritePermissionsTest.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.configuration.reader;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.Set;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * EDG-882 review v03, R3-07 — the replacement configuration file must never be readable by anyone the
+ * file it replaces was not, at any point while it holds the configuration.
+ * <p>
+ * {@code config.xml} carries bridge passwords, keystore and truststore passwords and adapter
+ * credentials. The first version of the replace-by-move wrote the rendered document into a file created
+ * by {@code FileWriter}, which takes the process umask — commonly {@code 0644} — and only narrowed it to
+ * the target's mode afterwards. Between those two steps a world-readable file held every secret in the
+ * configuration, on every REST write to any subsystem.
+ * <p>
+ * That window did not exist before the branch that introduced it: writing in place reused the file's own
+ * inode and therefore its own mode. This is a regression, which is why the behaviour here is fail-closed
+ * rather than best-effort.
+ * <p>
+ * The creation-time property is the one that matters and it cannot be observed end to end — the write is
+ * synchronous and the temporary file is gone by the time any assertion could run — so it is pinned
+ * directly on the helper that establishes it. {@code ConfigFileWriterTest} covers the end-to-end mode
+ * preservation and the symbolic-link case.
+ */
+public class ConfigWritePermissionsTest {
+
+    private static final @NotNull Set<PosixFilePermission> OWNER_ONLY = PosixFilePermissions.fromString("rw-------");
+    private static final @NotNull Set<PosixFilePermission> WORLD_READABLE =
+            PosixFilePermissions.fromString("rw-r--r--");
+    private static final @NotNull Set<PosixFilePermission> WORLD_WRITABLE =
+            PosixFilePermissions.fromString("rw-rw-rw-");
+
+    @TempDir
+    private @NotNull Path directory;
+
+    private @NotNull Path partial;
+
+    @BeforeEach
+    public void requirePosix() {
+        assumeTrue(
+                directory.getFileSystem().supportedFileAttributeViews().contains("posix"),
+                "no POSIX permissions on this file system, so there is nothing to protect");
+        partial = directory.resolve("config.xml.partial");
+    }
+
+    /**
+     * The defect, at the only moment it is observable. A target the operator restricted to {@code 0600}
+     * must not produce a replacement that is briefly readable by everyone — so the file is created
+     * owner-only and widened afterwards, never the other way round.
+     */
+    @Test
+    public void createPartialFile_createsTheReplacementOwnerOnly() throws IOException {
+        ConfigFileReaderWriter.createPartialFile(partial, OWNER_ONLY);
+
+        assertEquals(
+                OWNER_ONLY,
+                Files.getPosixFilePermissions(partial),
+                "the replacement was readable by someone before it had been written");
+    }
+
+    /**
+     * And owner-only even when the file it will replace is wider. The creation mode is not "the target's
+     * mode" but "the narrowest mode that can become the target's mode": a file created as {@code 0644}
+     * and written is disclosed for the duration of the write regardless of what it ends up as.
+     */
+    @Test
+    public void createPartialFile_isOwnerOnlyEvenWhenTheTargetIsWorldReadable() throws IOException {
+        ConfigFileReaderWriter.createPartialFile(partial, WORLD_READABLE);
+
+        assertEquals(
+                OWNER_ONLY,
+                Files.getPosixFilePermissions(partial),
+                "the replacement of a world-readable file is still written under owner-only protection");
+    }
+
+    /**
+     * A partial file left behind by a killed process must not be reopened: {@code FileWriter} on an
+     * existing file keeps that file's mode, so reusing a leftover {@code 0666} partial would reinstate
+     * exactly the disclosure this closes.
+     */
+    @Test
+    public void createPartialFile_replacesAStalePartialRatherThanReusingIt() throws IOException {
+        Files.createFile(partial, PosixFilePermissions.asFileAttribute(WORLD_WRITABLE));
+        Files.writeString(partial, "left behind by a killed write");
+
+        ConfigFileReaderWriter.createPartialFile(partial, OWNER_ONLY);
+
+        assertEquals(
+                OWNER_ONLY,
+                Files.getPosixFilePermissions(partial),
+                "a stale partial file was reopened and kept its permissive mode");
+        assertEquals("", Files.readString(partial), "the stale content survived into the new write");
+    }
+
+    /**
+     * With no mode to reproduce — a configuration file being created for the first time — the
+     * replacement is created normally and takes the umask, which is what that file would have had
+     * anyway. Narrowing it here would silently change the mode of every newly created configuration.
+     */
+    @Test
+    public void createPartialFile_withNothingToReproduce_createsTheFileNormally() throws IOException {
+        ConfigFileReaderWriter.createPartialFile(partial, null);
+
+        assertTrue(Files.exists(partial), "the replacement must still be created");
+    }
+
+    /** The widening step: the written replacement ends up with exactly the target's mode. */
+    @Test
+    public void applyPermissions_givesTheReplacementTheTargetsExactMode() throws IOException {
+        ConfigFileReaderWriter.createPartialFile(partial, WORLD_READABLE);
+
+        ConfigFileReaderWriter.applyPermissions(partial, WORLD_READABLE);
+
+        assertEquals(WORLD_READABLE, Files.getPosixFilePermissions(partial), "the target's mode was not reproduced");
+    }
+
+    /**
+     * Fail closed. R3-07's second half: the original carried the mode over best-effort and moved the
+     * file either way, so a failure left the umask's mode on a file full of credentials, permanently,
+     * announced at debug level. Refusing the replacement keeps the previous configuration file, which is
+     * intact and correctly permissioned.
+     */
+    @Test
+    public void applyPermissions_whenTheModeCannotBeReproduced_thenTheWriteIsAborted() throws IOException {
+        ConfigFileReaderWriter.createPartialFile(partial, OWNER_ONLY);
+        Files.delete(partial); // the replacement is gone, so its mode cannot be set
+
+        assertThrows(
+                IOException.class,
+                () -> ConfigFileReaderWriter.applyPermissions(partial, OWNER_ONLY),
+                "a mode that cannot be reproduced must abort the replacement, not be logged and ignored");
+    }
+
+    /** Nothing to reproduce is not a failure — it is the answer for a first-time configuration file. */
+    @Test
+    public void applyPermissions_withNothingToReproduce_isANoOp() throws IOException {
+        ConfigFileReaderWriter.createPartialFile(partial, null);
+
+        ConfigFileReaderWriter.applyPermissions(partial, null);
+
+        assertTrue(Files.exists(partial));
+    }
+
+    @Test
+    public void posixPermissionsOf_readsTheModeOfAnExistingFile() throws IOException {
+        final Path target = directory.resolve("config.xml");
+        Files.createFile(target, PosixFilePermissions.asFileAttribute(OWNER_ONLY));
+
+        assertEquals(OWNER_ONLY, ConfigFileReaderWriter.posixPermissionsOf(target));
+    }
+
+    /** A file that does not exist yet has no mode to carry, which is a null answer rather than a throw. */
+    @Test
+    public void posixPermissionsOf_aMissingFile_hasNothingToReproduce() {
+        assertNull(ConfigFileReaderWriter.posixPermissionsOf(directory.resolve("not-written-yet.xml")));
+    }
+
+    /**
+     * The two halves together, in the order the writer runs them: created narrow, written, widened to
+     * the target's mode. This is the sequence R3-07 asks for, and the assertion in the middle is the one
+     * the end-to-end test cannot make.
+     */
+    @Test
+    public void theReplacementIsNeverWiderThanItsTargetWhileItHoldsTheConfiguration() throws IOException {
+        final Path target = directory.resolve("config.xml");
+        Files.createFile(target, PosixFilePermissions.asFileAttribute(WORLD_READABLE));
+        final Set<PosixFilePermission> targetMode = ConfigFileReaderWriter.posixPermissionsOf(target);
+
+        ConfigFileReaderWriter.createPartialFile(partial, targetMode);
+        assertEquals(
+                OWNER_ONLY,
+                Files.getPosixFilePermissions(partial),
+                "the secrets are written into a file wider than owner-only");
+        Files.writeString(partial, "<hivemq><bridge><password>s3cr3t</password></bridge></hivemq>");
+        assertEquals(
+                OWNER_ONLY,
+                Files.getPosixFilePermissions(partial),
+                "the file was widened while it still held the configuration");
+
+        ConfigFileReaderWriter.applyPermissions(partial, targetMode);
+
+        assertEquals(WORLD_READABLE, Files.getPosixFilePermissions(partial), "the target's mode must be reproduced");
+        assertFalse(
+                Files.getPosixFilePermissions(partial).isEmpty(),
+                "the replacement must carry a mode, not be left with none");
+    }
+}

--- a/hivemq-edge/src/test/java/com/hivemq/configuration/writer/AbstractConfigWriterTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/configuration/writer/AbstractConfigWriterTest.java
@@ -39,6 +39,7 @@ import com.hivemq.configuration.service.ConfigurationService;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.util.List;
 import org.apache.commons.io.FileUtils;
 import org.jetbrains.annotations.NotNull;
@@ -94,11 +95,21 @@ public abstract class AbstractConfigWriterTest {
         return configFileReader;
     }
 
+    /**
+     * The fixture, staged in a directory of this test's own.
+     * <p>
+     * It used to be one fixed path under {@code java.io.tmpdir}, shared by every test in every class and
+     * every Gradle fork on the machine — so two of them running at once wrote each other's configuration,
+     * and a leftover from a previous run was picked up by the next (EDG-882 review v02, R2-19).
+     */
     protected @NotNull File loadTestConfigFile() throws IOException {
         try (final InputStream is =
                 requireNonNull(AbstractConfigWriterTest.class.getResourceAsStream("/test-config.xml"))) {
-            final File tempFile = new File(System.getProperty("java.io.tmpdir"), "original-config.xml");
+            final File tempFile = Files.createTempDirectory("edge-config-writer-test")
+                    .resolve("original-config.xml")
+                    .toFile();
             tempFile.deleteOnExit();
+            tempFile.getParentFile().deleteOnExit();
             FileUtils.copyInputStreamToFile(is, tempFile);
             return tempFile;
         }

--- a/hivemq-edge/src/test/java/com/hivemq/configuration/writer/ConfigFileWriterTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/configuration/writer/ConfigFileWriterTest.java
@@ -55,12 +55,40 @@ public class ConfigFileWriterTest extends AbstractConfigWriterTest {
 
         final String copiedFileContent = FileUtils.readFileToString(tempFile, UTF_8);
 
-        final Diff diff = XMLUnit.compareXML(originalXml, copiedFileContent);
-        if (!diff.identical()) {
-            System.err.println("xml diff found " + diff);
-            System.err.println(originalXml);
-            System.err.println(copiedFileContent);
+        // identical(), not similar(): XMLUnit calls a different child sequence a *recoverable* difference,
+        // so a write-back that reordered the operator's <mqtt-topic-filter> elements satisfied similar()
+        // -- which is one of the two regressions this test is named for (EDG-882 review v02, R2-19).
+        //
+        // Whitespace and comments are normalised first, or identical() fails on every indentation
+        // difference between the operator's file and the marshaller's output: it compares child *indices*,
+        // and a text node between two elements shifts all of them. Element order is what has to be
+        // significant here, not formatting.
+        //
+        // The flags are static and global to the JVM, so they are restored -- Gradle runs many classes per
+        // fork and a class that leaves them set changes what every later comparison means.
+        //
+        // The fixture's *elements* are in the order the marshaller emits them, deliberately: the write-back
+        // reorders the children of <hivemq> and of <forwarded-topic> to the schema's order, which is
+        // cosmetic churn of the operator's file and pre-existing, and leaving it in would make this test
+        // fail for a reason it is not about. What is deliberately *not* canonical is the order of the two
+        // <mqtt-topic-filter> elements inside <filters> -- that one has to survive verbatim, because a
+        // reorder there reads as a changed bridge on the next reload and restarts it (EDG-882 F-07).
+        final boolean previousIgnoreWhitespace = XMLUnit.getIgnoreWhitespace();
+        final boolean previousIgnoreComments = XMLUnit.getIgnoreComments();
+        final Diff diff;
+        try {
+            XMLUnit.setIgnoreWhitespace(true);
+            XMLUnit.setIgnoreComments(true);
+            diff = XMLUnit.compareXML(originalXml, copiedFileContent);
+            if (!diff.identical()) {
+                System.err.println("xml diff found " + diff);
+                System.err.println(originalXml);
+                System.err.println(copiedFileContent);
+            }
+            assertTrue(diff.identical(), "XML Content Should Match");
+        } finally {
+            XMLUnit.setIgnoreWhitespace(previousIgnoreWhitespace);
+            XMLUnit.setIgnoreComments(previousIgnoreComments);
         }
-        assertTrue(diff.similar(), "XML Content Should Match");
     }
 }

--- a/hivemq-edge/src/test/java/com/hivemq/configuration/writer/ConfigFileWriterTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/configuration/writer/ConfigFileWriterTest.java
@@ -16,13 +16,20 @@
 package com.hivemq.configuration.writer;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import com.hivemq.configuration.entity.HiveMQConfigEntity;
 import com.hivemq.configuration.entity.api.PreLoginNoticeEntity;
 import com.hivemq.configuration.reader.ConfigFileReaderWriter;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.Set;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -90,5 +97,56 @@ public class ConfigFileWriterTest extends AbstractConfigWriterTest {
             XMLUnit.setIgnoreWhitespace(previousIgnoreWhitespace);
             XMLUnit.setIgnoreComments(previousIgnoreComments);
         }
+    }
+
+    /**
+     * The write replaces {@code config.xml} with a file written beside it, and a new file carries the
+     * process umask rather than the mode of the file it replaces. {@code config.xml} holds bridge
+     * passwords, keystore passwords and client secrets, so widening a deliberately restricted file on
+     * the first REST write of any subsystem would undo what the operator set — silently, and on a file
+     * this branch is otherwise working to keep secrets out of.
+     */
+    @Test
+    public void writeConfigWithSync_keepsTheModeOfTheFileItReplaces() throws IOException {
+        final File tempFile = loadTestConfigFile();
+        final Path path = tempFile.toPath();
+        assumeTrue(
+                path.getFileSystem().supportedFileAttributeViews().contains("posix"),
+                "no POSIX permissions on this file system, so there is nothing to carry over");
+
+        final Set<PosixFilePermission> restricted = PosixFilePermissions.fromString("rw-------");
+        Files.setPosixFilePermissions(path, restricted);
+
+        final ConfigFileReaderWriter configFileReader = createFileReaderWriter(tempFile);
+        configFileReader.applyConfig();
+        configFileReader.writeConfigWithSync();
+
+        assertEquals(restricted, Files.getPosixFilePermissions(path), "the operator's mode must survive a write");
+    }
+
+    /**
+     * A symbolic link is a path whose last component <em>is</em> the link, so replacing the path
+     * replaces the link. Writing into the file followed it, which is what a mounted configuration
+     * directory or an operator's link into a versioned tree relies on; the replace-by-move has to keep
+     * doing that or the link is gone after the first write.
+     */
+    @Test
+    public void writeConfigWithSync_writesThroughASymbolicLink() throws IOException {
+        final File target = loadTestConfigFile();
+        final Path link = target.toPath().resolveSibling("linked-config.xml");
+        try {
+            Files.createSymbolicLink(link, target.toPath());
+        } catch (final UnsupportedOperationException | IOException e) {
+            assumeTrue(false, "symbolic links are not available here: " + e.getMessage());
+        }
+
+        final ConfigFileReaderWriter configFileReader = createFileReaderWriter(link.toFile());
+        configFileReader.applyConfig();
+        configFileReader.writeConfigWithSync();
+
+        assertTrue(Files.isSymbolicLink(link), "the link must still be a link");
+        assertTrue(
+                FileUtils.readFileToString(target, UTF_8).contains("<hivemq"),
+                "the write must have gone through the link to the file it points at");
     }
 }

--- a/hivemq-edge/src/test/java/com/hivemq/configuration/writer/ConfigFileWriterTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/configuration/writer/ConfigFileWriterTest.java
@@ -21,7 +21,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.hivemq.configuration.entity.HiveMQConfigEntity;
 import com.hivemq.configuration.entity.api.PreLoginNoticeEntity;
 import com.hivemq.configuration.reader.ConfigFileReaderWriter;
-import com.hivemq.configuration.reader.ConfigurationFile;
 import java.io.File;
 import java.io.IOException;
 import org.apache.commons.io.FileUtils;
@@ -46,12 +45,15 @@ public class ConfigFileWriterTest extends AbstractConfigWriterTest {
         final PreLoginNoticeEntity notice = entity.getApiConfig().getPreLoginNotice();
         Assertions.assertNotNull(notice);
 
-        final File tempCopyFile = new File(System.getProperty("java.io.tmpdir"), "copy-config.xml");
-        tempFile.deleteOnExit();
-        configFileReader.writeConfigToXML(
-                new ConfigurationFile(tempCopyFile).file().get(), false, false);
+        // writeConfigWithSync, not writeConfigToXML: only this one runs the extractors' sync step, and
+        // that step is where the entity is rebuilt from the runtime objects. Marshalling the entity
+        // straight back out compares the JAXB round trip with itself and cannot fail -- so this test
+        // passed while a write-back was silently dropping a bridge's <queue-limit> and reordering the
+        // operator's topic filters (EDG-882 QA round 2). This is the path production takes on every
+        // REST write of any subsystem.
+        configFileReader.writeConfigWithSync();
 
-        final String copiedFileContent = FileUtils.readFileToString(tempCopyFile, UTF_8);
+        final String copiedFileContent = FileUtils.readFileToString(tempFile, UTF_8);
 
         final Diff diff = XMLUnit.compareXML(originalXml, copiedFileContent);
         if (!diff.identical()) {

--- a/hivemq-edge/src/test/java/com/hivemq/configuration/writer/ConfigFileWriterTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/configuration/writer/ConfigFileWriterTest.java
@@ -149,4 +149,42 @@ public class ConfigFileWriterTest extends AbstractConfigWriterTest {
                 FileUtils.readFileToString(target, UTF_8).contains("<hivemq"),
                 "the write must have gone through the link to the file it points at");
     }
+
+    /**
+     * The other direction, and the one the fail-closed handling of EDG-882 review v03 R3-07 makes
+     * possible to get wrong: a configuration an operator deliberately shares with a group must not come
+     * back owner-only either. The replacement is written under owner-only protection and then widened to
+     * exactly what it replaces — "exactly", in both directions.
+     */
+    @Test
+    public void writeConfigWithSync_doesNotNarrowAModeTheOperatorWidened() throws IOException {
+        final File tempFile = loadTestConfigFile();
+        final Path path = tempFile.toPath();
+        assumeTrue(
+                path.getFileSystem().supportedFileAttributeViews().contains("posix"),
+                "no POSIX permissions on this file system, so there is nothing to carry over");
+
+        final Set<PosixFilePermission> shared = PosixFilePermissions.fromString("rw-r--r--");
+        Files.setPosixFilePermissions(path, shared);
+
+        final ConfigFileReaderWriter configFileReader = createFileReaderWriter(tempFile);
+        configFileReader.applyConfig();
+        configFileReader.writeConfigWithSync();
+
+        assertEquals(shared, Files.getPosixFilePermissions(path), "the operator's mode must survive a write");
+    }
+
+    /** And the temporary file must never be left behind, whichever mode the target carried. */
+    @Test
+    public void writeConfigWithSync_leavesNoPartialFileBehind() throws IOException {
+        final File tempFile = loadTestConfigFile();
+
+        final ConfigFileReaderWriter configFileReader = createFileReaderWriter(tempFile);
+        configFileReader.applyConfig();
+        configFileReader.writeConfigWithSync();
+
+        assertTrue(
+                Files.notExists(tempFile.toPath().resolveSibling(tempFile.getName() + ".partial")),
+                "a partial file survived a successful write");
+    }
 }

--- a/hivemq-edge/src/test/java/com/hivemq/mqtt/handler/subscribe/IncomingSubscribeServiceTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/mqtt/handler/subscribe/IncomingSubscribeServiceTest.java
@@ -52,6 +52,8 @@ import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.util.concurrent.ImmediateEventExecutor;
 import java.util.HashSet;
 import java.util.Queue;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -357,7 +359,18 @@ public class IncomingSubscribeServiceTest {
 
         incomingSubscribeService.processSubscribe(ctx, subscribe, false);
 
+        // Asserted on the subscriptions, not only on the channel staying up: a client that is neither
+        // disconnected nor subscribed would look identical from the channel alone, so this test passed
+        // with the collision check deleted and with it never reached (EDG-882 review v02, R2-21).
         assertTrue(channel.isActive());
+        final ArgumentCaptor<ImmutableSet<Topic>> accepted = ArgumentCaptor.captor();
+        verify(clientSessionSubscriptionPersistence).addSubscriptions(eq("client"), accepted.capture());
+        assertEquals(
+                Set.of(
+                        "$share/group/plant/temp",
+                        "$share/$SAMPLER::customer/alerts",
+                        "$share/$FORWARDER::nothing-here/plant/temp"),
+                accepted.getValue().stream().map(Topic::getTopic).collect(Collectors.toSet()));
     }
 
     @Test

--- a/hivemq-edge/src/test/java/com/hivemq/mqtt/handler/subscribe/IncomingSubscribeServiceTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/mqtt/handler/subscribe/IncomingSubscribeServiceTest.java
@@ -25,6 +25,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.Futures;
 import com.hivemq.bootstrap.ClientConnection;
+import com.hivemq.bridge.MessageForwarder;
 import com.hivemq.configuration.service.MqttConfigurationService;
 import com.hivemq.configuration.service.RestrictionsConfigurationService;
 import com.hivemq.extension.sdk.api.auth.parameter.TopicPermission;
@@ -43,6 +44,7 @@ import com.hivemq.mqtt.message.subscribe.Topic;
 import com.hivemq.persistence.clientsession.ClientSessionSubscriptionPersistence;
 import com.hivemq.persistence.clientsession.SharedSubscriptionService;
 import com.hivemq.persistence.retained.RetainedMessagePersistence;
+import com.hivemq.sampling.SamplingService;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
@@ -88,6 +90,12 @@ public class IncomingSubscribeServiceTest {
     @Mock
     private RestrictionsConfigurationService restrictionsConfigurationService;
 
+    @Mock
+    private MessageForwarder messageForwarder;
+
+    @Mock
+    private SamplingService samplingService;
+
     private EmbeddedChannel channel;
     private IncomingSubscribeService incomingSubscribeService;
 
@@ -104,7 +112,9 @@ public class IncomingSubscribeServiceTest {
                 retainedMessagesSender,
                 mqttConfigurationService,
                 restrictionsConfigurationService,
-                new MqttServerDisconnectorImpl(eventLog));
+                new MqttServerDisconnectorImpl(eventLog),
+                () -> messageForwarder,
+                () -> samplingService);
 
         channel = new EmbeddedChannel();
         clientConnection = new ClientConnection(channel, null);
@@ -286,6 +296,68 @@ public class IncomingSubscribeServiceTest {
         // We need to make sure we got disconnected
         assertFalse(channel.isActive());
         verify(eventLog).clientWasDisconnected(any(Channel.class), anyString());
+    }
+
+    /**
+     * EDG-882 QA round 2: shared subscribers of one group take turns, so a client that joins a live
+     * bridge forwarder's group receives the bridge's messages instead of the bridge — and they are
+     * never forwarded to the remote broker. The group name embeds a digest a client can compute from
+     * the bridge's own configuration, so it is reachable rather than theoretical.
+     */
+    @Test
+    public void test_subscribe_colliding_with_a_live_forwarder_queue_is_refused() {
+        when(mqttConfigurationService.sharedSubscriptionsEnabled()).thenReturn(true);
+        channel.attr(ClientConnection.CHANNEL_ATTRIBUTE_NAME).get().setProtocolVersion(ProtocolVersion.MQTTv5);
+        final String shareName = "$FORWARDER::bridge-DNkmbgZ6ni59NniT9XDvig==";
+        when(messageForwarder.isForwarderQueue(shareName + "/plant/temp")).thenReturn(true);
+        final SUBSCRIBE subscribe = new SUBSCRIBE(
+                ImmutableList.copyOf(
+                        Lists.newArrayList(new Topic("$share/" + shareName + "/plant/temp", QoS.AT_LEAST_ONCE))),
+                1);
+
+        incomingSubscribeService.processSubscribe(ctx, subscribe, false);
+
+        assertFalse(channel.isActive());
+        verify(clientSessionSubscriptionPersistence, never()).addSubscriptions(any(), any());
+    }
+
+    @Test
+    public void test_subscribe_colliding_with_a_live_sampler_queue_is_refused() {
+        when(mqttConfigurationService.sharedSubscriptionsEnabled()).thenReturn(true);
+        channel.attr(ClientConnection.CHANNEL_ATTRIBUTE_NAME).get().setProtocolVersion(ProtocolVersion.MQTTv5);
+        when(samplingService.isSamplerQueue("$SAMPLER::plant/line1/plant/line1"))
+                .thenReturn(true);
+        final SUBSCRIBE subscribe = new SUBSCRIBE(
+                ImmutableList.copyOf(
+                        Lists.newArrayList(new Topic("$share/$SAMPLER::plant/line1/plant/line1", QoS.AT_LEAST_ONCE))),
+                1);
+
+        incomingSubscribeService.processSubscribe(ctx, subscribe, false);
+
+        assertFalse(channel.isActive());
+        verify(clientSessionSubscriptionPersistence, never()).addSubscriptions(any(), any());
+    }
+
+    /**
+     * The control, and the reason this is a collision check rather than a reserved-namespace rule: a
+     * share name is the client's to choose, and a group that merely looks internal but collides with
+     * nothing Edge is using belongs to the client (EDG-882 F-05, pinned end to end by
+     * {@code SamplerNamedSharedSubscriptionIT}).
+     */
+    @Test
+    public void test_subscribe_to_an_unused_group_that_looks_internal_is_accepted() {
+        when(mqttConfigurationService.sharedSubscriptionsEnabled()).thenReturn(true);
+        channel.attr(ClientConnection.CHANNEL_ATTRIBUTE_NAME).get().setProtocolVersion(ProtocolVersion.MQTTv5);
+        final SUBSCRIBE subscribe = new SUBSCRIBE(
+                ImmutableList.copyOf(Lists.newArrayList(
+                        new Topic("$share/group/plant/temp", QoS.AT_LEAST_ONCE),
+                        new Topic("$share/$SAMPLER::customer/alerts", QoS.AT_LEAST_ONCE),
+                        new Topic("$share/$FORWARDER::nothing-here/plant/temp", QoS.AT_LEAST_ONCE))),
+                1);
+
+        incomingSubscribeService.processSubscribe(ctx, subscribe, false);
+
+        assertTrue(channel.isActive());
     }
 
     @Test

--- a/hivemq-edge/src/test/java/com/hivemq/mqtt/handler/subscribe/retained/SendRetainedMessagesListenerTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/mqtt/handler/subscribe/retained/SendRetainedMessagesListenerTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyList;
 import static org.mockito.Mockito.anyLong;
 import static org.mockito.Mockito.anyString;
@@ -158,7 +159,7 @@ public class SendRetainedMessagesListenerTest {
         listener.operationComplete(channel.newSucceededFuture());
         channel.runPendingTasks();
 
-        verify(queuePersistence).add(eq("client"), eq(false), anyList(), eq(true), anyLong());
+        verify(queuePersistence).add(eq("client"), eq(false), anyList(), eq(true), anyLong(), any());
     }
 
     @Test
@@ -185,7 +186,7 @@ public class SendRetainedMessagesListenerTest {
         channel.runPendingTasks();
 
         final ArgumentCaptor<List<PUBLISH>> captor = ArgumentCaptor.forClass((Class<List<PUBLISH>>) (Class) List.class);
-        verify(queuePersistence).add(eq("client"), eq(false), captor.capture(), eq(true), anyLong());
+        verify(queuePersistence).add(eq("client"), eq(false), captor.capture(), eq(true), anyLong(), any());
 
         final PUBLISH publish = captor.getValue().get(0);
         assertEquals("topic", publish.getTopic());
@@ -263,7 +264,7 @@ public class SendRetainedMessagesListenerTest {
         channel.runPendingTasks();
 
         final ArgumentCaptor<List<PUBLISH>> captor = ArgumentCaptor.forClass((Class<List<PUBLISH>>) (Class) List.class);
-        verify(queuePersistence).add(eq("client"), eq(false), captor.capture(), eq(true), anyLong());
+        verify(queuePersistence).add(eq("client"), eq(false), captor.capture(), eq(true), anyLong(), any());
 
         final PUBLISH publish = captor.getValue().get(0);
         assertEquals("topic", publish.getTopic());
@@ -298,7 +299,7 @@ public class SendRetainedMessagesListenerTest {
         channel.runPendingTasks();
 
         final ArgumentCaptor<List<PUBLISH>> captor = ArgumentCaptor.forClass((Class<List<PUBLISH>>) (Class) List.class);
-        verify(queuePersistence).add(eq("client"), eq(false), captor.capture(), eq(true), anyLong());
+        verify(queuePersistence).add(eq("client"), eq(false), captor.capture(), eq(true), anyLong(), any());
 
         final PUBLISH publish = captor.getAllValues().get(0).get(0);
         assertEquals("topic", publish.getTopic());
@@ -441,7 +442,7 @@ public class SendRetainedMessagesListenerTest {
 
         final ImmutableSet<String> set = ImmutableSet.of("topic", "topic2");
         when(retainedMessagePersistence.getWithWildcards("#")).thenReturn(Futures.immediateFuture(set));
-        when(queuePersistence.add(eq("client"), eq(false), anyList(), eq(true), anyLong()))
+        when(queuePersistence.add(eq("client"), eq(false), anyList(), eq(true), anyLong(), any()))
                 .thenReturn(Futures.immediateFuture(null));
         final List<SubscriptionResult> subscriptions = newArrayList(
                 subResult(new Topic("topic", QoS.AT_LEAST_ONCE), false),
@@ -458,7 +459,7 @@ public class SendRetainedMessagesListenerTest {
 
         final ArgumentCaptor<List<PUBLISH>> captor = ArgumentCaptor.forClass((Class<List<PUBLISH>>) (Class) List.class);
         verify(queuePersistence, timeout(5000).times(2))
-                .add(eq("client"), eq(false), captor.capture(), eq(true), anyLong());
+                .add(eq("client"), eq(false), captor.capture(), eq(true), anyLong(), any());
 
         final PUBLISH publish = captor.getAllValues().get(0).get(0);
         assertEquals("topic", publish.getTopic());

--- a/hivemq-edge/src/test/java/com/hivemq/mqtt/handler/subscribe/retained/SendRetainedMessagesListenerTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/mqtt/handler/subscribe/retained/SendRetainedMessagesListenerTest.java
@@ -21,7 +21,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyList;
 import static org.mockito.Mockito.anyLong;
 import static org.mockito.Mockito.anyString;
@@ -44,6 +43,7 @@ import com.hivemq.mqtt.message.publish.PUBLISH;
 import com.hivemq.mqtt.message.subscribe.Topic;
 import com.hivemq.persistence.RetainedMessage;
 import com.hivemq.persistence.clientqueue.ClientQueuePersistence;
+import com.hivemq.persistence.clientqueue.QueuePolicy;
 import com.hivemq.persistence.clientsession.callback.SubscriptionResult;
 import com.hivemq.persistence.payload.PublishPayloadPersistence;
 import com.hivemq.persistence.retained.RetainedMessagePersistence;
@@ -159,7 +159,7 @@ public class SendRetainedMessagesListenerTest {
         listener.operationComplete(channel.newSucceededFuture());
         channel.runPendingTasks();
 
-        verify(queuePersistence).add(eq("client"), eq(false), anyList(), eq(true), anyLong(), any());
+        verify(queuePersistence).add(eq("client"), eq(false), anyList(), eq(true), anyLong(), eq(QueuePolicy.DEFAULT));
     }
 
     @Test
@@ -186,7 +186,8 @@ public class SendRetainedMessagesListenerTest {
         channel.runPendingTasks();
 
         final ArgumentCaptor<List<PUBLISH>> captor = ArgumentCaptor.forClass((Class<List<PUBLISH>>) (Class) List.class);
-        verify(queuePersistence).add(eq("client"), eq(false), captor.capture(), eq(true), anyLong(), any());
+        verify(queuePersistence)
+                .add(eq("client"), eq(false), captor.capture(), eq(true), anyLong(), eq(QueuePolicy.DEFAULT));
 
         final PUBLISH publish = captor.getValue().get(0);
         assertEquals("topic", publish.getTopic());
@@ -264,7 +265,8 @@ public class SendRetainedMessagesListenerTest {
         channel.runPendingTasks();
 
         final ArgumentCaptor<List<PUBLISH>> captor = ArgumentCaptor.forClass((Class<List<PUBLISH>>) (Class) List.class);
-        verify(queuePersistence).add(eq("client"), eq(false), captor.capture(), eq(true), anyLong(), any());
+        verify(queuePersistence)
+                .add(eq("client"), eq(false), captor.capture(), eq(true), anyLong(), eq(QueuePolicy.DEFAULT));
 
         final PUBLISH publish = captor.getValue().get(0);
         assertEquals("topic", publish.getTopic());
@@ -299,7 +301,8 @@ public class SendRetainedMessagesListenerTest {
         channel.runPendingTasks();
 
         final ArgumentCaptor<List<PUBLISH>> captor = ArgumentCaptor.forClass((Class<List<PUBLISH>>) (Class) List.class);
-        verify(queuePersistence).add(eq("client"), eq(false), captor.capture(), eq(true), anyLong(), any());
+        verify(queuePersistence)
+                .add(eq("client"), eq(false), captor.capture(), eq(true), anyLong(), eq(QueuePolicy.DEFAULT));
 
         final PUBLISH publish = captor.getAllValues().get(0).get(0);
         assertEquals("topic", publish.getTopic());
@@ -442,7 +445,7 @@ public class SendRetainedMessagesListenerTest {
 
         final ImmutableSet<String> set = ImmutableSet.of("topic", "topic2");
         when(retainedMessagePersistence.getWithWildcards("#")).thenReturn(Futures.immediateFuture(set));
-        when(queuePersistence.add(eq("client"), eq(false), anyList(), eq(true), anyLong(), any()))
+        when(queuePersistence.add(eq("client"), eq(false), anyList(), eq(true), anyLong(), eq(QueuePolicy.DEFAULT)))
                 .thenReturn(Futures.immediateFuture(null));
         final List<SubscriptionResult> subscriptions = newArrayList(
                 subResult(new Topic("topic", QoS.AT_LEAST_ONCE), false),
@@ -459,7 +462,7 @@ public class SendRetainedMessagesListenerTest {
 
         final ArgumentCaptor<List<PUBLISH>> captor = ArgumentCaptor.forClass((Class<List<PUBLISH>>) (Class) List.class);
         verify(queuePersistence, timeout(5000).times(2))
-                .add(eq("client"), eq(false), captor.capture(), eq(true), anyLong(), any());
+                .add(eq("client"), eq(false), captor.capture(), eq(true), anyLong(), eq(QueuePolicy.DEFAULT));
 
         final PUBLISH publish = captor.getAllValues().get(0).get(0);
         assertEquals("topic", publish.getTopic());

--- a/hivemq-edge/src/test/java/com/hivemq/mqtt/services/PublishDistributorImplTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/mqtt/services/PublishDistributorImplTest.java
@@ -41,8 +41,10 @@ import com.hivemq.mqtt.message.publish.PUBLISHFactory;
 import com.hivemq.mqtt.topic.SubscriberWithIdentifiers;
 import com.hivemq.persistence.SingleWriterService;
 import com.hivemq.persistence.clientqueue.ClientQueuePersistence;
+import com.hivemq.persistence.clientqueue.QueuePolicy;
 import com.hivemq.persistence.clientsession.ClientSession;
 import com.hivemq.persistence.clientsession.ClientSessionPersistence;
+import com.hivemq.sampling.SamplingService;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -66,6 +68,7 @@ public class PublishDistributorImplTest {
     private final @NotNull BridgeExtractor bridgeConfiguration = mock();
     private final @NotNull MqttBridge bridge = mock();
     private final @NotNull MqttConfigurationService mqttConfigurationService = mock();
+    private final @NotNull SamplingService samplingService = mock();
 
     private @NotNull PublishDistributorImpl publishDistributor;
     private @NotNull SingleWriterService singleWriterService;
@@ -79,7 +82,7 @@ public class PublishDistributorImplTest {
         when(configurationService.bridgeExtractor()).thenReturn(bridgeConfiguration);
         singleWriterService = TestSingleWriterFactory.defaultSingleWriter(internalConfigurationService);
         publishDistributor = new PublishDistributorImpl(
-                clientQueuePersistence, () -> clientSessionPersistence, configurationService);
+                clientQueuePersistence, () -> clientSessionPersistence, configurationService, () -> samplingService);
         when(bridgeConfiguration.getBridges()).thenReturn(List.of(bridge));
     }
 
@@ -118,7 +121,7 @@ public class PublishDistributorImplTest {
     @Timeout(5)
     public void test_success() throws ExecutionException, InterruptedException {
         when(clientSessionPersistence.getSession("client", false)).thenReturn(new ClientSession(true, 1000L));
-        when(clientQueuePersistence.add(eq("client"), eq(false), any(PUBLISH.class), anyBoolean(), anyLong()))
+        when(clientQueuePersistence.add(eq("client"), eq(false), any(PUBLISH.class), anyBoolean(), anyLong(), any()))
                 .thenReturn(Futures.immediateFuture(null));
 
         final PublishStatus status = publishDistributor
@@ -126,7 +129,7 @@ public class PublishDistributorImplTest {
                         createPublish(QoS.AT_LEAST_ONCE), "client", 0, false, false, ImmutableIntArray.of(1))
                 .get();
 
-        verify(clientQueuePersistence).add(eq("client"), eq(false), any(PUBLISH.class), anyBoolean(), anyLong());
+        verify(clientQueuePersistence).add(eq("client"), eq(false), any(PUBLISH.class), anyBoolean(), anyLong(), any());
         assertEquals(PublishStatus.DELIVERED, status);
     }
 
@@ -134,7 +137,7 @@ public class PublishDistributorImplTest {
     @Timeout(5)
     public void test_failed() throws ExecutionException, InterruptedException {
         when(clientSessionPersistence.getSession("client", false)).thenReturn(new ClientSession(true, 1000L));
-        when(clientQueuePersistence.add(eq("client"), eq(false), any(PUBLISH.class), anyBoolean(), anyLong()))
+        when(clientQueuePersistence.add(eq("client"), eq(false), any(PUBLISH.class), anyBoolean(), anyLong(), any()))
                 .thenReturn(Futures.immediateFailedFuture(new RuntimeException("test")));
 
         final PublishStatus status = publishDistributor
@@ -142,14 +145,77 @@ public class PublishDistributorImplTest {
                         createPublish(QoS.AT_LEAST_ONCE), "client", 0, false, false, ImmutableIntArray.of(1))
                 .get();
 
-        verify(clientQueuePersistence).add(eq("client"), eq(false), any(PUBLISH.class), anyBoolean(), anyLong());
+        verify(clientQueuePersistence).add(eq("client"), eq(false), any(PUBLISH.class), anyBoolean(), anyLong(), any());
         assertEquals(PublishStatus.FAILED, status);
+    }
+
+    /**
+     * EDG-882 F-05. A queue ID is built from a share name, and a share name is the client's to choose:
+     * {@code $share/$SAMPLER::customer/alerts} is a legal subscription that no part of Edge owns. It
+     * must be queued like any other shared subscription — the configured limit, the configured overflow
+     * strategy — and not turned into the ten-message ring that sampling uses, which would discard the
+     * client's own messages under a policy meant for diagnostics.
+     */
+    @Test
+    @Timeout(5)
+    public void test_client_shared_subscription_named_like_a_sampler_gets_the_ordinary_policy()
+            throws ExecutionException, InterruptedException {
+        when(samplingService.isSamplerQueue("$SAMPLER::customer/alerts")).thenReturn(false);
+        when(mqttConfigurationService.maxQueuedMessages()).thenReturn(1000L);
+        when(clientQueuePersistence.add(
+                        eq("$SAMPLER::customer/alerts"), eq(true), any(PUBLISH.class), anyBoolean(), anyLong(), any()))
+                .thenReturn(Futures.immediateFuture(null));
+
+        publishDistributor
+                .sendMessageToSubscriber(
+                        createPublish(QoS.AT_MOST_ONCE),
+                        "$SAMPLER::customer/alerts",
+                        0,
+                        true,
+                        false,
+                        ImmutableIntArray.of(1))
+                .get();
+
+        verify(clientQueuePersistence)
+                .add(
+                        eq("$SAMPLER::customer/alerts"),
+                        eq(true),
+                        any(PUBLISH.class),
+                        anyBoolean(),
+                        eq(1000L),
+                        eq(QueuePolicy.DEFAULT));
+    }
+
+    /** And a queue the sampling service does own still gets the ring: the fix must not disable it. */
+    @Test
+    @Timeout(5)
+    public void test_a_real_sampler_queue_gets_the_sample_ring_policy()
+            throws ExecutionException, InterruptedException {
+        final String queueId = SamplingService.createQueueId("plant/line1");
+        when(samplingService.isSamplerQueue(queueId)).thenReturn(true);
+        when(clientQueuePersistence.add(eq(queueId), eq(true), any(PUBLISH.class), anyBoolean(), anyLong(), any()))
+                .thenReturn(Futures.immediateFuture(null));
+
+        publishDistributor
+                .sendMessageToSubscriber(
+                        createPublish(QoS.AT_MOST_ONCE), queueId, 0, true, false, ImmutableIntArray.of(1))
+                .get();
+
+        verify(clientQueuePersistence)
+                .add(
+                        eq(queueId),
+                        eq(true),
+                        any(PUBLISH.class),
+                        anyBoolean(),
+                        eq(SamplingService.SAMPLER_QUEUE_LIMIT),
+                        eq(QueuePolicy.SAMPLE_RING));
     }
 
     @Test
     @Timeout(5)
     public void test_success_shared() throws ExecutionException, InterruptedException {
-        when(clientQueuePersistence.add(eq("group/topic"), eq(true), any(PUBLISH.class), anyBoolean(), anyLong()))
+        when(clientQueuePersistence.add(
+                        eq("group/topic"), eq(true), any(PUBLISH.class), anyBoolean(), anyLong(), any()))
                 .thenReturn(Futures.immediateFuture(null));
 
         final PublishStatus status = publishDistributor
@@ -157,7 +223,8 @@ public class PublishDistributorImplTest {
                         createPublish(QoS.AT_LEAST_ONCE), "group/topic", 0, true, false, ImmutableIntArray.of(1))
                 .get();
 
-        verify(clientQueuePersistence).add(eq("group/topic"), eq(true), any(PUBLISH.class), anyBoolean(), anyLong());
+        verify(clientQueuePersistence)
+                .add(eq("group/topic"), eq(true), any(PUBLISH.class), anyBoolean(), anyLong(), any());
         assertEquals(PublishStatus.DELIVERED, status);
     }
 
@@ -166,9 +233,9 @@ public class PublishDistributorImplTest {
     public void test_distribute_to_non_shared() {
         when(clientSessionPersistence.getSession("client1", false)).thenReturn(new ClientSession(true, 1000L));
         when(clientSessionPersistence.getSession("client2", false)).thenReturn(new ClientSession(true, 1000L));
-        when(clientQueuePersistence.add(eq("client1"), eq(false), any(PUBLISH.class), anyBoolean(), anyLong()))
+        when(clientQueuePersistence.add(eq("client1"), eq(false), any(PUBLISH.class), anyBoolean(), anyLong(), any()))
                 .thenReturn(Futures.immediateFuture(null));
-        when(clientQueuePersistence.add(eq("client2"), eq(false), any(PUBLISH.class), anyBoolean(), anyLong()))
+        when(clientQueuePersistence.add(eq("client2"), eq(false), any(PUBLISH.class), anyBoolean(), anyLong(), any()))
                 .thenReturn(Futures.immediateFuture(null));
 
         final Map<String, SubscriberWithIdentifiers> subscribers = Map.of(
@@ -178,16 +245,20 @@ public class PublishDistributorImplTest {
         publishDistributor.distributeToNonSharedSubscribers(
                 subscribers, TestMessageUtil.createMqtt5Publish(), MoreExecutors.newDirectExecutorService());
 
-        verify(clientQueuePersistence).add(eq("client1"), eq(false), any(PUBLISH.class), anyBoolean(), anyLong());
-        verify(clientQueuePersistence).add(eq("client2"), eq(false), any(PUBLISH.class), anyBoolean(), anyLong());
+        verify(clientQueuePersistence)
+                .add(eq("client1"), eq(false), any(PUBLISH.class), anyBoolean(), anyLong(), any());
+        verify(clientQueuePersistence)
+                .add(eq("client2"), eq(false), any(PUBLISH.class), anyBoolean(), anyLong(), any());
     }
 
     @Test
     @SuppressWarnings("FutureReturnValueIgnored")
     public void test_distribute_to_shared_subs() {
-        when(clientQueuePersistence.add(eq("name/topic1"), eq(true), any(PUBLISH.class), anyBoolean(), anyLong()))
+        when(clientQueuePersistence.add(
+                        eq("name/topic1"), eq(true), any(PUBLISH.class), anyBoolean(), anyLong(), any()))
                 .thenReturn(Futures.immediateFuture(null));
-        when(clientQueuePersistence.add(eq("name/topic2"), eq(true), any(PUBLISH.class), anyBoolean(), anyLong()))
+        when(clientQueuePersistence.add(
+                        eq("name/topic2"), eq(true), any(PUBLISH.class), anyBoolean(), anyLong(), any()))
                 .thenReturn(Futures.immediateFuture(null));
 
         final Set<String> subscribers = Set.of("name/topic1", "name/topic2");
@@ -195,8 +266,10 @@ public class PublishDistributorImplTest {
         publishDistributor.distributeToSharedSubscribers(
                 subscribers, TestMessageUtil.createMqtt5Publish("topic"), MoreExecutors.newDirectExecutorService());
 
-        verify(clientQueuePersistence).add(eq("name/topic1"), eq(true), any(PUBLISH.class), anyBoolean(), anyLong());
-        verify(clientQueuePersistence).add(eq("name/topic2"), eq(true), any(PUBLISH.class), anyBoolean(), anyLong());
+        verify(clientQueuePersistence)
+                .add(eq("name/topic1"), eq(true), any(PUBLISH.class), anyBoolean(), anyLong(), any());
+        verify(clientQueuePersistence)
+                .add(eq("name/topic2"), eq(true), any(PUBLISH.class), anyBoolean(), anyLong(), any());
     }
 
     private PUBLISH createPublish(final @NotNull QoS qos) {

--- a/hivemq-edge/src/test/java/com/hivemq/mqtt/services/PublishDistributorImplTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/mqtt/services/PublishDistributorImplTest.java
@@ -15,6 +15,7 @@
  */
 package com.hivemq.mqtt.services;
 
+import static com.hivemq.bridge.MessageForwarderImpl.FORWARDER_PREFIX;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -23,11 +24,14 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.google.common.primitives.ImmutableIntArray;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.MoreExecutors;
+import com.hivemq.bridge.MessageForwarder;
+import com.hivemq.bridge.config.LocalSubscription;
 import com.hivemq.bridge.config.MqttBridge;
 import com.hivemq.configuration.reader.BridgeExtractor;
 import com.hivemq.configuration.service.ConfigurationService;
@@ -54,6 +58,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.mockito.ArgumentCaptor;
 import util.TestMessageUtil;
 import util.TestSingleWriterFactory;
 
@@ -69,6 +74,7 @@ public class PublishDistributorImplTest {
     private final @NotNull MqttBridge bridge = mock();
     private final @NotNull MqttConfigurationService mqttConfigurationService = mock();
     private final @NotNull SamplingService samplingService = mock();
+    private final @NotNull MessageForwarder messageForwarder = mock();
 
     private @NotNull PublishDistributorImpl publishDistributor;
     private @NotNull SingleWriterService singleWriterService;
@@ -82,7 +88,11 @@ public class PublishDistributorImplTest {
         when(configurationService.bridgeExtractor()).thenReturn(bridgeConfiguration);
         singleWriterService = TestSingleWriterFactory.defaultSingleWriter(internalConfigurationService);
         publishDistributor = new PublishDistributorImpl(
-                clientQueuePersistence, () -> clientSessionPersistence, configurationService, () -> samplingService);
+                clientQueuePersistence,
+                () -> clientSessionPersistence,
+                configurationService,
+                () -> samplingService,
+                () -> messageForwarder);
         when(bridgeConfiguration.getBridges()).thenReturn(List.of(bridge));
     }
 
@@ -209,6 +219,96 @@ public class PublishDistributorImplTest {
                         anyBoolean(),
                         eq(SamplingService.SAMPLER_QUEUE_LIMIT),
                         eq(QueuePolicy.SAMPLE_RING));
+    }
+
+    /**
+     * EDG-882 QA round 2, the same rule as the sampler tests above applied to the branch above them.
+     * The forwarder branch decided from the spelling of the queue ID, and a share name is the client's
+     * to choose: subscribing to {@code $share/$FORWARDER::<a live forwarder id>/t} put an ordinary
+     * client's queue under a bridge's queue limit and, against a {@code persist=false} bridge, silently
+     * rewrote its QoS to 0 — so its own messages stopped being persisted.
+     */
+    @Test
+    @Timeout(5)
+    public void test_client_shared_subscription_named_like_a_forwarder_gets_the_ordinary_treatment()
+            throws ExecutionException, InterruptedException {
+        final String queueId = FORWARDER_PREFIX + "bridge-DNkmbgZ6ni59NniT9XDvig==/factory/temp";
+        when(messageForwarder.isForwarderQueue(queueId)).thenReturn(false);
+        when(samplingService.isSamplerQueue(queueId)).thenReturn(false);
+        when(mqttConfigurationService.maxQueuedMessages()).thenReturn(1000L);
+        when(clientQueuePersistence.add(eq(queueId), eq(true), any(PUBLISH.class), anyBoolean(), anyLong(), any()))
+                .thenReturn(Futures.immediateFuture(null));
+
+        publishDistributor
+                .sendMessageToSubscriber(
+                        createPublish(QoS.AT_LEAST_ONCE), queueId, 1, true, false, ImmutableIntArray.of(1))
+                .get();
+
+        final ArgumentCaptor<PUBLISH> queued = ArgumentCaptor.forClass(PUBLISH.class);
+        verify(clientQueuePersistence)
+                .add(eq(queueId), eq(true), queued.capture(), anyBoolean(), eq(1000L), eq(QueuePolicy.DEFAULT));
+        // the node default, not the bridge's limit; and the client's own QoS, not the bridge's rewrite
+        assertEquals(QoS.AT_LEAST_ONCE, queued.getValue().getQoS());
+        verifyNoInteractions(bridge);
+    }
+
+    /** The positive control: a queue a forwarder really owns still gets its bridge's limits. */
+    @Test
+    @Timeout(5)
+    public void test_a_real_forwarder_queue_gets_the_bridge_limits() throws ExecutionException, InterruptedException {
+        final LocalSubscription subscription = new LocalSubscription(List.of("factory/#"), "{#}");
+        final String queueId = FORWARDER_PREFIX + "bridge-" + subscription.calculateUniqueId() + "/factory/#";
+        when(bridge.getId()).thenReturn("bridge");
+        when(bridge.isPersist()).thenReturn(false);
+        when(bridge.getLocalSubscriptions()).thenReturn(List.of(subscription));
+        when(messageForwarder.isForwarderQueue(queueId)).thenReturn(true);
+        when(mqttConfigurationService.maxQueuedMessages()).thenReturn(1000L);
+        when(clientQueuePersistence.add(eq(queueId), eq(true), any(PUBLISH.class), anyBoolean(), anyLong(), any()))
+                .thenReturn(Futures.immediateFuture(null));
+
+        publishDistributor
+                .sendMessageToSubscriber(
+                        createPublish(QoS.AT_LEAST_ONCE), queueId, 1, true, false, ImmutableIntArray.of(1))
+                .get();
+
+        final ArgumentCaptor<PUBLISH> queued = ArgumentCaptor.forClass(PUBLISH.class);
+        verify(clientQueuePersistence)
+                .add(eq(queueId), eq(true), queued.capture(), anyBoolean(), anyLong(), eq(QueuePolicy.DEFAULT));
+        // persist=false is what downgrades it, and that is the bridge's own configuration
+        assertEquals(QoS.AT_MOST_ONCE, queued.getValue().getQoS());
+    }
+
+    /**
+     * The resolution used {@code contains}, so a bridge whose id merely appeared inside another
+     * bridge's queue ID answered for it. Anchored matching keeps them apart (EDG-882 QA round 2).
+     */
+    @Test
+    @Timeout(5)
+    public void test_a_forwarder_queue_is_not_matched_to_a_bridge_whose_id_is_a_substring()
+            throws ExecutionException, InterruptedException {
+        final LocalSubscription subscription = new LocalSubscription(List.of("factory/#"), "{#}");
+        final MqttBridge otherBridge = mock();
+        when(otherBridge.getId()).thenReturn("plant");
+        when(otherBridge.isPersist()).thenReturn(false);
+        when(otherBridge.getLocalSubscriptions()).thenReturn(List.of(subscription));
+        when(bridgeConfiguration.getBridges()).thenReturn(List.of(otherBridge));
+        // the queue belongs to "plant-north", whose id contains "plant"
+        final String queueId = FORWARDER_PREFIX + "plant-north-" + subscription.calculateUniqueId() + "/factory/#";
+        when(messageForwarder.isForwarderQueue(queueId)).thenReturn(true);
+        when(mqttConfigurationService.maxQueuedMessages()).thenReturn(1000L);
+        when(clientQueuePersistence.add(eq(queueId), eq(true), any(PUBLISH.class), anyBoolean(), anyLong(), any()))
+                .thenReturn(Futures.immediateFuture(null));
+
+        publishDistributor
+                .sendMessageToSubscriber(
+                        createPublish(QoS.AT_LEAST_ONCE), queueId, 1, true, false, ImmutableIntArray.of(1))
+                .get();
+
+        final ArgumentCaptor<PUBLISH> queued = ArgumentCaptor.forClass(PUBLISH.class);
+        verify(clientQueuePersistence)
+                .add(eq(queueId), eq(true), queued.capture(), anyBoolean(), eq(1000L), eq(QueuePolicy.DEFAULT));
+        // "plant"'s persist=false must not reach a queue that is not "plant"'s
+        assertEquals(QoS.AT_LEAST_ONCE, queued.getValue().getQoS());
     }
 
     @Test

--- a/hivemq-edge/src/test/java/com/hivemq/mqtt/services/PublishDistributorImplTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/mqtt/services/PublishDistributorImplTest.java
@@ -256,7 +256,12 @@ public class PublishDistributorImplTest {
     @Test
     @Timeout(5)
     public void test_a_real_forwarder_queue_gets_the_bridge_limits() throws ExecutionException, InterruptedException {
-        final LocalSubscription subscription = new LocalSubscription(List.of("factory/#"), "{#}");
+        // A limit of its own, so the assertion below can name it. With queueLimit = null the bridge and
+        // the node-wide default are the same number and anyLong() cannot tell which one was applied,
+        // which left the "gets the bridge limits" half of this test's name unproven (R2-21).
+        final long bridgeQueueLimit = 77L;
+        final LocalSubscription subscription =
+                new LocalSubscription(List.of("factory/#"), "{#}", List.of(), List.of(), false, 2, bridgeQueueLimit);
         final String queueId = FORWARDER_PREFIX + "bridge-" + subscription.calculateUniqueId() + "/factory/#";
         when(bridge.getId()).thenReturn("bridge");
         when(bridge.isPersist()).thenReturn(false);
@@ -273,7 +278,13 @@ public class PublishDistributorImplTest {
 
         final ArgumentCaptor<PUBLISH> queued = ArgumentCaptor.forClass(PUBLISH.class);
         verify(clientQueuePersistence)
-                .add(eq(queueId), eq(true), queued.capture(), anyBoolean(), anyLong(), eq(QueuePolicy.DEFAULT));
+                .add(
+                        eq(queueId),
+                        eq(true),
+                        queued.capture(),
+                        anyBoolean(),
+                        eq(bridgeQueueLimit),
+                        eq(QueuePolicy.DEFAULT));
         // persist=false is what downgrades it, and that is the bridge's own configuration
         assertEquals(QoS.AT_MOST_ONCE, queued.getValue().getQoS());
     }

--- a/hivemq-edge/src/test/java/com/hivemq/persistence/clientqueue/ClientQueuePersistenceImplTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/persistence/clientqueue/ClientQueuePersistenceImplTest.java
@@ -568,6 +568,36 @@ public class ClientQueuePersistenceImplTest {
     }
 
     /**
+     * The shutdown starting <em>inside</em> the sweep, which is the case the loop-top guard cannot cover
+     * (EDG-882 QA round 4, review v02 R2-21).
+     * <p>
+     * The test above trips the guard at the top of the iteration: the node is already shutting down when
+     * the sweep begins. The window that costs messages is narrower — the bridge shutdown hook
+     * un-registers every forwarder <em>while</em> {@code isOrphaned} is running, so a queue that was live
+     * when the iteration started reads as orphaned by the time the clear is reached. That is why the
+     * guard is re-read immediately before the destructive call, and this is what pins it: the shutdown is
+     * triggered from inside the ownership lookup itself.
+     */
+    @Test
+    @Timeout(5)
+    public void test_a_shutdown_beginning_during_the_ownership_lookup_still_reclaims_nothing()
+            throws ExecutionException, InterruptedException {
+        final String forwarderQueueId = MessageForwarderImpl.FORWARDER_PREFIX + "bridge-Bt80p78iNo/w7W1W7bGwcg==/topic";
+        when(localPersistence.cleanUp(eq(0))).thenReturn(ImmutableSet.of(forwarderQueueId));
+        when(messageForwarder.isForwarderQueue(forwarderQueueId)).thenReturn(false);
+        // the hook fires while ownership is being resolved, exactly as the bridge hook does
+        when(topicTree.getSharedSubscriber(anyString(), anyString())).thenAnswer(invocation -> {
+            shutdownHooks.runShutdownHooks();
+            return ImmutableSet.of();
+        });
+
+        clientQueuePersistence.cleanUp(0).get();
+
+        verify(topicTree, atLeastOnce()).getSharedSubscriber(anyString(), anyString());
+        verify(localPersistence, never()).clear(anyString(), anyBoolean(), anyInt());
+    }
+
+    /**
      * The positive control for the test above: the skip must be tied to the shutdown, not to the
      * queue — otherwise a passing "nothing was cleared" would only prove that nothing is ever cleared.
      */

--- a/hivemq-edge/src/test/java/com/hivemq/persistence/clientqueue/ClientQueuePersistenceImplTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/persistence/clientqueue/ClientQueuePersistenceImplTest.java
@@ -140,8 +140,34 @@ public class ClientQueuePersistenceImplTest {
                         eq(1000L),
                         eq(QueuedMessagesStrategy.DISCARD),
                         anyBoolean(),
+                        eq(false), // applyMaxToQos0: only sampler queues opt in (EDG-885)
                         anyInt());
         verify(messageDroppedService, never()).queueFull("client", "topic", 1);
+    }
+
+    /**
+     * EDG-885: a sampler queue is a ring buffer of the most recent samples, so it alone asks the
+     * persistence to apply the count limit to QoS 0 as well. Without it, a sampled topic whose
+     * publishers use QoS 0 is bounded only by the node-wide QoS 0 memory budget and can starve every
+     * other QoS 0 consumer on the node.
+     */
+    @Test
+    @Timeout(5)
+    public void test_add_sampler_queue_opts_into_the_qos0_count_limit()
+            throws ExecutionException, InterruptedException {
+        clientQueuePersistence
+                .add("$SAMPLER::topic/topic", true, createPublish(1, QoS.AT_MOST_ONCE, "topic"), false, 10L)
+                .get();
+        verify(localPersistence)
+                .add(
+                        eq("$SAMPLER::topic/topic"),
+                        eq(true),
+                        any(PUBLISH.class),
+                        eq(10L),
+                        eq(QueuedMessagesStrategy.DISCARD_OLDEST),
+                        anyBoolean(),
+                        eq(true),
+                        anyInt());
     }
 
     @Test
@@ -158,6 +184,7 @@ public class ClientQueuePersistenceImplTest {
                         eq(1000L),
                         eq(QueuedMessagesStrategy.DISCARD),
                         anyBoolean(),
+                        eq(false), // applyMaxToQos0: only sampler queues opt in (EDG-885)
                         anyInt());
     }
 
@@ -421,6 +448,7 @@ public class ClientQueuePersistenceImplTest {
                         eq(1000L),
                         eq(QueuedMessagesStrategy.DISCARD),
                         anyBoolean(),
+                        eq(false), // applyMaxToQos0: only sampler queues opt in (EDG-885)
                         anyInt());
         verify(clientSessionLocalPersistence, never())
                 .getSession("client"); // Get session because new publishes are available
@@ -442,6 +470,7 @@ public class ClientQueuePersistenceImplTest {
                         eq(1000L),
                         eq(QueuedMessagesStrategy.DISCARD),
                         anyBoolean(),
+                        eq(false), // applyMaxToQos0: only sampler queues opt in (EDG-885)
                         anyInt());
         verify(clientSessionLocalPersistence).getSession("client"); // Get session because new publishes are available
         verify(messageDroppedService, never()).queueFull("client", "topic", 1);

--- a/hivemq-edge/src/test/java/com/hivemq/persistence/clientqueue/ClientQueuePersistenceImplTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/persistence/clientqueue/ClientQueuePersistenceImplTest.java
@@ -130,7 +130,7 @@ public class ClientQueuePersistenceImplTest {
     @Timeout(5)
     public void test_add() throws ExecutionException, InterruptedException {
         clientQueuePersistence
-                .add("client", false, createPublish(1, QoS.AT_LEAST_ONCE, "topic"), false, 1000L)
+                .add("client", false, createPublish(1, QoS.AT_LEAST_ONCE, "topic"), false, 1000L, QueuePolicy.DEFAULT)
                 .get();
         verify(localPersistence)
                 .add(
@@ -146,17 +146,22 @@ public class ClientQueuePersistenceImplTest {
     }
 
     /**
-     * EDG-885: a sampler queue is a ring buffer of the most recent samples, so it alone asks the
+     * EDG-885: a sample ring is a ring buffer of the most recent samples, so it alone asks the
      * persistence to apply the count limit to QoS 0 as well. Without it, a sampled topic whose
      * publishers use QoS 0 is bounded only by the node-wide QoS 0 memory budget and can starve every
      * other QoS 0 consumer on the node.
      */
     @Test
     @Timeout(5)
-    public void test_add_sampler_queue_opts_into_the_qos0_count_limit()
-            throws ExecutionException, InterruptedException {
+    public void test_add_sample_ring_opts_into_the_qos0_count_limit() throws ExecutionException, InterruptedException {
         clientQueuePersistence
-                .add("$SAMPLER::topic/topic", true, createPublish(1, QoS.AT_MOST_ONCE, "topic"), false, 10L)
+                .add(
+                        "$SAMPLER::topic/topic",
+                        true,
+                        createPublish(1, QoS.AT_MOST_ONCE, "topic"),
+                        false,
+                        10L,
+                        QueuePolicy.SAMPLE_RING)
                 .get();
         verify(localPersistence)
                 .add(
@@ -170,11 +175,104 @@ public class ClientQueuePersistenceImplTest {
                         anyInt());
     }
 
+    /**
+     * EDG-882 F-05, the regression. The policy comes from the producer, so a queue ID that merely
+     * looks like a sampler's gets ordinary treatment: the configured overflow strategy, and QoS 0 left
+     * to the node-wide memory budget.
+     * <p>
+     * The ID here is what a client subscribing to {@code $share/$SAMPLER::customer/alerts} produces —
+     * a legal subscription, and the client's own messages. Deciding from the ID meant discarding them
+     * under a policy meant for diagnostics, and there was nothing the client could do about it but
+     * rename its subscription group.
+     */
+    @Test
+    @Timeout(5)
+    public void test_add_client_shared_queue_named_like_a_sampler_is_treated_normally()
+            throws ExecutionException, InterruptedException {
+        clientQueuePersistence
+                .add(
+                        "$SAMPLER::customer/alerts",
+                        true,
+                        createPublish(1, QoS.AT_MOST_ONCE, "alerts"),
+                        false,
+                        1000L,
+                        QueuePolicy.DEFAULT)
+                .get();
+        verify(localPersistence)
+                .add(
+                        eq("$SAMPLER::customer/alerts"),
+                        eq(true),
+                        any(PUBLISH.class),
+                        eq(1000L),
+                        eq(QueuedMessagesStrategy.DISCARD),
+                        anyBoolean(),
+                        eq(false),
+                        anyInt());
+    }
+
+    /** The batch path must read the policy the same way; it had its own copy of the inference. */
+    @Test
+    @Timeout(5)
+    public void test_add_batch_client_shared_queue_named_like_a_sampler_is_treated_normally()
+            throws ExecutionException, InterruptedException {
+        clientQueuePersistence
+                .add(
+                        "$SAMPLER::customer/alerts",
+                        true,
+                        ImmutableList.of(createPublish(1, QoS.AT_MOST_ONCE, "alerts")),
+                        false,
+                        1000L,
+                        QueuePolicy.DEFAULT)
+                .get();
+        verify(localPersistence)
+                .add(
+                        eq("$SAMPLER::customer/alerts"),
+                        eq(true),
+                        anyList(),
+                        eq(1000L),
+                        eq(QueuedMessagesStrategy.DISCARD),
+                        anyBoolean(),
+                        eq(false),
+                        anyInt());
+    }
+
+    /** And the batch path must still honour a sample ring when the producer asks for one. */
+    @Test
+    @Timeout(5)
+    public void test_add_batch_sample_ring_opts_into_the_qos0_count_limit()
+            throws ExecutionException, InterruptedException {
+        clientQueuePersistence
+                .add(
+                        "$SAMPLER::topic/topic",
+                        true,
+                        ImmutableList.of(createPublish(1, QoS.AT_MOST_ONCE, "topic")),
+                        false,
+                        10L,
+                        QueuePolicy.SAMPLE_RING)
+                .get();
+        verify(localPersistence)
+                .add(
+                        eq("$SAMPLER::topic/topic"),
+                        eq(true),
+                        anyList(),
+                        eq(10L),
+                        eq(QueuedMessagesStrategy.DISCARD_OLDEST),
+                        anyBoolean(),
+                        eq(true),
+                        anyInt());
+    }
+
     @Test
     @Timeout(5)
     public void test_add_shared() throws ExecutionException, InterruptedException {
         clientQueuePersistence
-                .add("name/topic", true, createPublish(1, QoS.AT_LEAST_ONCE, "topic"), false, 1000L)
+                .add(
+                        "name/topic",
+                        true,
+                        createPublish(1, QoS.AT_LEAST_ONCE, "topic"),
+                        false,
+                        1000L,
+                        QueuePolicy.DEFAULT)
                 .get();
         verify(localPersistence)
                 .add(
@@ -439,7 +537,9 @@ public class ClientQueuePersistenceImplTest {
         when(localPersistence.size(eq("client"), anyBoolean(), anyInt())).thenReturn(1);
         final ImmutableList<PUBLISH> publishes = ImmutableList.of(
                 createPublish(1, QoS.AT_LEAST_ONCE, "topic1"), createPublish(2, QoS.AT_LEAST_ONCE, "topic2"));
-        clientQueuePersistence.add("client", false, publishes, false, 1000L).get();
+        clientQueuePersistence
+                .add("client", false, publishes, false, 1000L, QueuePolicy.DEFAULT)
+                .get();
         verify(localPersistence)
                 .add(
                         eq("client"),
@@ -461,7 +561,9 @@ public class ClientQueuePersistenceImplTest {
         when(localPersistence.size(eq("client"), anyBoolean(), anyInt())).thenReturn(0);
         final ImmutableList<PUBLISH> publishes = ImmutableList.of(
                 createPublish(1, QoS.AT_LEAST_ONCE, "topic1"), createPublish(2, QoS.AT_LEAST_ONCE, "topic2"));
-        clientQueuePersistence.add("client", false, publishes, false, 1000L).get();
+        clientQueuePersistence
+                .add("client", false, publishes, false, 1000L, QueuePolicy.DEFAULT)
+                .get();
         verify(localPersistence)
                 .add(
                         eq("client"),

--- a/hivemq-edge/src/test/java/com/hivemq/persistence/clientqueue/ClientQueuePersistenceImplTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/persistence/clientqueue/ClientQueuePersistenceImplTest.java
@@ -27,6 +27,7 @@ import com.google.common.primitives.ImmutableIntArray;
 import com.hivemq.bootstrap.ClientConnection;
 import com.hivemq.bridge.MessageForwarder;
 import com.hivemq.bridge.MessageForwarderImpl;
+import com.hivemq.common.shutdown.ShutdownHooks;
 import com.hivemq.configuration.service.InternalConfigurationService;
 import com.hivemq.configuration.service.InternalConfigurations;
 import com.hivemq.configuration.service.MqttConfigurationService;
@@ -92,6 +93,8 @@ public class ClientQueuePersistenceImplTest {
     @Mock
     private MessageForwarder messageForwarder;
 
+    private final @NotNull ShutdownHooks shutdownHooks = new ShutdownHooks();
+
     private ClientQueuePersistenceImpl clientQueuePersistence;
 
     final int bucketSize = 4;
@@ -119,7 +122,8 @@ public class ClientQueuePersistenceImplTest {
                 topicTree,
                 connectionPersistence,
                 () -> publishPollService,
-                messageForwarder);
+                messageForwarder,
+                shutdownHooks);
     }
 
     @AfterEach
@@ -540,11 +544,81 @@ public class ClientQueuePersistenceImplTest {
         verify(localPersistence, never()).clear(anyString(), anyBoolean(), anyInt());
     }
 
+    /**
+     * EDG-882 QA round 1: the other end of the start-up gate. The bridge shutdown hook has priority
+     * HIGH and un-registers every forwarder, while this job stays scheduled until the persistence hook
+     * runs — so between them every live bridge queue reads as unowned, and a sweep landing there clears
+     * the backlog the shutdown deliberately did not clear.
+     */
+    @Test
+    @Timeout(5)
+    public void test_clean_up_while_shutting_down_reclaims_nothing() throws ExecutionException, InterruptedException {
+        final String forwarderQueueId = MessageForwarderImpl.FORWARDER_PREFIX + "bridge-Bt80p78iNo/w7W1W7bGwcg==/topic";
+        when(localPersistence.cleanUp(eq(0))).thenReturn(ImmutableSet.of(forwarderQueueId, "group/topic"));
+        when(messageForwarder.isForwarderQueue(forwarderQueueId)).thenReturn(false);
+        when(topicTree.getSharedSubscriber(anyString(), anyString())).thenReturn(ImmutableSet.of());
+        shutdownHooks.runShutdownHooks();
+
+        clientQueuePersistence.cleanUp(0).get();
+
+        // expiry still ran; nothing was reclaimed, and ownership was not even asked about
+        verify(localPersistence).cleanUp(0);
+        verify(localPersistence, never()).clear(anyString(), anyBoolean(), anyInt());
+        verify(topicTree, never()).getSharedSubscriber(anyString(), anyString());
+    }
+
+    /**
+     * The positive control for the test above: the skip must be tied to the shutdown, not to the
+     * queue — otherwise a passing "nothing was cleared" would only prove that nothing is ever cleared.
+     */
+    @Test
+    @Timeout(5)
+    public void test_clean_up_while_running_still_reclaims_orphans() throws ExecutionException, InterruptedException {
+        final String forwarderQueueId = MessageForwarderImpl.FORWARDER_PREFIX + "bridge-Bt80p78iNo/w7W1W7bGwcg==/topic";
+        when(localPersistence.cleanUp(eq(0))).thenReturn(ImmutableSet.of(forwarderQueueId));
+        when(messageForwarder.isForwarderQueue(forwarderQueueId)).thenReturn(false);
+        when(topicTree.getSharedSubscriber(anyString(), anyString())).thenReturn(ImmutableSet.of());
+
+        clientQueuePersistence.cleanUp(0).get();
+
+        verify(localPersistence).clear(forwarderQueueId, true, 0);
+    }
+
     @Test
     @Timeout(5)
     public void test_shared_publish_available() {
         clientQueuePersistence.sharedPublishAvailable("group/topic");
         verify(publishPollService).pollSharedPublishes("group/topic");
+    }
+
+    @Test
+    @Timeout(5)
+    public void test_shared_publish_available_for_a_registered_forwarder_queue_notifies_the_forwarder() {
+        final String queueId = MessageForwarderImpl.FORWARDER_PREFIX + "bridge-abc/topic";
+        when(messageForwarder.isForwarderQueue(queueId)).thenReturn(true);
+
+        clientQueuePersistence.sharedPublishAvailable(queueId);
+
+        verify(messageForwarder).messageAvailable(queueId);
+        verify(publishPollService, never()).pollSharedPublishes(anyString());
+    }
+
+    /**
+     * EDG-882 QA round 2: a client may legally choose "$FORWARDER::anything" as its share group. The
+     * notification used to be handed to the message forwarder purely because of how the ID was spelled
+     * — so the client was never told to poll, and the ID stayed in the forwarder's notEmptyQueues set
+     * for the life of the node, once for every distinct share name the client cared to invent.
+     */
+    @Test
+    @Timeout(5)
+    public void test_shared_publish_available_for_a_client_queue_named_like_a_forwarder_polls_the_client() {
+        final String queueId = MessageForwarderImpl.FORWARDER_PREFIX + "anything/topic";
+        when(messageForwarder.isForwarderQueue(queueId)).thenReturn(false);
+
+        clientQueuePersistence.sharedPublishAvailable(queueId);
+
+        verify(publishPollService).pollSharedPublishes(queueId);
+        verify(messageForwarder, never()).messageAvailable(anyString());
     }
 
     @Test

--- a/hivemq-edge/src/test/java/com/hivemq/persistence/clientqueue/ClientQueuePersistenceImplTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/persistence/clientqueue/ClientQueuePersistenceImplTest.java
@@ -107,6 +107,9 @@ public class ClientQueuePersistenceImplTest {
         singleWriterService = TestSingleWriterFactory.defaultSingleWriter(internalConfigurationService);
         when(mqttConfigurationService.maxQueuedMessages()).thenReturn(1000L);
         when(mqttConfigurationService.getQueuedMessagesStrategy()).thenReturn(QueuedMessagesStrategy.DISCARD);
+        // the bridges have started in every test but the one that says otherwise: before that, forwarder
+        // queues are deliberately left alone (EDG-882)
+        when(messageForwarder.hasAppliedBridgeConfiguration()).thenReturn(true);
         clientQueuePersistence = new ClientQueuePersistenceImpl(
                 localPersistence,
                 singleWriterService,
@@ -432,6 +435,26 @@ public class ClientQueuePersistenceImplTest {
                 + "bridge-Bt80p78iNo/w7W1W7bGwcg==/miele/v1/production/sapdm/dev/+/+/from-plc-to-dm";
         when(localPersistence.cleanUp(eq(0))).thenReturn(ImmutableSet.of(queueId));
         when(messageForwarder.isForwarderQueue(queueId)).thenReturn(true);
+
+        clientQueuePersistence.cleanUp(0).get();
+
+        verify(localPersistence, never()).clear(anyString(), anyBoolean(), anyInt());
+        verify(topicTree, never()).getSharedSubscriber(anyString(), anyString());
+    }
+
+    /**
+     * EDG-882: before any bridge configuration has been applied, a forwarder queue nobody owns is a
+     * bridge that has not started yet, not an abandoned queue. The clean-up service is scheduled
+     * during persistence bootstrap and the bridge subsystem is built after it, so a sweep in that
+     * window would delete the queues of every bridge on the node while they wait to be started.
+     */
+    @Test
+    @Timeout(5)
+    public void test_clean_up_before_any_bridge_configuration_leaves_forwarder_queues_alone()
+            throws ExecutionException, InterruptedException {
+        final String queueId = MessageForwarderImpl.FORWARDER_PREFIX + "bridge-Bt80p78iNo/w7W1W7bGwcg==/topic";
+        when(localPersistence.cleanUp(eq(0))).thenReturn(ImmutableSet.of(queueId));
+        when(messageForwarder.hasAppliedBridgeConfiguration()).thenReturn(false);
 
         clientQueuePersistence.cleanUp(0).get();
 

--- a/hivemq-edge/src/test/java/com/hivemq/persistence/clientqueue/ClientQueuePersistenceImplTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/persistence/clientqueue/ClientQueuePersistenceImplTest.java
@@ -26,6 +26,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.primitives.ImmutableIntArray;
 import com.hivemq.bootstrap.ClientConnection;
 import com.hivemq.bridge.MessageForwarder;
+import com.hivemq.bridge.MessageForwarderImpl;
 import com.hivemq.configuration.service.InternalConfigurationService;
 import com.hivemq.configuration.service.InternalConfigurations;
 import com.hivemq.configuration.service.MqttConfigurationService;
@@ -36,6 +37,7 @@ import com.hivemq.mqtt.message.dropping.MessageDroppedService;
 import com.hivemq.mqtt.message.publish.PUBLISH;
 import com.hivemq.mqtt.message.publish.PUBLISHFactory;
 import com.hivemq.mqtt.services.PublishPollService;
+import com.hivemq.mqtt.topic.SubscriberWithQoS;
 import com.hivemq.mqtt.topic.tree.LocalTopicTree;
 import com.hivemq.persistence.SingleWriterService;
 import com.hivemq.persistence.clientsession.ClientSession;
@@ -44,6 +46,7 @@ import com.hivemq.persistence.local.ClientSessionLocalPersistence;
 import com.hivemq.persistence.local.memory.ClientQueueMemoryLocalPersistence;
 import com.hivemq.persistence.local.xodus.bucket.BucketUtils;
 import com.hivemq.persistence.payload.PublishPayloadPersistence;
+import com.hivemq.sampling.SamplingService;
 import io.netty.channel.Channel;
 import io.netty.channel.embedded.EmbeddedChannel;
 import java.util.concurrent.ExecutionException;
@@ -86,6 +89,9 @@ public class ClientQueuePersistenceImplTest {
     @Mock
     private PublishPollService publishPollService;
 
+    @Mock
+    private MessageForwarder messageForwarder;
+
     private ClientQueuePersistenceImpl clientQueuePersistence;
 
     final int bucketSize = 4;
@@ -110,7 +116,7 @@ public class ClientQueuePersistenceImplTest {
                 topicTree,
                 connectionPersistence,
                 () -> publishPollService,
-                mock(MessageForwarder.class));
+                messageForwarder);
     }
 
     @AfterEach
@@ -289,6 +295,101 @@ public class ClientQueuePersistenceImplTest {
         clientQueuePersistence.cleanUp(0).get();
 
         verify(topicTree).getSharedSubscriber(anyString(), anyString());
+    }
+
+    @Test
+    @Timeout(5)
+    public void test_clean_up_active_forwarder_queue_with_slash_in_hash_not_cleared()
+            throws ExecutionException, InterruptedException {
+        // EDG-882: the Base64 subscription hash in a forwarder queue ID may contain '/', which made
+        // the clean-up misparse the queue ID and wipe a live bridge queue
+        final String queueId = MessageForwarderImpl.FORWARDER_PREFIX
+                + "bridge-Bt80p78iNo/w7W1W7bGwcg==/miele/v1/production/sapdm/dev/+/+/from-plc-to-dm";
+        when(localPersistence.cleanUp(eq(0))).thenReturn(ImmutableSet.of(queueId));
+        when(messageForwarder.isForwarderQueue(queueId)).thenReturn(true);
+
+        clientQueuePersistence.cleanUp(0).get();
+
+        verify(localPersistence, never()).clear(anyString(), anyBoolean(), anyInt());
+        verify(topicTree, never()).getSharedSubscriber(anyString(), anyString());
+    }
+
+    @Test
+    @Timeout(5)
+    public void test_clean_up_orphaned_forwarder_queue_cleared() throws ExecutionException, InterruptedException {
+        final String queueId = MessageForwarderImpl.FORWARDER_PREFIX
+                + "bridge-Bt80p78iNo/w7W1W7bGwcg==/miele/v1/production/sapdm/dev/+/+/from-plc-to-dm";
+        when(localPersistence.cleanUp(eq(0))).thenReturn(ImmutableSet.of(queueId));
+        when(messageForwarder.isForwarderQueue(queueId)).thenReturn(false);
+        when(topicTree.getSharedSubscriber(anyString(), anyString())).thenReturn(ImmutableSet.of());
+
+        clientQueuePersistence.cleanUp(0).get();
+
+        verify(localPersistence).clear(queueId, true, 0);
+    }
+
+    @Test
+    @Timeout(5)
+    public void test_clean_up_active_sampler_queue_for_topic_with_slash_not_cleared()
+            throws ExecutionException, InterruptedException {
+        // the sampler share name is $SAMPLER::<topic>, so for a hierarchical topic the share-name
+        // boundary is not the first '/': splitting there resolves an owner that never existed
+        final String topic = "a/b/c";
+        final String queueId = SamplingService.createQueueId(topic);
+        when(localPersistence.cleanUp(eq(0))).thenReturn(ImmutableSet.of(queueId));
+        when(topicTree.getSharedSubscriber(anyString(), anyString())).thenReturn(ImmutableSet.of());
+        when(topicTree.getSharedSubscriber(SamplingService.SAMPLER_PREFIX + topic, topic))
+                .thenReturn(ImmutableSet.of(
+                        new SubscriberWithQoS(SamplingService.SAMPLER_PREFIX + topic, 1, (byte) 0, null)));
+
+        clientQueuePersistence.cleanUp(0).get();
+
+        verify(localPersistence, never()).clear(anyString(), anyBoolean(), anyInt());
+    }
+
+    @Test
+    @Timeout(5)
+    public void test_clean_up_orphaned_sampler_queue_cleared() throws ExecutionException, InterruptedException {
+        final String queueId = SamplingService.createQueueId("a/b/c");
+        when(localPersistence.cleanUp(eq(0))).thenReturn(ImmutableSet.of(queueId));
+        when(topicTree.getSharedSubscriber(anyString(), anyString())).thenReturn(ImmutableSet.of());
+
+        clientQueuePersistence.cleanUp(0).get();
+
+        verify(localPersistence).clear(queueId, true, 0);
+    }
+
+    @Test
+    @Timeout(5)
+    public void test_clean_up_client_shared_subscription_colliding_with_sampler_prefix_not_cleared()
+            throws ExecutionException, InterruptedException {
+        // symmetric to the $FORWARDER:: case: a client may legally use "$SAMPLER::grp" as a share
+        // group, and the generic split resolves it correctly — it must not be treated as a sampler
+        final String queueId = SamplingService.SAMPLER_PREFIX + "grp/topic";
+        when(localPersistence.cleanUp(eq(0))).thenReturn(ImmutableSet.of(queueId));
+        when(topicTree.getSharedSubscriber(SamplingService.SAMPLER_PREFIX + "grp", "topic"))
+                .thenReturn(ImmutableSet.of(new SubscriberWithQoS("client", 1, (byte) 0, null)));
+
+        clientQueuePersistence.cleanUp(0).get();
+
+        verify(localPersistence, never()).clear(anyString(), anyBoolean(), anyInt());
+    }
+
+    @Test
+    @Timeout(5)
+    public void test_clean_up_client_shared_subscription_colliding_with_forwarder_prefix_not_cleared()
+            throws ExecutionException, InterruptedException {
+        // a client may legally subscribe to $share/$FORWARDER::group/topic: no forwarder owns that
+        // queue, so ownership must still be resolved through the topic tree rather than assumed absent
+        final String queueId = MessageForwarderImpl.FORWARDER_PREFIX + "group/topic";
+        when(localPersistence.cleanUp(eq(0))).thenReturn(ImmutableSet.of(queueId));
+        when(messageForwarder.isForwarderQueue(queueId)).thenReturn(false);
+        when(topicTree.getSharedSubscriber(MessageForwarderImpl.FORWARDER_PREFIX + "group", "topic"))
+                .thenReturn(ImmutableSet.of(new SubscriberWithQoS("client", 1, (byte) 0, null)));
+
+        clientQueuePersistence.cleanUp(0).get();
+
+        verify(localPersistence, never()).clear(anyString(), anyBoolean(), anyInt());
     }
 
     @Test

--- a/hivemq-edge/src/test/java/com/hivemq/persistence/local/memory/ClientQueueMemoryLocalPersistenceQos0LimitTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/persistence/local/memory/ClientQueueMemoryLocalPersistenceQos0LimitTest.java
@@ -195,6 +195,92 @@ public class ClientQueueMemoryLocalPersistenceQos0LimitTest {
     }
 
     /**
+     * EDG-882 F-03, mirrored from the file-native side, where the same scenario emptied the ring.
+     * <p>
+     * The node sits at its global QoS 0 ceiling — the budget is node-wide and shared with every other
+     * QoS 0 consumer, so this is the ordinary state of a busy node. The trim evicts the old sample and
+     * releases its memory, and that release is precisely the room the new one needs, so the ring must
+     * rotate rather than empty itself. This implementation reads the counter after the trim and gets it
+     * right; the assertion is here so that it cannot quietly stop doing so, and so that the two
+     * implementations of one contract are held to the same case.
+     * <p>
+     * Sized so that the sampler's own sample carries the node over the line, because that is the only
+     * case the trim can rescue: unrelated traffic that exceeds the budget on its own is over it before
+     * and after, and is meant to be rejected.
+     */
+    @Test
+    public void test_atTheGlobalCeiling_theRingStillRotates() {
+        withGlobalBudgetOfAbout(8 * 1024);
+
+        // unrelated QoS 0 traffic, comfortably inside the budget on its own
+        persistence.add(
+                "some/other/consumer",
+                true,
+                qos0("x".repeat(512)),
+                Long.MAX_VALUE,
+                QueuedMessagesStrategy.DISCARD_OLDEST,
+                false,
+                false,
+                BUCKET);
+        // and the sample that takes the node over it
+        add("x".repeat(32 * 1024), 1, true);
+        assertEquals(1, persistence.size(QUEUE_ID, true, BUCKET), "the ring must start with the sample it rotates out");
+
+        add("new", 1, true);
+
+        assertEquals(1, persistence.size(QUEUE_ID, true, BUCKET), "the ring emptied itself instead of rotating");
+        assertEquals(List.of("new"), payloadsInQueue(), "the newest sample must be the one that survived");
+    }
+
+    /**
+     * The ceiling still has to mean something: a queue that does no trimming frees nothing, and once
+     * the node is over the budget its messages must be dropped exactly as before.
+     */
+    @Test
+    public void test_atTheGlobalCeiling_aQueueThatFreesNothingIsStillBounded() {
+        withGlobalBudgetOfAbout(8 * 1024);
+
+        persistence.add(
+                "some/other/consumer",
+                true,
+                qos0("x".repeat(32 * 1024)),
+                Long.MAX_VALUE,
+                QueuedMessagesStrategy.DISCARD_OLDEST,
+                false,
+                false,
+                BUCKET);
+        final int sizeAtCeiling = persistence.size("some/other/consumer", true, BUCKET);
+
+        persistence.add(
+                "some/other/consumer",
+                true,
+                qos0("rejected"),
+                Long.MAX_VALUE,
+                QueuedMessagesStrategy.DISCARD_OLDEST,
+                false,
+                false,
+                BUCKET);
+
+        assertEquals(
+                sizeAtCeiling,
+                persistence.size("some/other/consumer", true, BUCKET),
+                "the node-wide QoS 0 budget must still reject what it cannot hold");
+    }
+
+    /**
+     * Rebuilds the persistence with a node-wide QoS 0 budget of roughly {@code bytes}. Derived from the
+     * heap rather than fixed, because the limit is {@code maxHeap / divisor} and the heap differs
+     * between a laptop and a CI agent; the tests using it work with messages an order of magnitude
+     * either side of the budget, so they never depend on the exact per-message overhead.
+     */
+    private void withGlobalBudgetOfAbout(final int bytes) {
+        InternalConfigurations.QOS_0_MEMORY_HARD_LIMIT_DIVISOR.set(
+                (int) Math.max(1, Runtime.getRuntime().maxMemory() / bytes));
+        persistence = new ClientQueueMemoryLocalPersistence(
+                payloadPersistence, messageDroppedService, new MetricRegistry(), internalConfigurationService);
+    }
+
+    /**
      * QoS 1 traffic on an opted-in queue must still take the ordinary path. Sampling subscribes at
      * {@code AT_LEAST_ONCE}, so a QoS 1 publisher produces QoS 1 samples, and those were never the
      * problem — they were always count-bounded.

--- a/hivemq-edge/src/test/java/com/hivemq/persistence/local/memory/ClientQueueMemoryLocalPersistenceQos0LimitTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/persistence/local/memory/ClientQueueMemoryLocalPersistenceQos0LimitTest.java
@@ -20,6 +20,7 @@ import static com.hivemq.configuration.service.MqttConfigurationService.QueuedMe
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
@@ -399,5 +400,98 @@ public class ClientQueueMemoryLocalPersistenceQos0LimitTest {
         }
 
         assertEquals(MAX, persistence.size(QUEUE_ID, true, BUCKET));
+    }
+
+    /**
+     * The case {@code test_atTheGlobalCeiling_theRingStillRotates} does not cover: the node is over the
+     * QoS 0 budget because of traffic that belongs to <em>another</em> queue, so the space the ring
+     * frees by rotating cannot bring it back under.
+     * <p>
+     * Trimming first and checking the guards afterwards destroyed the sample the ring held and then
+     * rejected its replacement against pressure the ring never caused — leaving it empty, and leaving it
+     * empty again on every sample that followed, because each one repeated the trade. The diagnostic the
+     * bound exists to protect showed nothing at all (EDG-882 review v03, R3-05).
+     * <p>
+     * The oracle is the surviving payload, not the size: a ring that rejected the incoming sample
+     * <em>and</em> kept the old one is the whole point, and a size assertion alone would pass on a ring
+     * that had swapped one for the other.
+     */
+    @Test
+    public void test_atTheGlobalCeiling_unrelatedPressureDoesNotEmptyTheRing() {
+        withGlobalBudgetOfAbout(8 * 1024);
+
+        add("old", 1, true);
+        assertEquals(List.of("old"), payloadsInQueue(), "the ring must start holding the sample under test");
+
+        // pressure that belongs to somebody else, and that the ring cannot free by rotating
+        persistence.add(
+                "some/other/consumer",
+                true,
+                qos0("x".repeat(32 * 1024)),
+                Long.MAX_VALUE,
+                QueuedMessagesStrategy.DISCARD_OLDEST,
+                false,
+                false,
+                BUCKET);
+
+        add("new", 1, true);
+
+        assertEquals(
+                List.of("old"),
+                payloadsInQueue(),
+                "the ring gave up the sample it held for a replacement that was then rejected");
+        assertEquals(1, persistence.size(QUEUE_ID, true, BUCKET), "the ring must not have emptied itself");
+    }
+
+    /**
+     * And it must not empty itself over many attempts either. One rejected sample leaving the ring intact
+     * is the fix; the defect's real shape was that every sample after the first repeated it, so a ring
+     * that survives one attempt but erodes over ten would still be broken.
+     */
+    @Test
+    public void test_atTheGlobalCeiling_unrelatedPressureLeavesTheRingIntactOverManyAttempts() {
+        withGlobalBudgetOfAbout(8 * 1024);
+
+        add("old", 1, true);
+        persistence.add(
+                "some/other/consumer",
+                true,
+                qos0("x".repeat(32 * 1024)),
+                Long.MAX_VALUE,
+                QueuedMessagesStrategy.DISCARD_OLDEST,
+                false,
+                false,
+                BUCKET);
+
+        for (int i = 0; i < 10; i++) {
+            add("rejected-" + i, 1, true);
+        }
+
+        assertEquals(List.of("old"), payloadsInQueue(), "the ring eroded under repeated rejected samples");
+    }
+
+    /**
+     * The rejection is still a rejection: refusing to destroy what the ring holds must not also stop the
+     * node reporting that it could not accept the message.
+     */
+    @Test
+    public void test_atTheGlobalCeiling_unrelatedPressureStillReportsTheDrop() {
+        withGlobalBudgetOfAbout(8 * 1024);
+
+        add("old", 1, true);
+        persistence.add(
+                "some/other/consumer",
+                true,
+                qos0("x".repeat(32 * 1024)),
+                Long.MAX_VALUE,
+                QueuedMessagesStrategy.DISCARD_OLDEST,
+                false,
+                false,
+                BUCKET);
+
+        add("new", 1, true);
+
+        verify(messageDroppedService, atLeastOnce())
+                .qos0MemoryExceededShared(eq(QUEUE_ID), anyString(), anyInt(), anyLong(), anyLong());
     }
 }

--- a/hivemq-edge/src/test/java/com/hivemq/persistence/local/memory/ClientQueueMemoryLocalPersistenceQos0LimitTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/persistence/local/memory/ClientQueueMemoryLocalPersistenceQos0LimitTest.java
@@ -19,7 +19,13 @@ import static com.hivemq.configuration.service.InternalConfigurations.PERSISTENC
 import static com.hivemq.configuration.service.MqttConfigurationService.QueuedMessagesStrategy;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 import com.codahale.metrics.MetricRegistry;
 import com.hivemq.configuration.service.InternalConfigurations;
@@ -126,6 +132,42 @@ public class ClientQueueMemoryLocalPersistenceQos0LimitTest {
             expected.add("m" + i);
         }
         assertEquals(expected, payloadsInQueue(), "the ring must hold the most recent MAX payloads, in order");
+    }
+
+    /**
+     * EDG-882 QA round 1: rotation is not a drop. Reporting it through the dropped-message service put
+     * every sample a UI topic preview replaces on the node-wide dropped-message counter and wrote an
+     * event.log line per publish — so opening a topic in the UI made the node look like it was losing
+     * customer messages, and the one metric an operator watches for real loss became useless.
+     */
+    @Test
+    public void test_whenOptedIn_thenRotationIsNotReportedAsADroppedMessage() {
+        for (int i = 0; i < 25; i++) {
+            add("m" + i, true);
+        }
+
+        verifyNoInteractions(messageDroppedService);
+    }
+
+    /** The control: a real drop is still reported. */
+    @Test
+    public void test_whenNotOptedIn_andTheQos1LimitBites_thenTheDropIsStillReported() {
+        for (int i = 0; i < 25; i++) {
+            persistence.add(QUEUE_ID, true, qos1("m" + i), 5L, QueuedMessagesStrategy.DISCARD, false, false, BUCKET);
+        }
+
+        verify(messageDroppedService, atLeastOnce()).queueFullShared(eq(QUEUE_ID), anyString(), anyInt());
+    }
+
+    private static @NotNull PUBLISH qos1(final @NotNull String payload) {
+        return new PUBLISHFactory.Mqtt5Builder()
+                .withQoS(QoS.AT_LEAST_ONCE)
+                .withOnwardQos(QoS.AT_LEAST_ONCE)
+                .withPublishId(1L)
+                .withPayload(payload.getBytes(UTF_8))
+                .withTopic("plant/line1")
+                .withHivemqId("hivemqId")
+                .build();
     }
 
     @Test

--- a/hivemq-edge/src/test/java/com/hivemq/persistence/local/memory/ClientQueueMemoryLocalPersistenceQos0LimitTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/persistence/local/memory/ClientQueueMemoryLocalPersistenceQos0LimitTest.java
@@ -38,6 +38,9 @@ import com.hivemq.persistence.payload.PublishPayloadPersistence;
 import java.util.ArrayList;
 import java.util.List;
 import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -65,11 +68,57 @@ public class ClientQueueMemoryLocalPersistenceQos0LimitTest {
 
     private ClientQueueMemoryLocalPersistence persistence;
 
+    /**
+     * The node-wide QoS 0 settings as this class found them.
+     * <p>
+     * {@code InternalConfigurations} holds plain statics and Gradle runs many test classes in one JVM, so
+     * what is set here outlives the class. Left set, the budget this class wants — the whole heap, and no
+     * per-client limit — is precisely the regime in which QoS 0 drop behaviour can no longer be observed,
+     * so every later class that constructs a queue persistence would quietly stop testing what it says it
+     * tests (EDG-882 review v02, R2-15).
+     * <p>
+     * Captured once in {@code @BeforeAll} rather than on each test: a per-test capture reads whatever the
+     * previous test left behind, so a single missed restore would be recorded as the value to restore
+     * <em>to</em> and the pollution would become permanent instead of being corrected.
+     */
+    private static int originalQos0HardLimitDivisor;
+
+    private static int originalQos0LimitPerClientBytes;
+
+    @BeforeAll
+    public static void captureTheNodeWideQos0Settings() {
+        originalQos0HardLimitDivisor = InternalConfigurations.QOS_0_MEMORY_HARD_LIMIT_DIVISOR.get();
+        originalQos0LimitPerClientBytes = InternalConfigurations.QOS_0_MEMORY_LIMIT_PER_CLIENT_BYTES.get();
+    }
+
+    @AfterEach
+    public void restoreTheNodeWideQos0Settings() {
+        InternalConfigurations.QOS_0_MEMORY_HARD_LIMIT_DIVISOR.set(originalQos0HardLimitDivisor);
+        InternalConfigurations.QOS_0_MEMORY_LIMIT_PER_CLIENT_BYTES.set(originalQos0LimitPerClientBytes);
+    }
+
+    /**
+     * The restore above cannot be asserted by any test in this class — what it protects is whatever runs
+     * next in the same JVM. This is the closest thing to an oracle for it, and it is what fails if a
+     * later change adds a mutation without a matching restore.
+     */
+    @AfterAll
+    public static void theNodeWideQos0SettingsAreAsTheyWereFound() {
+        assertEquals(
+                originalQos0HardLimitDivisor,
+                InternalConfigurations.QOS_0_MEMORY_HARD_LIMIT_DIVISOR.get(),
+                "this class leaked its QoS 0 memory divisor into every test class that runs after it");
+        assertEquals(
+                originalQos0LimitPerClientBytes,
+                InternalConfigurations.QOS_0_MEMORY_LIMIT_PER_CLIENT_BYTES.get(),
+                "this class leaked its per-client QoS 0 limit into every test class that runs after it");
+    }
+
     @BeforeEach
     public void setUp() {
         internalConfigurationService.set(PERSISTENCE_BUCKET_COUNT, "4");
         // a generous global QoS 0 budget, so that what this test observes is the count bound and never
-        // the memory backstop
+        // the memory backstop. Undone by restoreTheNodeWideQos0Settings; these are process-global.
         InternalConfigurations.QOS_0_MEMORY_HARD_LIMIT_DIVISOR.set(1);
         InternalConfigurations.QOS_0_MEMORY_LIMIT_PER_CLIENT_BYTES.set(Integer.MAX_VALUE);
         persistence = new ClientQueueMemoryLocalPersistence(

--- a/hivemq-edge/src/test/java/com/hivemq/persistence/local/memory/ClientQueueMemoryLocalPersistenceQos0LimitTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/persistence/local/memory/ClientQueueMemoryLocalPersistenceQos0LimitTest.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.persistence.local.memory;
+
+import static com.hivemq.configuration.service.InternalConfigurations.PERSISTENCE_BUCKET_COUNT;
+import static com.hivemq.configuration.service.MqttConfigurationService.QueuedMessagesStrategy;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+
+import com.codahale.metrics.MetricRegistry;
+import com.hivemq.configuration.service.InternalConfigurations;
+import com.hivemq.configuration.service.impl.InternalConfigurationServiceImpl;
+import com.hivemq.mqtt.message.QoS;
+import com.hivemq.mqtt.message.dropping.MessageDroppedService;
+import com.hivemq.mqtt.message.publish.PUBLISH;
+import com.hivemq.mqtt.message.publish.PUBLISHFactory;
+import com.hivemq.persistence.payload.PublishPayloadPersistence;
+import java.util.ArrayList;
+import java.util.List;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * EDG-885: the QoS 0 branch of {@code add} never read the {@code max} it was handed, so a queue whose
+ * publishers use QoS 0 was bounded only by the node-wide QoS 0 memory budget — 25 % of heap by default,
+ * shared with every other QoS 0 consumer on the node.
+ * <p>
+ * Sampler queues opt in to the count bound because they are ring buffers of the most recent
+ * {@code SamplingService.SAMPLE_SIZE} payloads. Everything else must keep the old behaviour: imposing a
+ * count limit on QoS 0 elsewhere would silently shrink the outage buffer of every {@code persist=false}
+ * bridge, which is a separate decision from this one.
+ */
+@SuppressWarnings("NullabilityAnnotations")
+public class ClientQueueMemoryLocalPersistenceQos0LimitTest {
+
+    private static final @NotNull String QUEUE_ID = "$SAMPLER::plant/line1";
+    private static final int BUCKET = 0;
+    private static final long MAX = 10;
+
+    private final @NotNull PublishPayloadPersistence payloadPersistence = mock();
+    private final @NotNull MessageDroppedService messageDroppedService = mock();
+    private final @NotNull InternalConfigurationServiceImpl internalConfigurationService =
+            new InternalConfigurationServiceImpl();
+
+    private ClientQueueMemoryLocalPersistence persistence;
+
+    @BeforeEach
+    public void setUp() {
+        internalConfigurationService.set(PERSISTENCE_BUCKET_COUNT, "4");
+        // a generous global QoS 0 budget, so that what this test observes is the count bound and never
+        // the memory backstop
+        InternalConfigurations.QOS_0_MEMORY_HARD_LIMIT_DIVISOR.set(1);
+        InternalConfigurations.QOS_0_MEMORY_LIMIT_PER_CLIENT_BYTES.set(Integer.MAX_VALUE);
+        persistence = new ClientQueueMemoryLocalPersistence(
+                payloadPersistence, messageDroppedService, new MetricRegistry(), internalConfigurationService);
+    }
+
+    private static @NotNull PUBLISH qos0(final @NotNull String payload) {
+        return new PUBLISHFactory.Mqtt5Builder()
+                .withQoS(QoS.AT_MOST_ONCE)
+                .withOnwardQos(QoS.AT_MOST_ONCE)
+                .withPublishId(1L)
+                .withPayload(payload.getBytes(UTF_8))
+                .withTopic("plant/line1")
+                .withHivemqId("hivemqId")
+                .build();
+    }
+
+    private void add(final @NotNull String payload, final boolean applyMaxToQos0) {
+        add(payload, MAX, applyMaxToQos0);
+    }
+
+    private void add(final @NotNull String payload, final long max, final boolean applyMaxToQos0) {
+        persistence.add(
+                QUEUE_ID,
+                true,
+                qos0(payload),
+                max,
+                QueuedMessagesStrategy.DISCARD_OLDEST,
+                false,
+                applyMaxToQos0,
+                BUCKET);
+    }
+
+    private @NotNull List<String> payloadsInQueue() {
+        final List<String> payloads = new ArrayList<>();
+        for (final PUBLISH publish : persistence.peek(QUEUE_ID, true, Long.MAX_VALUE, Integer.MAX_VALUE, BUCKET)) {
+            payloads.add(new String(publish.getPayload(), UTF_8));
+        }
+        return payloads;
+    }
+
+    @Test
+    public void test_whenOptedIn_thenTheQueueNeverExceedsTheLimit() {
+        for (int i = 0; i < 100; i++) {
+            add("m" + i, true);
+        }
+
+        assertEquals(MAX, persistence.size(QUEUE_ID, true, BUCKET), "queue must be capped at max");
+    }
+
+    /** Drop-oldest, not drop-newest: a sample is only useful if it is recent. */
+    @Test
+    public void test_whenOptedIn_thenTheOldestAreDroppedAndTheNewestKept() {
+        for (int i = 0; i < 25; i++) {
+            add("m" + i, true);
+        }
+
+        final List<String> expected = new ArrayList<>();
+        for (int i = 15; i < 25; i++) {
+            expected.add("m" + i);
+        }
+        assertEquals(expected, payloadsInQueue(), "the ring must hold the most recent MAX payloads, in order");
+    }
+
+    @Test
+    public void test_whenOptedIn_andBelowTheLimit_thenNothingIsDropped() {
+        for (int i = 0; i < 3; i++) {
+            add("m" + i, true);
+        }
+
+        assertEquals(3, persistence.size(QUEUE_ID, true, BUCKET));
+        assertEquals(List.of("m0", "m1", "m2"), payloadsInQueue());
+    }
+
+    @Test
+    public void test_whenOptedIn_andExactlyAtTheLimit_thenNothingIsDropped() {
+        for (int i = 0; i < MAX; i++) {
+            add("m" + i, true);
+        }
+
+        assertEquals(MAX, persistence.size(QUEUE_ID, true, BUCKET));
+        assertEquals("m0", payloadsInQueue().get(0), "the first message is still present at exactly max");
+    }
+
+    /**
+     * The guard that keeps this change contained. Every other QoS 0 queue — ordinary client queues, and
+     * the {@code persist=false} bridges deliberately downgraded to QoS 0 — must be untouched.
+     */
+    @Test
+    public void test_whenNotOptedIn_thenTheCountLimitIsIgnoredExactlyAsBefore() {
+        for (int i = 0; i < 100; i++) {
+            add("m" + i, false);
+        }
+
+        assertEquals(100, persistence.size(QUEUE_ID, true, BUCKET), "QoS 0 must stay memory-bounded only");
+    }
+
+    /** Trimming must keep the queue usable indefinitely, not merely bounded once. */
+    @Test
+    public void test_whenOptedIn_thenTheRingKeepsRotatingOverManyCycles() {
+        for (int i = 0; i < 10_000; i++) {
+            add("m" + i, true);
+        }
+
+        assertEquals(MAX, persistence.size(QUEUE_ID, true, BUCKET));
+        assertEquals("m9999", payloadsInQueue().get((int) MAX - 1), "the most recent payload must survive");
+    }
+
+    /**
+     * A limit of one is the tightest ring and the likeliest off-by-one: only the newest may remain.
+     */
+    @Test
+    public void test_aLimitOfOneKeepsOnlyTheNewest() {
+        add("first", 1, true);
+        add("second", 1, true);
+        add("third", 1, true);
+
+        assertEquals(1, persistence.size(QUEUE_ID, true, BUCKET));
+        assertEquals(List.of("third"), payloadsInQueue());
+    }
+
+    /** A non-positive limit disables the bound rather than trimming forever or emptying the queue. */
+    @Test
+    public void test_aNonPositiveLimitDisablesTheBound() {
+        add("only", 0, true);
+        add("second", 0, true);
+
+        assertEquals(2, persistence.size(QUEUE_ID, true, BUCKET));
+    }
+
+    /**
+     * QoS 1 traffic on an opted-in queue must still take the ordinary path. Sampling subscribes at
+     * {@code AT_LEAST_ONCE}, so a QoS 1 publisher produces QoS 1 samples, and those were never the
+     * problem — they were always count-bounded.
+     */
+    @Test
+    public void test_qos1MessagesOnAnOptedInQueueAreStillBoundedAsBefore() {
+        for (int i = 0; i < 25; i++) {
+            persistence.add(
+                    QUEUE_ID,
+                    true,
+                    new PUBLISHFactory.Mqtt5Builder()
+                            .withQoS(QoS.AT_LEAST_ONCE)
+                            .withOnwardQos(QoS.AT_LEAST_ONCE)
+                            .withPublishId(1L)
+                            .withPayload(("q" + i).getBytes(UTF_8))
+                            .withTopic("plant/line1")
+                            .withHivemqId("hivemqId")
+                            .withPersistence(payloadPersistence)
+                            .build(),
+                    MAX,
+                    QueuedMessagesStrategy.DISCARD_OLDEST,
+                    false,
+                    true,
+                    BUCKET);
+        }
+
+        assertEquals(MAX, persistence.size(QUEUE_ID, true, BUCKET));
+    }
+}

--- a/hivemq-edge/src/test/java/com/hivemq/sampling/SamplingServiceLifecycleTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/sampling/SamplingServiceLifecycleTest.java
@@ -31,8 +31,6 @@ import static org.mockito.Mockito.withSettings;
 
 import com.hivemq.mqtt.topic.tree.LocalTopicTree;
 import com.hivemq.persistence.clientqueue.ClientQueuePersistence;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
@@ -48,13 +46,19 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 /**
- * EDG-885: sampling is started by the mapping editor so it can infer a schema, and until this work it
- * was never stopped — {@code stopSampling} had no production caller, and could not have worked if it
- * had one. The subscription therefore outlived every watcher and its queue was never reclaimed.
+ * EDG-885 / EDG-882 F-06: what sampling's lifecycle actually is, rather than what it looked like.
  * <p>
- * These tests cover the watcher lifecycle: the subscription must appear on the first watcher, survive
- * every release but the last, and disappear on the last — with the transition atomic enough that a
- * release cannot tear down a subscription an overlapping acquire has just created.
+ * It was written as a watcher count — subscribe on the first, unsubscribe on the last — but
+ * {@code startSampling} is reached from a POST that carries no watcher identity, so retries, a
+ * remounted panel and a second browser tab are indistinguishable, and each one incremented a count
+ * that nothing ever decremented. No release added later could have balanced it, because it would have
+ * no way to know which acquire it was balancing. What is left is the truthful shape: starting is
+ * idempotent, stopping unsubscribes, and neither pretends to be reference-counted.
+ * <p>
+ * <b>Still open, deliberately:</b> nothing in production stops sampling, so a sampled topic keeps its
+ * subscription and its ten-message queue for the life of the node. Closing that needs a release the
+ * caller can be identified by, or a lease that expires — both decisions about the product's API
+ * surface, both EDG-885's.
  */
 @SuppressWarnings("FutureReturnValueIgnored") // submitted work reports failures through the shared holder
 public class SamplingServiceLifecycleTest {
@@ -72,7 +76,7 @@ public class SamplingServiceLifecycleTest {
     }
 
     @Test
-    public void test_firstWatcherSubscribes_andLastWatcherUnsubscribes() {
+    public void test_startingSubscribes_andStoppingUnsubscribes() {
         assertFalse(samplingService.isSampling(TOPIC));
 
         samplingService.startSampling(TOPIC);
@@ -85,19 +89,20 @@ public class SamplingServiceLifecycleTest {
     }
 
     /**
-     * The reason for counting at all: one client closing its panel must not blind another that is
-     * still watching the same topic.
+     * Starting is idempotent. A POST carries no watcher identity, so a retry, a remounted panel and a
+     * second tab are the same request as far as this service can tell — and they must not each leave
+     * something behind that has to be undone separately.
      */
     @Test
-    public void test_aSecondWatcherKeepsTheSubscriptionAliveWhenTheFirstReleases() {
+    public void test_startingAgainWhileSamplingChangesNothing() {
         samplingService.startSampling(TOPIC);
         samplingService.startSampling(TOPIC);
+        samplingService.startSampling(TOPIC);
+
+        assertTrue(samplingService.isSampling(TOPIC));
         verify(topicTree, times(1)).addTopic(eq(CLIENT_ID), any(), anyByte(), eq(CLIENT_ID));
 
-        samplingService.stopSampling(TOPIC);
-        assertTrue(samplingService.isSampling(TOPIC), "one watcher remains");
-        verify(topicTree, never()).removeSubscriber(any(), any(), any());
-
+        // and one stop is enough: repeated starts did not stack anything that survives it
         samplingService.stopSampling(TOPIC);
         assertFalse(samplingService.isSampling(TOPIC));
         verify(topicTree, times(1)).removeSubscriber(eq(CLIENT_ID), eq(TOPIC), eq(CLIENT_ID));
@@ -120,20 +125,20 @@ public class SamplingServiceLifecycleTest {
     }
 
     @Test
-    public void test_releasingATopicNobodyWatchesIsANoOp() {
+    public void test_stoppingATopicNobodyIsSamplingIsANoOp() {
         samplingService.stopSampling(TOPIC);
 
         assertFalse(samplingService.isSampling(TOPIC));
         verify(topicTree, never()).removeSubscriber(any(), any(), any());
 
-        // and the count must not have gone negative: a later acquire still subscribes
+        // and nothing was corrupted by it: a later start still subscribes
         samplingService.startSampling(TOPIC);
         assertTrue(samplingService.isSampling(TOPIC));
         verify(topicTree, times(1)).addTopic(eq(CLIENT_ID), any(), anyByte(), eq(CLIENT_ID));
     }
 
     @Test
-    public void test_releasingTwiceAfterOneAcquireIsANoOpTheSecondTime() {
+    public void test_stoppingTwiceIsANoOpTheSecondTime() {
         samplingService.startSampling(TOPIC);
         samplingService.stopSampling(TOPIC);
         samplingService.stopSampling(TOPIC);
@@ -143,7 +148,7 @@ public class SamplingServiceLifecycleTest {
     }
 
     @Test
-    public void test_aTopicCanBeSampledAgainAfterItsLastWatcherLeft() {
+    public void test_aTopicCanBeSampledAgainAfterItWasStopped() {
         samplingService.startSampling(TOPIC);
         samplingService.stopSampling(TOPIC);
         samplingService.startSampling(TOPIC);
@@ -154,7 +159,7 @@ public class SamplingServiceLifecycleTest {
     }
 
     @Test
-    public void test_topicsAreCountedIndependently() {
+    public void test_topicsAreTrackedIndependently() {
         final String other = "plant/line2/from-plc";
         samplingService.startSampling(TOPIC);
         samplingService.startSampling(other);
@@ -162,7 +167,7 @@ public class SamplingServiceLifecycleTest {
         samplingService.stopSampling(TOPIC);
 
         assertFalse(samplingService.isSampling(TOPIC));
-        assertTrue(samplingService.isSampling(other), "releasing one topic must not affect another");
+        assertTrue(samplingService.isSampling(other), "stopping one topic must not affect another");
         verify(topicTree, times(1)).removeSubscriber(eq(CLIENT_ID), eq(TOPIC), eq(CLIENT_ID));
     }
 
@@ -185,38 +190,43 @@ public class SamplingServiceLifecycleTest {
         verify(topicTree, times(1)).removeSubscriber(eq(clientId), eq(topic), eq(clientId));
     }
 
+    /**
+     * Many starts, one stop. This is the case the counting got wrong in the direction that matters: a
+     * browser that retried a POST twenty-five times would have needed twenty-five releases, and there
+     * is no caller anywhere that could have issued them.
+     */
     @Test
-    public void test_manyWatchersNeedAsManyReleases() {
-        final int watchers = 25;
-        for (int i = 0; i < watchers; i++) {
+    public void test_manyStartsStillNeedOnlyOneStop() {
+        for (int i = 0; i < 25; i++) {
             samplingService.startSampling(TOPIC);
         }
-        for (int i = 0; i < watchers - 1; i++) {
-            samplingService.stopSampling(TOPIC);
-            assertTrue(samplingService.isSampling(TOPIC), "release " + i + " must not unsubscribe");
-        }
-        verify(topicTree, never()).removeSubscriber(any(), any(), any());
+        verify(topicTree, times(1)).addTopic(eq(CLIENT_ID), any(), anyByte(), eq(CLIENT_ID));
 
         samplingService.stopSampling(TOPIC);
+
         assertFalse(samplingService.isSampling(TOPIC));
         verify(topicTree, times(1)).removeSubscriber(eq(CLIENT_ID), eq(TOPIC), eq(CLIENT_ID));
     }
 
     /**
-     * The race the {@code compute} exists for, and the only one that matters.
+     * The race the atomic {@code compute} exists for.
      * <p>
-     * A release that has decided to unsubscribe must not remove a subscriber that an overlapping
-     * acquire has just added. The failure is silent and sticky: the count would say "watched" while
-     * the topic tree says "not subscribed", so no samples would ever arrive and the clean-up would
-     * rightly reclaim the queue.
+     * A stop must not tear down a subscription a start has just created in a way that leaves the two
+     * records disagreeing: this service's map saying "sampled" while the topic tree says "not
+     * subscribed" is silent and sticky — no samples would ever arrive, the clean-up would rightly
+     * reclaim the queue, and nothing would re-register until the topic changed.
      * <p>
-     * Asserted against a topic tree that actually tracks state, so the invariant checked is the real
-     * one — <em>if anybody is watching, a subscriber exists</em> — rather than a count of mock calls.
-     * One-sided: it can only fail on a broken implementation, never spuriously on a correct one.
+     * The invariant is asserted at quiescence, against a topic tree that actually tracks state, and it
+     * is the strongest one that holds without watcher identity: <em>the two records agree</em>. During
+     * the storm they cannot be compared, because a stop from another thread may legitimately end
+     * sampling between any two instructions of this one — which is not a race but the honest
+     * consequence of a POST that says "sample this" without saying who is asking. A release path that
+     * lets one caller's stop not affect another needs a token to identify it, and that is EDG-885's
+     * decision to make.
      */
     @Test
     @Timeout(120)
-    public void test_overlappingAcquireAndReleaseNeverLeaveAWatchedTopicUnsubscribed() throws Exception {
+    public void test_overlappingStartAndStopLeaveTheTwoRecordsAgreeing() throws Exception {
         final Set<String> subscribed = ConcurrentHashMap.newKeySet();
         final LocalTopicTree statefulTree =
                 mock(LocalTopicTree.class, withSettings().stubOnly());
@@ -246,12 +256,6 @@ public class SamplingServiceLifecycleTest {
                         start.await();
                         for (int i = 0; i < iterations; i++) {
                             service.startSampling(TOPIC);
-                            // while this thread holds a watch, the subscription must exist
-                            if (!subscribed.contains(CLIENT_ID)) {
-                                throw new AssertionError(
-                                        "topic is watched but has no subscriber: samples would never arrive "
-                                                + "and the clean-up would reclaim the queue");
-                            }
                             service.stopSampling(TOPIC);
                         }
                     } catch (final Throwable e) {
@@ -267,57 +271,26 @@ public class SamplingServiceLifecycleTest {
             executor.shutdownNow();
             executor.awaitTermination(10, TimeUnit.SECONDS);
         }
-
         if (failure.get() != null) {
             throw new AssertionError("concurrent failure", failure.get());
         }
-        // every acquire was paired, so nothing may remain watched or subscribed
-        assertFalse(service.isSampling(TOPIC), "watchers leaked");
-        assertTrue(subscribed.isEmpty(), "subscription leaked: this queue would never be reclaimed");
+
+        assertEquals(
+                samplingServiceSaysSampled(service),
+                subscribed.contains(CLIENT_ID),
+                "this service and the topic tree disagree about whether the topic is sampled; samples "
+                        + "would never arrive and nothing would re-register until the topic changed");
+
+        // and the service is still usable afterwards: the storm left no wedged state
+        service.startSampling(TOPIC);
+        assertTrue(service.isSampling(TOPIC));
+        assertTrue(subscribed.contains(CLIENT_ID));
+        service.stopSampling(TOPIC);
+        assertFalse(service.isSampling(TOPIC));
+        assertFalse(subscribed.contains(CLIENT_ID));
     }
 
-    /**
-     * Balanced concurrent acquire/release across several topics must leave nothing behind — a leaked
-     * watcher is a sampler queue that grows forever, which is the defect EDG-885 exists to close.
-     */
-    @Test
-    @Timeout(120)
-    public void test_concurrentLifecyclesAcrossTopicsLeaveNothingBehind() throws Exception {
-        final List<String> topics = List.of("a/b", "c", "plant/line1/+", "", "x/y/z");
-        final ExecutorService executor = Executors.newFixedThreadPool(topics.size());
-        final CountDownLatch start = new CountDownLatch(1);
-        final CountDownLatch done = new CountDownLatch(topics.size());
-        final List<Throwable> failures = new ArrayList<>();
-        try {
-            for (final String topic : topics) {
-                executor.submit(() -> {
-                    try {
-                        start.await();
-                        for (int i = 0; i < 10_000; i++) {
-                            samplingService.startSampling(topic);
-                            samplingService.startSampling(topic);
-                            samplingService.stopSampling(topic);
-                            samplingService.stopSampling(topic);
-                        }
-                    } catch (final Throwable e) {
-                        synchronized (failures) {
-                            failures.add(e);
-                        }
-                    } finally {
-                        done.countDown();
-                    }
-                });
-            }
-            start.countDown();
-            assertTrue(done.await(120, TimeUnit.SECONDS), "threads did not finish");
-        } finally {
-            executor.shutdownNow();
-            executor.awaitTermination(10, TimeUnit.SECONDS);
-        }
-
-        assertEquals(List.of(), failures);
-        for (final String topic : topics) {
-            assertFalse(samplingService.isSampling(topic), "watcher leaked for '" + topic + "'");
-        }
+    private static boolean samplingServiceSaysSampled(final @NotNull SamplingService service) {
+        return service.isSampling(TOPIC);
     }
 }

--- a/hivemq-edge/src/test/java/com/hivemq/sampling/SamplingServiceLifecycleTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/sampling/SamplingServiceLifecycleTest.java
@@ -1,0 +1,323 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.sampling;
+
+import static com.hivemq.sampling.SamplingService.SAMPLER_PREFIX;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyByte;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.withSettings;
+
+import com.hivemq.mqtt.topic.tree.LocalTopicTree;
+import com.hivemq.persistence.clientqueue.ClientQueuePersistence;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * EDG-885: sampling is started by the mapping editor so it can infer a schema, and until this work it
+ * was never stopped — {@code stopSampling} had no production caller, and could not have worked if it
+ * had one. The subscription therefore outlived every watcher and its queue was never reclaimed.
+ * <p>
+ * These tests cover the watcher lifecycle: the subscription must appear on the first watcher, survive
+ * every release but the last, and disappear on the last — with the transition atomic enough that a
+ * release cannot tear down a subscription an overlapping acquire has just created.
+ */
+@SuppressWarnings("FutureReturnValueIgnored") // submitted work reports failures through the shared holder
+public class SamplingServiceLifecycleTest {
+
+    private static final @NotNull String TOPIC = "plant/line1/from-plc";
+    private static final @NotNull String CLIENT_ID = SAMPLER_PREFIX + TOPIC;
+
+    private LocalTopicTree topicTree;
+    private SamplingService samplingService;
+
+    @BeforeEach
+    public void setUp() {
+        topicTree = mock(LocalTopicTree.class);
+        samplingService = new SamplingService(topicTree, mock(ClientQueuePersistence.class));
+    }
+
+    @Test
+    public void test_firstWatcherSubscribes_andLastWatcherUnsubscribes() {
+        assertFalse(samplingService.isSampling(TOPIC));
+
+        samplingService.startSampling(TOPIC);
+        assertTrue(samplingService.isSampling(TOPIC));
+        verify(topicTree, times(1)).addTopic(eq(CLIENT_ID), any(), anyByte(), eq(CLIENT_ID));
+
+        samplingService.stopSampling(TOPIC);
+        assertFalse(samplingService.isSampling(TOPIC));
+        verify(topicTree, times(1)).removeSubscriber(eq(CLIENT_ID), eq(TOPIC), eq(CLIENT_ID));
+    }
+
+    /**
+     * The reason for counting at all: one client closing its panel must not blind another that is
+     * still watching the same topic.
+     */
+    @Test
+    public void test_aSecondWatcherKeepsTheSubscriptionAliveWhenTheFirstReleases() {
+        samplingService.startSampling(TOPIC);
+        samplingService.startSampling(TOPIC);
+        verify(topicTree, times(1)).addTopic(eq(CLIENT_ID), any(), anyByte(), eq(CLIENT_ID));
+
+        samplingService.stopSampling(TOPIC);
+        assertTrue(samplingService.isSampling(TOPIC), "one watcher remains");
+        verify(topicTree, never()).removeSubscriber(any(), any(), any());
+
+        samplingService.stopSampling(TOPIC);
+        assertFalse(samplingService.isSampling(TOPIC));
+        verify(topicTree, times(1)).removeSubscriber(eq(CLIENT_ID), eq(TOPIC), eq(CLIENT_ID));
+    }
+
+    /**
+     * The regression test for the defect that made the whole lifecycle unbuildable: {@code subscribe}
+     * registers a <em>shared</em> subscription under a share name, and the removal must name it.
+     * Passing {@code null} sends {@code MatchingNodeSubscriptions.removeSubscriberFromStructures} down
+     * its non-shared branch, which searches a map this subscription was never in — so the removal
+     * silently does nothing and the sampler lives forever.
+     */
+    @Test
+    public void test_unsubscribeNamesTheShareNameItSubscribedUnder() {
+        samplingService.startSampling(TOPIC);
+        samplingService.stopSampling(TOPIC);
+
+        verify(topicTree).removeSubscriber(CLIENT_ID, TOPIC, CLIENT_ID);
+        verify(topicTree, never()).removeSubscriber(CLIENT_ID, TOPIC, null);
+    }
+
+    @Test
+    public void test_releasingATopicNobodyWatchesIsANoOp() {
+        samplingService.stopSampling(TOPIC);
+
+        assertFalse(samplingService.isSampling(TOPIC));
+        verify(topicTree, never()).removeSubscriber(any(), any(), any());
+
+        // and the count must not have gone negative: a later acquire still subscribes
+        samplingService.startSampling(TOPIC);
+        assertTrue(samplingService.isSampling(TOPIC));
+        verify(topicTree, times(1)).addTopic(eq(CLIENT_ID), any(), anyByte(), eq(CLIENT_ID));
+    }
+
+    @Test
+    public void test_releasingTwiceAfterOneAcquireIsANoOpTheSecondTime() {
+        samplingService.startSampling(TOPIC);
+        samplingService.stopSampling(TOPIC);
+        samplingService.stopSampling(TOPIC);
+
+        assertFalse(samplingService.isSampling(TOPIC));
+        verify(topicTree, times(1)).removeSubscriber(eq(CLIENT_ID), eq(TOPIC), eq(CLIENT_ID));
+    }
+
+    @Test
+    public void test_aTopicCanBeSampledAgainAfterItsLastWatcherLeft() {
+        samplingService.startSampling(TOPIC);
+        samplingService.stopSampling(TOPIC);
+        samplingService.startSampling(TOPIC);
+
+        assertTrue(samplingService.isSampling(TOPIC));
+        verify(topicTree, times(2)).addTopic(eq(CLIENT_ID), any(), anyByte(), eq(CLIENT_ID));
+        verify(topicTree, times(1)).removeSubscriber(eq(CLIENT_ID), eq(TOPIC), eq(CLIENT_ID));
+    }
+
+    @Test
+    public void test_topicsAreCountedIndependently() {
+        final String other = "plant/line2/from-plc";
+        samplingService.startSampling(TOPIC);
+        samplingService.startSampling(other);
+
+        samplingService.stopSampling(TOPIC);
+
+        assertFalse(samplingService.isSampling(TOPIC));
+        assertTrue(samplingService.isSampling(other), "releasing one topic must not affect another");
+        verify(topicTree, times(1)).removeSubscriber(eq(CLIENT_ID), eq(TOPIC), eq(CLIENT_ID));
+    }
+
+    /**
+     * Topics containing '/' are the EDG-882 shape — the sampler queue ID repeats the topic around a
+     * separator, so the share name itself contains slashes. Nothing in the lifecycle may treat them
+     * specially. The empty topic is degenerate but reachable through the same REST path.
+     */
+    @ParameterizedTest
+    @ValueSource(strings = {"a/b", "a/b/c", "/", "//", "", "sport/tennis/+/#", "äöü/中文", "$SAMPLER::x"})
+    public void test_lifecycleIsIndifferentToTheShapeOfTheTopic(final String topic) {
+        final String clientId = SAMPLER_PREFIX + topic;
+
+        samplingService.startSampling(topic);
+        assertTrue(samplingService.isSampling(topic));
+        verify(topicTree, times(1)).addTopic(eq(clientId), any(), anyByte(), eq(clientId));
+
+        samplingService.stopSampling(topic);
+        assertFalse(samplingService.isSampling(topic));
+        verify(topicTree, times(1)).removeSubscriber(eq(clientId), eq(topic), eq(clientId));
+    }
+
+    @Test
+    public void test_manyWatchersNeedAsManyReleases() {
+        final int watchers = 25;
+        for (int i = 0; i < watchers; i++) {
+            samplingService.startSampling(TOPIC);
+        }
+        for (int i = 0; i < watchers - 1; i++) {
+            samplingService.stopSampling(TOPIC);
+            assertTrue(samplingService.isSampling(TOPIC), "release " + i + " must not unsubscribe");
+        }
+        verify(topicTree, never()).removeSubscriber(any(), any(), any());
+
+        samplingService.stopSampling(TOPIC);
+        assertFalse(samplingService.isSampling(TOPIC));
+        verify(topicTree, times(1)).removeSubscriber(eq(CLIENT_ID), eq(TOPIC), eq(CLIENT_ID));
+    }
+
+    /**
+     * The race the {@code compute} exists for, and the only one that matters.
+     * <p>
+     * A release that has decided to unsubscribe must not remove a subscriber that an overlapping
+     * acquire has just added. The failure is silent and sticky: the count would say "watched" while
+     * the topic tree says "not subscribed", so no samples would ever arrive and the clean-up would
+     * rightly reclaim the queue.
+     * <p>
+     * Asserted against a topic tree that actually tracks state, so the invariant checked is the real
+     * one — <em>if anybody is watching, a subscriber exists</em> — rather than a count of mock calls.
+     * One-sided: it can only fail on a broken implementation, never spuriously on a correct one.
+     */
+    @Test
+    @Timeout(120)
+    public void test_overlappingAcquireAndReleaseNeverLeaveAWatchedTopicUnsubscribed() throws Exception {
+        final Set<String> subscribed = ConcurrentHashMap.newKeySet();
+        final LocalTopicTree statefulTree =
+                mock(LocalTopicTree.class, withSettings().stubOnly());
+        doAnswer(invocation -> subscribed.add(invocation.getArgument(0)))
+                .when(statefulTree)
+                .addTopic(any(), any(), anyByte(), any());
+        doAnswer(invocation -> {
+                    subscribed.remove(invocation.<String>getArgument(0));
+                    return null;
+                })
+                .when(statefulTree)
+                .removeSubscriber(any(), any(), any());
+
+        final SamplingService service = new SamplingService(
+                statefulTree, mock(ClientQueuePersistence.class, withSettings().stubOnly()));
+
+        final int threads = 6;
+        final int iterations = 20_000;
+        final ExecutorService executor = Executors.newFixedThreadPool(threads);
+        final AtomicReference<Throwable> failure = new AtomicReference<>();
+        final CountDownLatch start = new CountDownLatch(1);
+        final CountDownLatch done = new CountDownLatch(threads);
+        try {
+            for (int t = 0; t < threads; t++) {
+                executor.submit(() -> {
+                    try {
+                        start.await();
+                        for (int i = 0; i < iterations; i++) {
+                            service.startSampling(TOPIC);
+                            // while this thread holds a watch, the subscription must exist
+                            if (!subscribed.contains(CLIENT_ID)) {
+                                throw new AssertionError(
+                                        "topic is watched but has no subscriber: samples would never arrive "
+                                                + "and the clean-up would reclaim the queue");
+                            }
+                            service.stopSampling(TOPIC);
+                        }
+                    } catch (final Throwable e) {
+                        failure.compareAndSet(null, e);
+                    } finally {
+                        done.countDown();
+                    }
+                });
+            }
+            start.countDown();
+            assertTrue(done.await(120, TimeUnit.SECONDS), "threads did not finish");
+        } finally {
+            executor.shutdownNow();
+            executor.awaitTermination(10, TimeUnit.SECONDS);
+        }
+
+        if (failure.get() != null) {
+            throw new AssertionError("concurrent failure", failure.get());
+        }
+        // every acquire was paired, so nothing may remain watched or subscribed
+        assertFalse(service.isSampling(TOPIC), "watchers leaked");
+        assertTrue(subscribed.isEmpty(), "subscription leaked: this queue would never be reclaimed");
+    }
+
+    /**
+     * Balanced concurrent acquire/release across several topics must leave nothing behind — a leaked
+     * watcher is a sampler queue that grows forever, which is the defect EDG-885 exists to close.
+     */
+    @Test
+    @Timeout(120)
+    public void test_concurrentLifecyclesAcrossTopicsLeaveNothingBehind() throws Exception {
+        final List<String> topics = List.of("a/b", "c", "plant/line1/+", "", "x/y/z");
+        final ExecutorService executor = Executors.newFixedThreadPool(topics.size());
+        final CountDownLatch start = new CountDownLatch(1);
+        final CountDownLatch done = new CountDownLatch(topics.size());
+        final List<Throwable> failures = new ArrayList<>();
+        try {
+            for (final String topic : topics) {
+                executor.submit(() -> {
+                    try {
+                        start.await();
+                        for (int i = 0; i < 10_000; i++) {
+                            samplingService.startSampling(topic);
+                            samplingService.startSampling(topic);
+                            samplingService.stopSampling(topic);
+                            samplingService.stopSampling(topic);
+                        }
+                    } catch (final Throwable e) {
+                        synchronized (failures) {
+                            failures.add(e);
+                        }
+                    } finally {
+                        done.countDown();
+                    }
+                });
+            }
+            start.countDown();
+            assertTrue(done.await(120, TimeUnit.SECONDS), "threads did not finish");
+        } finally {
+            executor.shutdownNow();
+            executor.awaitTermination(10, TimeUnit.SECONDS);
+        }
+
+        assertEquals(List.of(), failures);
+        for (final String topic : topics) {
+            assertFalse(samplingService.isSampling(topic), "watcher leaked for '" + topic + "'");
+        }
+    }
+}

--- a/hivemq-edge/src/test/java/com/hivemq/sampling/SamplingServiceLifecycleTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/sampling/SamplingServiceLifecycleTest.java
@@ -29,6 +29,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.withSettings;
 
+import ch.qos.logback.classic.Level;
 import com.hivemq.mqtt.topic.tree.LocalTopicTree;
 import com.hivemq.persistence.clientqueue.ClientQueuePersistence;
 import java.util.Set;
@@ -39,11 +40,14 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.slf4j.LoggerFactory;
 
 /**
  * EDG-885 / EDG-882 F-06: what sampling's lifecycle actually is, rather than what it looked like.
@@ -68,6 +72,34 @@ public class SamplingServiceLifecycleTest {
 
     private LocalTopicTree topicTree;
     private SamplingService samplingService;
+
+    private static Level previousSamplingLogLevel;
+
+    /**
+     * Silences {@link SamplingService}'s own logging for the duration of this class.
+     * <p>
+     * Not cosmetic, and the second time this exact defect has bitten on this branch — see the same
+     * guard in {@code MessageForwarderQueueOwnershipConcurrencyTest}. {@code startSampling} and
+     * {@code stopSampling} log at DEBUG on every call, and the concurrency tests below make hundreds
+     * of thousands of calls across a thread pool. Gradle captures that output into the JUnit XML,
+     * which produced a <b>27 MB result file</b> whose CDATA section exceeds libxml2's limit: CI's
+     * test-result reporter fails with {@code XMLSyntaxError: CData section too big} and reds the check
+     * while every test passes. Leave this in place, or restore it if the logging here ever changes.
+     */
+    @BeforeAll
+    public static void silenceSamplingLogging() {
+        final ch.qos.logback.classic.Logger logger =
+                (ch.qos.logback.classic.Logger) LoggerFactory.getLogger(SamplingService.class);
+        previousSamplingLogLevel = logger.getLevel();
+        logger.setLevel(Level.OFF);
+    }
+
+    /** Restores the level so this class cannot affect others sharing the JVM. */
+    @AfterAll
+    public static void restoreSamplingLogging() {
+        ((ch.qos.logback.classic.Logger) LoggerFactory.getLogger(SamplingService.class))
+                .setLevel(previousSamplingLogLevel);
+    }
 
     @BeforeEach
     public void setUp() {

--- a/hivemq-edge/src/test/java/com/hivemq/sampling/SamplingServiceTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/sampling/SamplingServiceTest.java
@@ -26,7 +26,10 @@ import static org.mockito.Mockito.verify;
 import com.hivemq.mqtt.message.subscribe.Topic;
 import com.hivemq.mqtt.topic.tree.LocalTopicTree;
 import com.hivemq.persistence.clientqueue.ClientQueuePersistence;
+import java.util.ArrayList;
+import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
@@ -34,20 +37,179 @@ import org.mockito.ArgumentCaptor;
 public class SamplingServiceTest {
 
     @ParameterizedTest
-    @ValueSource(strings = {"topic", "a/b", "a/b/c", "a//b", "sport/tennis/player1/#", "$share", "/", "//"})
+    @ValueSource(
+            strings = {
+                "topic",
+                "a/b",
+                "a/b/c",
+                "a//b",
+                "sport/tennis/player1/#",
+                "$share",
+                "/",
+                "//",
+                "aa",
+                "a/a",
+                "$SAMPLER::x",
+                "$FORWARDER::bridge-hash/t"
+            })
     public void test_extractSampledTopic_recovers_every_sampled_topic(final String topic) {
         assertEquals(topic, SamplingService.extractSampledTopic(SamplingService.createQueueId(topic)));
+    }
+
+    /** The empty topic is degenerate but reachable through the same code path; it must round-trip. */
+    @Test
+    public void test_extractSampledTopic_recovers_the_empty_topic() {
+        assertEquals("", SamplingService.extractSampledTopic(SamplingService.createQueueId("")));
+        assertEquals(SAMPLER_PREFIX + "/", SamplingService.createQueueId(""));
     }
 
     @Test
     public void test_extractSampledTopic_rejects_ids_that_are_not_sampler_queues() {
         assertNull(SamplingService.extractSampledTopic("group/topic"));
         assertNull(SamplingService.extractSampledTopic("$FORWARDER::bridge-hash/topic"));
+        assertNull(SamplingService.extractSampledTopic(""));
+        assertNull(SamplingService.extractSampledTopic("$SAMPLER:")); // prefix truncated
         // right prefix, but not the <topic>/<topic> shape a sampler queue has
         assertNull(SamplingService.extractSampledTopic(SAMPLER_PREFIX + "a/b"));
         assertNull(SamplingService.extractSampledTopic(SAMPLER_PREFIX + "ab/ba"));
         assertNull(SamplingService.extractSampledTopic(SAMPLER_PREFIX + "topic"));
         assertNull(SamplingService.extractSampledTopic(SAMPLER_PREFIX));
+        // odd length and a '/' at the midpoint, but the halves differ
+        assertNull(SamplingService.extractSampledTopic(SAMPLER_PREFIX + "ab/cd"));
+        // even length can never be <topic>/<topic>
+        assertNull(SamplingService.extractSampledTopic(SAMPLER_PREFIX + "ab/c"));
+        // right shape, wrong separator character
+        assertNull(SamplingService.extractSampledTopic(SAMPLER_PREFIX + "ab.ab"));
+    }
+
+    /**
+     * The worst case for the in-place half comparison: odd length, a '/' exactly at the midpoint, and
+     * halves that agree everywhere except the final character. A comparison that stopped early, or one
+     * that compared the wrong span, would accept this.
+     */
+    @Test
+    public void test_extractSampledTopic_rejects_a_near_miss_differing_only_in_the_last_character() {
+        for (int length = 1; length <= 64; length++) {
+            final String left = "a".repeat(length);
+            final String right = "a".repeat(length - 1) + "b";
+            assertNull(
+                    SamplingService.extractSampledTopic(SAMPLER_PREFIX + left + "/" + right),
+                    "halves of length " + length + " differing in the last character");
+            assertNull(
+                    SamplingService.extractSampledTopic(SAMPLER_PREFIX + right + "/" + left),
+                    "halves of length " + length + " differing in the first-half last character");
+        }
+    }
+
+    /**
+     * Topics that are themselves well-formed queue IDs of some other kind. Nothing about the sampler
+     * shape is special-cased, so these must round-trip like any other topic — and must not be confused
+     * with the queues they resemble.
+     */
+    @ParameterizedTest
+    @ValueSource(
+            strings = {
+                "$SAMPLER::a/a",
+                "$FORWARDER::bridge-Ab/cd==/t",
+                "$share/group/topic",
+                "$SAMPLER::",
+                "a/a/a",
+                "//",
+                "äöü/中文/🚀"
+            })
+    public void test_extractSampledTopic_round_trips_topics_that_look_like_other_queue_ids(final String topic) {
+        assertEquals(topic, SamplingService.extractSampledTopic(SamplingService.createQueueId(topic)));
+    }
+
+    /**
+     * A topic long enough that the two halves span far beyond any small-string optimisation, checked
+     * both for a hit and for a single-character corruption in the middle of the second half.
+     */
+    @Test
+    public void test_extractSampledTopic_handles_long_topics_and_their_near_misses() {
+        final String longTopic = "plant/line/".repeat(500) + "sensor";
+        assertEquals(longTopic, SamplingService.extractSampledTopic(SamplingService.createQueueId(longTopic)));
+
+        final String corrupted = SAMPLER_PREFIX
+                + longTopic
+                + "/"
+                + longTopic.substring(0, longTopic.length() / 2)
+                + "X"
+                + longTopic.substring(longTopic.length() / 2 + 1);
+        assertNull(SamplingService.extractSampledTopic(corrupted));
+    }
+
+    /**
+     * A sampler queue ID whose two halves are equal but whose midpoint character is not the separator
+     * — the shape a comparison-only check would wrongly accept.
+     */
+    @Test
+    public void test_extractSampledTopic_requires_the_separator_at_the_midpoint() {
+        assertNull(SamplingService.extractSampledTopic(SAMPLER_PREFIX + "ab" + "x" + "ab"));
+        assertNull(SamplingService.extractSampledTopic(SAMPLER_PREFIX + "a/b" + "x" + "a/b"));
+        // separator present but off-centre
+        assertNull(SamplingService.extractSampledTopic(SAMPLER_PREFIX + "a/bcd"));
+    }
+
+    /**
+     * Differential test against the implementation this one replaced. The rewrite is a legibility
+     * change and must be observationally identical, so the strongest available evidence is exhaustive
+     * agreement over a generated corpus rather than a handful of chosen examples.
+     * <p>
+     * The corpus is every string over {@code {a, b, /}} up to length 6, taken both bare and with the
+     * sampler prefix attached — every arrangement of separator placement, parity and half-equality the
+     * decision procedure can encounter.
+     */
+    @Test
+    @Timeout(30)
+    public void test_extractSampledTopic_agrees_with_the_previous_implementation_exhaustively() {
+        int checked = 0;
+        for (final String candidate : corpus()) {
+            assertEquals(
+                    referenceExtractSampledTopic(candidate),
+                    SamplingService.extractSampledTopic(candidate),
+                    "bare candidate: " + candidate);
+            final String prefixed = SAMPLER_PREFIX + candidate;
+            assertEquals(
+                    referenceExtractSampledTopic(prefixed),
+                    SamplingService.extractSampledTopic(prefixed),
+                    "prefixed candidate: " + prefixed);
+            checked++;
+        }
+        // guards against the corpus silently collapsing to nothing if the generator is edited
+        assertEquals(1093, checked, "corpus size");
+    }
+
+    private static List<String> corpus() {
+        final char[] alphabet = {'a', 'b', '/'};
+        final List<String> corpus = new ArrayList<>();
+        corpus.add("");
+        List<String> frontier = List.of("");
+        for (int length = 1; length <= 6; length++) {
+            final List<String> next = new ArrayList<>();
+            for (final String prefix : frontier) {
+                for (final char c : alphabet) {
+                    next.add(prefix + c);
+                }
+            }
+            corpus.addAll(next);
+            frontier = next;
+        }
+        return corpus;
+    }
+
+    /** The implementation in place before the rewrite, kept verbatim as the behavioural oracle. */
+    private static String referenceExtractSampledTopic(final String queueId) {
+        if (!queueId.startsWith(SAMPLER_PREFIX)) {
+            return null;
+        }
+        final String topicTwice = queueId.substring(SAMPLER_PREFIX.length());
+        final int separator = topicTwice.length() / 2;
+        if (topicTwice.length() % 2 == 0 || topicTwice.charAt(separator) != '/') {
+            return null;
+        }
+        final String topic = topicTwice.substring(0, separator);
+        return topic.equals(topicTwice.substring(separator + 1)) ? topic : null;
     }
 
     /**

--- a/hivemq-edge/src/test/java/com/hivemq/sampling/SamplingServiceTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/sampling/SamplingServiceTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.sampling;
+
+import static com.hivemq.sampling.SamplingService.SAMPLER_PREFIX;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.anyByte;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import com.hivemq.mqtt.message.subscribe.Topic;
+import com.hivemq.mqtt.topic.tree.LocalTopicTree;
+import com.hivemq.persistence.clientqueue.ClientQueuePersistence;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+
+public class SamplingServiceTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {"topic", "a/b", "a/b/c", "a//b", "sport/tennis/player1/#", "$share", "/", "//"})
+    public void test_extractSampledTopic_recovers_every_sampled_topic(final String topic) {
+        assertEquals(topic, SamplingService.extractSampledTopic(SamplingService.createQueueId(topic)));
+    }
+
+    @Test
+    public void test_extractSampledTopic_rejects_ids_that_are_not_sampler_queues() {
+        assertNull(SamplingService.extractSampledTopic("group/topic"));
+        assertNull(SamplingService.extractSampledTopic("$FORWARDER::bridge-hash/topic"));
+        // right prefix, but not the <topic>/<topic> shape a sampler queue has
+        assertNull(SamplingService.extractSampledTopic(SAMPLER_PREFIX + "a/b"));
+        assertNull(SamplingService.extractSampledTopic(SAMPLER_PREFIX + "ab/ba"));
+        assertNull(SamplingService.extractSampledTopic(SAMPLER_PREFIX + "topic"));
+        assertNull(SamplingService.extractSampledTopic(SAMPLER_PREFIX));
+    }
+
+    /**
+     * Binds the queue-ID convention to what {@code startSampling} actually registers: the queue is
+     * named {@code <share name>/<topic filter>}, so if the share name ever stops being
+     * {@code $SAMPLER::<topic>} the clean-up would resolve the wrong owner and wipe live samples.
+     */
+    @ParameterizedTest
+    @ValueSource(strings = {"topic", "a/b/c"})
+    public void test_createQueueId_matches_the_subscription_startSampling_registers(final String topic) {
+        final LocalTopicTree topicTree = mock(LocalTopicTree.class);
+        new SamplingService(topicTree, mock(ClientQueuePersistence.class)).startSampling(topic);
+
+        final ArgumentCaptor<Topic> registeredTopic = ArgumentCaptor.forClass(Topic.class);
+        final ArgumentCaptor<String> shareName = ArgumentCaptor.forClass(String.class);
+        verify(topicTree).addTopic(anyString(), registeredTopic.capture(), anyByte(), shareName.capture());
+
+        assertEquals(
+                shareName.getValue() + "/" + registeredTopic.getValue().getTopic(),
+                SamplingService.createQueueId(topic));
+    }
+}

--- a/hivemq-edge/src/test/java/com/hivemq/sampling/SamplingServiceTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/sampling/SamplingServiceTest.java
@@ -287,19 +287,22 @@ public class SamplingServiceTest {
         assertFalse(samplingService.isSamplerQueue(""));
     }
 
-    /** A second watcher keeps the queue a sampler until the last one lets go. */
+    /**
+     * Starting again while the topic is already sampled changes nothing, and one stop ends it. The
+     * POST behind this carries no watcher identity, so a retry and a second panel are the same
+     * request — counting them would build an obligation no caller could ever discharge (F-06).
+     */
     @Test
     @Timeout(5)
-    public void test_isSamplerQueue_follows_the_watcher_count() {
+    public void test_isSamplerQueue_isIndifferentToRepeatedStarts() {
         final SamplingService samplingService = samplingService();
         final String queueId = SamplingService.createQueueId("plant/line1");
         samplingService.startSampling("plant/line1");
         samplingService.startSampling("plant/line1");
 
-        samplingService.stopSampling("plant/line1");
-        assertTrue(samplingService.isSamplerQueue(queueId), "one watcher is still looking");
+        assertTrue(samplingService.isSamplerQueue(queueId));
 
         samplingService.stopSampling("plant/line1");
-        assertFalse(samplingService.isSamplerQueue(queueId));
+        assertFalse(samplingService.isSamplerQueue(queueId), "one stop ends it, however many starts there were");
     }
 }

--- a/hivemq-edge/src/test/java/com/hivemq/sampling/SamplingServiceTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/sampling/SamplingServiceTest.java
@@ -17,7 +17,9 @@ package com.hivemq.sampling;
 
 import static com.hivemq.sampling.SamplingService.SAMPLER_PREFIX;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyByte;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -28,6 +30,7 @@ import com.hivemq.mqtt.topic.tree.LocalTopicTree;
 import com.hivemq.persistence.clientqueue.ClientQueuePersistence;
 import java.util.ArrayList;
 import java.util.List;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -230,5 +233,73 @@ public class SamplingServiceTest {
         assertEquals(
                 shareName.getValue() + "/" + registeredTopic.getValue().getTopic(),
                 SamplingService.createQueueId(topic));
+    }
+
+    private static @NotNull SamplingService samplingService() {
+        return new SamplingService(mock(LocalTopicTree.class), mock(ClientQueuePersistence.class));
+    }
+
+    /**
+     * EDG-882 F-05. The publish path asks this before applying a policy that discards the oldest
+     * messages, so it must answer about what the service owns, not about how the ID is spelled.
+     */
+    @Test
+    @Timeout(5)
+    public void test_isSamplerQueue_only_while_the_topic_is_actually_sampled() {
+        final SamplingService samplingService = samplingService();
+        final String queueId = SamplingService.createQueueId("plant/line1");
+
+        assertFalse(samplingService.isSamplerQueue(queueId), "nothing is being sampled yet");
+
+        samplingService.startSampling("plant/line1");
+        assertTrue(samplingService.isSamplerQueue(queueId));
+
+        samplingService.stopSampling("plant/line1");
+        assertFalse(samplingService.isSamplerQueue(queueId), "the last watcher let go");
+    }
+
+    /**
+     * The case the ticket is about: a client subscribing to {@code $share/$SAMPLER::customer/alerts}
+     * produces this queue ID. Its messages are its own and must not be evicted under the sampler's
+     * policy — and the two halves differ, so the ID is not even the shape sampling produces.
+     */
+    @Test
+    @Timeout(5)
+    public void test_isSamplerQueue_rejects_a_client_shared_subscription_named_like_a_sampler() {
+        final SamplingService samplingService = samplingService();
+        samplingService.startSampling("customer");
+
+        assertFalse(samplingService.isSamplerQueue("$SAMPLER::customer/alerts"));
+    }
+
+    /**
+     * And a client that contrives the doubled shape is still not a sampler: nobody asked for samples
+     * of that topic, so the watchers map — the same one {@code startSampling} maintains — says no.
+     */
+    @Test
+    @Timeout(5)
+    public void test_isSamplerQueue_rejects_the_sampler_shape_when_nothing_is_sampled() {
+        final SamplingService samplingService = samplingService();
+        samplingService.startSampling("some/other/topic");
+
+        assertFalse(samplingService.isSamplerQueue(SamplingService.createQueueId("alerts/alerts")));
+        assertFalse(samplingService.isSamplerQueue("ordinary/queue"));
+        assertFalse(samplingService.isSamplerQueue(""));
+    }
+
+    /** A second watcher keeps the queue a sampler until the last one lets go. */
+    @Test
+    @Timeout(5)
+    public void test_isSamplerQueue_follows_the_watcher_count() {
+        final SamplingService samplingService = samplingService();
+        final String queueId = SamplingService.createQueueId("plant/line1");
+        samplingService.startSampling("plant/line1");
+        samplingService.startSampling("plant/line1");
+
+        samplingService.stopSampling("plant/line1");
+        assertTrue(samplingService.isSamplerQueue(queueId), "one watcher is still looking");
+
+        samplingService.stopSampling("plant/line1");
+        assertFalse(samplingService.isSamplerQueue(queueId));
     }
 }

--- a/hivemq-edge/src/test/java/com/hivemq/util/render/EnvVarUtilTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/util/render/EnvVarUtilTest.java
@@ -16,13 +16,16 @@
 package com.hivemq.util.render;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.hivemq.exceptions.UnrecoverableException;
 import java.lang.reflect.Field;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
@@ -166,7 +169,8 @@ public class EnvVarUtilTest {
     public void collectPlaceholders_collectsAConcatenatedSpanWhole() {
         System.setProperty("EDG882_UNIT_SITE", "berlin");
         try {
-            final var collected = EnvVarUtil.collectPlaceholders("<host>edge-${ENV:EDG882_UNIT_SITE}</host>");
+            final var collected = EnvVarUtil.collectPlaceholders("<host>edge-${ENV:EDG882_UNIT_SITE}</host>")
+                    .placeholders();
 
             assertEquals(1, collected.size());
             assertEquals("host", collected.get(0).name());
@@ -181,7 +185,8 @@ public class EnvVarUtilTest {
     public void collectPlaceholders_collectsAnAttributeSpan() {
         System.setProperty("EDG882_UNIT_DIR", "/etc/edge");
         try {
-            final var collected = EnvVarUtil.collectPlaceholders("<keystore path=\"${ENV:EDG882_UNIT_DIR}/k.jks\"/>");
+            final var collected = EnvVarUtil.collectPlaceholders("<keystore path=\"${ENV:EDG882_UNIT_DIR}/k.jks\"/>")
+                    .placeholders();
 
             assertEquals(1, collected.size());
             assertEquals("path", collected.get(0).name());
@@ -198,6 +203,7 @@ public class EnvVarUtilTest {
         assertEquals(
                 0,
                 EnvVarUtil.collectPlaceholders("<host>edge-${ENV:EDG882_UNIT_NOT_SET}</host>")
+                        .placeholders()
                         .size());
     }
 
@@ -263,5 +269,183 @@ public class EnvVarUtilTest {
         final String document = "<x><host xmlns=\"urn:other\">shared.example.com</host></x>";
 
         assertEquals(document, EnvVarUtil.restorePlaceholders(document, java.util.List.of(placeholder)));
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // EDG-882 review v03, R3-08. The collector used to store the raw XML source span and compare it
+    // with post-marshal output. XML parsing normalises the representation without changing the value,
+    // so three ordinary ways of writing a placeholder rendered to something the restore could not find:
+    // it took the "not in the document" branch and let the credential onto disk. Each of the three is
+    // pinned here on the collector and again on the document the marshaller would have produced.
+    // ---------------------------------------------------------------------------------------------
+
+    private static final @NotNull String PW = "EDG882_UNIT_PW";
+    private static final @NotNull String SECRET = "s3cr3t-do-not-write-me";
+
+    private @NotNull EnvVarUtil.CollectedPlaceholders collectWithSecret(final @NotNull String xml) {
+        System.setProperty(PW, SECRET);
+        try {
+            return EnvVarUtil.collectPlaceholders(xml);
+        } finally {
+            System.clearProperty(PW);
+        }
+    }
+
+    /**
+     * A numeric character reference. The parser turns it into the character it denotes long before JAXB
+     * marshals anything, so a collector storing the source span searched the document for a string
+     * containing the reference and never found it.
+     */
+    @Test
+    public void collectPlaceholders_normalisesANumericCharacterReference() {
+        final var collected = collectWithSecret("<password>prefix&#45;${ENV:" + PW + "}</password>");
+
+        assertEquals(1, collected.placeholders().size());
+        assertEquals(0, collected.unaccountedTokens());
+        assertEquals("prefix-${ENV:" + PW + "}", collected.placeholders().get(0).literal());
+        assertEquals("prefix-" + SECRET, collected.placeholders().get(0).value());
+    }
+
+    @Test
+    public void restorePlaceholders_putsBackASpanWrittenWithACharacterReference() {
+        final var collected = collectWithSecret("<password>prefix&#45;${ENV:" + PW + "}</password>");
+
+        // What JAXB writes: the parsed value, with the reference already resolved.
+        final String restored =
+                EnvVarUtil.restorePlaceholders("<x><password>prefix-" + SECRET + "</password></x>", collected);
+
+        assertFalse(restored.contains(SECRET), "the credential was written to config.xml");
+        assertEquals("<x><password>prefix-${ENV:" + PW + "}</password></x>", restored);
+    }
+
+    /** CRLF padding. The parser normalises the line endings; the raw span kept the carriage returns. */
+    @Test
+    public void collectPlaceholders_normalisesCrlfPadding() {
+        final var collected = collectWithSecret("<password>\r\n  ${ENV:" + PW + "}\r\n</password>");
+
+        assertEquals(1, collected.placeholders().size());
+        assertEquals(0, collected.unaccountedTokens());
+        assertFalse(collected.placeholders().get(0).value().contains("\r"), "the carriage returns survived the parse");
+        assertEquals("\n  " + SECRET + "\n", collected.placeholders().get(0).value());
+    }
+
+    @Test
+    public void restorePlaceholders_putsBackASpanWrittenWithCrlfPadding() {
+        final var collected = collectWithSecret("<password>\r\n  ${ENV:" + PW + "}\r\n</password>");
+
+        final String restored =
+                EnvVarUtil.restorePlaceholders("<x><password>\n  " + SECRET + "\n</password></x>", collected);
+
+        assertFalse(restored.contains(SECRET), "the credential was written to config.xml");
+        assertEquals("<x><password>\n  ${ENV:" + PW + "}\n</password></x>", restored);
+    }
+
+    /**
+     * CDATA, which the old pattern could not match at all — so nothing was collected, the restore never
+     * ran, and the secret went out with no message of any kind.
+     */
+    @Test
+    public void collectPlaceholders_seesInsideACdataSection() {
+        final var collected = collectWithSecret("<password><![CDATA[prefix-${ENV:" + PW + "}]]></password>");
+
+        assertEquals(1, collected.placeholders().size(), "a placeholder inside CDATA was invisible to the collector");
+        assertEquals(0, collected.unaccountedTokens());
+        assertEquals("prefix-" + SECRET, collected.placeholders().get(0).value());
+    }
+
+    @Test
+    public void restorePlaceholders_putsBackASpanWrittenInsideCdata() {
+        final var collected = collectWithSecret("<password><![CDATA[prefix-${ENV:" + PW + "}]]></password>");
+
+        final String restored =
+                EnvVarUtil.restorePlaceholders("<x><password>prefix-" + SECRET + "</password></x>", collected);
+
+        assertFalse(restored.contains(SECRET), "the credential was written to config.xml");
+        assertEquals("<x><password>prefix-${ENV:" + PW + "}</password></x>", restored);
+    }
+
+    /** Single-quoted attributes are as valid as double-quoted ones; the old pattern matched only one. */
+    @Test
+    public void collectPlaceholders_seesASingleQuotedAttribute() {
+        System.setProperty("EDG882_UNIT_DIR", "/etc/edge");
+        try {
+            final var collected = EnvVarUtil.collectPlaceholders("<keystore path='${ENV:EDG882_UNIT_DIR}/k.jks'/>");
+
+            assertEquals(1, collected.placeholders().size());
+            assertEquals(0, collected.unaccountedTokens());
+            assertEquals("path", collected.placeholders().get(0).name());
+            assertEquals("/etc/edge/k.jks", collected.placeholders().get(0).value());
+            assertTrue(collected.placeholders().get(0).attribute());
+        } finally {
+            System.clearProperty("EDG882_UNIT_DIR");
+        }
+    }
+
+    /**
+     * A literal that needs escaping on the way back out. The collected literal is now parsed text, so an
+     * operator's escaped ampersand is a bare one by the time it is restored; writing it raw would produce
+     * a config.xml that does not parse on the next start.
+     */
+    @Test
+    public void restorePlaceholders_escapesTheLiteralItWritesBack() {
+        System.setProperty("EDG882_UNIT_SITE", "berlin");
+        try {
+            final var collected = EnvVarUtil.collectPlaceholders("<host>a&amp;b-${ENV:EDG882_UNIT_SITE}</host>");
+
+            final String restored = EnvVarUtil.restorePlaceholders("<x><host>a&amp;b-berlin</host></x>", collected);
+
+            assertEquals("<x><host>a&amp;b-${ENV:EDG882_UNIT_SITE}</host></x>", restored);
+        } finally {
+            System.clearProperty("EDG882_UNIT_SITE");
+        }
+    }
+
+    /** A commented-out block is counted as seen so that it does not read as an unaccounted placeholder. */
+    @Test
+    public void collectPlaceholders_countsACommentedPlaceholderAsSeenButDoesNotRestoreIt() {
+        final var collected = collectWithSecret("<x><!-- <password>${ENV:" + PW + "}</password> --></x>");
+
+        assertEquals(0, collected.placeholders().size(), "a commented-out block is not part of the configuration");
+        assertEquals(0, collected.unaccountedTokens(), "and it must not read as a placeholder that was missed");
+    }
+
+    /**
+     * The safety net. The branch-by-branch reasoning can only speak for the spans the collector handed
+     * over; a token it never saw has no branch at all, which is exactly how the three cases above got a
+     * credential onto disk. So an unaccounted token refuses the write rather than assuming.
+     */
+    @Test
+    public void restorePlaceholders_whenATokenIsUnaccountedFor_thenTheWriteIsRefused() {
+        final var collected = new EnvVarUtil.CollectedPlaceholders(List.of(), 1);
+
+        assertThrows(
+                UnrecoverableException.class,
+                () -> EnvVarUtil.restorePlaceholders("<x><host>testhost</host></x>", collected),
+                "a placeholder the collector could not locate must refuse the write");
+    }
+
+    /** And nothing unaccounted for is the ordinary case, which must not refuse anything. */
+    @Test
+    public void restorePlaceholders_whenEveryTokenIsAccountedFor_thenTheWriteProceeds() {
+        final var collected = new EnvVarUtil.CollectedPlaceholders(List.of(), 0);
+        final String document = "<x><host>testhost</host></x>";
+
+        assertEquals(document, EnvVarUtil.restorePlaceholders(document, collected));
+    }
+
+    /**
+     * The last word, asked of the finished document rather than of the branch that produced it. Here the
+     * restore succeeds on the {@code <password>} element and the same value is also written literally in a
+     * second one, so the document still carries the credential when the restore believes it is done.
+     */
+    @Test
+    public void restorePlaceholders_whenACredentialSurvivesTheRestore_thenTheWriteIsRefused() {
+        final var placeholder = new EnvVarUtil.ElementPlaceholder("password", "${ENV:PW}", SECRET, false);
+
+        assertThrows(
+                UnrecoverableException.class,
+                () -> EnvVarUtil.restorePlaceholders(
+                        "<x><password>" + SECRET + "</password><note>" + SECRET + "</note></x>", List.of(placeholder)),
+                "a credential still in the document when the restore finishes must refuse the write");
     }
 }

--- a/hivemq-edge/src/test/java/com/hivemq/util/render/EnvVarUtilTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/util/render/EnvVarUtilTest.java
@@ -519,6 +519,58 @@ public class EnvVarUtilTest {
     }
 
     // ---------------------------------------------------------------------------------------------
+    // EDG-882 review v04, finding 2.4. Two questions on this path are asked of the document's values
+    // rather than its text, and each one parsed the whole document again -- once per span the marshaller
+    // normalised, on every write. They are the same document; the parse is now kept for as long as the
+    // document has not changed, which is a change nothing above may notice.
+    // ---------------------------------------------------------------------------------------------
+
+    /** Several spans the restore cannot locate: each is still judged on its own, and each is reported. */
+    @Test
+    public void restorePlaceholders_whenSeveralSpansCannotBeLocated_thenEachIsStillReported() {
+        final var capture = LogbackCapturingAppender.Factory.weaveInto(LoggerFactory.getLogger(EnvVarUtil.class));
+        final var host = new EnvVarUtil.ElementPlaceholder("host", "${ENV:HOSTNAME}", "shared.example.com", false);
+        final var port = new EnvVarUtil.ElementPlaceholder("port", "${ENV:PORT}", "01883", false);
+        final String document = "<x><renamed>shared.example.com</renamed><port>1883</port></x>";
+
+        final String restored = EnvVarUtil.restorePlaceholders(document, List.of(host, port));
+
+        assertEquals(document, restored, "a non-secret that cannot be located keeps its value");
+        final List<String> errors = capture.getCapturedLogs().stream()
+                .filter(event -> event.getLevel() == Level.ERROR)
+                .map(ILoggingEvent::getFormattedMessage)
+                .toList();
+        assertEquals(2, errors.size(), errors.toString());
+        assertTrue(errors.stream().anyMatch(message -> message.contains("'host'")), errors.toString());
+        assertTrue(errors.stream().anyMatch(message -> message.contains("'port'")), errors.toString());
+    }
+
+    /**
+     * And the document the last question is asked of is the one the loop produced, not the one it started
+     * with — which is the whole risk of keeping a parse around.
+     * <p>
+     * The order is what makes this bite: the first placeholder cannot be located, so the document is parsed
+     * while the credential is still in it; the second is restored, which rewrites the document; and the
+     * sweep then has to look at the rewritten one. A parse kept across that rewrite would find the
+     * credential it had already replaced and refuse a write that is perfectly good.
+     */
+    @Test
+    public void restorePlaceholders_whenTheDocumentChangesAfterItWasParsed_thenTheSweepSeesTheChange() {
+        final var unlocatable =
+                new EnvVarUtil.ElementPlaceholder("host", "${ENV:HOSTNAME}", "shared.example.com", false);
+        final var credential = new EnvVarUtil.ElementPlaceholder("password", "${ENV:PW}", SECRET, false);
+
+        final String restored = EnvVarUtil.restorePlaceholders(
+                "<x><renamed>shared.example.com</renamed><password>" + SECRET + "</password></x>",
+                List.of(unlocatable, credential));
+
+        assertEquals(
+                "<x><renamed>shared.example.com</renamed><password>${ENV:PW}</password></x>",
+                restored,
+                "the sweep judged a document that no longer exists");
+    }
+
+    // ---------------------------------------------------------------------------------------------
     // EDG-882 review v04, finding 1.6. A variable set to the empty string leaves nothing in the written
     // document for the placeholder to be put back into, so the operator's reference is dropped the next
     // time the configuration is written. Every other way of losing one is reported; this one was silent.

--- a/hivemq-edge/src/test/java/com/hivemq/util/render/EnvVarUtilTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/util/render/EnvVarUtilTest.java
@@ -439,19 +439,64 @@ public class EnvVarUtilTest {
     }
 
     /**
-     * The last word, asked of the finished document rather than of the branch that produced it. Here the
-     * restore succeeds on the {@code <password>} element and the same value is also written literally in a
-     * second one, so the document still carries the credential when the restore believes it is done.
+     * The last word, asked of the finished document rather than of the branch that produced it, and asked
+     * of the spans where a credential belongs. Here the restore succeeds on the {@code <password>} element
+     * and the same string is also the whole value of an element the restore never touched -- which the
+     * restore cannot have put there, because it only ever replaces a span with its own literal. That is the
+     * operator's own text, and refusing over it is what left a bridge whose password equalled its host name
+     * unable to persist anything (EDG-882 review v04, finding 1.4).
      */
     @Test
-    public void restorePlaceholders_whenACredentialSurvivesTheRestore_thenTheWriteIsRefused() {
+    public void restorePlaceholders_whenAnUnrelatedElementHoldsTheSameValue_thenTheWriteProceeds() {
+        final var placeholder = new EnvVarUtil.ElementPlaceholder("password", "${ENV:PW}", SECRET, false);
+
+        final String restored = EnvVarUtil.restorePlaceholders(
+                "<x><password>" + SECRET + "</password><note>" + SECRET + "</note></x>", List.of(placeholder));
+
+        assertEquals("<x><password>${ENV:PW}</password><note>" + SECRET + "</note></x>", restored);
+    }
+
+    /** The shape Sam's finding named, at unit level: a username that happens to equal the password. */
+    @Test
+    public void restorePlaceholders_whenAUsernameEqualsThePassword_thenTheWriteProceeds() {
+        final var placeholder = new EnvVarUtil.ElementPlaceholder("password", "${ENV:PW}", "admin", false);
+
+        final String restored = EnvVarUtil.restorePlaceholders(
+                "<x><username>admin</username><password>admin</password></x>", List.of(placeholder));
+
+        assertEquals("<x><username>admin</username><password>${ENV:PW}</password></x>", restored);
+    }
+
+    /**
+     * And the narrowing stops at the credential elements. A second one holding the same value is the case
+     * the sweep is for: either the restore left it there, or the operator wrote the credential in plain
+     * text twice, and neither is a document to write.
+     */
+    @Test
+    public void restorePlaceholders_whenASecondCredentialElementHoldsTheSameValue_thenTheWriteIsRefused() {
         final var placeholder = new EnvVarUtil.ElementPlaceholder("password", "${ENV:PW}", SECRET, false);
 
         assertThrows(
                 UnrecoverableException.class,
                 () -> EnvVarUtil.restorePlaceholders(
-                        "<x><password>" + SECRET + "</password><note>" + SECRET + "</note></x>", List.of(placeholder)),
-                "a credential still in the document when the restore finishes must refuse the write");
+                        "<x><password>" + SECRET + "</password><private-key-password>" + SECRET
+                                + "</private-key-password></x>",
+                        List.of(placeholder)),
+                "a credential still in a credential element when the restore finishes must refuse the write");
+    }
+
+    /**
+     * The broad question is still asked where it is warranted: when the span itself has gone missing there
+     * is no telling where the marshaller put the value, so any element holding it refuses the write.
+     */
+    @Test
+    public void restorePlaceholders_whenTheSpanIsMissingAndAnyElementHoldsTheValue_thenTheWriteIsRefused() {
+        final var placeholder = new EnvVarUtil.ElementPlaceholder("password", "${ENV:PW}", SECRET, false);
+
+        assertThrows(
+                UnrecoverableException.class,
+                () -> EnvVarUtil.restorePlaceholders("<x><note>" + SECRET + "</note></x>", List.of(placeholder)),
+                "a vanished span with its value loose in the document must refuse the write");
     }
 
     // ---------------------------------------------------------------------------------------------

--- a/hivemq-edge/src/test/java/com/hivemq/util/render/EnvVarUtilTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/util/render/EnvVarUtilTest.java
@@ -284,6 +284,7 @@ public class EnvVarUtilTest {
     // ---------------------------------------------------------------------------------------------
 
     private static final @NotNull String PW = "EDG882_UNIT_PW";
+    private static final @NotNull String OTHER = "EDG882_UNIT_OTHER";
     private static final @NotNull String SECRET = "s3cr3t-do-not-write-me";
 
     private @NotNull EnvVarUtil.CollectedPlaceholders collectWithSecret(final @NotNull String xml) {
@@ -451,6 +452,79 @@ public class EnvVarUtilTest {
                 () -> EnvVarUtil.restorePlaceholders(
                         "<x><password>" + SECRET + "</password><note>" + SECRET + "</note></x>", List.of(placeholder)),
                 "a credential still in the document when the restore finishes must refuse the write");
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // EDG-882 review v04, finding 1.3. The accounting subtracted a count taken from the parsed document
+    // from one taken from the file's bytes, and the two measure different populations: a placeholder
+    // spelled with a character reference exists only in the second. The difference went negative, and the
+    // guard refuses on "not zero" -- so a configuration with nothing wrong with it could never be written
+    // again. It is compared per variable now, and only a shortfall counts.
+    // ---------------------------------------------------------------------------------------------
+
+    /** The reported case: one ordinary placeholder, one the raw file cannot see. Nothing is missing. */
+    @Test
+    public void collectPlaceholders_whenAPlaceholderIsSpelledWithACharacterReference_thenNothingIsUnaccountedFor() {
+        System.setProperty(OTHER, "probe-host");
+        try {
+            final var collected = collectWithSecret(
+                    "<x><host>${ENV:" + OTHER + "}</host><password>$&#123;ENV:" + PW + "}</password></x>");
+
+            assertEquals(
+                    0,
+                    collected.unaccountedTokens(),
+                    "a placeholder only the parser can see is not a placeholder the walk missed");
+            assertEquals(2, collected.placeholders().size(), "both spans are still restorable");
+        } finally {
+            System.clearProperty(OTHER);
+        }
+    }
+
+    /** And such a configuration can still be written, which is what the negative count took away. */
+    @Test
+    public void restorePlaceholders_whenAPlaceholderIsSpelledWithACharacterReference_thenTheWriteProceeds() {
+        System.setProperty(OTHER, "probe-host");
+        try {
+            final var collected = collectWithSecret(
+                    "<x><host>${ENV:" + OTHER + "}</host><password>$&#123;ENV:" + PW + "}</password></x>");
+
+            // What the marshaller holds: the resolved host, and the literal text of the escaped token,
+            // which the render never resolved because it works on the file's bytes.
+            final String written = EnvVarUtil.restorePlaceholders(
+                    "<x><host>probe-host</host><password>${ENV:" + PW + "}</password></x>", collected);
+
+            assertEquals("<x><host>${ENV:" + OTHER + "}</host><password>${ENV:" + PW + "}</password></x>", written);
+            assertFalse(written.contains(SECRET), "the escaped token's value was never rendered, so it cannot leak");
+        } finally {
+            System.clearProperty(OTHER);
+        }
+    }
+
+    /**
+     * The reason the totals were not simply clamped. A placeholder the walk genuinely could not account
+     * for and one only the parser can see used to cancel each other out to zero, which reads as "every
+     * token accounted for" — the one answer this guard must never give by accident.
+     */
+    @Test
+    public void collectPlaceholders_whenAnUnaccountedTokenMeetsAnEscapedOne_thenTheyDoNotCancelOut() {
+        final var collected =
+                collectWithSecret("<x><note>${ENV:</note><password>$&#123;ENV:" + PW + "}</password></x>");
+
+        assertEquals(1, collected.unaccountedTokens(), "a token this cannot name must stay unaccounted for");
+        assertThrows(
+                UnrecoverableException.class,
+                () -> EnvVarUtil.restorePlaceholders("<x><note>${ENV:</note></x>", collected),
+                "an unaccounted token must refuse the write whatever else the file holds");
+    }
+
+    /** A placeholder named twice is accounted for twice, not once. */
+    @Test
+    public void collectPlaceholders_countsEachOccurrenceOfTheSameVariable() {
+        final var collected = collectWithSecret("<x><password>${ENV:" + PW + "}</password><keystore-password>${ENV:"
+                + PW + "}</keystore-password></x>");
+
+        assertEquals(0, collected.unaccountedTokens());
+        assertEquals(2, collected.placeholders().size());
     }
 
     // ---------------------------------------------------------------------------------------------

--- a/hivemq-edge/src/test/java/com/hivemq/util/render/EnvVarUtilTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/util/render/EnvVarUtilTest.java
@@ -448,4 +448,85 @@ public class EnvVarUtilTest {
                         "<x><password>" + SECRET + "</password><note>" + SECRET + "</note></x>", List.of(placeholder)),
                 "a credential still in the document when the restore finishes must refuse the write");
     }
+
+    // ---------------------------------------------------------------------------------------------
+    // EDG-882 review v04, finding 2. That last word used to be asked of the serialised XML with
+    // String.contains, which reads markup as content: a password of 'admin' was "still present" in any
+    // configuration holding an <admin-api> element, so every write was refused from then on -- the node
+    // stayed up and silently stopped being able to persist anything. It is asked of the parsed
+    // document's element text and attribute values now.
+    // ---------------------------------------------------------------------------------------------
+
+    /** Sam's reproduction: the credential is an element name in the file, and nothing else. */
+    @Test
+    public void restorePlaceholders_whenAnElementNameContainsTheCredential_thenTheWriteProceeds() {
+        final var placeholder = new EnvVarUtil.ElementPlaceholder("password", "${ENV:PW}", "admin", false);
+
+        final String restored = EnvVarUtil.restorePlaceholders(
+                "<x><admin-api><enabled>true</enabled></admin-api><password>admin</password></x>",
+                List.of(placeholder));
+
+        assertEquals(
+                "<x><admin-api><enabled>true</enabled></admin-api><password>${ENV:PW}</password></x>",
+                restored,
+                "an element name that contains the credential is markup, not a disclosure");
+    }
+
+    /** And an ordinary value that has the credential inside it is the operator's own text, not the secret. */
+    @Test
+    public void restorePlaceholders_whenAnUnrelatedValueContainsTheCredential_thenTheWriteProceeds() {
+        final var placeholder = new EnvVarUtil.ElementPlaceholder("password", "${ENV:PW}", "1", false);
+
+        final String restored =
+                EnvVarUtil.restorePlaceholders("<x><port>1883</port><password>1</password></x>", List.of(placeholder));
+
+        assertEquals(
+                "<x><port>1883</port><password>${ENV:PW}</password></x>",
+                restored,
+                "a port of 1883 is not a disclosure of a password of 1");
+    }
+
+    /**
+     * The narrowing stops there. Inside a credential-bearing span, a value that merely contains the
+     * secret is the concatenation case and is exactly the disclosure this exists to catch.
+     */
+    @Test
+    public void restorePlaceholders_whenACredentialSurvivesInsideAnotherCredentialElement_thenTheWriteIsRefused() {
+        final var placeholder = new EnvVarUtil.ElementPlaceholder("password", "${ENV:PW}", SECRET, false);
+
+        assertThrows(
+                UnrecoverableException.class,
+                () -> EnvVarUtil.restorePlaceholders(
+                        "<x><password>" + SECRET + "</password><keystore-password>prefix-" + SECRET
+                                + "</keystore-password></x>",
+                        List.of(placeholder)),
+                "a credential left inside another credential element must refuse the write");
+    }
+
+    /** Attribute values are values too, and an attribute can be the credential-bearing span. */
+    @Test
+    public void restorePlaceholders_whenACredentialSurvivesInAnAttribute_thenTheWriteIsRefused() {
+        final var placeholder = new EnvVarUtil.ElementPlaceholder("password", "${ENV:PW}", SECRET, false);
+
+        assertThrows(
+                UnrecoverableException.class,
+                () -> EnvVarUtil.restorePlaceholders(
+                        "<x><password>" + SECRET + "</password><keystore password=\"prefix-" + SECRET + "\"/></x>",
+                        List.of(placeholder)),
+                "a credential left in an attribute must refuse the write");
+    }
+
+    /**
+     * A document that cannot be read back cannot be cleared of credentials either, and "cannot tell" is
+     * not "there is none". The previous config.xml is intact and parses.
+     */
+    @Test
+    public void restorePlaceholders_whenTheFinishedDocumentCannotBeParsed_thenTheWriteIsRefused() {
+        final var placeholder = new EnvVarUtil.ElementPlaceholder("password", "${ENV:PW}", SECRET, false);
+
+        assertThrows(
+                UnrecoverableException.class,
+                () -> EnvVarUtil.restorePlaceholders("<x><password>${ENV:PW}</password>", List.of(placeholder)),
+                "a document this cannot parse must refuse the write rather than assume it is clean");
+    }
 }

--- a/hivemq-edge/src/test/java/com/hivemq/util/render/EnvVarUtilTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/util/render/EnvVarUtilTest.java
@@ -154,4 +154,114 @@ public class EnvVarUtilTest {
             }
         }
     }
+
+    // ---------------------------------------------------------------------------------------------
+    // EDG-882 review v03, R3-01. The collection unit is the whole span -- an element's entire text or an
+    // attribute's entire value -- rather than a placeholder that occupies all of it, which is what makes
+    // a concatenation restorable. And the "cannot locate it" branch no longer returns a document that
+    // still holds the credential.
+    // ---------------------------------------------------------------------------------------------
+
+    @Test
+    public void collectPlaceholders_collectsAConcatenatedSpanWhole() {
+        System.setProperty("EDG882_UNIT_SITE", "berlin");
+        try {
+            final var collected = EnvVarUtil.collectPlaceholders("<host>edge-${ENV:EDG882_UNIT_SITE}</host>");
+
+            assertEquals(1, collected.size());
+            assertEquals("host", collected.get(0).name());
+            assertEquals("edge-${ENV:EDG882_UNIT_SITE}", collected.get(0).literal());
+            assertEquals("edge-berlin", collected.get(0).value());
+        } finally {
+            System.clearProperty("EDG882_UNIT_SITE");
+        }
+    }
+
+    @Test
+    public void collectPlaceholders_collectsAnAttributeSpan() {
+        System.setProperty("EDG882_UNIT_DIR", "/etc/edge");
+        try {
+            final var collected = EnvVarUtil.collectPlaceholders("<keystore path=\"${ENV:EDG882_UNIT_DIR}/k.jks\"/>");
+
+            assertEquals(1, collected.size());
+            assertEquals("path", collected.get(0).name());
+            assertEquals("/etc/edge/k.jks", collected.get(0).value());
+            assertEquals(true, collected.get(0).attribute());
+        } finally {
+            System.clearProperty("EDG882_UNIT_DIR");
+        }
+    }
+
+    /** A span whose variable is unset is not collected: the whole-file render throws on it moments later. */
+    @Test
+    public void collectPlaceholders_skipsASpanWithAnUnsetVariable() {
+        assertEquals(
+                0,
+                EnvVarUtil.collectPlaceholders("<host>edge-${ENV:EDG882_UNIT_NOT_SET}</host>")
+                        .size());
+    }
+
+    @Test
+    public void restorePlaceholders_putsAConcatenatedSpanBack() {
+        final var placeholder = new EnvVarUtil.ElementPlaceholder("host", "edge-${ENV:SITE}", "edge-berlin", false);
+
+        final String restored =
+                EnvVarUtil.restorePlaceholders("<x><host>edge-berlin</host></x>", java.util.List.of(placeholder));
+
+        assertEquals("<x><host>edge-${ENV:SITE}</host></x>", restored);
+    }
+
+    @Test
+    public void restorePlaceholders_putsAnAttributeSpanBack() {
+        final var placeholder = new EnvVarUtil.ElementPlaceholder("path", "${ENV:DIR}/k.jks", "/etc/edge/k.jks", true);
+
+        final String restored =
+                EnvVarUtil.restorePlaceholders("<keystore path=\"/etc/edge/k.jks\"/>", java.util.List.of(placeholder));
+
+        assertEquals("<keystore path=\"${ENV:DIR}/k.jks\"/>", restored);
+    }
+
+    /**
+     * The branch R3-01 named. The span cannot be located -- the marshaller wrote it in a form the
+     * collector did not predict -- but the credential is unmistakably still in the document. Returning it
+     * is what the old code did; refusing the write is the only answer that keeps the secret off the disk,
+     * and the write has not opened the file yet when this runs.
+     */
+    @Test
+    public void restorePlaceholders_whenACredentialIsPresentButUnlocatable_thenTheWriteIsRefused() {
+        final var placeholder =
+                new EnvVarUtil.ElementPlaceholder("password", "${ENV:PW}", "s3cr3t-do-not-write-me", false);
+
+        assertThrows(
+                UnrecoverableException.class,
+                () -> EnvVarUtil.restorePlaceholders(
+                        "<x><password xmlns=\"urn:other\">s3cr3t-do-not-write-me</password></x>",
+                        java.util.List.of(placeholder)));
+    }
+
+    /**
+     * And the other side of that judgement: when the value is genuinely gone from the document there is
+     * nothing to leak, so the write proceeds. Refusing here would stop a node writing its configuration
+     * because an element was removed.
+     */
+    @Test
+    public void restorePlaceholders_whenTheSpanIsGoneAltogether_thenTheWriteProceeds() {
+        final var placeholder =
+                new EnvVarUtil.ElementPlaceholder("password", "${ENV:PW}", "s3cr3t-do-not-write-me", false);
+
+        final String document = "<x><host>testhost</host></x>";
+
+        assertEquals(document, EnvVarUtil.restorePlaceholders(document, java.util.List.of(placeholder)));
+    }
+
+    /** A non-secret that cannot be located keeps its value: losing an indirection is not a disclosure. */
+    @Test
+    public void restorePlaceholders_whenANonSecretIsPresentButUnlocatable_thenTheWriteProceeds() {
+        final var placeholder =
+                new EnvVarUtil.ElementPlaceholder("host", "${ENV:HOSTNAME}", "shared.example.com", false);
+
+        final String document = "<x><host xmlns=\"urn:other\">shared.example.com</host></x>";
+
+        assertEquals(document, EnvVarUtil.restorePlaceholders(document, java.util.List.of(placeholder)));
+    }
 }

--- a/hivemq-edge/src/test/java/com/hivemq/util/render/EnvVarUtilTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/util/render/EnvVarUtilTest.java
@@ -21,6 +21,8 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
 import com.hivemq.exceptions.UnrecoverableException;
 import java.lang.reflect.Field;
 import java.util.Collections;
@@ -28,7 +30,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import util.LogbackCapturingAppender;
 
 public class EnvVarUtilTest {
 
@@ -497,6 +502,125 @@ public class EnvVarUtilTest {
                 UnrecoverableException.class,
                 () -> EnvVarUtil.restorePlaceholders("<x><note>" + SECRET + "</note></x>", List.of(placeholder)),
                 "a vanished span with its value loose in the document must refuse the write");
+    }
+
+    @AfterEach
+    public void releaseAnyLogCapture() {
+        LogbackCapturingAppender.Factory.cleanUp();
+    }
+
+    private static @NotNull List<String> warningsWhileCollecting(final @NotNull String xml) {
+        final var capture = LogbackCapturingAppender.Factory.weaveInto(LoggerFactory.getLogger(EnvVarUtil.class));
+        EnvVarUtil.collectPlaceholders(xml);
+        return capture.getCapturedLogs().stream()
+                .filter(event -> event.getLevel() == Level.WARN)
+                .map(ILoggingEvent::getFormattedMessage)
+                .toList();
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // EDG-882 review v04, finding 1.6. A variable set to the empty string leaves nothing in the written
+    // document for the placeholder to be put back into, so the operator's reference is dropped the next
+    // time the configuration is written. Every other way of losing one is reported; this one was silent.
+    // ---------------------------------------------------------------------------------------------
+
+    /** The span is not restorable, and now says so before the write that will drop it. */
+    @Test
+    public void collectPlaceholders_whenAVariableResolvesToNothing_thenItIsReported() {
+        System.setProperty(PW, "");
+        try {
+            final List<String> warnings =
+                    warningsWhileCollecting("<x><description>${ENV:" + PW + "}</description></x>");
+
+            assertEquals(1, warnings.size(), warnings.toString());
+            assertTrue(warnings.get(0).contains("description"), warnings.get(0));
+            assertTrue(warnings.get(0).contains("${ENV:" + PW + "}"), warnings.get(0));
+        } finally {
+            System.clearProperty(PW);
+        }
+    }
+
+    /** It is still accounted for: not restorable is not the same as not seen. */
+    @Test
+    public void collectPlaceholders_whenAVariableResolvesToNothing_thenTheTokenIsStillAccountedFor() {
+        System.setProperty(PW, "");
+        try {
+            final var collected = EnvVarUtil.collectPlaceholders("<x><description>${ENV:" + PW + "}</description></x>");
+
+            assertEquals(0, collected.placeholders().size(), "an empty span gives the restore nothing to find");
+            assertEquals(0, collected.unaccountedTokens(), "and it must not read as a placeholder that was missed");
+        } finally {
+            System.clearProperty(PW);
+        }
+    }
+
+    /** An unset variable is not reported here: the whole-file render throws on it with a better message. */
+    @Test
+    public void collectPlaceholders_whenAVariableIsUnset_thenNothingIsReportedHere() {
+        assertEquals(
+                List.of(),
+                warningsWhileCollecting("<x><description>${ENV:EDG882_UNIT_NOT_SET}</description></x>"),
+                "the render's own error is the one the operator needs, and it comes moments later");
+    }
+
+    /** An ordinary placeholder says nothing at all. */
+    @Test
+    public void collectPlaceholders_whenAVariableResolvesToAValue_thenNothingIsReported() {
+        System.setProperty(PW, SECRET);
+        try {
+            assertEquals(List.of(), warningsWhileCollecting("<x><password>${ENV:" + PW + "}</password></x>"));
+        } finally {
+            System.clearProperty(PW);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // EDG-882 review v04, finding 1.7. A value is spliced into the file as raw text before it is parsed,
+    // so one containing '<' or '&' makes the document malformed and the node stops at a parser error
+    // about a line the operator never wrote. The splice is what lets a fragment bring in markup, so it
+    // stays; what is named here is which variable to look at.
+    // ---------------------------------------------------------------------------------------------
+
+    @Test
+    public void variablesWhoseValueIsNotText_namesTheOnesThatCannotBeSpliced() {
+        System.setProperty(PW, "p@ss&word");
+        System.setProperty(OTHER, "ordinary");
+        try {
+            final List<String> named = EnvVarUtil.variablesWhoseValueIsNotText(
+                    "<x><password>${ENV:" + PW + "}</password><host>${ENV:" + OTHER + "}</host></x>");
+
+            assertEquals(List.of(PW), named);
+        } finally {
+            System.clearProperty(PW);
+            System.clearProperty(OTHER);
+        }
+    }
+
+    /** A value carrying a left angle bracket is the same problem, and an unset variable is not this one. */
+    @Test
+    public void variablesWhoseValueIsNotText_coversAngleBracketsAndIgnoresUnsetVariables() {
+        System.setProperty(PW, "<not-text/>");
+        try {
+            assertEquals(
+                    List.of(PW),
+                    EnvVarUtil.variablesWhoseValueIsNotText(
+                            "<x><a>${ENV:" + PW + "}</a><b>${ENV:EDG882_NONE}</b></x>"));
+        } finally {
+            System.clearProperty(PW);
+        }
+    }
+
+    /** Named once, however often it is used. */
+    @Test
+    public void variablesWhoseValueIsNotText_namesEachVariableOnce() {
+        System.setProperty(PW, "a&b");
+        try {
+            assertEquals(
+                    List.of(PW),
+                    EnvVarUtil.variablesWhoseValueIsNotText("<x><a>${ENV:" + PW + "}</a><b>${ENV:" + PW + "}</b></x>"));
+        } finally {
+            System.clearProperty(PW);
+        }
     }
 
     // ---------------------------------------------------------------------------------------------

--- a/hivemq-edge/src/test/java/com/hivemq/util/render/EnvVarUtilTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/util/render/EnvVarUtilTest.java
@@ -228,10 +228,14 @@ public class EnvVarUtilTest {
     }
 
     /**
-     * The branch R3-01 named. The span cannot be located -- the marshaller wrote it in a form the
-     * collector did not predict -- but the credential is unmistakably still in the document. Returning it
+     * The branch R3-01 named. The span cannot be located -- the marshaller wrote the value somewhere the
+     * restore is not anchored to -- but the credential is unmistakably still in the document. Returning it
      * is what the old code did; refusing the write is the only answer that keeps the secret off the disk,
      * and the write has not opened the file yet when this runs.
+     * <p>
+     * The value sits in an element of another name, which is what "unlocatable" means now that the span
+     * tolerates attributes: an element written as {@code <password attr="x">} is located and restored, and
+     * no longer reaches this branch.
      */
     @Test
     public void restorePlaceholders_whenACredentialIsPresentButUnlocatable_thenTheWriteIsRefused() {
@@ -241,7 +245,7 @@ public class EnvVarUtilTest {
         assertThrows(
                 UnrecoverableException.class,
                 () -> EnvVarUtil.restorePlaceholders(
-                        "<x><password xmlns=\"urn:other\">s3cr3t-do-not-write-me</password></x>",
+                        "<x><renamed-by-the-marshaller>s3cr3t-do-not-write-me</renamed-by-the-marshaller></x>",
                         java.util.List.of(placeholder)));
     }
 
@@ -266,7 +270,7 @@ public class EnvVarUtilTest {
         final var placeholder =
                 new EnvVarUtil.ElementPlaceholder("host", "${ENV:HOSTNAME}", "shared.example.com", false);
 
-        final String document = "<x><host xmlns=\"urn:other\">shared.example.com</host></x>";
+        final String document = "<x><renamed-by-the-marshaller>shared.example.com</renamed-by-the-marshaller></x>";
 
         assertEquals(document, EnvVarUtil.restorePlaceholders(document, java.util.List.of(placeholder)));
     }
@@ -447,6 +451,78 @@ public class EnvVarUtilTest {
                 () -> EnvVarUtil.restorePlaceholders(
                         "<x><password>" + SECRET + "</password><note>" + SECRET + "</note></x>", List.of(placeholder)),
                 "a credential still in the document when the restore finishes must refuse the write");
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // EDG-882 review v04, finding 1.2. The span was built as <name>value</name> and compared literally,
+    // so an element the marshaller wrote with an attribute was never found: a credential in one refused
+    // every configuration write, and a non-secret in one had its placeholder replaced by its value. No
+    // element in today's schema both carries an attribute and holds text -- the arbitrary XML in the file
+    // is unmarshalled into maps, which drop attributes before this ever sees them -- so what is pinned
+    // here is the trap, not a live disclosure.
+    // ---------------------------------------------------------------------------------------------
+
+    /** The element is located through its attributes, and keeps them. */
+    @Test
+    public void restorePlaceholders_putsBackASpanOnAnElementWithAnAttribute() {
+        final var placeholder = new EnvVarUtil.ElementPlaceholder("password", "${ENV:PW}", SECRET, false);
+
+        final String restored = EnvVarUtil.restorePlaceholders(
+                "<x><password enc=\"aes\">" + SECRET + "</password></x>", List.of(placeholder));
+
+        assertEquals("<x><password enc=\"aes\">${ENV:PW}</password></x>", restored);
+    }
+
+    /** Several attributes, in the order the marshaller wrote them, including one holding a right angle bracket. */
+    @Test
+    public void restorePlaceholders_keepsEveryAttributeOfTheElementItRestores() {
+        final var placeholder = new EnvVarUtil.ElementPlaceholder("password", "${ENV:PW}", SECRET, false);
+
+        final String restored = EnvVarUtil.restorePlaceholders(
+                "<x><password enc=\"aes\" note=\"a>b\" id=\"7\">" + SECRET + "</password></x>", List.of(placeholder));
+
+        assertEquals("<x><password enc=\"aes\" note=\"a>b\" id=\"7\">${ENV:PW}</password></x>", restored);
+    }
+
+    /** An attributed element and a bare one holding the same value are one group, and both are restored. */
+    @Test
+    public void restorePlaceholders_putsBackBothAnAttributedAndABareSpan() {
+        final var placeholder = new EnvVarUtil.ElementPlaceholder("password", "${ENV:PW}", SECRET, false);
+        final var second = new EnvVarUtil.ElementPlaceholder("password", "${ENV:PW}", SECRET, false);
+
+        final String restored = EnvVarUtil.restorePlaceholders(
+                "<x><password enc=\"aes\">" + SECRET + "</password><password>" + SECRET + "</password></x>",
+                List.of(placeholder, second));
+
+        assertEquals(
+                "<x><password enc=\"aes\">${ENV:PW}</password><password>${ENV:PW}</password></x>",
+                restored,
+                "the count check must see both spans, or it refuses a document it can restore");
+    }
+
+    /** What is written in place of an unrestorable credential lands in the element, not on top of it. */
+    @Test
+    public void restorePlaceholders_poisonsAnAttributedElementWithoutLosingItsAttributes() {
+        final var one = new EnvVarUtil.ElementPlaceholder("password", "${ENV:PW}", SECRET, false);
+        final var other = new EnvVarUtil.ElementPlaceholder("password", "${ENV:OTHER_PW}", SECRET, false);
+
+        final String restored = EnvVarUtil.restorePlaceholders(
+                "<x><password enc=\"aes\">" + SECRET + "</password></x>", List.of(one, other));
+
+        assertEquals("<x><password enc=\"aes\">${ENV:EDGE_UNRESTORED_SECRET}</password></x>", restored);
+    }
+
+    /** A start tag is not a place to look for another element: the pattern stays inside one of them. */
+    @Test
+    public void restorePlaceholders_doesNotMatchAcrossElements() {
+        final var placeholder = new EnvVarUtil.ElementPlaceholder("password", "${ENV:PW}", SECRET, false);
+
+        final String document = "<x><password>other</password><note>" + SECRET + "</note></x>";
+
+        assertThrows(
+                UnrecoverableException.class,
+                () -> EnvVarUtil.restorePlaceholders(document, List.of(placeholder)),
+                "the span must not be found by matching one element's tag against another's text");
     }
 
     // ---------------------------------------------------------------------------------------------

--- a/hivemq-edge/src/test/resources/test-config.xml
+++ b/hivemq-edge/src/test/resources/test-config.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <hivemq xsi:schemaLocation="config.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <internal/>
     <config-version>1</config-version>
     <mqtt-listeners>
         <tcp-listener>
@@ -150,7 +151,8 @@
             <forwarded-topics>
                 <forwarded-topic>
                     <filters>
-                        <mqtt-topic-filter>#</mqtt-topic-filter>
+                        <mqtt-topic-filter>zone-b/#</mqtt-topic-filter>
+                        <mqtt-topic-filter>alarms/#</mqtt-topic-filter>
                     </filters>
                     <max-qos>0</max-qos>
                     <preserve-retain>true</preserve-retain>
@@ -162,6 +164,7 @@
                         </user-property>
                     </custom-user-properties>
                     <excludes/>
+                    <queue-limit>500</queue-limit>
                 </forwarded-topic>
             </forwarded-topics>
             <loop-prevention>
@@ -360,5 +363,4 @@
         <managed-assets/>
     </pulse>
     <modules/>
-    <internal/>
 </hivemq>


### PR DESCRIPTION
## What this fixes

A bridge forwarder queue is named `$FORWARDER::<bridgeId>-<digest>/<topic>`, where the digest is an MD5 of the subscription's filters and destination in **standard Base64** — an alphabet that includes `/`. Roughly one subscription in three therefore has a queue name with more than one slash and no way to tell from the string which one separates the owner from the topic.

The periodic clean-up assumed the first one did:

```java
final SharedSubscription sharedSubscription = SharedSubscriptionServiceImpl.splitTopicAndGroup(sharedQueue);
final ImmutableSet<SubscriberWithQoS> sharedSubscriber = topicTree.getSharedSubscriber(
        sharedSubscription.getShareName(), sharedSubscription.getTopicFilter());
if (sharedSubscriber.isEmpty()) {
    localPersistence.clear(sharedQueue, true, bucketIndex);
}
```

For an affected configuration that split lands inside the digest, so the job asks the topic tree about a share name that has never existed, is truthfully told nobody owns it, and clears a **live** bridge queue — every message buffered while the remote broker was unreachable, deleted, with no error and no metric. Reported by Maibornwolff on 2026.10 and 2026.11 and reproduced from their configuration.

This is a steady state, not a race. A given queue is visited every few minutes: `INTERVAL_BETWEEN_CLEANUP_JOBS_SEC` is 4, but each tick handles one bucket-and-persistence pair, there are four persistences, `CLEANUP_JOB_PARALLELISM` is 1, and the bucket count defaults to twice the processor count — about four minutes per bucket on an eight-core node. Every sweep that reaches an affected queue empties it again.

The same line had a second victim: payload sampling names its queue `$SAMPLER::<topic>/<topic>`, so for any hierarchical topic the first slash is again the wrong one and every sample was wiped on every sweep.

## What changed

**Ownership is asked, not parsed.** `ClientQueuePersistenceImpl.cleanUp` delegates to `isOrphaned`, which tries three readings — a registered bridge forwarder, the ordinary first-slash split, a sampler queue whose topic is sampled right now — and clears only when none finds an owner. The forwarder question is answered by a reference-counted index in `MessageForwarderImpl` keyed by the exact queue id, so no parsing happens. The sampler question is answered by `SamplingService.extractSampledTopic`, which uses the fact that both halves of `<topic>/<topic>` have equal length, so the shape is decidable in three checks.

**Queue names are unchanged, deliberately.** Re-encoding the digest into a slash-free alphabet is a smaller change and was rejected: it renames every persisted queue, so on upgrade the messages already in the old names become unreachable. That trades a message-loss bug for a message-loss upgrade. Every change here keeps the names byte-identical to what a 2026.11 node wrote.

**The clean-up job was not the only site that parsed a queue name.** `PublishDistributorImpl` decided a shared queue belonged to a bridge with `client.startsWith(FORWARDER_PREFIX)` and resolved which subscription's limits to apply with `contains`. A share name is the client's to choose, so a subscription to `$share/$FORWARDER::<a live forwarder id>/t` took the bridge branch: an ordinary client got a bridge's queue limit and, against a `persist=false` bridge, its QoS silently rewritten to 0. The `contains` match separately let one bridge whose id merely appears inside another's queue id answer for it. Both are now asked of the owning registry and anchored respectively. The original ticket said the housekeeping job was the only affected site; it was not, and the ticket has been corrected.

**"Nobody owns it" no longer means two different things.** The registry is legitimately empty during node start, before any bridge configuration has been applied, and during shutdown, after the bridge hook has un-registered every forwarder while the clean-up is still scheduled. Both are gated (`hasAppliedBridgeConfiguration`, and a `ShutdownHooks` check inside the reclamation loop). A third mechanism, `MessageForwarder.reserveQueues`, is ownership without a forwarder: taken at the top of every start and before every restart's stop, released once the replacements register. It is what lets a bridge that *fails* to start keep its backlog while the operator corrects the configuration.

**A colliding configuration is refused instead of silently losing a subscription.** The digest joins sorted filters with an empty separator, so `["ab","c"]` and `["a","bc"]` collide; both forwarders started and the second took the first's queues out of the index. `BridgeMqttClient.verifyForwarderIdsAreUnique` now throws before anything is registered, naming both subscriptions, their destinations and the shared id. The bridge fails to start; the node and every other bridge come up normally; nothing is discarded.

**A SUBSCRIBE can no longer take a live internal queue.** `IncomingSubscribeService` refuses a shared subscription that collides with a forwarder or sampler queue that exists at that moment. Shared subscribers take turns, so without this a client could be handed a bridge's own messages and they would never be forwarded. The `$FORWARDER::`/`$SAMPLER::` namespace stays open otherwise — reserving it outright was implemented, found to break a client's legal `$share/$SAMPLER::customer/alerts` subscription, and reverted.

**And a client that got there first is taken off it.** The refusal above cannot cover the one window that matters — a client that subscribed to the group *before* the bridge existed, when there was nothing to collide with. `MessageForwarderImpl` takes the group back when the forwarder registers, and it looks under **every** split of the queue id rather than the forwarder's own. The broker stores a shared subscription by splitting at the first slash after `$share/`, which for a slash-bearing digest falls inside the digest: the client sits on a topic-tree node the forwarder's own split never visits, while the queue it actually drains — keyed off the concatenated string — is byte-identical to the bridge's. The removal string does not depend on which split found it, since group and filter rejoin to the same queue id however it was cut.

**Restarts that nobody asked for (EDG-884).** `LocalSubscription.equals` compared a lazily-computed digest, so an unchanged file always compared as changed and the reload restarted the bridge in the queue-discarding mode. Filters and excludes are now canonicalised at construction so a reorder is not a change, and `MqttBridge.equals` compares the subscription lists as multisets for the same reason one level up. A REST update was expressed as remove-then-add, which the bridge subsystem read as "this bridge is gone" and answered with `internalStopBridge(active, clearQueue = true, retain = List.of())` — an empty retain list clears **every** queue of the bridge, including the subscriptions the request never mentioned. `BridgeExtractor.replaceBridge` makes it one transition, so it is classified as an update and keeps the surviving forwarders' queues. `persist` also joined `equals`, which `hashCode` had always included: once an update stopped being a remove-then-add, that comparison is what decides whether the bridge restarts.

**The configuration write-back stops damaging the operator's file.** Any REST write of any subsystem rewrites `config.xml` from the in-memory model, and that write dropped `<queue-limit>`, reordered topic filters, added a `<client-id>` nobody wrote, and materialised `${ENV:...}` placeholders — putting a bridge password on disk in plain text. Each of those makes the next reload see a changed bridge and restart it. It also opened the file before a schema-validating marshal, and opening truncates, so a rejected value could leave an emptied `config.xml` while the REST call answered 200. All four are preserved now, the document is rendered in full before the file is opened, and the rendered document is written beside `config.xml` and moved onto it rather than written into it — a crash or a full disk between open and close used to leave the operator with a file cut off mid-element and a node that would not start.

**A credential supplied through `${ENV:...}` stays out of that file.** The placeholders are collected from the *parsed* configuration rather than from its bytes, so what is stored is the value JAXB will hold and marshal. A numeric character reference, CRLF padding or a CDATA section all reach the restore as the value the marshaller writes, where a collector working on the source span searched the document for a string that was never in it, found nothing, and let the credential through. Where the restore genuinely cannot decide, it no longer completes the write quietly: an unrestorable credential is written as `${ENV:EDGE_UNRESTORED_SECRET}`, which no variable sets, so the node carries on with the value it already holds and the next start stops and names it; a credential still sitting in one of the file's credential-bearing elements, or a placeholder the collector could not account for at all, refuses the write and leaves `config.xml` untouched.

**And the replacement is no wider than the file it replaces.** It carries the original's owner, group, mode and any ACL, applied while it is still owner-only and verified before the move. Failing to reproduce the mode, the group or the list aborts the write rather than proceeding — those decide who *else* can read the file. The owner is the exception: changing it is privileged everywhere this runs, so it falls back to the account that wrote the file, with a warning, rather than making a configuration installed by one account and served by another unwritable. The rolling backup goes through the same sequence, having previously been a plain copy that carried the mode and left the group to whatever the process had. A file created by `FileWriter` takes the process umask and the creating process's group, so preserving the mode alone still hands group-read of every secret in the configuration to a different set of principals — on every REST write to any subsystem.

**QoS 0 sampler queues are bounded (EDG-885).** The ten-message limit was never applied to QoS 0 and the per-queue cap is skipped for shared queues, so a sampled QoS 0 topic grew until it exhausted the node-wide QoS 0 budget — a quarter of heap, shared with every QoS 0 consumer on the node. `applyMaxToQos0` is threaded through the persistence contract, defaulted to the historical behaviour and passed true only for sampler queues. Rotating that ring is no longer counted as a dropped message, which had made the one metric an operator watches for real loss useless.

## What review rounds 4 and 5 changed

Nine commits on top of the above, all in the configuration write path, and all with the same shape: a check
that asserted how something is *written down* rather than what it means.

- **The survivor sweep and the unlocatable-span check ask the parsed document's values, not its text.**
  Searching serialised XML with `contains` read markup as content: a password of `admin` was "still present"
  in any file with an `<admin-api>` element, and every configuration write was refused from then on. The
  sweep additionally asks only of credential-bearing spans, because the restore cannot move a value into a
  span it never touched — so the same string in `<username>` or `<host>` is the operator's own text, and
  refusing over it made a bridge whose password equalled its host name unwritable.
- **Access-control lists are judged by the access they grant.** Both ACL checks demanded that the list read
  back equal the list set, which is a claim about a file store's representation rather than about who can
  read the file — and the only platform that path exists for is the one nobody in the review loop can run.
  They compare per principal over ALLOW and DENY now, so reordering, merged entries and inheritance flags
  pass while an extra grant or a lost denial does not.
- **The replacement is only written where the node could have written the file in place.** Replace-by-move
  needs permission on the directory, so a write-protected `config.xml` was being replaced anyway, and
  quietly changing owner in the process.
- **A placeholder span is located on an element that carries attributes**, and placeholder tokens are
  accounted for per variable rather than by a total that could go negative and refuse every write.
- **What cannot be done is said.** A variable that resolves to nothing is reported before the write that
  drops its placeholder; a value containing `<` or `&` — which cannot be spliced into the file as text at
  all — names the variable responsible when the parse fails, and never its value; and a refused write states
  the consequence rather than logging a message-less stack trace: the node is correct, `config.xml` is
  stale, a restart would lose the change.

Verified by 5138 unit tests, a 36-test integration slice over the config and bridge paths, and 30 external
assertions against the built distribution driven through the REST API — including 160 concurrent writes
followed by a restart from the configuration those writes produced.

## What this does not fix

`stopSampling` still has **no production caller**, so a topic sampled once stays sampled for the life of the node. The method itself was broken — it passed `null` as the share name, so the removal silently did nothing — and that is fixed, but the release path needs a DELETE endpoint with a watcher token or an expiring lease, both of which change the API surface. **EDG-885 should stay open after this merges.**

Also deliberately deferred: the canonical/versioned forwarder id with a queue-name migration; relaxing the config schema so a username can be stored without a password (today the pair is dropped, costing one spurious restart); and a client that takes a *sampler's* group, which costs sample fidelity rather than customer messages.

Two more from the review rounds. The access-control path is proven for every shape a file store can return, but **nothing here executes on Windows** — every workflow in this repo is `ubuntu-latest`, and closing that needs a capability-gated test class plus one Windows job, which is a CI change with its own cost and its own ticket. And the rule that decides which elements hold a credential is a five-suffix list (`password`, `secret`, `passphrase`, `token`, `credentials`); every decision on that path turns on it, and whether anything in the schema or in an adapter configuration falls outside it has not been surveyed.

## Delivery unit

Merges together with **hivemq/hivemq-edge-test#431** and **hivemq/hivemq-edge-commercial-modules#357**.

`ClientQueueLocalPersistence` gained a parameter, and the direction of the `default` is what decides whether a mismatched pair is survivable. It sits on the **new** signature and delegates to the old one. A default protects callers of the signature it replaces and core has none of those left; what needs protecting is implementors, because `ModuleLoader` reads those jars from `HIVEMQ_HOME/modules` at run time and an older module implements only what existed when it was built. The other way round — the shape this branch carried until review — a core-only upgrade that leaves an old module in place fails with `AbstractMethodError` on **every queued publish**, not only on a sampled QoS 0 one, which on a file-native node is the whole message path.

As it stands an old module keeps working and gives up only the QoS 0 sampler bound, which is the previous behaviour, and `ClientQueueLocalPersistenceProvider` probes the loaded implementation once at start-up and says plainly what a stale module costs. `ClientQueueModuleCompatibilityTest` pins the three cases: a module predating the parameter, a current one, and one implementing half the contract.

The three still ship together — #357 carries the Xodus fixes this ticket depends on, and only that pairing gives a file-native node the bounded ring — but a partial upgrade is now a logged degradation rather than an outage.

## Scope note for reviewers

This reaches outside the bridge subsystem — `ConfigFileReaderWriter`, `EnvVarUtil`, `PublishDistributorImpl`, `IncomingSubscribeService`, `BridgeUtils`. Each of those either destroys data on its own or undoes something this branch fixes (a lossy write-back re-triggers the restart EDG-884 exists to prevent), and several were made reachable or worse by this branch. Called out here rather than left to be discovered in the diff.

47 files: 23 under `src/main`, 24 under `src/test`.

## Evidence

Four adversarial review rounds, run requirements-first rather than against a spec derived from the code, confirmed 38 defects. Rounds 1–2 found 14; round 3, run specifically over the fixes those rounds produced, found 14 more — six of them introduced by the earlier fixes, the worst being the truncating `config.xml` write; round 4 and a findings audit found 10 survivors, including `MqttBridge.equals` omitting `persist`, which this branch's own REST change had made reachable.

Three rounds of external review on top of that — 10 findings, then 22, then two more raised against the fixes for the second. Both of the last two were on the configuration write-back this branch introduced: the placeholder restore compared a raw XML source span against post-marshal output, so a character reference, CRLF padding or a CDATA section each put a credential on disk; and the replacement carried the file's mode but not the principals that mode refers to. Both are closed here.

Round 3 also produced a fix that round 4 had to revert: moving `writeConfigWithSync` outside the `BridgeExtractor` monitor closed a lock-order inversion and opened a worse one, where the config watcher could revert an operator's REST change and clear the queues the reverted configuration no longer held. It is back in master's shape with the reasoning recorded in the code, and the pre-existing inversion is written up for its own ticket.

Every fix is mutation-checked: reverted, suite re-run, the named test observed to fail and only that test. One ordering (per-bridge metrics cleared before the stop future completes) is intra-method and says so in a comment rather than claiming a test.

5131 core unit tests, 254 commercial, 1161 in the `hivemq-edge-test` suite, spotless clean. Integration coverage includes the customer's own slash-bearing digest in both persistence modes, a node restart with a file-native backlog, orphan reclamation asserted in both modes so a "fix" that simply never reaps forwarder queues would fail, colliding subscriptions, the config-file reload and REST update paths, a client that takes a forwarder's shared-subscription group, and the eviction of one stored under any split of a slash-bearing queue id.


