### PR TITLE
EDG-899: Emit the @JsonValue form for enums in adapter config schemas

### DIFF
--- a/hivemq-edge/src/main/java/com/hivemq/api/json/CustomConfigSchemaGenerator.java
+++ b/hivemq-edge/src/main/java/com/hivemq/api/json/CustomConfigSchemaGenerator.java
@@ -63,7 +63,14 @@ public class CustomConfigSchemaGenerator {
                 .with(new JacksonSchemaModule(
                         JacksonOption.RESPECT_JSONPROPERTY_REQUIRED,
                         JacksonOption.INCLUDE_ONLY_JSONPROPERTY_ANNOTATED_METHODS,
-                        JacksonOption.RESPECT_JSONPROPERTY_ORDER))
+                        JacksonOption.RESPECT_JSONPROPERTY_ORDER,
+                        // Without this, an enum is advertised by its Java constant names while Jackson
+                        // reads and writes the @JsonValue form, so every value the schema offers is
+                        // rejected on deserialization. OpcuaConditionType is the case in point: the
+                        // schema listed ALARM_CONDITION, the API only accepts AlarmConditionType, and
+                        // a tag saved from the UI was dropped when the adapter reloaded.
+                        // Enums without a @JsonValue accessor keep using their constant names.
+                        JacksonOption.FLATTENED_ENUMS_FROM_JSONVALUE))
                 .with(new ModuleConfigSchemaGeneratorModule());
         withEnumDisplayNameProvider(configBuilder);
         withMutuallyExclusiveFieldsMarker(configBuilder);

--- a/hivemq-edge/src/test/java/com/hivemq/api/auth/BasicAuthenticationTests.java
+++ b/hivemq-edge/src/test/java/com/hivemq/api/auth/BasicAuthenticationTests.java
@@ -53,8 +53,10 @@ public class BasicAuthenticationTests {
     protected final Logger logger = LoggerFactory.getLogger(BasicAuthenticationTests.class);
 
     static final int TEST_HTTP_PORT = 8088;
-    static final int CONNECT_TIMEOUT = 1000;
-    static final int READ_TIMEOUT = 1000;
+    // See BearerTokenAuthTests: the first request pays the server bootstrap cost and a 1s budget
+    // makes whichever test runs first flaky on a loaded CI agent. Matches JaxrsResourceTests.
+    static final int CONNECT_TIMEOUT = 5000;
+    static final int READ_TIMEOUT = 5000;
     static final String HTTP = "http";
 
     protected static JaxrsHttpServer server;

--- a/hivemq-edge/src/test/java/com/hivemq/api/auth/BearerTokenAuthTests.java
+++ b/hivemq-edge/src/test/java/com/hivemq/api/auth/BearerTokenAuthTests.java
@@ -69,8 +69,12 @@ public class BearerTokenAuthTests {
     protected final Logger logger = LoggerFactory.getLogger(BearerTokenAuthTests.class);
 
     static final int TEST_HTTP_PORT = 8088;
-    static final int CONNECT_TIMEOUT = 1000;
-    static final int READ_TIMEOUT = 1000;
+    // The first request against the freshly started server pays the Jersey/Jackson bootstrap cost,
+    // which is orders of magnitude slower than every later request. A 1s budget is not enough for
+    // that on a loaded CI agent, so the first test to run would time out at random. Matches
+    // JaxrsResourceTests. These timeouts only exist to stop a hung test, not to assert latency.
+    static final int CONNECT_TIMEOUT = 5000;
+    static final int READ_TIMEOUT = 5000;
     static final String HTTP = "http";
 
     protected static JaxrsHttpServer server;

--- a/hivemq-edge/src/test/java/com/hivemq/api/auth/ChainedAuthTests.java
+++ b/hivemq-edge/src/test/java/com/hivemq/api/auth/ChainedAuthTests.java
@@ -68,8 +68,10 @@ public class ChainedAuthTests {
     protected final Logger logger = LoggerFactory.getLogger(ChainedAuthTests.class);
 
     static final int TEST_HTTP_PORT = 8088;
-    static final int CONNECT_TIMEOUT = 1000;
-    static final int READ_TIMEOUT = 1000;
+    // See BearerTokenAuthTests: the first request pays the server bootstrap cost and a 1s budget
+    // makes whichever test runs first flaky on a loaded CI agent. Matches JaxrsResourceTests.
+    static final int CONNECT_TIMEOUT = 5000;
+    static final int READ_TIMEOUT = 5000;
     static final String HTTP = "http";
 
     protected static JaxrsHttpServer server;

--- a/hivemq-edge/src/test/java/com/hivemq/api/auth/LdapAuthenticationTests.java
+++ b/hivemq-edge/src/test/java/com/hivemq/api/auth/LdapAuthenticationTests.java
@@ -63,8 +63,10 @@ public class LdapAuthenticationTests {
     protected final Logger logger = LoggerFactory.getLogger(LdapAuthenticationTests.class);
 
     static final int TEST_HTTP_PORT = 8088;
-    static final int CONNECT_TIMEOUT = 1000;
-    static final int READ_TIMEOUT = 1000;
+    // See BearerTokenAuthTests: the first request pays the server bootstrap cost and a 1s budget
+    // makes whichever test runs first flaky on a loaded CI agent. Matches JaxrsResourceTests.
+    static final int CONNECT_TIMEOUT = 5000;
+    static final int READ_TIMEOUT = 5000;
     static final String HTTP = "http";
 
     protected static JaxrsHttpServer server;

--- a/hivemq-edge/src/test/java/com/hivemq/api/json/CustomConfigSchemaGeneratorTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/api/json/CustomConfigSchemaGeneratorTest.java
@@ -19,10 +19,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.hivemq.adapter.sdk.api.annotations.ModuleConfigField;
 import com.hivemq.adapter.sdk.api.annotations.MutuallyExclusiveFields;
 import com.hivemq.edge.modules.adapters.simulation.tag.SimulationTagDefinition;
+import java.util.ArrayList;
+import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.Test;
@@ -212,6 +215,80 @@ class CustomConfigSchemaGeneratorTest {
 
         public @Nullable String getBar() {
             return bar;
+        }
+    }
+
+    @Test
+    void enumWithJsonValue_emitsWireFormNotConstantNames() {
+        final JsonNode schema = generator.generateJsonSchema(EnumPojo.class);
+        final JsonNode field = schema.path("properties").path("flavour");
+
+        // Jackson reads and writes the @JsonValue form, so that is what the schema has to advertise.
+        // Emitting the constant names instead makes every offered value fail deserialization.
+        final List<String> values = new ArrayList<>();
+        field.path("enum").forEach(node -> values.add(node.asText()));
+        assertThat(values).containsExactly("plain-vanilla", "double-chocolate");
+
+        // A declared default has to be one of the values the same schema offers, or the form both
+        // pre-fills and rejects it.
+        assertThat(field.path("default").asText()).isEqualTo("plain-vanilla");
+        assertThat(values).contains(field.path("default").asText());
+    }
+
+    @Test
+    void enumWithoutJsonValue_keepsConstantNames() {
+        final JsonNode schema = generator.generateJsonSchema(EnumPojo.class);
+
+        final List<String> values = new ArrayList<>();
+        schema.path("properties").path("size").path("enum").forEach(node -> values.add(node.asText()));
+        assertThat(values).containsExactly("SMALL", "LARGE");
+    }
+
+    public enum Flavour {
+        VANILLA("plain-vanilla"),
+        CHOCOLATE("double-chocolate");
+
+        private final @NotNull String wireName;
+
+        Flavour(final @NotNull String wireName) {
+            this.wireName = wireName;
+        }
+
+        @JsonValue
+        public @NotNull String wireName() {
+            return wireName;
+        }
+    }
+
+    public enum Size {
+        SMALL,
+        LARGE
+    }
+
+    public static final class EnumPojo {
+
+        @JsonProperty("flavour")
+        @ModuleConfigField(title = "Flavour", defaultValue = "plain-vanilla")
+        private final @Nullable Flavour flavour;
+
+        @JsonProperty("size")
+        @ModuleConfigField(title = "Size")
+        private final @Nullable Size size;
+
+        @JsonCreator
+        public EnumPojo(
+                @JsonProperty("flavour") final @Nullable Flavour flavour,
+                @JsonProperty("size") final @Nullable Size size) {
+            this.flavour = flavour;
+            this.size = size;
+        }
+
+        public @Nullable Flavour getFlavour() {
+            return flavour;
+        }
+
+        public @Nullable Size getSize() {
+            return size;
         }
     }
 }


### PR DESCRIPTION
**Motivation**

Resolves [EDG-899](https://linear.app/hivemq/issue/EDG-899/adapter-config-schema-advertises-enum-constant-names-instead-of-the)

`CustomConfigSchemaGenerator` advertised enums by their Java constant names while Jackson reads and writes the `@JsonValue` form. Where the two differ, every value the schema offers is rejected on deserialization, and a declared default can be a value the same schema calls invalid.

`OpcuaConditionType` (EDG-835, 8c25c19b2) is the first adapter config enum to declare `@JsonValue`, so it is the first to hit this. `GET /api/v1/management/protocol-adapters/tag-schemas/opcua` returned:

```
definition.type.enum    = [CONDITION, ACKNOWLEDGEABLE_CONDITION, ALARM_CONDITION, ...]
definition.type.default = "AlarmConditionType"     # not a member of its own enum
```

That left no way to create an OPC UA tag from the UI:

- **Keep the pre-filled default** — AJV rejects it (`'Node type' must be equal to one of the allowed values`) and the tag drawer will not save.
- **Pick any offered value** — `POST .../adapters/{id}/tags` returns 200, then `ProtocolAdapterManager.refresh` throws and the tag is dropped. No error toast, no tag, no monitored item:

```
java.lang.IllegalArgumentException: Cannot construct instance of OpcuaConditionType,
problem: Unknown OPC UA condition type 'ALARM_CONDITION'.
Known types: ConditionType, AcknowledgeableConditionType, AlarmConditionType, ...
(through reference chain: OpcuaTag["definition"]->OpcuaTagDefinition["type"])
    at ProtocolAdapterFactory.convertTagDefinitionObjects(ProtocolAdapterFactory.java:81)
```

Found by the HiveMQ Edge smoke test suite against `2026.13-SNAPSHOT`. Master only — not in any released version.

**Changes**

- Add `JacksonOption.FLATTENED_ENUMS_FROM_JSONVALUE` to the `JacksonSchemaModule` in `CustomConfigSchemaGenerator`, so the schema advertises the form Jackson actually serializes.
- Two regression tests in `CustomConfigSchemaGeneratorTest`.

Enums without a `@JsonValue` accessor keep their constant names, so `OpcuaTagKind` and every other adapter enum are unaffected — `OpcuaConditionType` is currently the only `@JsonValue` enum in the adapter configs. The regenerated schema is self-consistent:

```
type.enum    = [ConditionType, AcknowledgeableConditionType, AlarmConditionType, ...]
type.default = AlarmConditionType     # in enum: true
kind.enum    = [VALUE, CONDITION, REFRESH, EVENT_SUBSCRIPTION]   # unchanged
```

The `defaultValue = "AlarmConditionType"` on `OpcuaTagDefinition.type` was always the correct wire value, so it is left as is — the enum was the broken side.

**Verification**

- `CustomConfigSchemaGeneratorTest` 6/6. The new tests cover both directions, since the risk here is to enums that were already fine: one asserts the wire form is emitted *and* that a declared default is a member of the emitted enum; the other asserts enums without `@JsonValue` still emit constant names.
- Rebuilt the full distribution and re-ran the smoke suite end to end. The tag saves, Edge logs `Added monitored items: [ns=1;s=Temperature]`, the northbound mapping publishes to MQTT, and adapter deletion cleans up — green over consecutive runs.