### PR TITLE
EDG-835: Accept an explicitly null comment in a condition command

### DIFF
--- a/modules/hivemq-edge-module-opcua/build.gradle.kts
+++ b/modules/hivemq-edge-module-opcua/build.gradle.kts
@@ -63,6 +63,11 @@ dependencies {
     // hundred-megabyte JUnit XML that GitHub's result parser refuses. Nothing in main uses Logback directly;
     // the adapter logs through SLF4J and the binding is the runtime's business.
     testImplementation(libs.logback.classic)
+    // Test-only: the same validator Edge puts in front of a southbound write, so a published schema can be
+    // checked by running a payload through the gate rather than by reading the rendered type. hivemq-edge has
+    // it as an `implementation` dependency, so it reaches this module's test runtime but not its compile
+    // classpath. See ConditionSchemaNullableFieldsTest for the finding that needed it.
+    testImplementation(libs.json.schema.validator)
 }
 
 configurations {

--- a/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/condition/ConditionSchemas.java
+++ b/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/condition/ConditionSchemas.java
@@ -344,6 +344,39 @@ public final class ConditionSchemas {
      * condition as a whole. {@link ConditionUpdate.Method.Arguments} is the list. A static schema cannot
      * express that dependency, so the fields are optional here and the adapter checks them per method before
      * making the call.
+     * <p>
+     * <b>Optional and nullable are different questions, and only {@code comment} answers yes to the second.</b>
+     * Optionality in JSON Schema is about whether a key must be present; nullability is about whether
+     * {@code null} is a value the field can carry. A field can be omitted freely and still not admit a null,
+     * and four of the five are exactly that.
+     * <p>
+     * {@code comment} admits null because the specification gives null a meaning there. OPC 10000-9 §5.7.3
+     * makes the {@code Comment} argument a {@code LocalizedText} that may be NULL and says what NULL does —
+     * leave the condition's existing comment untouched, as against {@code ""} to erase it and text to set it.
+     * {@link ConditionUpdate#fromJson} has always implemented all three, and the user documentation promises
+     * them; declaring the field a bare string was the one thing making the promise unreachable, so the command
+     * an operator sends most often was refused over a field they deliberately said nothing about. Found by QA
+     * as EDG-835 P4.3.
+     * <p>
+     * {@code eventId}, {@code duration} and {@code selectedResponse} are <b>deliberately not nullable</b>, and
+     * the reason is that they are OPC UA method arguments rather than free-form fields of Edge's own: where each
+     * applies the specification makes it <em>required</em> — {@code Acknowledge}'s {@code EventId} (§5.7.2),
+     * {@code TimedShelve}'s {@code ShelvingTime} (§5.8.10.4), {@code Respond}'s {@code SelectedResponse}
+     * (§5.6.3). There is no such thing as a null {@code EventId} that means something; a caller who does not
+     * have one has nothing to say about the field, and the way to say nothing is to omit the key. Declaring them
+     * nullable would advertise a value the protocol cannot carry and no method accepts.
+     * <p>
+     * The consequence is worth stating rather than leaving to be met: a client that builds this command as a
+     * struct and serialises it must <b>suppress its null keys</b>, because Jackson,
+     * {@code JSON.stringify} and {@code json.dumps} all emit {@code "field": null} for a field that was never
+     * assigned. {@code @JsonInclude(NON_NULL)}, a {@code JSON.stringify} replacer, or
+     * {@code model_dump(exclude_none=True)} is what that takes. Sending {@code "duration": null} on an
+     * {@code ACKNOWLEDGE} is refused at the gate, and that refusal is the intended contract — the field is not
+     * a place to put a null.
+     * <p>
+     * {@code method} is not nullable either, for a third reason again: it is the field that decides which of the
+     * others apply, so a command that does not name an action is not an under-specified command but a different
+     * kind of thing. It is rejected as early as it can be, which is here.
      */
     public static @NotNull Schema writeSchema() {
         return new SchemaBuilder()
@@ -359,13 +392,17 @@ public final class ConditionSchemas {
                 .scalar(ScalarType.BINARY)
                 .description("The EventId from the northbound message being responded to, echoed back "
                         + "unchanged. Required for ACKNOWLEDGE, CONFIRM and ADD_COMMENT, which act on one "
-                        + "specific transition.")
+                        + "specific transition. Omit it for every other method, which acts on the condition "
+                        + "rather than on one of its transitions.")
                 .writable()
                 .readable(false)
                 .endProperty()
                 .property(ConditionUpdate.FIELD_COMMENT)
                 .scalar(ScalarType.STRING)
-                .description("Free text recorded by the server alongside the transition.")
+                .nullable()
+                .description("Free text recorded by the server alongside the transition. Three intents, "
+                        + "distinguished by shape (OPC 10000-9 §5.7.3): null or absent leaves any existing "
+                        + "comment unchanged, an empty string erases it, and text sets it.")
                 .writable()
                 .readable(false)
                 .endProperty()

--- a/modules/hivemq-edge-module-opcua/src/test/java/com/hivemq/edge/adapters/opcua/condition/ConditionSchemaNullableFieldsTest.java
+++ b/modules/hivemq-edge-module-opcua/src/test/java/com/hivemq/edge/adapters/opcua/condition/ConditionSchemaNullableFieldsTest.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright 2023-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.edge.adapters.opcua.condition;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.hivemq.adapter.sdk.api.schema.SchemaJsonRepresentation;
+import com.hivemq.adapter.sdk.api.schema.TagSchemaCreationOutput;
+import com.hivemq.edge.adapters.opcua.config.tag.OpcuaConditionType;
+import com.hivemq.protocols.tag.TagSchemaCreationOutputImpl;
+import com.hivemq.protocols.tag.TagSchemaDirection;
+import com.networknt.schema.JsonSchemaFactory;
+import com.networknt.schema.SpecVersion;
+import com.networknt.schema.ValidationMessage;
+import java.util.List;
+import java.util.Set;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Which fields of a condition command admit {@code null}, and — the part worth a test of its own — which
+ * deliberately do not.
+ * <p>
+ * <b>{@code comment} does, and that is EDG-835 QA finding P4.3.</b> The other tests in this package check the
+ * schema by reading it and the parser by running payloads through it, and neither could find that defect: the
+ * schema said {@code comment} was a string and meant it, {@code fromJson} read an explicit {@code null} as
+ * "leave the existing comment alone" and meant that, and both were right on their own. What was wrong was only
+ * visible <em>between</em> them — the gate refused the payload before the parser that understood it was reached.
+ * So this test drives the gate itself: the same networknt validator Edge puts in front of a southbound write,
+ * against the same composed document a client fetches from
+ * {@code GET .../writing-schema?direction=SOUTHBOUND}. The assertions are about acceptance rather than about a
+ * rendered type, because a type array is a proxy for what broke and what broke is a validator answering no.
+ * <p>
+ * <b>{@code eventId}, {@code duration} and {@code selectedResponse} do not, and that is a decision rather than
+ * an oversight.</b> They are OPC UA method arguments, required by the specification wherever they apply
+ * ({@code Acknowledge}'s {@code EventId} §5.7.2, {@code TimedShelve}'s {@code ShelvingTime} §5.8.10.4,
+ * {@code Respond}'s {@code SelectedResponse} §5.6.3), and there is no null value of any of them that means
+ * anything. A caller with nothing to say about such a field omits the key. This half of the test exists because
+ * the argument for relaxing them is easy to make and was made — a client that serialises a command struct emits
+ * {@code "field": null} for every unset field by default, so these refusals are met in practice — and the
+ * answer is that the client suppresses its null keys, not that the schema advertises a value no method accepts.
+ * Recorded here so a future reader meets the reasoning rather than an inconsistency.
+ */
+class ConditionSchemaNullableFieldsTest {
+
+    private static final @NotNull ObjectMapper MAPPER = new ObjectMapper();
+
+    /** A real base64 EventId, since that is what a client echoes back from a northbound message. */
+    private static final @NotNull String EVENT_ID = "aGVsbG8gd29ybGQ=";
+
+    /**
+     * The three fields that are OPC UA method arguments. Optional in this schema — most methods take none of
+     * them — but never nullable, which is the distinction this test is about.
+     */
+    private static final @NotNull List<String> ARGUMENT_FIELDS = List.of(
+            ConditionUpdate.FIELD_EVENT_ID, ConditionUpdate.FIELD_DURATION, ConditionUpdate.FIELD_SELECTED_RESPONSE);
+
+    // ── the finding: comment admits null ─────────────────────────────────────────────────────────────
+
+    @Test
+    void anExplicitNullCommentIsAcceptedAsTheAbsentIntent() throws Exception {
+        // The finding verbatim. Before the fix this failed with
+        // "$.value.comment: null found, string expected" -- the schema refusing an intent the specification
+        // defines, the parser implements and the documentation promises.
+        assertThat(gateErrors("{\"method\": \"ACKNOWLEDGE\", \"eventId\": \"" + EVENT_ID + "\", \"comment\": null}"))
+                .as("a null comment is the 'leave the existing comment alone' intent, not a malformed command")
+                .isEmpty();
+    }
+
+    @Test
+    void andTheParserBehindTheGateReadsItThatWay() throws Exception {
+        // The other half, so the pair states the whole contract rather than half of it: the gate lets it
+        // through, and what is behind the gate does the right thing with it. Pinned on its own in
+        // ConditionUpdateMethodFieldTest; repeated here because "accepted" is only good news if the intent
+        // survives the parse.
+        final ConditionUpdate update = ConditionUpdate.fromJson(
+                json("{\"method\": \"ACKNOWLEDGE\", \"eventId\": \"" + EVENT_ID + "\", \"comment\": null}"));
+
+        assertThat(update.comment()).isNull();
+    }
+
+    @Test
+    void theThreeCommentIntentsRemainDistinctAndAllValid() throws Exception {
+        // Admitting null must not collapse the three meanings into two. All three shapes pass the gate, and the
+        // parser still tells them apart -- absent and null leave the comment alone, "" erases it.
+        assertThat(gateErrors("{\"method\": \"ENABLE\"}")).isEmpty();
+        assertThat(gateErrors("{\"method\": \"ENABLE\", \"comment\": null}")).isEmpty();
+        assertThat(gateErrors("{\"method\": \"ENABLE\", \"comment\": \"\"}")).isEmpty();
+        assertThat(gateErrors("{\"method\": \"ENABLE\", \"comment\": \"seen it\"}"))
+                .isEmpty();
+
+        assertThat(ConditionUpdate.fromJson(json("{\"method\": \"ENABLE\"}")).comment())
+                .isNull();
+        assertThat(ConditionUpdate.fromJson(json("{\"method\": \"ENABLE\", \"comment\": null}"))
+                        .comment())
+                .isNull();
+        assertThat(ConditionUpdate.fromJson(json("{\"method\": \"ENABLE\", \"comment\": \"\"}"))
+                        .comment())
+                .isEmpty();
+    }
+
+    // ── the decision: the argument fields do not ─────────────────────────────────────────────────────
+
+    @Test
+    void commentIsTheOnlyFieldThatAdmitsNull() throws Exception {
+        // The contract in one place. `comment` takes a null because OPC 10000-9 §5.7.3 gives null a meaning
+        // there; an argument field does not, because there is no null EventId, shelving time or response index
+        // that means anything. Driven off the list so a new argument field has to declare which side it is on.
+        assertThat(gateErrors("{\"method\": \"ENABLE\", \"comment\": null}"))
+                .as("comment carries the specification's 'leave it unchanged' intent as a null")
+                .isEmpty();
+
+        for (final String field : ARGUMENT_FIELDS) {
+            assertThat(gateErrors("{\"method\": \"ENABLE\", \"" + field + "\": null}"))
+                    .as("'%s' is an OPC UA method argument, so null is not a value it can carry -- omit the key", field)
+                    .isNotEmpty();
+        }
+    }
+
+    @Test
+    void aStructSerialisedWithItsNullKeysIntactIsRefusedOnThoseFields() throws Exception {
+        // The case a client meets first, asserted so the refusal reads as intended rather than as a bug someone
+        // finds again later. Jackson, JSON.stringify and json.dumps all emit "field": null for a field that was
+        // never assigned, so an ACKNOWLEDGE built as a five-field struct arrives carrying nulls for the two
+        // arguments it does not use -- and is refused on both.
+        assertThat(gateErrors("{\"method\": \"ACKNOWLEDGE\", \"eventId\": \"" + EVENT_ID + "\", "
+                        + "\"comment\": null, \"duration\": null, \"selectedResponse\": null}"))
+                .as("the argument fields are refused; the caller suppresses null keys rather than the schema "
+                        + "admitting a value no method accepts")
+                .isNotEmpty();
+    }
+
+    @Test
+    void andTheSameCommandWithItsNullKeysSuppressedIsAccepted() throws Exception {
+        // The other side of the same coin, and the actionable half: @JsonInclude(NON_NULL), a JSON.stringify
+        // replacer or exclude_none produces this, and it passes. `comment` keeps its null, because that one is
+        // a value the field genuinely carries rather than an unset key.
+        assertThat(gateErrors("{\"method\": \"ACKNOWLEDGE\", \"eventId\": \"" + EVENT_ID + "\", \"comment\": null}"))
+                .isEmpty();
+        assertThat(gateErrors("{\"method\": \"TIMED_SHELVE\", \"duration\": 60000, \"comment\": null}"))
+                .isEmpty();
+        assertThat(gateErrors("{\"method\": \"RESPOND\", \"selectedResponse\": 1, \"comment\": null}"))
+                .isEmpty();
+        assertThat(gateErrors("{\"method\": \"ENABLE\"}")).isEmpty();
+    }
+
+    // ── what deliberately did not change ────────────────────────────────────────────────────────────
+
+    @Test
+    void aNullMethodIsStillRefusedByTheGate() throws Exception {
+        // `method` decides which of the others apply, so a command that does not name an action is not an
+        // under-specified command but a different kind of thing. Refused as early as it can be, which is here.
+        assertThat(gateErrors("{\"method\": null}"))
+                .as("a command that names no action must not reach the adapter")
+                .isNotEmpty();
+    }
+
+    @Test
+    void aMistypedFieldIsStillRefused() throws Exception {
+        // Admitting a null on one field is not admitting anything anywhere. A number where a note belongs is
+        // still a defect the gate catches -- and `comment` is the field where a coercion would be dangerous,
+        // since the empty string an object or a number can coerce to is the deliberate erase.
+        assertThat(gateErrors("{\"method\": \"ENABLE\", \"comment\": 42}")).isNotEmpty();
+        assertThat(gateErrors("{\"method\": \"ENABLE\", \"comment\": {}}")).isNotEmpty();
+        assertThat(gateErrors("{\"method\": \"TIMED_SHELVE\", \"duration\": \"soon\"}"))
+                .isNotEmpty();
+    }
+
+    @Test
+    void selectedResponseKeepsItsInt32Bounds() throws Exception {
+        // The bounds exist so a generated client cannot build a request the protocol cannot express. Asserted
+        // here because this is the field where a nullable type array would have sat beside them, and the check
+        // is worth keeping whichever way that went.
+        assertThat(gateErrors("{\"method\": \"RESPOND\", \"selectedResponse\": 1}"))
+                .isEmpty();
+        assertThat(gateErrors("{\"method\": \"RESPOND\", \"selectedResponse\": 4294967296}"))
+                .as("an Int32 index cannot exceed %d", Integer.MAX_VALUE)
+                .isNotEmpty();
+        assertThat(gateErrors("{\"method\": \"RESPOND\", \"selectedResponse\": -1}"))
+                .as("an index into ResponseOptionSet cannot be negative")
+                .isNotEmpty();
+    }
+
+    @Test
+    void theRefreshCommandStillRequiresTheOneFieldItHas() throws Exception {
+        // The refresh command is deliberately shaped like a condition command, and its single field is the same
+        // kind of field as `method`: the action itself. It has nothing nullable to gain, so nothing here changed
+        // -- stated so that "a command field admits null" is not read as applying to it too.
+        final ObjectNode refresh =
+                SchemaJsonRepresentation.INSTANCE.toJsonSchemaDocument(ConditionSchemas.refreshCommandSchema());
+
+        assertThat(validate(refresh, json("{\"method\": \"REFRESH\"}"))).isEmpty();
+        assertThat(validate(refresh, json("{\"method\": null}"))).isNotEmpty();
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────────────────────────────────────
+
+    /**
+     * Runs a condition command through the gate and returns its complaints — empty meaning accepted.
+     * <p>
+     * The document is the one a client actually fetches for a condition tag:
+     * {@link ConditionSchemas#writeSchema()} composed by {@link TagSchemaCreationOutputImpl}, so the error paths
+     * are the ones an operator sees ({@code $.value.comment}) and the composition cannot be what breaks the
+     * contract. The command is wrapped in the {@code value} envelope that document describes.
+     */
+    private static @NotNull Set<ValidationMessage> gateErrors(final @NotNull String command) throws Exception {
+        final var output = new TagSchemaCreationOutputImpl();
+        output.finish(new TagSchemaCreationOutput.DataPointSchema(
+                ConditionSchemas.readSchema(
+                        OpcuaConditionType.fromBrowseName("AlarmConditionType").orElseThrow()),
+                null,
+                null,
+                ConditionSchemas.writeSchema()));
+
+        return validate(output.getSchema(TagSchemaDirection.SOUTHBOUND), json("{\"value\": " + command + "}"));
+    }
+
+    private static @NotNull Set<ValidationMessage> validate(
+            final @NotNull ObjectNode document, final @NotNull JsonNode message) {
+        return JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V201909)
+                .getSchema(document)
+                .validate(message);
+    }
+
+    private static @NotNull JsonNode json(final @NotNull String raw) throws JsonProcessingException {
+        return MAPPER.readTree(raw);
+    }
+}


### PR DESCRIPTION
Closes QA finding **P4.3** on [EDG-835](https://linear.app/hivemq/issue/EDG-835/implement-opc-ua-alarms-and-conditions-support-in-edge), raised by @estefaniaamundaray after #1707 merged.

## The defect

OPC 10000-9 §5.7.3 gives a condition method's `Comment` argument three meanings, and null is one of them:

| Payload | Intent |
|---|---|
| `{"method": "ACKNOWLEDGE", "eventId": "…"}` | leave the existing comment unchanged |
| `… "comment": ""` | **erase** it |
| `… "comment": "Erwin has seen this"` | set it |

`ConditionUpdate.fromJson` has always implemented all three — an explicit `"comment": null` is read as absent, with the reasoning in the code — and the user documentation promises it. But `ConditionSchemas.writeSchema()` declared the field a bare `string`, and JSON `string` does not admit `null`. So the payload was refused at the southbound schema gate before the parser that understood it was reached:

```
$.value.comment: null found, string expected
```

Nothing unusual is needed to hit it. Jackson, `JSON.stringify` and `json.dumps` all emit `"field": null` for a field that was never assigned — omitting the key is what takes configuration — so a service that builds an acknowledgement as a struct and serialises it had every command rejected over a field it deliberately said nothing about. And `comment` is the operator's audit note: §5.5.2 fires a fresh event on any comment change, so the null-vs-empty distinction is the difference between "don't touch the note" and telling every other client the note is gone.

## The fix

`comment` is now nullable — `type: ["string", "null"]`. The semantics behind it were already correct.

## What deliberately stays strict

`eventId`, `duration` and `selectedResponse` are **not** nullable. They are OPC UA method arguments, required by the specification wherever they apply — `Acknowledge`'s `EventId` (§5.7.2), `TimedShelve`'s `ShelvingTime` (§5.8.10.4), `Respond`'s `SelectedResponse` (§5.6.3) — and there is no null value of any of them that means anything. A caller with nothing to say about such a field omits the key.

The consequence is real and is stated in the javadoc rather than left to be discovered: **a client that serialises the whole command object must suppress its null keys** (`@JsonInclude(NON_NULL)`, a `JSON.stringify` replacer, `model_dump(exclude_none=True)`). Sending `"duration": null` on an `ACKNOWLEDGE` is refused, and that refusal is the intended contract.

I first relaxed all four and was corrected: the serialiser argument is not a reason to advertise a value the protocol cannot carry. The javadoc now records both halves so the asymmetry reads as a decision rather than an inconsistency.

## Tests

`ConditionSchemaNullableFieldsTest` — 10 tests. It drives **the gate itself**: the same networknt validator Edge puts in front of a southbound write, against the composed document a client fetches from `GET .../writing-schema?direction=SOUTHBOUND`. That is deliberate — the defect was invisible to the tests already in this package, because the schema was right on its own and the parser was right on its own, and what was wrong was only visible between them. Asserting acceptance rather than a rendered type also means the error paths are the `$.value.comment` an operator sees.

It pins the strictness of the three argument fields as well as the fix, driven off a list so a new argument field has to declare which side it is on, and carries the serialiser case both ways: the struct with nulls intact is refused on those fields, the same command with nulls suppressed is accepted.

`libs.json.schema.validator` is added as a **test-only** dependency. hivemq-edge has it as `implementation`, so it reached this module's test runtime but not its compile classpath.

## Verification

- `./gradlew :hivemq-edge-build:hivemq-edge-module-opcua:check --rerun-tasks` — **BUILD SUCCESSFUL**, 681 tests, 0 failures, 1 pre-existing skip.
- `spotlessApply` from the composite root.
- **Negative check:** with the one `.nullable()` removed, 4 tests fail with `$.value.comment: null found, string expected` — the finding's assertion verbatim. The 3 tests guarding the argument fields pass either way, correctly, since they are guard-rails rather than regression proofs.
- No OpenAPI impact — tag schemas are generated at runtime, not baked into `ext/hivemq-edge-openapi.yaml`. No integration test pins these type strings.

## One thing not fixed here

`PropertyItem.tsx:52` looks its type icon and label up by a single type name, so a `type: ["string","null"]` misses and falls back to a generic icon. `comment` is now one such field on the southbound side — but the condition **read** schema has marked every field nullable since #1707, through the same `JsonSchemaBrowser` path, so this is pre-existing and cosmetic rather than introduced here. Same shape as the `ConnectionStatusBadge` finding from code review v09; worth its own ticket.