### PR TITLE
EDG-907: Refuse an unreadable adapter configuration at the API, not on the reload

### DIFF
--- a/hivemq-edge/src/main/java/com/hivemq/api/resources/impl/ProtocolAdaptersResourceImpl.java
+++ b/hivemq-edge/src/main/java/com/hivemq/api/resources/impl/ProtocolAdaptersResourceImpl.java
@@ -27,6 +27,7 @@ import static com.hivemq.protocols.ProtocolAdapterUtils.createProtocolAdapterMap
 import static com.hivemq.util.ErrorResponseUtil.errorResponse;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
 import com.google.common.collect.ImmutableList;
@@ -89,6 +90,7 @@ import com.hivemq.edge.modules.adapters.impl.ProtocolAdapterDiscoveryOutputImpl;
 import com.hivemq.persistence.topicfilter.TopicFilterPersistence;
 import com.hivemq.persistence.topicfilter.TopicFilterPojo;
 import com.hivemq.protocols.InternalProtocolAdapterWritingService;
+import com.hivemq.protocols.ProtocolAdapterConfigConverter;
 import com.hivemq.protocols.ProtocolAdapterManager;
 import com.hivemq.protocols.ProtocolAdapterSchemaManager;
 import com.hivemq.protocols.ProtocolAdapterWrapper;
@@ -143,6 +145,7 @@ public class ProtocolAdaptersResourceImpl extends AbstractApi implements Protoco
     private final @NotNull CustomConfigSchemaGenerator customConfigSchemaGenerator;
     private final @NotNull SystemInformation systemInformation;
     private final @NotNull ProtocolAdapterExtractor configExtractor;
+    private final @NotNull ProtocolAdapterConfigConverter configConverter;
 
     @Inject
     public ProtocolAdaptersResourceImpl(
@@ -154,7 +157,8 @@ public class ProtocolAdaptersResourceImpl extends AbstractApi implements Protoco
             final @NotNull VersionProvider versionProvider,
             final @NotNull TopicFilterPersistence topicFilterPersistence,
             final @NotNull SystemInformation systemInformation,
-            final @NotNull ProtocolAdapterExtractor configExtractor) {
+            final @NotNull ProtocolAdapterExtractor configExtractor,
+            final @NotNull ProtocolAdapterConfigConverter configConverter) {
         this.remoteService = remoteService;
         this.configurationService = configurationService;
         this.protocolAdapterManager = protocolAdapterManager;
@@ -164,6 +168,7 @@ public class ProtocolAdaptersResourceImpl extends AbstractApi implements Protoco
         this.topicFilterPersistence = topicFilterPersistence;
         this.systemInformation = systemInformation;
         this.configExtractor = configExtractor;
+        this.configConverter = configConverter;
         this.customConfigSchemaGenerator = new CustomConfigSchemaGenerator();
     }
 
@@ -311,15 +316,21 @@ public class ProtocolAdaptersResourceImpl extends AbstractApi implements Protoco
             return errorResponse(new AdapterFailedSchemaValidationError(errorMessages.toErrorList()));
         }
 
+        final ProtocolAdapterEntity entity = new ProtocolAdapterEntity(
+                adapter.getId(),
+                adapterType,
+                type.get().getCurrentConfigVersion(),
+                (LinkedHashMap<String, Object>) adapter.getConfig(),
+                List.of(),
+                List.of(),
+                List.of());
+        final Optional<Response> unconvertible = refuseUnconvertibleConfiguration(entity);
+        if (unconvertible.isPresent()) {
+            return unconvertible.get();
+        }
+
         try {
-            if (configExtractor.addAdapter(new ProtocolAdapterEntity(
-                    adapter.getId(),
-                    adapterType,
-                    type.get().getCurrentConfigVersion(),
-                    (LinkedHashMap<String, Object>) adapter.getConfig(),
-                    List.of(),
-                    List.of(),
-                    List.of()))) {
+            if (configExtractor.addAdapter(entity)) {
                 if (logger.isDebugEnabled()) {
                     logger.debug("Added protocol adapter of type {} with ID {}.", adapterType, adapter.getId());
                 }
@@ -351,6 +362,10 @@ public class ProtocolAdaptersResourceImpl extends AbstractApi implements Protoco
                                     oldInstance.getNorthboundMappings(),
                                     oldInstance.getSouthboundMappings(),
                                     oldInstance.getTags());
+                            final Optional<Response> unconvertible = refuseUnconvertibleConfiguration(newConfig);
+                            if (unconvertible.isPresent()) {
+                                return unconvertible.get();
+                            }
                             if (!configExtractor.updateAdapter(newConfig)) {
                                 return adapterCannotBeUpdatedError(adapterId);
                             }
@@ -829,19 +844,25 @@ public class ProtocolAdaptersResourceImpl extends AbstractApi implements Protoco
             return errorResponse(new DuplicateTagError(adapterId, duplicateTag.get()));
         }
 
+        final ProtocolAdapterEntity entity = new ProtocolAdapterEntity(
+                adapterId,
+                adapterType,
+                maybeInfo.get().getCurrentConfigVersion(),
+                (Map<String, Object>) adapterConfig.getConfig().getConfig(),
+                adapterConfig.getNorthboundMappings().stream()
+                        .map(NorthboundMappingEntity::fromApi)
+                        .toList(),
+                adapterConfig.getSouthboundMappings().stream()
+                        .map(this::toSouthboundMappingEntity)
+                        .toList(),
+                adapterConfig.getTags().stream().map(this::toTagEntity).toList());
+        final Optional<Response> unconvertible = refuseUnconvertibleConfiguration(entity);
+        if (unconvertible.isPresent()) {
+            return unconvertible.get();
+        }
+
         try {
-            configExtractor.addAdapter(new ProtocolAdapterEntity(
-                    adapterId,
-                    adapterType,
-                    maybeInfo.get().getCurrentConfigVersion(),
-                    (Map<String, Object>) adapterConfig.getConfig().getConfig(),
-                    adapterConfig.getNorthboundMappings().stream()
-                            .map(NorthboundMappingEntity::fromApi)
-                            .toList(),
-                    adapterConfig.getSouthboundMappings().stream()
-                            .map(this::toSouthboundMappingEntity)
-                            .toList(),
-                    adapterConfig.getTags().stream().map(this::toTagEntity).toList()));
+            configExtractor.addAdapter(entity);
         } catch (final IllegalArgumentException e) {
             if (e.getCause() instanceof UnrecognizedPropertyException) {
                 addValidationError(
@@ -1113,6 +1134,91 @@ public class ProtocolAdaptersResourceImpl extends AbstractApi implements Protoco
         validator
                 .validateObject(adapter.getConfig())
                 .forEach(e -> addValidationError(apiErrorMessages, e.getFieldName(), e.getMessage()));
+    }
+
+    /**
+     * Refuses a configuration the reload would refuse, while the caller is still there to be told.
+     *
+     * <p>Writing the entity is not the end of the story: {@link ProtocolAdapterExtractor} notifies
+     * {@link ProtocolAdapterManager#refresh}, which converts the entity on its own executor, long after
+     * this response has gone out. A configuration that does not convert was therefore answered with 200
+     * and then never appeared - every later {@code GET /adapters/{id}} a 404, for good, and the reason
+     * only in Edge's log and its event stream. Anything polling for the adapter burns its full timeout
+     * and reports that timeout, which names nothing about the configuration. Converting here, with the
+     * converter and the mapper the reload itself uses, puts that verdict back in front of the caller.
+     *
+     * <p>Schema validation does not cover this and should not be made to. The generated schema does not
+     * set {@code additionalProperties: false}, and setting it would make the API stricter than the
+     * configuration file, which warns and drops an unknown setting for every adapter except the ones
+     * that opt out of that. Converting borrows each adapter's own posture instead of restating it, and
+     * covers every way a configuration can fail to convert - a rejected enum value, a value that will
+     * not coerce, a tag definition the adapter cannot read - not only an unknown setting.
+     *
+     * @param entity the entity that is about to be written to the configuration
+     * @return the response to return instead of writing, or empty when the configuration converts
+     */
+    private @NotNull Optional<Response> refuseUnconvertibleConfiguration(final @NotNull ProtocolAdapterEntity entity) {
+        try {
+            configConverter.fromEntity(entity);
+            return Optional.empty();
+        } catch (final VirtualMachineError e) {
+            // A JVM that cannot allocate is not this request's problem to report.
+            throw e;
+        } catch (final Throwable t) {
+            // Everything else is this configuration's problem, whatever its type: conversion runs
+            // adapter-module code, so enumerating the hierarchy is a losing game - the same reasoning
+            // ProtocolAdapterManager.convertConfigs applies on the reload side.
+            log.debug("Adapter '{}' was refused because its configuration could not be read", entity.getAdapterId(), t);
+            final ApiErrorMessages errorMessages = ApiErrorUtils.createErrorContainer();
+            addValidationError(errorMessages, unconvertibleField(t), unconvertibleReason(t));
+            return Optional.of(errorResponse(new AdapterFailedSchemaValidationError(errorMessages.toErrorList())));
+        }
+    }
+
+    /**
+     * The path through the caller's own payload that failed, as {@code opcuaToMqtt.publishingInterval}.
+     * <p>
+     * Jackson records it as a reference chain on the mapping exception; {@code "config"} is the fallback
+     * for a failure raised before any property was reached, such as a missing adapter factory.
+     */
+    private static @NotNull String unconvertibleField(final @NotNull Throwable thrown) {
+        for (Throwable t = thrown; t != null; t = t.getCause()) {
+            if (t instanceof final JsonMappingException mapping
+                    && !mapping.getPath().isEmpty()) {
+                final StringBuilder path = new StringBuilder();
+                for (final JsonMappingException.Reference reference : mapping.getPath()) {
+                    if (reference.getFieldName() == null) {
+                        path.append('[').append(reference.getIndex()).append(']');
+                    } else {
+                        if (path.length() > 0) {
+                            path.append('.');
+                        }
+                        path.append(reference.getFieldName());
+                    }
+                }
+                return path.toString();
+            }
+            if (t.getCause() == t) {
+                break;
+            }
+        }
+        return "config";
+    }
+
+    /**
+     * The innermost message, which is the one the adapter's own configuration class wrote.
+     * <p>
+     * {@code ObjectMapper.convertValue} wraps that in an {@link IllegalArgumentException} around a
+     * {@link JsonMappingException}, and neither wrapper says anything the caller can act on - the
+     * middle one only repeats the reference chain already carried as the field name.
+     */
+    private static @NotNull String unconvertibleReason(final @NotNull Throwable thrown) {
+        Throwable root = thrown;
+        while (root.getCause() != null && root.getCause() != root) {
+            root = root.getCause();
+        }
+        final String message = root.getMessage();
+        return message == null || message.isBlank() ? root.toString() : message;
     }
 
     private @NotNull AdaptersList getAdaptersInternal(final @Nullable String adapterType) {

--- a/hivemq-edge/src/test/java/com/hivemq/api/resources/impl/ProtocolAdaptersResourceImplTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/api/resources/impl/ProtocolAdaptersResourceImplTest.java
@@ -22,12 +22,18 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hivemq.adapter.sdk.api.ProtocolAdapter;
 import com.hivemq.adapter.sdk.api.ProtocolAdapterInformation;
+import com.hivemq.adapter.sdk.api.config.ProtocolSpecificAdapterConfig;
+import com.hivemq.adapter.sdk.api.factories.ProtocolAdapterFactory;
 import com.hivemq.adapter.sdk.api.schema.ScalarType;
 import com.hivemq.adapter.sdk.api.schema.SchemaBuilder;
 import com.hivemq.adapter.sdk.api.schema.TagSchemaCreationOutput;
@@ -47,6 +53,7 @@ import com.hivemq.configuration.service.ConfigurationService;
 import com.hivemq.edge.HiveMQEdgeRemoteService;
 import com.hivemq.edge.VersionProvider;
 import com.hivemq.edge.api.model.Adapter;
+import com.hivemq.edge.api.model.AdapterConfig;
 import com.hivemq.edge.api.model.DomainTagList;
 import com.hivemq.edge.api.model.DomainTagOwnerList;
 import com.hivemq.edge.api.model.FieldMapping;
@@ -59,6 +66,8 @@ import com.hivemq.persistence.domain.DomainTag;
 import com.hivemq.persistence.domain.DomainTagAddResult;
 import com.hivemq.persistence.topicfilter.TopicFilterPersistence;
 import com.hivemq.protocols.InternalProtocolAdapterWritingService;
+import com.hivemq.protocols.ProtocolAdapterConfigConverter;
+import com.hivemq.protocols.ProtocolAdapterFactoryManager;
 import com.hivemq.protocols.ProtocolAdapterManager;
 import com.hivemq.protocols.ProtocolAdapterWrapper;
 import jakarta.ws.rs.core.Response;
@@ -66,11 +75,13 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Base64;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.IntStream;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -85,6 +96,9 @@ class ProtocolAdaptersResourceImplTest {
     private final @NotNull TopicFilterPersistence topicFilterPersistence = mock();
     private final @NotNull SystemInformation systemInformation = mock();
     private final @NotNull ProtocolAdapterExtractor protocolAdapterExtractor = mock();
+    private final @NotNull ProtocolAdapterFactoryManager protocolAdapterFactoryManager = mock();
+    private final @NotNull ProtocolAdapterConfigConverter configConverter =
+            new ProtocolAdapterConfigConverter(protocolAdapterFactoryManager, new ObjectMapper());
 
     private final ProtocolAdaptersResourceImpl protocolAdaptersResource = new ProtocolAdaptersResourceImpl(
             remoteService,
@@ -95,7 +109,8 @@ class ProtocolAdaptersResourceImplTest {
             versionProvider,
             topicFilterPersistence,
             systemInformation,
-            protocolAdapterExtractor);
+            protocolAdapterExtractor,
+            configConverter);
 
     @BeforeEach
     public void setUp() {
@@ -1022,5 +1037,200 @@ class ProtocolAdaptersResourceImplTest {
                 .createTagSchema(any(), any());
         when(protocolAdapterManager.getProtocolAdapterWrapperByAdapterId("adapter"))
                 .thenReturn(Optional.of(wrapper));
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // A configuration that will not convert must be refused while the caller is still there.
+    //
+    // The write is answered before the configuration is read: the extractor notifies
+    // ProtocolAdapterManager.refresh, which converts on its own executor. A configuration that does not
+    // convert used to be answered 200 and then never appear - every later GET a 404, for good, and the
+    // reason only in Edge's log and event stream. Anything polling for the adapter burns its whole
+    // timeout and then reports that timeout, which names nothing about the configuration.
+    // ---------------------------------------------------------------------------------------------
+
+    @Test
+    void addAdapter_whenTheConfigurationDoesNotConvert_thenTheCallerIsToldWhyAndNothingIsWritten() {
+        mockConvertibleAdapterType("refusing");
+
+        final Response response = protocolAdaptersResource.addAdapter(
+                "refusing", adapterModel("new-adapter", "refusing", Map.of("publishChangedDataOnly", true)));
+
+        assertEquals(400, response.getStatus());
+        final ProblemDetails problem = assertInstanceOf(ProblemDetails.class, response.getEntity());
+        assertThat(problem.getErrors())
+                .extracting(com.hivemq.http.error.Error::getDetail)
+                .as("the caller must be told which setting was refused, not merely that something was invalid")
+                .allSatisfy(detail -> assertThat(detail).contains("'publishChangedDataOnly'"));
+        verify(protocolAdapterExtractor, never()).addAdapter(any());
+    }
+
+    @Test
+    void addAdapter_whenTheConfigurationConverts_thenItIsWritten() {
+        mockConvertibleAdapterType("refusing");
+        when(protocolAdapterExtractor.addAdapter(any())).thenReturn(true);
+
+        final Response response = protocolAdaptersResource.addAdapter(
+                "refusing", adapterModel("new-adapter", "refusing", Map.of("hostname", "machine-1")));
+
+        assertEquals(200, response.getStatus());
+        verify(protocolAdapterExtractor).addAdapter(any());
+    }
+
+    @Test
+    void updateAdapter_whenTheConfigurationDoesNotConvert_thenTheCallerIsToldWhyAndNothingIsWritten() {
+        // This path never validated the payload at all, so an unreadable configuration reached the
+        // configuration file unopposed and took the running adapter's next reload with it.
+        final ProtocolAdapterEntity existing = existingEntity("existing", "refusing");
+        when(protocolAdapterExtractor.getAdapterByAdapterId("existing")).thenReturn(Optional.of(existing));
+
+        final Response response = protocolAdaptersResource.updateAdapter(
+                "existing", adapterModel("existing", "refusing", Map.of("publishChangedDataOnly", true)));
+
+        assertEquals(400, response.getStatus());
+        final ProblemDetails problem = assertInstanceOf(ProblemDetails.class, response.getEntity());
+        assertThat(problem.getErrors())
+                .extracting(com.hivemq.http.error.Error::getDetail)
+                .allSatisfy(detail -> assertThat(detail).contains("'publishChangedDataOnly'"));
+        verify(protocolAdapterExtractor, never()).updateAdapter(any());
+    }
+
+    @Test
+    void updateAdapter_whenTheConfigurationConverts_thenItIsWritten() {
+        final ProtocolAdapterEntity existing = existingEntity("existing", "refusing");
+        when(protocolAdapterExtractor.getAdapterByAdapterId("existing")).thenReturn(Optional.of(existing));
+        when(protocolAdapterExtractor.updateAdapter(any())).thenReturn(true);
+
+        final Response response = protocolAdaptersResource.updateAdapter(
+                "existing", adapterModel("existing", "refusing", Map.of("hostname", "machine-1")));
+
+        assertEquals(200, response.getStatus());
+        verify(protocolAdapterExtractor).updateAdapter(any());
+    }
+
+    @Test
+    void createCompleteAdapter_whenTheConfigurationDoesNotConvert_thenTheCallerIsToldWhyAndNothingIsWritten() {
+        mockConvertibleAdapterType("refusing");
+
+        final AdapterConfig adapterConfig = new AdapterConfig()
+                .config(adapterModel("new-adapter", "refusing", Map.of("publishChangedDataOnly", true)))
+                .tags(List.of())
+                .northboundMappings(List.of())
+                .southboundMappings(List.of());
+
+        final Response response =
+                protocolAdaptersResource.createCompleteAdapter("refusing", "new-adapter", adapterConfig);
+
+        assertEquals(400, response.getStatus());
+        final ProblemDetails problem = assertInstanceOf(ProblemDetails.class, response.getEntity());
+        assertThat(problem.getErrors())
+                .extracting(com.hivemq.http.error.Error::getDetail)
+                .allSatisfy(detail -> assertThat(detail).contains("'publishChangedDataOnly'"));
+        verify(protocolAdapterExtractor, never()).addAdapter(any());
+    }
+
+    @Test
+    void whenTheFailureIsNested_thenTheReportedFieldIsThePathThroughTheCallersOwnPayload() {
+        // The reference chain, not the class that threw: "nested.publishChangedDataOnly" is a path
+        // through what the caller wrote, which is the only path they can act on.
+        mockConvertibleAdapterType("refusing");
+
+        final Response response = protocolAdaptersResource.addAdapter(
+                "refusing",
+                adapterModel("new-adapter", "refusing", Map.of("nested", Map.of("publishChangedDataOnly", true))));
+
+        assertEquals(400, response.getStatus());
+        final ProblemDetails problem = assertInstanceOf(ProblemDetails.class, response.getEntity());
+        assertThat(problem.getErrors())
+                .extracting(com.hivemq.http.error.Error::getParameter)
+                .containsExactly("nested.publishChangedDataOnly");
+    }
+
+    @Test
+    void whenTheFailureHasNoPropertyPath_thenItIsReportedAgainstTheConfigurationItself() {
+        // No factory for the protocol id: the conversion fails before a single property is reached, so
+        // there is no path to name and the complaint belongs to the configuration as a whole.
+        mockConvertibleAdapterType("refusing");
+        when(protocolAdapterFactoryManager.get("refusing")).thenReturn(Optional.empty());
+
+        final Response response = protocolAdaptersResource.addAdapter(
+                "refusing", adapterModel("new-adapter", "refusing", Map.of("hostname", "machine-1")));
+
+        assertEquals(400, response.getStatus());
+        final ProblemDetails problem = assertInstanceOf(ProblemDetails.class, response.getEntity());
+        assertThat(problem.getErrors())
+                .extracting(com.hivemq.http.error.Error::getParameter)
+                .containsExactly("config");
+        assertThat(problem.getErrors())
+                .extracting(com.hivemq.http.error.Error::getDetail)
+                .allSatisfy(detail -> assertThat(detail).contains("No Factory was found"));
+        verify(protocolAdapterExtractor, never()).addAdapter(any());
+    }
+
+    private @NotNull Adapter adapterModel(
+            final @NotNull String id, final @NotNull String type, final @NotNull Map<String, Object> config) {
+        // The resource casts the config to a LinkedHashMap, which is what Jackson hands it off the wire.
+        return new Adapter(id).type(type).config(new LinkedHashMap<>(config));
+    }
+
+    private @NotNull ProtocolAdapterEntity existingEntity(
+            final @NotNull String adapterId, final @NotNull String protocolId) {
+        final ProtocolAdapterEntity entity = mock(ProtocolAdapterEntity.class);
+        when(entity.getAdapterId()).thenReturn(adapterId);
+        when(entity.getProtocolId()).thenReturn(protocolId);
+        when(entity.getTags()).thenReturn(List.of());
+        when(entity.getNorthboundMappings()).thenReturn(List.of());
+        when(entity.getSouthboundMappings()).thenReturn(List.of());
+        mockRefusingFactory(protocolId);
+        return entity;
+    }
+
+    /**
+     * An adapter type whose configuration class refuses a setting it does not have, wired into both the
+     * type lookup the resource does and the factory lookup the converter does.
+     */
+    private void mockConvertibleAdapterType(final @NotNull String protocolId) {
+        final ProtocolAdapterInformation information = mock(ProtocolAdapterInformation.class);
+        when(protocolAdapterManager.getAdapterTypeById(protocolId)).thenReturn(Optional.of(information));
+        when(protocolAdapterManager.getAllAvailableAdapterTypes()).thenReturn(Map.of(protocolId, information));
+        //noinspection unchecked
+        when((Object) information.configurationClassNorthbound()).thenReturn(RefusingAdapterConfig.class);
+        //noinspection unchecked
+        when((Object) information.configurationClassNorthAndSouthbound()).thenReturn(RefusingAdapterConfig.class);
+        mockRefusingFactory(protocolId);
+    }
+
+    private void mockRefusingFactory(final @NotNull String protocolId) {
+        final ProtocolAdapterFactory<?> factory = mock(ProtocolAdapterFactory.class);
+        when(protocolAdapterFactoryManager.get(protocolId)).thenReturn(Optional.of(factory));
+        // Drive the converter's own mapper exactly as a real factory does - the mapper is the point,
+        // since it is the one an operator's configuration file goes through.
+        when(factory.convertConfigObject(any(), any(), org.mockito.ArgumentMatchers.anyBoolean()))
+                .thenAnswer(invocation -> {
+                    final ObjectMapper mapper = invocation.getArgument(0);
+                    final Map<String, Object> config = invocation.getArgument(1);
+                    return mapper.convertValue(config, RefusingAdapterConfig.class);
+                });
+        when(factory.convertTagDefinitionObjects(any(), any())).thenReturn(List.of());
+    }
+
+    /**
+     * Stands in for {@code OpcUaSpecificAdapterConfig}, which core cannot reference: the module depends
+     * on the adapter SDK, not the other way round. What is pinned here is the mechanism - a config class
+     * that refuses a setting it does not have - not OPC UA's particular settings.
+     */
+    static class RefusingAdapterConfig implements ProtocolSpecificAdapterConfig {
+
+        @JsonProperty("hostname")
+        public @Nullable String hostname;
+
+        @JsonProperty("nested")
+        public @Nullable RefusingAdapterConfig nested;
+
+        @JsonAnySetter
+        void refuseUnknownSetting(final @NotNull String name, final @Nullable Object value) {
+            throw new IllegalArgumentException(
+                    "The adapter configuration contains '" + name + "', which is not a setting it has.");
+        }
     }
 }


### PR DESCRIPTION
EDG-907

## The defect

`POST` / `PUT` / `createCompleteAdapter` answer the caller before Edge has read the
configuration they submitted. `ProtocolAdapterExtractor` writes the entity and notifies
`ProtocolAdapterManager.refresh`, which converts it on a dedicated single-thread executor —
after `Response.ok()` has already gone out. A configuration that does not convert therefore
gets a 200 and then never appears: every later `GET /adapters/{id}` is a 404, permanently,
and the reason lives only in Edge's log and in the adapter-scoped `CRITICAL` event
`convertConfigs` fires. Anything polling for readiness burns its full timeout and reports
that timeout, which names nothing about the configuration.

Schema validation does not catch it: `CustomConfigSchemaGenerator` emits
`additionalProperties: false` only on the `oneOf` branches it synthesises for
mutually-exclusive field groups, never on the top-level configuration object. `PUT` had no
validation of the submitted configuration at all.

## The fix

Convert the entity through `ProtocolAdapterConfigConverter.fromEntity` — the same converter
and the same mapper the reload uses — before handing it to the extractor, and return 400
when it throws. The error carries the Jackson reference chain as the `parameter` and the
innermost message as the `detail`, so the caller gets the path through their own payload
plus the sentence the adapter's own configuration class wrote. Same split
`ProtocolAdapterSchemaManager.convertMessage` already uses.

Wired into all three endpoints that accept an operator-supplied config.

## Why not `additionalProperties: false`

It would make the API stricter than the configuration file.
`ProtocolAdapterUtils.ReportUnknownPropertyHandler` is the application-wide posture — warn
and carry on without the setting — so that a configuration written for another version
still starts. Only `OpcUaSpecificAdapterConfig` opts out and refuses. A blanket schema
restriction would reject payloads Edge loads happily from a file, and would state each
adapter's posture in a second place where the two could drift. Converting borrows the
posture rather than duplicating it, and covers every conversion failure — rejected enum
value, uncoercible value, unreadable tag definition — not only an undeclared setting.

## Verification

- 7 new tests in `ProtocolAdaptersResourceImplTest`: all three paths refuse and write
  nothing; all three still accept a good config; nested reference-chain reporting; the
  no-path fallback. Uses a purpose-built refusing config class — core cannot reference the
  OPC UA module.
- Full `:hivemq-edge:test` suite green.
- `spotlessApply` from the composite root; `spotlessJavaCheck` verified on `hivemq-edge`
  and `hivemq-edge-module-opcua`.
- Companion PR in `hivemq-edge-test` proves it end to end against a real Edge over real
  HTTP, and cleans a fixture carrying two settings OPC UA has never had.

GET → PUT round trips are unaffected: `unconvertConfigObject` runs with
`AUTO_DETECT_GETTERS` off, so only `@JsonProperty` members serialise, and those are by
definition settings the class declares.
