### PR TITLE
EDG-894: QA findings P6, P7 and P8 from the OPC UA Alarms & Conditions pass

### DIFF
--- a/edge-plugins/src/main/kotlin/com/hivemq/versionupdater/VersionUpdaterPlugin.kt
+++ b/edge-plugins/src/main/kotlin/com/hivemq/versionupdater/VersionUpdaterPlugin.kt
@@ -8,6 +8,26 @@ class VersionUpdaterPlugin : Plugin<Project> {
 
     override fun apply(project: Project) {
         project.tasks.register<UpdateVersionTask>(UPDATE_VERSION_TASK_NAME)
+
+        // Workaround for a CI build-cache issue: cyclonedxDirectBom must not be served from the cache.
+        //
+        // The task is registered per-project by com.hivemq.tools.license, which applies the CycloneDX plugin
+        // and then configures cyclonedxDirectBom against that project's runtimeClasspath. Seventeen projects
+        // across six repositories apply it, and the composite root does not, so there is no single build
+        // script to put this in.
+        //
+        // It lives here, in a plugin otherwise concerned only with version bumping, because of the six
+        // com.hivemq.* convention plugins this is the only one every affected project applies --
+        // repository-convention and jacoco-convention miss four of them, errorprone and nullaway three,
+        // spotless two. The withId guard means this is inert wherever the license plugin is absent, which
+        // includes the roots that apply this plugin without ever registering the task.
+        //
+        // Remove once the caching issue itself is fixed; nothing else here depends on it.
+        project.plugins.withId("com.hivemq.tools.license") {
+            project.tasks.named("cyclonedxDirectBom") {
+                outputs.cacheIf { false }
+            }
+        }
     }
 }
 

--- a/hivemq-edge/src/main/java/com/hivemq/api/resources/impl/ProtocolAdaptersResourceImpl.java
+++ b/hivemq-edge/src/main/java/com/hivemq/api/resources/impl/ProtocolAdaptersResourceImpl.java
@@ -747,11 +747,24 @@ public class ProtocolAdaptersResourceImpl extends AbstractApi implements Protoco
             log.debug("Original exception: ", e);
             return errorResponse(new InternalServerError(null));
         } catch (final @NotNull ExecutionException e) {
+            // Prefer the adapter's own account of what went wrong. TagSchemaCreationOutputImpl.fail(String)
+            // records the adapter's sentence on the output and completes the future with a fixed
+            // "Json schema creation for tag failed.", so reading only the cause discards the only text that
+            // says anything -- and every one of the OPC UA adapter's schema failures takes that route. The
+            // symptom was a 500 whose whole body was that fixed sentence, which QA could not diagnose from and
+            // reported as a possible regression in the direction parameter (EDG-894 P7); the adapter had in
+            // fact said "Discovery failed: ClientConnection not connected or not initialized" and nothing
+            // carried it to the caller.
+            //
+            // Falling back to the cause rather than replacing it: fail(Throwable, null) leaves no message on
+            // the output, and there the throwable is the only account there is.
             final Throwable cause = e.getCause();
+            final String adapterReason = tagSchemaCreationOutput.getMessage();
             final String message;
-            if (cause == null) {
+            if (adapterReason != null && !adapterReason.isBlank()) {
+                message = adapterReason;
+            } else if (cause == null) {
                 message = "unknown error";
-                ;
             } else {
                 message = cause.getMessage();
             }

--- a/hivemq-edge/src/test/java/com/hivemq/api/resources/impl/ProtocolAdaptersResourceImplTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/api/resources/impl/ProtocolAdaptersResourceImplTest.java
@@ -936,4 +936,91 @@ class ProtocolAdaptersResourceImplTest {
         assertThat(response.getLocation().toString())
                 .isEqualTo("/api/v1/management/protocol-adapters/schema/adapter/tag?direction=SOUTHBOUND");
     }
+
+    /**
+     * EDG-894 P7: when schema generation fails, the 500 must say what the adapter said.
+     * <p>
+     * {@code TagSchemaCreationOutput.fail(String)} records the adapter's reason on the output and completes the
+     * future with a fixed {@code "Json schema creation for tag failed."}. This layer read only the cause, so the
+     * entire body of the 500 was that fixed sentence — and every schema failure in the OPC UA adapter takes that
+     * route. QA met it as an unexplained 500 on an ordinary VALUE tag and could not tell from the response
+     * whether the fault was in schema generation or in the {@code direction} parameter that had just been added,
+     * so it was reported as a possible API compatibility break. The adapter had in fact said its connection was
+     * not established, and nothing carried that sentence to the caller.
+     */
+    @Test
+    void getSchema_whenTheAdapterGivesAReason_thenTheResponseCarriesIt() {
+        mockAdapterFailingSchemaWith("Discovery failed: ClientConnection not connected or not initialized");
+
+        final Response response = protocolAdaptersResource.getSchema("adapter", "tag", null);
+
+        assertEquals(500, response.getStatus());
+        assertThat(response.getEntity().toString())
+                .as("the operator has to be told which condition stopped the schema being built")
+                .contains("ClientConnection not connected")
+                .doesNotContain("Json schema creation for tag failed.");
+    }
+
+    @Test
+    void getSchema_whenTheAdapterGivesNoReason_thenTheCauseIsStillReported() {
+        // fail(Throwable, null) leaves no message on the output, and there the throwable is the only account
+        // there is. Preferring the adapter's reason must not mean discarding the cause when there isn't one.
+        final ProtocolAdapterWrapper wrapper = mock();
+        final ProtocolAdapter adapter = mock();
+        when(wrapper.getAdapter()).thenReturn(adapter);
+        doAnswer(invocation -> {
+                    final TagSchemaCreationOutput output = invocation.getArgument(1);
+                    output.fail(new IllegalStateException("the node is not readable"), null);
+                    return null;
+                })
+                .when(adapter)
+                .createTagSchema(any(), any());
+        when(protocolAdapterManager.getProtocolAdapterWrapperByAdapterId("adapter"))
+                .thenReturn(Optional.of(wrapper));
+
+        final Response response = protocolAdaptersResource.getSchema("adapter", "tag", null);
+
+        assertEquals(500, response.getStatus());
+        assertThat(response.getEntity().toString()).contains("the node is not readable");
+    }
+
+    @Test
+    void getSchema_withoutDirection_takesTheSamePathAsNorthbound() {
+        // The other half of P7, and the half that refutes its stated hypothesis. The finding could not reach the
+        // NORTHBOUND call to compare, and offered "if NORTHBOUND succeeds, the defect is the default direction".
+        // It cannot: an absent direction resolves to NORTHBOUND, and createTagSchema runs and fails before the
+        // direction is consulted at all, so the two answers are identical whether the adapter succeeds or fails.
+        mockAdapterFailingSchemaWith("Discovery failed: ClientConnection not connected or not initialized");
+        final Response withoutDirection = protocolAdaptersResource.getSchema("adapter", "tag", null);
+
+        mockAdapterFailingSchemaWith("Discovery failed: ClientConnection not connected or not initialized");
+        final Response northbound = protocolAdaptersResource.getSchema("adapter", "tag", "NORTHBOUND");
+
+        assertEquals(withoutDirection.getStatus(), northbound.getStatus());
+        assertThat(withoutDirection.getEntity().toString())
+                .isEqualTo(northbound.getEntity().toString());
+
+        mockAdapterWithTagSchema("adapter");
+        final Response okWithout = protocolAdaptersResource.getSchema("adapter", "tag", null);
+        mockAdapterWithTagSchema("adapter");
+        final Response okNorthbound = protocolAdaptersResource.getSchema("adapter", "tag", "NORTHBOUND");
+
+        assertEquals(200, okWithout.getStatus());
+        assertThat((JsonNode) okWithout.getEntity()).isEqualTo((JsonNode) okNorthbound.getEntity());
+    }
+
+    private void mockAdapterFailingSchemaWith(final @NotNull String reason) {
+        final ProtocolAdapterWrapper wrapper = mock();
+        final ProtocolAdapter adapter = mock();
+        when(wrapper.getAdapter()).thenReturn(adapter);
+        doAnswer(invocation -> {
+                    final TagSchemaCreationOutput output = invocation.getArgument(1);
+                    output.fail(reason);
+                    return null;
+                })
+                .when(adapter)
+                .createTagSchema(any(), any());
+        when(protocolAdapterManager.getProtocolAdapterWrapperByAdapterId("adapter"))
+                .thenReturn(Optional.of(wrapper));
+    }
 }

--- a/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/condition/EventPropagationVerifier.java
+++ b/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/condition/EventPropagationVerifier.java
@@ -50,9 +50,10 @@ import org.jetbrains.annotations.Nullable;
  * failure, unmappable continuation, or hierarchy deeper than the safety bound is {@link Result.Unverified};
  * callers retain compatibility for those servers but must make that uncertainty visible to the operator.
  * <p>
- * The Server object is the one notifier the walk is not asked about at all: the specification guarantees
- * every event of the server is accessible there, so no answer the walk could give would be worth having.
- * See {@link #isRootNotifier}.
+ * The Server object is the one notifier the <em>walk</em> is not asked about: the specification guarantees
+ * every event of the server is accessible there, so no answer the walk could give about the hierarchy would
+ * be worth having. It is still asked whether the narrowing node exists — see {@link #isRootNotifier} and
+ * {@link #presentInAddressSpace}.
  */
 public final class EventPropagationVerifier {
 
@@ -71,12 +72,12 @@ public final class EventPropagationVerifier {
      * broad makes {@link Result.OutsideHierarchy} unreachable here by definition — there is no node in the
      * address space whose events are not accessible at the Server object.
      * <p>
-     * So the walk must not be allowed to answer. It infers from modelled references, and a server is free to
-     * deliver an event to the Server object while modelling none of the inverse {@code HasNotifier} chain
-     * that would let the walk find its way back up — sparse address spaces and browse views filtered by user
-     * permission both produce exactly that. The walk would then browse a clean zero-parent answer, conclude
-     * {@code OutsideHierarchy}, and drop a tag that would have published, telling the operator their source
-     * is outside a hierarchy that by construction contains everything.
+     * So the walk must not be allowed to answer <em>that</em> question. It infers from modelled references,
+     * and a server is free to deliver an event to the Server object while modelling none of the inverse
+     * {@code HasNotifier} chain that would let the walk find its way back up — sparse address spaces and
+     * browse views filtered by user permission both produce exactly that. The walk would then browse a clean
+     * zero-parent answer, conclude {@code OutsideHierarchy}, and drop a tag that would have published,
+     * telling the operator their source is outside a hierarchy that by construction contains everything.
      * <p>
      * Distinct from {@code NotifierResolver}'s deliberate refusal to <em>fall back</em> to the Server object,
      * which is a scope argument: choosing Server on an operator's behalf silently widens a tag from one area
@@ -85,6 +86,59 @@ public final class EventPropagationVerifier {
      */
     private static boolean isRootNotifier(final @NotNull NodeId notifier) {
         return NodeIds.Server.equals(notifier);
+    }
+
+    /**
+     * The only question left to ask about a narrowing node once the notifier is the root: is it there?
+     * <p>
+     * <b>Why anything is asked at all.</b> {@link #isRootNotifier} settles the <em>hierarchy</em> question and
+     * nothing else, but the walk it replaces was answering two questions rather than one. Alongside "does this
+     * node's event path reach the selected notifier" it was incidentally answering "is this node something the
+     * server has", because a node the server does not hold produces a browse failure rather than a clean
+     * negative. Short-circuiting the walk dropped both, and §8.3.2 licenses dropping only the first: it
+     * promises that every event of the server is accessible at the Server object, which says nothing whatever
+     * about whether some node id the operator typed is an event source, or a node, or anything at all.
+     * <p>
+     * The gap that left is the one QA reported as EDG-894 P6. A query tag rooted at the Server object — the
+     * natural choice for a plant-wide subscription — narrowed by a {@code sourceNode} or {@code conditionNode}
+     * that is a typo, a stale id from a migrated configuration, or a plain variable was accepted without
+     * anything being looked at. It subscribes cleanly, its where clause matches nothing, and it stays silent
+     * for the life of the adapter with no event, log line or status naming it. That is indistinguishable from
+     * a quiet plant, which is the worst thing a tag can be.
+     * <p>
+     * <b>Why the answer is {@link Result.Unverified} and never {@link Result.OutsideHierarchy}.</b> Absence is
+     * not proof of a mistake: OPC 10000-9 §4.3 permits a server to keep its condition instances out of the
+     * address space entirely and deliver them through events alone, and §5.7.3 requires the ConditionId to be
+     * accepted regardless. So a missing node may be a working configuration on such a server. {@code Unverified}
+     * keeps the tag subscribed — which is the whole of review-09 finding 4, and must not be undone — while
+     * routing through the caller's {@code reportUnverifiedTag} so the operator is told which tag, which field
+     * and which node id, and what to check first if it never publishes.
+     */
+    private static @NotNull CompletableFuture<Result> presentInAddressSpace(
+            final @NotNull OpcUaClient client, final @NotNull NodeId node) {
+
+        // The same browse the walk's first hop makes, so a server that permits one permits the other and this
+        // check cannot fail for a reason the walk would not also have hit. What is read from it is different:
+        // not who the parents are -- under the root notifier that is settled -- but whether the server
+        // answered about this node at all. Good with zero references is a node that exists and simply has no
+        // modelled event source, which is the ordinary case here and is fine.
+        final BrowseDescription browse = new BrowseDescription(
+                node,
+                BrowseDirection.Inverse,
+                NodeIds.HasEventSource,
+                true,
+                uint(0),
+                uint(BrowseResultMask.All.getValue()));
+
+        return Browsing.browseAll(client, browse)
+                .<Result>thenApply(references -> new Result.Reachable())
+                .exceptionally(throwable -> {
+                    if (Browsing.nodeNotInAddressSpace(throwable)) {
+                        return new Result.Unverified("the server does not expose " + node.toParseableString()
+                                + " in its address space, so nothing can be confirmed to match this predicate");
+                    }
+                    return unverified(node, throwable);
+                });
     }
 
     /** Outcome of checking one narrowing node against one selected notifier. */
@@ -110,8 +164,11 @@ public final class EventPropagationVerifier {
     public static @NotNull CompletableFuture<Result> conditionCanEmitThrough(
             final @NotNull OpcUaClient client, final @NotNull NodeId conditionNode, final @NotNull NodeId notifier) {
 
-        if (conditionNode.equals(notifier) || isRootNotifier(notifier)) {
+        if (conditionNode.equals(notifier)) {
             return CompletableFuture.completedFuture(new Result.Reachable());
+        }
+        if (isRootNotifier(notifier)) {
+            return presentInAddressSpace(client, conditionNode);
         }
 
         final BrowseDescription conditionSources = new BrowseDescription(
@@ -134,8 +191,13 @@ public final class EventPropagationVerifier {
     /** Checks a {@code SourceNode} operand against its selected notifier. */
     public static @NotNull CompletableFuture<Result> sourceCanEmitThrough(
             final @NotNull OpcUaClient client, final @NotNull NodeId sourceNode, final @NotNull NodeId notifier) {
-        if (isRootNotifier(notifier)) {
+        // Named ahead of the root check rather than left to walkUpwards' own frontier test, which would
+        // otherwise browse the Server object to establish that the Server object exists.
+        if (sourceNode.equals(notifier)) {
             return CompletableFuture.completedFuture(new Result.Reachable());
+        }
+        if (isRootNotifier(notifier)) {
+            return presentInAddressSpace(client, sourceNode);
         }
         return walkUpwards(client, List.of(sourceNode), notifier);
     }

--- a/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/config/tag/OpcuaConditionType.java
+++ b/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/config/tag/OpcuaConditionType.java
@@ -581,14 +581,40 @@ public enum OpcuaConditionType implements EventFieldSet {
 
     /**
      * Reads the type from configuration by its address-space name.
+     * <p>
+     * <b>Blank means unset</b>, and yields null so the field's documented default applies — no type predicate
+     * at all for {@code filterType}, {@code AlarmConditionType} for {@code type}. That is the same rule
+     * {@code OpcuaTagDefinition} already applied to the three narrowing <em>node id</em> fields through its
+     * {@code blankToNull}, and the same rule {@code EnumParsing} applies to the security config enums: blank
+     * or absent input means the setting resolves to its default.
+     * <p>
+     * It has to be decided here rather than in the constructor, which is where it looks like it belongs. The
+     * fields are typed as this enum, so Jackson has to produce an instance <em>before</em> the constructor is
+     * invoked — a {@code blankToNull} beside the other three would never run, and could not be written anyway
+     * since it would be handed an enum rather than the string.
+     * <p>
+     * Getting this wrong lost configuration silently. A blank string is what a UI form submits when a box is
+     * cleared and what a config generator emits for an unset optional; the throw failed the conversion of the
+     * whole adapter configuration, which leaves the running adapter untouched — so the write was accepted,
+     * nothing was reported, and the tag was simply absent when read back. Found by QA as EDG-894 P8.
      *
-     * @throws IllegalArgumentException when the name is not a standard condition type — a typo in the config
-     *                                  is reported rather than silently becoming some default.
+     * @throws IllegalArgumentException when a non-blank name is not a standard condition type. A typo is still
+     *                                  reported rather than silently becoming some default: unset resolves to
+     *                                  a usable default, and quietly treating {@code AlarmConditonType} as
+     *                                  unset would publish a different shape than was written.
      */
     @JsonCreator
-    public static @NotNull OpcuaConditionType fromConfig(final @Nullable String browseName) {
-        return fromBrowseName(browseName)
-                .orElseThrow(() -> new IllegalArgumentException("Unknown OPC UA condition type '" + browseName
+    public static @Nullable OpcuaConditionType fromConfig(final @Nullable String browseName) {
+        if (browseName == null || browseName.isBlank()) {
+            return null;
+        }
+        // Trimmed because surrounding whitespace is never part of a browse name, and because Jackson's own
+        // enum handling trims before matching -- so the two enums on this tag would otherwise disagree about
+        // " VALUE " versus " AlarmConditionType ". Case is not normalised: a browse name is a case-sensitive
+        // OPC UA identifier, and accepting a different casing would be a wider claim than this fix makes.
+        final String trimmed = browseName.trim();
+        return fromBrowseName(trimmed)
+                .orElseThrow(() -> new IllegalArgumentException("Unknown OPC UA condition type '" + trimmed
                         + "'. Known types: "
                         + Arrays.stream(values())
                                 .map(OpcuaConditionType::browseName)

--- a/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/config/tag/OpcuaTagDefinition.java
+++ b/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/config/tag/OpcuaTagDefinition.java
@@ -123,7 +123,17 @@ public class OpcuaTagDefinition implements TagDefinition {
         this.type = type == null ? OpcuaConditionType.ALARM_CONDITION : type;
     }
 
-    /** An omitted node id and one typed as whitespace mean the same thing: no narrowing on that dimension. */
+    /**
+     * An omitted node id and one typed as whitespace mean the same thing: no narrowing on that dimension.
+     * <p>
+     * The same rule holds for this tag's three <em>enum</em> fields — {@code kind}, {@code type} and
+     * {@code filterType} — but it cannot be applied here, and the asymmetry is worth explaining because this
+     * is where a reader will look for it. Those fields are typed as their enums, so Jackson must construct a
+     * value before this constructor is entered: a {@code blankToNull} call beside the three above would never
+     * run, and could not be written at all, since it would be handed an enum rather than the string the
+     * operator wrote. Blank is therefore decided in {@link OpcuaConditionType#fromConfig} and
+     * {@link OpcuaTagKind#fromConfig}, which return null for it so the defaults below apply.
+     */
     private static @Nullable String blankToNull(final @Nullable String value) {
         return value == null || value.isBlank() ? null : value;
     }

--- a/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/config/tag/OpcuaTagKind.java
+++ b/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/config/tag/OpcuaTagKind.java
@@ -15,6 +15,11 @@
  */
 package com.hivemq.edge.adapters.opcua.config.tag;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+import org.jetbrains.annotations.Nullable;
+
 /**
  * What kind of thing an OPC-UA tag points at.
  * <p>
@@ -65,5 +70,42 @@ public enum OpcuaTagKind {
      * A query against a notifier, delivering events from potentially many conditions beneath it.
      * Northbound only — there is no single target to write to.
      */
-    EVENT_SUBSCRIPTION
+    EVENT_SUBSCRIPTION;
+
+    /**
+     * Reads the kind from configuration, treating <b>blank as unset</b> so the documented default
+     * ({@link #VALUE}) applies.
+     * <p>
+     * The same rule and the same reason as {@link OpcuaConditionType#fromConfig} — a cleared UI field or an
+     * unset optional in a generator arrives as {@code "   "}, and failing on it lost the tag silently. Reached
+     * by a different route, which is why it needed its own fix: with no creator, Jackson's own coercion decided
+     * the question and refused with {@code "Cannot coerce empty String to OpcuaTagKind value"}, a message about
+     * Jackson's configuration rather than about the operator's.
+     * <p>
+     * Written as a creator rather than by enabling {@code CoercionConfig} on the mapper: the mapper is shared
+     * by every adapter's configuration, and blank-means-unset is true of this field rather than of every enum
+     * in the product.
+     *
+     * @throws IllegalArgumentException when a non-blank value names no kind. Unlike blank, that is a typo, and
+     *                                 a tag whose kind was mistyped must not silently become a plain value —
+     *                                 it would subscribe to an alarm node's Value attribute and publish
+     *                                 nothing.
+     */
+    @JsonCreator
+    public static @Nullable OpcuaTagKind fromConfig(final @Nullable String kind) {
+        if (kind == null || kind.isBlank()) {
+            return null;
+        }
+        // Trimmed to match what Jackson's default enum handling did before this creator took the decision over.
+        final String trimmed = kind.trim();
+        for (final OpcuaTagKind candidate : values()) {
+            if (candidate.name().equals(trimmed)) {
+                return candidate;
+            }
+        }
+        throw new IllegalArgumentException("Unknown OPC UA tag kind '"
+                + trimmed
+                + "'. Known kinds: "
+                + Arrays.stream(values()).map(Enum::name).collect(Collectors.joining(", ")));
+    }
 }

--- a/modules/hivemq-edge-module-opcua/src/test/java/com/hivemq/edge/adapters/opcua/condition/EventPropagationVerifierTest.java
+++ b/modules/hivemq-edge-module-opcua/src/test/java/com/hivemq/edge/adapters/opcua/condition/EventPropagationVerifierTest.java
@@ -30,6 +30,7 @@ import java.util.concurrent.CompletableFuture;
 import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
 import org.eclipse.milo.opcua.stack.core.NamespaceTable;
 import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
@@ -68,35 +69,78 @@ class EventPropagationVerifierTest {
      * or permission-filtered address space it would browse a clean zero-parent answer, conclude the source
      * is outside the hierarchy, and drop a tag that would have published.
      * <p>
-     * {@code verifyNoInteractions} is the assertion that matters: the answer must come from the
-     * specification, not from whatever the address space happens to model.
+     * The narrowing node here exists and has no modelled ancestry at all — precisely the shape that used to
+     * produce a confident {@code OutsideHierarchy}.
      */
     @Test
     void theServerObjectCarriesEverythingSoNothingIsOutsideIt() {
-        final OpcUaClient client = mock(OpcUaClient.class);
+        final OpcUaClient client = client(Map.of(NODE, List.of()), Map.of(), Set.of(), Set.of());
 
         assertThat(EventPropagationVerifier.sourceCanEmitThrough(client, NODE, NodeIds.Server)
                         .join())
                 .isEqualTo(new EventPropagationVerifier.Result.Reachable());
         assertThat(EventPropagationVerifier.conditionCanEmitThrough(client, NODE, NodeIds.Server)
+                        .join())
+                .isEqualTo(new EventPropagationVerifier.Result.Reachable());
+    }
+
+    /** A narrowing node that is the Server object itself needs no browse to settle either question. */
+    @Test
+    void andTheServerObjectNarrowedByItselfIsSettledWithoutAskingTheServer() {
+        final OpcUaClient client = mock(OpcUaClient.class);
+
+        assertThat(EventPropagationVerifier.sourceCanEmitThrough(client, NodeIds.Server, NodeIds.Server)
+                        .join())
+                .isEqualTo(new EventPropagationVerifier.Result.Reachable());
+        assertThat(EventPropagationVerifier.conditionCanEmitThrough(client, NodeIds.Server, NodeIds.Server)
                         .join())
                 .isEqualTo(new EventPropagationVerifier.Result.Reachable());
         verifyNoInteractions(client);
     }
 
+    /**
+     * EDG-894 P6: exempting the Server object from the <em>hierarchy</em> question must not exempt the
+     * narrowing node from existing.
+     * <p>
+     * §8.3.2 promises that every event of the server is accessible at the Server object. It promises nothing
+     * about a node id the operator typed, so a query tag rooted at Server narrowed by a node the server does
+     * not hold used to be accepted with nothing looked at — subscribing cleanly to a where clause that can
+     * never match, silent for the life of the adapter. The answer is {@code Unverified} rather than
+     * {@code OutsideHierarchy} because OPC 10000-9 §4.3 lets a server hide its condition instances, so the
+     * tag must still subscribe; what it must not do is subscribe without saying so.
+     */
     @Test
-    void andThatHoldsEvenWhenTheServerModelsNoAncestryAtAll() {
-        // The same case driven through a real browse fixture rather than an unstubbed mock: the node exists,
-        // the browse succeeds, and it returns no parents. That is precisely the shape that used to produce a
-        // confident OutsideHierarchy, so it is worth pinning separately from the short-circuit above.
-        final OpcUaClient client = client(Map.of(NODE, List.of()), Map.of(), Set.of());
+    void butANarrowingNodeTheServerDoesNotHoldIsNamedRatherThanSilentlyAccepted() {
+        final OpcUaClient client = client(Map.of(), Map.of(), Set.of(), Set.of(NODE));
 
         assertThat(EventPropagationVerifier.sourceCanEmitThrough(client, NODE, NodeIds.Server)
                         .join())
-                .isEqualTo(new EventPropagationVerifier.Result.Reachable());
+                .asInstanceOf(org.assertj.core.api.InstanceOfAssertFactories.type(
+                        EventPropagationVerifier.Result.Unverified.class))
+                .satisfies(unverified -> assertThat(unverified.reason())
+                        .contains("does not expose")
+                        .contains("ns=2;s=Node")
+                        .contains("nothing can be confirmed to match this predicate"));
         assertThat(EventPropagationVerifier.conditionCanEmitThrough(client, NODE, NodeIds.Server)
                         .join())
-                .isEqualTo(new EventPropagationVerifier.Result.Reachable());
+                .asInstanceOf(org.assertj.core.api.InstanceOfAssertFactories.type(
+                        EventPropagationVerifier.Result.Unverified.class))
+                .satisfies(unverified -> assertThat(unverified.reason())
+                        .contains("does not expose")
+                        .contains("ns=2;s=Node"));
+    }
+
+    /** A browse that fails for any other reason under the root notifier is uncertainty, not a clean answer. */
+    @Test
+    void andABrowseThatCouldNotSettleItUnderTheRootNotifierIsUncertaintyToo() {
+        final OpcUaClient client = client(Map.of(), Map.of(), Set.of(NODE), Set.of());
+
+        assertThat(EventPropagationVerifier.sourceCanEmitThrough(client, NODE, NodeIds.Server)
+                        .join())
+                .asInstanceOf(org.assertj.core.api.InstanceOfAssertFactories.type(
+                        EventPropagationVerifier.Result.Unverified.class))
+                .satisfies(unverified ->
+                        assertThat(unverified.reason()).contains("ns=2;s=Node").contains("browse denied"));
     }
 
     @Test
@@ -168,11 +212,29 @@ class EventPropagationVerifierTest {
             final @NotNull Map<NodeId, List<NodeId>> parents,
             final @NotNull Map<NodeId, List<NodeId>> conditionSources,
             final @NotNull Set<NodeId> failedEventSourceBrowses) {
+        return client(parents, conditionSources, failedEventSourceBrowses, Set.of());
+    }
+
+    /**
+     * @param absentNodes nodes the server answers {@code Bad_NodeIdUnknown} about — the one browse outcome
+     *     that is a statement about the address space rather than about the connection.
+     */
+    private static @NotNull OpcUaClient client(
+            final @NotNull Map<NodeId, List<NodeId>> parents,
+            final @NotNull Map<NodeId, List<NodeId>> conditionSources,
+            final @NotNull Set<NodeId> failedEventSourceBrowses,
+            final @NotNull Set<NodeId> absentNodes) {
         final OpcUaClient client = mock(OpcUaClient.class);
         when(client.getNamespaceTable()).thenReturn(new NamespaceTable());
         when(client.browseAsync(any(BrowseDescription.class))).thenAnswer(invocation -> {
             final BrowseDescription browse = invocation.getArgument(0);
             final NodeId node = browse.getNodeId();
+            if (absentNodes.contains(node)) {
+                return CompletableFuture.completedFuture(new BrowseResult(
+                        new StatusCode(StatusCodes.Bad_NodeIdUnknown),
+                        ByteString.NULL_VALUE,
+                        new ReferenceDescription[0]));
+            }
             final boolean eventSource = NodeIds.HasEventSource.equals(browse.getReferenceTypeId());
             if (eventSource && failedEventSourceBrowses.contains(node)) {
                 return CompletableFuture.failedFuture(new IllegalStateException("browse denied"));

--- a/modules/hivemq-edge-module-opcua/src/test/java/com/hivemq/edge/adapters/opcua/config/tag/OpcuaTagDefinitionTest.java
+++ b/modules/hivemq-edge-module-opcua/src/test/java/com/hivemq/edge/adapters/opcua/config/tag/OpcuaTagDefinitionTest.java
@@ -107,4 +107,102 @@ class OpcuaTagDefinitionTest {
         assertThatThrownBy(() -> mapper.readValue("{\"type\":\"CONDITION\"}", OpcuaTagDefinition.class))
                 .isInstanceOf(Exception.class);
     }
+
+    // ── blank means unset, on every optional field (EDG-894 P8) ─────────────────────────────────────
+
+    /**
+     * The three node-id fields have always read blank as "no narrowing", through {@code blankToNull}. The three
+     * enum fields did not, and refused the tag instead — and because that refusal happens while converting the
+     * adapter's configuration, the running adapter was left untouched: the write was accepted, nothing was
+     * reported, and the tag was absent on read-back. A blank string is exactly what a cleared UI field and an
+     * unset optional in a config generator produce, so this was the ordinary path rather than an odd one.
+     */
+    @Test
+    void whenFilterTypeIsBlank_thenThereIsNoTypePredicate() throws Exception {
+        // The finding verbatim: a query tag whose filter box was cleared.
+        final OpcuaTagDefinition definition = mapper.readValue(
+                "{\"node\":\"ns=1;i=9100\",\"kind\":\"EVENT_SUBSCRIPTION\",\"filterType\":\"   \"}",
+                OpcuaTagDefinition.class);
+
+        assertThat(definition.getFilterType())
+                .as("a blank filterType is the documented 'every event type the notifier carries'")
+                .isNull();
+        assertThat(definition.getKind()).isEqualTo(OpcuaTagKind.EVENT_SUBSCRIPTION);
+    }
+
+    @Test
+    void andAnEmptyFilterTypeMeansTheSame() throws Exception {
+        assertThat(mapper.readValue("{\"node\":\"ns=1;i=9100\",\"filterType\":\"\"}", OpcuaTagDefinition.class)
+                        .getFilterType())
+                .isNull();
+    }
+
+    @Test
+    void whenTheNodeTypeIsBlank_thenItFallsBackToItsDocumentedDefault() throws Exception {
+        // The same defect on the sibling field, which the finding did not name: `type` reaches the same creator,
+        // so a cleared type box refused the tag too. Absent already meant AlarmConditionType, and blank now
+        // agrees with absent.
+        for (final String blank : new String[] {"\"   \"", "\"\"", "null"}) {
+            assertThat(mapper.readValue("{\"node\":\"ns=1;i=1\",\"type\":" + blank + "}", OpcuaTagDefinition.class)
+                            .getType())
+                    .as("type=%s must mean unset, like an omitted type", blank)
+                    .isEqualTo(OpcuaConditionType.ALARM_CONDITION);
+        }
+    }
+
+    @Test
+    void whenTheKindIsBlank_thenTheTagIsAValue() throws Exception {
+        // And the third, which failed by a different route -- no creator at all, so Jackson's own coercion
+        // refused with "Cannot coerce empty String to OpcuaTagKind value". Worth its own case because `kind`
+        // decides what the tag is: a silently dropped kind is a dropped tag.
+        for (final String blank : new String[] {"\"   \"", "\"\"", "null"}) {
+            assertThat(mapper.readValue("{\"node\":\"ns=1;i=1\",\"kind\":" + blank + "}", OpcuaTagDefinition.class)
+                            .getKind())
+                    .as("kind=%s must mean unset, like an omitted kind", blank)
+                    .isEqualTo(OpcuaTagKind.VALUE);
+        }
+    }
+
+    @Test
+    void whenEveryOptionalFieldIsBlank_thenTheTagEqualsOneThatOmitsThemAll() throws Exception {
+        // The round-trip the finding asks for, over all six optional fields at once: this is the document a UI
+        // submits when nothing optional was filled in, and it must mean the same as the minimal document.
+        final OpcuaTagDefinition allBlank = mapper.readValue("""
+                {"node":"ns=1;i=1","kind":"  ","type":"  ","notifierNode":"  ",
+                 "sourceNode":"  ","conditionNode":"  ","filterType":"  "}
+                """, OpcuaTagDefinition.class);
+        final OpcuaTagDefinition allOmitted = mapper.readValue("{\"node\":\"ns=1;i=1\"}", OpcuaTagDefinition.class);
+
+        assertThat(allBlank).isEqualTo(allOmitted);
+    }
+
+    @Test
+    void butANonBlankValueThatNamesNothingIsStillRefused() throws Exception {
+        // Blank-tolerance must not become anything-tolerance. A typo is a different thing from an empty box: an
+        // unset field resolves to a usable default, so quietly treating 'AlarmConditonType' as unset would
+        // publish a different shape than was written, and a mistyped kind would subscribe to an alarm node's
+        // Value attribute and publish nothing at all.
+        assertThatThrownBy(() -> mapper.readValue(
+                        "{\"node\":\"ns=1;i=1\",\"filterType\":\"AlarmConditonType\"}", OpcuaTagDefinition.class))
+                .hasMessageContaining("AlarmConditonType")
+                .hasMessageContaining("AlarmConditionType");
+        assertThatThrownBy(() ->
+                        mapper.readValue("{\"node\":\"ns=1;i=1\",\"kind\":\"CONDTION\"}", OpcuaTagDefinition.class))
+                .hasMessageContaining("CONDTION")
+                .hasMessageContaining("EVENT_SUBSCRIPTION");
+    }
+
+    @Test
+    void andSurroundingWhitespaceDoesNotHideAValidValue() throws Exception {
+        // Jackson trimmed before matching an enum, so taking that decision over in a creator had to keep it --
+        // otherwise adding the creator to `kind` would have turned " VALUE " from working into a dropped tag.
+        assertThat(mapper.readValue("{\"node\":\"ns=1;i=1\",\"kind\":\" CONDITION \"}", OpcuaTagDefinition.class)
+                        .getKind())
+                .isEqualTo(OpcuaTagKind.CONDITION);
+        assertThat(mapper.readValue(
+                                "{\"node\":\"ns=1;i=1\",\"type\":\" ExclusiveLevelAlarmType \"}",
+                                OpcuaTagDefinition.class)
+                        .getType())
+                .isEqualTo(OpcuaConditionType.EXCLUSIVE_LEVEL_ALARM);
+    }
 }


### PR DESCRIPTION
Three QA findings from the [EDG-889](https://linear.app/hivemq/issue/EDG-889) test pass against [EDG-835](https://linear.app/hivemq/issue/EDG-835/implement-opc-ua-alarms-and-conditions-support-in-edge), raised by @estefaniaamundaray on [EDG-894](https://linear.app/hivemq/issue/EDG-894).

**Split out of #1716.** These three previously sat stacked on top of the nullable-`comment` fix. That PR now carries only its own commit, so each fix can be reviewed and land on its own. The commits here are byte-identical to what QA tested as `8a75a6538`, `7197513ae` and `917525e1d`; only the parent chain changed.

**A fourth finding (P4a) was on that stack and is not here.** Advertising per-method required arguments in the southbound schema needed a new member on the adapter SDK's public `ObjectSchema`, and that surface is versioned separately and consumed by third-party adapter authors — not a change to make under release pressure for a Low-severity discoverability gap. hivemq/hivemq-edge-adapter-sdk#142 is closed and [EDG-906](https://linear.app/hivemq/issue/EDG-906) stays open. The behaviour was never wrong: a command missing a method-specific argument is refused, naming the method and the field.

---

## P8 — a blank tag enum drops the tag instead of refusing it

`OpcuaTagDefinition` normalised its three narrowing node-id fields with `blankToNull` and its three enum fields not at all. So `"filterType": "   "` matched no constant, the tag failed to deserialise, and it was **dropped rather than refused** — the write was accepted, nothing was reported, and the tag was simply absent on read-back, because the throw fails conversion of the whole adapter configuration and that leaves the running adapter untouched.

A blank string is what a UI form submits when a box is cleared and what a config generator emits for an unset optional, so this is the ordinary path rather than an odd one.

**The fix is not where the finding puts it.** It proposes `blankToNull(filterType)` beside the other three, which cannot compile — the field is typed as the enum, not as a `String` — and would not run in time if it could, since Jackson constructs the enum before the constructor is entered. Blank is therefore decided in the creators.

A probe found the same defect on two fields the finding does not name:

| Field | `"   "` / `""` before |
|---|---|
| `filterType` | threw (reported) |
| `type` | threw — same creator; absent already meant `AlarmConditionType` |
| `kind` | threw via Jackson's own coercion with no creator at all: `Cannot coerce empty String to OpcuaTagKind value` — a message about Jackson's configuration rather than the operator's mistake |

`kind` is the worst of the three, because it decides what the tag is.

Blank now yields `null` in `OpcuaConditionType.fromConfig` and in a new `OpcuaTagKind.fromConfig`, so each field falls back to the default its own documentation already promises. This is the doctrine `EnumParsing` states one package over for the security config enums: blank or absent means unset, an unrecognised non-blank value is a configuration error and is rejected. **The rejection is kept deliberately** — unset resolves to a usable default, so quietly reading `AlarmConditonType` as unset would publish a different shape than was written, and a mistyped `kind` would subscribe to an alarm node's `Value` attribute and publish nothing.

Both creators trim, because Jackson's default enum handling trimmed before a creator took the decision over; without it, adding one to `kind` would have turned `" CONDITION "` from working into a dropped tag.

Checked rather than assumed: adding `@JsonCreator` to `OpcuaTagKind` does not change how the generated tag config schema renders it — still all four constants with default `VALUE`, and `type` still lists 22. EDG-899's generator keys on `@JsonValue`, which is not added here.

## P7 — `getSchema` could not say why a schema failed

The endpoint answered 500 whose entire body was `Json schema creation for tag failed.` for an ordinary `VALUE` tag. That sentence is the fixed message `TagSchemaCreationOutputImpl.fail(String)` completes its future with; the adapter's own account is recorded separately, on the output, and this layer read only the cause and discarded it. **Every** schema failure in the OPC UA adapter takes that route, so the endpoint could not explain any of them.

The cost was not only cosmetic. QA could not tell whether the fault was in schema generation or in the `direction` parameter that had just arrived with EDG-845, and reported it as a possible compatibility break for every pre-split API client. The adapter had in fact said `Discovery failed: ClientConnection not connected or not initialized`, and nothing carried that to the caller.

The reason is now preferred with the cause kept as fallback: `fail(Throwable, null)` leaves no message on the output, and there the throwable is the only account there is.

**On the rest of P7, which is not changed here.** The finding offers "if NORTHBOUND succeeds, the defect is the default direction". It cannot: an absent direction resolves to `NORTHBOUND`, the same enum value through the same call, and `createTagSchema` runs and fails before the direction is consulted at all. A test pins that the two answers are identical on both the success and the failure path, so **this is not an EDG-845 compatibility break**. What remains is that `conn.client()` is empty until the connection context is set at the end of `start()` while monitored items are created earlier — the known "nothing correct to wait on" gap rather than a new defect.

The status code is left alone. 500 is what this resource does for "the adapter is not usable yet" — `discoverDataPoints` does the same with an even less informative message — so answering 503 with `Retry-After` is an API contract decision rather than a bug fix.

## P6 — a narrowing node under the root notifier was never looked at

`f480b2f94` exempted the Server object from the propagation walk, and that exemption is right: OPC 10000-5 §8.3.2 makes every event of the server accessible at the Server object, which renders `OutsideHierarchy` unreachable there by definition.

But the walk was answering **two** questions. Alongside "does this node's event path reach the selected notifier" it incidentally answered "is this node something the server has", because a node the server does not hold produces a browse failure rather than a clean negative. Short-circuiting dropped both, and §8.3.2 licenses dropping only the first.

So a query tag rooted at the Server object — the natural choice for a plant-wide subscription — narrowed by a typo or a stale id from a migrated configuration was accepted without anything being looked at. It subscribes cleanly, its where clause matches nothing, and it stays silent for the life of the adapter. That is indistinguishable from a quiet plant, which is the outcome everyone hopes for, so nobody investigates.

`presentInAddressSpace` makes the same inverse `HasEventSource` browse the walk's first hop makes, so a server that permits one permits the other. What is read from it differs: not who the parents are, which under the root notifier is settled, but whether the server answered about this node at all.

**The answer is `Unverified`, never `OutsideHierarchy`.** OPC 10000-9 §4.3 permits a server to keep condition instances out of the address space entirely and deliver them through events alone, with §5.7.3 requiring the ConditionId be accepted regardless — so a missing node may be a working configuration. `Unverified` keeps the tag subscribed, which is the whole of review-09 finding 4 and must not be undone, while routing through `reportUnverifiedTag` so the operator is told which tag, which field and which node id.

**Not fixed here, deliberately:** the check is existence only. A narrowing node that exists and is a plain `Variable` — which no event can ever match — still subscribes silently, because `NodeClass` is never read. The caution above is sound for absence and does not extend to a node the server has positively described as a Variable, but that is a separate change, filed as [EDG-908](https://linear.app/hivemq/issue/EDG-908).

---

## Verification

Run on this branch's tree, rebased onto `2de6b49eb`, since these three had only ever been tested stacked on the now-discarded P4a work:

- `./gradlew :hivemq-edge-build:hivemq-edge-module-opcua:check` — **BUILD SUCCESSFUL**
- `./gradlew :hivemq-edge-build:hivemq-edge:test --tests '*ProtocolAdaptersResourceImplTest*'` — **BUILD SUCCESSFUL**
- `./gradlew :hivemq-edge-build:hivemq-edge:spotlessCheck` — clean
- `OpcuaTagDefinitionTest` 15, `EventPropagationVerifierTest` 9, `ProtocolAdaptersResourceImplTest` 34 — **58 tests, 0 failures**
- `hivemq-edge:compileTestJava` compiles without the adapter-SDK `requiredWhen` API, confirming nothing here depends on the discarded SDK change

## For QA

[EDG-908](https://linear.app/hivemq/issue/EDG-908) records its suite state (48 green / 3 red / 13 skipped) against `917525e1d` + adapter-SDK `a5bcd8a`, a stack that no longer exists. The red **count** should hold but not its composition — anything that was green because of P4a will now fail. Worth a re-run against this head and #1716's rather than trusting those numbers.

---

## Also here: a CI build-cache workaround (`a76baf28c`)

Unrelated to the three findings, carried on this branch so the Jenkins `edge-composite` job can go green. `cyclonedxDirectBom` is declared non-cacheable so it re-executes rather than being restored from a cache entry.

It sits in `VersionUpdaterPlugin` — a plugin otherwise only about version bumping — because the task is registered per-project by `com.hivemq.tools.license` across **17 projects in 6 repositories**, and is absent from `hivemq-edge-composite`, so there is no single build script for it. Of the six `com.hivemq.*` convention plugins, `edge-version-updater` is the only one all 17 apply (`repository-convention` and `jacoco-convention` miss four, `errorprone`/`nullaway` three, `spotless` two). The `plugins.withId` guard keeps it inert where the license plugin is absent.

Verified against a populated cache: without the change `cyclonedxDirectBom` returns **FROM-CACHE**; with it the task executes and regenerates `bom.json`/`bom.xml`. Coverage spot-checked on `hivemq-edge-module-databases` and `hivemq-edge-adapter-sdk`, two of the four `repository-convention` would have missed.

**Remove once the underlying caching issue is fixed** — a permanently non-cacheable SBOM task costs time on every CI run.
