### PR TITLE
Fix the frontend Snyk monitor: --all-projects cannot be combined with --project-name

### DIFF
--- a/.github/workflows/snyk-push.yml
+++ b/.github/workflows/snyk-push.yml
@@ -52,10 +52,20 @@ jobs:
         with:
           node-version: '24.16.0'
 
+      # Snyk only needs pnpm-lock.yaml (overrides are already resolved into it). When a
+      # pnpm-workspace.yaml sits next to the lockfile, the Snyk pnpm plugin treats the dir
+      # as a workspace and refuses to scan unless --all-projects is passed, but that flag
+      # cannot be combined with --project-name (SNYK-CLI-0004), and --project-name is what
+      # names this project in the Snyk dashboard. Removing the (settings-only) workspace
+      # file from this throwaway CI checkout lets Snyk auto-detect the single pnpm project
+      # again. Same treatment as snyk-pr.yml.
+      - name: Hide pnpm-workspace.yaml from the Snyk pnpm scan
+        run: rm -f hivemq-edge/hivemq-edge-frontend/pnpm-workspace.yaml
+
       - name: Run Snyk Frontend monitor
         shell: bash
         run: >
-          snyk monitor --all-projects --target-reference=${{ steps.select_github_ref.outputs.selected_github_ref }} --org=hivemq-edge
+          snyk monitor --target-reference=${{ steps.select_github_ref.outputs.selected_github_ref }} --org=hivemq-edge
           --project-name=hivemq-edge-frontend --remote-repo-url=hivemq-edge-frontend --project-lifecycle=development -d
           hivemq-edge/hivemq-edge-frontend
         env:

--- a/.github/workflows/snyk-release.yml
+++ b/.github/workflows/snyk-release.yml
@@ -37,9 +37,19 @@ jobs:
         with:
           node-version: '24.16.0'
 
+      # Snyk only needs pnpm-lock.yaml (overrides are already resolved into it). When a
+      # pnpm-workspace.yaml sits next to the lockfile, the Snyk pnpm plugin treats the dir
+      # as a workspace and refuses to scan unless --all-projects is passed, but that flag
+      # cannot be combined with --project-name (SNYK-CLI-0004), and --project-name is what
+      # names this project in the Snyk dashboard. Removing the (settings-only) workspace
+      # file from this throwaway CI checkout lets Snyk auto-detect the single pnpm project
+      # again. Same treatment as snyk-pr.yml.
+      - name: Hide pnpm-workspace.yaml from the Snyk pnpm scan
+        run: rm -f hivemq-edge/hivemq-edge-frontend/pnpm-workspace.yaml
+
       - name: Run Snyk Frontend monitor
         shell: bash
-        run: snyk monitor --all-projects --target-reference=${{ github.ref_name }} --org=hivemq-releases --project-name=hivemq-edge-frontend --remote-repo-url=hivemq-edge-frontend --project-lifecycle=production -d hivemq-edge/hivemq-edge-frontend
+        run: snyk monitor --target-reference=${{ github.ref_name }} --org=hivemq-releases --project-name=hivemq-edge-frontend --remote-repo-url=hivemq-edge-frontend --project-lifecycle=production -d hivemq-edge/hivemq-edge-frontend
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.JENKINS_GITHUB_TOKEN }}


### PR DESCRIPTION
## Problem

The frontend Snyk monitor has been dead in both non-PR workflows.

`Run Snyk monitor on push` fails on **every** commit to master — the last eight runs are all red, most recently
[run 32457405971](https://github.com/hivemq/hivemq-edge/actions/runs/32457405971/job/96697249445). `Run Snyk monitor on
releases` fails identically: last green was **2026.9** (2026-05-27), and **2026.10, 2026.11, 2026.12 and 2026.13** all
failed, so four releases shipped with no frontend dependency tree registered in Snyk.

In both workflows the backend monitor succeeds and only the frontend step dies, with:

```
FATAL   Invalid flag option (SNYK-CLI-0004)
        The following option combination is not currently supported: project-name + all-projects
exit code 2
```

`--all-projects` produces N projects, so a single `--project-name` has no meaning, and Snyk CLI 1.1306.4 rejects the
pair outright. Nothing in this repo changed those flags — the last commit to `snyk-push.yml` was a renovate action bump
— so this is a CLI-side behaviour change, which matches the timeline: the release monitor went red between 2026-05-27
and 2026-06-16 with no workflow edit in between.

## Solution

Drop `--all-projects` from the frontend monitor in `snyk-push.yml` and `snyk-release.yml`, and delete
`pnpm-workspace.yaml` from the throwaway CI checkout before the scan so the Snyk pnpm plugin auto-detects a single
project again.

This is exactly what `snyk-pr.yml` already does (`Hide pnpm-workspace.yaml from the Snyk pnpm scan`, added when the PR
workflow hit the same pnpm-workspace detection problem from the other direction).

## This also unblocks the PR security gate

`Check for new issues (hivemq-edge-frontend)` currently fails on **every** open PR — EDG-920, EDG-882, EDG-911,
PLT-1577 and this one — with six high-severity `browserslist` findings reported as newly introduced:

```
New issues introduced !
1/6: SNYK-JS-BROWSERSLIST-18854715  Prototype Pollution [High, 8.7]
     Via: @sentry/vite-plugin@5.4.0 => @sentry/bundler-plugins@10.69.0 => webpack => browserslist@4.28.6
```

That is a downstream symptom of the same bug. `snyk-delta` measures a PR against the baseline project in Snyk, and that
baseline is refreshed by the `snyk monitor` run on master push — the step that has been dead since June. The baseline
therefore still holds the 2026-05-27 dependency snapshot, and both flagged packages reached master after it:

| package | entered `pnpm-lock.yaml` | commit |
| --- | --- | --- |
| `browserslist@4.28.6` | 2026-07-12 | `99a665f68` |
| `@sentry/vite-plugin@5.4.0` | 2026-08-10 | `d17a0de00` |

The baseline never saw either version, so when the `browserslist` advisories were published they showed up only on the
PR side of the diff and read as "introduced by this PR", whatever the PR actually changes. The broken monitor is not
only a missing dashboard entry: it has been quietly poisoning the PR gate for two months.

This is inference, not a Snyk API reading — I have no token to query the baseline project's snapshot date. The
competing explanation is that these are genuine new vulnerabilities on master needing a `@sentry/vite-plugin` bump.
Merging separates the two: if the gate goes green on the next PR once master's baseline refreshes, the stale baseline
is confirmed; if it stays red, the remediation is a real dependency bump and belongs in its own ticket.

## Why this shape

The conflict can be resolved from either side. Removing `--project-name` would be the smaller diff and the wrong fix:
for `snyk monitor` that flag is the project's name in the Snyk dashboard. Dropping it would rename and re-split the
tracked `hivemq-edge-frontend` project and orphan its issue history, so the conflict is resolved from the
`--all-projects` side instead.

Removing `pnpm-workspace.yaml` does not change what is scanned. It carries no `packages:` key — only `minimumReleaseAge`,
`allowBuilds` and `overrides` — and the overrides are already resolved into `pnpm-lock.yaml`, which is the file Snyk
actually reads. The step runs after the backend Gradle scan and no install or build follows it, so nothing else in the
job sees the modified checkout.

`snyk-pr.yml` is untouched; it never passed `--all-projects` and was never broken.

## Verification

**No check on this PR can validate the change.** `snyk-push.yml` triggers on push to `master**` and `snyk-release.yml`
on published releases, so neither runs against a PR branch.

So it was verified out of band. This exact commit was pushed to a throwaway `master**` branch, which fires
`snyk-push.yml` for real — real runner, real `SNYK_TOKEN`, same CLI 1.1306.4 that was rejecting the flag pair.
[Run 32467330019](https://github.com/hivemq/hivemq-edge/actions/runs/32467330019) is **green on every step**, and the
frontend monitor did the work rather than merely exiting 0:

```
Run rm -f hivemq-edge/hivemq-edge-frontend/pnpm-workspace.yaml
snyk sending request to: https://api.snyk.io/v1/monitor/pnpm/graph
Monitoring hivemq-edge/hivemq-edge-frontend (hivemq-edge-frontend)...
Explore this snapshot at https://app.snyk.io/org/hivemq-edge/project/e040b4df-2240-4de2-a90f-0d8bcbbe118a/...
```

One project, one snapshot, `"status":"success"` with `"errors":[]`, and `--project-name` accepted and carried through.
The backend monitor step is green in the same run. That snapshot is the first time the frontend dependency tree has
been registered in Snyk since 2026-05-27; it lands under the throwaway branch's target reference, alongside master's
rather than replacing it.

YAML parses and step ordering is as intended in both files.

Both red checks on this PR are pre-existing and repo-wide, neither caused by this change:
`scan-for-new-issues` is the `browserslist` failure described above, red on every open PR, and
`check-frontend / SonarQube` has been failing since ~2026-08-18 on a SonarCloud token that no longer authorizes
analysis — it runs here only because every path filter in `check.yml` includes `.github/**`.
