### PR TITLE
EDG-924: Exclude the Chakra UI v3 cluster from Renovate updates

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -12,4 +12,36 @@
     addLabels: [
         'edge-team',
     ],
+    packageRules: [
+        {
+            description: 'Chakra UI v3 is a rewrite with no upgrade path for this frontend - 117 of the 201 Chakra symbols we use are gone, across 274 files, and the codemods close less than a third of the gap. @chakra-ui/{anatomy,icons,radio,skip-nav,theme-tools,utils} have no v3 release at all. Deferred to a dedicated migration, see EDG-827',
+            matchManagers: [
+                'npm',
+            ],
+            matchPackageNames: [
+                '@chakra-ui/**',
+            ],
+            allowedVersions: '<3',
+        },
+        {
+            description: 'chakra-react-select v6 peers on @chakra-ui/react 3.x - blocked by the Chakra UI v3 decision above. v5 still peers on 2.x and stays available',
+            matchManagers: [
+                'npm',
+            ],
+            matchPackageNames: [
+                'chakra-react-select',
+            ],
+            allowedVersions: '<6',
+        },
+        {
+            description: '@rjsf/chakra-ui v6 peers on @chakra-ui/react >=3.16.1 and chakra-react-select >=6 - blocked by the Chakra UI v3 decision above. The @rjsf packages must move as a set, so the whole scope is held at v5',
+            matchManagers: [
+                'npm',
+            ],
+            matchPackageNames: [
+                '@rjsf/**',
+            ],
+            allowedVersions: '<6',
+        },
+    ],
 }


### PR DESCRIPTION
Closes the recurring Chakra UI v3 Renovate PRs by encoding the decision in `renovate.json5` instead of re-litigating it on every run.

## Why

`@chakra-ui/react` 3.x is a rewrite, and #1640 is a bare version bump with no migration — the production build fails with **487 `MISSING_EXPORT` errors** (`extendTheme`, `useToast`, `DrawerCloseButton`, `DrawerOverlay`, …). This matches the analysis recorded in EDG-827:

- **117 of the 201** Chakra symbols this codebase uses no longer exist in v3, across **274 files**
- v3 alone produces **1810** errors; running all 60 `@chakra-ui/codemod` transforms only gets to **1217**
- **100% of those errors are in our own source**, so no dependency bump can close the gap
- `@chakra-ui/{anatomy,icons,radio,skip-nav,theme-tools,utils}` have no v3 release at all

A v3 migration stays possible on its own merits — it is just not a Renovate PR.

## What changed

Three `packageRules`, each carrying a `description` explaining the block:

| matchPackageNames | allowedVersions | Closes |
| -- | -- | -- |
| `@chakra-ui/**` | `<3` | #1640 |
| `chakra-react-select` | `<6` | #1653 |
| `@rjsf/**` | `<6` | #1697 |

All three had to move together: `chakra-react-select@6` peers on `@chakra-ui/react: 3.x`, and `@rjsf/chakra-ui@6` peers on `@chakra-ui/react >=3.16.1` **and** `chakra-react-select >=6` (the `@rjsf/*` packages must move as a set). Blocking only Chakra would leave the other two regenerating forever.

`allowedVersions` is used rather than disabling majors, so v2 minor/patch updates keep flowing and `chakra-react-select` v5 — still Chakra-2 peered — stays available as a legitimate upgrade.

## Verification

- `renovate-config-validator` passes
- Globs checked against minimatch: all intended packages match; `@emotion/react` and `framer-motion` are correctly untouched

## Note

This deliberately stays repo-scoped and must **not** move into `hivemq/renovate-config:default.json5` — the Pulse frontend is already on `@chakra-ui/react ^3.32.0` + `@rjsf/* 6.2.5`, and a shared-preset rule would pin it backwards.

The matching change for `hivemq-edge-adapter-sdk` is in hivemq/hivemq-edge-adapter-sdk#144.