### PR TITLE
EDG-929: Release Edge resources on shutdown instead of leaking them

### DIFF
--- a/hivemq-edge/src/main/java/com/hivemq/HiveMQEdgeMain.java
+++ b/hivemq-edge/src/main/java/com/hivemq/HiveMQEdgeMain.java
@@ -138,6 +138,15 @@ public class HiveMQEdgeMain {
     protected void stopApiServer() {
         if (jaxrsServer != null) {
             jaxrsServer.stopServer();
+            // Drop the reference, not just the listener. stopServer() closes the HTTP endpoint but the field
+            // still points at the whole JAX-RS graph -- the HK2 injection registry, the routing tables and the
+            // provider chain -- and this object is reachable from the starting thread. In a JVM that starts and
+            // stops an embedded Edge repeatedly that retains one full REST stack per instance; a heap dump of
+            // one test JVM traced its largest retained set along
+            // HiveMQEdgeMain.jaxrsServer -> JaxrsHttpServer -> JaxrsProviders -> ..., with 1603 accumulated
+            // ApiAuthenticationFeature$AuthenticationFilter instances. startGateway() always calls
+            // initializeApiServer() before startApiServer(), so a null field is re-populated on restart.
+            jaxrsServer = null;
         }
     }
 

--- a/hivemq-edge/src/main/java/com/hivemq/bootstrap/factories/DataCombiningTransformationServiceFactory.java
+++ b/hivemq-edge/src/main/java/com/hivemq/bootstrap/factories/DataCombiningTransformationServiceFactory.java
@@ -17,12 +17,41 @@ package com.hivemq.bootstrap.factories;
 
 import com.codahale.metrics.MetricRegistry;
 import com.hivemq.combining.mapping.DataCombiningTransformationService;
+import com.hivemq.common.shutdown.ShutdownHooks;
 import com.hivemq.mqtt.services.PrePublishProcessorService;
 import org.jetbrains.annotations.NotNull;
 
 public interface DataCombiningTransformationServiceFactory {
+
+    /**
+     * @deprecated implement {@link #build(PrePublishProcessorService, MetricRegistry, ShutdownHooks)} instead,
+     *         so the service can release whatever it holds when Edge shuts down. Retained because modules
+     *         compiled against the older interface implement only this method.
+     */
+    @Deprecated
     @NotNull
     DataCombiningTransformationService build(
             final @NotNull PrePublishProcessorService prePublishProcessorService,
             final @NotNull MetricRegistry metricRegistry);
+
+    /**
+     * Builds the service and gives the module a chance to register its own cleanup.
+     * <p>
+     * A module that holds resources -- the Data Hub implementation owns a script runtime whose JavaScript
+     * engine pools each run a guard daemon thread -- registers a shutdown hook here. Leaving that to the
+     * module keeps <i>what</i> to release opaque to Edge: the core only learns that something wants to run at
+     * shutdown, never what it does.
+     * <p>
+     * The default delegates to the two-argument overload and registers nothing, so a module compiled against
+     * the older interface keeps working unchanged: default methods are resolved against the interface at
+     * runtime, so such a module inherits this body without having been compiled with it. Threads it leaks are
+     * invisible in production (the process exits at shutdown) and only accumulate in a JVM that starts and
+     * stops an embedded Edge repeatedly.
+     */
+    default @NotNull DataCombiningTransformationService build(
+            final @NotNull PrePublishProcessorService prePublishProcessorService,
+            final @NotNull MetricRegistry metricRegistry,
+            final @NotNull ShutdownHooks shutdownHooks) {
+        return build(prePublishProcessorService, metricRegistry);
+    }
 }

--- a/hivemq-edge/src/main/java/com/hivemq/bootstrap/factories/DataCombiningTransformationServiceProvider.java
+++ b/hivemq-edge/src/main/java/com/hivemq/bootstrap/factories/DataCombiningTransformationServiceProvider.java
@@ -19,6 +19,7 @@ import com.codahale.metrics.MetricRegistry;
 import com.hivemq.bootstrap.services.EdgeCoreFactoryService;
 import com.hivemq.combining.mapping.DataCombiningTransformationService;
 import com.hivemq.combining.vanilla.VanillaDataCombiningTransformationService;
+import com.hivemq.common.shutdown.ShutdownHooks;
 import com.hivemq.mqtt.services.PrePublishProcessorService;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
@@ -31,15 +32,18 @@ public class DataCombiningTransformationServiceProvider {
     private final @NotNull EdgeCoreFactoryService edgeCoreFactoryService;
     private final @NotNull PrePublishProcessorService prePublishProcessorService;
     private final @NotNull MetricRegistry metricRegistry;
+    private final @NotNull ShutdownHooks shutdownHooks;
 
     @Inject
     public DataCombiningTransformationServiceProvider(
             final @NotNull EdgeCoreFactoryService edgeCoreFactoryService,
             final @NotNull PrePublishProcessorService prePublishProcessorService,
-            final @NotNull MetricRegistry metricRegistry) {
+            final @NotNull MetricRegistry metricRegistry,
+            final @NotNull ShutdownHooks shutdownHooks) {
         this.edgeCoreFactoryService = edgeCoreFactoryService;
         this.prePublishProcessorService = prePublishProcessorService;
         this.metricRegistry = metricRegistry;
+        this.shutdownHooks = shutdownHooks;
     }
 
     public @NotNull DataCombiningTransformationService get() {
@@ -48,6 +52,9 @@ public class DataCombiningTransformationServiceProvider {
         if (serviceFactory == null) {
             return new VanillaDataCombiningTransformationService(prePublishProcessorService);
         }
-        return serviceFactory.build(prePublishProcessorService, metricRegistry);
+        // The three-argument overload lets the module register its own shutdown cleanup. A module compiled
+        // against the older interface implements only the two-argument form and inherits the default, which
+        // delegates to it and registers nothing.
+        return serviceFactory.build(prePublishProcessorService, metricRegistry, shutdownHooks);
     }
 }

--- a/hivemq-edge/src/main/java/com/hivemq/common/executors/ioc/ExecutorsModule.java
+++ b/hivemq-edge/src/main/java/com/hivemq/common/executors/ioc/ExecutorsModule.java
@@ -15,6 +15,8 @@
  */
 package com.hivemq.common.executors.ioc;
 
+import com.hivemq.common.shutdown.HiveMQShutdownHook;
+import com.hivemq.common.shutdown.ShutdownHooks;
 import dagger.Module;
 import dagger.Provides;
 import jakarta.inject.Singleton;
@@ -22,6 +24,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * @author Simon L Johnson
@@ -36,14 +39,46 @@ public abstract class ExecutorsModule {
 
     @Provides
     @Singleton
-    static ScheduledExecutorService scheduledExecutor() {
-        return Executors.newScheduledThreadPool(4, new HiveMQEdgeThreadFactory(SCHEDULED_WORKER_GROUP_NAME));
+    static ScheduledExecutorService scheduledExecutor(final @NotNull ShutdownHooks shutdownHooks) {
+        final ScheduledExecutorService service =
+                Executors.newScheduledThreadPool(4, new HiveMQEdgeThreadFactory(SCHEDULED_WORKER_GROUP_NAME));
+        shutdownHooks.add(shutdownHook("Edge Scheduled Executor Shutdown", service));
+        return service;
     }
 
     @Provides
     @Singleton
-    static ExecutorService executorService() {
-        return Executors.newCachedThreadPool(new HiveMQEdgeThreadFactory(CACHED_WORKER_GROUP_NAME));
+    static ExecutorService executorService(final @NotNull ShutdownHooks shutdownHooks) {
+        final ExecutorService service =
+                Executors.newCachedThreadPool(new HiveMQEdgeThreadFactory(CACHED_WORKER_GROUP_NAME));
+        shutdownHooks.add(shutdownHook("Edge Cached Executor Shutdown", service));
+        return service;
+    }
+
+    /**
+     * Without this the pool's idle workers stay parked for the lifetime of the JVM. That is invisible in
+     * production (the process exits anyway) but decisive in tests, which start and stop an embedded Edge
+     * hundreds of times in one JVM: threads are GC roots, so every parked worker keeps its whole object
+     * graph -- including the retired Edge that created it -- permanently reachable.
+     */
+    private static @NotNull HiveMQShutdownHook shutdownHook(
+            final @NotNull String name, final @NotNull ExecutorService service) {
+        return new HiveMQShutdownHook() {
+            @Override
+            public @NotNull String name() {
+                return name;
+            }
+
+            @Override
+            public @NotNull Priority priority() {
+                return Priority.MEDIUM;
+            }
+
+            @Override
+            public void run() {
+                service.shutdownNow();
+            }
+        };
     }
 
     static class HiveMQEdgeThreadFactory implements ThreadFactory {
@@ -60,6 +95,10 @@ public abstract class ExecutorsModule {
         public Thread newThread(final Runnable r) {
             synchronized (group) {
                 Thread thread = new Thread(coreGroup, r, String.format(factoryName + "-%d", counter++));
+                // Daemon so a missed pool shutdown cannot keep the JVM alive, and so an embedded Edge that
+                // is stopped does not leave its workers parked for the lifetime of the process. Threads are
+                // GC roots: a parked worker is never reclaimed and pins everything it references.
+                thread.setDaemon(true);
                 return thread;
             }
         }

--- a/hivemq-edge/src/main/java/com/hivemq/common/shutdown/ShutdownHooks.java
+++ b/hivemq-edge/src/main/java/com/hivemq/common/shutdown/ShutdownHooks.java
@@ -121,6 +121,15 @@ public class ShutdownHooks {
         }
         executorService.shutdown();
 
+        // Drop the hooks once they have run. Each hook holds the component that registered it, so the registry
+        // reaches most of the object graph of the Edge instance it belongs to. Keeping them after shutdown is
+        // pointless -- they have already run and `shuttingDown` prevents a second pass -- but in a JVM that
+        // starts and stops an embedded Edge repeatedly it retains every retired instance: a heap dump of one
+        // test JVM traced 14 live JaxrsHttpServer instances (and their whole JAX-RS graphs) along
+        // ShutdownHooks.synchronousHooks -> ... -> JaxrsHttpServer$Shutdown, with the registry itself kept
+        // reachable by still-running Netty threads holding bridge MQTT clients.
+        synchronousHooks.clear();
+
         log.info("Shutdown completed.");
     }
 }

--- a/hivemq-edge/src/main/java/com/hivemq/persistence/InFileSingleWriter.java
+++ b/hivemq-edge/src/main/java/com/hivemq/persistence/InFileSingleWriter.java
@@ -47,6 +47,7 @@ public class InFileSingleWriter implements SingleWriterService {
     private static final @NotNull Logger log = LoggerFactory.getLogger(InFileSingleWriter.class);
 
     private static final int AMOUNT_OF_PRODUCERS = 5;
+    private static final int SHUTDOWN_AWAIT_TERMINATION_SEC = 2;
     private static final int RETAINED_MESSAGE_QUEUE_INDEX = 0;
     private static final int CLIENT_SESSION_QUEUE_INDEX = 1;
     private static final int SUBSCRIPTION_QUEUE_INDEX = 2;
@@ -202,7 +203,23 @@ public class InFileSingleWriter implements SingleWriterService {
         singleWriterExecutor.shutdown();
 
         try {
-            singleWriterExecutor.awaitTermination(shutdownGracePeriod, TimeUnit.SECONDS);
+            // This used to pass shutdownGracePeriod (a MILLISECOND value, see
+            // PERSISTENCE_SHUTDOWN_GRACE_PERIOD_MSEC, default 500) to a method taking SECONDS, making this a
+            // 500-second wait. A writer that did not drain promptly then held the whole shutdown, and in an
+            // embedded Edge that is stopped and restarted (tests) the pools piled up: 20 threads per
+            // instance, 260 still parked after 31 instances.
+            //
+            // Note what that bug concealed: with a 500-second wait, in-flight work ALWAYS finished before we
+            // gave up, so the race between shutdown and still-running tasks never surfaced. Correcting the
+            // unit exposes it -- a task that outlives the wait has its completion callback rejected by the
+            // shutting-down executor, which Guava logs at error level. That is a pre-existing race being
+            // revealed, not a new one.
+            //
+            // Hence the explicit 2 seconds rather than the raw 500 ms: long enough that normal drainage wins
+            // comfortably, short enough that a genuinely stuck writer cannot hold shutdown open. The shared
+            // constant stays at 500 ms because InMemoryProducerQueues consumes it as milliseconds and should
+            // not inherit this value.
+            singleWriterExecutor.awaitTermination(SHUTDOWN_AWAIT_TERMINATION_SEC, TimeUnit.SECONDS);
             if (log.isTraceEnabled()) {
                 log.trace("Finished single writer shutdown in {} ms", (System.currentTimeMillis() - start));
             }

--- a/hivemq-edge/src/main/java/com/hivemq/persistence/PersistenceShutdownHook.java
+++ b/hivemq-edge/src/main/java/com/hivemq/persistence/PersistenceShutdownHook.java
@@ -45,6 +45,12 @@ public class PersistenceShutdownHook implements HiveMQShutdownHook {
 
     private static final Logger log = LoggerFactory.getLogger(PersistenceShutdownHook.class);
 
+    /**
+     * How long to wait for a single Xodus job processor thread to end. Deliberately short: a processor that
+     * will stop does so at once, and one that will not is a leak we tolerate rather than a shutdown we hang.
+     */
+    private static final int XODUS_JOIN_TIMEOUT_MSEC = 1000;
+
     private final @NotNull ClientSessionPersistence clientSessionPersistence;
     private final @NotNull ClientSessionSubscriptionPersistence clientSessionSubscriptionPersistence;
     private final @NotNull IncomingMessageFlowPersistence incomingMessageFlowPersistence;
@@ -161,15 +167,8 @@ public class PersistenceShutdownHook implements HiveMQShutdownHook {
                 return;
             }
             for (final Object processor : (Iterable<?>) processors) {
-                try {
-                    // finish() only *requests* termination; waitUntilFinished() joins the worker. Without the
-                    // second call the thread is still alive when the next embedded Edge starts, so the pool
-                    // keeps growing and every retired instance leaves its pollers behind.
-                    processor.getClass().getMethod("finish").invoke(processor);
-                    processor.getClass().getMethod("waitUntilFinished").invoke(processor);
+                if (finishProcessor(processor)) {
                     finished++;
-                } catch (final Exception e) {
-                    log.debug("Could not finish Xodus job processor {}", processor, e);
                 }
             }
             finished += finishSpawner(poolClass);
@@ -177,6 +176,75 @@ public class PersistenceShutdownHook implements HiveMQShutdownHook {
         } catch (final Throwable t) {
             log.debug("Could not finish Xodus job processors", t);
         }
+    }
+
+    /**
+     * Ask one job processor to stop and wait briefly for its thread, returning whether it ended.
+     * <p>
+     * NEVER call Xodus's {@code finish()} or {@code waitUntilFinished()} here. Both end in a bare
+     * {@link Thread#join()} with NO timeout, so a worker that does not come back wedges the whole shutdown
+     * silently -- no log line, no exception, nothing to interrupt. {@code finish()} is additionally guarded on
+     * an internal {@code started} flag and does nothing at all when the processor was never started, so
+     * calling {@code waitUntilFinished()} separately reaches past that guard and joins a thread the library
+     * itself would have declined to wait for.
+     * <p>
+     * {@code queueFinish()} is the non-blocking equivalent: it queues the termination job and returns. The
+     * wait is then ours to bound, via the processor's private {@code thread} field.
+     */
+    private boolean finishProcessor(final @NotNull Object processor) {
+        try {
+            processor.getClass().getMethod("queueFinish").invoke(processor);
+            return joinBriefly(threadOf(processor));
+        } catch (final Exception e) {
+            log.debug("Could not finish Xodus job processor {}", processor, e);
+            return false;
+        }
+    }
+
+    /**
+     * The worker thread behind a Xodus job processor, or {@code null} if it cannot be reached.
+     * <p>
+     * Private field, deliberately: the class exposes no bounded way to wait for its thread, and the only
+     * public alternatives block forever.
+     */
+    private @Nullable Thread threadOf(final @NotNull Object processor) {
+        try {
+            final java.lang.reflect.Field field = processor.getClass().getDeclaredField("thread");
+            field.setAccessible(true);
+            return field.get(processor) instanceof Thread thread ? thread : null;
+        } catch (final Throwable t) {
+            log.debug("Could not reach the thread of Xodus job processor {}", processor, t);
+            return null;
+        }
+    }
+
+    /**
+     * Join [thread] for at most {@link #XODUS_JOIN_TIMEOUT_MSEC}, returning whether it actually ended.
+     * <p>
+     * The bound is short on purpose. A processor that is going to stop stops immediately -- it is parked on a
+     * queue and the termination job is already in it. One that does not stop within a second was not going to,
+     * and waiting longer only converts a leak into a hang. Giving up leaves exactly the leak that existed
+     * before any of this cleanup was written, which is the worst case we are entitled to; a wedged shutdown
+     * would be strictly worse than that.
+     */
+    private boolean joinBriefly(final @Nullable Thread thread) {
+        if (thread == null || !thread.isAlive()) {
+            return thread != null;
+        }
+        try {
+            thread.join(XODUS_JOIN_TIMEOUT_MSEC);
+        } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return false;
+        }
+        if (thread.isAlive()) {
+            log.debug(
+                    "Xodus job processor thread {} did not stop within {} ms; leaving it",
+                    thread.getName(),
+                    XODUS_JOIN_TIMEOUT_MSEC);
+            return false;
+        }
+        return true;
     }
 
     /**
@@ -199,9 +267,8 @@ public class PersistenceShutdownHook implements HiveMQShutdownHook {
             if (spawner == null) {
                 return 0;
             }
-            spawner.getClass().getMethod("finish").invoke(spawner);
-            spawner.getClass().getMethod("waitUntilFinished").invoke(spawner);
-            return 1;
+            // Same bounded stop as the pooled processors: the blocking Xodus methods join without a timeout.
+            return finishProcessor(spawner) ? 1 : 0;
         } catch (final Throwable t) {
             log.debug("Could not finish the Xodus job processor pool spawner", t);
             return 0;

--- a/hivemq-edge/src/main/java/com/hivemq/persistence/PersistenceShutdownHook.java
+++ b/hivemq-edge/src/main/java/com/hivemq/persistence/PersistenceShutdownHook.java
@@ -34,6 +34,7 @@ import jakarta.inject.Inject;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -121,5 +122,118 @@ public class PersistenceShutdownHook implements HiveMQShutdownHook {
 
         persistenceScheduledExecutorService.shutdownNow();
         persistenceExecutorService.shutdown();
+
+        finishXodusJobProcessors();
+    }
+
+    /**
+     * Terminate the job processors Xodus keeps in its process-wide {@link ThreadJobProcessorPool}.
+     * <p>
+     * The pool is static, so it outlives the Edge instance that caused a processor to be created. Each
+     * {@link ThreadJobProcessor} is a live thread -- a GC root -- and additionally keeps an explicit
+     * {@code classLoader} field referencing the module classloader of the Edge that created it. Nothing in
+     * Xodus releases them, so every retired Edge stays reachable through its classloader and every class that
+     * classloader ever loaded stays resident.
+     * <p>
+     * Invisible in production (one Edge, process exits anyway), but decisive when a JVM starts and stops an
+     * embedded Edge repeatedly: a heap dump of one test JVM showed 44 pooled processors pinning 72 module
+     * classloaders. Interrupting the threads is not sufficient -- that is what the test harness already tries
+     * -- because it neither clears the {@code classLoader} field nor removes the processor from the pool.
+     */
+    private void finishXodusJobProcessors() {
+        // Reflection on purpose: Xodus is not on this module's compile classpath -- it arrives with the
+        // commercial persistence module, which Edge loads in its own classloader -- and this is internal Xodus
+        // API. Hence also the classloader dance below: a plain Class.forName() here resolves against *this*
+        // class's loader, which has never seen Xodus, so it throws ClassNotFoundException and the whole
+        // cleanup silently does nothing. Ask the persistence implementations instead: at runtime those are the
+        // Xodus-backed classes from the commercial module, so their loader is the one that holds the pool.
+        final ClassLoader loader = xodusClassLoader();
+        if (loader == null) {
+            log.debug("No Xodus-capable classloader found; skipping job processor cleanup");
+            return;
+        }
+        int finished = 0;
+        try {
+            final Class<?> poolClass =
+                    Class.forName("jetbrains.exodus.core.execution.ThreadJobProcessorPool", false, loader);
+            final Object processors = poolClass.getMethod("getProcessors").invoke(null);
+            if (!(processors instanceof Iterable<?>)) {
+                return;
+            }
+            for (final Object processor : (Iterable<?>) processors) {
+                try {
+                    // finish() only *requests* termination; waitUntilFinished() joins the worker. Without the
+                    // second call the thread is still alive when the next embedded Edge starts, so the pool
+                    // keeps growing and every retired instance leaves its pollers behind.
+                    processor.getClass().getMethod("finish").invoke(processor);
+                    processor.getClass().getMethod("waitUntilFinished").invoke(processor);
+                    finished++;
+                } catch (final Exception e) {
+                    log.debug("Could not finish Xodus job processor {}", processor, e);
+                }
+            }
+            finished += finishSpawner(poolClass);
+            log.debug("Finished {} Xodus job processors", finished);
+        } catch (final Throwable t) {
+            log.debug("Could not finish Xodus job processors", t);
+        }
+    }
+
+    /**
+     * Stop the pool's {@code SPAWNER}, returning 1 if it was stopped and 0 otherwise.
+     * <p>
+     * The spawner is created in the pool class's static initializer and held in a private static field that
+     * {@code getProcessors()} does not report, so finishing the reported processors always leaves it running.
+     * Because each module classloader loads its own copy of the pool class, that is one surviving thread per
+     * embedded Edge -- measured as a count that climbed 1, 2, 3 ... 70 over a single test run.
+     * <p>
+     * Reflection on a private field of a third-party class is deliberate and deliberately fail-soft: if a Xodus
+     * upgrade renames or removes the field this degrades to a debug line and the pre-existing (smaller) leak,
+     * never to a shutdown failure.
+     */
+    private int finishSpawner(final @NotNull Class<?> poolClass) {
+        try {
+            final java.lang.reflect.Field field = poolClass.getDeclaredField("SPAWNER");
+            field.setAccessible(true);
+            final Object spawner = field.get(null);
+            if (spawner == null) {
+                return 0;
+            }
+            spawner.getClass().getMethod("finish").invoke(spawner);
+            spawner.getClass().getMethod("waitUntilFinished").invoke(spawner);
+            return 1;
+        } catch (final Throwable t) {
+            log.debug("Could not finish the Xodus job processor pool spawner", t);
+            return 0;
+        }
+    }
+
+    /**
+     * A classloader that can resolve Xodus, or {@code null}. Tries the loaders of the injected persistences --
+     * whichever of them is Xodus-backed brings the library with it -- then this class's own loader as a
+     * fallback for deployments where everything shares one classpath.
+     */
+    private @Nullable ClassLoader xodusClassLoader() {
+        final Object[] candidates = {
+            clientQueuePersistence,
+            clientSessionPersistence,
+            retainedMessagePersistence,
+            payloadPersistence,
+            clientSessionSubscriptionPersistence,
+            this
+        };
+        for (final Object candidate : candidates) {
+            final ClassLoader loader = candidate.getClass().getClassLoader();
+            if (loader == null) {
+                continue;
+            }
+            try {
+                Class.forName("jetbrains.exodus.core.execution.ThreadJobProcessorPool", false, loader);
+                return loader;
+            } catch (final Throwable ignored) {
+                // try the next candidate
+            }
+        }
+        return null;
     }
 }

--- a/hivemq-edge/src/main/java/com/hivemq/protocols/ProtocolAdapterManager.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/ProtocolAdapterManager.java
@@ -170,10 +170,15 @@ public class ProtocolAdapterManager {
                 new LinkedBlockingQueue<>(ADAPTER_LIFECYCLE_QUEUE_CAPACITY),
                 ThreadFactoryUtil.create("protocol-adapter-lifecycle-%d"),
                 new ThreadPoolExecutor.CallerRunsPolicy());
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-            executorService.shutdown();
-            adapterLifecycleExecutor.shutdown();
-        }));
+        // No JVM shutdown hook here on purpose. Both executors are shut down by shutdown() below, which is
+        // reached on every path that matters: HiveMQEdgeMain.start() registers a JVM hook that runs the whole
+        // stop path (covering abrupt termination), and EmbeddedHiveMQImpl calls shutdownProtocolAdapters()
+        // directly. A hook registered here would additionally be a permanent leak: the JVM's hook registry is
+        // a GC root that is never cleared, the lambda captures `this` (not just the two executors), and this
+        // manager references the whole Edge object graph. In a test JVM that starts an embedded Edge per test
+        // that pinned every retired instance -- a heap dump showed 116 registered hooks holding 57 complete
+        // Edge instances and ~740 MB, which drove full GCs to ~80% of wall clock. Deregistering inside the
+        // hook is not an option: removeShutdownHook throws once the JVM is already exiting.
         protocolAdapterWritingService.addWritingChangedCallback(() ->
                 protocolAdapterFactoryManager.writingEnabledChanged(protocolAdapterWritingService.writingEnabled()));
     }

--- a/hivemq-edge/src/test/java/com/hivemq/common/shutdown/ShutdownHooksTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/common/shutdown/ShutdownHooksTest.java
@@ -74,7 +74,7 @@ public class ShutdownHooksTest {
     }
 
     @Test
-    public void hooksWhenRunThenCanNotBeRemoved() {
+    public void hooksWhenRunThenRegistryIsCleared() {
 
         final HiveMQShutdownHook shutdownHook = createShutdownHook("name", Priority.DOES_NOT_MATTER);
         shutdownHooks.add(shutdownHook);
@@ -84,8 +84,14 @@ public class ShutdownHooksTest {
         shutdownHooks.runShutdownHooks();
         assertTrue(shutdownHooks.isShuttingDown());
 
+        // The hooks have run, so the registry drops them: each one holds the component that registered it, and
+        // an embedded Edge that is stopped must not stay reachable through this map. `remove` is still a no-op
+        // once shutdown has started -- that guard exists so a component cannot skip its own cleanup mid-run --
+        // but after the run there is nothing left to remove.
+        assertEquals(0, shutdownHooks.getShutdownHooks().size());
+
         shutdownHooks.remove(shutdownHook);
-        assertEquals(1, shutdownHooks.getShutdownHooks().size());
+        assertEquals(0, shutdownHooks.getShutdownHooks().size());
     }
 
     @Test


### PR DESCRIPTION
## Description (the why)

Stopping an embedded Edge did not release everything it started. Six places kept a per-instance object alive past `stop()`, and each leaked its threads into the JVM.

In production this is close to invisible: Edge starts once and the process exits. It matters in any JVM that starts and stops an embedded Edge repeatedly, which is what the integration suite does roughly once per test. A heap dump of a single test JVM showed **57 complete retired Edge instances and ~740 MB retained**, which drove full GCs to about 80% of wall clock.

Each leak is fixed where it is created, rather than swept up by the test harness.

Linear: [EDG-929](https://linear.app/hivemq/issue/EDG-929/fix-five-thread-leaks-that-survive-an-embedded-edge-shutdown)

Companion PRs: `hivemq-edge-commercial-modules` and `hivemq-edge-test`, same branch name.

| Where | Defect | Fix |
| -- | -- | -- |
| `ProtocolAdapterManager` | Registered a JVM shutdown hook capturing `this`. The JVM hook registry is a GC root that is never cleared, so every retired manager and the Edge behind it was pinned forever. A heap dump showed **116 registered hooks holding 57 Edge instances**. | Hook removed. The executors it guarded are already shut down on every path that matters. Deregistering inside the hook is not an option: `removeShutdownHook` throws once the JVM is exiting. |
| `PersistenceShutdownHook` | Xodus' process-wide `ThreadJobProcessorPool` kept a live processor per Edge, each holding the module classloader that created it, plus a per-classloader `SPAWNER` thread that `getProcessors()` does not report. Measured: **44 pooled processors pinning 72 module classloaders**. | Both finished, reflectively, fail-soft, and with a **bounded** wait — see below. |
| `HiveMQEdgeMain` | `stopApiServer()` stopped the server but left `jaxrsServer` set, retaining the HK2 registry, routing tables and provider chain. Traced **1603 accumulated `AuthenticationFilter` instances**. | Field nulled. `startGateway()` always re-initialises, so restart is unaffected. |
| `ShutdownHooks` | `runShutdownHooks()` never cleared the registry, and each hook holds the component that registered it. | Cleared once they have run. The `remove()` guard during shutdown is untouched. |
| `InFileSingleWriter` | `awaitTermination(shutdownGracePeriod, SECONDS)` where the constant is `PERSISTENCE_SHUTDOWN_GRACE_PERIOD_MSEC` = 500 — a 1000x unit error, so the wait was 500 s. | Given its own explicit 2-second constant. |
| `ExecutorsModule` | The Edge scheduled and cached executors were never shut down and their threads were non-daemon, so idle workers stayed parked as GC roots. | Both register shutdown hooks; the thread factory marks threads daemon. |

## Acceptance Criteria (the what)

- [ ] Every thread family that grows per embedded-Edge instance returns to zero on shutdown
- [ ] Shutdown always terminates — no unbounded wait anywhere on the path
- [ ] A module compiled against the previous `DataCombiningTransformationServiceFactory` still loads and runs unchanged
- [ ] Production shutdown still terminates promptly when a writer cannot drain
- [ ] The integration suite passes

## Non-Goals

- Making the integration tests themselves leak-free; this fixes Edge, not the harness
- Any change to Xodus itself, or to how the commercial persistence module is loaded

## Notes for the reviewer

Three points want an eye:

**The Xodus wait had to be bounded, and this is worth reading closely.** Xodus' own `finish()` and `waitUntilFinished()` both end in a bare `Thread.join()` with **no timeout**. A worker that does not come back wedges shutdown with no log line, no exception and nothing to interrupt. Calling both is additionally wrong twice over: `finish()` already performs that join internally *and* is guarded on an internal `started` flag, so it does nothing at all for a processor that was never started — meaning a separate `waitUntilFinished()` reaches past the library's own guard and joins a thread the library itself declined to wait for.

The cleanup now uses the non-blocking `queueFinish()` and bounds the join at **1 second**, via the processor's private `thread` field (the class exposes no bounded alternative). One second is deliberate: a processor that is going to stop stops at once, since it is parked on a queue with the termination job already in it. Giving up leaves exactly the leak that existed before this cleanup was written — strictly better than a shutdown that never returns.

This was not theoretical. Before the bound was added, **three CI builds hung after their tests had completed** and had to be aborted by hand.

**`InFileSingleWriter` changes production shutdown timing.** A busy writer now gets 2 s to drain instead of 500 s. The shared constant is left at 500 ms because `InMemoryProducerQueues` consumes it correctly as milliseconds; only this call site gets its own value. The code force-terminates immediately afterwards regardless.

**`DataCombiningTransformationServiceFactory` gains a three-argument `build()` overload** so a module can register its own cleanup. The existing two-argument method stays, and the new one defaults to delegating to it, so **a module compiled against the old interface keeps working unchanged** — a Java class compiled against an interface without a default method still inherits it at runtime.

`ShutdownHooksTest#hooksWhenRunThenCanNotBeRemoved` asserted that hooks survive shutdown, i.e. it encoded the leak as expected behaviour. Renamed and inverted.

The Xodus cleanup reflects on a private static field of a third-party class. That is deliberate, commented, and fail-soft: a rename or removal in a future Xodus degrades to a debug line and the pre-existing smaller leak, never to a shutdown failure.
