### PR TITLE
EDG-931: Stop six core API test classes sharing a hardcoded HTTP port

### DIFF
--- a/hivemq-edge/src/test/java/com/hivemq/api/JaxrsResourceTests.java
+++ b/hivemq-edge/src/test/java/com/hivemq/api/JaxrsResourceTests.java
@@ -43,7 +43,9 @@ public class JaxrsResourceTests {
 
     protected final Logger logger = LoggerFactory.getLogger(JaxrsResourceTests.class);
 
-    static final int TEST_HTTP_PORT = RandomPortGenerator.get();
+    // A random free port, so that tests running in parallel do not conflict. A conflict would surface
+    // as a ProcessingException out of startServer(), logged as "The port ... is already in use".
+    static int testHttpPort;
     static final int CONNECT_TIMEOUT = 5000;
     static final int READ_TIMEOUT = 5000;
     static final String HTTP = "http";
@@ -53,8 +55,9 @@ public class JaxrsResourceTests {
 
     @BeforeAll
     public static void setUp() throws Exception {
+        testHttpPort = RandomPortGenerator.get();
         final JaxrsHttpServerConfiguration config = new JaxrsHttpServerConfiguration();
-        config.setPort(TEST_HTTP_PORT);
+        config.setPort(testHttpPort);
         config.addResourceClasses(TestApiResource.class);
         // -- ensure we supplied our own test mapper as this can effect output
         final ObjectMapper mapper = new ObjectMapper();
@@ -70,7 +73,7 @@ public class JaxrsResourceTests {
 
     protected static String getTestServerAddress(final @NotNull String uri) {
         return String.format(
-                "%s://%s:%s/%s", JaxrsResourceTests.HTTP, "localhost", JaxrsResourceTests.TEST_HTTP_PORT, uri);
+                "%s://%s:%s/%s", JaxrsResourceTests.HTTP, "localhost", JaxrsResourceTests.testHttpPort, uri);
     }
 
     @Test

--- a/hivemq-edge/src/test/java/com/hivemq/api/JaxrsSSLTests.java
+++ b/hivemq-edge/src/test/java/com/hivemq/api/JaxrsSSLTests.java
@@ -56,10 +56,9 @@ public class JaxrsSSLTests {
 
     protected final Logger logger = LoggerFactory.getLogger(JaxrsSSLTests.class);
 
-    // Picked per class rather than shared (EDG-931). Six classes in this source set used to bind the same
-    // hardcoded 8088; whichever ran second on a busy agent could block forever in setup, with no failure
-    // and no timeout to end it -- three CI builds had to be aborted by hand.
-    private static int testHttpPort;
+    // A random free port, so that tests running in parallel do not conflict. A conflict would surface
+    // as a ProcessingException out of startServer(), logged as "The port ... is already in use".
+    private int testHttpPort;
     static final int CONNECT_TIMEOUT = 1000;
     static final int READ_TIMEOUT = 1000;
     static final String HTTPS = "https";

--- a/hivemq-edge/src/test/java/com/hivemq/api/JaxrsSSLTests.java
+++ b/hivemq-edge/src/test/java/com/hivemq/api/JaxrsSSLTests.java
@@ -69,10 +69,8 @@ public class JaxrsSSLTests {
 
     @BeforeEach
     public void setUp() throws Exception {
-        testHttpPort = RandomPortGenerator.get();
         testKeyStoreGenerator = new TestKeyStoreGenerator();
         JaxrsHttpServerConfiguration config = new JaxrsHttpServerConfiguration();
-        config.setPort(testHttpPort);
         config.setProtocol(HTTPS);
         context = getSslContext("testpassword");
         config.setSslContext(context);
@@ -88,6 +86,10 @@ public class JaxrsSSLTests {
         // -- ensure we supplied our own test mapper as this can effect output
         ObjectMapper mapper = new ObjectMapper();
         config.setObjectMapper(mapper);
+        // Taken last, so that the key generation above happens before the port is claimed rather
+        // than between claiming it and binding it.
+        testHttpPort = RandomPortGenerator.get();
+        config.setPort(testHttpPort);
         server = new JaxrsHttpServer(mock(), List.of(config), null);
         server.startServer();
     }

--- a/hivemq-edge/src/test/java/com/hivemq/api/JaxrsSSLTests.java
+++ b/hivemq-edge/src/test/java/com/hivemq/api/JaxrsSSLTests.java
@@ -46,6 +46,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import util.RandomPortGenerator;
 import util.TestKeyStoreGenerator;
 
 /**
@@ -55,7 +56,10 @@ public class JaxrsSSLTests {
 
     protected final Logger logger = LoggerFactory.getLogger(JaxrsSSLTests.class);
 
-    static final int TEST_HTTP_PORT = 8088;
+    // Picked per class rather than shared (EDG-931). Six classes in this source set used to bind the same
+    // hardcoded 8088; whichever ran second on a busy agent could block forever in setup, with no failure
+    // and no timeout to end it -- three CI builds had to be aborted by hand.
+    private static int testHttpPort;
     static final int CONNECT_TIMEOUT = 1000;
     static final int READ_TIMEOUT = 1000;
     static final String HTTPS = "https";
@@ -66,9 +70,10 @@ public class JaxrsSSLTests {
 
     @BeforeEach
     public void setUp() throws Exception {
+        testHttpPort = RandomPortGenerator.get();
         testKeyStoreGenerator = new TestKeyStoreGenerator();
         JaxrsHttpServerConfiguration config = new JaxrsHttpServerConfiguration();
-        config.setPort(TEST_HTTP_PORT);
+        config.setPort(testHttpPort);
         config.setProtocol(HTTPS);
         context = getSslContext("testpassword");
         config.setSslContext(context);
@@ -142,7 +147,7 @@ public class JaxrsSSLTests {
         HttpsURLConnection.setDefaultHostnameVerifier((string, ssls) -> true);
 
         HttpResponse response = HttpUrlConnectionClient.get(
-                null, getTestServerAddress(HTTPS, TEST_HTTP_PORT, "test/get"), CONNECT_TIMEOUT, READ_TIMEOUT);
+                null, getTestServerAddress(HTTPS, testHttpPort, "test/get"), CONNECT_TIMEOUT, READ_TIMEOUT);
         assertEquals(200, response.getStatusCode(), "Resource should exist");
     }
 
@@ -150,7 +155,7 @@ public class JaxrsSSLTests {
     public void testGetResourceOnWrongProtocol() {
         assertThrows(SocketException.class, () -> {
             HttpUrlConnectionClient.get(
-                    null, getTestServerAddress("http", TEST_HTTP_PORT, "test/get"), CONNECT_TIMEOUT, READ_TIMEOUT);
+                    null, getTestServerAddress("http", testHttpPort, "test/get"), CONNECT_TIMEOUT, READ_TIMEOUT);
         });
     }
 }

--- a/hivemq-edge/src/test/java/com/hivemq/api/auth/BasicAuthenticationTests.java
+++ b/hivemq-edge/src/test/java/com/hivemq/api/auth/BasicAuthenticationTests.java
@@ -44,6 +44,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import util.RandomPortGenerator;
 
 /**
  * @author Simon L Johnson
@@ -52,7 +53,10 @@ public class BasicAuthenticationTests {
 
     protected final Logger logger = LoggerFactory.getLogger(BasicAuthenticationTests.class);
 
-    static final int TEST_HTTP_PORT = 8088;
+    // Picked per class rather than shared (EDG-931). Six classes in this source set used to bind the same
+    // hardcoded 8088; whichever ran second on a busy agent could block forever in setup, with no failure
+    // and no timeout to end it -- three CI builds had to be aborted by hand.
+    private static int testHttpPort;
     // See BearerTokenAuthTests: the first request pays the server bootstrap cost and a 1s budget
     // makes whichever test runs first flaky on a loaded CI agent. Matches JaxrsResourceTests.
     static final int CONNECT_TIMEOUT = 5000;
@@ -63,8 +67,9 @@ public class BasicAuthenticationTests {
 
     @BeforeAll
     public static void setUp() throws Exception {
+        testHttpPort = RandomPortGenerator.get();
         final var config = new JaxrsHttpServerConfiguration();
-        config.setPort(TEST_HTTP_PORT);
+        config.setPort(testHttpPort);
         // -- ensure we supplied our own test mapper as this can affect output
         config.setObjectMapper(new ObjectMapper());
 
@@ -101,7 +106,7 @@ public class BasicAuthenticationTests {
         } else {
             headers = null;
         }
-        final var serverAddress = String.format("%s://%s:%s/%s", HTTP, "localhost", TEST_HTTP_PORT, path);
+        final var serverAddress = String.format("%s://%s:%s/%s", HTTP, "localhost", testHttpPort, path);
         return HttpUrlConnectionClient.get(headers, serverAddress, CONNECT_TIMEOUT, READ_TIMEOUT);
     }
 

--- a/hivemq-edge/src/test/java/com/hivemq/api/auth/BasicAuthenticationTests.java
+++ b/hivemq-edge/src/test/java/com/hivemq/api/auth/BasicAuthenticationTests.java
@@ -53,9 +53,8 @@ public class BasicAuthenticationTests {
 
     protected final Logger logger = LoggerFactory.getLogger(BasicAuthenticationTests.class);
 
-    // Picked per class rather than shared (EDG-931). Six classes in this source set used to bind the same
-    // hardcoded 8088; whichever ran second on a busy agent could block forever in setup, with no failure
-    // and no timeout to end it -- three CI builds had to be aborted by hand.
+    // A random free port, so that tests running in parallel do not conflict. A conflict would surface
+    // as a ProcessingException out of startServer(), logged as "The port ... is already in use".
     private static int testHttpPort;
     // See BearerTokenAuthTests: the first request pays the server bootstrap cost and a 1s budget
     // makes whichever test runs first flaky on a loaded CI agent. Matches JaxrsResourceTests.

--- a/hivemq-edge/src/test/java/com/hivemq/api/auth/BearerTokenAuthTests.java
+++ b/hivemq-edge/src/test/java/com/hivemq/api/auth/BearerTokenAuthTests.java
@@ -69,9 +69,8 @@ public class BearerTokenAuthTests {
 
     protected final Logger logger = LoggerFactory.getLogger(BearerTokenAuthTests.class);
 
-    // Picked per class rather than shared (EDG-931). Six classes in this source set used to bind the same
-    // hardcoded 8088; whichever ran second on a busy agent could block forever in setup, with no failure
-    // and no timeout to end it -- three CI builds had to be aborted by hand.
+    // A random free port, so that tests running in parallel do not conflict. A conflict would surface
+    // as a ProcessingException out of startServer(), logged as "The port ... is already in use".
     private static int testHttpPort;
     // The first request against the freshly started server pays the Jersey/Jackson bootstrap cost,
     // which is orders of magnitude slower than every later request. A 1s budget is not enough for

--- a/hivemq-edge/src/test/java/com/hivemq/api/auth/BearerTokenAuthTests.java
+++ b/hivemq-edge/src/test/java/com/hivemq/api/auth/BearerTokenAuthTests.java
@@ -60,6 +60,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import util.RandomPortGenerator;
 
 /**
  * @author Simon L Johnson
@@ -68,7 +69,10 @@ public class BearerTokenAuthTests {
 
     protected final Logger logger = LoggerFactory.getLogger(BearerTokenAuthTests.class);
 
-    static final int TEST_HTTP_PORT = 8088;
+    // Picked per class rather than shared (EDG-931). Six classes in this source set used to bind the same
+    // hardcoded 8088; whichever ran second on a busy agent could block forever in setup, with no failure
+    // and no timeout to end it -- three CI builds had to be aborted by hand.
+    private static int testHttpPort;
     // The first request against the freshly started server pays the Jersey/Jackson bootstrap cost,
     // which is orders of magnitude slower than every later request. A 1s budget is not enough for
     // that on a loaded CI agent, so the first test to run would time out at random. Matches
@@ -82,9 +86,10 @@ public class BearerTokenAuthTests {
 
     @BeforeAll
     public static void setUp() throws Exception {
+        testHttpPort = RandomPortGenerator.get();
 
         final JaxrsHttpServerConfiguration config = new JaxrsHttpServerConfiguration();
-        config.setPort(TEST_HTTP_PORT);
+        config.setPort(testHttpPort);
         // -- ensure we supplied our own test mapper as this can effect output
         config.setObjectMapper(objectMapper);
 
@@ -125,13 +130,13 @@ public class BearerTokenAuthTests {
 
     protected static HttpResponse get(final @NotNull String path, final @Nullable Map<String, String> headers)
             throws IOException {
-        final var serverAddress = String.format("%s://%s:%s/%s", HTTP, "localhost", TEST_HTTP_PORT, path);
+        final var serverAddress = String.format("%s://%s:%s/%s", HTTP, "localhost", testHttpPort, path);
         return HttpUrlConnectionClient.get(headers, serverAddress, CONNECT_TIMEOUT, READ_TIMEOUT);
     }
 
     protected static HttpResponse post(final @NotNull String path, final ByteArrayInputStream body) throws IOException {
         final var headers = HttpUrlConnectionClient.JSON_HEADERS;
-        final var serverAddress = String.format("%s://%s:%s/%s", HTTP, "localhost", TEST_HTTP_PORT, path);
+        final var serverAddress = String.format("%s://%s:%s/%s", HTTP, "localhost", testHttpPort, path);
         return HttpUrlConnectionClient.post(headers, serverAddress, body, CONNECT_TIMEOUT, READ_TIMEOUT);
     }
 
@@ -249,7 +254,7 @@ public class BearerTokenAuthTests {
     protected static HttpResponse post(
             final @NotNull String path, final @NotNull Map<String, String> headers, final ByteArrayInputStream body)
             throws IOException {
-        final var serverAddress = String.format("%s://%s:%s/%s", HTTP, "localhost", TEST_HTTP_PORT, path);
+        final var serverAddress = String.format("%s://%s:%s/%s", HTTP, "localhost", testHttpPort, path);
         return HttpUrlConnectionClient.post(headers, serverAddress, body, CONNECT_TIMEOUT, READ_TIMEOUT);
     }
 }

--- a/hivemq-edge/src/test/java/com/hivemq/api/auth/ChainedAuthTests.java
+++ b/hivemq-edge/src/test/java/com/hivemq/api/auth/ChainedAuthTests.java
@@ -68,9 +68,8 @@ public class ChainedAuthTests {
 
     protected final Logger logger = LoggerFactory.getLogger(ChainedAuthTests.class);
 
-    // Picked per class rather than shared (EDG-931). Six classes in this source set used to bind the same
-    // hardcoded 8088; whichever ran second on a busy agent could block forever in setup, with no failure
-    // and no timeout to end it -- three CI builds had to be aborted by hand.
+    // A random free port, so that tests running in parallel do not conflict. A conflict would surface
+    // as a ProcessingException out of startServer(), logged as "The port ... is already in use".
     private static int testHttpPort;
     // See BearerTokenAuthTests: the first request pays the server bootstrap cost and a 1s budget
     // makes whichever test runs first flaky on a loaded CI agent. Matches JaxrsResourceTests.

--- a/hivemq-edge/src/test/java/com/hivemq/api/auth/ChainedAuthTests.java
+++ b/hivemq-edge/src/test/java/com/hivemq/api/auth/ChainedAuthTests.java
@@ -59,6 +59,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import util.RandomPortGenerator;
 
 /**
  * @author Simon L Johnson
@@ -67,7 +68,10 @@ public class ChainedAuthTests {
 
     protected final Logger logger = LoggerFactory.getLogger(ChainedAuthTests.class);
 
-    static final int TEST_HTTP_PORT = 8088;
+    // Picked per class rather than shared (EDG-931). Six classes in this source set used to bind the same
+    // hardcoded 8088; whichever ran second on a busy agent could block forever in setup, with no failure
+    // and no timeout to end it -- three CI builds had to be aborted by hand.
+    private static int testHttpPort;
     // See BearerTokenAuthTests: the first request pays the server bootstrap cost and a 1s budget
     // makes whichever test runs first flaky on a loaded CI agent. Matches JaxrsResourceTests.
     static final int CONNECT_TIMEOUT = 5000;
@@ -79,8 +83,9 @@ public class ChainedAuthTests {
 
     @BeforeAll
     public static void setUp() throws Exception {
+        testHttpPort = RandomPortGenerator.get();
         final JaxrsHttpServerConfiguration config = new JaxrsHttpServerConfiguration();
-        config.setPort(TEST_HTTP_PORT);
+        config.setPort(testHttpPort);
         // -- ensure we supplied our own test mapper as this can effect output
         config.setObjectMapper(objectMapper);
 
@@ -122,7 +127,7 @@ public class ChainedAuthTests {
             final @com.hivemq.extension.sdk.api.annotations.NotNull String path,
             final @Nullable Map<String, String> headers)
             throws IOException {
-        final var serverAddress = String.format("%s://%s:%s/%s", HTTP, "localhost", TEST_HTTP_PORT, path);
+        final var serverAddress = String.format("%s://%s:%s/%s", HTTP, "localhost", testHttpPort, path);
         return HttpUrlConnectionClient.get(headers, serverAddress, CONNECT_TIMEOUT, READ_TIMEOUT);
     }
 
@@ -130,7 +135,7 @@ public class ChainedAuthTests {
             final @com.hivemq.extension.sdk.api.annotations.NotNull String path, final ByteArrayInputStream body)
             throws IOException {
         final var headers = HttpUrlConnectionClient.JSON_HEADERS;
-        final var serverAddress = String.format("%s://%s:%s/%s", HTTP, "localhost", TEST_HTTP_PORT, path);
+        final var serverAddress = String.format("%s://%s:%s/%s", HTTP, "localhost", testHttpPort, path);
         return HttpUrlConnectionClient.post(headers, serverAddress, body, CONNECT_TIMEOUT, READ_TIMEOUT);
     }
 

--- a/hivemq-edge/src/test/java/com/hivemq/api/auth/EnforceApiAuthTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/api/auth/EnforceApiAuthTest.java
@@ -44,6 +44,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import util.RandomPortGenerator;
 
 /**
  * @author martin Schoenert
@@ -55,17 +56,22 @@ public class EnforceApiAuthTest {
 
     protected final Logger logger = LoggerFactory.getLogger(BasicAuthenticationTests.class);
 
-    static final int TEST_HTTP_PORT = 8088;
     static final int CONNECT_TIMEOUT = 1000;
     static final int READ_TIMEOUT = 1000;
     static final String HTTP = "http";
+
+    // Picked per class rather than shared (EDG-931). Six classes in this source set used to bind the same
+    // hardcoded 8088; whichever ran second on a busy agent could block forever in this @BeforeAll, with no
+    // failure and no timeout to end it -- three CI builds had to be aborted by hand.
+    private static int testHttpPort;
 
     protected static JaxrsHttpServer server;
 
     @BeforeAll
     public static void setUp() throws Exception {
+        testHttpPort = RandomPortGenerator.get();
         final var config = new JaxrsHttpServerConfiguration();
-        config.setPort(TEST_HTTP_PORT);
+        config.setPort(testHttpPort);
         // -- ensure we supplied our own test mapper as this can effect output
         config.setObjectMapper(new ObjectMapper());
 
@@ -102,7 +108,7 @@ public class EnforceApiAuthTest {
         } else {
             headers = null;
         }
-        final var serverAddress = String.format("%s://%s:%s/%s", HTTP, "localhost", TEST_HTTP_PORT, path);
+        final var serverAddress = String.format("%s://%s:%s/%s", HTTP, "localhost", testHttpPort, path);
         return HttpUrlConnectionClient.get(headers, serverAddress, CONNECT_TIMEOUT, READ_TIMEOUT);
     }
 

--- a/hivemq-edge/src/test/java/com/hivemq/api/auth/EnforceApiAuthTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/api/auth/EnforceApiAuthTest.java
@@ -60,9 +60,8 @@ public class EnforceApiAuthTest {
     static final int READ_TIMEOUT = 1000;
     static final String HTTP = "http";
 
-    // Picked per class rather than shared (EDG-931). Six classes in this source set used to bind the same
-    // hardcoded 8088; whichever ran second on a busy agent could block forever in this @BeforeAll, with no
-    // failure and no timeout to end it -- three CI builds had to be aborted by hand.
+    // A random free port, so that tests running in parallel do not conflict. A conflict would surface
+    // as a ProcessingException out of startServer(), logged as "The port ... is already in use".
     private static int testHttpPort;
 
     protected static JaxrsHttpServer server;

--- a/hivemq-edge/src/test/java/com/hivemq/api/auth/LdapAuthenticationTests.java
+++ b/hivemq-edge/src/test/java/com/hivemq/api/auth/LdapAuthenticationTests.java
@@ -63,9 +63,8 @@ public class LdapAuthenticationTests {
 
     protected final Logger logger = LoggerFactory.getLogger(LdapAuthenticationTests.class);
 
-    // Picked per class rather than shared (EDG-931). Six classes in this source set used to bind the same
-    // hardcoded 8088; whichever ran second on a busy agent could block forever in setup, with no failure
-    // and no timeout to end it -- three CI builds had to be aborted by hand.
+    // A random free port, so that tests running in parallel do not conflict. A conflict would surface
+    // as a ProcessingException out of startServer(), logged as "The port ... is already in use".
     private static int testHttpPort;
     // See BearerTokenAuthTests: the first request pays the server bootstrap cost and a 1s budget
     // makes whichever test runs first flaky on a loaded CI agent. Matches JaxrsResourceTests.

--- a/hivemq-edge/src/test/java/com/hivemq/api/auth/LdapAuthenticationTests.java
+++ b/hivemq-edge/src/test/java/com/hivemq/api/auth/LdapAuthenticationTests.java
@@ -76,7 +76,6 @@ public class LdapAuthenticationTests {
 
     @BeforeAll
     static void setUp() throws Exception {
-        testHttpPort = RandomPortGenerator.get();
         // Get the dynamically mapped port from the container
         final var host = LLDAP_CONTAINER.getHost();
         final var port = LLDAP_CONTAINER.getLdapPort();
@@ -116,6 +115,9 @@ public class LdapAuthenticationTests {
         final var config = new JaxrsHttpServerConfiguration();
         // -- ensure we supplied our own test mapper as this can effect output
         config.setObjectMapper(new ObjectMapper());
+        // Taken last, so that the container round trip above happens before the port is claimed
+        // rather than between claiming it and binding it.
+        testHttpPort = RandomPortGenerator.get();
         config.setPort(testHttpPort);
 
         final Set<IAuthenticationHandler> authenticationHandlers = new HashSet<>();

--- a/hivemq-edge/src/test/java/com/hivemq/api/auth/LdapAuthenticationTests.java
+++ b/hivemq-edge/src/test/java/com/hivemq/api/auth/LdapAuthenticationTests.java
@@ -53,6 +53,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
+import util.RandomPortGenerator;
 
 @Testcontainers
 public class LdapAuthenticationTests {
@@ -62,7 +63,10 @@ public class LdapAuthenticationTests {
 
     protected final Logger logger = LoggerFactory.getLogger(LdapAuthenticationTests.class);
 
-    static final int TEST_HTTP_PORT = 8088;
+    // Picked per class rather than shared (EDG-931). Six classes in this source set used to bind the same
+    // hardcoded 8088; whichever ran second on a busy agent could block forever in setup, with no failure
+    // and no timeout to end it -- three CI builds had to be aborted by hand.
+    private static int testHttpPort;
     // See BearerTokenAuthTests: the first request pays the server bootstrap cost and a 1s budget
     // makes whichever test runs first flaky on a loaded CI agent. Matches JaxrsResourceTests.
     static final int CONNECT_TIMEOUT = 5000;
@@ -73,6 +77,7 @@ public class LdapAuthenticationTests {
 
     @BeforeAll
     static void setUp() throws Exception {
+        testHttpPort = RandomPortGenerator.get();
         // Get the dynamically mapped port from the container
         final var host = LLDAP_CONTAINER.getHost();
         final var port = LLDAP_CONTAINER.getLdapPort();
@@ -112,7 +117,7 @@ public class LdapAuthenticationTests {
         final var config = new JaxrsHttpServerConfiguration();
         // -- ensure we supplied our own test mapper as this can effect output
         config.setObjectMapper(new ObjectMapper());
-        config.setPort(TEST_HTTP_PORT);
+        config.setPort(testHttpPort);
 
         final Set<IAuthenticationHandler> authenticationHandlers = new HashSet<>();
         authenticationHandlers.add(new BasicAuthenticationHandler(
@@ -146,7 +151,7 @@ public class LdapAuthenticationTests {
     @Test
     public void testGetSecuredResourceWithoutCreds() throws IOException {
         final var response = HttpUrlConnectionClient.get(
-                null, getTestServerAddress(HTTP, TEST_HTTP_PORT, "test/get/auth/admin"), CONNECT_TIMEOUT, READ_TIMEOUT);
+                null, getTestServerAddress(HTTP, testHttpPort, "test/get/auth/admin"), CONNECT_TIMEOUT, READ_TIMEOUT);
         assertThat(response.getStatusCode()).as("Resource should be denied").isEqualTo(401);
     }
 
@@ -157,7 +162,7 @@ public class LdapAuthenticationTests {
                 BasicAuthenticationHandler.getBasicAuthenticationHeaderValue("testaWRONG", TEST_PASSWORD));
         final var response = HttpUrlConnectionClient.get(
                 headers,
-                getTestServerAddress(HTTP, TEST_HTTP_PORT, "test/get/auth/admin"),
+                getTestServerAddress(HTTP, testHttpPort, "test/get/auth/admin"),
                 CONNECT_TIMEOUT,
                 READ_TIMEOUT);
         assertThat(response.getStatusCode()).as("Resource should be denied").isEqualTo(401);
@@ -170,7 +175,7 @@ public class LdapAuthenticationTests {
                 BasicAuthenticationHandler.getBasicAuthenticationHeaderValue(TEST_USERNAME, "incorrect"));
         final var response = HttpUrlConnectionClient.get(
                 headers,
-                getTestServerAddress(HTTP, TEST_HTTP_PORT, "test/get/auth/admin"),
+                getTestServerAddress(HTTP, testHttpPort, "test/get/auth/admin"),
                 CONNECT_TIMEOUT,
                 READ_TIMEOUT);
         assertThat(response.getStatusCode()).as("Resource should be denied").isEqualTo(401);
@@ -183,7 +188,7 @@ public class LdapAuthenticationTests {
                 BasicAuthenticationHandler.getBasicAuthenticationHeaderValue(TEST_USERNAME, TEST_PASSWORD));
         final var response = HttpUrlConnectionClient.get(
                 headers,
-                getTestServerAddress(HTTP, TEST_HTTP_PORT, "test/get/auth/admin"),
+                getTestServerAddress(HTTP, testHttpPort, "test/get/auth/admin"),
                 CONNECT_TIMEOUT,
                 READ_TIMEOUT);
         assertThat(response.getStatusCode()).as("Resource should be accepted").isEqualTo(200);

--- a/hivemq-edge/src/test/java/com/hivemq/api/auth/LdapAuthenticationTests.java
+++ b/hivemq-edge/src/test/java/com/hivemq/api/auth/LdapAuthenticationTests.java
@@ -115,10 +115,6 @@ public class LdapAuthenticationTests {
         final var config = new JaxrsHttpServerConfiguration();
         // -- ensure we supplied our own test mapper as this can effect output
         config.setObjectMapper(new ObjectMapper());
-        // Taken last, so that the container round trip above happens before the port is claimed
-        // rather than between claiming it and binding it.
-        testHttpPort = RandomPortGenerator.get();
-        config.setPort(testHttpPort);
 
         final Set<IAuthenticationHandler> authenticationHandlers = new HashSet<>();
         authenticationHandlers.add(new BasicAuthenticationHandler(
@@ -132,6 +128,12 @@ public class LdapAuthenticationTests {
         resourceConfig.register(TestApiResource.class);
         resourceConfig.register(TestPermitAllApiResource.class);
         resourceConfig.register(TestResourceLevelRolesApiResource.class);
+
+        // Taken last, so that the container round trips above happen before the port is claimed
+        // rather than between claiming it and binding it. There are two: createTestUser, and the
+        // LdapUsernameRolesProvider constructor, which starts an LdapClient and opens a pool.
+        testHttpPort = RandomPortGenerator.get();
+        config.setPort(testHttpPort);
 
         server = new JaxrsHttpServer(mock(), List.of(config), resourceConfig);
         server.startServer();

--- a/hivemq-edge/src/test/java/com/hivemq/api/auth/oidc/OidcServiceImplRedirectTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/api/auth/oidc/OidcServiceImplRedirectTest.java
@@ -56,7 +56,8 @@ class OidcServiceImplRedirectTest {
     void resourceRetriever_doesNotFollowRedirects() throws Exception {
         // The second server records every hit; if a redirect were followed, its counter would move.
         final AtomicInteger secondServerHits = new AtomicInteger();
-        secondServer = HttpServer.create(new InetSocketAddress(RandomPortGenerator.get()), 0);
+        final int secondPort = RandomPortGenerator.get();
+        secondServer = HttpServer.create(new InetSocketAddress(secondPort), 0);
         secondServer.createContext("/", exchange -> {
             secondServerHits.incrementAndGet();
             final byte[] body = "{}".getBytes(StandardCharsets.UTF_8);
@@ -65,19 +66,18 @@ class OidcServiceImplRedirectTest {
             exchange.close();
         });
         secondServer.start();
-        final int secondPort = secondServer.getAddress().getPort();
 
         // The first server answers every request with a 302 pointing at the second server.
-        redirectingServer = HttpServer.create(new InetSocketAddress(RandomPortGenerator.get()), 0);
+        final int redirectingPort = RandomPortGenerator.get();
+        redirectingServer = HttpServer.create(new InetSocketAddress(redirectingPort), 0);
         redirectingServer.createContext("/", exchange -> {
             exchange.getResponseHeaders().add("Location", "http://127.0.0.1:" + secondPort + "/");
             exchange.sendResponseHeaders(302, -1);
             exchange.close();
         });
         redirectingServer.start();
-        final URL firstUrl = URI.create(
-                        "http://127.0.0.1:" + redirectingServer.getAddress().getPort() + "/")
-                .toURL();
+        final URL firstUrl =
+                URI.create("http://127.0.0.1:" + redirectingPort + "/").toURL();
 
         // Retrieving through the retriever must not chase the redirect: it fails on the 302 instead of
         // fetching the second server's body, and the second server is never contacted.

--- a/hivemq-edge/src/test/java/com/hivemq/api/auth/oidc/OidcServiceImplRedirectTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/api/auth/oidc/OidcServiceImplRedirectTest.java
@@ -30,6 +30,7 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import util.RandomPortGenerator;
 
 /**
  * Verifies that the resource retriever used for the discovery and JWKS fetches does not follow HTTP
@@ -55,7 +56,7 @@ class OidcServiceImplRedirectTest {
     void resourceRetriever_doesNotFollowRedirects() throws Exception {
         // The second server records every hit; if a redirect were followed, its counter would move.
         final AtomicInteger secondServerHits = new AtomicInteger();
-        secondServer = HttpServer.create(new InetSocketAddress(0), 0);
+        secondServer = HttpServer.create(new InetSocketAddress(RandomPortGenerator.get()), 0);
         secondServer.createContext("/", exchange -> {
             secondServerHits.incrementAndGet();
             final byte[] body = "{}".getBytes(StandardCharsets.UTF_8);
@@ -67,7 +68,7 @@ class OidcServiceImplRedirectTest {
         final int secondPort = secondServer.getAddress().getPort();
 
         // The first server answers every request with a 302 pointing at the second server.
-        redirectingServer = HttpServer.create(new InetSocketAddress(0), 0);
+        redirectingServer = HttpServer.create(new InetSocketAddress(RandomPortGenerator.get()), 0);
         redirectingServer.createContext("/", exchange -> {
             exchange.getResponseHeaders().add("Location", "http://127.0.0.1:" + secondPort + "/");
             exchange.sendResponseHeaders(302, -1);

--- a/hivemq-edge/src/test/java/com/hivemq/edge/impl/remote/HiveMQEdgeHttpServiceImplTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/edge/impl/remote/HiveMQEdgeHttpServiceImplTest.java
@@ -243,8 +243,8 @@ class HiveMQEdgeHttpServiceImplTest {
             final CountDownLatch configRequestReceived = new CountDownLatch(1);
             final CountDownLatch allowConfigResponse = new CountDownLatch(1);
 
-            final HttpServer localServer = HttpServer.create(new InetSocketAddress(0), 0);
-            final int localPort = localServer.getAddress().getPort();
+            final int localPort = RandomPortGenerator.get();
+            final HttpServer localServer = HttpServer.create(new InetSocketAddress(localPort), 0);
 
             final String servicesJson = String.format("""
                     {


### PR DESCRIPTION
## Description (the why)

Six test classes each start a real `JaxrsHttpServer` on the **same hardcoded** `TEST_HTTP_PORT = 8088`: `JaxrsSSLTests`, `BasicAuthenticationTests`, `BearerTokenAuthTests`, `ChainedAuthTests`, `EnforceApiAuthTest` and `LdapAuthenticationTests`.

Sequentially on an idle machine they never clash. On a shared CI agent they do — and the failure mode is not a failed test. Whichever class binds second blocks in its setup and never returns.

**Three consecutive CI builds on the EDG-929 branch hung there and had to be aborted by hand:**

| build | last test to complete | silent for |
| -- | -- | -- |
| #1 | `JaxrsSSLTests.testGetResource()` | 31 min |
| #2 | `EnforceApiAuthTest.testGetSecuredResourceWithValidCreds()` | ~22 min |
| #3 | `EnforceApiAuthTest.testGetSecuredResourceWithValidCreds()` | same point |

The signature is distinctive: the last line is a **passing** test, the next class never prints even `STARTED`, and every test that started also finished — so nothing is stuck *inside* a test.

Linear: [EDG-931](https://linear.app/hivemq/issue/EDG-931/stop-six-core-api-test-classes-sharing-a-hardcoded-http-port)

## Acceptance Criteria (the what)

- [ ] No test class binds a port shared with another class
- [ ] The six classes run concurrently without colliding, in any order
- [ ] One port-picking approach across the repo, with no per-site judgement call

## Non-Goals

- A default test timeout for `hivemq-edge` — the module has none, which is why the hangs were silent, but a JUnit default timeout governs test *execution*, not a `@BeforeAll` that never returns. It would not have caught these. Worth doing under its own issue.
- The three database lifecycle tests in `hivemq-edge-test`, which pin a host port chosen at class load — real, different repo, tracked separately.

## Notes for the reviewer

**Each class now takes its port from `util.RandomPortGenerator` in setup.** That helper already exists in this source set, and `JaxrsResourceTests` — the seventh class in this family, and the only one that never had the problem — has always used it. This makes the other six match their own neighbour.

**On the check-then-bind window.** The generator picks a random number, proves it free by opening a socket, closes it, and returns the number, so there is a formal gap before the server binds. It is negligible here: the range is 40000 wide, `Math.random()` is seeded per JVM so concurrent forks do not correlate, the window is microseconds, and a CI agent runs essentially nothing else. It is used at ~150 sites across both repos without producing collisions.

**Why not bind to port 0**, which has no window at all because the OS chooses and binds in one step: it only applies where the test itself creates the socket. Roughly **145 of ~150** port acquisitions across both repos cannot use it — the port must be known *before* anything binds, because it goes into a config XML, a builder, or a fake server's constructor, and an embedded Edge binds it later. Nothing exists to interrogate at the moment the number is needed.

So bind-to-zero could only ever cover a handful of sites. Two tests did use it — `OidcServiceImplRedirectTest` and `HiveMQEdgeHttpServiceImplTest` — and the second commit converts them to the generator too. **Two exceptions cost more in inconsistency than the theoretical window is worth.**

Verified: the whole `com.hivemq.api` package plus both converted tests, green before and after.
