### PR TITLE
EDG-935: Merge service files in the shadow jars instead of dropping duplicates

### DIFF
--- a/hivemq-edge/build.gradle.kts
+++ b/hivemq-edge/build.gradle.kts
@@ -415,6 +415,12 @@ tasks.named("sourcesJar") {
 }
 
 tasks.shadowJar {
+    // ShadowJar defaults its duplicatesStrategy to EXCLUDE, and that filtering runs before
+    // mergeServiceFiles() below, so without this override the merge never sees a second copy: only
+    // the first META-INF/services file of a given name reaches the jar and every other provider is
+    // dropped silently. The override is scoped to service files, so every other duplicated resource
+    // still lands in the jar exactly once.
+    filesMatching("META-INF/services/**") { duplicatesStrategy = DuplicatesStrategy.INCLUDE }
     mergeServiceFiles()
     from(frontendBinary) {
         into("httpd")

--- a/modules/hivemq-edge-module-databases/build.gradle.kts
+++ b/modules/hivemq-edge-module-databases/build.gradle.kts
@@ -70,6 +70,16 @@ tasks.register<Copy>("copyAllDependencies") {
 
 tasks.named("assemble") { finalizedBy("copyAllDependencies") }
 
+tasks.shadowJar {
+    // ShadowJar defaults its duplicatesStrategy to EXCLUDE, and that filtering runs before the
+    // service-file merge: without the override below, only the first META-INF/services file of a
+    // given name survives and every other provider is dropped silently. Here that would leave the
+    // PostgreSQL driver as the only registered java.sql.Driver. The override is scoped to service
+    // files so every other duplicated resource still lands in the jar exactly once.
+    filesMatching("META-INF/services/**") { duplicatesStrategy = DuplicatesStrategy.INCLUDE }
+    mergeServiceFiles()
+}
+
 // ******************** artifacts ********************
 
 val releaseBinary: Configuration by configurations.creating {

--- a/modules/hivemq-edge-module-etherip-cip-odva/build.gradle.kts
+++ b/modules/hivemq-edge-module-etherip-cip-odva/build.gradle.kts
@@ -73,6 +73,15 @@ tasks.register<Copy>("copyAllDependencies") {
 
 tasks.named("assemble") { finalizedBy("copyAllDependencies") }
 
+tasks.shadowJar {
+    // ShadowJar defaults its duplicatesStrategy to EXCLUDE, and that filtering runs before the
+    // service-file merge, so without this override only the first META-INF/services file of a given
+    // name reaches the jar and every other provider is dropped silently. The override is scoped to
+    // service files, so every other duplicated resource still lands in the jar exactly once.
+    filesMatching("META-INF/services/**") { duplicatesStrategy = DuplicatesStrategy.INCLUDE }
+    mergeServiceFiles()
+}
+
 // ******************** artifacts ********************
 
 val releaseBinary: Configuration by configurations.creating {

--- a/modules/hivemq-edge-module-etherip/build.gradle.kts
+++ b/modules/hivemq-edge-module-etherip/build.gradle.kts
@@ -73,6 +73,15 @@ tasks.register<Copy>("copyAllDependencies") {
 
 tasks.named("assemble") { finalizedBy("copyAllDependencies") }
 
+tasks.shadowJar {
+    // ShadowJar defaults its duplicatesStrategy to EXCLUDE, and that filtering runs before the
+    // service-file merge, so without this override only the first META-INF/services file of a given
+    // name reaches the jar and every other provider is dropped silently. The override is scoped to
+    // service files, so every other duplicated resource still lands in the jar exactly once.
+    filesMatching("META-INF/services/**") { duplicatesStrategy = DuplicatesStrategy.INCLUDE }
+    mergeServiceFiles()
+}
+
 // ******************** artifacts ********************
 
 val releaseBinary: Configuration by configurations.creating {

--- a/modules/hivemq-edge-module-file/build.gradle.kts
+++ b/modules/hivemq-edge-module-file/build.gradle.kts
@@ -61,6 +61,15 @@ tasks.register<Copy>("copyAllDependencies") {
 
 tasks.named("assemble") { finalizedBy("copyAllDependencies") }
 
+tasks.shadowJar {
+    // ShadowJar defaults its duplicatesStrategy to EXCLUDE, and that filtering runs before the
+    // service-file merge, so without this override only the first META-INF/services file of a given
+    // name reaches the jar and every other provider is dropped silently. The override is scoped to
+    // service files, so every other duplicated resource still lands in the jar exactly once.
+    filesMatching("META-INF/services/**") { duplicatesStrategy = DuplicatesStrategy.INCLUDE }
+    mergeServiceFiles()
+}
+
 // ******************** artifacts ********************
 
 val releaseBinary: Configuration by configurations.creating {

--- a/modules/hivemq-edge-module-http/build.gradle.kts
+++ b/modules/hivemq-edge-module-http/build.gradle.kts
@@ -64,6 +64,15 @@ tasks.register<Copy>("copyAllDependencies") {
 
 tasks.named("assemble") { finalizedBy("copyAllDependencies") }
 
+tasks.shadowJar {
+    // ShadowJar defaults its duplicatesStrategy to EXCLUDE, and that filtering runs before the
+    // service-file merge, so without this override only the first META-INF/services file of a given
+    // name reaches the jar and every other provider is dropped silently. The override is scoped to
+    // service files, so every other duplicated resource still lands in the jar exactly once.
+    filesMatching("META-INF/services/**") { duplicatesStrategy = DuplicatesStrategy.INCLUDE }
+    mergeServiceFiles()
+}
+
 // ******************** artifacts ********************
 
 val releaseBinary: Configuration by configurations.creating {

--- a/modules/hivemq-edge-module-modbus/build.gradle.kts
+++ b/modules/hivemq-edge-module-modbus/build.gradle.kts
@@ -65,6 +65,15 @@ tasks.register<Copy>("copyAllDependencies") {
 
 tasks.named("assemble") { finalizedBy("copyAllDependencies") }
 
+tasks.shadowJar {
+    // ShadowJar defaults its duplicatesStrategy to EXCLUDE, and that filtering runs before the
+    // service-file merge, so without this override only the first META-INF/services file of a given
+    // name reaches the jar and every other provider is dropped silently. The override is scoped to
+    // service files, so every other duplicated resource still lands in the jar exactly once.
+    filesMatching("META-INF/services/**") { duplicatesStrategy = DuplicatesStrategy.INCLUDE }
+    mergeServiceFiles()
+}
+
 // ******************** artifacts ********************
 
 val releaseBinary: Configuration by configurations.creating {

--- a/modules/hivemq-edge-module-mtconnect/build.gradle.kts
+++ b/modules/hivemq-edge-module-mtconnect/build.gradle.kts
@@ -67,6 +67,15 @@ tasks.register<Copy>("copyAllDependencies") {
 
 tasks.named("assemble") { finalizedBy("copyAllDependencies") }
 
+tasks.shadowJar {
+    // ShadowJar defaults its duplicatesStrategy to EXCLUDE, and that filtering runs before the
+    // service-file merge, so without this override only the first META-INF/services file of a given
+    // name reaches the jar and every other provider is dropped silently. The override is scoped to
+    // service files, so every other duplicated resource still lands in the jar exactly once.
+    filesMatching("META-INF/services/**") { duplicatesStrategy = DuplicatesStrategy.INCLUDE }
+    mergeServiceFiles()
+}
+
 // ******************** artifacts ********************
 
 val releaseBinary: Configuration by configurations.creating {

--- a/modules/hivemq-edge-module-opcua/build.gradle.kts
+++ b/modules/hivemq-edge-module-opcua/build.gradle.kts
@@ -97,6 +97,15 @@ tasks.register<Copy>("copyAllDependencies") {
 
 tasks.named("assemble") { finalizedBy("copyAllDependencies") }
 
+tasks.shadowJar {
+    // ShadowJar defaults its duplicatesStrategy to EXCLUDE, and that filtering runs before the
+    // service-file merge, so without this override only the first META-INF/services file of a given
+    // name reaches the jar and every other provider is dropped silently. The override is scoped to
+    // service files, so every other duplicated resource still lands in the jar exactly once.
+    filesMatching("META-INF/services/**") { duplicatesStrategy = DuplicatesStrategy.INCLUDE }
+    mergeServiceFiles()
+}
+
 // ******************** artifacts ********************
 
 val releaseBinary: Configuration by configurations.creating {

--- a/modules/hivemq-edge-module-plc4x/build.gradle.kts
+++ b/modules/hivemq-edge-module-plc4x/build.gradle.kts
@@ -83,6 +83,18 @@ tasks.register<Copy>("copyAllDependencies") {
 
 tasks.named("assemble") { finalizedBy("copyAllDependencies") }
 
+tasks.shadowJar {
+    // ShadowJar defaults its duplicatesStrategy to EXCLUDE, and that filtering runs before the
+    // service-file merge, so without this override only the first META-INF/services file of a given
+    // name reaches the jar and every other provider is dropped silently. That is what used to hide
+    // the ADS driver behind the S7 one, and it is why this module carried hand-written copies of
+    // the PlcDriver and Transport descriptors; those are gone now that the merge does its job. The
+    // override is scoped to service files, so every other duplicated resource still lands in the
+    // jar exactly once.
+    filesMatching("META-INF/services/**") { duplicatesStrategy = DuplicatesStrategy.INCLUDE }
+    mergeServiceFiles()
+}
+
 // ******************** artifacts ********************
 
 val releaseBinary: Configuration by configurations.creating {

--- a/modules/hivemq-edge-module-plc4x/src/main/resources/META-INF/services/org.apache.plc4x.java.api.PlcDriver
+++ b/modules/hivemq-edge-module-plc4x/src/main/resources/META-INF/services/org.apache.plc4x.java.api.PlcDriver
@@ -1,2 +1,0 @@
-org.apache.plc4x.java.ads.AdsPlcDriver
-org.apache.plc4x.java.s7.readwrite.S7Driver

--- a/modules/hivemq-edge-module-plc4x/src/main/resources/META-INF/services/org.apache.plc4x.java.spi.transport.Transport
+++ b/modules/hivemq-edge-module-plc4x/src/main/resources/META-INF/services/org.apache.plc4x.java.spi.transport.Transport
@@ -1,2 +1,0 @@
-org.apache.plc4x.java.transport.tcp.TcpTransport
-org.apache.plc4x.java.transport.serial.SerialTransport


### PR DESCRIPTION
**Motivation**

[EDG-935](https://linear.app/hivemq/issue/EDG-935/shadowjar-default-duplicatesstrategyexclude-silently-defeats)

`ShadowJar` sets `duplicatesStrategy = EXCLUDE` in its own init block, and Gradle applies that filtering *before* the resource transformers run. `mergeServiceFiles()` therefore never saw a second copy: only the first `META-INF/services` file of a given name reached the jar, and every other provider was dropped silently. Shadow reports this once per matched file, which is the wall of warnings on every `:hivemq-edge:shadowJar`.

Diffing the fat jar's 38 service files against the union of the resolved `runtimeClasspath` showed **12 provider registrations missing**:

| Service file | Kept | Dropped |
| --- | --- | --- |
| `com.fasterxml.jackson.databind.Module` | `JavaTimeModule` | `Jdk8Module`, `JakartaXmlBindAnnotationModule`, `JsonNullableModule` |
| `jackson.core.JsonFactory` / `ObjectCodec` | the XML pair | jackson-core `JsonFactory`, databind `ObjectMapper`, both YAML |
| `jersey…spi.AutoDiscoverable` | `JacksonAutoDiscoverable` | `LoggingFeature…`, `MultiPartFeature…`, `ServerFilters…` |
| `jersey…BootstrapPreinitialization` | server | `ClientBootstrapPreinitialization` |
| `jakarta.ws.rs.ext.RuntimeDelegate` | jersey-server impl | jersey-common impl |

Nothing was visibly broken by those, because no code path here relies on SPI discovery — there is no `findAndRegisterModules()`, `LoggingFeature` is registered explicitly, and there are no multipart endpoints. The jar's registry was simply wrong, and stayed harmless only as long as the copy order held.

The adapter modules never called `mergeServiceFiles()` at all, so they had no warning and no merge either. `hivemq-edge-module-databases` shipped `org.postgresql.Driver` as the only registered `java.sql.Driver`; MySQL and MSSQL worked solely through the explicit `Class.forName` calls in the adapter.

**Changes**

- Every `shadowJar` that bundles dependencies now merges service files, with the duplicates strategy overridden for `META-INF/services/**` so the transformer sees every copy. The override is deliberately **not** global: a global `INCLUDE` would also stop de-duplicating licence files and every other shared resource, writing each of them into the jar once per source.
- Removed plc4x's hand-written `PlcDriver` and `Transport` descriptors. They were added to work around this very bug ("provide own service descriptor file, to prevent overwriting by shadow plugin", #199) and had rotted: the `Transport` one named `SerialTransport`, whose class is not bundled, so enumerating that SPI threw `ServiceConfigurationError`. Verified by injecting the old descriptor into the fixed jar.

**Verification**

- Core fat jar: 12 dropped entries → **0**, by re-running the same union diff.
- `databases`: `java.sql.Driver` now lists PostgreSQL, MariaDB and MSSQL.
- `plc4x`: SPI enumerates cleanly — drivers `s7`, `s7-light`, `ads`; transports `raw`, `raw-passive`, `tcp`; every listed provider class is present in the jar and instantiates.
- `hivemqEdgeFullZip` is green with **zero** duplicate-strategy warnings, and the shipped module jars carry the merged descriptors.
- `spotlessApply` was a no-op; `spotlessCheck` plus `check` on plc4x and databases pass.

Companion PRs on branches of the same name apply the same fix elsewhere: https://github.com/hivemq/hivemq-edge-commercial-modules/pull/364 and https://github.com/hivemq/hivemq-edge-module-bacnetip/pull/88. All three need to land together for a composite build to be consistent.
