### PR TITLE
EDG-935: Merge service files in the v2 module shadow jars

### DIFF
--- a/modules/hivemq-edge-module-databases-v2/build.gradle.kts
+++ b/modules/hivemq-edge-module-databases-v2/build.gradle.kts
@@ -72,6 +72,16 @@ tasks.register<Copy>("copyAllDependencies") {
 
 tasks.named("assemble") { finalizedBy("copyAllDependencies") }
 
+tasks.shadowJar {
+    // ShadowJar defaults its duplicatesStrategy to EXCLUDE, and that filtering runs before the
+    // service-file merge: without the override below, only the first META-INF/services file of a
+    // given name survives and every other provider is dropped silently. Here that would leave a
+    // single registered java.sql.Driver instead of the three bundled above. The override is scoped
+    // to service files so every other duplicated resource still lands in the jar exactly once.
+    filesMatching("META-INF/services/**") { duplicatesStrategy = DuplicatesStrategy.INCLUDE }
+    mergeServiceFiles()
+}
+
 // ******************** artifacts ********************
 
 val releaseBinary: Configuration by configurations.creating {

--- a/modules/hivemq-edge-module-file-v2/build.gradle.kts
+++ b/modules/hivemq-edge-module-file-v2/build.gradle.kts
@@ -66,6 +66,15 @@ tasks.register<Copy>("copyAllDependencies") {
 
 tasks.named("assemble") { finalizedBy("copyAllDependencies") }
 
+tasks.shadowJar {
+    // ShadowJar defaults its duplicatesStrategy to EXCLUDE, and that filtering runs before the
+    // service-file merge, so without this override only the first META-INF/services file of a given
+    // name reaches the jar and every other provider is dropped silently. The override is scoped to
+    // service files, so every other duplicated resource still lands in the jar exactly once.
+    filesMatching("META-INF/services/**") { duplicatesStrategy = DuplicatesStrategy.INCLUDE }
+    mergeServiceFiles()
+}
+
 // ******************** artifacts ********************
 
 val releaseBinary: Configuration by configurations.creating {

--- a/modules/hivemq-edge-module-http-v2/build.gradle.kts
+++ b/modules/hivemq-edge-module-http-v2/build.gradle.kts
@@ -67,6 +67,15 @@ tasks.register<Copy>("copyAllDependencies") {
 
 tasks.named("assemble") { finalizedBy("copyAllDependencies") }
 
+tasks.shadowJar {
+    // ShadowJar defaults its duplicatesStrategy to EXCLUDE, and that filtering runs before the
+    // service-file merge, so without this override only the first META-INF/services file of a given
+    // name reaches the jar and every other provider is dropped silently. The override is scoped to
+    // service files, so every other duplicated resource still lands in the jar exactly once.
+    filesMatching("META-INF/services/**") { duplicatesStrategy = DuplicatesStrategy.INCLUDE }
+    mergeServiceFiles()
+}
+
 // ******************** artifacts ********************
 
 val releaseBinary: Configuration by configurations.creating {


### PR DESCRIPTION
**Motivation**

[EDG-935](https://linear.app/hivemq/issue/EDG-935/shadowjar-default-duplicatesstrategyexclude-silently-defeats)

The fix for this landed on `master` in #1729, but the SDK v2 adapter modules only exist on `initiative/nevsky-protocol-adapter-v2`, so it never reached them. They carry the same defect: `ShadowJar` sets `duplicatesStrategy = EXCLUDE` in its own init block, and Gradle applies that filtering *before* the resource transformers run, so only the first `META-INF/services` file of a given name reaches the jar and every other provider is dropped.

`hivemq-edge-module-databases-v2` shades the PostgreSQL, MariaDB and MSSQL drivers plus HikariCP, and was shipping exactly one of them:

| `META-INF/services/java.sql.Driver` in the shipped jar | |
| --- | --- |
| before | `org.postgresql.Driver` |
| after | `org.postgresql.Driver`, `org.mariadb.jdbc.Driver`, `com.microsoft.sqlserver.jdbc.SQLServerDriver` |

As on `master`, nothing is visibly broken by this today: `DatabasesProtocolAdapter#doConnect` calls `Class.forName` on all three drivers under the module classloader before opening a pool, and PostgreSQL and MSSQL reach their drivers through `setDataSourceClassName` rather than the SPI at all. Only the MySQL path goes through a JDBC URL and `DriverManager`, and the explicit registration above it is what makes that work. The jar's registry was simply wrong, and stayed harmless only because every consumer registers explicitly — the same latent-correctness argument as #1729.

Worth flagging for anyone auditing this: **the build was warning-free the whole time.** Shadow's duplicates-strategy check only fires for files claimed by a *registered* transformer, and these modules never called `mergeServiceFiles()`, so there was no transformer, no warning, and the providers vanished silently. `hivemqEdgeFullZip` was green with zero warnings while the jar was wrong. The wall of warnings in the original report came from core `hivemq-edge`, the one task that already called `mergeServiceFiles()`. Grepping build logs does not find this class of breakage — you have to enumerate the jar.

**Changes**

- `databases-v2`, `file-v2` and `http-v2` now merge service files, with the duplicates strategy overridden for `META-INF/services/**` so the transformer sees every copy. This matches what their v1 counterparts got in #1729.
- The override is deliberately **not** global: a global `INCLUDE` would also stop de-duplicating licence files and every other shared resource, writing each of them into the jar once per source.
- For `file-v2` and `http-v2` the change is preventive — neither bundles a runtime dependency today, so nothing is merged yet. It keeps all six file/http/databases modules consistent and means the next bundled dependency does not silently lose its providers.

`hivemq-edge-module-chaos` and `hivemq-edge-module-workload` match a text search for "shadow" but only in comments; neither applies the plugin, so neither is affected.

**Verification**

- `databases-v2`: `java.sql.Driver` goes from 1 to 3 registered drivers, confirmed in the jar unpacked from `hivemq-edge-full-2026.14-SNAPSHOT.zip`, not just the build output. Both before and after were built with `--rerun-tasks` so neither came from the build cache.
- All three v2 `ProtocolAdapterFactory` descriptors survive the merge intact.
- `hivemqEdgeFullZip` is green, with zero duplicate-strategy warnings.
- `check` passes on all three modules — Spotless (including `spotlessKotlinGradleCheck` on the edited build scripts), ErrorProne, NullAway and the module tests.

Targets `initiative/nevsky-protocol-adapter-v2`, not `master`. No companion PRs: `hivemq-edge-commercial-modules` and `hivemq-edge-module-bacnetip` were already fixed on `master` by hivemq/hivemq-edge-commercial-modules#364 and hivemq/hivemq-edge-module-bacnetip#88, and this branch is the only place left where the issue survives.
