### PR TITLE
EDG-934: Fork the core unit tests and stop MessageExpiryHandlerTest sleeping

### DIFF
--- a/hivemq-edge/build.gradle.kts
+++ b/hivemq-edge/build.gradle.kts
@@ -300,11 +300,10 @@ dependencies {
 
 tasks.test {
     useJUnitPlatform()
-    // Run the unit tests in parallel JVMs, one per 3 cores, overridable with -PunitTestForks=N.
-    // 3 forks was the optimum on a 10-core M4; changes to the suite or the machine may shift that,
-    // though not dramatically.
+    // Run the unit tests in parallel JVMs, one per 2 cores, overridable with -PunitTestForks=N.
+    // Same formula as the integration suite, so there is one rule rather than two to keep straight.
     maxParallelForks = (project.findProperty("unitTestForks") as String?)?.toIntOrNull()
-        ?: (Runtime.getRuntime().availableProcessors() / 3).coerceAtLeast(1)
+        ?: (Runtime.getRuntime().availableProcessors() / 2).coerceAtLeast(1)
     minHeapSize = "128m"
     maxHeapSize = "2048m"
     jvmArgs(

--- a/hivemq-edge/build.gradle.kts
+++ b/hivemq-edge/build.gradle.kts
@@ -300,6 +300,11 @@ dependencies {
 
 tasks.test {
     useJUnitPlatform()
+    // Run the unit tests in parallel JVMs, one per 3 cores, overridable with -PunitTestForks=N.
+    // 3 forks was the optimum on a 10-core M4; changes to the suite or the machine may shift that,
+    // though not dramatically.
+    maxParallelForks = (project.findProperty("unitTestForks") as String?)?.toIntOrNull()
+        ?: (Runtime.getRuntime().availableProcessors() / 3).coerceAtLeast(1)
     minHeapSize = "128m"
     maxHeapSize = "2048m"
     jvmArgs(

--- a/hivemq-edge/src/test/java/com/hivemq/mqtt/handler/publish/MessageExpiryHandlerTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/mqtt/handler/publish/MessageExpiryHandlerTest.java
@@ -25,12 +25,11 @@ import com.hivemq.mqtt.event.PubrelDroppedEvent;
 import com.hivemq.mqtt.message.ProtocolVersion;
 import com.hivemq.mqtt.message.QoS;
 import com.hivemq.mqtt.message.publish.PUBLISH;
+import com.hivemq.mqtt.message.publish.PUBLISHFactory;
 import com.hivemq.mqtt.message.pubrel.PUBREL;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.embedded.EmbeddedChannel;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -46,12 +45,26 @@ import util.TestMessageUtil;
  */
 public class MessageExpiryHandlerTest {
 
+    // ELAPSED_MILLIS must exceed EXPIRY_INTERVAL, and by more than a second: the handler computes the
+    // elapsed time in whole seconds by integer division, so 1500ms elapsed still reads as 1s and would
+    // leave a 1s interval intact rather than expiring it.
+    private static final long EXPIRY_INTERVAL = 1;
+    private static final long ELAPSED_MILLIS = 2000;
+
     @Mock
     private ChannelHandlerContext ctx;
 
     private EmbeddedChannel channel;
 
     LogbackCapturingAppender logCapture;
+
+    // Several tests below flip these two mutable public statics. They are process-wide, so without the
+    // save/restore in setUp and tearDown a test leaks its setting into whatever runs next in the same
+    // JVM. Harmless while this suite ran sequentially in one JVM; a hazard now that it forks.
+    private boolean expireInflightMessages;
+    private boolean expireInflightPubrels;
+
+    private boolean dropped;
 
     @BeforeEach
     public void setUp() throws Exception {
@@ -65,177 +78,129 @@ public class MessageExpiryHandlerTest {
         channel.pipeline().addLast(messageExpiryHandler);
         when(ctx.channel()).thenReturn(channel);
         logCapture = LogbackCapturingAppender.Factory.weaveInto(MessageExpiryHandler.log);
+        expireInflightMessages = InternalConfigurations.EXPIRE_INFLIGHT_MESSAGES_ENABLED;
+        expireInflightPubrels = InternalConfigurations.EXPIRE_INFLIGHT_PUBRELS_ENABLED;
     }
 
     @AfterEach
     public void tearDown() throws Exception {
         LogbackCapturingAppender.Factory.cleanUp();
+        InternalConfigurations.EXPIRE_INFLIGHT_MESSAGES_ENABLED = expireInflightMessages;
+        InternalConfigurations.EXPIRE_INFLIGHT_PUBRELS_ENABLED = expireInflightPubrels;
     }
 
-    @Test
-    public void test_message_expired_qos_0() throws Exception {
+    /**
+     * A PUBLISH whose expiry interval has already lapsed.
+     * <p>
+     * The handler compares the message timestamp against the current time, so backdating the timestamp is
+     * equivalent to waiting for the interval to pass, and costs nothing.
+     */
+    private static @NotNull PUBLISH expiredPublish(final @NotNull QoS qos, final boolean duplicateDelivery) {
+        // The timestamp can only be set at construction, so rebuild the standard test PUBLISH with a
+        // backdated one rather than hand-rolling a builder here.
+        final PUBLISH publish = new PUBLISHFactory.Mqtt5Builder()
+                .fromPublish(TestMessageUtil.createMqtt5Publish("topic", qos))
+                .withTimestamp(System.currentTimeMillis() - ELAPSED_MILLIS)
+                .build();
+        publish.setMessageExpiryInterval(EXPIRY_INTERVAL);
+        publish.setDuplicateDelivery(duplicateDelivery);
+        return publish;
+    }
 
-        final PUBLISH publish = TestMessageUtil.createMqtt5Publish("topic", QoS.AT_MOST_ONCE);
-        publish.setMessageExpiryInterval(1);
-
-        Thread.sleep(2000);
-
-        final CountDownLatch droppedEventFiredLatch = new CountDownLatch(1);
+    /**
+     * Writes the message and reports whether the handler fired the given drop event.
+     * <p>
+     * A plain boolean rather than a CountDownLatch: EmbeddedChannel runs the pipeline on the calling
+     * thread, so by the time write returns the event has either fired or it never will. Waiting on a
+     * latch here bought nothing but wall-clock time -- and worse, the "should not be dropped" cases had
+     * to wait out the full timeout to prove a negative.
+     * <p>
+     * Each call adds another listener to the pipeline and resets the flag, so a second call reports only
+     * its own write -- but the listeners from earlier calls are still installed and will also see it.
+     * Every test here writes once.
+     */
+    private boolean writeAndCheckDropped(final @NotNull Object message, final @NotNull Class<?> dropEventType) {
+        // A field rather than a local: the anonymous handler below cannot assign to a local variable.
+        // A plain boolean suffices -- EmbeddedChannel fires the event on the thread that calls
+        // writeOutbound, so it is written and read by the same thread.
+        dropped = false;
         channel.pipeline().addLast(new ChannelInboundHandlerAdapter() {
             @Override
-            public void userEventTriggered(final ChannelHandlerContext ctx, final @NotNull Object evt)
-                    throws Exception {
-                if (evt instanceof PublishDroppedEvent) {
-                    droppedEventFiredLatch.countDown();
+            public void userEventTriggered(final ChannelHandlerContext ctx, final @NotNull Object evt) {
+                if (dropEventType.isInstance(evt)) {
+                    dropped = true;
                 }
             }
         });
-        channel.writeOutbound(ctx, publish, channel.newPromise());
+        channel.writeOutbound(ctx, message, channel.newPromise());
+        return dropped;
+    }
 
-        assertTrue(droppedEventFiredLatch.await(5, TimeUnit.SECONDS));
+    @Test
+    public void test_message_expired_qos_0() {
+        final PUBLISH publish = expiredPublish(QoS.AT_MOST_ONCE, false);
+
+        assertTrue(writeAndCheckDropped(publish, PublishDroppedEvent.class));
         assertEquals(0, publish.getMessageExpiryInterval());
     }
 
     @Test
-    public void test_message_expired_qos_1() throws Exception {
+    public void test_message_expired_qos_1() {
+        final PUBLISH publish = expiredPublish(QoS.AT_LEAST_ONCE, false);
 
-        final PUBLISH publish = TestMessageUtil.createMqtt5Publish("topic", QoS.AT_LEAST_ONCE);
-        publish.setMessageExpiryInterval(1);
-
-        Thread.sleep(2000);
-
-        final CountDownLatch droppedEventFiredLatch = new CountDownLatch(1);
-        channel.pipeline().addLast(new ChannelInboundHandlerAdapter() {
-            @Override
-            public void userEventTriggered(final ChannelHandlerContext ctx, final @NotNull Object evt)
-                    throws Exception {
-                if (evt instanceof PublishDroppedEvent) {
-                    droppedEventFiredLatch.countDown();
-                }
-            }
-        });
-        channel.writeOutbound(ctx, publish, channel.newPromise());
-
-        assertTrue(droppedEventFiredLatch.await(5, TimeUnit.SECONDS));
+        assertTrue(writeAndCheckDropped(publish, PublishDroppedEvent.class));
         assertEquals(0, publish.getMessageExpiryInterval());
     }
 
     @Test
-    public void test_message_expired_qos_2_not_dup() throws Exception {
+    public void test_message_expired_qos_2_not_dup() {
+        final PUBLISH publish = expiredPublish(QoS.EXACTLY_ONCE, false);
 
-        final PUBLISH publish = TestMessageUtil.createMqtt5Publish("topic", QoS.EXACTLY_ONCE);
-        publish.setMessageExpiryInterval(1);
-
-        Thread.sleep(2000);
-
-        final CountDownLatch droppedEventFiredLatch = new CountDownLatch(1);
-        channel.pipeline().addLast(new ChannelInboundHandlerAdapter() {
-            @Override
-            public void userEventTriggered(final ChannelHandlerContext ctx, final @NotNull Object evt)
-                    throws Exception {
-                if (evt instanceof PublishDroppedEvent) {
-                    droppedEventFiredLatch.countDown();
-                }
-            }
-        });
-        channel.writeOutbound(ctx, publish, channel.newPromise());
-
-        assertTrue(droppedEventFiredLatch.await(5, TimeUnit.SECONDS));
+        assertTrue(writeAndCheckDropped(publish, PublishDroppedEvent.class));
         assertEquals(0, publish.getMessageExpiryInterval());
     }
 
     @Test
-    public void test_message_qos_2_dup() throws Exception {
-        final PUBLISH publish = TestMessageUtil.createMqtt5Publish("topic", QoS.EXACTLY_ONCE);
-        publish.setMessageExpiryInterval(1);
-        publish.setDuplicateDelivery(true);
+    public void test_message_qos_2_dup() {
+        final PUBLISH publish = expiredPublish(QoS.EXACTLY_ONCE, true);
 
-        Thread.sleep(2000);
-
-        final CountDownLatch droppedEventFiredLatch = new CountDownLatch(1);
-        channel.pipeline().addLast(new ChannelInboundHandlerAdapter() {
-            @Override
-            public void userEventTriggered(final ChannelHandlerContext ctx, final @NotNull Object evt)
-                    throws Exception {
-                if (evt instanceof PublishDroppedEvent) {
-                    droppedEventFiredLatch.countDown();
-                }
-            }
-        });
-        channel.writeOutbound(ctx, publish, channel.newPromise());
-
-        assertFalse(droppedEventFiredLatch.await(1, TimeUnit.SECONDS));
+        assertFalse(writeAndCheckDropped(publish, PublishDroppedEvent.class));
         assertEquals(0, publish.getMessageExpiryInterval());
     }
 
     @Test
-    public void test_message_expired_qos_2_dup() throws Exception {
+    public void test_message_expired_qos_2_dup() {
         InternalConfigurations.EXPIRE_INFLIGHT_MESSAGES_ENABLED = true;
-        final PUBLISH publish = TestMessageUtil.createMqtt5Publish("topic", QoS.EXACTLY_ONCE);
-        publish.setMessageExpiryInterval(1);
-        publish.setDuplicateDelivery(true);
+        final PUBLISH publish = expiredPublish(QoS.EXACTLY_ONCE, true);
 
-        Thread.sleep(2000);
-
-        final CountDownLatch droppedEventFiredLatch = new CountDownLatch(1);
-        channel.pipeline().addLast(new ChannelInboundHandlerAdapter() {
-            @Override
-            public void userEventTriggered(final ChannelHandlerContext ctx, final @NotNull Object evt)
-                    throws Exception {
-                if (evt instanceof PublishDroppedEvent) {
-                    droppedEventFiredLatch.countDown();
-                }
-            }
-        });
-        channel.writeOutbound(ctx, publish, channel.newPromise());
-
-        assertTrue(droppedEventFiredLatch.await(5, TimeUnit.SECONDS));
+        assertTrue(writeAndCheckDropped(publish, PublishDroppedEvent.class));
         assertEquals(0, publish.getMessageExpiryInterval());
     }
 
+    // The two PUBREL tests deliberately do not use expiredPublish() and do not backdate: an interval of 0
+    // is already expired whatever the timestamp says, so they never needed to wait in the first place.
+    // They were slow only because of the latch, not because of a sleep.
     @Test
-    public void test_pubrel_expired() throws InterruptedException {
+    public void test_pubrel_expired() {
         InternalConfigurations.EXPIRE_INFLIGHT_PUBRELS_ENABLED = true;
 
         final PUBREL pubrel = new PUBREL(1);
         pubrel.setMessageExpiryInterval(0L);
         pubrel.setPublishTimestamp(System.currentTimeMillis());
-        final CountDownLatch droppedEventFiredLatch = new CountDownLatch(1);
-        channel.pipeline().addLast(new ChannelInboundHandlerAdapter() {
-            @Override
-            public void userEventTriggered(final ChannelHandlerContext ctx, final @NotNull Object evt)
-                    throws Exception {
-                if (evt instanceof PubrelDroppedEvent) {
-                    droppedEventFiredLatch.countDown();
-                }
-            }
-        });
 
-        channel.writeOutbound(pubrel);
-        assertTrue(droppedEventFiredLatch.await(5, TimeUnit.SECONDS));
+        assertTrue(writeAndCheckDropped(pubrel, PubrelDroppedEvent.class));
         assertEquals(0L, pubrel.getMessageExpiryInterval().longValue());
     }
 
     @Test
-    public void test_pubrel_dont_expired() throws InterruptedException {
+    public void test_pubrel_dont_expired() {
         InternalConfigurations.EXPIRE_INFLIGHT_PUBRELS_ENABLED = false;
+
         final PUBREL pubrel = new PUBREL(1);
         pubrel.setMessageExpiryInterval(0L);
         pubrel.setPublishTimestamp(System.currentTimeMillis());
-        final CountDownLatch droppedEventFiredLatch = new CountDownLatch(1);
 
-        channel.pipeline().addLast(new ChannelInboundHandlerAdapter() {
-            @Override
-            public void userEventTriggered(final ChannelHandlerContext ctx, final @NotNull Object evt)
-                    throws Exception {
-                if (evt instanceof PubrelDroppedEvent) {
-                    droppedEventFiredLatch.countDown();
-                }
-            }
-        });
-
-        channel.writeOutbound(pubrel);
-        assertFalse(droppedEventFiredLatch.await(50, TimeUnit.MILLISECONDS));
+        assertFalse(writeAndCheckDropped(pubrel, PubrelDroppedEvent.class));
         assertEquals(0L, pubrel.getMessageExpiryInterval().longValue());
     }
 }


### PR DESCRIPTION
## Description (the why)

The core unit test task ran 537 test classes sequentially in a single JVM, taking ~92s. Two things blocked forking it, and both have now landed on master:

- **Docker** — ten classes started containers; each fork would have raced to start its own. Moved out in EDG-932 (#1728).
- **A shared hardcoded port** — six classes bound the same HTTP port; sequentially they never clashed, concurrently they would. Fixed in EDG-931 (#1727).

Three commits, deliberately separate:

**1. Fork the core unit tests** (`hivemq-edge/build.gradle.kts`, +5)

```kotlin
maxParallelForks = (project.findProperty("unitTestForks") as String?)?.toIntOrNull()
    ?: (Runtime.getRuntime().availableProcessors() / 2).coerceAtLeast(1)
```

Measured on a 10-core M4, `--rerun` so compilation stays cached and the wall clock is essentially test time:

| forks | wall clock | speedup |
| -- | -- | -- |
| 1 | 97, 92, 92s | 1.00x |
| 2 | 67, 68, 66s | 1.40x |
| 3 | 42, 43, 46s | **2.14x** |
| 4 | 44, 44s | 2.14x |
| 8 | 42, 42s | 2.24x |

`coerceAtLeast(1)` is required rather than defensive: the division is 0 on a 1-core agent and Gradle then refuses to configure the task at all. The override is named `unitTestForks` rather than something shared, so that nobody tunes one suite and silently mis-tunes the other.

**3. Use `cores/2`, the same formula as the integration suite** (`hivemq-edge/build.gradle.kts`, +7 −4)

The table above plateaus at 3 forks, which is why this landed as `/3` first. That plateau turns out to be an artifact of *distribution*, not of the suite: Gradle deals class *i* to fork *(i mod maxParallelForks)* in scan order and never rebalances or steals work, so a fork that draws several slow classes runs long after the others are idle. Measured here: 88s of work over a 39s span — 2.24x of 3 forks, with all three busy for only 13s of it. Raising the fork count without fixing the distribution buys nothing, which is exactly what the flat plateau was showing.

Ordering the classes slowest-first in a zigzag ([EDG-930](https://linear.app/hivemq/issue/EDG-930/order-integration-test-classes-by-measured-runtime-to-balance-the) in `hivemq-edge-test`) changes that. Ported here as a throwaway experiment and measured on the same machine:

| forks | span, ordered | parallelism |
| -- | -- | -- |
| 3 | 34.0s | 2.61x |
| 5 | 28.6s | **4.04x** |
| 8 | 30.3s | 5.90x (total work inflates — oversubscribed) |

So `cores/2` is the better point once the classes are ordered, and 3 is marginally better until then — today this costs a second or two on a 10-core machine (44s -> 48s). Taking that cost now keeps **one rule for both suites** instead of two divisors that have to be explained and kept straight every time someone reads them.

The ordering work itself is deliberately **not** in this PR: it belongs in its own issue and should cover the integration and unit suites at once.

**2. Stop `MessageExpiryHandlerTest` sleeping** (`MessageExpiryHandlerTest.java`, +84 −119)

At 11.09s this was the slowest class in the suite, of which 10s was five `Thread.sleep(2000)` calls waiting for a 1s message expiry to lapse. It is now **0.002s**. Same seven tests, same assertions.

`MessageExpiryHandler` decides expiry from `currentTimeMillis() - message.getTimestamp()`, so a message built with a backdated timestamp is already expired — waiting is unnecessary. The timestamp can only be set at construction, so the helper rebuilds the standard `TestMessageUtil` PUBLISH via `Mqtt5Builder.fromPublish()` and overrides it. **No production code changes.**

The `CountDownLatch`es went too: `EmbeddedChannel` runs the pipeline inline on the calling thread, so by the time `writeOutbound` returns the drop event has fired or it never will. That also removes a second hidden cost — the one test asserting a message is *not* dropped previously had to wait out a full second to prove a negative.

Three of these tests also set mutable public statics on `InternalConfigurations` and never restored them, leaking into whatever ran next in the same JVM. Harmless while the suite was one JVM in a fixed order; a hazard now that it forks. Both flags are now saved in `setUp` and restored in `tearDown`. (`ClientQueueMemoryLocalPersistenceTest` already sets `EXPIRE_INFLIGHT_PUBRELS_ENABLED = false` in its own setup, which reads as a workaround for exactly this leak.)

Linear: [EDG-934](https://linear.app/hivemq/issue/EDG-934/fork-the-core-unit-tests-and-shorten-the-classes-that-only-sleep)

## Verification that the tests still bite

Removing a wait from a test raises an obvious question: does it still fail when the implementation is wrong, or does it now pass because it checks nothing? "It still passes" does not answer that — a test that no longer checks anything also passes.

So `MessageExpiryHandler` was mutated three times, one mutation at a time, with the expected failures predicted **before** each run. The full class was run against each mutant.

**Mutant 1 — never drop anything.**

```java
final boolean drop = false && (publish.getMessageExpiryInterval() == 0) && (!isInflight || expireInflight);
```

Predicted: the four tests that assert a message *is* dropped fail; the "should be kept" test and the two PUBREL tests pass. Observed exactly that:

```
test_message_expired_qos_0()          FAILED
test_message_expired_qos_1()          FAILED
test_message_expired_qos_2_not_dup()  FAILED
test_message_expired_qos_2_dup()      FAILED
test_message_qos_2_dup()              PASSED
test_pubrel_expired()                 PASSED
test_pubrel_dont_expired()            PASSED
```

**Mutant 2 — drop unconditionally when expired, ignoring the in-flight exception.**

```java
final boolean drop = (publish.getMessageExpiryInterval() == 0);
```

This removes the substance of the class: a QoS-2 *redelivery* is mid-handshake with the client and must be kept even when expired, unless `EXPIRE_INFLIGHT_MESSAGES_ENABLED` says otherwise. Predicted: only `test_message_qos_2_dup` fails. Observed exactly that — one failure, six passes.

**Mutant 3 — ignore elapsed time in the recalculation.**

```java
final long waitingInSeconds = 0;
```

This is the decisive one for this change. The rewrite replaced "sleep until the expiry lapses" with "backdate the timestamp", and the risk in that swap is that the tests stop depending on the timestamp being read at all — they would then pass for the wrong reason and a real regression in the elapsed-time calculation would slip through. Predicted: all five PUBLISH tests fail, both PUBREL tests pass (they use a separate code path keyed on `getPublishTimestamp()` with an interval of 0). Observed exactly that:

```
test_message_expired_qos_0()          FAILED
test_message_expired_qos_1()          FAILED
test_message_expired_qos_2_not_dup()  FAILED
test_message_expired_qos_2_dup()      FAILED
test_message_qos_2_dup()              FAILED
test_pubrel_expired()                 PASSED
test_pubrel_dont_expired()            PASSED
```

Each mutant failed precisely the tests that claim to pin that behaviour and nothing else. The handler was then restored, `git status` confirmed clean, and all seven tests pass again.

## Acceptance Criteria

- [x] `:hivemq-edge-build:hivemq-edge:test` runs with `maxParallelForks`; 537 classes / 4796 tests / 0 failures
- [x] `-PunitTestForks=N` overrides the fork count for measurement
- [x] The chosen formula is documented at the call site with the measurement behind it
- [x] `MessageExpiryHandlerTest` no longer sleeps: 11.09s -> 0.002s, same seven tests and assertions
- [x] The tests are shown to still fail when the implementation is broken (three mutants above)
- [x] Global config flags set by those tests are restored, so they cannot leak between forked JVMs
- [x] `spotlessCheck` passes

## Non-Goals

- **Running tests concurrently *within* one JVM.** Tried: JUnit's parallel execution gave 1m07s but 86 failures, 79 of them from `LogbackCapturingAppender`, a test helper holding a `private static final List` whose `getLastCapturedLog()` returns whatever was logged last process-wide. Adding `@ResourceLock` to serialise the 11 classes using it made it **worse** (253 failures), proving that is not the only global state. Real work of unknown size; a separate issue if pursued.
- **The remaining sleep-heavy classes.** ~19s of hardcoded `Thread.sleep` remains across 28 classes. The two next-largest were investigated and are *not* the same easy case:
  - `ClientQueueMemoryLocalPersistenceTest` (6s) — the sleep establishes an ordering, not merely elapsed time. Messages must be read out of the queue while still live and expire afterwards while in flight; the read path skips expired messages, so backdating changes what the test exercises. Confirmed by trying it: one of the two tests failed.
  - `KeepAliveDisconnectHandlerTest` / `KeepAliveDisconnectServiceTest` (~10s) — the handler schedules its timeout task on the channel's event loop with a real 2s delay, and the test helper only runs tasks that are due. Confirmed by forcing an immediate poll interval: unchanged at 2.19s. Making these fast needs the scheduler injected, which is a larger change.
- Touching the integration suite's parallelism (different repo, different shape).

