### PR TITLE
EDG-951: Stop the protocol adapters before tearing down the messaging layer

### DIFF
--- a/hivemq-edge/src/main/java/com/hivemq/embedded/internal/EmbeddedHiveMQImpl.java
+++ b/hivemq-edge/src/main/java/com/hivemq/embedded/internal/EmbeddedHiveMQImpl.java
@@ -224,8 +224,21 @@ class EmbeddedHiveMQImpl implements EmbeddedHiveMQ {
 
             try {
                 if (hiveMQServer != null) {
-                    hiveMQServer.stop();
+                    // Adapters FIRST, then the broker they publish into (EDG-951).
+                    //
+                    // The other order lets every adapter keep polling its device and publishing for the
+                    // whole duration of stop(), into a broker that is being dismantled underneath it. The
+                    // publish callback is registered with an executor; once that executor is shutting down
+                    // the callback cannot run, StandardPublishCallback.onFailure rethrows, and the publish's
+                    // completion future -- which is only ever completed INSIDE that callback -- is left
+                    // hanging. The visible symptom is a "RuntimeException while executing runnable
+                    // CallbackListener" error; the quiet one is an abandoned publish.
+                    //
+                    // shutdownProtocolAdapters() waits for each adapter to stop, bounded by
+                    // SHUTDOWN_STOP_TIMEOUT_SECONDS, so this also gives in-flight work time to drain
+                    // without risking a wedged shutdown.
                     hiveMQServer.shutdownProtocolAdapters();
+                    hiveMQServer.stop();
                 }
             } catch (final Exception ex) {
                 if (desiredState == State.CLOSED) {


### PR DESCRIPTION
## Description (the why)

[EDG-951](https://linear.app/hivemq/issue/EDG-951/stop-the-protocol-adapters-before-tearing-down-the-messaging-layer)

Shutdown tore down the messaging layer **first** and stopped the protocol adapters **afterwards**:

```java
hiveMQServer.stop();                      // shutdown hooks: executors, persistence, listeners
hiveMQServer.shutdownProtocolAdapters();  // only now do the adapters stop polling
```

So for the whole duration of `stop()`, every adapter kept polling its device and publishing into a broker that was being dismantled underneath it.

### What goes wrong

`PublishDistributorImpl` registers `StandardPublishCallback` on the delivery future **with an executor**:

```java
Futures.addCallback(publishFuture, new StandardPublishCallback(...), executorService);
```

Once that executor is shutting down the callback cannot run, `StandardPublishCallback.onFailure` rethrows via `Exceptions.rethrowError`, and Guava logs:

```
RuntimeException while executing runnable CallbackListener{StandardPublishCallback}
with executor ThreadPoolExecutor[Shutting down, pool size = 1, active threads = 1, completed tasks = 11]
```

**That error is the visible half.** The quiet half is `publishFinishedFuture`, which is completed *only inside that callback* — on both the success and failure paths. If the callback never runs, nothing completes it, and whoever waits on it waits forever or is torn down still waiting. A publish can be abandoned without either finishing or reporting.

## What changed

Two lines swapped, in `EmbeddedHiveMQImpl.stop()`:

```java
hiveMQServer.shutdownProtocolAdapters();   // adapters first
hiveMQServer.stop();                       // then the broker they publish into
```

**No new waiting was needed.** `ProtocolAdapterManager.shutdown()` already stops each adapter and waits on it, bounded by `SHUTDOWN_STOP_TIMEOUT_SECONDS`. Running it first therefore drains in-flight work as a side effect, with the bound already in place — so this cannot introduce a shutdown that hangs. That bound matters: a leaked publish is recoverable, a wedged shutdown is not.

The remaining twelve lines of the diff are a comment naming the mechanism, so nobody swaps the calls back on the reasonable assumption that two adjacent shutdown calls are order-independent.

## How it was found

`SimpleModbusIT` polls every 10 ms with `publishChangedDataOnly=false` — **100 publishes per second**, of which the test consumes exactly one before returning. There is essentially always work in flight when teardown starts.

Across every branch in the last two weeks it failed **6 times on 6 distinct branches**, including `master` — an intermittent, not one bad branch. Any test with a fast-polling adapter is exposed; the poll rate only changes the odds.

## Verification

Five consecutive local runs of `SimpleModbusIT`, all green.

**Weak evidence, stated plainly:** this test passes most of the time regardless — that is what makes it flaky rather than broken. Five clean runs show the change does not break anything; they do not demonstrate the flake is gone. What carries the weight is the mechanism, which is now understood rather than guessed, and the two-week failure history.

## Acceptance Criteria

- [ ] Embedded Edge stops adapters before the broker
- [ ] No `RuntimeException while executing runnable CallbackListener` on a clean stop
- [ ] Shutdown stays bounded — no new path that can hang
- [ ] `SimpleModbusIT` stops appearing in the flaky list

## Non-Goals

* **The standalone (non-embedded) shutdown path.** `HiveMQEdgeMain.stop()` calls only `stopGateway()`, and nothing on that path reaches `protocolAdapterManager().shutdown()` at all — `shutdownProtocolAdapters()` is annotated `@VisibleForTesting` and called solely from `EmbeddedHiveMQImpl`. That is a wider change with its own risk and deserves separate treatment. **A JVM shutdown hook is not the answer**: see the comment in `ProtocolAdapterManager` describing a heap dump where 116 registered hooks pinned 57 complete Edge instances and ~740 MB.
* **Whether a publish interrupted by shutdown should be `ERROR` at all.** If it is expected during a clean stop, `rethrowError` is the wrong response and a debug note would do. Independent of the ordering, and decidable after it.
* **Silencing the message in tests.** `addAllowedError` matches by substring, so it would blind the whole test rather than just teardown.
