### PR TITLE
EDG-954: Fix two defects in the concurrency occupancy report

### DIFF
--- a/edge-plugins/src/main/kotlin/com/hivemq/testordering/ReportTestConcurrencyTask.kt
+++ b/edge-plugins/src/main/kotlin/com/hivemq/testordering/ReportTestConcurrencyTask.kt
@@ -183,12 +183,22 @@ abstract class ReportTestConcurrencyTask : DefaultTask() {
         }
 
         // (start, end) in epoch millis for every class in every log file.
+        //
+        // NESTED CLASSES ARE SKIPPED, and they must be. A class with @Nested inner classes writes a
+        // line per nested class AND a line for the enclosing class whose duration already SPANS all
+        // of them, so counting every line charges that work twice: it inflated one real run's class
+        // time from 64m38s to 66m29s and the concurrency it implies from 4.8x to 5.0x. A nested
+        // class is also never dispatched on its own -- Gradle hands out the enclosing class and
+        // JUnit runs the nested ones inside it -- so the outer class is the only unit that
+        // corresponds to a fork being occupied. See ForkAttributionListener, which documents the
+        // same trap at the point the lines are written.
         val all = mutableListOf<Pair<Long, Long>>()
         files.forEach { file ->
             file.forEachLine { line ->
                 if (line.startsWith("#")) return@forEachLine
                 val f = line.split(' ')
                 if (f.size < 5) return@forEachLine
+                if (f[4].contains('$')) return@forEachLine
                 val end = f[0].toLongOrNull() ?: return@forEachLine
                 val duration = f[2].toLongOrNull() ?: return@forEachLine
                 all += (end - duration) to end
@@ -226,7 +236,14 @@ abstract class ReportTestConcurrencyTask : DefaultTask() {
             busyUntil = maxOf(busyUntil, span.second)
         }
 
-        val spans = runs.last()
+        // THE LARGEST RUN, NOT THE LAST ONE. `runs.last()` looks right -- the newest burst of
+        // activity is presumably the run just finished -- but it is wrong whenever anything ran
+        // after the suite: re-running one failing class, or an IDE running a single test, appends a
+        // later and much smaller segment. Observed printing "8s of class time in 8s of wall clock =
+        // 1.0 effective average concurrency" for a run of 336 classes and over an hour of work,
+        // because a stray 9-second single-class invocation followed it. The suite outweighs such
+        // strays by two orders of magnitude, so size is the reliable signal.
+        val spans = runs.maxBy { it.size }
         val ignored = all.size - spans.size
         val otherRuns = runs.size - 1
 


### PR DESCRIPTION
## Description (the why)

[EDG-954](https://linear.app/hivemq/issue/EDG-954/fix-two-defects-in-the-reporttestconcurrency-occupancy-report)

`./gradlew reportTestConcurrency` reads the per-fork logs written by `ForkAttributionListener` and reports how well a local test run filled its forks. Two defects in the **occupancy** half made its numbers wrong. The ordering half is fine and untouched.

Both bugs look correct at a glance, which is why they survived.

### Defect 1 — nested classes counted twice

A class with `@Nested` inner classes writes a line **per nested class** AND a line for the enclosing class whose duration already **spans all of them**. The report summed every line, charging that work twice.

The tell was the occupancy chart printing **6.0 forks busy** in the first decile of a run on a **5**-fork machine — impossible, and a direct consequence of the double-count.

`ForkAttributionListener` documents this trap at the point the lines are written (`EtherIpCipOdvaIT` once reported 176s for 88s of work), and `ClassFiles.kt` and `JUnitResults.kt` both filter on `$` correctly. Only `reportOccupancy()` was missing it.

### Defect 2 — the last run, not the largest

The fork-log directory accumulates; Gradle never clears it. The report splits it into runs by activity, then took `runs.last()` — the most recent burst.

That breaks whenever anything runs after the suite: re-running one failing class, or an IDE running a single test, appends a later and much smaller segment. Real output for a run of 336 classes and over an hour of work:

```
8s of class time in 8s of wall clock = 1.0 effective average concurrency
```

because a stray 9-second single-class invocation followed the suite.

## What changed

Two changes in `ReportTestConcurrencyTask.reportOccupancy()`:

```kotlin
if (f[4].contains('$')) return@forEachLine   // outer classes only
```

```kotlin
val spans = runs.maxBy { it.size }           // was runs.last()
```

The other 16 lines of the diff are comments naming the failure each one prevents.

## Verification

Mutation test on real fork logs — reverting the filter restores the inflated numbers exactly, so the change demonstrably bites:

```
WITH nested (old)        353 classes  work 67m06s  wall 13m39s  = 4.9x
WITHOUT nested (fixed)   332 classes  work 65m25s  wall 13m39s  = 4.8x
```

21 phantom classes and 1m41s of imaginary work removed. Running the task on the same logs before and after:

| | before | after |
| -- | -- | -- |
| first decile | **6.0 forks busy** (on 5 forks) | 5.0 |
| class time | 67m06s | 65m25s |
| concurrency | 4.9x | **4.8x** |

## Acceptance Criteria

- [ ] Occupancy never reports more forks busy than the run had
- [ ] A stray single-class run after the suite does not become "the run"
- [ ] Class time matches the sum of outer-class durations
- [ ] The ordering half of the report is unchanged

## Non-Goals

* **The ordering half of the report.** It already filters nested classes correctly in both `ClassFiles.kt` and `JUnitResults.kt`.
* **`ForkAttributionListener` itself.** Writing a line per nested class is correct and useful — the reader has to filter. Changing the writer would lose information.
* **Stamping a run id to separate runs.** Deliberately rejected and documented in the code: the id would have to differ per invocation, and a system property is part of a test task's cache key, so the task could then never be restored from the build cache — 61 cache hits against master's 130 when this was measured.

## Impact

Diagnostic only — no test behaviour changes, and the task is local-only (gated on `CI_RUN` being unset). But the report exists to decide whether adopting a re-ordering is worth it, and an inflated concurrency figure makes a run look better balanced than it is.
