### PR TITLE
EDG-959: Derive the test source path without searching for "out"

### DIFF
--- a/hivemq-edge/src/test/java/com/hivemq/extensions/classloader/IsolatedExtensionClassloaderTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/extensions/classloader/IsolatedExtensionClassloaderTest.java
@@ -29,7 +29,11 @@ import java.io.File;
 import java.io.InputStream;
 import java.lang.reflect.Field;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Enumeration;
+import java.util.List;
 import java.util.Map;
 import org.apache.commons.io.FileUtils;
 import org.jetbrains.annotations.NotNull;
@@ -271,33 +275,49 @@ public class IsolatedExtensionClassloaderTest {
         FileUtils.writeStringToFile(file, content, UTF_8);
     }
 
+    /**
+     * The {@code .java} source of {@code clazz}, so the test can copy, modify and recompile it.
+     * <p>
+     * The module root is derived by removing the build system's fixed output suffix from the class location --
+     * {@code build/classes/java/test} for Gradle, {@code out/test/classes} for IntelliJ. Both are constants of
+     * the build system, so nothing here depends on what any directory in the path happens to be called.
+     * <p>
+     * The previous version searched instead: it walked up until a path {@code endsWith("out")}, meaning
+     * IntelliJ's output folder. Under Gradle no such segment exists, so the walk was designed to run all the
+     * way to {@code /}, whose parent is {@code null}, which makes {@code new File((File) null, "src")} a
+     * RELATIVE path that Gradle then resolves against the module working directory. It worked, but only by
+     * that accident, and {@code endsWith} matches a string rather than a directory name -- so a Jenkins
+     * workspace derived from a branch called {@code .../something-timeout} ends with "out", the walk stopped
+     * on the workspace itself, and every derived path was wrong. Three tests failed on every build of that
+     * branch and passed after nothing but a rename (EDG-959).
+     */
     private File getJavaSrcFileForClassFile(final Class<?> clazz) {
-        final File f = new File(
+        final File classesRoot = new File(
                 clazz.getProtectionDomain().getCodeSource().getLocation().getPath());
-        File gradleHivemqParentFolder = f.getParentFile();
-        while (!gradleHivemqParentFolder.getAbsolutePath().equals("/")
-                && !gradleHivemqParentFolder.getAbsolutePath().endsWith("out")) {
-            gradleHivemqParentFolder = gradleHivemqParentFolder.getParentFile();
-        }
-        gradleHivemqParentFolder = gradleHivemqParentFolder.getParentFile();
-        final File gradleSrcFolder = new File(gradleHivemqParentFolder, "src");
-        File gradleTestFolder = new File(gradleSrcFolder, "test");
-        if (!gradleTestFolder.exists()) {
-            gradleTestFolder = new File(gradleSrcFolder, "core/test");
-        }
-        final File gradleJavaFolder = new File(gradleTestFolder, "java");
+        final Path classes = classesRoot.toPath().toAbsolutePath().normalize();
 
-        final File gradleFile =
-                new File(gradleJavaFolder, clazz.getCanonicalName().replace(".", File.separator) + ".java");
-        if (gradleFile.exists()) {
-            return gradleFile;
+        Path moduleRoot = null;
+        for (final String suffix : List.of("build/classes/java/test", "out/test/classes")) {
+            final Path relative = Paths.get(suffix);
+            if (classes.endsWith(relative)) {
+                moduleRoot =
+                        classes.getRoot().resolve(classes.subpath(0, classes.getNameCount() - relative.getNameCount()));
+                break;
+            }
         }
+        // Fail with the path we looked at. Deriving a wrong path silently is what made the branch-name bug
+        // cost an evening: the failure named a file that never existed and gave no hint why.
+        assertNotNull(
+                moduleRoot,
+                "Cannot derive the module root from the class location '" + classes
+                        + "'. Expected it to end with 'build/classes/java/test' (Gradle) or 'out/test/classes'"
+                        + " (IntelliJ). Add the new layout's suffix here.");
 
-        final File hivemqParentFolder = f.getParentFile().getParentFile().getParentFile();
-        final File srcFolder = new File(hivemqParentFolder, "src");
-        final File testFolder = new File(srcFolder, "test");
-        final File javaFolder = new File(testFolder, "java");
-
-        return new File(javaFolder, clazz.getCanonicalName().replace(".", File.separator) + ".java");
+        Path testJava = moduleRoot.resolve("src/test/java");
+        if (!Files.isDirectory(testJava)) {
+            testJava = moduleRoot.resolve("src/core/test/java");
+        }
+        return testJava.resolve(clazz.getCanonicalName().replace(".", File.separator) + ".java")
+                .toFile();
     }
 }


### PR DESCRIPTION
## Description (the why)

[EDG-959](https://linear.app/hivemq/issue/EDG-959/a-branch-name-ending-in-out-breaks-isolatedextensionclassloadertest)

Three tests in `IsolatedExtensionClassloaderTest` fail on **every** build of a branch whose name ends in the letters `out`:

```
java.io.FileNotFoundException: Source '/opt/jenkins/workspace/958_where-am-i-marker-on-timeout/
  hivemq-edge/hivemq-edge/build/src/test/java/com/hivemq/extensions/classloader/ClassLoadedClass.java'
  does not exist
```

Demonstrated by controlled comparison — same commit, only the branch name differing:

| branch name ends in | builds | result |
| -- | -- | -- |
| `…-on-timeout` | #1, #2 | **3 failures**, both times |
| `…-completely-different` | #1 | **0 failures** |

Deterministic, not flaky.

## The mechanism, including why the old code worked at all

`getJavaSrcFileForClassFile` reconstructs a `.java` **source** path from a compiled **class** location, so the test can copy, modify and recompile that source. To find the module root it walked up until a path `endsWith("out")` — IntelliJ's output folder (`<module>/out/...`).

Under Gradle no such segment exists, so **the walk was designed to fail**: it ran all the way to `/`, whose `getParentFile()` is `null`, and `new File((File) null, "src")` yields a **relative** path that Gradle then resolves against the module working directory. Correct result, entirely by accident.

**`String.endsWith` matches characters, not path segments.** Jenkins derives its workspace directory from the branch, so `test/EDG-958/where-am-i-marker-on-timeout` becomes `958_where-am-i-marker-on-timeout` — which ends with "out". The walk stopped on the workspace directory itself, the accident no longer applied, and every derived path was wrong.

Any branch ending in `timeout`, `rollout`, `checkout`, `fanout`, `layout`, `dropout` does this. `timeout` is not exotic in a test repository.

## What changed

**Stop searching; strip a known suffix.** The class location is the module root plus a fixed, layout-specific suffix:

| layout | suffix |
| -- | -- |
| Gradle | `build/classes/java/test` |
| IntelliJ | `out/test/classes` |

```java
Path moduleRoot = null;
for (final String suffix : List.of("build/classes/java/test", "out/test/classes")) {
    final Path relative = Paths.get(suffix);
    if (classes.endsWith(relative)) {
        moduleRoot = classes.getRoot()
                .resolve(classes.subpath(0, classes.getNameCount() - relative.getNameCount()));
        break;
    }
}
```

The decisive change is `Path.endsWith` rather than `String.endsWith`: it compares whole path **segments**, so it can only match a real directory named `test` inside `java` inside `classes` inside `build`. No directory name elsewhere in the path can influence the result.

**An unrecognised layout now fails loudly**, naming the path examined and the suffixes expected, instead of silently deriving a wrong one:

```
Cannot derive the module root from the class location '<path>'. Expected it to end with
'build/classes/java/test' (Gradle) or 'out/test/classes' (IntelliJ). Add the new layout's suffix here.
```

That is a deliberate behaviour change and the point of the fix. The old code checked whether its first guess existed and silently fell through to a second; the silent fallback is what made this expensive to diagnose, because the failure reported a missing file and gave no hint the branch name was involved.

The 15-line comment on the method records why the old version worked and how it broke, so nobody reintroduces the search.

## Verification

* **All 11 tests in the class pass** locally via the composite build.
* **The derivation checked against three workspace names** — including `958_where-am-i-marker-on-timeout`, the one that broke — plus the IntelliJ layout. All produce identical, correct module roots.
* Spotless applied.

## Acceptance Criteria

- [x] The source lookup cannot be influenced by any directory name in the path
- [x] An unrecognised layout fails with a clear message naming the path it examined
- [ ] A branch named `.../something-timeout` builds green — needs CI to confirm

## Non-Goals

* **Rewriting what the tests verify.** Classloader isolation coverage is untouched; only the source-file lookup changed.
* **Removing the runtime-compilation approach.** Gradle could pass the test-source directory in as a system property, making this helper unnecessary — a larger change, worth considering separately.
