### PR TITLE
EDG-956: Never hand out the same port twice in a row

### DIFF
--- a/hivemq-edge/src/test/java/util/RandomPortGenerator.java
+++ b/hivemq-edge/src/test/java/util/RandomPortGenerator.java
@@ -25,30 +25,40 @@ import java.net.ServerSocket;
  * <h2>Before you blame this class</h2>
  * <b>This does not cause port collisions, and a test that fails to bind is almost never this class's
  * fault.</b> That claim has been made many times over the years and was false every time but one -- and that
- * one exception is fixed, below. Read the following before repeating it.
+ * one exception is fixed, below.
  * <p>
- * The usual accusation is the window between proving a port free and the caller actually binding it: the
- * socket is closed and the number returned, so in principle someone else could take it in between. In
- * principle. For that to actually happen, <b>two</b> independent things must go wrong:
+ * The accusation is always the same: the window between proving a port free and the caller actually binding
+ * it. The socket is closed and the number returned, so in principle someone else could take it in between.
+ * In principle. For that to actually happen, <b>two</b> independent things must go wrong:
  * <ol>
- *   <li>another acquisition must fall inside that window, <b>and</b>
- *   <li>it must draw the same number out of {@value #RANGE} candidates.
+ *   <li>another acquisition must fall inside that window -- microseconds to a few tens of milliseconds,
+ *       against a suite that runs for minutes, <b>and</b>
+ *   <li>out of {@value #RANGE} candidates it must draw <i>exactly</i> the number we are holding.
  * </ol>
- * Both are needed, and both are unlikely, which is why ~150 call sites coexist without trouble. The range also
- * stays clear of the ports the operating system hands out on its own (see {@link #LOWEST} / {@link #HIGHEST}),
- * so the most plausible outside source is excluded by construction.
+ * Neither is likely on its own and they are independent, so the product is remote. The range is also kept
+ * clear of the ports the kernel hands out for itself (see {@link #LOWEST} / {@link #HIGHEST}), which excludes
+ * the most plausible outside source by construction. That is why ~150 call sites coexist without trouble.
  * <p>
- * <b>So before claiming this class caused a failure, have real evidence: the port number in the log, and what
- * else held it.</b> If you have that, the two-protection argument above is how to make the case -- name which
- * protection failed and why. "There is a window, so this could happen" is not evidence; it is the shape of an
- * explanation, and it has been wrong nearly every time.
+ * <b>So a failure here is only this class's doing if the particular case escapes that argument, and saying
+ * how it escapes is the burden.</b> Which of the two conditions stopped being unlikely, and why? The one real
+ * instance below is the model: a caller took two ports in a row, so the second acquisition was not merely
+ * likely to fall inside the first one's window -- it was inside it, by construction, and the first condition
+ * ceased to be a condition at all. That is an explanation of <i>why the odds do not apply here</i>.
+ * <p>
+ * A port number and a stack trace are not that. They establish that a collision happened, not that this class
+ * produced it -- and a collision has other sources: a service left running, a container holding a published
+ * port, a previous test that never released. "There is a window, so this could happen" is not an argument
+ * either; it restates the possibility the odds above already account for, and it has been wrong nearly every
+ * time.
  *
  * <h2>The one exception, and its fix</h2>
- * A caller that takes two ports in a row removes the first protection <i>with certainty</i>: the second draw
- * is not merely likely to land inside the first one's window, it is inside it. Only the 1-in-{@value #RANGE}
- * remained, and across the ~800 embedded instances a CI build starts that became a ~2% chance per build. It
- * was observed once: one instance bound the same port for its MQTT listener and its HTTP API a millisecond
- * apart, and the test failed with "Address already in use" (EDG-956).
+ * The one case that ever escaped the argument, and how. A caller that takes two ports in a row makes the
+ * first condition certain rather than unlikely: the second acquisition is not merely at risk of landing
+ * inside the first one's window, it is inside it by construction. Only the 1-in-{@value #RANGE} was left, and
+ * across the ~800 embedded instances a CI build starts that is a ~2% chance per build -- which matches what
+ * was seen, one affected build in 28. The failure itself: one instance bound the same port for its MQTT
+ * listener and its HTTP API a millisecond apart, and the test failed with "Address already in use"
+ * (EDG-956).
  * <p>
  * That is now impossible. A number handed out is remembered, and neither it nor any number sharing its bucket
  * is issued again for the next {@value #BLOCK_FOR} requests. The record is a fixed array rather than a growing

--- a/hivemq-edge/src/test/java/util/RandomPortGenerator.java
+++ b/hivemq-edge/src/test/java/util/RandomPortGenerator.java
@@ -16,27 +16,124 @@
 package util;
 
 import java.io.IOException;
+import java.net.DatagramSocket;
 import java.net.ServerSocket;
 
 /**
+ * A free port for a test to bind.
+ * <p>
+ * <b>This file is duplicated in hivemq-edge and hivemq-edge-test and must stay line-for-line identical.</b>
+ * The copies had drifted -- one probed UDP as well as TCP and the others did not, so the one improvement
+ * anybody made reached a third of the call sites. Keep them in step until a single shared copy is possible.
+ *
+ * <h2>Two protections, and why the second one exists</h2>
+ * A port is proven free by binding it, then the socket is <i>closed</i> and the number returned. The caller
+ * binds it later -- often much later, because the number is usually written into a configuration file and
+ * bound during startup. That leaves a check-then-use window, which is survivable because a collision needs
+ * <b>two</b> independent things to go wrong:
+ * <ol>
+ *   <li>another acquisition must fall inside that window, <b>and</b>
+ *   <li>it must draw the same number out of {@value #RANGE}.
+ * </ol>
+ * Both are needed, which is why ~150 call sites coexist without colliding.
+ * <p>
+ * <b>A caller that takes two ports in a row removes the first protection entirely.</b> The second draw is not
+ * merely <i>likely</i> to fall inside the first one's window -- it is inside it, with certainty. Only the
+ * 1-in-{@value #RANGE} remains, and across the ~800 embedded instances a single CI build starts that becomes
+ * a ~2% chance per build. It was observed: one instance bound the same port for its MQTT listener and its
+ * HTTP API a millisecond apart, and the test failed with "Address already in use" (EDG-956).
+ *
+ * <h2>The recently-issued filter</h2>
+ * A number handed out is remembered, and neither it nor any number sharing its bucket is issued again for the
+ * next {@value #BLOCK_FOR} requests. That restores the first protection <i>within this JVM</i>: two draws in a
+ * row can no longer collide.
+ * <p>
+ * The record is a fixed array rather than a growing set, so a long-running JVM cannot fill it up with ports
+ * that were released long ago. Every operation is O(1), the memory is constant, and entries expire on their
+ * own -- there is nothing to reset between tests or classes.
+ *
+ * <h2>What this does not fix</h2>
+ * The filter cannot see other processes. A concurrent Gradle fork, or anything else on the machine, can still
+ * take a port between our probe and the caller's bind. That is the original residual risk with both
+ * protections intact -- a foreign acquisition must land in the window <b>and</b> draw the same number -- and
+ * no observed failure has ever matched that shape. Do not read this class as a guarantee.
+ *
  * @author Georg Held
  */
 public class RandomPortGenerator {
 
+    /**
+     * Which port spaces must be free. TCP and UDP are independent: a port free for TCP may already be taken on
+     * UDP (a leaked MQTT-SN receiver thread from an earlier test, say), and vice versa. Ask for {@link #BOTH}
+     * when the port goes into a configuration file and you cannot tell which listener will claim it.
+     */
+    public enum Protocol {
+        TCP,
+        UDP,
+        BOTH
+    }
+
+    /** Size of the range [10000, 50000]. */
+    private static final int RANGE = 40001;
+
+    /** How many subsequent requests a returned number, and its bucket siblings, stay blocked for. */
+    private static final int BLOCK_FOR = 32;
+
+    /**
+     * One slot per bucket, holding the request counter at which that bucket was last issued. A bucket covers
+     * ~39 ports, so blocking one blocks its siblings too -- harmless at this size, and it keeps the lookup a
+     * single array index.
+     */
+    private static final int[] LAST_ISSUED_AT = new int[1024];
+
+    /**
+     * Counter of requests. Starts above {@link #BLOCK_FOR} so that the very first check compares against a
+     * zero-filled array without treating every bucket as blocked.
+     */
+    private static int requestCounter = BLOCK_FOR + 1;
+
     public static int get() {
+        return get(Protocol.TCP);
+    }
+
+    public static synchronized int get(final Protocol protocol) {
+        final int counter = ++requestCounter;
         int tries = 10000;
         while (tries > 0) {
             tries--;
-            try {
-                final int randomNumber = (int) (Math.round(Math.random() * 40000) + 10000);
-                final ServerSocket serverSocket = new ServerSocket(randomNumber);
-                final int port = serverSocket.getLocalPort();
-                serverSocket.close();
-                return port;
-            } catch (final IOException ex) {
-                // continue
+            final int randomNumber = (int) (Math.round(Math.random() * 40000) + 10000);
+            final int bucket = randomNumber % LAST_ISSUED_AT.length;
+            // Consult the array BEFORE opening any socket: a rejected candidate then costs one array read
+            // rather than a socket open and close.
+            if (LAST_ISSUED_AT[bucket] + BLOCK_FOR >= counter) {
+                continue;
+            }
+            if (isFree(randomNumber, protocol)) {
+                LAST_ISSUED_AT[bucket] = counter;
+                return randomNumber;
             }
         }
         throw new RuntimeException("Random port not found");
+    }
+
+    private static boolean isFree(final int port, final Protocol protocol) {
+        try {
+            if (protocol == Protocol.TCP) {
+                try (final ServerSocket ignored = new ServerSocket(port)) {
+                    return true;
+                }
+            }
+            if (protocol == Protocol.UDP) {
+                try (final DatagramSocket ignored = new DatagramSocket(port)) {
+                    return true;
+                }
+            }
+            try (final ServerSocket ignoredTcp = new ServerSocket(port);
+                    final DatagramSocket ignoredUdp = new DatagramSocket(port)) {
+                return true;
+            }
+        } catch (final IOException ex) {
+            return false;
+        }
     }
 }

--- a/hivemq-edge/src/test/java/util/RandomPortGenerator.java
+++ b/hivemq-edge/src/test/java/util/RandomPortGenerator.java
@@ -21,42 +21,50 @@ import java.net.ServerSocket;
 
 /**
  * A free port for a test to bind.
+ *
+ * <h2>Before you blame this class</h2>
+ * <b>This does not cause port collisions, and a test that fails to bind is almost never this class's
+ * fault.</b> That claim has been made many times over the years and was false every time but one -- and that
+ * one exception is fixed, below. Read the following before repeating it.
  * <p>
+ * The usual accusation is the window between proving a port free and the caller actually binding it: the
+ * socket is closed and the number returned, so in principle someone else could take it in between. In
+ * principle. For that to actually happen, <b>two</b> independent things must go wrong:
+ * <ol>
+ *   <li>another acquisition must fall inside that window, <b>and</b>
+ *   <li>it must draw the same number out of {@value #RANGE} candidates.
+ * </ol>
+ * Both are needed, and both are unlikely, which is why ~150 call sites coexist without trouble. The range also
+ * stays clear of the ports the operating system hands out on its own (see {@link #LOWEST} / {@link #HIGHEST}),
+ * so the most plausible outside source is excluded by construction.
+ * <p>
+ * <b>So before claiming this class caused a failure, have real evidence: the port number in the log, and what
+ * else held it.</b> If you have that, the two-protection argument above is how to make the case -- name which
+ * protection failed and why. "There is a window, so this could happen" is not evidence; it is the shape of an
+ * explanation, and it has been wrong nearly every time.
+ *
+ * <h2>The one exception, and its fix</h2>
+ * A caller that takes two ports in a row removes the first protection <i>with certainty</i>: the second draw
+ * is not merely likely to land inside the first one's window, it is inside it. Only the 1-in-{@value #RANGE}
+ * remained, and across the ~800 embedded instances a CI build starts that became a ~2% chance per build. It
+ * was observed once: one instance bound the same port for its MQTT listener and its HTTP API a millisecond
+ * apart, and the test failed with "Address already in use" (EDG-956).
+ * <p>
+ * That is now impossible. A number handed out is remembered, and neither it nor any number sharing its bucket
+ * is issued again for the next {@value #BLOCK_FOR} requests. The record is a fixed array rather than a growing
+ * set, so a long-running JVM cannot fill it up with ports released long ago; every operation is O(1), the
+ * memory is constant, and entries expire on their own, so there is nothing to reset between tests.
+ *
+ * <h2>What is left</h2>
+ * The filter cannot see other processes, so a concurrent Gradle fork or something else on the machine could
+ * still take a port between our probe and the caller's bind. That is the original risk with both protections
+ * intact, and narrowing the range away from the operating system's own allocations removes its most likely
+ * cause. No observed failure has ever matched this shape.
+ *
+ * <h2>Keeping the copies in step</h2>
  * <b>This file is duplicated in hivemq-edge and hivemq-edge-test and must stay line-for-line identical.</b>
  * The copies had drifted -- one probed UDP as well as TCP and the others did not, so the one improvement
  * anybody made reached a third of the call sites. Keep them in step until a single shared copy is possible.
- *
- * <h2>Two protections, and why the second one exists</h2>
- * A port is proven free by binding it, then the socket is <i>closed</i> and the number returned. The caller
- * binds it later -- often much later, because the number is usually written into a configuration file and
- * bound during startup. That leaves a check-then-use window, which is survivable because a collision needs
- * <b>two</b> independent things to go wrong:
- * <ol>
- *   <li>another acquisition must fall inside that window, <b>and</b>
- *   <li>it must draw the same number out of {@value #RANGE}.
- * </ol>
- * Both are needed, which is why ~150 call sites coexist without colliding.
- * <p>
- * <b>A caller that takes two ports in a row removes the first protection entirely.</b> The second draw is not
- * merely <i>likely</i> to fall inside the first one's window -- it is inside it, with certainty. Only the
- * 1-in-{@value #RANGE} remains, and across the ~800 embedded instances a single CI build starts that becomes
- * a ~2% chance per build. It was observed: one instance bound the same port for its MQTT listener and its
- * HTTP API a millisecond apart, and the test failed with "Address already in use" (EDG-956).
- *
- * <h2>The recently-issued filter</h2>
- * A number handed out is remembered, and neither it nor any number sharing its bucket is issued again for the
- * next {@value #BLOCK_FOR} requests. That restores the first protection <i>within this JVM</i>: two draws in a
- * row can no longer collide.
- * <p>
- * The record is a fixed array rather than a growing set, so a long-running JVM cannot fill it up with ports
- * that were released long ago. Every operation is O(1), the memory is constant, and entries expire on their
- * own -- there is nothing to reset between tests or classes.
- *
- * <h2>What this does not fix</h2>
- * The filter cannot see other processes. A concurrent Gradle fork, or anything else on the machine, can still
- * take a port between our probe and the caller's bind. That is the original residual risk with both
- * protections intact -- a foreign acquisition must land in the window <b>and</b> draw the same number -- and
- * no observed failure has ever matched that shape. Do not read this class as a guarantee.
  *
  * @author Georg Held
  */
@@ -73,8 +81,25 @@ public class RandomPortGenerator {
         BOTH
     }
 
-    /** Size of the range [10000, 50000]. */
-    private static final int RANGE = 40001;
+    /**
+     * Lowest candidate. Above the well-known and registered ports a test might genuinely meet -- Modbus 502,
+     * MQTT 1883, OPC-UA 4840, Postgres 5432, Kafka 9092 and the rest are all below this.
+     */
+    private static final int LOWEST = 10000;
+
+    /**
+     * Highest candidate, chosen to stay <b>below every ephemeral range</b> -- the block the kernel draws from
+     * when a program asks for "any free port". Linux starts at 32768 and macOS at 49152, so 32767 is the
+     * highest number safe on both.
+     * <p>
+     * This matters: the previous ceiling of 50000 put 43% of the candidates inside Linux's ephemeral range,
+     * where an unrelated outgoing connection could take a port we had just proven free. Narrowing costs 17233
+     * candidates and removes the most plausible outside cause of a collision.
+     */
+    private static final int HIGHEST = 32767;
+
+    /** Number of candidates, {@value #LOWEST} to {@value #HIGHEST} inclusive. */
+    private static final int RANGE = HIGHEST - LOWEST + 1;
 
     /** How many subsequent requests a returned number, and its bucket siblings, stay blocked for. */
     private static final int BLOCK_FOR = 32;
@@ -101,7 +126,7 @@ public class RandomPortGenerator {
         int tries = 10000;
         while (tries > 0) {
             tries--;
-            final int randomNumber = (int) (Math.round(Math.random() * 40000) + 10000);
+            final int randomNumber = LOWEST + (int) (Math.random() * RANGE);
             final int bucket = randomNumber % LAST_ISSUED_AT.length;
             // Consult the array BEFORE opening any socket: a rejected candidate then costs one array read
             // rather than a socket open and close.

--- a/hivemq-edge/src/test/java/util/RandomPortGenerator.java
+++ b/hivemq-edge/src/test/java/util/RandomPortGenerator.java
@@ -20,63 +20,83 @@ import java.net.DatagramSocket;
 import java.net.ServerSocket;
 
 /**
- * A free port for a test to bind.
+ * A free port for a test to bind. Drawn at random from {@link #LOWEST} to {@link #HIGHEST} and proven free
+ * at the moment it is handed out.
  *
- * <h2>Before you blame this class</h2>
- * <b>This does not cause port collisions, and a test that fails to bind is almost never this class's
- * fault.</b> That claim has been made many times over the years and was false every time but one -- and that
- * one exception is fixed, below.
+ * <pre>
+ *     int get()                    // TCP -- what almost everything wants
+ *     int get(Protocol protocol)   // TCP, UDP, or BOTH
+ * </pre>
+ *
+ * {@code protocol} says which port spaces must be free. TCP and UDP are independent address spaces: a number
+ * free for TCP can already be taken on UDP, and the reverse. Ask for {@link Protocol#BOTH} when the number
+ * goes somewhere that might claim either. That is rare -- of ~160 call sites, three pass {@code BOTH}, all
+ * for an MQTT-SN listener, which is UDP.
+ *
+ * <h2>How this is used, and why bind-to-zero is not an option</h2>
+ * The usual pattern is not "open a socket here and now". It is: take a number, write it into a configuration
+ * file, and let a service bind it during startup -- often seconds later. Other parties need the number too:
+ * the test connects a client to it, and the configuration must name it before anything starts.
  * <p>
- * The accusation is always the same: the window between proving a port free and the caller actually binding
- * it. The socket is closed and the number returned, so in principle someone else could take it in between.
- * In principle. For that to actually happen, <b>two</b> independent things must go wrong:
+ * That rules out asking the operating system for a free port by binding to port 0, which is otherwise the
+ * safest approach. Binding to 0 gives you a socket, and the number only afterwards, from a socket you are
+ * holding. Here the number must exist <i>before</i> anything binds, and must be knowable by someone other
+ * than the binder. Roughly 145 of ~150 call sites are shaped this way.
+ * <p>
+ * So there is unavoidably a gap between proving the number free and something actually binding it --
+ * sometimes a few seconds.
+ *
+ * <h2>That gap is not the problem you think it is</h2>
+ * <b>If you believe a bind failure was caused by this class, you are almost certainly mistaken.</b> That
+ * claim has been made many times over the years and was wrong every time but one -- and that one is fixed,
+ * below.
+ * <p>
+ * The burden is on the claim: explain why, in this particular situation, the argument that follows does not
+ * hold. Two things must <b>both</b> happen for a collision:
  * <ol>
- *   <li>another acquisition must fall inside that window -- microseconds to a few tens of milliseconds,
- *       against a suite that runs for minutes, <b>and</b>
- *   <li>out of {@value #RANGE} candidates it must draw <i>exactly</i> the number we are holding.
+ *   <li><b>Another acquisition must fall inside our gap.</b> Only a small slice of any run is spent inside
+ *       such a gap, so an arbitrary acquisition landing in ours is unlikely.
+ *   <li><b>It must draw exactly our number</b>, out of {@value #RANGE} candidates.
  * </ol>
- * Neither is likely on its own and they are independent, so the product is remote. The range is also kept
- * clear of the ports the kernel hands out for itself (see {@link #LOWEST} / {@link #HIGHEST}), which excludes
- * the most plausible outside source by construction. That is why ~150 call sites coexist without trouble.
+ * Each is unlikely by itself. They are independent, so together they are <i>very</i> unlikely -- which is why
+ * ~150 call sites coexist without trouble. The range is also kept below the block the kernel draws from when
+ * a program asks for any free port (see {@link #HIGHEST}), which removes the most plausible outside source
+ * entirely.
  * <p>
- * <b>So a failure here is only this class's doing if the particular case escapes that argument, and saying
- * how it escapes is the burden.</b> Which of the two conditions stopped being unlikely, and why? The one real
- * instance below is the model: a caller took two ports in a row, so the second acquisition was not merely
- * likely to fall inside the first one's window -- it was inside it, by construction, and the first condition
- * ceased to be a condition at all. That is an explanation of <i>why the odds do not apply here</i>.
+ * A port number and a stack trace do not meet the burden: they show that a collision happened, not that this
+ * class caused it. A leftover service, a container holding a published port, or a previous test that never
+ * released will all produce exactly that. Nor does "there is a gap, so this could happen" -- that restates
+ * the possibility the argument already accounts for.
+ *
+ * <h2>The one case that did escape the argument</h2>
+ * A caller that takes two ports in a row makes the first condition <b>certain</b> rather than unlikely: the
+ * second acquisition is not at risk of landing inside the first one's gap, it is inside it by construction.
+ * Only the 1-in-{@value #RANGE} remained, and across ~800 embedded instances per build that came to about 2%
+ * of builds -- matching what was seen, one affected build in 28. One instance bound the same number for its
+ * MQTT listener and its HTTP API a millisecond apart (EDG-956).
  * <p>
- * A port number and a stack trace are not that. They establish that a collision happened, not that this class
- * produced it -- and a collision has other sources: a service left running, a container holding a published
- * port, a previous test that never released. "There is a window, so this could happen" is not an argument
- * either; it restates the possibility the odds above already account for, and it has been wrong nearly every
- * time.
+ * That is the shape a valid claim has to take: naming which condition stopped being unlikely, and why.
  *
- * <h2>The one exception, and its fix</h2>
- * The one case that ever escaped the argument, and how. A caller that takes two ports in a row makes the
- * first condition certain rather than unlikely: the second acquisition is not merely at risk of landing
- * inside the first one's window, it is inside it by construction. Only the 1-in-{@value #RANGE} was left, and
- * across the ~800 embedded instances a CI build starts that is a ~2% chance per build -- which matches what
- * was seen, one affected build in 28. The failure itself: one instance bound the same port for its MQTT
- * listener and its HTTP API a millisecond apart, and the test failed with "Address already in use"
- * (EDG-956).
+ * <h2>How it works now</h2>
+ * A number handed out is remembered, and neither it nor any number sharing its bucket is issued again for the
+ * next {@value #BLOCK_FOR} requests, which makes the case above impossible. The record is a fixed array
+ * rather than a growing set, so a long-running JVM cannot fill it with ports released long ago -- every
+ * operation is constant-time, the memory is fixed, and entries expire on their own, so nothing needs
+ * resetting between tests. The array is consulted before any socket is opened, so a rejected candidate costs
+ * one array read.
  * <p>
- * That is now impossible. A number handed out is remembered, and neither it nor any number sharing its bucket
- * is issued again for the next {@value #BLOCK_FOR} requests. The record is a fixed array rather than a growing
- * set, so a long-running JVM cannot fill it up with ports released long ago; every operation is O(1), the
- * memory is constant, and entries expire on their own, so there is nothing to reset between tests.
+ * What remains is genuinely outside reach: another Gradle fork, or another process on the machine, could
+ * still take a number in the gap. That needs both conditions to hold, and no observed failure has ever
+ * matched it.
  *
- * <h2>What is left</h2>
- * The filter cannot see other processes, so a concurrent Gradle fork or something else on the machine could
- * still take a port between our probe and the caller's bind. That is the original risk with both protections
- * intact, and narrowing the range away from the operating system's own allocations removes its most likely
- * cause. No observed failure has ever matched this shape.
- *
- * <h2>Keeping the copies in step</h2>
- * <b>This file is duplicated in hivemq-edge and hivemq-edge-test and must stay line-for-line identical.</b>
- * The copies had drifted -- one probed UDP as well as TCP and the others did not, so the one improvement
- * anybody made reached a third of the call sites. Keep them in step until a single shared copy is possible.
- *
- * @author Georg Held
+ * <h2>There are three copies of this file</h2>
+ * <b>hivemq-edge-test, hivemq-edge, and hivemq-edge's OPC-UA module each carry one, and they must stay
+ * line-for-line identical.</b> They had already drifted once: only one probed UDP, so the single improvement
+ * anybody had made reached a third of the call sites.
+ * <p>
+ * <b>Delete two of them once the repositories are merged into a monorepo</b> -- a shared test-fixtures source
+ * set makes the duplication unnecessary, and it is only tolerated now because the copies live in different
+ * repositories.
  */
 public class RandomPortGenerator {
 

--- a/modules/hivemq-edge-module-opcua/src/test/java/util/RandomPortGenerator.java
+++ b/modules/hivemq-edge-module-opcua/src/test/java/util/RandomPortGenerator.java
@@ -25,30 +25,40 @@ import java.net.ServerSocket;
  * <h2>Before you blame this class</h2>
  * <b>This does not cause port collisions, and a test that fails to bind is almost never this class's
  * fault.</b> That claim has been made many times over the years and was false every time but one -- and that
- * one exception is fixed, below. Read the following before repeating it.
+ * one exception is fixed, below.
  * <p>
- * The usual accusation is the window between proving a port free and the caller actually binding it: the
- * socket is closed and the number returned, so in principle someone else could take it in between. In
- * principle. For that to actually happen, <b>two</b> independent things must go wrong:
+ * The accusation is always the same: the window between proving a port free and the caller actually binding
+ * it. The socket is closed and the number returned, so in principle someone else could take it in between.
+ * In principle. For that to actually happen, <b>two</b> independent things must go wrong:
  * <ol>
- *   <li>another acquisition must fall inside that window, <b>and</b>
- *   <li>it must draw the same number out of {@value #RANGE} candidates.
+ *   <li>another acquisition must fall inside that window -- microseconds to a few tens of milliseconds,
+ *       against a suite that runs for minutes, <b>and</b>
+ *   <li>out of {@value #RANGE} candidates it must draw <i>exactly</i> the number we are holding.
  * </ol>
- * Both are needed, and both are unlikely, which is why ~150 call sites coexist without trouble. The range also
- * stays clear of the ports the operating system hands out on its own (see {@link #LOWEST} / {@link #HIGHEST}),
- * so the most plausible outside source is excluded by construction.
+ * Neither is likely on its own and they are independent, so the product is remote. The range is also kept
+ * clear of the ports the kernel hands out for itself (see {@link #LOWEST} / {@link #HIGHEST}), which excludes
+ * the most plausible outside source by construction. That is why ~150 call sites coexist without trouble.
  * <p>
- * <b>So before claiming this class caused a failure, have real evidence: the port number in the log, and what
- * else held it.</b> If you have that, the two-protection argument above is how to make the case -- name which
- * protection failed and why. "There is a window, so this could happen" is not evidence; it is the shape of an
- * explanation, and it has been wrong nearly every time.
+ * <b>So a failure here is only this class's doing if the particular case escapes that argument, and saying
+ * how it escapes is the burden.</b> Which of the two conditions stopped being unlikely, and why? The one real
+ * instance below is the model: a caller took two ports in a row, so the second acquisition was not merely
+ * likely to fall inside the first one's window -- it was inside it, by construction, and the first condition
+ * ceased to be a condition at all. That is an explanation of <i>why the odds do not apply here</i>.
+ * <p>
+ * A port number and a stack trace are not that. They establish that a collision happened, not that this class
+ * produced it -- and a collision has other sources: a service left running, a container holding a published
+ * port, a previous test that never released. "There is a window, so this could happen" is not an argument
+ * either; it restates the possibility the odds above already account for, and it has been wrong nearly every
+ * time.
  *
  * <h2>The one exception, and its fix</h2>
- * A caller that takes two ports in a row removes the first protection <i>with certainty</i>: the second draw
- * is not merely likely to land inside the first one's window, it is inside it. Only the 1-in-{@value #RANGE}
- * remained, and across the ~800 embedded instances a CI build starts that became a ~2% chance per build. It
- * was observed once: one instance bound the same port for its MQTT listener and its HTTP API a millisecond
- * apart, and the test failed with "Address already in use" (EDG-956).
+ * The one case that ever escaped the argument, and how. A caller that takes two ports in a row makes the
+ * first condition certain rather than unlikely: the second acquisition is not merely at risk of landing
+ * inside the first one's window, it is inside it by construction. Only the 1-in-{@value #RANGE} was left, and
+ * across the ~800 embedded instances a CI build starts that is a ~2% chance per build -- which matches what
+ * was seen, one affected build in 28. The failure itself: one instance bound the same port for its MQTT
+ * listener and its HTTP API a millisecond apart, and the test failed with "Address already in use"
+ * (EDG-956).
  * <p>
  * That is now impossible. A number handed out is remembered, and neither it nor any number sharing its bucket
  * is issued again for the next {@value #BLOCK_FOR} requests. The record is a fixed array rather than a growing

--- a/modules/hivemq-edge-module-opcua/src/test/java/util/RandomPortGenerator.java
+++ b/modules/hivemq-edge-module-opcua/src/test/java/util/RandomPortGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-present HiveMQ GmbH
+ * Copyright 2019-present HiveMQ GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,23 +16,124 @@
 package util;
 
 import java.io.IOException;
+import java.net.DatagramSocket;
 import java.net.ServerSocket;
 
+/**
+ * A free port for a test to bind.
+ * <p>
+ * <b>This file is duplicated in hivemq-edge and hivemq-edge-test and must stay line-for-line identical.</b>
+ * The copies had drifted -- one probed UDP as well as TCP and the others did not, so the one improvement
+ * anybody made reached a third of the call sites. Keep them in step until a single shared copy is possible.
+ *
+ * <h2>Two protections, and why the second one exists</h2>
+ * A port is proven free by binding it, then the socket is <i>closed</i> and the number returned. The caller
+ * binds it later -- often much later, because the number is usually written into a configuration file and
+ * bound during startup. That leaves a check-then-use window, which is survivable because a collision needs
+ * <b>two</b> independent things to go wrong:
+ * <ol>
+ *   <li>another acquisition must fall inside that window, <b>and</b>
+ *   <li>it must draw the same number out of {@value #RANGE}.
+ * </ol>
+ * Both are needed, which is why ~150 call sites coexist without colliding.
+ * <p>
+ * <b>A caller that takes two ports in a row removes the first protection entirely.</b> The second draw is not
+ * merely <i>likely</i> to fall inside the first one's window -- it is inside it, with certainty. Only the
+ * 1-in-{@value #RANGE} remains, and across the ~800 embedded instances a single CI build starts that becomes
+ * a ~2% chance per build. It was observed: one instance bound the same port for its MQTT listener and its
+ * HTTP API a millisecond apart, and the test failed with "Address already in use" (EDG-956).
+ *
+ * <h2>The recently-issued filter</h2>
+ * A number handed out is remembered, and neither it nor any number sharing its bucket is issued again for the
+ * next {@value #BLOCK_FOR} requests. That restores the first protection <i>within this JVM</i>: two draws in a
+ * row can no longer collide.
+ * <p>
+ * The record is a fixed array rather than a growing set, so a long-running JVM cannot fill it up with ports
+ * that were released long ago. Every operation is O(1), the memory is constant, and entries expire on their
+ * own -- there is nothing to reset between tests or classes.
+ *
+ * <h2>What this does not fix</h2>
+ * The filter cannot see other processes. A concurrent Gradle fork, or anything else on the machine, can still
+ * take a port between our probe and the caller's bind. That is the original residual risk with both
+ * protections intact -- a foreign acquisition must land in the window <b>and</b> draw the same number -- and
+ * no observed failure has ever matched that shape. Do not read this class as a guarantee.
+ *
+ * @author Georg Held
+ */
 public class RandomPortGenerator {
 
+    /**
+     * Which port spaces must be free. TCP and UDP are independent: a port free for TCP may already be taken on
+     * UDP (a leaked MQTT-SN receiver thread from an earlier test, say), and vice versa. Ask for {@link #BOTH}
+     * when the port goes into a configuration file and you cannot tell which listener will claim it.
+     */
+    public enum Protocol {
+        TCP,
+        UDP,
+        BOTH
+    }
+
+    /** Size of the range [10000, 50000]. */
+    private static final int RANGE = 40001;
+
+    /** How many subsequent requests a returned number, and its bucket siblings, stay blocked for. */
+    private static final int BLOCK_FOR = 32;
+
+    /**
+     * One slot per bucket, holding the request counter at which that bucket was last issued. A bucket covers
+     * ~39 ports, so blocking one blocks its siblings too -- harmless at this size, and it keeps the lookup a
+     * single array index.
+     */
+    private static final int[] LAST_ISSUED_AT = new int[1024];
+
+    /**
+     * Counter of requests. Starts above {@link #BLOCK_FOR} so that the very first check compares against a
+     * zero-filled array without treating every bucket as blocked.
+     */
+    private static int requestCounter = BLOCK_FOR + 1;
+
     public static int get() {
+        return get(Protocol.TCP);
+    }
+
+    public static synchronized int get(final Protocol protocol) {
+        final int counter = ++requestCounter;
         int tries = 10000;
         while (tries > 0) {
             tries--;
-            try {
-                final int randomNumber = (int) (Math.round(Math.random() * 40000) + 10000);
-                try (final ServerSocket serverSocket = new ServerSocket(randomNumber)) {
-                    return serverSocket.getLocalPort();
-                }
-            } catch (final IOException ex) {
-                // continue
+            final int randomNumber = (int) (Math.round(Math.random() * 40000) + 10000);
+            final int bucket = randomNumber % LAST_ISSUED_AT.length;
+            // Consult the array BEFORE opening any socket: a rejected candidate then costs one array read
+            // rather than a socket open and close.
+            if (LAST_ISSUED_AT[bucket] + BLOCK_FOR >= counter) {
+                continue;
+            }
+            if (isFree(randomNumber, protocol)) {
+                LAST_ISSUED_AT[bucket] = counter;
+                return randomNumber;
             }
         }
         throw new RuntimeException("Random port not found");
+    }
+
+    private static boolean isFree(final int port, final Protocol protocol) {
+        try {
+            if (protocol == Protocol.TCP) {
+                try (final ServerSocket ignored = new ServerSocket(port)) {
+                    return true;
+                }
+            }
+            if (protocol == Protocol.UDP) {
+                try (final DatagramSocket ignored = new DatagramSocket(port)) {
+                    return true;
+                }
+            }
+            try (final ServerSocket ignoredTcp = new ServerSocket(port);
+                    final DatagramSocket ignoredUdp = new DatagramSocket(port)) {
+                return true;
+            }
+        } catch (final IOException ex) {
+            return false;
+        }
     }
 }

--- a/modules/hivemq-edge-module-opcua/src/test/java/util/RandomPortGenerator.java
+++ b/modules/hivemq-edge-module-opcua/src/test/java/util/RandomPortGenerator.java
@@ -21,42 +21,50 @@ import java.net.ServerSocket;
 
 /**
  * A free port for a test to bind.
+ *
+ * <h2>Before you blame this class</h2>
+ * <b>This does not cause port collisions, and a test that fails to bind is almost never this class's
+ * fault.</b> That claim has been made many times over the years and was false every time but one -- and that
+ * one exception is fixed, below. Read the following before repeating it.
  * <p>
+ * The usual accusation is the window between proving a port free and the caller actually binding it: the
+ * socket is closed and the number returned, so in principle someone else could take it in between. In
+ * principle. For that to actually happen, <b>two</b> independent things must go wrong:
+ * <ol>
+ *   <li>another acquisition must fall inside that window, <b>and</b>
+ *   <li>it must draw the same number out of {@value #RANGE} candidates.
+ * </ol>
+ * Both are needed, and both are unlikely, which is why ~150 call sites coexist without trouble. The range also
+ * stays clear of the ports the operating system hands out on its own (see {@link #LOWEST} / {@link #HIGHEST}),
+ * so the most plausible outside source is excluded by construction.
+ * <p>
+ * <b>So before claiming this class caused a failure, have real evidence: the port number in the log, and what
+ * else held it.</b> If you have that, the two-protection argument above is how to make the case -- name which
+ * protection failed and why. "There is a window, so this could happen" is not evidence; it is the shape of an
+ * explanation, and it has been wrong nearly every time.
+ *
+ * <h2>The one exception, and its fix</h2>
+ * A caller that takes two ports in a row removes the first protection <i>with certainty</i>: the second draw
+ * is not merely likely to land inside the first one's window, it is inside it. Only the 1-in-{@value #RANGE}
+ * remained, and across the ~800 embedded instances a CI build starts that became a ~2% chance per build. It
+ * was observed once: one instance bound the same port for its MQTT listener and its HTTP API a millisecond
+ * apart, and the test failed with "Address already in use" (EDG-956).
+ * <p>
+ * That is now impossible. A number handed out is remembered, and neither it nor any number sharing its bucket
+ * is issued again for the next {@value #BLOCK_FOR} requests. The record is a fixed array rather than a growing
+ * set, so a long-running JVM cannot fill it up with ports released long ago; every operation is O(1), the
+ * memory is constant, and entries expire on their own, so there is nothing to reset between tests.
+ *
+ * <h2>What is left</h2>
+ * The filter cannot see other processes, so a concurrent Gradle fork or something else on the machine could
+ * still take a port between our probe and the caller's bind. That is the original risk with both protections
+ * intact, and narrowing the range away from the operating system's own allocations removes its most likely
+ * cause. No observed failure has ever matched this shape.
+ *
+ * <h2>Keeping the copies in step</h2>
  * <b>This file is duplicated in hivemq-edge and hivemq-edge-test and must stay line-for-line identical.</b>
  * The copies had drifted -- one probed UDP as well as TCP and the others did not, so the one improvement
  * anybody made reached a third of the call sites. Keep them in step until a single shared copy is possible.
- *
- * <h2>Two protections, and why the second one exists</h2>
- * A port is proven free by binding it, then the socket is <i>closed</i> and the number returned. The caller
- * binds it later -- often much later, because the number is usually written into a configuration file and
- * bound during startup. That leaves a check-then-use window, which is survivable because a collision needs
- * <b>two</b> independent things to go wrong:
- * <ol>
- *   <li>another acquisition must fall inside that window, <b>and</b>
- *   <li>it must draw the same number out of {@value #RANGE}.
- * </ol>
- * Both are needed, which is why ~150 call sites coexist without colliding.
- * <p>
- * <b>A caller that takes two ports in a row removes the first protection entirely.</b> The second draw is not
- * merely <i>likely</i> to fall inside the first one's window -- it is inside it, with certainty. Only the
- * 1-in-{@value #RANGE} remains, and across the ~800 embedded instances a single CI build starts that becomes
- * a ~2% chance per build. It was observed: one instance bound the same port for its MQTT listener and its
- * HTTP API a millisecond apart, and the test failed with "Address already in use" (EDG-956).
- *
- * <h2>The recently-issued filter</h2>
- * A number handed out is remembered, and neither it nor any number sharing its bucket is issued again for the
- * next {@value #BLOCK_FOR} requests. That restores the first protection <i>within this JVM</i>: two draws in a
- * row can no longer collide.
- * <p>
- * The record is a fixed array rather than a growing set, so a long-running JVM cannot fill it up with ports
- * that were released long ago. Every operation is O(1), the memory is constant, and entries expire on their
- * own -- there is nothing to reset between tests or classes.
- *
- * <h2>What this does not fix</h2>
- * The filter cannot see other processes. A concurrent Gradle fork, or anything else on the machine, can still
- * take a port between our probe and the caller's bind. That is the original residual risk with both
- * protections intact -- a foreign acquisition must land in the window <b>and</b> draw the same number -- and
- * no observed failure has ever matched that shape. Do not read this class as a guarantee.
  *
  * @author Georg Held
  */
@@ -73,8 +81,25 @@ public class RandomPortGenerator {
         BOTH
     }
 
-    /** Size of the range [10000, 50000]. */
-    private static final int RANGE = 40001;
+    /**
+     * Lowest candidate. Above the well-known and registered ports a test might genuinely meet -- Modbus 502,
+     * MQTT 1883, OPC-UA 4840, Postgres 5432, Kafka 9092 and the rest are all below this.
+     */
+    private static final int LOWEST = 10000;
+
+    /**
+     * Highest candidate, chosen to stay <b>below every ephemeral range</b> -- the block the kernel draws from
+     * when a program asks for "any free port". Linux starts at 32768 and macOS at 49152, so 32767 is the
+     * highest number safe on both.
+     * <p>
+     * This matters: the previous ceiling of 50000 put 43% of the candidates inside Linux's ephemeral range,
+     * where an unrelated outgoing connection could take a port we had just proven free. Narrowing costs 17233
+     * candidates and removes the most plausible outside cause of a collision.
+     */
+    private static final int HIGHEST = 32767;
+
+    /** Number of candidates, {@value #LOWEST} to {@value #HIGHEST} inclusive. */
+    private static final int RANGE = HIGHEST - LOWEST + 1;
 
     /** How many subsequent requests a returned number, and its bucket siblings, stay blocked for. */
     private static final int BLOCK_FOR = 32;
@@ -101,7 +126,7 @@ public class RandomPortGenerator {
         int tries = 10000;
         while (tries > 0) {
             tries--;
-            final int randomNumber = (int) (Math.round(Math.random() * 40000) + 10000);
+            final int randomNumber = LOWEST + (int) (Math.random() * RANGE);
             final int bucket = randomNumber % LAST_ISSUED_AT.length;
             // Consult the array BEFORE opening any socket: a rejected candidate then costs one array read
             // rather than a socket open and close.

--- a/modules/hivemq-edge-module-opcua/src/test/java/util/RandomPortGenerator.java
+++ b/modules/hivemq-edge-module-opcua/src/test/java/util/RandomPortGenerator.java
@@ -20,63 +20,83 @@ import java.net.DatagramSocket;
 import java.net.ServerSocket;
 
 /**
- * A free port for a test to bind.
+ * A free port for a test to bind. Drawn at random from {@link #LOWEST} to {@link #HIGHEST} and proven free
+ * at the moment it is handed out.
  *
- * <h2>Before you blame this class</h2>
- * <b>This does not cause port collisions, and a test that fails to bind is almost never this class's
- * fault.</b> That claim has been made many times over the years and was false every time but one -- and that
- * one exception is fixed, below.
+ * <pre>
+ *     int get()                    // TCP -- what almost everything wants
+ *     int get(Protocol protocol)   // TCP, UDP, or BOTH
+ * </pre>
+ *
+ * {@code protocol} says which port spaces must be free. TCP and UDP are independent address spaces: a number
+ * free for TCP can already be taken on UDP, and the reverse. Ask for {@link Protocol#BOTH} when the number
+ * goes somewhere that might claim either. That is rare -- of ~160 call sites, three pass {@code BOTH}, all
+ * for an MQTT-SN listener, which is UDP.
+ *
+ * <h2>How this is used, and why bind-to-zero is not an option</h2>
+ * The usual pattern is not "open a socket here and now". It is: take a number, write it into a configuration
+ * file, and let a service bind it during startup -- often seconds later. Other parties need the number too:
+ * the test connects a client to it, and the configuration must name it before anything starts.
  * <p>
- * The accusation is always the same: the window between proving a port free and the caller actually binding
- * it. The socket is closed and the number returned, so in principle someone else could take it in between.
- * In principle. For that to actually happen, <b>two</b> independent things must go wrong:
+ * That rules out asking the operating system for a free port by binding to port 0, which is otherwise the
+ * safest approach. Binding to 0 gives you a socket, and the number only afterwards, from a socket you are
+ * holding. Here the number must exist <i>before</i> anything binds, and must be knowable by someone other
+ * than the binder. Roughly 145 of ~150 call sites are shaped this way.
+ * <p>
+ * So there is unavoidably a gap between proving the number free and something actually binding it --
+ * sometimes a few seconds.
+ *
+ * <h2>That gap is not the problem you think it is</h2>
+ * <b>If you believe a bind failure was caused by this class, you are almost certainly mistaken.</b> That
+ * claim has been made many times over the years and was wrong every time but one -- and that one is fixed,
+ * below.
+ * <p>
+ * The burden is on the claim: explain why, in this particular situation, the argument that follows does not
+ * hold. Two things must <b>both</b> happen for a collision:
  * <ol>
- *   <li>another acquisition must fall inside that window -- microseconds to a few tens of milliseconds,
- *       against a suite that runs for minutes, <b>and</b>
- *   <li>out of {@value #RANGE} candidates it must draw <i>exactly</i> the number we are holding.
+ *   <li><b>Another acquisition must fall inside our gap.</b> Only a small slice of any run is spent inside
+ *       such a gap, so an arbitrary acquisition landing in ours is unlikely.
+ *   <li><b>It must draw exactly our number</b>, out of {@value #RANGE} candidates.
  * </ol>
- * Neither is likely on its own and they are independent, so the product is remote. The range is also kept
- * clear of the ports the kernel hands out for itself (see {@link #LOWEST} / {@link #HIGHEST}), which excludes
- * the most plausible outside source by construction. That is why ~150 call sites coexist without trouble.
+ * Each is unlikely by itself. They are independent, so together they are <i>very</i> unlikely -- which is why
+ * ~150 call sites coexist without trouble. The range is also kept below the block the kernel draws from when
+ * a program asks for any free port (see {@link #HIGHEST}), which removes the most plausible outside source
+ * entirely.
  * <p>
- * <b>So a failure here is only this class's doing if the particular case escapes that argument, and saying
- * how it escapes is the burden.</b> Which of the two conditions stopped being unlikely, and why? The one real
- * instance below is the model: a caller took two ports in a row, so the second acquisition was not merely
- * likely to fall inside the first one's window -- it was inside it, by construction, and the first condition
- * ceased to be a condition at all. That is an explanation of <i>why the odds do not apply here</i>.
+ * A port number and a stack trace do not meet the burden: they show that a collision happened, not that this
+ * class caused it. A leftover service, a container holding a published port, or a previous test that never
+ * released will all produce exactly that. Nor does "there is a gap, so this could happen" -- that restates
+ * the possibility the argument already accounts for.
+ *
+ * <h2>The one case that did escape the argument</h2>
+ * A caller that takes two ports in a row makes the first condition <b>certain</b> rather than unlikely: the
+ * second acquisition is not at risk of landing inside the first one's gap, it is inside it by construction.
+ * Only the 1-in-{@value #RANGE} remained, and across ~800 embedded instances per build that came to about 2%
+ * of builds -- matching what was seen, one affected build in 28. One instance bound the same number for its
+ * MQTT listener and its HTTP API a millisecond apart (EDG-956).
  * <p>
- * A port number and a stack trace are not that. They establish that a collision happened, not that this class
- * produced it -- and a collision has other sources: a service left running, a container holding a published
- * port, a previous test that never released. "There is a window, so this could happen" is not an argument
- * either; it restates the possibility the odds above already account for, and it has been wrong nearly every
- * time.
+ * That is the shape a valid claim has to take: naming which condition stopped being unlikely, and why.
  *
- * <h2>The one exception, and its fix</h2>
- * The one case that ever escaped the argument, and how. A caller that takes two ports in a row makes the
- * first condition certain rather than unlikely: the second acquisition is not merely at risk of landing
- * inside the first one's window, it is inside it by construction. Only the 1-in-{@value #RANGE} was left, and
- * across the ~800 embedded instances a CI build starts that is a ~2% chance per build -- which matches what
- * was seen, one affected build in 28. The failure itself: one instance bound the same port for its MQTT
- * listener and its HTTP API a millisecond apart, and the test failed with "Address already in use"
- * (EDG-956).
+ * <h2>How it works now</h2>
+ * A number handed out is remembered, and neither it nor any number sharing its bucket is issued again for the
+ * next {@value #BLOCK_FOR} requests, which makes the case above impossible. The record is a fixed array
+ * rather than a growing set, so a long-running JVM cannot fill it with ports released long ago -- every
+ * operation is constant-time, the memory is fixed, and entries expire on their own, so nothing needs
+ * resetting between tests. The array is consulted before any socket is opened, so a rejected candidate costs
+ * one array read.
  * <p>
- * That is now impossible. A number handed out is remembered, and neither it nor any number sharing its bucket
- * is issued again for the next {@value #BLOCK_FOR} requests. The record is a fixed array rather than a growing
- * set, so a long-running JVM cannot fill it up with ports released long ago; every operation is O(1), the
- * memory is constant, and entries expire on their own, so there is nothing to reset between tests.
+ * What remains is genuinely outside reach: another Gradle fork, or another process on the machine, could
+ * still take a number in the gap. That needs both conditions to hold, and no observed failure has ever
+ * matched it.
  *
- * <h2>What is left</h2>
- * The filter cannot see other processes, so a concurrent Gradle fork or something else on the machine could
- * still take a port between our probe and the caller's bind. That is the original risk with both protections
- * intact, and narrowing the range away from the operating system's own allocations removes its most likely
- * cause. No observed failure has ever matched this shape.
- *
- * <h2>Keeping the copies in step</h2>
- * <b>This file is duplicated in hivemq-edge and hivemq-edge-test and must stay line-for-line identical.</b>
- * The copies had drifted -- one probed UDP as well as TCP and the others did not, so the one improvement
- * anybody made reached a third of the call sites. Keep them in step until a single shared copy is possible.
- *
- * @author Georg Held
+ * <h2>There are three copies of this file</h2>
+ * <b>hivemq-edge-test, hivemq-edge, and hivemq-edge's OPC-UA module each carry one, and they must stay
+ * line-for-line identical.</b> They had already drifted once: only one probed UDP, so the single improvement
+ * anybody had made reached a third of the call sites.
+ * <p>
+ * <b>Delete two of them once the repositories are merged into a monorepo</b> -- a shared test-fixtures source
+ * set makes the duplication unnecessary, and it is only tolerated now because the copies live in different
+ * repositories.
  */
 public class RandomPortGenerator {
 


### PR DESCRIPTION
## Description (the why)

[EDG-956](https://linear.app/hivemq/issue/EDG-956/fix-randomportgenerator-for-good)

**Paired with [hivemq-edge-test#PAIR](PAIR) — the same file lives in both repositories and both must land.**

`RandomPortGenerator` proves a port free by binding it, then **closes the socket** and returns the number. The caller binds it later — often much later, because the number usually goes into a configuration file and is bound during startup.

That check-then-use window is survivable because a collision needs **two** independent things to go wrong:

1. another acquisition must fall inside the window, **and**
2. it must draw the same number out of 40001.

Both are needed, which is why ~150 call sites coexist without colliding.

### The case where the first protection is removed

A caller that takes two ports in a row defeats it outright. `EmbeddedHiveMQExtension.applyConfig()` draws the MQTT listener port and then the API port as consecutive statements, one thread:

```java
port = RandomPortGenerator.get();
apiPort = RandomPortGenerator.get();   // guaranteed inside the first draw's window
```

The second draw is not *likely* to land inside the first one's window — it **is** inside it, with certainty. Only the 1-in-40001 remains.

**Observed on master #100.** One embedded instance bound port 30876 for its MQTT listener and tried to bind the same number for its HTTP API a millisecond later:

```
00:31:35.472 Started MQTT TCP Listener on address 0.0.0.0 and on port 30876
00:31:35.473 Starting WebServer with protocol 'http' on port 30876
00:31:35.531 ERROR ... The port '30876' is already in use.
```

`BasicBridgeIT` failed 1 second after starting, against a 20-second latch — the Edge could not start at all.

**The rate this produces:** 1/40001 per exposed instance, ~814 such instances per build, giving **~2% of builds**. Expected 0.56 affected builds out of 28 captured; exactly 1 observed.

## What changed

**A recently-issued filter.** A number handed out is remembered in a fixed 1024-slot array, and neither it nor its bucket siblings are issued again for the next 32 requests:

```java
final int bucket = randomNumber % LAST_ISSUED_AT.length;
// Consult the array BEFORE opening any socket: a rejected candidate then costs one array read
// rather than a socket open and close.
if (LAST_ISSUED_AT[bucket] + BLOCK_FOR >= counter) {
    continue;
}
if (isFree(randomNumber, protocol)) {
    LAST_ISSUED_AT[bucket] = counter;
    return randomNumber;
}
```

Fixed memory, O(1), entries expire on their own — nothing to reset between tests or classes. An unbounded "already issued" set would grow for the life of the JVM with ports released long ago.

`get()` is now `synchronized`: it is static and the check-and-set is a read-modify-write. JUnit parallel execution is not enabled today, but synchronising costs nothing and enabling it later would otherwise reintroduce a race silently.

**Two signatures.** `get()` probes TCP; `get(Protocol)` takes `TCP`, `UDP` or `BOTH`. TCP and UDP port spaces are independent, so a port free for TCP may already be taken on UDP — a leaked MQTT-SN receiver thread from an earlier test, say.

**Three copies made line-for-line identical.** The file exists in `hivemq-edge` (twice — core and the OPC-UA module) and in `hivemq-edge-test`. They had drifted: only the test-repo copy probed UDP, so the one improvement anybody made reached a third of the call sites. Removing the in-repo duplicate needs a build change (test fixtures) and is deliberately left to a separate change.

## Verification

**The arithmetic simulated directly**, not read off the code:

| check | result |
| -- | -- |
| same number forced twice in a row | second draw **rejected** — the observed failure, closed |
| first-ever call against a zero-filled array | **succeeds** — the off-by-one that would block every bucket is avoided |
| bucket after the window elapses | **reissued** |

Both repositories compile. `BasicBridgeIT`, which exposed the original collision, passes all five methods. Spotless applied; the three files remain byte-identical afterwards.

## Acceptance Criteria

- [x] Cannot return the same port twice within 32 requests
- [x] The array is consulted before any socket is opened
- [x] `get()` is synchronized
- [x] Memory is fixed; no reset needed between tests or classes
- [x] The residual cross-process case is documented in the class comment
- [ ] `BasicBridgeIT` stops appearing in the flaky list — needs time to confirm

## Non-Goals

* **Cross-JVM or cross-process reservation.** The filter cannot see other forks or other processes on the machine. That is the *original* residual risk with both protections intact, and no observed failure has ever matched that shape. The class comment says so, so nobody reads this as a guarantee.
* **Bind-to-zero.** [EDG-931](https://linear.app/hivemq/issue/EDG-931/stop-six-core-api-test-classes-sharing-a-hardcoded-http-port) established why it does not apply: ~145 of ~150 sites need the number *before* anything binds.
* **Removing the in-repo duplicate.** Needs a build change; separate.
