### PR TITLE
EDG-942: Do not report OPC UA teardown as an error

### DIFF
--- a/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/OpcUaClientConnection.java
+++ b/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/OpcUaClientConnection.java
@@ -243,14 +243,17 @@ public class OpcUaClientConnection {
         this.adapterId = adapterId;
         this.protocolAdapterState = protocolAdapterState;
         this.tags = tags;
-        // Bound to this connection rather than shared with every other one the adapter makes. What arrives is
-        // a template carrying the adapter's settings; what this connection attaches to its own client is its
-        // own copy, which knows without being told that a fault reaching it belongs to this connection.
+        // This connection's own copy of the service-fault listener, which reports the errors an OPC UA server
+        // raises. The argument is a template holding the adapter's settings and is not used directly: every
+        // connection derives a copy that serves it alone and registers that on its own client. The copy can
+        // then recognise a fault raised by this connection on its way out -- a closing connection provokes
+        // faults that are expected rather than actionable -- which one listener shared between connections
+        // could not do reliably. See OpcUaServiceFaultListener#forConnection.
         //
-        // The method reference escapes `this` from a constructor, which is worth stating rather than leaving
-        // to be noticed: it is only stored here, never invoked, and the earliest it can run is a fault on a
-        // client this connection has not created yet. The state it reads is a field initializer, so it is
-        // already assigned before this line.
+        // Passing a method reference publishes `this` before the constructor has finished, which is safe only
+        // because nothing calls it yet: it is stored, and the earliest it can run is a fault on a client this
+        // connection has not created. The state it reads is assigned by a field initializer, so it is in
+        // place before this line runs.
         this.serviceFaultListener = serviceFaultListener.forConnection(this::handlerWasAbandoned);
         this.statusPublisher = statusPublisher;
         this.prepareForUse = prepareForUse;
@@ -467,23 +470,25 @@ public class OpcUaClientConnection {
         final var subscriptionOptional = subscriptionLifecycleHandler.subscribe(client);
 
         if (subscriptionOptional.isEmpty()) {
-            // An empty answer says the subscription was not established. It does not say why, and the two
-            // reasons deserve different volumes: the server refused, or a teardown told the handler to stop.
-            // The second is the ordinary end of a connection that is closing anyway -- abandon() is what makes
-            // subscribe() give up between tags -- and reporting it as a fault is what made a shutdown look
-            // like a failure, to operators and to the tests that fail on any unexpected ERROR (EDG-942).
+            // No subscription was established, and how loudly to say so depends on why. An empty answer has
+            // two causes that it does not distinguish: the server refused, or this connection was closed
+            // while the subscription was still being set up. The second is ordinary -- closing calls
+            // abandon(), which is what makes the tag-by-tag setup give up part way -- and reporting it as a
+            // fault made every shutdown look like a failure, to operators and to the integration tests that
+            // fail on any unexpected ERROR (EDG-942).
             //
-            // Asking the handler rather than reading `closed` above: a teardown that arrived after that check
-            // still reaches the handler, and it is the handler's flag that actually stopped the work.
+            // The handler is asked rather than this connection's own `closed` flag, checked further up: a
+            // teardown arriving after that check still reaches the handler, and the handler's flag is the one
+            // that actually stopped the work.
             //
-            // The residual race is a genuine failure whose abandonment lands between subscribe() returning and
-            // this read -- a few instructions with no server call in them, against a failure path that spans
-            // at least one. Losing it downgrades one real fault to debug on a connection being torn down
-            // regardless. Carrying the reason out of subscribe() would close it, at the cost of a wider
-            // return type on every caller for a window this narrow.
+            // Known gap: a genuine failure is reported quietly if the connection is closed in the moment
+            // between the answer arriving and this check -- a few instructions with no server call in them,
+            // against a failure path containing at least one. Closing it would mean carrying the reason out
+            // in the return type, widening every caller for a window this narrow, and the cost of losing the
+            // race is one real fault logged at debug on a connection that is being torn down anyway.
             //
-            // Only the reporting is conditional. The client is closed and the attempt fails either way, so
-            // the outcome does not depend on which branch answered -- and there is one copy of it to edit.
+            // Only the reporting differs between the branches. The client is closed and the attempt fails
+            // either way, so there is one copy of that below rather than one per branch.
             if (subscriptionLifecycleHandler.isAbandoned()) {
                 log.debug(
                         "Adapter '{}': no OPC UA subscription was established, the connection was closed while"
@@ -491,12 +496,13 @@ public class OpcUaClientConnection {
                         adapterId);
             } else {
                 log.error("Failed to create or transfer OPC UA subscription. Closing client connection.");
-                // Deliberately inside the else, and the one part of this that is state rather than a message.
-                // A teardown owns the adapter's final status: stop() leaves it to the wrapper, which drains
-                // the connection FSM back to Disconnected, and destroy() publishes DISCONNECTED as it
-                // releases the connection. Publishing ERROR from here during a close would overwrite one of
-                // those with a status describing an attempt nobody is waiting for. A failure with no teardown
-                // in progress is still the adapter's current condition, and still published.
+                // Publishing ERROR changes the adapter's visible status, so unlike the lines around it this
+                // is state rather than a message -- which is why it sits in this branch only. A close already
+                // owns the final status: stop() leaves it to the wrapper, which walks the connection state
+                // machine back to Disconnected, and destroy() publishes DISCONNECTED as it releases the
+                // connection. Publishing ERROR from a connection attempt that is being abandoned would
+                // overwrite that with a status describing an attempt nobody is waiting for. A failure with no
+                // close in progress is the adapter's actual condition and is still published.
                 publishStatus(ProtocolAdapterState.ConnectionStatus.ERROR);
                 eventService
                         .createAdapterEvent(adapterId, PROTOCOL_ID_OPCUA)
@@ -1005,14 +1011,20 @@ public class OpcUaClientConnection {
     }
 
     /**
-     * Whether a teardown has reached this connection's subscription handler -- that is, whether this
-     * connection has been discarded, by a shutdown or by a reconnect replacing it.
+     * Whether this connection is being discarded — closed either because the adapter is stopping or because
+     * a reconnect is replacing it.
      * <p>
-     * The one question both quiet paths ask. {@link #stop} and {@link #destroy} mark the handler before they
-     * disconnect anything, so this is true for the whole of a close rather than only at the end of it. Also
-     * read by the tests that pin that ordering: the mark can land while {@link #start} holds the monitor,
-     * which is the window in which it is worth anything and the one in which it previously could not be set
-     * at all.
+     * Errors raised while that is true are the expected noise of a close rather than faults to act on, so
+     * both places that report errors consult this before choosing how loudly to speak: the subscription
+     * setup in {@link #start}, and the service-fault listener this connection registers on its client.
+     * <p>
+     * The answer comes from the subscription handler, which {@link #stop} and {@link #destroy} mark before
+     * they disconnect anything — deliberately, so that work already in flight can stop early. Because the
+     * mark comes first, this reads true for the whole of a close and not merely at the end of it. False
+     * before a handler exists, since a connection that has not got that far has not been discarded either.
+     * <p>
+     * Also read by the tests covering that ordering: the mark can land while {@link #start} still holds this
+     * object's monitor, which is the window in which it earns its keep.
      */
     boolean handlerWasAbandoned() {
         final OpcUaSubscriptionLifecycleHandler handler = subscriptionHandler.get();

--- a/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/OpcUaClientConnection.java
+++ b/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/OpcUaClientConnection.java
@@ -902,12 +902,13 @@ public class OpcUaClientConnection {
      */
     private void markClosed() {
         closed.set(true);
-        // Forwarded here rather than left for the listener to ask about, and unconditionally, because this
-        // listener belongs to this connection alone and exists from construction -- there is nothing to check
-        // for and no ordering to get right. Told before anything is disconnected, so the faults a close
-        // provokes are already expected by the time they arrive: deleting the subscription answers any
-        // publish still in flight with Bad_NoSubscription, which is ordinary rather than actionable.
-        serviceFaultListener.connectionClosing();
+        // The same fact reaching a second object, which is why it carries the same name. Forwarded rather
+        // than left for the listener to ask about, and unconditionally: this listener belongs to this
+        // connection alone and exists from construction, so there is nothing to check for and no ordering to
+        // get right. Told before anything is disconnected, so the faults a close provokes are already
+        // expected by the time they arrive -- deleting the subscription answers any publish still in flight
+        // with Bad_NoSubscription, which is ordinary rather than actionable.
+        serviceFaultListener.markClosed();
         final FutureTask<Void> preparation = preparationTask.get();
         if (preparation != null) {
             preparation.cancel(true);

--- a/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/OpcUaClientConnection.java
+++ b/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/OpcUaClientConnection.java
@@ -57,6 +57,7 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.MessageSecurityMode;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -906,7 +907,7 @@ public class OpcUaClientConnection {
         // for and no ordering to get right. Told before anything is disconnected, so the faults a close
         // provokes are already expected by the time they arrive: deleting the subscription answers any
         // publish still in flight with Bad_NoSubscription, which is ordinary rather than actionable.
-        serviceFaultListener.connectionDiscarded();
+        serviceFaultListener.connectionClosing();
         final FutureTask<Void> preparation = preparationTask.get();
         if (preparation != null) {
             preparation.cancel(true);
@@ -1020,6 +1021,7 @@ public class OpcUaClientConnection {
      * be set at all. False before a handler exists, since a connection that has not got that far has nothing
      * to abandon.
      */
+    @VisibleForTesting
     boolean handlerWasAbandoned() {
         final OpcUaSubscriptionLifecycleHandler handler = subscriptionHandler.get();
         return handler != null && handler.isAbandoned();

--- a/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/OpcUaClientConnection.java
+++ b/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/OpcUaClientConnection.java
@@ -46,6 +46,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
+import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
@@ -57,7 +58,6 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.MessageSecurityMode;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.jetbrains.annotations.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -160,6 +160,16 @@ public class OpcUaClientConnection {
      */
     private final @NotNull AtomicReference<OpcUaSubscriptionLifecycleHandler> subscriptionHandler =
             new AtomicReference<>();
+
+    /**
+     * This connection's answer to "have you been discarded?", handed to the shared fault listener.
+     * <p>
+     * A field rather than a method reference written at each use, because the listener withdraws it by
+     * identity: a fresh {@code this::handlerWasAbandoned} is a different object every time it is written, so
+     * the withdrawal would never match and a reconnect's replacement watch could be cleared by the connection
+     * it replaced.
+     */
+    private final @NotNull BooleanSupplier discarded = this::handlerWasAbandoned;
 
     /**
      * Whether {@link #stop} or {@link #destroy} has been called on this connection.
@@ -368,6 +378,10 @@ public class OpcUaClientConnection {
                     endpointFilter,
                     ignore -> {},
                     new OpcUaClientConfigurator(adapterId, parsedConfig, config));
+            // Point the shared fault listener at this connection before its client can raise anything. A
+            // fault says nothing about whether the client it came from still matters; this connection knows,
+            // because a teardown marks its handler abandoned before it disconnects anything.
+            serviceFaultListener.watch(discarded);
             client.addFaultListener(serviceFaultListener);
             client.addSessionActivityListener(activityListener);
 
@@ -397,7 +411,7 @@ public class OpcUaClientConnection {
                         .withSeverity(Event.SEVERITY.ERROR)
                         .fire();
                 publishStatus(ProtocolAdapterState.ConnectionStatus.ERROR);
-                quietlyCloseClient(client, false, serviceFaultListener, null);
+                quietlyCloseClient(client, false, serviceFaultListener, null, discarded);
                 return false;
             } catch (final InterruptedException e) {
                 Thread.currentThread().interrupt();
@@ -408,7 +422,7 @@ public class OpcUaClientConnection {
                         .withSeverity(Event.SEVERITY.ERROR)
                         .fire();
                 publishStatus(ProtocolAdapterState.ConnectionStatus.ERROR);
-                quietlyCloseClient(client, false, serviceFaultListener, null);
+                quietlyCloseClient(client, false, serviceFaultListener, null, discarded);
                 return false;
             } catch (final ExecutionException e) {
                 final Throwable cause = e.getCause();
@@ -420,7 +434,7 @@ public class OpcUaClientConnection {
                         .withSeverity(Event.SEVERITY.ERROR)
                         .fire();
                 publishStatus(ProtocolAdapterState.ConnectionStatus.ERROR);
-                quietlyCloseClient(client, false, serviceFaultListener, null);
+                quietlyCloseClient(client, false, serviceFaultListener, null, discarded);
                 return false;
             }
         } catch (final UaException e) {
@@ -497,7 +511,7 @@ public class OpcUaClientConnection {
                         .withSeverity(Event.SEVERITY.ERROR)
                         .fire();
             }
-            quietlyCloseClient(client, false, serviceFaultListener, activityListener);
+            quietlyCloseClient(client, false, serviceFaultListener, activityListener, discarded);
             return false;
         }
 
@@ -518,7 +532,7 @@ public class OpcUaClientConnection {
                     "OPC UA adapter '{}': the connection was closed while it was being established; "
                             + "discarding the client rather than publishing it",
                     adapterId);
-            quietlyCloseClient(client, false, serviceFaultListener, activityListener);
+            quietlyCloseClient(client, false, serviceFaultListener, activityListener, discarded);
             // Said here rather than left to the activity listener, which cannot say it: quietlyCloseClient
             // removes that listener before disconnecting, precisely so a teardown does not announce itself as
             // a fault. The initial onSessionActive deliberately does not report CONNECTED; the connection
@@ -576,7 +590,7 @@ public class OpcUaClientConnection {
         } catch (final CancellationException e) {
             if (closed.get()) {
                 log.debug("OPC UA metadata preparation was cancelled during teardown for adapter '{}'", adapterId);
-                quietlyCloseClient(client, false, serviceFaultListener, activityListener);
+                quietlyCloseClient(client, false, serviceFaultListener, activityListener, discarded);
                 return false;
             }
             return continueWithoutBrowseMetadata("OPC UA metadata preparation was cancelled", e);
@@ -604,7 +618,7 @@ public class OpcUaClientConnection {
             // The session would then still be closing while the attempt returned and a retry was scheduled.
             // Catching InterruptedException cleared the flag for us, so the window to do the work is now.
             try {
-                quietlyCloseClient(client, false, serviceFaultListener, activityListener);
+                quietlyCloseClient(client, false, serviceFaultListener, activityListener, discarded);
             } finally {
                 Thread.currentThread().interrupt();
             }
@@ -931,7 +945,7 @@ public class OpcUaClientConnection {
     private synchronized void closeContext(final boolean keepSubscription) {
         final ConnectionContext ctx = context.getAndSet(null);
         if (ctx != null) {
-            quietlyCloseClient(ctx.client(), keepSubscription, ctx.faultListener(), ctx.activityListener());
+            quietlyCloseClient(ctx.client(), keepSubscription, ctx.faultListener(), ctx.activityListener(), discarded);
             publishStatus(ProtocolAdapterState.ConnectionStatus.DISCONNECTED);
         }
     }
@@ -998,13 +1012,15 @@ public class OpcUaClientConnection {
     }
 
     /**
-     * Whether a teardown has reached this connection's subscription handler.
+     * Whether a teardown has reached this connection's subscription handler -- that is, whether this
+     * connection has been discarded, by a shutdown or by a reconnect replacing it.
      * <p>
-     * Visible for the tests that pin the ordering this fix is about: that {@link #stop} and {@link #destroy}
-     * can set the flag while {@link #start} holds the monitor, which is the window in which it is worth
-     * anything and the one in which it previously could not be set at all.
+     * The one question both quiet paths ask. {@link #stop} and {@link #destroy} mark the handler before they
+     * disconnect anything, so this is true for the whole of a close rather than only at the end of it. Also
+     * read by the tests that pin that ordering: the mark can land while {@link #start} holds the monitor,
+     * which is the window in which it is worth anything and the one in which it previously could not be set
+     * at all.
      */
-    @VisibleForTesting
     boolean handlerWasAbandoned() {
         final OpcUaSubscriptionLifecycleHandler handler = subscriptionHandler.get();
         return handler != null && handler.isAbandoned();
@@ -1028,7 +1044,8 @@ public class OpcUaClientConnection {
             final @NotNull OpcUaClient client,
             final boolean keepSubscription,
             final @Nullable ServiceFaultListener faultListener,
-            final @Nullable SessionActivityListener activityListener) {
+            final @Nullable SessionActivityListener activityListener,
+            final @NotNull BooleanSupplier withdraw) {
 
         client.getSubscriptions().forEach(subscription -> {
             subscription.setSubscriptionListener(null);
@@ -1041,6 +1058,11 @@ public class OpcUaClientConnection {
                 client.removeFaultListener(faultListener);
             } catch (final Throwable e) {
                 log.error("Failed to remove fault listener {}: {}", faultListener, e.getMessage());
+            }
+            // Withdraw this connection's answer along with the listener, and only if it is still the one
+            // being consulted -- a reconnect's replacement may already have installed its own.
+            if (faultListener instanceof final OpcUaServiceFaultListener owned) {
+                owned.unwatch(withdraw);
             }
         }
         if (activityListener != null) {

--- a/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/OpcUaClientConnection.java
+++ b/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/OpcUaClientConnection.java
@@ -46,7 +46,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
-import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
@@ -162,16 +161,6 @@ public class OpcUaClientConnection {
             new AtomicReference<>();
 
     /**
-     * This connection's answer to "have you been discarded?", handed to the shared fault listener.
-     * <p>
-     * A field rather than a method reference written at each use, because the listener withdraws it by
-     * identity: a fresh {@code this::handlerWasAbandoned} is a different object every time it is written, so
-     * the withdrawal would never match and a reconnect's replacement watch could be cleared by the connection
-     * it replaced.
-     */
-    private final @NotNull BooleanSupplier discarded = this::handlerWasAbandoned;
-
-    /**
      * Whether {@link #stop} or {@link #destroy} has been called on this connection.
      * <p>
      * One-way, and per connection object rather than per adapter: every attempt — first start, retry and
@@ -254,7 +243,15 @@ public class OpcUaClientConnection {
         this.adapterId = adapterId;
         this.protocolAdapterState = protocolAdapterState;
         this.tags = tags;
-        this.serviceFaultListener = serviceFaultListener;
+        // Bound to this connection rather than shared with every other one the adapter makes. What arrives is
+        // a template carrying the adapter's settings; what this connection attaches to its own client is its
+        // own copy, which knows without being told that a fault reaching it belongs to this connection.
+        //
+        // The method reference escapes `this` from a constructor, which is worth stating rather than leaving
+        // to be noticed: it is only stored here, never invoked, and the earliest it can run is a fault on a
+        // client this connection has not created yet. The state it reads is a field initializer, so it is
+        // already assigned before this line.
+        this.serviceFaultListener = serviceFaultListener.forConnection(this::handlerWasAbandoned);
         this.statusPublisher = statusPublisher;
         this.prepareForUse = prepareForUse;
         this.publishReady = publishReady;
@@ -378,10 +375,6 @@ public class OpcUaClientConnection {
                     endpointFilter,
                     ignore -> {},
                     new OpcUaClientConfigurator(adapterId, parsedConfig, config));
-            // Point the shared fault listener at this connection before its client can raise anything. A
-            // fault says nothing about whether the client it came from still matters; this connection knows,
-            // because a teardown marks its handler abandoned before it disconnects anything.
-            serviceFaultListener.watch(discarded);
             client.addFaultListener(serviceFaultListener);
             client.addSessionActivityListener(activityListener);
 
@@ -411,7 +404,7 @@ public class OpcUaClientConnection {
                         .withSeverity(Event.SEVERITY.ERROR)
                         .fire();
                 publishStatus(ProtocolAdapterState.ConnectionStatus.ERROR);
-                quietlyCloseClient(client, false, serviceFaultListener, null, discarded);
+                quietlyCloseClient(client, false, serviceFaultListener, null);
                 return false;
             } catch (final InterruptedException e) {
                 Thread.currentThread().interrupt();
@@ -422,7 +415,7 @@ public class OpcUaClientConnection {
                         .withSeverity(Event.SEVERITY.ERROR)
                         .fire();
                 publishStatus(ProtocolAdapterState.ConnectionStatus.ERROR);
-                quietlyCloseClient(client, false, serviceFaultListener, null, discarded);
+                quietlyCloseClient(client, false, serviceFaultListener, null);
                 return false;
             } catch (final ExecutionException e) {
                 final Throwable cause = e.getCause();
@@ -434,7 +427,7 @@ public class OpcUaClientConnection {
                         .withSeverity(Event.SEVERITY.ERROR)
                         .fire();
                 publishStatus(ProtocolAdapterState.ConnectionStatus.ERROR);
-                quietlyCloseClient(client, false, serviceFaultListener, null, discarded);
+                quietlyCloseClient(client, false, serviceFaultListener, null);
                 return false;
             }
         } catch (final UaException e) {
@@ -511,7 +504,7 @@ public class OpcUaClientConnection {
                         .withSeverity(Event.SEVERITY.ERROR)
                         .fire();
             }
-            quietlyCloseClient(client, false, serviceFaultListener, activityListener, discarded);
+            quietlyCloseClient(client, false, serviceFaultListener, activityListener);
             return false;
         }
 
@@ -532,7 +525,7 @@ public class OpcUaClientConnection {
                     "OPC UA adapter '{}': the connection was closed while it was being established; "
                             + "discarding the client rather than publishing it",
                     adapterId);
-            quietlyCloseClient(client, false, serviceFaultListener, activityListener, discarded);
+            quietlyCloseClient(client, false, serviceFaultListener, activityListener);
             // Said here rather than left to the activity listener, which cannot say it: quietlyCloseClient
             // removes that listener before disconnecting, precisely so a teardown does not announce itself as
             // a fault. The initial onSessionActive deliberately does not report CONNECTED; the connection
@@ -590,7 +583,7 @@ public class OpcUaClientConnection {
         } catch (final CancellationException e) {
             if (closed.get()) {
                 log.debug("OPC UA metadata preparation was cancelled during teardown for adapter '{}'", adapterId);
-                quietlyCloseClient(client, false, serviceFaultListener, activityListener, discarded);
+                quietlyCloseClient(client, false, serviceFaultListener, activityListener);
                 return false;
             }
             return continueWithoutBrowseMetadata("OPC UA metadata preparation was cancelled", e);
@@ -618,7 +611,7 @@ public class OpcUaClientConnection {
             // The session would then still be closing while the attempt returned and a retry was scheduled.
             // Catching InterruptedException cleared the flag for us, so the window to do the work is now.
             try {
-                quietlyCloseClient(client, false, serviceFaultListener, activityListener, discarded);
+                quietlyCloseClient(client, false, serviceFaultListener, activityListener);
             } finally {
                 Thread.currentThread().interrupt();
             }
@@ -945,7 +938,7 @@ public class OpcUaClientConnection {
     private synchronized void closeContext(final boolean keepSubscription) {
         final ConnectionContext ctx = context.getAndSet(null);
         if (ctx != null) {
-            quietlyCloseClient(ctx.client(), keepSubscription, ctx.faultListener(), ctx.activityListener(), discarded);
+            quietlyCloseClient(ctx.client(), keepSubscription, ctx.faultListener(), ctx.activityListener());
             publishStatus(ProtocolAdapterState.ConnectionStatus.DISCONNECTED);
         }
     }
@@ -1044,8 +1037,7 @@ public class OpcUaClientConnection {
             final @NotNull OpcUaClient client,
             final boolean keepSubscription,
             final @Nullable ServiceFaultListener faultListener,
-            final @Nullable SessionActivityListener activityListener,
-            final @NotNull BooleanSupplier withdraw) {
+            final @Nullable SessionActivityListener activityListener) {
 
         client.getSubscriptions().forEach(subscription -> {
             subscription.setSubscriptionListener(null);
@@ -1058,11 +1050,6 @@ public class OpcUaClientConnection {
                 client.removeFaultListener(faultListener);
             } catch (final Throwable e) {
                 log.error("Failed to remove fault listener {}: {}", faultListener, e.getMessage());
-            }
-            // Withdraw this connection's answer along with the listener, and only if it is still the one
-            // being consulted -- a reconnect's replacement may already have installed its own.
-            if (faultListener instanceof final OpcUaServiceFaultListener owned) {
-                owned.unwatch(withdraw);
             }
         }
         if (activityListener != null) {

--- a/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/OpcUaClientConnection.java
+++ b/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/OpcUaClientConnection.java
@@ -244,17 +244,12 @@ public class OpcUaClientConnection {
         this.protocolAdapterState = protocolAdapterState;
         this.tags = tags;
         // This connection's own copy of the service-fault listener, which reports the errors an OPC UA server
-        // raises. The argument is a template holding the adapter's settings and is not used directly: every
-        // connection derives a copy that serves it alone and registers that on its own client. The copy can
-        // then recognise a fault raised by this connection on its way out -- a closing connection provokes
-        // faults that are expected rather than actionable -- which one listener shared between connections
-        // could not do reliably. See OpcUaServiceFaultListener#forConnection.
-        //
-        // Passing a method reference publishes `this` before the constructor has finished, which is safe only
-        // because nothing calls it yet: it is stored, and the earliest it can run is a fault on a client this
-        // connection has not created. The state it reads is assigned by a field initializer, so it is in
-        // place before this line runs.
-        this.serviceFaultListener = serviceFaultListener.forConnection(this::handlerWasAbandoned);
+        // raises. The argument is a template holding the adapter's settings and is never registered anywhere:
+        // every connection takes a copy that serves it alone and registers that on its own client. Serving
+        // one connection is what lets markClosed() tell it to fall quiet, and one listener shared between
+        // connections could not do that -- a closing connection would silence a live one's faults. See
+        // OpcUaServiceFaultListener#forConnection.
+        this.serviceFaultListener = serviceFaultListener.forConnection();
         this.statusPublisher = statusPublisher;
         this.prepareForUse = prepareForUse;
         this.publishReady = publishReady;
@@ -906,6 +901,12 @@ public class OpcUaClientConnection {
      */
     private void markClosed() {
         closed.set(true);
+        // Forwarded here rather than left for the listener to ask about, and unconditionally, because this
+        // listener belongs to this connection alone and exists from construction -- there is nothing to check
+        // for and no ordering to get right. Told before anything is disconnected, so the faults a close
+        // provokes are already expected by the time they arrive: deleting the subscription answers any
+        // publish still in flight with Bad_NoSubscription, which is ordinary rather than actionable.
+        serviceFaultListener.connectionDiscarded();
         final FutureTask<Void> preparation = preparationTask.get();
         if (preparation != null) {
             preparation.cancel(true);
@@ -1011,20 +1012,13 @@ public class OpcUaClientConnection {
     }
 
     /**
-     * Whether this connection is being discarded — closed either because the adapter is stopping or because
-     * a reconnect is replacing it.
+     * Whether a close has reached this connection's subscription handler, telling it to stop verifying tags.
      * <p>
-     * Errors raised while that is true are the expected noise of a close rather than faults to act on, so
-     * both places that report errors consult this before choosing how loudly to speak: the subscription
-     * setup in {@link #start}, and the service-fault listener this connection registers on its client.
-     * <p>
-     * The answer comes from the subscription handler, which {@link #stop} and {@link #destroy} mark before
-     * they disconnect anything — deliberately, so that work already in flight can stop early. Because the
-     * mark comes first, this reads true for the whole of a close and not merely at the end of it. False
-     * before a handler exists, since a connection that has not got that far has not been discarded either.
-     * <p>
-     * Also read by the tests covering that ordering: the mark can land while {@link #start} still holds this
-     * object's monitor, which is the window in which it earns its keep.
+     * Visible for the tests covering the ordering this depends on: {@link #stop} and {@link #destroy} mark
+     * the handler before disconnecting anything, and that mark can land while {@link #start} still holds this
+     * object's monitor — the window in which it earns its keep, and the one in which it previously could not
+     * be set at all. False before a handler exists, since a connection that has not got that far has nothing
+     * to abandon.
      */
     boolean handlerWasAbandoned() {
         final OpcUaSubscriptionLifecycleHandler handler = subscriptionHandler.get();

--- a/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/OpcUaClientConnection.java
+++ b/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/OpcUaClientConnection.java
@@ -474,21 +474,29 @@ public class OpcUaClientConnection {
             // at least one. Losing it downgrades one real fault to debug on a connection being torn down
             // regardless. Carrying the reason out of subscribe() would close it, at the cost of a wider
             // return type on every caller for a window this narrow.
+            //
+            // Only the reporting is conditional. The client is closed and the attempt fails either way, so
+            // the outcome does not depend on which branch answered -- and there is one copy of it to edit.
             if (subscriptionLifecycleHandler.isAbandoned()) {
                 log.debug(
                         "Adapter '{}': no OPC UA subscription was established, the connection was closed while"
                                 + " it was being set up",
                         adapterId);
-                quietlyCloseClient(client, false, serviceFaultListener, activityListener);
-                return false;
+            } else {
+                log.error("Failed to create or transfer OPC UA subscription. Closing client connection.");
+                // Deliberately inside the else, and the one part of this that is state rather than a message.
+                // A teardown owns the adapter's final status: stop() leaves it to the wrapper, which drains
+                // the connection FSM back to Disconnected, and destroy() publishes DISCONNECTED as it
+                // releases the connection. Publishing ERROR from here during a close would overwrite one of
+                // those with a status describing an attempt nobody is waiting for. A failure with no teardown
+                // in progress is still the adapter's current condition, and still published.
+                publishStatus(ProtocolAdapterState.ConnectionStatus.ERROR);
+                eventService
+                        .createAdapterEvent(adapterId, PROTOCOL_ID_OPCUA)
+                        .withMessage("Failed to create or transfer OPC UA subscription. Closing client connection.")
+                        .withSeverity(Event.SEVERITY.ERROR)
+                        .fire();
             }
-            log.error("Failed to create or transfer OPC UA subscription. Closing client connection.");
-            publishStatus(ProtocolAdapterState.ConnectionStatus.ERROR);
-            eventService
-                    .createAdapterEvent(adapterId, PROTOCOL_ID_OPCUA)
-                    .withMessage("Failed to create or transfer OPC UA subscription. Closing client connection.")
-                    .withSeverity(Event.SEVERITY.ERROR)
-                    .fire();
             quietlyCloseClient(client, false, serviceFaultListener, activityListener);
             return false;
         }

--- a/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/OpcUaClientConnection.java
+++ b/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/OpcUaClientConnection.java
@@ -460,6 +460,28 @@ public class OpcUaClientConnection {
         final var subscriptionOptional = subscriptionLifecycleHandler.subscribe(client);
 
         if (subscriptionOptional.isEmpty()) {
+            // An empty answer says the subscription was not established. It does not say why, and the two
+            // reasons deserve different volumes: the server refused, or a teardown told the handler to stop.
+            // The second is the ordinary end of a connection that is closing anyway -- abandon() is what makes
+            // subscribe() give up between tags -- and reporting it as a fault is what made a shutdown look
+            // like a failure, to operators and to the tests that fail on any unexpected ERROR (EDG-942).
+            //
+            // Asking the handler rather than reading `closed` above: a teardown that arrived after that check
+            // still reaches the handler, and it is the handler's flag that actually stopped the work.
+            //
+            // The residual race is a genuine failure whose abandonment lands between subscribe() returning and
+            // this read -- a few instructions with no server call in them, against a failure path that spans
+            // at least one. Losing it downgrades one real fault to debug on a connection being torn down
+            // regardless. Carrying the reason out of subscribe() would close it, at the cost of a wider
+            // return type on every caller for a window this narrow.
+            if (subscriptionLifecycleHandler.isAbandoned()) {
+                log.debug(
+                        "Adapter '{}': no OPC UA subscription was established, the connection was closed while"
+                                + " it was being set up",
+                        adapterId);
+                quietlyCloseClient(client, false, serviceFaultListener, activityListener);
+                return false;
+            }
             log.error("Failed to create or transfer OPC UA subscription. Closing client connection.");
             publishStatus(ProtocolAdapterState.ConnectionStatus.ERROR);
             eventService

--- a/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/OpcUaProtocolAdapter.java
+++ b/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/OpcUaProtocolAdapter.java
@@ -180,12 +180,7 @@ public class OpcUaProtocolAdapter implements WritingProtocolAdapter, BulkTagBrow
                 input.moduleServices().eventService(),
                 adapterId,
                 this::reconnect,
-                config.getConnectionOptions().autoReconnect(),
-                // `stopped` rather than the connection's own abandonment flag, because stop() and destroy()
-                // both release the connection reference before closing it -- so for the whole window in which
-                // the closing client can still raise a fault, there is no current connection left to ask.
-                // `stopped` is set before that release in both, and stays true across it.
-                () -> stopped);
+                config.getConnectionOptions().autoReconnect());
     }
 
     /**

--- a/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/OpcUaProtocolAdapter.java
+++ b/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/OpcUaProtocolAdapter.java
@@ -180,7 +180,12 @@ public class OpcUaProtocolAdapter implements WritingProtocolAdapter, BulkTagBrow
                 input.moduleServices().eventService(),
                 adapterId,
                 this::reconnect,
-                config.getConnectionOptions().autoReconnect());
+                config.getConnectionOptions().autoReconnect(),
+                // `stopped` rather than the connection's own abandonment flag, because stop() and destroy()
+                // both release the connection reference before closing it -- so for the whole window in which
+                // the closing client can still raise a fault, there is no current connection left to ask.
+                // `stopped` is set before that release in both, and stays true across it.
+                () -> stopped);
     }
 
     /**

--- a/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/listeners/OpcUaServiceFaultListener.java
+++ b/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/listeners/OpcUaServiceFaultListener.java
@@ -43,7 +43,7 @@ import org.slf4j.LoggerFactory;
  * <b>One instance is built per connection, not per adapter.</b> The adapter builds a template carrying its
  * settings; each connection takes its own copy with {@link #forConnection} and registers that on its own
  * client. The copy serves that connection alone, so when the connection begins closing it can call
- * {@link #connectionDiscarded()} and this listener knows the faults that follow are the ordinary noise of a
+ * {@link #connectionClosing()} and this listener knows the faults that follow are the ordinary noise of a
  * close rather than something to report or recover from.
  */
 public class OpcUaServiceFaultListener implements ServiceFaultListener {
@@ -56,9 +56,9 @@ public class OpcUaServiceFaultListener implements ServiceFaultListener {
     private final boolean reconnectOnServiceFault;
 
     /**
-     * Whether the connection this listener serves has been discarded — set by {@link #connectionDiscarded()}
-     * when that connection begins closing, either because the adapter is stopping or because a reconnect is
-     * replacing it.
+     * Whether the connection this listener serves is closing — set by {@link #connectionClosing()} when that
+     * connection begins closing, either because the adapter is stopping or because a reconnect is replacing
+     * it. The connection's own flag of the same name is what gets forwarded here.
      * <p>
      * Faults raised by a connection on its way out are expected rather than actionable. Closing a connection
      * deletes its subscription while its client is still live, so a publish already in flight comes back
@@ -70,7 +70,7 @@ public class OpcUaServiceFaultListener implements ServiceFaultListener {
      * False until told otherwise, so a listener nobody claimed reports everything: with no connection to
      * vouch for a fault being expected, the louder report is the safe answer.
      */
-    private final @NotNull AtomicBoolean discarded = new AtomicBoolean();
+    private final @NotNull AtomicBoolean closed = new AtomicBoolean();
 
     public OpcUaServiceFaultListener(
             @NotNull final ProtocolAdapterMetricsService protocolAdapterMetricsService,
@@ -98,7 +98,7 @@ public class OpcUaServiceFaultListener implements ServiceFaultListener {
      * <p>
      * It matters because an adapter can have two connections alive at once: a reconnect starts a replacement
      * while the connection it replaces is still finishing or closing. One shared listener would have a single
-     * discarded flag for both, so the closing connection would silence the live one's faults.
+     * closed flag for both, so the closing connection would silence the live one's faults.
      */
     public @NotNull OpcUaServiceFaultListener forConnection() {
         return new OpcUaServiceFaultListener(
@@ -106,15 +106,15 @@ public class OpcUaServiceFaultListener implements ServiceFaultListener {
     }
 
     /**
-     * Tells this listener that the connection it serves is being discarded, so that faults from here on are
-     * the expected noise of a close rather than something to report or recover from.
+     * Tells this listener that the connection it serves is closing, so that faults from here on are the
+     * expected noise of a close rather than something to report or recover from.
      * <p>
      * Called by that connection as it begins closing, before it disconnects anything — which is what makes
-     * this cover the whole close rather than only its end. One-way and idempotent: a discarded connection is
-     * never reopened.
+     * this cover the whole close rather than only its end. One-way and idempotent: a closed connection is
+     * never reopened, and a stop followed by a destroy reaches the same connection twice.
      */
-    public void connectionDiscarded() {
-        discarded.set(true);
+    public void connectionClosing() {
+        closed.set(true);
     }
 
     @Override
@@ -133,11 +133,11 @@ public class OpcUaServiceFaultListener implements ServiceFaultListener {
         // auto-reconnect off. Whether a connection is closing has nothing to do with that setting.
         //
         // Returning here also skips the reconnect the critical branch would trigger, which is what should
-        // happen: a connection already being discarded is not one to recover.
-        if (discarded.get()) {
+        // happen: a connection that is already closing is not one to recover.
+        if (closed.get()) {
             log.info(
-                    "OPC UA service fault for adapter '{}' on a connection being closed: {}. Expected while"
-                            + " the connection is discarded.",
+                    "OPC UA service fault for adapter '{}' on a connection that is closing: {}. Expected"
+                            + " while the connection is closed.",
                     adapterId,
                     statusCode);
             return;

--- a/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/listeners/OpcUaServiceFaultListener.java
+++ b/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/listeners/OpcUaServiceFaultListener.java
@@ -21,7 +21,7 @@ import com.hivemq.adapter.sdk.api.events.EventService;
 import com.hivemq.adapter.sdk.api.events.model.Event;
 import com.hivemq.adapter.sdk.api.services.ProtocolAdapterMetricsService;
 import com.hivemq.edge.adapters.opcua.Constants;
-import java.util.function.BooleanSupplier;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.eclipse.milo.opcua.sdk.client.ServiceFaultListener;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
@@ -41,9 +41,10 @@ import org.slf4j.LoggerFactory;
  * an adapter event, and trigger a reconnect. Everything else is logged at WARN with an event and no action.
  * <p>
  * <b>One instance is built per connection, not per adapter.</b> The adapter builds a template carrying its
- * settings; each connection derives its own copy with {@link #forConnection} and registers that copy on its
- * own client. The copy is bound at construction to the connection it serves, which is what lets it tell a
- * genuine fault from the noise a closing connection makes — see {@link #discarded}.
+ * settings; each connection takes its own copy with {@link #forConnection} and registers that on its own
+ * client. The copy serves that connection alone, so when the connection begins closing it can call
+ * {@link #connectionDiscarded()} and this listener knows the faults that follow are the ordinary noise of a
+ * close rather than something to report or recover from.
  */
 public class OpcUaServiceFaultListener implements ServiceFaultListener {
 
@@ -55,8 +56,9 @@ public class OpcUaServiceFaultListener implements ServiceFaultListener {
     private final boolean reconnectOnServiceFault;
 
     /**
-     * Asks the connection this listener serves whether it has been discarded — that is, whether it is being
-     * closed, either because the adapter is stopping or because a reconnect is replacing it.
+     * Whether the connection this listener serves has been discarded — set by {@link #connectionDiscarded()}
+     * when that connection begins closing, either because the adapter is stopping or because a reconnect is
+     * replacing it.
      * <p>
      * Faults raised by a connection on its way out are expected rather than actionable. Closing a connection
      * deletes its subscription while its client is still live, so a publish already in flight comes back
@@ -64,16 +66,11 @@ public class OpcUaServiceFaultListener implements ServiceFaultListener {
      * this existed, every shutdown produced errors that looked like failures to operators and failed
      * whichever integration test happened to be finishing (EDG-942).
      * <p>
-     * <b>Why a supplier rather than a reference to the connection:</b> the answer changes over the lifetime
-     * of the connection, so it has to be asked at the moment a fault arrives rather than read once. The
-     * connection answers from the mark its teardown sets on its subscription handler before disconnecting
-     * anything, so the answer is already true for the whole of a close rather than only at the end of it.
-     * <p>
-     * Final, because a listener serves exactly one connection for its whole life. On a template that no
-     * connection derived from, this is permanently false: with nobody to vouch for a fault being expected,
-     * the louder report is the safe answer.
+     * One-way, because a connection is never reopened — a reconnect builds a new one, with a new listener.
+     * False until told otherwise, so a listener nobody claimed reports everything: with no connection to
+     * vouch for a fault being expected, the louder report is the safe answer.
      */
-    private final @NotNull BooleanSupplier discarded;
+    private final @NotNull AtomicBoolean discarded = new AtomicBoolean();
 
     public OpcUaServiceFaultListener(
             @NotNull final ProtocolAdapterMetricsService protocolAdapterMetricsService,
@@ -81,59 +78,43 @@ public class OpcUaServiceFaultListener implements ServiceFaultListener {
             @NotNull final String adapterId,
             @Nullable final Runnable reconnectionCallback,
             final boolean reconnectOnServiceFault) {
-        this(
-                protocolAdapterMetricsService,
-                eventService,
-                adapterId,
-                reconnectionCallback,
-                reconnectOnServiceFault,
-                () -> false);
-    }
-
-    private OpcUaServiceFaultListener(
-            @NotNull final ProtocolAdapterMetricsService protocolAdapterMetricsService,
-            @NotNull final EventService eventService,
-            @NotNull final String adapterId,
-            @Nullable final Runnable reconnectionCallback,
-            final boolean reconnectOnServiceFault,
-            @NotNull final BooleanSupplier discarded) {
         this.protocolAdapterMetricsService = protocolAdapterMetricsService;
         this.eventService = eventService;
         this.adapterId = adapterId;
         this.reconnectionCallback = reconnectionCallback;
         this.reconnectOnServiceFault = reconnectOnServiceFault;
-        this.discarded = discarded;
     }
 
     /**
-     * Derives a copy of this listener that serves one connection, to be registered on that connection's
-     * client. The copy keeps this listener's settings and adds the one thing it cannot infer: a way to ask
-     * that connection whether it is being closed.
+     * Returns a listener with the same settings for one connection to register on its own client, leaving
+     * this one untouched. Callers are connections; the adapter builds one listener as a template and
+     * registers it nowhere.
      * <p>
-     * Callers are connections. An adapter builds one listener and never registers it anywhere; every
-     * connection derives its own and registers that.
+     * <b>Why every connection needs its own rather than sharing the adapter's:</b> a fault says nothing about
+     * where it came from. Milo's callback takes only the fault, and the fault names neither the client nor
+     * the session, so a listener cannot look up the connection that raised it. What identifies the connection
+     * is which listener Milo called — it calls the one registered on the client that faulted — and that only
+     * identifies anything if each listener serves a single connection.
      * <p>
-     * <b>Why a copy per connection, when one listener would do:</b> a fault says nothing about where it came
-     * from. Milo's callback takes only the fault, and the fault names neither the client nor the session, so
-     * a listener cannot look up the connection that raised it. What it can know is the connection it was
-     * built for — Milo calls the listener registered on the client that faulted, so the instance receiving
-     * the call already identifies the connection, provided that instance serves only one.
-     * <p>
-     * <b>Why one shared listener would be wrong:</b> an adapter can have two connections alive at once, since
-     * a reconnect starts a replacement while the connection it replaces is still finishing or closing. A
-     * shared listener would need a mutable pointer to whichever connection to ask, and that pointer would be
-     * written by whichever connection set it last rather than by whichever is current. A slow start
-     * completing late could aim a live connection's reporting at a discarded one and silence real faults.
-     * Binding at construction removes the possibility instead of guarding against it.
+     * It matters because an adapter can have two connections alive at once: a reconnect starts a replacement
+     * while the connection it replaces is still finishing or closing. One shared listener would have a single
+     * discarded flag for both, so the closing connection would silence the live one's faults.
      */
-    public @NotNull OpcUaServiceFaultListener forConnection(final @NotNull BooleanSupplier connectionDiscarded) {
+    public @NotNull OpcUaServiceFaultListener forConnection() {
         return new OpcUaServiceFaultListener(
-                protocolAdapterMetricsService,
-                eventService,
-                adapterId,
-                reconnectionCallback,
-                reconnectOnServiceFault,
-                connectionDiscarded);
+                protocolAdapterMetricsService, eventService, adapterId, reconnectionCallback, reconnectOnServiceFault);
+    }
+
+    /**
+     * Tells this listener that the connection it serves is being discarded, so that faults from here on are
+     * the expected noise of a close rather than something to report or recover from.
+     * <p>
+     * Called by that connection as it begins closing, before it disconnects anything — which is what makes
+     * this cover the whole close rather than only its end. One-way and idempotent: a discarded connection is
+     * never reopened.
+     */
+    public void connectionDiscarded() {
+        discarded.set(true);
     }
 
     @Override
@@ -153,7 +134,7 @@ public class OpcUaServiceFaultListener implements ServiceFaultListener {
         //
         // Returning here also skips the reconnect the critical branch would trigger, which is what should
         // happen: a connection already being discarded is not one to recover.
-        if (discarded.getAsBoolean()) {
+        if (discarded.get()) {
             log.info(
                     "OPC UA service fault for adapter '{}' on a connection being closed: {}. Expected while"
                             + " the connection is discarded.",

--- a/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/listeners/OpcUaServiceFaultListener.java
+++ b/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/listeners/OpcUaServiceFaultListener.java
@@ -91,25 +91,31 @@ public class OpcUaServiceFaultListener implements ServiceFaultListener {
         final StatusCode statusCode = serviceFault.getResponseHeader().getServiceResult();
         protocolAdapterMetricsService.increment(Constants.METRIC_SUBSCRIPTION_SERVICE_FAULT_COUNT);
 
+        // The same fault means two different things depending on whether this adapter is being torn down.
+        // Closing a connection deletes its subscription while this listener is still attached, so a publish
+        // already in flight comes back Bad_NoSubscription -- the expected end of a subscription that was
+        // deliberately removed, not a fault anyone can act on. Reporting it as a fault made every shutdown
+        // look like a failure, to operators and to the tests that fail on any unexpected ERROR (EDG-942).
+        //
+        // Above the critical/non-critical split rather than inside it. Which branch a fault takes depends on
+        // `reconnectOnServiceFault`, an operator's autoReconnect setting -- so a check inside the critical
+        // branch would let the identical shutdown fault stay noisy for anyone who turned auto-reconnect off.
+        // Teardown is a property of this adapter, not of that setting.
+        //
+        // The reconnect the critical branch would have triggered is skipped with it. That costs nothing: it
+        // reads the very same flag on entry and returns without doing anything. The two are one guard asked
+        // twice, not two independent ones.
+        if (stopping.getAsBoolean()) {
+            log.info(
+                    "OPC UA service fault for adapter '{}' while it is stopping: {}. Expected while the"
+                            + " connection is being closed.",
+                    adapterId,
+                    statusCode);
+            return;
+        }
+
         // Check if this is a critical fault requiring immediate reconnection
         if (reconnectOnServiceFault && isCriticalFault(statusCode)) {
-            // The same fault means two different things depending on whether this adapter is being torn down.
-            // Closing a connection deletes its subscription while this listener is still attached, so a
-            // publish already in flight comes back Bad_NoSubscription -- the expected end of a subscription
-            // that was deliberately removed, not a fault anyone can act on. Reporting it at ERROR made every
-            // shutdown look like a failure, to operators and to the tests that fail on any unexpected ERROR
-            // (EDG-942).
-            //
-            // Only the volume changes. The reconnect below is left exactly as it was: it already returns
-            // quietly when the adapter has been stopped, so the recovery half was never the problem.
-            if (stopping.getAsBoolean()) {
-                log.info(
-                        "OPC UA service fault for adapter '{}' while it is stopping: {}. Expected while the"
-                                + " connection is being closed.",
-                        adapterId,
-                        statusCode);
-                return;
-            }
             log.error("Critical OPC UA service fault detected for adapter '{}': {}", adapterId, statusCode);
 
             eventService

--- a/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/listeners/OpcUaServiceFaultListener.java
+++ b/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/listeners/OpcUaServiceFaultListener.java
@@ -21,6 +21,7 @@ import com.hivemq.adapter.sdk.api.events.EventService;
 import com.hivemq.adapter.sdk.api.events.model.Event;
 import com.hivemq.adapter.sdk.api.services.ProtocolAdapterMetricsService;
 import com.hivemq.edge.adapters.opcua.Constants;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BooleanSupplier;
 import org.eclipse.milo.opcua.sdk.client.ServiceFaultListener;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
@@ -41,49 +42,62 @@ public class OpcUaServiceFaultListener implements ServiceFaultListener {
     private final boolean reconnectOnServiceFault;
 
     /**
-     * Whether the adapter this listener belongs to is being torn down.
+     * Whether the connection whose client raised the fault has been discarded.
      * <p>
-     * The listener is built once per adapter and attached to whichever client is current, so it cannot tell
-     * on its own that the connection a fault arrived on is closing. This is how it asks. Consulted only to
-     * choose the volume of the report, never to decide whether to act.
+     * A fault arrives on a client, and this listener cannot tell from the fault alone whether that client
+     * still matters. The connection that owns the client can: it marks its subscription handler abandoned
+     * before it disconnects anything, precisely so that work already in flight can stop. That mark is what
+     * this asks for, and it is set early enough to cover the whole close.
+     * <p>
+     * Settable rather than constructor-injected because this listener outlives a single connection -- the
+     * adapter builds one and hands it to each connection in turn -- so the connection to ask changes. Each
+     * connection points it at itself as it attaches, and clears it as it detaches. Answers false while
+     * unset, which is the behaviour this class had before the distinction existed: a caller that cannot say
+     * whether its connection is being discarded gets the louder report, not the quieter one.
      */
-    private final @NotNull BooleanSupplier stopping;
+    private final @NotNull AtomicReference<BooleanSupplier> discarded = new AtomicReference<>();
 
-    /**
-     * A listener for a connection that is never torn down, which is every caller that has no adapter to ask.
-     * <p>
-     * The default is "not stopping" rather than the reverse because that is the behaviour this class had
-     * before the distinction existed: every critical fault reported at ERROR. A caller that cannot say
-     * whether it is closing gets the louder answer, not the quieter one.
-     */
     public OpcUaServiceFaultListener(
             @NotNull final ProtocolAdapterMetricsService protocolAdapterMetricsService,
             @NotNull final EventService eventService,
             @NotNull final String adapterId,
             @Nullable final Runnable reconnectionCallback,
             final boolean reconnectOnServiceFault) {
-        this(
-                protocolAdapterMetricsService,
-                eventService,
-                adapterId,
-                reconnectionCallback,
-                reconnectOnServiceFault,
-                () -> false);
-    }
-
-    public OpcUaServiceFaultListener(
-            @NotNull final ProtocolAdapterMetricsService protocolAdapterMetricsService,
-            @NotNull final EventService eventService,
-            @NotNull final String adapterId,
-            @Nullable final Runnable reconnectionCallback,
-            final boolean reconnectOnServiceFault,
-            @NotNull final BooleanSupplier stopping) {
         this.protocolAdapterMetricsService = protocolAdapterMetricsService;
         this.eventService = eventService;
         this.adapterId = adapterId;
         this.reconnectionCallback = reconnectionCallback;
         this.reconnectOnServiceFault = reconnectOnServiceFault;
-        this.stopping = stopping;
+    }
+
+    /**
+     * Names the connection whose discard state this listener should consult.
+     * <p>
+     * Called by a connection as it attaches this listener to its client. The most recent caller wins, which
+     * is what a reconnect needs: the replacement connection attaches before the old one has finished closing,
+     * and it is the replacement whose faults matter from then on.
+     */
+    public void watch(final @NotNull BooleanSupplier connectionDiscarded) {
+        discarded.set(connectionDiscarded);
+    }
+
+    /**
+     * Stops consulting {@code connectionDiscarded}, if it is still the one being consulted.
+     * <p>
+     * Conditional, and that is the whole point. A connection clears its watch as it detaches, but a reconnect
+     * has the replacement attach <em>before</em> the old connection finishes closing -- so a blind clear here
+     * would wipe the live connection's watch and leave this listener answering "not discarded" for a
+     * connection that may since have been discarded. Clearing only what this connection itself installed
+     * leaves a newer watch alone.
+     */
+    public void unwatch(final @NotNull BooleanSupplier connectionDiscarded) {
+        discarded.compareAndSet(connectionDiscarded, null);
+    }
+
+    /** Whether the connection that raised this fault is being discarded; false when nobody has said. */
+    private boolean isDiscarded() {
+        final BooleanSupplier source = discarded.get();
+        return source != null && source.getAsBoolean();
     }
 
     @Override
@@ -91,24 +105,27 @@ public class OpcUaServiceFaultListener implements ServiceFaultListener {
         final StatusCode statusCode = serviceFault.getResponseHeader().getServiceResult();
         protocolAdapterMetricsService.increment(Constants.METRIC_SUBSCRIPTION_SERVICE_FAULT_COUNT);
 
-        // The same fault means two different things depending on whether this adapter is being torn down.
-        // Closing a connection deletes its subscription while this listener is still attached, so a publish
-        // already in flight comes back Bad_NoSubscription -- the expected end of a subscription that was
-        // deliberately removed, not a fault anyone can act on. Reporting it as a fault made every shutdown
+        // The same fault means two different things depending on whether the connection it arrived on still
+        // matters. Discarding a connection deletes its subscription while this listener is still attached, so
+        // a publish already in flight comes back Bad_NoSubscription -- the expected end of a subscription that
+        // was deliberately removed, not a fault anyone can act on. Reporting it as a fault made every shutdown
         // look like a failure, to operators and to the tests that fail on any unexpected ERROR (EDG-942).
+        //
+        // "Discarded" rather than "the adapter is stopping", because those differ: a reconnect discards a
+        // connection while the adapter stays up. Both cases want silence for the same reason -- a replacement
+        // is coming, or nothing is -- and in neither is the old connection's failure something to act on.
         //
         // Above the critical/non-critical split rather than inside it. Which branch a fault takes depends on
         // `reconnectOnServiceFault`, an operator's autoReconnect setting -- so a check inside the critical
-        // branch would let the identical shutdown fault stay noisy for anyone who turned auto-reconnect off.
-        // Teardown is a property of this adapter, not of that setting.
+        // branch would let the identical fault stay noisy for anyone who turned auto-reconnect off. Being
+        // discarded is a property of the connection, not of that setting.
         //
-        // The reconnect the critical branch would have triggered is skipped with it. That costs nothing: it
-        // reads the very same flag on entry and returns without doing anything. The two are one guard asked
-        // twice, not two independent ones.
-        if (stopping.getAsBoolean()) {
+        // The reconnect the critical branch would have triggered is skipped with it, and that is right rather
+        // than merely harmless: a connection that has already been discarded is not the one to recover from.
+        if (isDiscarded()) {
             log.info(
-                    "OPC UA service fault for adapter '{}' while it is stopping: {}. Expected while the"
-                            + " connection is being closed.",
+                    "OPC UA service fault for adapter '{}' on a connection being closed: {}. Expected while"
+                            + " the connection is discarded.",
                     adapterId,
                     statusCode);
             return;

--- a/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/listeners/OpcUaServiceFaultListener.java
+++ b/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/listeners/OpcUaServiceFaultListener.java
@@ -21,7 +21,6 @@ import com.hivemq.adapter.sdk.api.events.EventService;
 import com.hivemq.adapter.sdk.api.events.model.Event;
 import com.hivemq.adapter.sdk.api.services.ProtocolAdapterMetricsService;
 import com.hivemq.edge.adapters.opcua.Constants;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BooleanSupplier;
 import org.eclipse.milo.opcua.sdk.client.ServiceFaultListener;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
@@ -44,18 +43,17 @@ public class OpcUaServiceFaultListener implements ServiceFaultListener {
     /**
      * Whether the connection whose client raised the fault has been discarded.
      * <p>
-     * A fault arrives on a client, and this listener cannot tell from the fault alone whether that client
-     * still matters. The connection that owns the client can: it marks its subscription handler abandoned
-     * before it disconnects anything, precisely so that work already in flight can stop. That mark is what
-     * this asks for, and it is set early enough to cover the whole close.
+     * A fault carries a status code and nothing else -- Milo's callback takes one argument, and the fault
+     * names neither the client nor the session it came from. So a listener cannot ask about the fault's
+     * origin; it can only know the connection it was <em>built for</em>. That is why {@link #forConnection}
+     * exists and why this is final: being called is the identification.
      * <p>
-     * Settable rather than constructor-injected because this listener outlives a single connection -- the
-     * adapter builds one and hands it to each connection in turn -- so the connection to ask changes. Each
-     * connection points it at itself as it attaches, and clears it as it detaches. Answers false while
-     * unset, which is the behaviour this class had before the distinction existed: a caller that cannot say
-     * whether its connection is being discarded gets the louder report, not the quieter one.
+     * What it asks is whether the connection marked its subscription handler abandoned, which a teardown
+     * does before it disconnects anything, so the answer covers the whole close rather than only its end.
+     * Always false on an instance nobody bound, which is the behaviour this class had before the
+     * distinction existed: a listener with no connection to ask reports at full volume.
      */
-    private final @NotNull AtomicReference<BooleanSupplier> discarded = new AtomicReference<>();
+    private final @NotNull BooleanSupplier discarded;
 
     public OpcUaServiceFaultListener(
             @NotNull final ProtocolAdapterMetricsService protocolAdapterMetricsService,
@@ -63,41 +61,53 @@ public class OpcUaServiceFaultListener implements ServiceFaultListener {
             @NotNull final String adapterId,
             @Nullable final Runnable reconnectionCallback,
             final boolean reconnectOnServiceFault) {
+        this(
+                protocolAdapterMetricsService,
+                eventService,
+                adapterId,
+                reconnectionCallback,
+                reconnectOnServiceFault,
+                () -> false);
+    }
+
+    private OpcUaServiceFaultListener(
+            @NotNull final ProtocolAdapterMetricsService protocolAdapterMetricsService,
+            @NotNull final EventService eventService,
+            @NotNull final String adapterId,
+            @Nullable final Runnable reconnectionCallback,
+            final boolean reconnectOnServiceFault,
+            @NotNull final BooleanSupplier discarded) {
         this.protocolAdapterMetricsService = protocolAdapterMetricsService;
         this.eventService = eventService;
         this.adapterId = adapterId;
         this.reconnectionCallback = reconnectionCallback;
         this.reconnectOnServiceFault = reconnectOnServiceFault;
+        this.discarded = discarded;
     }
 
     /**
-     * Names the connection whose discard state this listener should consult.
+     * A copy of this listener bound to one connection, for that connection's client alone.
      * <p>
-     * Called by a connection as it attaches this listener to its client. The most recent caller wins, which
-     * is what a reconnect needs: the replacement connection attaches before the old one has finished closing,
-     * and it is the replacement whose faults matter from then on.
-     */
-    public void watch(final @NotNull BooleanSupplier connectionDiscarded) {
-        discarded.set(connectionDiscarded);
-    }
-
-    /**
-     * Stops consulting {@code connectionDiscarded}, if it is still the one being consulted.
+     * The adapter builds one of these and every connection derives its own, rather than all of them sharing
+     * the adapter's. Sharing was the defect: an adapter can have two connections alive at once -- a
+     * replacement starting while the connection it replaces is still finishing or closing -- so a single
+     * mutable pointer to "the connection to ask" is written by whichever starts last, not by whichever is
+     * current. A slow start could therefore redirect a live connection's reporting at a discarded one and
+     * silence real faults.
      * <p>
-     * Conditional, and that is the whole point. A connection clears its watch as it detaches, but a reconnect
-     * has the replacement attach <em>before</em> the old connection finishes closing -- so a blind clear here
-     * would wipe the live connection's watch and leave this listener answering "not discarded" for a
-     * connection that may since have been discarded. Clearing only what this connection itself installed
-     * leaves a newer watch alone.
+     * Binding at construction removes the question rather than guarding it. Milo calls the listener attached
+     * to the client that raised the fault, and each connection attaches its own, so the instance receiving
+     * the call already identifies the connection. Nothing to overwrite, nothing to withdraw, no ordering to
+     * get right.
      */
-    public void unwatch(final @NotNull BooleanSupplier connectionDiscarded) {
-        discarded.compareAndSet(connectionDiscarded, null);
-    }
-
-    /** Whether the connection that raised this fault is being discarded; false when nobody has said. */
-    private boolean isDiscarded() {
-        final BooleanSupplier source = discarded.get();
-        return source != null && source.getAsBoolean();
+    public @NotNull OpcUaServiceFaultListener forConnection(final @NotNull BooleanSupplier connectionDiscarded) {
+        return new OpcUaServiceFaultListener(
+                protocolAdapterMetricsService,
+                eventService,
+                adapterId,
+                reconnectionCallback,
+                reconnectOnServiceFault,
+                connectionDiscarded);
     }
 
     @Override
@@ -122,7 +132,7 @@ public class OpcUaServiceFaultListener implements ServiceFaultListener {
         //
         // The reconnect the critical branch would have triggered is skipped with it, and that is right rather
         // than merely harmless: a connection that has already been discarded is not the one to recover from.
-        if (isDiscarded()) {
+        if (discarded.getAsBoolean()) {
             log.info(
                     "OPC UA service fault for adapter '{}' on a connection being closed: {}. Expected while"
                             + " the connection is discarded.",

--- a/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/listeners/OpcUaServiceFaultListener.java
+++ b/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/listeners/OpcUaServiceFaultListener.java
@@ -31,6 +31,20 @@ import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Reports service faults raised by an OPC UA server, and recovers from the ones worth recovering from.
+ * <p>
+ * A service fault is how an OPC UA server rejects a request: the response carries a status code instead of a
+ * result. Milo hands every one of them to the listeners registered on the client that made the request. This
+ * listener counts them all, and then splits them. A handful of status codes mean the session or subscription
+ * no longer exists, so nothing will work again until the client reconnects — those are logged at ERROR, raise
+ * an adapter event, and trigger a reconnect. Everything else is logged at WARN with an event and no action.
+ * <p>
+ * <b>One instance is built per connection, not per adapter.</b> The adapter builds a template carrying its
+ * settings; each connection derives its own copy with {@link #forConnection} and registers that copy on its
+ * own client. The copy is bound at construction to the connection it serves, which is what lets it tell a
+ * genuine fault from the noise a closing connection makes — see {@link #discarded}.
+ */
 public class OpcUaServiceFaultListener implements ServiceFaultListener {
 
     private static final Logger log = LoggerFactory.getLogger(OpcUaServiceFaultListener.class);
@@ -41,17 +55,23 @@ public class OpcUaServiceFaultListener implements ServiceFaultListener {
     private final boolean reconnectOnServiceFault;
 
     /**
-     * Whether the connection whose client raised the fault has been discarded.
+     * Asks the connection this listener serves whether it has been discarded — that is, whether it is being
+     * closed, either because the adapter is stopping or because a reconnect is replacing it.
      * <p>
-     * A fault carries a status code and nothing else -- Milo's callback takes one argument, and the fault
-     * names neither the client nor the session it came from. So a listener cannot ask about the fault's
-     * origin; it can only know the connection it was <em>built for</em>. That is why {@link #forConnection}
-     * exists and why this is final: being called is the identification.
+     * Faults raised by a connection on its way out are expected rather than actionable. Closing a connection
+     * deletes its subscription while its client is still live, so a publish already in flight comes back
+     * {@code Bad_NoSubscription}: the ordinary end of a subscription that was deliberately removed. Before
+     * this existed, every shutdown produced errors that looked like failures to operators and failed
+     * whichever integration test happened to be finishing (EDG-942).
      * <p>
-     * What it asks is whether the connection marked its subscription handler abandoned, which a teardown
-     * does before it disconnects anything, so the answer covers the whole close rather than only its end.
-     * Always false on an instance nobody bound, which is the behaviour this class had before the
-     * distinction existed: a listener with no connection to ask reports at full volume.
+     * <b>Why a supplier rather than a reference to the connection:</b> the answer changes over the lifetime
+     * of the connection, so it has to be asked at the moment a fault arrives rather than read once. The
+     * connection answers from the mark its teardown sets on its subscription handler before disconnecting
+     * anything, so the answer is already true for the whole of a close rather than only at the end of it.
+     * <p>
+     * Final, because a listener serves exactly one connection for its whole life. On a template that no
+     * connection derived from, this is permanently false: with nobody to vouch for a fault being expected,
+     * the louder report is the safe answer.
      */
     private final @NotNull BooleanSupplier discarded;
 
@@ -86,19 +106,25 @@ public class OpcUaServiceFaultListener implements ServiceFaultListener {
     }
 
     /**
-     * A copy of this listener bound to one connection, for that connection's client alone.
+     * Derives a copy of this listener that serves one connection, to be registered on that connection's
+     * client. The copy keeps this listener's settings and adds the one thing it cannot infer: a way to ask
+     * that connection whether it is being closed.
      * <p>
-     * The adapter builds one of these and every connection derives its own, rather than all of them sharing
-     * the adapter's. Sharing was the defect: an adapter can have two connections alive at once -- a
-     * replacement starting while the connection it replaces is still finishing or closing -- so a single
-     * mutable pointer to "the connection to ask" is written by whichever starts last, not by whichever is
-     * current. A slow start could therefore redirect a live connection's reporting at a discarded one and
-     * silence real faults.
+     * Callers are connections. An adapter builds one listener and never registers it anywhere; every
+     * connection derives its own and registers that.
      * <p>
-     * Binding at construction removes the question rather than guarding it. Milo calls the listener attached
-     * to the client that raised the fault, and each connection attaches its own, so the instance receiving
-     * the call already identifies the connection. Nothing to overwrite, nothing to withdraw, no ordering to
-     * get right.
+     * <b>Why a copy per connection, when one listener would do:</b> a fault says nothing about where it came
+     * from. Milo's callback takes only the fault, and the fault names neither the client nor the session, so
+     * a listener cannot look up the connection that raised it. What it can know is the connection it was
+     * built for — Milo calls the listener registered on the client that faulted, so the instance receiving
+     * the call already identifies the connection, provided that instance serves only one.
+     * <p>
+     * <b>Why one shared listener would be wrong:</b> an adapter can have two connections alive at once, since
+     * a reconnect starts a replacement while the connection it replaces is still finishing or closing. A
+     * shared listener would need a mutable pointer to whichever connection to ask, and that pointer would be
+     * written by whichever connection set it last rather than by whichever is current. A slow start
+     * completing late could aim a live connection's reporting at a discarded one and silence real faults.
+     * Binding at construction removes the possibility instead of guarding against it.
      */
     public @NotNull OpcUaServiceFaultListener forConnection(final @NotNull BooleanSupplier connectionDiscarded) {
         return new OpcUaServiceFaultListener(
@@ -115,23 +141,18 @@ public class OpcUaServiceFaultListener implements ServiceFaultListener {
         final StatusCode statusCode = serviceFault.getResponseHeader().getServiceResult();
         protocolAdapterMetricsService.increment(Constants.METRIC_SUBSCRIPTION_SERVICE_FAULT_COUNT);
 
-        // The same fault means two different things depending on whether the connection it arrived on still
-        // matters. Discarding a connection deletes its subscription while this listener is still attached, so
-        // a publish already in flight comes back Bad_NoSubscription -- the expected end of a subscription that
-        // was deliberately removed, not a fault anyone can act on. Reporting it as a fault made every shutdown
-        // look like a failure, to operators and to the tests that fail on any unexpected ERROR (EDG-942).
+        // Faults from a connection that is closing are expected, so they are recorded quietly and nothing is
+        // recovered. Closing deletes the subscription while the client is still live, so a publish already in
+        // flight comes back Bad_NoSubscription -- the ordinary end of a subscription that was deliberately
+        // removed, and not something an operator can act on.
         //
-        // "Discarded" rather than "the adapter is stopping", because those differ: a reconnect discards a
-        // connection while the adapter stays up. Both cases want silence for the same reason -- a replacement
-        // is coming, or nothing is -- and in neither is the old connection's failure something to act on.
+        // Placed above the critical/non-critical split below, not inside it. Which branch a fault takes
+        // depends on `reconnectOnServiceFault`, which comes from the operator's autoReconnect setting; a
+        // check inside one branch would leave the identical shutdown fault noisy for anyone who turned
+        // auto-reconnect off. Whether a connection is closing has nothing to do with that setting.
         //
-        // Above the critical/non-critical split rather than inside it. Which branch a fault takes depends on
-        // `reconnectOnServiceFault`, an operator's autoReconnect setting -- so a check inside the critical
-        // branch would let the identical fault stay noisy for anyone who turned auto-reconnect off. Being
-        // discarded is a property of the connection, not of that setting.
-        //
-        // The reconnect the critical branch would have triggered is skipped with it, and that is right rather
-        // than merely harmless: a connection that has already been discarded is not the one to recover from.
+        // Returning here also skips the reconnect the critical branch would trigger, which is what should
+        // happen: a connection already being discarded is not one to recover.
         if (discarded.getAsBoolean()) {
             log.info(
                     "OPC UA service fault for adapter '{}' on a connection being closed: {}. Expected while"

--- a/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/listeners/OpcUaServiceFaultListener.java
+++ b/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/listeners/OpcUaServiceFaultListener.java
@@ -21,6 +21,7 @@ import com.hivemq.adapter.sdk.api.events.EventService;
 import com.hivemq.adapter.sdk.api.events.model.Event;
 import com.hivemq.adapter.sdk.api.services.ProtocolAdapterMetricsService;
 import com.hivemq.edge.adapters.opcua.Constants;
+import java.util.function.BooleanSupplier;
 import org.eclipse.milo.opcua.sdk.client.ServiceFaultListener;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
@@ -39,17 +40,50 @@ public class OpcUaServiceFaultListener implements ServiceFaultListener {
     private final @Nullable Runnable reconnectionCallback;
     private final boolean reconnectOnServiceFault;
 
+    /**
+     * Whether the adapter this listener belongs to is being torn down.
+     * <p>
+     * The listener is built once per adapter and attached to whichever client is current, so it cannot tell
+     * on its own that the connection a fault arrived on is closing. This is how it asks. Consulted only to
+     * choose the volume of the report, never to decide whether to act.
+     */
+    private final @NotNull BooleanSupplier stopping;
+
+    /**
+     * A listener for a connection that is never torn down, which is every caller that has no adapter to ask.
+     * <p>
+     * The default is "not stopping" rather than the reverse because that is the behaviour this class had
+     * before the distinction existed: every critical fault reported at ERROR. A caller that cannot say
+     * whether it is closing gets the louder answer, not the quieter one.
+     */
     public OpcUaServiceFaultListener(
             @NotNull final ProtocolAdapterMetricsService protocolAdapterMetricsService,
             @NotNull final EventService eventService,
             @NotNull final String adapterId,
             @Nullable final Runnable reconnectionCallback,
             final boolean reconnectOnServiceFault) {
+        this(
+                protocolAdapterMetricsService,
+                eventService,
+                adapterId,
+                reconnectionCallback,
+                reconnectOnServiceFault,
+                () -> false);
+    }
+
+    public OpcUaServiceFaultListener(
+            @NotNull final ProtocolAdapterMetricsService protocolAdapterMetricsService,
+            @NotNull final EventService eventService,
+            @NotNull final String adapterId,
+            @Nullable final Runnable reconnectionCallback,
+            final boolean reconnectOnServiceFault,
+            @NotNull final BooleanSupplier stopping) {
         this.protocolAdapterMetricsService = protocolAdapterMetricsService;
         this.eventService = eventService;
         this.adapterId = adapterId;
         this.reconnectionCallback = reconnectionCallback;
         this.reconnectOnServiceFault = reconnectOnServiceFault;
+        this.stopping = stopping;
     }
 
     @Override
@@ -59,6 +93,23 @@ public class OpcUaServiceFaultListener implements ServiceFaultListener {
 
         // Check if this is a critical fault requiring immediate reconnection
         if (reconnectOnServiceFault && isCriticalFault(statusCode)) {
+            // The same fault means two different things depending on whether this adapter is being torn down.
+            // Closing a connection deletes its subscription while this listener is still attached, so a
+            // publish already in flight comes back Bad_NoSubscription -- the expected end of a subscription
+            // that was deliberately removed, not a fault anyone can act on. Reporting it at ERROR made every
+            // shutdown look like a failure, to operators and to the tests that fail on any unexpected ERROR
+            // (EDG-942).
+            //
+            // Only the volume changes. The reconnect below is left exactly as it was: it already returns
+            // quietly when the adapter has been stopped, so the recovery half was never the problem.
+            if (stopping.getAsBoolean()) {
+                log.info(
+                        "OPC UA service fault for adapter '{}' while it is stopping: {}. Expected while the"
+                                + " connection is being closed.",
+                        adapterId,
+                        statusCode);
+                return;
+            }
             log.error("Critical OPC UA service fault detected for adapter '{}': {}", adapterId, statusCode);
 
             eventService

--- a/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/listeners/OpcUaServiceFaultListener.java
+++ b/modules/hivemq-edge-module-opcua/src/main/java/com/hivemq/edge/adapters/opcua/listeners/OpcUaServiceFaultListener.java
@@ -43,8 +43,8 @@ import org.slf4j.LoggerFactory;
  * <b>One instance is built per connection, not per adapter.</b> The adapter builds a template carrying its
  * settings; each connection takes its own copy with {@link #forConnection} and registers that on its own
  * client. The copy serves that connection alone, so when the connection begins closing it can call
- * {@link #connectionClosing()} and this listener knows the faults that follow are the ordinary noise of a
- * close rather than something to report or recover from.
+ * {@link #markClosed()} and this listener knows the faults that follow are the ordinary noise of a close
+ * rather than something to report or recover from.
  */
 public class OpcUaServiceFaultListener implements ServiceFaultListener {
 
@@ -56,7 +56,7 @@ public class OpcUaServiceFaultListener implements ServiceFaultListener {
     private final boolean reconnectOnServiceFault;
 
     /**
-     * Whether the connection this listener serves is closing — set by {@link #connectionClosing()} when that
+     * Whether the connection this listener serves is closing — set by {@link #markClosed()} when that
      * connection begins closing, either because the adapter is stopping or because a reconnect is replacing
      * it. The connection's own flag of the same name is what gets forwarded here.
      * <p>
@@ -106,14 +106,15 @@ public class OpcUaServiceFaultListener implements ServiceFaultListener {
     }
 
     /**
-     * Tells this listener that the connection it serves is closing, so that faults from here on are the
+     * Records that the connection this listener serves is closing, so that faults from here on are the
      * expected noise of a close rather than something to report or recover from.
      * <p>
-     * Called by that connection as it begins closing, before it disconnects anything — which is what makes
-     * this cover the whole close rather than only its end. One-way and idempotent: a closed connection is
-     * never reopened, and a stop followed by a destroy reaches the same connection twice.
+     * Called from the connection's own {@code markClosed()}, which is why it shares the name: it is the same
+     * fact reaching a second object. That happens before anything is disconnected, so this covers the whole
+     * close rather than only its end. One-way and idempotent — a closed connection is never reopened, and a
+     * stop followed by a destroy reaches the same connection twice.
      */
-    public void connectionClosing() {
+    public void markClosed() {
         closed.set(true);
     }
 

--- a/modules/hivemq-edge-module-opcua/src/test/java/com/hivemq/edge/adapters/opcua/listeners/OpcUaServiceFaultListenerTest.java
+++ b/modules/hivemq-edge-module-opcua/src/test/java/com/hivemq/edge/adapters/opcua/listeners/OpcUaServiceFaultListenerTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2023-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.edge.adapters.opcua.listeners;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.hivemq.adapter.sdk.api.events.EventService;
+import com.hivemq.adapter.sdk.api.events.model.Event;
+import com.hivemq.adapter.sdk.api.events.model.EventBuilder;
+import com.hivemq.adapter.sdk.api.services.ProtocolAdapterMetricsService;
+import com.hivemq.edge.adapters.opcua.Constants;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
+import org.eclipse.milo.opcua.stack.core.types.structured.ServiceFault;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The reporting half of {@link OpcUaServiceFaultListener}: whether a critical fault is an operator-visible
+ * error or the ordinary noise of a connection being closed.
+ * <p>
+ * Closing a connection deletes its subscription while this listener is still attached, so a publish already
+ * in flight answers {@code Bad_NoSubscription}. Reporting that at ERROR made every shutdown look like a
+ * failure (EDG-942). These tests pin that the distinction is made, and that it is made on the teardown
+ * question alone -- a fault outside teardown keeps every bit of its old behaviour.
+ */
+class OpcUaServiceFaultListenerTest {
+
+    private final @NotNull ProtocolAdapterMetricsService metrics = mock(ProtocolAdapterMetricsService.class);
+    private final @NotNull EventService events = mock(EventService.class, RETURNS_DEEP_STUBS);
+
+    private @NotNull ServiceFault faultWith(final long statusCode) {
+        final ServiceFault fault = mock(ServiceFault.class, RETURNS_DEEP_STUBS);
+        when(fault.getResponseHeader().getServiceResult()).thenReturn(new StatusCode(statusCode));
+        return fault;
+    }
+
+    @Test
+    void onServiceFault_whenCriticalWhileStopping_firesNoEventAndDoesNotReconnect() {
+        final AtomicBoolean reconnected = new AtomicBoolean();
+        final OpcUaServiceFaultListener listener = new OpcUaServiceFaultListener(
+                metrics, events, "adapter", () -> reconnected.set(true), true, () -> true);
+
+        listener.onServiceFault(faultWith(StatusCodes.Bad_NoSubscription));
+
+        // The whole point of the change: a fault raised by the close itself is not an operator's problem, so
+        // nothing reaches the event log that a shutdown would have to explain.
+        verify(events, never()).createAdapterEvent(anyString(), anyString());
+        assertThat(reconnected).isFalse();
+    }
+
+    @Test
+    void onServiceFault_whenCriticalWhileRunning_firesAnErrorEventAndReconnects() {
+        final AtomicBoolean reconnected = new AtomicBoolean();
+        final EventBuilder builder = mock(EventBuilder.class, RETURNS_DEEP_STUBS);
+        when(events.createAdapterEvent(anyString(), anyString())).thenReturn(builder);
+        when(builder.withSeverity(any())).thenReturn(builder);
+        when(builder.withPayload(any())).thenReturn(builder);
+        when(builder.withMessage(anyString())).thenReturn(builder);
+
+        final OpcUaServiceFaultListener listener = new OpcUaServiceFaultListener(
+                metrics, events, "adapter", () -> reconnected.set(true), true, () -> false);
+
+        listener.onServiceFault(faultWith(StatusCodes.Bad_NoSubscription));
+
+        // The same fault outside teardown is unchanged: still an error, still a reconnect. Without this the
+        // quiet branch could swallow everything and the suite would not notice.
+        verify(builder).withSeverity(Event.SEVERITY.ERROR);
+        assertThat(reconnected).isTrue();
+    }
+
+    @Test
+    void onServiceFault_whileStopping_stillCountsTheFault() {
+        final OpcUaServiceFaultListener listener =
+                new OpcUaServiceFaultListener(metrics, events, "adapter", () -> {}, true, () -> true);
+
+        listener.onServiceFault(faultWith(StatusCodes.Bad_NoSubscription));
+
+        // Quieter, not invisible. The metric is what a fault rate is measured from, and a subscription torn
+        // down during shutdown is still a service fault that happened.
+        verify(metrics).increment(Constants.METRIC_SUBSCRIPTION_SERVICE_FAULT_COUNT);
+    }
+
+    @Test
+    void onServiceFault_whenNotCritical_isUnaffectedByStopping() {
+        final EventBuilder builder = mock(EventBuilder.class, RETURNS_DEEP_STUBS);
+        when(events.createAdapterEvent(anyString(), anyString())).thenReturn(builder);
+        when(builder.withSeverity(any())).thenReturn(builder);
+        when(builder.withPayload(any())).thenReturn(builder);
+        when(builder.withMessage(anyString())).thenReturn(builder);
+
+        final OpcUaServiceFaultListener listener =
+                new OpcUaServiceFaultListener(metrics, events, "adapter", () -> {}, true, () -> true);
+
+        listener.onServiceFault(faultWith(StatusCodes.Bad_Timeout));
+
+        // The teardown check guards the critical branch only. A non-critical fault keeps its WARN even during
+        // a shutdown, because nothing about closing a connection explains it.
+        verify(builder).withSeverity(Event.SEVERITY.WARN);
+    }
+
+    @Test
+    void onServiceFault_defaultConstructor_reportsCriticalFaultsAsBefore() {
+        final EventBuilder builder = mock(EventBuilder.class, RETURNS_DEEP_STUBS);
+        when(events.createAdapterEvent(anyString(), anyString())).thenReturn(builder);
+        when(builder.withSeverity(any())).thenReturn(builder);
+        when(builder.withPayload(any())).thenReturn(builder);
+        when(builder.withMessage(anyString())).thenReturn(builder);
+
+        final OpcUaServiceFaultListener listener =
+                new OpcUaServiceFaultListener(metrics, events, "adapter", () -> {}, true);
+
+        listener.onServiceFault(faultWith(StatusCodes.Bad_NoSubscription));
+
+        // A caller with no adapter to ask gets the louder answer, not the quieter one.
+        verify(builder).withSeverity(Event.SEVERITY.ERROR);
+    }
+}

--- a/modules/hivemq-edge-module-opcua/src/test/java/com/hivemq/edge/adapters/opcua/listeners/OpcUaServiceFaultListenerTest.java
+++ b/modules/hivemq-edge-module-opcua/src/test/java/com/hivemq/edge/adapters/opcua/listeners/OpcUaServiceFaultListenerTest.java
@@ -30,6 +30,7 @@ import com.hivemq.adapter.sdk.api.events.model.EventBuilder;
 import com.hivemq.adapter.sdk.api.services.ProtocolAdapterMetricsService;
 import com.hivemq.edge.adapters.opcua.Constants;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BooleanSupplier;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.structured.ServiceFault;
@@ -37,15 +38,26 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 
 /**
- * The reporting half of {@link OpcUaServiceFaultListener}: whether a critical fault is an operator-visible
- * error or the ordinary noise of a connection being closed.
+ * The reporting half of {@link OpcUaServiceFaultListener}: whether a fault is an operator-visible error or the
+ * ordinary noise of a connection being discarded.
  * <p>
- * Closing a connection deletes its subscription while this listener is still attached, so a publish already
+ * Discarding a connection deletes its subscription while this listener is still attached, so a publish already
  * in flight answers {@code Bad_NoSubscription}. Reporting that at ERROR made every shutdown look like a
- * failure (EDG-942). These tests pin that the distinction is made, and that it is made on the teardown
- * question alone -- a fault outside teardown keeps every bit of its old behaviour.
+ * failure (EDG-942). These tests pin that the distinction is made, that it is made on the discard question
+ * alone -- a fault on a live connection keeps every bit of its old behaviour -- and that the watch a
+ * connection installs cannot outlive it or clobber its replacement's.
  */
 class OpcUaServiceFaultListenerTest {
+
+    // Constants rather than method references, and ErrorProne's UnnecessaryLambda suggestion is wrong here:
+    // the listener withdraws a watch by identity, so these tests need two stable objects they can hand over
+    // and later name again. A fresh method reference at each use would be a different object every time and
+    // the withdrawal cases below would pass for the wrong reason.
+    @SuppressWarnings("UnnecessaryLambda")
+    private static final @NotNull BooleanSupplier LIVE = () -> false;
+
+    @SuppressWarnings("UnnecessaryLambda")
+    private static final @NotNull BooleanSupplier DISCARDED = () -> true;
 
     private final @NotNull ProtocolAdapterMetricsService metrics = mock(ProtocolAdapterMetricsService.class);
     private final @NotNull EventService events = mock(EventService.class, RETURNS_DEEP_STUBS);
@@ -56,108 +68,146 @@ class OpcUaServiceFaultListenerTest {
         return fault;
     }
 
+    private @NotNull EventBuilder stubbedEventBuilder() {
+        final EventBuilder builder = mock(EventBuilder.class, RETURNS_DEEP_STUBS);
+        when(events.createAdapterEvent(anyString(), anyString())).thenReturn(builder);
+        when(builder.withSeverity(any())).thenReturn(builder);
+        when(builder.withPayload(any())).thenReturn(builder);
+        when(builder.withMessage(anyString())).thenReturn(builder);
+        return builder;
+    }
+
     @Test
-    void onServiceFault_whenCriticalWhileStopping_firesNoEventAndDoesNotReconnect() {
+    void onServiceFault_whenCriticalOnADiscardedConnection_firesNoEventAndDoesNotReconnect() {
         final AtomicBoolean reconnected = new AtomicBoolean();
-        final OpcUaServiceFaultListener listener = new OpcUaServiceFaultListener(
-                metrics, events, "adapter", () -> reconnected.set(true), true, () -> true);
+        final OpcUaServiceFaultListener listener =
+                new OpcUaServiceFaultListener(metrics, events, "adapter", () -> reconnected.set(true), true);
+        listener.watch(DISCARDED);
 
         listener.onServiceFault(faultWith(StatusCodes.Bad_NoSubscription));
 
-        // The whole point of the change: a fault raised by the close itself is not an operator's problem, so
-        // nothing reaches the event log that a shutdown would have to explain.
+        // The whole point: a fault raised by the close itself is not an operator's problem, so nothing
+        // reaches the event log that a shutdown would have to explain. And a connection already discarded is
+        // not the one to recover, so no reconnect is triggered from it either.
         verify(events, never()).createAdapterEvent(anyString(), anyString());
         assertThat(reconnected).isFalse();
     }
 
     @Test
-    void onServiceFault_whenCriticalWhileRunning_firesAnErrorEventAndReconnects() {
+    void onServiceFault_whenCriticalOnALiveConnection_firesAnErrorEventAndReconnects() {
         final AtomicBoolean reconnected = new AtomicBoolean();
-        final EventBuilder builder = mock(EventBuilder.class, RETURNS_DEEP_STUBS);
-        when(events.createAdapterEvent(anyString(), anyString())).thenReturn(builder);
-        when(builder.withSeverity(any())).thenReturn(builder);
-        when(builder.withPayload(any())).thenReturn(builder);
-        when(builder.withMessage(anyString())).thenReturn(builder);
-
-        final OpcUaServiceFaultListener listener = new OpcUaServiceFaultListener(
-                metrics, events, "adapter", () -> reconnected.set(true), true, () -> false);
+        final EventBuilder builder = stubbedEventBuilder();
+        final OpcUaServiceFaultListener listener =
+                new OpcUaServiceFaultListener(metrics, events, "adapter", () -> reconnected.set(true), true);
+        listener.watch(LIVE);
 
         listener.onServiceFault(faultWith(StatusCodes.Bad_NoSubscription));
 
-        // The same fault outside teardown is unchanged: still an error, still a reconnect. Without this the
-        // quiet branch could swallow everything and the suite would not notice.
+        // The same fault on a live connection is unchanged: still an error, still a reconnect. Without this
+        // the quiet branch could swallow everything and the suite would not notice.
         verify(builder).withSeverity(Event.SEVERITY.ERROR);
         assertThat(reconnected).isTrue();
     }
 
     @Test
-    void onServiceFault_whileStopping_stillCountsTheFault() {
+    void onServiceFault_onADiscardedConnectionWithAutoReconnectOff_isStillQuiet() {
         final OpcUaServiceFaultListener listener =
-                new OpcUaServiceFaultListener(metrics, events, "adapter", () -> {}, true, () -> true);
+                new OpcUaServiceFaultListener(metrics, events, "adapter", () -> {}, false);
+        listener.watch(DISCARDED);
+
+        listener.onServiceFault(faultWith(StatusCodes.Bad_NoSubscription));
+
+        // Whether a fault counts as critical depends on the operator's autoReconnect setting, so a discard
+        // check inside the critical branch would leave the identical fault noisy for anyone who turned
+        // auto-reconnect off. Being discarded is a property of the connection, not of that setting.
+        verify(events, never()).createAdapterEvent(anyString(), anyString());
+    }
+
+    @Test
+    void onServiceFault_onADiscardedConnection_stillCountsTheFault() {
+        final OpcUaServiceFaultListener listener =
+                new OpcUaServiceFaultListener(metrics, events, "adapter", () -> {}, true);
+        listener.watch(DISCARDED);
 
         listener.onServiceFault(faultWith(StatusCodes.Bad_NoSubscription));
 
         // Quieter, not invisible. The metric is what a fault rate is measured from, and a subscription torn
-        // down during shutdown is still a service fault that happened.
+        // down during a close is still a service fault that happened.
         verify(metrics).increment(Constants.METRIC_SUBSCRIPTION_SERVICE_FAULT_COUNT);
     }
 
     @Test
-    void onServiceFault_whileStoppingWithAutoReconnectOff_isStillQuiet() {
+    void onServiceFault_whenNotCriticalOnALiveConnection_keepsItsWarning() {
+        final EventBuilder builder = stubbedEventBuilder();
         final OpcUaServiceFaultListener listener =
-                new OpcUaServiceFaultListener(metrics, events, "adapter", () -> {}, false, () -> true);
-
-        listener.onServiceFault(faultWith(StatusCodes.Bad_NoSubscription));
-
-        // Whether a fault counts as critical depends on the operator's autoReconnect setting, so a teardown
-        // check inside the critical branch would leave the identical shutdown fault noisy for anyone who
-        // turned auto-reconnect off. Teardown is a property of the adapter, not of that setting.
-        verify(events, never()).createAdapterEvent(anyString(), anyString());
-    }
-
-    @Test
-    void onServiceFault_whenNotCriticalWhileRunning_keepsItsWarning() {
-        final EventBuilder builder = mock(EventBuilder.class, RETURNS_DEEP_STUBS);
-        when(events.createAdapterEvent(anyString(), anyString())).thenReturn(builder);
-        when(builder.withSeverity(any())).thenReturn(builder);
-        when(builder.withPayload(any())).thenReturn(builder);
-        when(builder.withMessage(anyString())).thenReturn(builder);
-
-        final OpcUaServiceFaultListener listener =
-                new OpcUaServiceFaultListener(metrics, events, "adapter", () -> {}, true, () -> false);
+                new OpcUaServiceFaultListener(metrics, events, "adapter", () -> {}, true);
+        listener.watch(LIVE);
 
         listener.onServiceFault(faultWith(StatusCodes.Bad_Timeout));
 
-        // Outside teardown nothing changes for a non-critical fault: still a WARN, still an event.
+        // On a live connection nothing changes for a non-critical fault: still a WARN, still an event.
         verify(builder).withSeverity(Event.SEVERITY.WARN);
     }
 
     @Test
-    void onServiceFault_whenNotCriticalWhileStopping_isQuiet() {
+    void onServiceFault_whenNotCriticalOnADiscardedConnection_isQuiet() {
         final OpcUaServiceFaultListener listener =
-                new OpcUaServiceFaultListener(metrics, events, "adapter", () -> {}, true, () -> true);
+                new OpcUaServiceFaultListener(metrics, events, "adapter", () -> {}, true);
+        listener.watch(DISCARDED);
 
         listener.onServiceFault(faultWith(StatusCodes.Bad_Timeout));
 
-        // A fault raised while the connection is being closed is teardown noise whatever its status code. The
-        // codes worth distinguishing are the ones that say what to recover from, and nothing is recovering.
+        // A fault raised while the connection is being discarded is noise whatever its status code. The codes
+        // worth distinguishing are the ones that say what to recover from, and nothing is recovering.
         verify(events, never()).createAdapterEvent(anyString(), anyString());
     }
 
     @Test
-    void onServiceFault_defaultConstructor_reportsCriticalFaultsAsBefore() {
-        final EventBuilder builder = mock(EventBuilder.class, RETURNS_DEEP_STUBS);
-        when(events.createAdapterEvent(anyString(), anyString())).thenReturn(builder);
-        when(builder.withSeverity(any())).thenReturn(builder);
-        when(builder.withPayload(any())).thenReturn(builder);
-        when(builder.withMessage(anyString())).thenReturn(builder);
-
+    void onServiceFault_withNobodyWatching_reportsCriticalFaultsAsBefore() {
+        final EventBuilder builder = stubbedEventBuilder();
         final OpcUaServiceFaultListener listener =
                 new OpcUaServiceFaultListener(metrics, events, "adapter", () -> {}, true);
 
         listener.onServiceFault(faultWith(StatusCodes.Bad_NoSubscription));
 
-        // A caller with no adapter to ask gets the louder answer, not the quieter one.
+        // No connection has claimed this listener, so there is nothing to say the fault is expected. The
+        // louder answer is the safe default: silence would have to be earned by someone taking responsibility
+        // for it.
+        verify(builder).withSeverity(Event.SEVERITY.ERROR);
+    }
+
+    @Test
+    void unwatch_fromASupersededConnection_leavesTheReplacementsWatchAlone() {
+        final OpcUaServiceFaultListener listener =
+                new OpcUaServiceFaultListener(metrics, events, "adapter", () -> {}, true);
+
+        // The reconnect ordering: the replacement attaches before the connection it replaces has finished
+        // closing, and that old connection then withdraws. A blind clear here would leave the listener
+        // answering "live" for a connection that may since have been discarded -- silencing nothing, but
+        // reporting a discarded replacement's shutdown noise as a fault all over again.
+        listener.watch(LIVE);
+        listener.watch(DISCARDED);
+        listener.unwatch(LIVE);
+
+        listener.onServiceFault(faultWith(StatusCodes.Bad_NoSubscription));
+
+        verify(events, never()).createAdapterEvent(anyString(), anyString());
+    }
+
+    @Test
+    void unwatch_fromTheCurrentConnection_restoresTheLouderDefault() {
+        final EventBuilder builder = stubbedEventBuilder();
+        final OpcUaServiceFaultListener listener =
+                new OpcUaServiceFaultListener(metrics, events, "adapter", () -> {}, true);
+
+        // A connection that closes with no replacement takes its answer with it. What is left is nobody
+        // watching, which reports rather than suppresses -- a listener must never keep quoting a connection
+        // that has gone.
+        listener.watch(DISCARDED);
+        listener.unwatch(DISCARDED);
+
+        listener.onServiceFault(faultWith(StatusCodes.Bad_NoSubscription));
+
         verify(builder).withSeverity(Event.SEVERITY.ERROR);
     }
 }

--- a/modules/hivemq-edge-module-opcua/src/test/java/com/hivemq/edge/adapters/opcua/listeners/OpcUaServiceFaultListenerTest.java
+++ b/modules/hivemq-edge-module-opcua/src/test/java/com/hivemq/edge/adapters/opcua/listeners/OpcUaServiceFaultListenerTest.java
@@ -37,13 +37,18 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 
 /**
- * The reporting half of {@link OpcUaServiceFaultListener}: whether a fault is an operator-visible error or the
- * ordinary noise of a connection being discarded.
+ * Covers how {@link OpcUaServiceFaultListener} decides whether a fault from an OPC UA server is an
+ * operator-visible error or the ordinary noise of a connection being closed.
  * <p>
- * Discarding a connection deletes its subscription while its client is still live, so a publish already in
- * flight answers {@code Bad_NoSubscription}. Reporting that at ERROR made every shutdown look like a failure
- * (EDG-942). A fault names neither client nor session, so a listener cannot ask about the origin of the fault
- * -- it can only know the connection it was built for, which is what {@code forConnection} is for.
+ * Closing a connection deletes its subscription while its client is still live, so a publish already in
+ * flight comes back {@code Bad_NoSubscription}. Reporting that at ERROR made every shutdown look like a
+ * failure (EDG-942). The listener therefore asks the connection it serves whether it is being discarded, and
+ * stays quiet when it is.
+ * <p>
+ * Two groups of tests. Those named {@code onServiceFault_*} check that decision across the cases that reach
+ * it. Those named {@code forConnection_*} check that a listener serves exactly one connection: an adapter can
+ * have two alive at once during a reconnect, and each must answer only for its own, whatever order they are
+ * created in.
  */
 class OpcUaServiceFaultListenerTest {
 

--- a/modules/hivemq-edge-module-opcua/src/test/java/com/hivemq/edge/adapters/opcua/listeners/OpcUaServiceFaultListenerTest.java
+++ b/modules/hivemq-edge-module-opcua/src/test/java/com/hivemq/edge/adapters/opcua/listeners/OpcUaServiceFaultListenerTest.java
@@ -42,13 +42,12 @@ import org.junit.jupiter.api.Test;
  * <p>
  * Closing a connection deletes its subscription while its client is still live, so a publish already in
  * flight comes back {@code Bad_NoSubscription}. Reporting that at ERROR made every shutdown look like a
- * failure (EDG-942). The listener therefore asks the connection it serves whether it is being discarded, and
- * stays quiet when it is.
+ * failure (EDG-942). A closing connection therefore calls {@code connectionDiscarded()} on the listener it
+ * owns, and everything after that is reported quietly.
  * <p>
  * Two groups of tests. Those named {@code onServiceFault_*} check that decision across the cases that reach
  * it. Those named {@code forConnection_*} check that a listener serves exactly one connection: an adapter can
- * have two alive at once during a reconnect, and each must answer only for its own, whatever order they are
- * created in.
+ * have two alive at once during a reconnect, and one falling quiet must not quieten the other.
  */
 class OpcUaServiceFaultListenerTest {
 
@@ -70,16 +69,18 @@ class OpcUaServiceFaultListenerTest {
         return builder;
     }
 
+    /** The adapter-level listener a connection would take its own copy from. */
     private @NotNull OpcUaServiceFaultListener template(
             final @NotNull Runnable reconnect, final boolean autoReconnect) {
         return new OpcUaServiceFaultListener(metrics, events, "adapter", reconnect, autoReconnect);
     }
 
     @Test
-    void onServiceFault_whenCriticalOnADiscardedConnection_firesNoEventAndDoesNotReconnect() {
+    void onServiceFault_whenCriticalAfterTheConnectionWasDiscarded_firesNoEventAndDoesNotReconnect() {
         final AtomicBoolean reconnected = new AtomicBoolean();
         final OpcUaServiceFaultListener listener =
-                template(() -> reconnected.set(true), true).forConnection(() -> true);
+                template(() -> reconnected.set(true), true).forConnection();
+        listener.connectionDiscarded();
 
         listener.onServiceFault(faultWith(StatusCodes.Bad_NoSubscription));
 
@@ -95,7 +96,7 @@ class OpcUaServiceFaultListenerTest {
         final AtomicBoolean reconnected = new AtomicBoolean();
         final EventBuilder builder = stubbedEventBuilder();
         final OpcUaServiceFaultListener listener =
-                template(() -> reconnected.set(true), true).forConnection(() -> false);
+                template(() -> reconnected.set(true), true).forConnection();
 
         listener.onServiceFault(faultWith(StatusCodes.Bad_NoSubscription));
 
@@ -106,8 +107,9 @@ class OpcUaServiceFaultListenerTest {
     }
 
     @Test
-    void onServiceFault_onADiscardedConnectionWithAutoReconnectOff_isStillQuiet() {
-        final OpcUaServiceFaultListener listener = template(() -> {}, false).forConnection(() -> true);
+    void onServiceFault_afterDiscardWithAutoReconnectOff_isStillQuiet() {
+        final OpcUaServiceFaultListener listener = template(() -> {}, false).forConnection();
+        listener.connectionDiscarded();
 
         listener.onServiceFault(faultWith(StatusCodes.Bad_NoSubscription));
 
@@ -118,8 +120,9 @@ class OpcUaServiceFaultListenerTest {
     }
 
     @Test
-    void onServiceFault_onADiscardedConnection_stillCountsTheFault() {
-        final OpcUaServiceFaultListener listener = template(() -> {}, true).forConnection(() -> true);
+    void onServiceFault_afterDiscard_stillCountsTheFault() {
+        final OpcUaServiceFaultListener listener = template(() -> {}, true).forConnection();
+        listener.connectionDiscarded();
 
         listener.onServiceFault(faultWith(StatusCodes.Bad_NoSubscription));
 
@@ -131,7 +134,7 @@ class OpcUaServiceFaultListenerTest {
     @Test
     void onServiceFault_whenNotCriticalOnALiveConnection_keepsItsWarning() {
         final EventBuilder builder = stubbedEventBuilder();
-        final OpcUaServiceFaultListener listener = template(() -> {}, true).forConnection(() -> false);
+        final OpcUaServiceFaultListener listener = template(() -> {}, true).forConnection();
 
         listener.onServiceFault(faultWith(StatusCodes.Bad_Timeout));
 
@@ -140,40 +143,42 @@ class OpcUaServiceFaultListenerTest {
     }
 
     @Test
-    void onServiceFault_whenNotCriticalOnADiscardedConnection_isQuiet() {
-        final OpcUaServiceFaultListener listener = template(() -> {}, true).forConnection(() -> true);
+    void onServiceFault_whenNotCriticalAfterDiscard_isQuiet() {
+        final OpcUaServiceFaultListener listener = template(() -> {}, true).forConnection();
+        listener.connectionDiscarded();
 
         listener.onServiceFault(faultWith(StatusCodes.Bad_Timeout));
 
-        // A fault raised while the connection is being discarded is noise whatever its status code. The codes
+        // A fault raised while the connection is being closed is noise whatever its status code. The codes
         // worth distinguishing are the ones that say what to recover from, and nothing is recovering.
         verify(events, never()).createAdapterEvent(anyString(), anyString());
     }
 
     @Test
-    void onServiceFault_onAnUnboundTemplate_reportsCriticalFaultsAsBefore() {
-        final EventBuilder builder = stubbedEventBuilder();
-        final OpcUaServiceFaultListener listener = template(() -> {}, true);
+    void connectionDiscarded_isIdempotent() {
+        final OpcUaServiceFaultListener listener = template(() -> {}, true).forConnection();
+        listener.connectionDiscarded();
+        listener.connectionDiscarded();
 
         listener.onServiceFault(faultWith(StatusCodes.Bad_NoSubscription));
 
-        // The adapter's template belongs to no connection, so nothing can say the fault is expected. The
-        // louder answer is the safe default: silence has to be earned by a connection taking responsibility
-        // for it. In production a template is never attached to a client, only derived from.
-        verify(builder).withSeverity(Event.SEVERITY.ERROR);
+        // stop() followed by destroy() reaches the same connection twice, so saying it again must not undo
+        // it. A discarded connection is never reopened.
+        verify(events, never()).createAdapterEvent(anyString(), anyString());
     }
 
     @Test
-    void forConnection_bindsEachCopyToItsOwnConnection() {
-        final OpcUaServiceFaultListener shared = template(() -> {}, true);
+    void forConnection_givesEachConnectionAListenerThatFallsQuietOnItsOwn() {
+        final OpcUaServiceFaultListener template = template(() -> {}, true);
 
-        // The defect this design removes. An adapter can have two connections alive at once -- a replacement
-        // starting while the connection it replaces is still closing -- and both derive from one template.
-        // Each copy answers for its own connection, so a discarded one going quiet cannot silence a live one.
-        final OpcUaServiceFaultListener onDiscarded = shared.forConnection(() -> true);
-        final OpcUaServiceFaultListener onLive = shared.forConnection(() -> false);
+        // The reason each connection needs its own. An adapter can have two alive at once -- a replacement
+        // starting while the connection it replaces is still closing -- and only the closing one should fall
+        // quiet. With a shared listener the closing connection would silence the live one's faults.
+        final OpcUaServiceFaultListener onClosing = template.forConnection();
+        final OpcUaServiceFaultListener onLive = template.forConnection();
+        onClosing.connectionDiscarded();
 
-        onDiscarded.onServiceFault(faultWith(StatusCodes.Bad_NoSubscription));
+        onClosing.onServiceFault(faultWith(StatusCodes.Bad_NoSubscription));
         verify(events, never()).createAdapterEvent(anyString(), anyString());
 
         final EventBuilder builder = stubbedEventBuilder();
@@ -182,17 +187,14 @@ class OpcUaServiceFaultListenerTest {
     }
 
     @Test
-    void forConnection_derivingAgainDoesNotDisturbAnEarlierCopy() {
-        final OpcUaServiceFaultListener shared = template(() -> {}, true);
-        final OpcUaServiceFaultListener onLive = shared.forConnection(() -> false);
-
-        // Order independence is what makes this safe against a slow start. Deriving a second copy after the
-        // first -- the replacement attaching while the superseded connection is still starting -- must not
-        // reach back into the first. With a single shared pointer it did, and a late-starting discarded
-        // connection could silence the live one.
+    void forConnection_leavesTheTemplateUnaffected() {
+        final OpcUaServiceFaultListener template = template(() -> {}, true);
         final EventBuilder builder = stubbedEventBuilder();
-        final OpcUaServiceFaultListener unused = shared.forConnection(() -> true);
-        onLive.onServiceFault(faultWith(StatusCodes.Bad_NoSubscription));
+
+        // Taking a copy and discarding it must not reach back into what it was copied from, or one closing
+        // connection would quieten every connection the adapter makes afterwards.
+        template.forConnection().connectionDiscarded();
+        template.onServiceFault(faultWith(StatusCodes.Bad_NoSubscription));
 
         verify(builder).withSeverity(Event.SEVERITY.ERROR);
     }

--- a/modules/hivemq-edge-module-opcua/src/test/java/com/hivemq/edge/adapters/opcua/listeners/OpcUaServiceFaultListenerTest.java
+++ b/modules/hivemq-edge-module-opcua/src/test/java/com/hivemq/edge/adapters/opcua/listeners/OpcUaServiceFaultListenerTest.java
@@ -103,7 +103,20 @@ class OpcUaServiceFaultListenerTest {
     }
 
     @Test
-    void onServiceFault_whenNotCritical_isUnaffectedByStopping() {
+    void onServiceFault_whileStoppingWithAutoReconnectOff_isStillQuiet() {
+        final OpcUaServiceFaultListener listener =
+                new OpcUaServiceFaultListener(metrics, events, "adapter", () -> {}, false, () -> true);
+
+        listener.onServiceFault(faultWith(StatusCodes.Bad_NoSubscription));
+
+        // Whether a fault counts as critical depends on the operator's autoReconnect setting, so a teardown
+        // check inside the critical branch would leave the identical shutdown fault noisy for anyone who
+        // turned auto-reconnect off. Teardown is a property of the adapter, not of that setting.
+        verify(events, never()).createAdapterEvent(anyString(), anyString());
+    }
+
+    @Test
+    void onServiceFault_whenNotCriticalWhileRunning_keepsItsWarning() {
         final EventBuilder builder = mock(EventBuilder.class, RETURNS_DEEP_STUBS);
         when(events.createAdapterEvent(anyString(), anyString())).thenReturn(builder);
         when(builder.withSeverity(any())).thenReturn(builder);
@@ -111,13 +124,24 @@ class OpcUaServiceFaultListenerTest {
         when(builder.withMessage(anyString())).thenReturn(builder);
 
         final OpcUaServiceFaultListener listener =
+                new OpcUaServiceFaultListener(metrics, events, "adapter", () -> {}, true, () -> false);
+
+        listener.onServiceFault(faultWith(StatusCodes.Bad_Timeout));
+
+        // Outside teardown nothing changes for a non-critical fault: still a WARN, still an event.
+        verify(builder).withSeverity(Event.SEVERITY.WARN);
+    }
+
+    @Test
+    void onServiceFault_whenNotCriticalWhileStopping_isQuiet() {
+        final OpcUaServiceFaultListener listener =
                 new OpcUaServiceFaultListener(metrics, events, "adapter", () -> {}, true, () -> true);
 
         listener.onServiceFault(faultWith(StatusCodes.Bad_Timeout));
 
-        // The teardown check guards the critical branch only. A non-critical fault keeps its WARN even during
-        // a shutdown, because nothing about closing a connection explains it.
-        verify(builder).withSeverity(Event.SEVERITY.WARN);
+        // A fault raised while the connection is being closed is teardown noise whatever its status code. The
+        // codes worth distinguishing are the ones that say what to recover from, and nothing is recovering.
+        verify(events, never()).createAdapterEvent(anyString(), anyString());
     }
 
     @Test

--- a/modules/hivemq-edge-module-opcua/src/test/java/com/hivemq/edge/adapters/opcua/listeners/OpcUaServiceFaultListenerTest.java
+++ b/modules/hivemq-edge-module-opcua/src/test/java/com/hivemq/edge/adapters/opcua/listeners/OpcUaServiceFaultListenerTest.java
@@ -42,7 +42,7 @@ import org.junit.jupiter.api.Test;
  * <p>
  * Closing a connection deletes its subscription while its client is still live, so a publish already in
  * flight comes back {@code Bad_NoSubscription}. Reporting that at ERROR made every shutdown look like a
- * failure (EDG-942). A closing connection therefore calls {@code connectionDiscarded()} on the listener it
+ * failure (EDG-942). A closing connection therefore calls {@code connectionClosing()} on the listener it
  * owns, and everything after that is reported quietly.
  * <p>
  * Two groups of tests. Those named {@code onServiceFault_*} check that decision across the cases that reach
@@ -76,16 +76,16 @@ class OpcUaServiceFaultListenerTest {
     }
 
     @Test
-    void onServiceFault_whenCriticalAfterTheConnectionWasDiscarded_firesNoEventAndDoesNotReconnect() {
+    void onServiceFault_whenCriticalOnAClosingConnection_firesNoEventAndDoesNotReconnect() {
         final AtomicBoolean reconnected = new AtomicBoolean();
         final OpcUaServiceFaultListener listener =
                 template(() -> reconnected.set(true), true).forConnection();
-        listener.connectionDiscarded();
+        listener.connectionClosing();
 
         listener.onServiceFault(faultWith(StatusCodes.Bad_NoSubscription));
 
         // The whole point: a fault raised by the close itself is not an operator's problem, so nothing
-        // reaches the event log that a shutdown would have to explain. And a connection already discarded is
+        // reaches the event log that a shutdown would have to explain. And a connection already closing is
         // not the one to recover, so no reconnect is triggered from it either.
         verify(events, never()).createAdapterEvent(anyString(), anyString());
         assertThat(reconnected).isFalse();
@@ -107,22 +107,22 @@ class OpcUaServiceFaultListenerTest {
     }
 
     @Test
-    void onServiceFault_afterDiscardWithAutoReconnectOff_isStillQuiet() {
+    void onServiceFault_whileClosingWithAutoReconnectOff_isStillQuiet() {
         final OpcUaServiceFaultListener listener = template(() -> {}, false).forConnection();
-        listener.connectionDiscarded();
+        listener.connectionClosing();
 
         listener.onServiceFault(faultWith(StatusCodes.Bad_NoSubscription));
 
-        // Whether a fault counts as critical depends on the operator's autoReconnect setting, so a discard
-        // check inside the critical branch would leave the identical fault noisy for anyone who turned
-        // auto-reconnect off. Being discarded is a property of the connection, not of that setting.
+        // Whether a fault counts as critical depends on the operator's autoReconnect setting, so a check
+        // inside the critical branch would leave the identical fault noisy for anyone who turned
+        // auto-reconnect off. Whether a connection is closing has nothing to do with that setting.
         verify(events, never()).createAdapterEvent(anyString(), anyString());
     }
 
     @Test
-    void onServiceFault_afterDiscard_stillCountsTheFault() {
+    void onServiceFault_whileClosing_stillCountsTheFault() {
         final OpcUaServiceFaultListener listener = template(() -> {}, true).forConnection();
-        listener.connectionDiscarded();
+        listener.connectionClosing();
 
         listener.onServiceFault(faultWith(StatusCodes.Bad_NoSubscription));
 
@@ -143,27 +143,27 @@ class OpcUaServiceFaultListenerTest {
     }
 
     @Test
-    void onServiceFault_whenNotCriticalAfterDiscard_isQuiet() {
+    void onServiceFault_whenNotCriticalOnAClosingConnection_isQuiet() {
         final OpcUaServiceFaultListener listener = template(() -> {}, true).forConnection();
-        listener.connectionDiscarded();
+        listener.connectionClosing();
 
         listener.onServiceFault(faultWith(StatusCodes.Bad_Timeout));
 
-        // A fault raised while the connection is being closed is noise whatever its status code. The codes
-        // worth distinguishing are the ones that say what to recover from, and nothing is recovering.
+        // A fault raised while the connection is closing is noise whatever its status code. The codes worth
+        // distinguishing are the ones that say what to recover from, and nothing is recovering.
         verify(events, never()).createAdapterEvent(anyString(), anyString());
     }
 
     @Test
-    void connectionDiscarded_isIdempotent() {
+    void connectionClosing_isIdempotent() {
         final OpcUaServiceFaultListener listener = template(() -> {}, true).forConnection();
-        listener.connectionDiscarded();
-        listener.connectionDiscarded();
+        listener.connectionClosing();
+        listener.connectionClosing();
 
         listener.onServiceFault(faultWith(StatusCodes.Bad_NoSubscription));
 
         // stop() followed by destroy() reaches the same connection twice, so saying it again must not undo
-        // it. A discarded connection is never reopened.
+        // it. A closed connection is never reopened.
         verify(events, never()).createAdapterEvent(anyString(), anyString());
     }
 
@@ -176,7 +176,7 @@ class OpcUaServiceFaultListenerTest {
         // quiet. With a shared listener the closing connection would silence the live one's faults.
         final OpcUaServiceFaultListener onClosing = template.forConnection();
         final OpcUaServiceFaultListener onLive = template.forConnection();
-        onClosing.connectionDiscarded();
+        onClosing.connectionClosing();
 
         onClosing.onServiceFault(faultWith(StatusCodes.Bad_NoSubscription));
         verify(events, never()).createAdapterEvent(anyString(), anyString());
@@ -191,9 +191,9 @@ class OpcUaServiceFaultListenerTest {
         final OpcUaServiceFaultListener template = template(() -> {}, true);
         final EventBuilder builder = stubbedEventBuilder();
 
-        // Taking a copy and discarding it must not reach back into what it was copied from, or one closing
+        // Taking a copy and closing it must not reach back into what it was copied from, or one closing
         // connection would quieten every connection the adapter makes afterwards.
-        template.forConnection().connectionDiscarded();
+        template.forConnection().connectionClosing();
         template.onServiceFault(faultWith(StatusCodes.Bad_NoSubscription));
 
         verify(builder).withSeverity(Event.SEVERITY.ERROR);

--- a/modules/hivemq-edge-module-opcua/src/test/java/com/hivemq/edge/adapters/opcua/listeners/OpcUaServiceFaultListenerTest.java
+++ b/modules/hivemq-edge-module-opcua/src/test/java/com/hivemq/edge/adapters/opcua/listeners/OpcUaServiceFaultListenerTest.java
@@ -30,7 +30,6 @@ import com.hivemq.adapter.sdk.api.events.model.EventBuilder;
 import com.hivemq.adapter.sdk.api.services.ProtocolAdapterMetricsService;
 import com.hivemq.edge.adapters.opcua.Constants;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.BooleanSupplier;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.structured.ServiceFault;
@@ -41,23 +40,12 @@ import org.junit.jupiter.api.Test;
  * The reporting half of {@link OpcUaServiceFaultListener}: whether a fault is an operator-visible error or the
  * ordinary noise of a connection being discarded.
  * <p>
- * Discarding a connection deletes its subscription while this listener is still attached, so a publish already
- * in flight answers {@code Bad_NoSubscription}. Reporting that at ERROR made every shutdown look like a
- * failure (EDG-942). These tests pin that the distinction is made, that it is made on the discard question
- * alone -- a fault on a live connection keeps every bit of its old behaviour -- and that the watch a
- * connection installs cannot outlive it or clobber its replacement's.
+ * Discarding a connection deletes its subscription while its client is still live, so a publish already in
+ * flight answers {@code Bad_NoSubscription}. Reporting that at ERROR made every shutdown look like a failure
+ * (EDG-942). A fault names neither client nor session, so a listener cannot ask about the origin of the fault
+ * -- it can only know the connection it was built for, which is what {@code forConnection} is for.
  */
 class OpcUaServiceFaultListenerTest {
-
-    // Constants rather than method references, and ErrorProne's UnnecessaryLambda suggestion is wrong here:
-    // the listener withdraws a watch by identity, so these tests need two stable objects they can hand over
-    // and later name again. A fresh method reference at each use would be a different object every time and
-    // the withdrawal cases below would pass for the wrong reason.
-    @SuppressWarnings("UnnecessaryLambda")
-    private static final @NotNull BooleanSupplier LIVE = () -> false;
-
-    @SuppressWarnings("UnnecessaryLambda")
-    private static final @NotNull BooleanSupplier DISCARDED = () -> true;
 
     private final @NotNull ProtocolAdapterMetricsService metrics = mock(ProtocolAdapterMetricsService.class);
     private final @NotNull EventService events = mock(EventService.class, RETURNS_DEEP_STUBS);
@@ -77,12 +65,16 @@ class OpcUaServiceFaultListenerTest {
         return builder;
     }
 
+    private @NotNull OpcUaServiceFaultListener template(
+            final @NotNull Runnable reconnect, final boolean autoReconnect) {
+        return new OpcUaServiceFaultListener(metrics, events, "adapter", reconnect, autoReconnect);
+    }
+
     @Test
     void onServiceFault_whenCriticalOnADiscardedConnection_firesNoEventAndDoesNotReconnect() {
         final AtomicBoolean reconnected = new AtomicBoolean();
         final OpcUaServiceFaultListener listener =
-                new OpcUaServiceFaultListener(metrics, events, "adapter", () -> reconnected.set(true), true);
-        listener.watch(DISCARDED);
+                template(() -> reconnected.set(true), true).forConnection(() -> true);
 
         listener.onServiceFault(faultWith(StatusCodes.Bad_NoSubscription));
 
@@ -98,8 +90,7 @@ class OpcUaServiceFaultListenerTest {
         final AtomicBoolean reconnected = new AtomicBoolean();
         final EventBuilder builder = stubbedEventBuilder();
         final OpcUaServiceFaultListener listener =
-                new OpcUaServiceFaultListener(metrics, events, "adapter", () -> reconnected.set(true), true);
-        listener.watch(LIVE);
+                template(() -> reconnected.set(true), true).forConnection(() -> false);
 
         listener.onServiceFault(faultWith(StatusCodes.Bad_NoSubscription));
 
@@ -111,9 +102,7 @@ class OpcUaServiceFaultListenerTest {
 
     @Test
     void onServiceFault_onADiscardedConnectionWithAutoReconnectOff_isStillQuiet() {
-        final OpcUaServiceFaultListener listener =
-                new OpcUaServiceFaultListener(metrics, events, "adapter", () -> {}, false);
-        listener.watch(DISCARDED);
+        final OpcUaServiceFaultListener listener = template(() -> {}, false).forConnection(() -> true);
 
         listener.onServiceFault(faultWith(StatusCodes.Bad_NoSubscription));
 
@@ -125,9 +114,7 @@ class OpcUaServiceFaultListenerTest {
 
     @Test
     void onServiceFault_onADiscardedConnection_stillCountsTheFault() {
-        final OpcUaServiceFaultListener listener =
-                new OpcUaServiceFaultListener(metrics, events, "adapter", () -> {}, true);
-        listener.watch(DISCARDED);
+        final OpcUaServiceFaultListener listener = template(() -> {}, true).forConnection(() -> true);
 
         listener.onServiceFault(faultWith(StatusCodes.Bad_NoSubscription));
 
@@ -139,9 +126,7 @@ class OpcUaServiceFaultListenerTest {
     @Test
     void onServiceFault_whenNotCriticalOnALiveConnection_keepsItsWarning() {
         final EventBuilder builder = stubbedEventBuilder();
-        final OpcUaServiceFaultListener listener =
-                new OpcUaServiceFaultListener(metrics, events, "adapter", () -> {}, true);
-        listener.watch(LIVE);
+        final OpcUaServiceFaultListener listener = template(() -> {}, true).forConnection(() -> false);
 
         listener.onServiceFault(faultWith(StatusCodes.Bad_Timeout));
 
@@ -151,9 +136,7 @@ class OpcUaServiceFaultListenerTest {
 
     @Test
     void onServiceFault_whenNotCriticalOnADiscardedConnection_isQuiet() {
-        final OpcUaServiceFaultListener listener =
-                new OpcUaServiceFaultListener(metrics, events, "adapter", () -> {}, true);
-        listener.watch(DISCARDED);
+        final OpcUaServiceFaultListener listener = template(() -> {}, true).forConnection(() -> true);
 
         listener.onServiceFault(faultWith(StatusCodes.Bad_Timeout));
 
@@ -163,50 +146,48 @@ class OpcUaServiceFaultListenerTest {
     }
 
     @Test
-    void onServiceFault_withNobodyWatching_reportsCriticalFaultsAsBefore() {
+    void onServiceFault_onAnUnboundTemplate_reportsCriticalFaultsAsBefore() {
         final EventBuilder builder = stubbedEventBuilder();
-        final OpcUaServiceFaultListener listener =
-                new OpcUaServiceFaultListener(metrics, events, "adapter", () -> {}, true);
+        final OpcUaServiceFaultListener listener = template(() -> {}, true);
 
         listener.onServiceFault(faultWith(StatusCodes.Bad_NoSubscription));
 
-        // No connection has claimed this listener, so there is nothing to say the fault is expected. The
-        // louder answer is the safe default: silence would have to be earned by someone taking responsibility
-        // for it.
+        // The adapter's template belongs to no connection, so nothing can say the fault is expected. The
+        // louder answer is the safe default: silence has to be earned by a connection taking responsibility
+        // for it. In production a template is never attached to a client, only derived from.
         verify(builder).withSeverity(Event.SEVERITY.ERROR);
     }
 
     @Test
-    void unwatch_fromASupersededConnection_leavesTheReplacementsWatchAlone() {
-        final OpcUaServiceFaultListener listener =
-                new OpcUaServiceFaultListener(metrics, events, "adapter", () -> {}, true);
+    void forConnection_bindsEachCopyToItsOwnConnection() {
+        final OpcUaServiceFaultListener shared = template(() -> {}, true);
 
-        // The reconnect ordering: the replacement attaches before the connection it replaces has finished
-        // closing, and that old connection then withdraws. A blind clear here would leave the listener
-        // answering "live" for a connection that may since have been discarded -- silencing nothing, but
-        // reporting a discarded replacement's shutdown noise as a fault all over again.
-        listener.watch(LIVE);
-        listener.watch(DISCARDED);
-        listener.unwatch(LIVE);
+        // The defect this design removes. An adapter can have two connections alive at once -- a replacement
+        // starting while the connection it replaces is still closing -- and both derive from one template.
+        // Each copy answers for its own connection, so a discarded one going quiet cannot silence a live one.
+        final OpcUaServiceFaultListener onDiscarded = shared.forConnection(() -> true);
+        final OpcUaServiceFaultListener onLive = shared.forConnection(() -> false);
 
-        listener.onServiceFault(faultWith(StatusCodes.Bad_NoSubscription));
-
+        onDiscarded.onServiceFault(faultWith(StatusCodes.Bad_NoSubscription));
         verify(events, never()).createAdapterEvent(anyString(), anyString());
+
+        final EventBuilder builder = stubbedEventBuilder();
+        onLive.onServiceFault(faultWith(StatusCodes.Bad_NoSubscription));
+        verify(builder).withSeverity(Event.SEVERITY.ERROR);
     }
 
     @Test
-    void unwatch_fromTheCurrentConnection_restoresTheLouderDefault() {
+    void forConnection_derivingAgainDoesNotDisturbAnEarlierCopy() {
+        final OpcUaServiceFaultListener shared = template(() -> {}, true);
+        final OpcUaServiceFaultListener onLive = shared.forConnection(() -> false);
+
+        // Order independence is what makes this safe against a slow start. Deriving a second copy after the
+        // first -- the replacement attaching while the superseded connection is still starting -- must not
+        // reach back into the first. With a single shared pointer it did, and a late-starting discarded
+        // connection could silence the live one.
         final EventBuilder builder = stubbedEventBuilder();
-        final OpcUaServiceFaultListener listener =
-                new OpcUaServiceFaultListener(metrics, events, "adapter", () -> {}, true);
-
-        // A connection that closes with no replacement takes its answer with it. What is left is nobody
-        // watching, which reports rather than suppresses -- a listener must never keep quoting a connection
-        // that has gone.
-        listener.watch(DISCARDED);
-        listener.unwatch(DISCARDED);
-
-        listener.onServiceFault(faultWith(StatusCodes.Bad_NoSubscription));
+        final OpcUaServiceFaultListener unused = shared.forConnection(() -> true);
+        onLive.onServiceFault(faultWith(StatusCodes.Bad_NoSubscription));
 
         verify(builder).withSeverity(Event.SEVERITY.ERROR);
     }

--- a/modules/hivemq-edge-module-opcua/src/test/java/com/hivemq/edge/adapters/opcua/listeners/OpcUaServiceFaultListenerTest.java
+++ b/modules/hivemq-edge-module-opcua/src/test/java/com/hivemq/edge/adapters/opcua/listeners/OpcUaServiceFaultListenerTest.java
@@ -42,8 +42,8 @@ import org.junit.jupiter.api.Test;
  * <p>
  * Closing a connection deletes its subscription while its client is still live, so a publish already in
  * flight comes back {@code Bad_NoSubscription}. Reporting that at ERROR made every shutdown look like a
- * failure (EDG-942). A closing connection therefore calls {@code connectionClosing()} on the listener it
- * owns, and everything after that is reported quietly.
+ * failure (EDG-942). A closing connection therefore calls {@code markClosed()} on the listener it owns, and
+ * everything after that is reported quietly.
  * <p>
  * Two groups of tests. Those named {@code onServiceFault_*} check that decision across the cases that reach
  * it. Those named {@code forConnection_*} check that a listener serves exactly one connection: an adapter can
@@ -80,7 +80,7 @@ class OpcUaServiceFaultListenerTest {
         final AtomicBoolean reconnected = new AtomicBoolean();
         final OpcUaServiceFaultListener listener =
                 template(() -> reconnected.set(true), true).forConnection();
-        listener.connectionClosing();
+        listener.markClosed();
 
         listener.onServiceFault(faultWith(StatusCodes.Bad_NoSubscription));
 
@@ -109,7 +109,7 @@ class OpcUaServiceFaultListenerTest {
     @Test
     void onServiceFault_whileClosingWithAutoReconnectOff_isStillQuiet() {
         final OpcUaServiceFaultListener listener = template(() -> {}, false).forConnection();
-        listener.connectionClosing();
+        listener.markClosed();
 
         listener.onServiceFault(faultWith(StatusCodes.Bad_NoSubscription));
 
@@ -122,7 +122,7 @@ class OpcUaServiceFaultListenerTest {
     @Test
     void onServiceFault_whileClosing_stillCountsTheFault() {
         final OpcUaServiceFaultListener listener = template(() -> {}, true).forConnection();
-        listener.connectionClosing();
+        listener.markClosed();
 
         listener.onServiceFault(faultWith(StatusCodes.Bad_NoSubscription));
 
@@ -145,7 +145,7 @@ class OpcUaServiceFaultListenerTest {
     @Test
     void onServiceFault_whenNotCriticalOnAClosingConnection_isQuiet() {
         final OpcUaServiceFaultListener listener = template(() -> {}, true).forConnection();
-        listener.connectionClosing();
+        listener.markClosed();
 
         listener.onServiceFault(faultWith(StatusCodes.Bad_Timeout));
 
@@ -155,10 +155,10 @@ class OpcUaServiceFaultListenerTest {
     }
 
     @Test
-    void connectionClosing_isIdempotent() {
+    void markClosed_isIdempotent() {
         final OpcUaServiceFaultListener listener = template(() -> {}, true).forConnection();
-        listener.connectionClosing();
-        listener.connectionClosing();
+        listener.markClosed();
+        listener.markClosed();
 
         listener.onServiceFault(faultWith(StatusCodes.Bad_NoSubscription));
 
@@ -176,7 +176,7 @@ class OpcUaServiceFaultListenerTest {
         // quiet. With a shared listener the closing connection would silence the live one's faults.
         final OpcUaServiceFaultListener onClosing = template.forConnection();
         final OpcUaServiceFaultListener onLive = template.forConnection();
-        onClosing.connectionClosing();
+        onClosing.markClosed();
 
         onClosing.onServiceFault(faultWith(StatusCodes.Bad_NoSubscription));
         verify(events, never()).createAdapterEvent(anyString(), anyString());
@@ -193,7 +193,7 @@ class OpcUaServiceFaultListenerTest {
 
         // Taking a copy and closing it must not reach back into what it was copied from, or one closing
         // connection would quieten every connection the adapter makes afterwards.
-        template.forConnection().connectionClosing();
+        template.forConnection().markClosed();
         template.onServiceFault(faultWith(StatusCodes.Bad_NoSubscription));
 
         verify(builder).withSeverity(Event.SEVERITY.ERROR);


### PR DESCRIPTION
## Description (the why)

Four OPC-UA test classes around tag browsing and import are the largest single source of CI flakiness — 586 bad test instances in a month, 28% of all bad builds across every branch. They do not fail on a browse assertion. They fail in *teardown*, on the embedded-broker fixture's check that no unexpected ERROR was logged:

```
org.opentest4j.AssertionFailedError: Unexpected Error logs were found:
  [ERROR] Failed to create or transfer OPC UA subscription. Closing client connection.
  [ERROR] Critical OPC UA service fault detected for adapter 'import-it-adapter':
          StatusCode[name=Bad_NoSubscription, value=0x80790000, quality=bad]
```

The tell is that `browse_invalidNodeId_throwsBrowseException` and `test_importMalformedJson_returns400` are on the failure list. Those tests assert an error path — they cannot be failing because browsing produced a wrong answer.

Both ERROR lines are raised by an OPC-UA adapter shutting down normally. Every occurrence measured in master #100 landed within 102 ms of the broker beginning to shut down; none occurred during a test body.

Linear: [EDG-942](https://linear.app/hivemq/issue/EDG-942/houston-browseimport-is-the-largest-single-source-of-ci-flakiness)

## What changes

Two logging decisions, one per ERROR line. Neither changes what the code *does* — only how loudly it reports it.

**1. An abandoned subscription is not a failed subscription.** Closing a connection calls `abandon()` on its subscription handler, which stops tag verification between tags, so `subscribe()` answers empty. The connect path logged that empty answer at ERROR and fired an adapter event at severity ERROR, indistinguishably from a server refusing. It now asks the handler whether it was abandoned first. The rebuild path already did exactly this — discard either way, re-consult the flag to decide how loudly to say so — so this makes the connect path match its counterpart rather than introducing a new pattern.

The public `isAbandoned()` it calls already existed, documented as being for "the connection to answer whether a teardown reached its handler", and had no caller.

**2. A service fault raised by teardown is not a critical fault.** Closing a connection deletes its subscription while the service-fault listener is still attached, so a publish already in flight comes back `Bad_NoSubscription` — the expected end of a subscription that was deliberately removed. The listener now asks whether the adapter is stopping before choosing the volume, reporting at INFO with no event when it is.

Only reporting changes: the reconnect this guards already returned quietly on a stopped adapter, so the recovery half was never at fault. The fault metric is still counted.

## Two details worth a reviewer's attention

**Why `stopped` and not the connection's abandonment flag.** The obvious choice fails silently here: `stop()` and `destroy()` both release the adapter's connection reference *before* closing the connection, so throughout the window in which the closing client can still raise a fault there is no current connection left to ask — it would answer "not stopping" at exactly the wrong moment. `stopped` is set before that release in both paths and stays true across it.

**The residual race, stated rather than hidden.** A genuine subscription failure whose abandonment lands between `subscribe()` returning and the flag being read would be downgraded to debug. That window is a few instructions with no server call in it, against a failure path spanning at least one, and the connection is being torn down regardless. Carrying the reason out of `subscribe()` in the return type would close it, at the cost of widening every caller for a window this narrow. The trade is recorded in a comment at the call site.

## Testing

`onServiceFault` had no test coverage at all, so a green suite said nothing about the change. Adds `OpcUaServiceFaultListenerTest` with five cases: quiet during teardown, unchanged ERROR and reconnect outside it, the metric still counted, non-critical faults unaffected, and the default constructor preserving the old behaviour.

Verified by mutation rather than by "it passes": with the new check disabled, the teardown test fails and the four control tests still pass.

Full OPC-UA module suite and Spotless green locally.

## Acceptance Criteria (the what)

- [ ] An OPC-UA adapter stopping normally logs no ERROR and fires no ERROR-severity adapter event
- [ ] A subscription that genuinely cannot be created keeps its ERROR log, its adapter event and its status change
- [ ] A critical service fault outside teardown keeps its ERROR log, its event and its reconnect
- [ ] Service faults are still counted in the metric during teardown
- [ ] The four Houston test classes stop failing on the two ERROR lines above

## Non-Goals

- Reordering the close path so the fault listener is detached before the subscription is deleted. That changes behaviour rather than reporting, and the ordering is defensible as it stands.
- Establishing whether `Bad_NoSubscription` indicates a product defect in its own right. EDG-942 asks this and it remains open; this PR explains the *test failures* only.
- Any change to the four Houston test classes. The symptom is not in the tests.
- The remaining OPC-UA flakiness (southbound reconnect, message security mode), which is a different mechanism.
