### PR TITLE
EDG-968: Let callers wait until a config change has been applied

### DIFF
--- a/hivemq-edge/src/main/java/com/hivemq/protocols/ProtocolAdapterManager.java
+++ b/hivemq-edge/src/main/java/com/hivemq/protocols/ProtocolAdapterManager.java
@@ -67,6 +67,7 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
@@ -121,6 +122,18 @@ public class ProtocolAdapterManager {
     private final @NotNull ExecutorService adapterLifecycleExecutor;
     private final @NotNull ProtocolAdapterPublishService adapterPublishService;
     private final @NotNull AtomicInteger refreshTasksInProgress = new AtomicInteger(0);
+
+    /**
+     * Whether the most recently completed configuration change reconciled every adapter.
+     * <p>
+     * Set by each refresh as it finishes, so it describes whichever change completed last rather than any
+     * particular one. See {@link #awaitConfigApplied()}, which is the only thing that reads it and which
+     * explains why that is sufficient.
+     * <p>
+     * Starts true: an Edge that has applied no configuration has not failed to apply one.
+     */
+    private final @NotNull AtomicBoolean lastConfigApplied = new AtomicBoolean(true);
+
     private final @NotNull AtomicReference<ProtocolAdapterManagerState> managerState =
             new AtomicReference<>(ProtocolAdapterManagerState.Idle);
     /**
@@ -194,6 +207,44 @@ public class ProtocolAdapterManager {
      */
     public boolean isBusy() {
         return refreshTasksInProgress.get() > 0;
+    }
+
+    /**
+     * Blocks until every configuration change requested so far has taken effect, and reports whether the last
+     * of them reconciled every adapter.
+     * <p>
+     * A configuration change is acknowledged before it is enacted: the request records it, queues the work of
+     * reconciling the running adapters with it, and returns. A caller that changes something and immediately
+     * acts on it therefore races that work, and nothing in the API distinguishes "configured" from "in
+     * effect" — an adapter reports itself started and connected part-way through a restart, before writes
+     * begin working again.
+     * <p>
+     * Waiting is expressed as an empty task rather than as a flag to poll. Refreshes run on a single-threaded
+     * queue and nothing else submits to it, so a task placed on the end cannot run until every refresh ahead
+     * of it has finished. That is the whole mechanism: no progress state to keep in step, and no window in
+     * which a caller can observe "not busy" before its own work has been picked up.
+     * <p>
+     * The returned value describes whichever change completed last, not specifically the caller's. Nothing
+     * distinguishes them, and nothing needs to: configuration changes arrive only through the API, one at a
+     * time, so a caller waiting here is waiting on its own work. A future caller that cannot rely on that
+     * would need something finer.
+     *
+     * @return true if the last completed change reconciled every adapter; false if any adapter failed, the
+     *         refresh threw, or the queue is shutting down and the wait could not be placed
+     * @throws InterruptedException if interrupted while waiting
+     */
+    public boolean awaitConfigApplied() throws InterruptedException {
+        try {
+            executorService.submit(() -> {}).get();
+        } catch (final RejectedExecutionException e) {
+            // Shutting down: nothing further will be applied, so reporting success would be a lie.
+            return false;
+        } catch (final ExecutionException e) {
+            // The empty task itself cannot fail. Treated as unsettled rather than swallowed.
+            LOGGER.warn("Waiting for the adapter configuration to be applied failed", e);
+            return false;
+        }
+        return lastConfigApplied.get();
     }
 
     /**
@@ -694,6 +745,10 @@ public class ProtocolAdapterManager {
                     refreshCreatedAdapters(toBeCreatedProtocolAdapterIdSet, protocolAdapterConfigs, failedAdapterSet);
                     refreshUpdatedAdapters(toBeUpdatedProtocolAdapterIdSet, protocolAdapterConfigs, failedAdapterSet);
 
+                    // False when only one adapter of several was rejected, matching what the event below
+                    // reports: "this change did not fully take effect" is what a caller can act on, and
+                    // which part of it failed is in the log.
+                    lastConfigApplied.set(failedAdapterSet.isEmpty());
                     if (failedAdapterSet.isEmpty()) {
                         eventService
                                 .configurationEvent()
@@ -708,6 +763,7 @@ public class ProtocolAdapterManager {
                                 .fire();
                     }
                 } catch (final Exception e) {
+                    lastConfigApplied.set(false);
                     LOGGER.error("Failed refreshing adapters", e);
                 } finally {
                     final int remainingTasks = refreshTasksInProgress.decrementAndGet();
@@ -717,6 +773,8 @@ public class ProtocolAdapterManager {
                 }
             });
         } catch (final RejectedExecutionException e) {
+            // Never queued, so it will never be applied.
+            lastConfigApplied.set(false);
             final int remainingTasks = refreshTasksInProgress.decrementAndGet();
             if (remainingTasks == 0) {
                 managerState.set(ProtocolAdapterManagerState.Idle);
@@ -727,6 +785,7 @@ public class ProtocolAdapterManager {
                 throw e;
             }
         } catch (final RuntimeException e) {
+            lastConfigApplied.set(false);
             final int remainingTasks = refreshTasksInProgress.decrementAndGet();
             if (remainingTasks == 0) {
                 managerState.set(ProtocolAdapterManagerState.Idle);


### PR DESCRIPTION
## Description (the why)

A configuration change is **acknowledged before it is enacted**. The REST call records the change, queues the work of reconciling the running adapters with it, and returns `200 OK`. Nothing in the API distinguishes "configured" from "in effect".

A caller that changes something and immediately acts on it therefore races that reconciliation, and the race is silent: a write published before the adapter's writing service has rebuilt its schema and data policy is dropped with **nothing logged**. Awaiting `STARTED`/`CONNECTED` does not close the gap — `ProtocolAdapterWrapper.startAdapter` sets `RuntimeStatus.STARTED` well before it calls `startWriting()`.

Today the only remedy available to a caller is to sleep and hope. The EtherNet/IP integration fixture carries two such sleeps (3s after every adapter delete, 2s after every mapping change); removing them is the companion PR, and this is what makes that possible.

Linear: [EDG-968](https://linear.app/hivemq/issue/EDG-968/wait-for-a-configuration-change-to-be-applied-instead-of-sleeping)

## What changes

One new method on `ProtocolAdapterManager`. Nothing existing is modified — this is purely additive.

**The wait is an empty task, not a polled flag.** Refreshes run on a single-threaded executor with exactly one other submitter (the refresh itself), so a task placed on the end of the queue cannot run until every refresh ahead of it has finished. No progress counter to keep in step, and no window in which a caller observes "not busy" before its own work has been picked up.

This is why the existing `isBusy()` is not the right tool for it: that reports a counter, so `false` means either "finished" or "not yet submitted", and a caller that has just made a change cannot tell those apart.

Alongside it, a flag recording whether the last completed refresh reconciled every adapter, so the wait can report success as well as completion. It describes whichever change finished last rather than the caller's specifically — configuration changes arrive only through the API, one at a time, so a caller waiting here is waiting on its own work. That assumption is written into the Javadoc, because a future caller that cannot rely on it would need something finer.

**No plumbing.** `Injector` already exposes `protocolAdapterManager()`, so nothing else needed widening — an earlier draft threaded the manager through `Services` and that turned out to be unnecessary.

## Testing

Exercised by the companion PR in `hivemq-edge-test`, which replaces both fixed sleeps in the EtherNet/IP fixture with this call. That class goes **81.8s → 36.2s** (two runs: 36.2s, 36.0s), all nine tests green.

The write test's own trace is the direct evidence that the wait does what it claims: its first write now round-trips in **104ms with no retries**, where it previously had to retry through the window in which writes were silently dropped.

## Acceptance Criteria (the what)

- [ ] A caller can block until every configuration change requested so far has been enacted
- [ ] The wait reports whether the last completed change succeeded
- [ ] No existing signature or behaviour changes

## Non-Goals

- **Distinguishing one caller's change from another's.** Not needed while changes arrive one at a time through the API; documented as the assumption it is.
- **Replacing `isBusy()`.** It has other callers and a different meaning.
