### PR TITLE
EDG-973: Give the unit tests a default timeout, from the shared plugin

### DIFF
--- a/edge-plugins/src/main/kotlin/com/hivemq/testordering/TestOrderingConventionPlugin.kt
+++ b/edge-plugins/src/main/kotlin/com/hivemq/testordering/TestOrderingConventionPlugin.kt
@@ -44,7 +44,36 @@ class TestOrderingConventionPlugin : Plugin<Project> {
         // then a cp between two paths that differ only in their directory.
         val generated = project.layout.buildDirectory.file("test-class-timings.csv")
 
+        // A default timeout for every test, so no single test can hang a build indefinitely.
+        //
+        // EDG-864 put this on the integration suite after a run of builds that hung for hours -- one for
+        // 22.4 hours before somebody killed it by hand. EDG-973 moved it here and gave the unit suite one
+        // too, which had none at all.
+        //
+        // WHY IT MATTERS BEYOND THE BUILD THAT HANGS: a test's runtime is written back into Test
+        // Distribution's per-class history, which keeps a rolling average (avg = avg * 0.9 + current * 0.1).
+        // The plugin sizes its executor request as ceil(total estimate / longest class estimate), so ONE
+        // 22-hour observation dragged a class average to ~2h and throttled EVERY later build to 3 executors
+        // until tens of clean runs diluted it out. That is what happened on 2026-08-03. A hang is not a
+        // one-build problem.
+        //
+        // EVERY PROJECT SETS ITS OWN VALUE in its gradle.properties, next to a note on why that number:
+        // 60s for the unit tests (slowest measured 5.2s), 10m for the integration suite (slowest whole
+        // class 67s). Both sit an order of magnitude above anything observed, so a healthy test cannot
+        // trip them while a runaway is caught long before it poisons anything. Explicit @Timeout
+        // annotations still win, so the deliberately long tests keep their own values.
+        //
+        // The fallback below is a backstop for a project that forgets, NOT a policy default. It matches the
+        // most generous value any suite here uses, so it cannot cut a legitimate test short, while still
+        // being far below the hours a hang costs. If you are reading this because a test failed at 10
+        // minutes, the fix is to set testTimeout in that project rather than to change this line.
+        //
+        // Set UNCONDITIONALLY, unlike the ordering below: this can only turn a hang into a named failure,
+        // and CI is exactly where the poisoned-history problem bites.
+        val timeout = project.findProperty("testTimeout") as String? ?: "10m"
+
         project.tasks.withType<Test>().configureEach {
+            systemProperty("junit.jupiter.execution.timeout.default", timeout)
             doFirst {
                 orderTestClasses(this as Test, committed.asFile)
             }

--- a/hivemq-edge/gradle.properties
+++ b/hivemq-edge/gradle.properties
@@ -3,3 +3,12 @@ version=2026.14-SNAPSHOT
 # Enable build cache.
 org.gradle.caching=true
 org.gradle.jvmargs=-Xmx1024M
+#
+# Default per-test timeout for this project (EDG-973). These are unit tests: the slowest of 4796 measured
+# 5.2s, so 60s is ~12x the worst observed case -- unreachable by a healthy test, and short enough that a
+# runaway is caught quickly.
+#
+# Why a timeout exists at all, and why it is an order of magnitude above normal rather than snug, is
+# documented where it is applied -- TestOrderingConventionPlugin in edge-plugins. Short version: a runaway
+# test poisons Test Distribution's per-class history for every LATER build, not just its own.
+testTimeout=60s


### PR DESCRIPTION
## Description (the why)

The integration suite has capped every test at 10 minutes since [EDG-864](https://linear.app/hivemq/issue/EDG-864/enforce-a-global-test-timeout-and-a-build-timeout-so-no-test-can-hang), after a run of builds that hung for hours — one for **22.4 hours** before somebody killed it by hand.

**The unit suite had no timeout at all.** No such setting in its build file, no `junit-platform.properties` in either repository. 537 classes run in forked JVMs with nothing bounding any of them.

Nothing has been observed hanging there. This is insurance — but the exposure is real, because the forks are shared: one unbounded wait stalls every class queued behind it in that fork.

**A hang is not a one-build problem, and that is what makes it worth doing before anything goes wrong.** A test's runtime is written back into Test Distribution's per-class history, which keeps a rolling average (`avg = avg * 0.9 + current * 0.1`). The executor request is sized as `ceil(total estimate / longest class estimate)`, so **one 22-hour observation dragged a class average to ~2h and throttled every later build to 3 executors** until dozens of clean runs diluted it out. That happened on 2026-08-03. The unit suite feeds the same history.

Linear: [EDG-973](https://linear.app/hivemq/issue/EDG-973/give-the-unit-tests-a-default-timeout-from-the-shared-plugin)

## What changes

**The setting goes in the test-ordering convention plugin** — not because it has anything to do with ordering, but because **both test projects already apply that plugin**. It is the one existing hook that reaches the unit suite and the integration suite alike, and a future test project inherits protection by applying it rather than by remembering a line.

**Each project sets its own value in its own `gradle.properties`**, beside a note on why that number:

| suite | slowest observed | value | ratio |
| -- | --: | --: | --: |
| unit (this repo) | 5.2s — one test of 4796 | **60s** | 11.5x |
| integration | 67s — slowest whole class of 14 tests | 10m | >9x |

Policy per project; the shared plugin carries only the mechanism. The plugin's own fallback is 10m — a backstop for a project that sets nothing, deliberately matching the most generous value in use so it cannot cut a legitimate test short.

**Set unconditionally**, unlike the class ordering in the same plugin. That is switched off when `CI_RUN` is set, because it manipulates `testClassesDirs` and a mistake there stops tests running rather than failing loudly. A timeout has the opposite risk profile — it can only turn a hang into a named failure — and CI is exactly where the poisoned-history problem bites.

## Testing

**Demonstrated that it fires**, rather than assumed: a unit test made to sleep 120s was killed at **60.158s** with `TimeoutException: zzz_temporary_timeout_probe() timed out after 60 seconds`, not left to run to completion. Probe reverted.

**Checked the other direction too**, which is the failure that would have been easy to miss: the integration suite still reads `10m` rather than silently inheriting a shorter value. Both confirmed by inspecting the system properties each test process is started with.

## What is deliberately unchanged

**The six tests that already declare 10 minutes** — `BridgePersistRestartIT` (two), `RemoteLateStartBridgeBufferIT`, `BridgeRestartQeueueLimitIT`, `DataHubPersistRestartIT`, `OpcUaAbstractSouthboundIT`. An explicit `@Timeout` always beats the default, so they keep their own values.

## Acceptance Criteria (the what)

- [ ] Every test task gets a default timeout, set in one place
- [ ] Unit tests default to 60s, integration to 10m
- [ ] It applies locally and on CI
- [ ] A hanging test fails as a timeout rather than stalling the build

## Non-Goals

- **A build-level timeout.** Already in place from EDG-864.
- **Changing the integration value.** Staying at 10 minutes deliberately.
