### PR TITLE
EDG-976: Report the newest full test run, not the oldest of equal size

### DIFF
--- a/edge-plugins/src/main/kotlin/com/hivemq/testordering/ReportTestConcurrencyTask.kt
+++ b/edge-plugins/src/main/kotlin/com/hivemq/testordering/ReportTestConcurrencyTask.kt
@@ -236,14 +236,20 @@ abstract class ReportTestConcurrencyTask : DefaultTask() {
             busyUntil = maxOf(busyUntil, span.second)
         }
 
-        // THE LARGEST RUN, NOT THE LAST ONE. `runs.last()` looks right -- the newest burst of
-        // activity is presumably the run just finished -- but it is wrong whenever anything ran
-        // after the suite: re-running one failing class, or an IDE running a single test, appends a
-        // later and much smaller segment. Observed printing "8s of class time in 8s of wall clock =
-        // 1.0 effective average concurrency" for a run of 336 classes and over an hour of work,
-        // because a stray 9-second single-class invocation followed it. The suite outweighs such
-        // strays by two orders of magnitude, so size is the reliable signal.
-        val spans = runs.maxBy { it.size }
+        // THE LARGEST RUN, AND AMONG EQUALS THE NEWEST. `runs.last()` looks right -- the newest
+        // burst of activity is presumably the run just finished -- but it is wrong whenever
+        // anything ran after the suite: re-running one failing class, or an IDE running a single
+        // test, appends a later and much smaller segment. Observed printing "8s of class time in
+        // 8s of wall clock = 1.0 effective average concurrency" for a run of 336 classes and over
+        // an hour of work, because a stray 9-second single-class invocation followed it. The suite
+        // outweighs such strays by two orders of magnitude, so size rejects them reliably.
+        //
+        // SIZE ALONE IS NOT ENOUGH THOUGH, because every full run of the suite has the SAME size.
+        // `maxBy` keeps the FIRST maximum, so once the directory held several complete runs this
+        // reported the OLDEST one for as long as those logs survived -- a report of a run four days
+        // stale, presented as the run just finished, with no hint anything was wrong. Ties are
+        // broken by start time so a full run always beats its own history.
+        val spans = runs.maxWith(compareBy({ it.size }, { it.minOf { span -> span.first } }))
         val ignored = all.size - spans.size
         val otherRuns = runs.size - 1
 


### PR DESCRIPTION
## Description (the why)

`reportTestConcurrency` picks which run to report by taking the largest group of class records in the accumulated `build/fork-logs` directory. That rule cannot break a tie, and **every complete run of the suite has the same size** -- so once the directory held several full runs, the task reported the OLDEST of them.

Observed on 2026-08-31: six runs tied at 332 class records, and the task reported one from **27 August** as if it were the run that had just finished. No warning, no hint -- the numbers simply describe a run days old, and stay wrong for as long as those logs survive. Anyone using this task to judge whether a change made the suite faster was reading stale data.

Found while reconciling the task against an independent analysis of the same logs, which disagreed on both wall clock and class count. Fixing this brought the two into exact agreement.

[EDG-976](https://linear.app/hivemq/issue/EDG-976/report-the-newest-full-test-run-not-the-oldest-one-with-the-same-size)

## What changed

`maxBy` keeps the FIRST maximum, and the runs are built in start order, so the first maximum is the oldest:

```kotlin
-        val spans = runs.maxBy { it.size }
+        val spans = runs.maxWith(compareBy({ it.size }, { it.minOf { span -> span.first } }))
```

Size is still the right signal for REJECTING strays -- an IDE running a single class, a re-run of one failure -- which is what the existing comment argues and what it remains correct about. It just never decided between several genuine full runs. The tiebreak does that, so a full run always beats its own history.

One line, plus a comment recording why size alone is not enough.

## Acceptance Criteria

- [x] With several complete runs in `build/fork-logs`, the task reports the most recent one.
- [x] A stray single-class run appended after the suite is still ignored.
- [x] The reported wall clock and occupancy match an independent reading of the same run.

Verified by re-running the task against a directory holding 78 runs: it now reports the run that just finished (337 classes, 62m01s of class time in 12m53s of wall clock) rather than the 27 August one, and every figure matches a separate reading of the same logs.

## Non-Goals

- Stamping a run id from the build. Rejected in the existing comment for a good reason: it would be a system property, part of the test task's cache key, and would make the task permanently uncacheable.
- Clearing the fork-log directory between runs. The accumulated history is what makes run separation possible at all.
