### PR TITLE
EDG-987: Measure how long a test class holds its fork, and smooth the timings

### DIFF
--- a/edge-plugins/src/main/kotlin/com/hivemq/testordering/JUnitResults.kt
+++ b/edge-plugins/src/main/kotlin/com/hivemq/testordering/JUnitResults.kt
@@ -89,9 +89,30 @@ fun readRunTotals(xmlDir: File): RunTotals {
  * class inside it there, so a nested class is never scheduled independently. Nested entries are folded into
  * their enclosing class.
  *
- * Durations are summed from the individual `<testcase time=>` values, never taken from the `<testsuite time=>`
- * attribute. That attribute spans first-attempt-start to last-attempt-end, so for a class that was retried it
- * includes the idle gap between attempts and can overstate the work by an order of magnitude.
+ * WHICH DURATION. What the ordering needs is how long a class OCCUPIES a fork, because that is what has to be
+ * packed. Neither attribute gives that on its own:
+ *
+ *  - `<testsuite time=>` is the right quantity -- it covers per-class setup and teardown, which for a class
+ *    that starts a container is nearly all of its cost. But when a class was RETRIED it spans
+ *    first-attempt-start to last-attempt-end, including the idle gap between attempts, and can overstate by an
+ *    order of magnitude (one retried class read 462s against 25s of actual work).
+ *  - Summing `<testcase time=>` is immune to that gap, but counts only time inside test METHODS. A class whose
+ *    work happens in `@BeforeAll`/`@BeforeEach` measures as near zero: `OidcServiceKeycloakIT` spends 25s
+ *    starting a Keycloak container and recorded 1.3s, so the ordering put the tenth-slowest class in the suite
+ *    last, where nothing was left to overlap it (EDG-987).
+ *
+ * So: use the suite time, EXCEPT where a retry makes it untrustworthy, and there fall back to the sum.
+ *
+ * DETECTING A RETRY. Not by repeated `<testcase name=>` -- a parameterised test writes the same name under
+ * several methods (`LdapDirectoryDescentIT` has `[1] OpenLDAP` six times and was never retried), and the XML
+ * carries no method attribute to separate the two. The usable signal is that a retry only happens after a
+ * FAILURE, so a class that recorded one or more failures may have been retried and its suite time may span an
+ * idle gap. A class with no failures cannot have been retried, whatever its names look like.
+ *
+ * That is deliberately conservative in one direction: a class that failed outright, with no retry, also falls
+ * back to the sum and is understated. That is the safe error -- it is the number this task used for every
+ * class before, and a failing class's timing is disturbed anyway (the task already warns that a failing class
+ * stops early and understates its real time).
  */
 fun readRunResults(xmlDir: File): Map<String, ClassResult> {
     val results = mutableMapOf<String, ClassResult>()
@@ -102,30 +123,53 @@ fun readRunResults(xmlDir: File): Map<String, ClassResult> {
     files.forEach { file ->
         val doc = runCatching { builder.parse(file) }.getOrNull() ?: return@forEach
         val cases = doc.getElementsByTagName("testcase")
+
+        // Per FILE, because the duration we want lives on the file's <testsuite> element.
+        var caseSeconds = 0.0
+        var failures = 0
+        var outerClass: String? = null
+
         for (i in 0 until cases.length) {
             val case = cases.item(i)
             val attrs = case.attributes ?: continue
             val rawClass = attrs.getNamedItem("classname")?.nodeValue ?: continue
             // Fold nested classes into the enclosing one -- only the outer class is ever dispatched.
-            val outer = rawClass.substringBefore('$')
-            val seconds = attrs.getNamedItem("time")?.nodeValue?.toDoubleOrNull() ?: 0.0
+            if (outerClass == null) {
+                outerClass = rawClass.substringBefore('$')
+            }
+            caseSeconds += attrs.getNamedItem("time")?.nodeValue?.toDoubleOrNull() ?: 0.0
 
-            var failures = 0
             val children = case.childNodes
             for (c in 0 until children.length) {
                 when (children.item(c).nodeName) {
                     "failure", "error" -> failures += 1
                 }
             }
-
-            val previous = results[outer]
-            results[outer] =
-                if (previous == null) {
-                    ClassResult(seconds, failures)
-                } else {
-                    ClassResult(previous.seconds + seconds, previous.failures + failures)
-                }
         }
+
+        val outer = outerClass ?: return@forEach
+        val suiteSeconds = doc.documentElement
+            ?.takeIf { it.nodeName == "testsuite" }
+            ?.getAttribute("time")
+            ?.toDoubleOrNull()
+
+        // Suite time unless something makes it untrustworthy: a failure (which may have been retried, and a
+        // retry's suite time spans the idle gap between attempts), or a suite time BELOW the work it
+        // contains, which no honest run produces.
+        val seconds = if (failures > 0 || suiteSeconds == null || suiteSeconds < caseSeconds) {
+            caseSeconds
+        } else {
+            suiteSeconds
+        }
+
+        val previous = results[outer]
+        results[outer] =
+            if (previous == null) {
+                ClassResult(seconds, failures)
+            } else {
+                // Nested classes write one file each; their durations add up to the enclosing class's cost.
+                ClassResult(previous.seconds + seconds, previous.failures + failures)
+            }
     }
     return results
 }

--- a/edge-plugins/src/main/kotlin/com/hivemq/testordering/Ordering.kt
+++ b/edge-plugins/src/main/kotlin/com/hivemq/testordering/Ordering.kt
@@ -28,7 +28,50 @@ fun arrange(
 ): List<String> = snake(classes.sortedWith(compareByDescending<String> { timings[it] ?: 0.0 }.thenBy { it }), forks)
 
 /**
- * Read a `class,seconds` CSV. Comments (`#`) and the header are skipped, as are nested-class rows.
+ * How much of the distance to a lower measurement is given up each time this file is adopted.
+ *
+ * A HALF, so a fall lands on the midpoint: `(committed + measured) / 2`. The unit here is an ADOPTION, not a
+ * test run -- this file changes only when someone runs the report and commits the result, which is a handful
+ * of times a month, not several times a day. A gentler decay would leave a class that genuinely got faster
+ * mis-scheduled for months of wall-clock time. (Gradle's own test distribution re-measures continuously and
+ * can afford to move in much smaller steps; this file cannot.)
+ *
+ * A class dropping from 30s to 2s then reads 16.0, 9.0, 5.5, 3.8, 2.9 -- settled within about five adoptions.
+ */
+const val DECAY = 0.5
+
+/**
+ * Fold a fresh measurement into the value the schedule uses: a rise is taken in full, a fall moves [DECAY] of
+ * the way -- with DECAY at 0.5, to the midpoint between the committed value and this run's.
+ *
+ * ASYMMETRIC ON PURPOSE. Underestimating a class is expensive and overestimating it is nearly free. A class
+ * scheduled too late runs when nothing is left to overlap it, so its whole duration lands on the critical
+ * path; a class scheduled too early merely runs alongside others. Halving a rise as well would take four
+ * adoptions -- months, at this file's cadence -- before a class that got slower was scheduled as slow, and
+ * that is the direction where being wrong costs something.
+ *
+ * [previous] is null for a class never seen before, which then simply takes its measured time.
+ *
+ * This is not what fixed EDG-987 -- that was a measurement reading the wrong attribute, and no amount of
+ * smoothing repairs a number that is wrong every time. It guards the different case of a class whose cost
+ * genuinely varies between runs, where the schedule should plan for the bad case.
+ */
+fun smooth(
+    previous: Double?,
+    measured: Double
+): Double =
+    when {
+        previous == null -> measured
+        measured >= previous -> measured
+        else -> previous - (previous - measured) * DECAY
+    }
+
+/**
+ * Read a `class,seconds[,measured]` CSV, returning the FIRST numeric column -- the smoothed value the
+ * ordering is built from. Comments (`#`) and the header are skipped, as are nested-class rows.
+ *
+ * Any further columns are history, carried for a reader to inspect, and are deliberately not consulted here:
+ * one number decides the order. Older files have only the one column and still read correctly.
  *
  * Nested classes may appear in a hand-edited file. They are ignored: a nested class is never dispatched on
  * its own, Gradle dispatches the outer class and JUnit runs the nested ones inside it.
@@ -46,21 +89,32 @@ fun readTimings(file: File): Map<String, Double> {
     return timings
 }
 
-/** Write [timings] as a `class,seconds` CSV, slowest first. */
+/**
+ * Write a `class,seconds,measured` CSV, slowest first.
+ *
+ * [timings] is the smoothed value the ordering is built from -- the first column, and the only one anything
+ * reads back. [measured] is what the run actually recorded for that class, written alongside so a reader can
+ * see why the two differ (a class whose smoothed value is far above its measurement is one on the way down
+ * from a slower run). A class absent from [measured] simply has an empty second field.
+ */
 fun writeTimings(
     file: File,
     timings: Map<String, Double>,
-    header: List<String>
+    header: List<String>,
+    measured: Map<String, Double> = emptyMap()
 ) {
     file.parentFile?.mkdirs()
     file.bufferedWriter().use { out ->
         // An empty header entry is a blank comment line -- written as a bare "#" so it carries no
         // trailing whitespace, which some editors and pre-commit hooks strip on sight.
         header.forEach { out.write(if (it.isEmpty()) "#\n" else "# $it\n") }
-        out.write("class,seconds\n")
+        out.write("class,seconds,measured\n")
         timings.entries
             .sortedWith(compareByDescending<Map.Entry<String, Double>> { it.value }.thenBy { it.key })
-            .forEach { out.write("${it.key},${"%.1f".format(it.value)}\n") }
+            .forEach { entry ->
+                val raw = measured[entry.key]?.let { "%.1f".format(it) } ?: ""
+                out.write("${entry.key},${"%.1f".format(entry.value)},$raw\n")
+            }
     }
 }
 

--- a/edge-plugins/src/main/kotlin/com/hivemq/testordering/ReportTestConcurrencyTask.kt
+++ b/edge-plugins/src/main/kotlin/com/hivemq/testordering/ReportTestConcurrencyTask.kt
@@ -101,9 +101,15 @@ abstract class ReportTestConcurrencyTask : DefaultTask() {
         val committedFile = committedTimings.orNull?.asFile
         val committed = committedFile?.let { readTimings(it) } ?: emptyMap()
 
+        // What gets WRITTEN is smoothed against the committed value: a class that got slower is believed at
+        // once, one that got faster comes down gradually (see `smooth`). What gets SIMULATED below is this
+        // run's raw durations -- the two orderings must be scored against the same clock, or the comparison
+        // measures the smoothing rather than the ordering.
+        val smoothed = runtimes.mapValues { (name, seconds) -> smooth(committed[name], seconds) }
+
         writeTimings(
             runTimings.get().asFile,
-            runtimes,
+            smoothed,
             // ONE header, because adopting a new ordering is a plain `cp` of this file over the committed
             // one. So it has to read as the committed file -- that is where someone will find it and wonder.
             // Short by design: the explanation lives in the Edge Lore, not in a data file.
@@ -123,8 +129,14 @@ abstract class ReportTestConcurrencyTask : DefaultTask() {
                 "If it shows a real gain, adopt this ordering and raise a PR:",
                 "  cp build/test-class-timings.csv gradle/test-class-timings.csv",
                 "",
+                "Columns: 'seconds' orders the classes and is smoothed -- a class that got",
+                "slower takes its new time at once, one that got faster moves halfway there,",
+                "so a single fast run cannot undo a real cost. 'measured' is what the last run",
+                "actually recorded, and is informational. Only the first number is read back.",
+                "",
                 "https://hivemq.github.io/hivemq-edge-lore/3-Quality-and-Testing/balancing-the-parallel-forks/"
-            )
+            ),
+            measured = runtimes
         )
 
         reportTotals()


### PR DESCRIPTION
## Description (the why)

[EDG-987](https://linear.app/hivemq/issue/EDG-987/test-ordering-timings-measure-test-method-time-so-a-class-whose-cost)

EDG-930 orders integration test classes slowest-first so the long ones start while there is still work to overlap them. `readRunResults` built that file by **summing `<testcase time=>`**, which counts only time spent inside test *methods*. What the ordering needs is how long a class **occupies a fork**, which is `<testsuite time=>`, setup and teardown included.

For most classes the two are close and the file looks right. For a class whose work happens in a fixture they diverge completely:

| class | held its fork | inside test methods | recorded as |
| --- | ---: | ---: | ---: |
| `OidcServiceKeycloakIT` | 30.9s | 2.5s | **1.3s** |
| `LdapDirectoryDescentIT` | 15.8s | 0.3s | **0.1s** |
| `BridgeReconnectCyclesIT` | 69.6s | 65.6s | 62.5s |

`OidcServiceKeycloakIT` spends **25.07s starting a Keycloak container**, every time it runs (`Container quay.io/keycloak/keycloak:26.0 started in PT25.071981S`; not an image pull, the image has been cached locally for months). The scheduler then did exactly as told: sorted by recorded cost, put these near-zero classes last, and they took half a minute with nothing left to overlap them.

Confirmed against a local run of 346 classes: **all twelve** LDAP/OIDC classes started in the last quarter. `OidcServiceKeycloakIT` is the **tenth-slowest class in the suite** and started at **90.5%** through the run, where every other class in the top fifteen started within the first 17%.

### Why the old code did it that way

It was a deliberate choice, not an oversight. Suite time is untrustworthy for a **retried** class: it spans first-attempt-start to last-attempt-end **including the idle gap between attempts**, and one retried class here read `<testsuite time="462.119">` against 25.1s of actual work. So neither attribute is safe alone.

The fix uses suite time **unless the class recorded a failure**, falling back to the case sum there. Detecting a retry by repeated `<testcase name=>` does **not** work: a parameterised test legitimately repeats names across methods (`LdapDirectoryDescentIT` has `[1] OpenLDAP` six times and was never retried), and the XML carries no method attribute to separate the two. The usable signal is `failures > 0`, since a retry only follows a failure.

That is conservative in one direction: a class that failed outright without retry also falls back and is understated. That is the safe error, and it is the number the task used for every class before.

Validated against four real files:

| class | cases | suite | failures | chosen |
| --- | ---: | ---: | ---: | ---: |
| `OidcServiceKeycloakIT` | 2.5 | 30.9 | 0 | **30.9** |
| `LdapDirectoryDescentIT` (parameterised) | 0.3 | 15.8 | 0 | **15.8** |
| `BridgeReconnectCyclesIT` | 65.6 | 69.6 | 0 | **69.6** |
| `BehaviorPolicyRestApiListIT` (retried) | 25.1 | 462.1 | 1 | **25.1** |

### Second change: smoothing

Not a fix for the above; a measurement that is wrong every time is not repaired by averaging. It guards the different case of a class whose cost genuinely varies between runs, and it is worth doing in the same visit to the file.

`smooth(previous, measured)` takes a **rise in full** and moves a **fall to the midpoint**. The unit is an **adoption of the file**, not a test run: this file changes only when someone runs the report and commits the result, a handful of times a month, so a gentler decay would leave a class that genuinely got faster mis-scheduled for months of wall-clock time.

The asymmetry is deliberate. Underestimating a class is expensive and overestimating it is nearly free: a class scheduled too late runs when nothing is left to overlap it, so its whole duration lands on the critical path, while a class scheduled too early merely runs alongside others.

## Acceptance Criteria (the what)

- [x] The recorded time is fork occupancy, so a class whose cost is container startup is scheduled as slow
- [x] A retried class does not have the idle gap between attempts counted as work
- [x] A parameterised test is not mistaken for a retried one
- [x] A fall in a class's measured time is taken gradually; a rise is taken at once
- [x] The file carries the raw measurement alongside the scheduling value, so a divergent row explains itself
- [x] Files written before this change still parse (the reader ignores extra columns)
- [x] `:edge-plugins:compileKotlin` green

Measured with the regenerated file adopted (companion PR in `hivemq-edge-test`):

| class | started before | started after |
| --- | ---: | ---: |
| `OidcServiceKeycloakIT` | 90.5% in | **26.1% in** |
| `LdapDirectoryDescentIT` | 85.9% in | **53.7% in** |

The trivially fast classes of the same family moved *later* (`LdapUsernameRolesProviderIT` to 96.6%, `OpenLdapIT` to 99.9%), which is correct. Wall clock fell from 611s to 536s and summed class time from 49.8 to 42.6 minutes, but that run also had no failures where the previous one had three, **so the ordering change cannot claim the whole gain**.

## Non-Goals

- Making `OidcServiceKeycloakIT` itself faster. A 25-second Keycloak boot is worth attacking separately (sharing a container across classes, say); this only stops the scheduler being lied to about it.
- Changing the snake-ordering or the fork model.
