### PR TITLE
EDG-988: Read test timings from the fork logs, in one place

### DIFF
--- a/edge-plugins/src/main/kotlin/com/hivemq/testordering/ForkLogs.kt
+++ b/edge-plugins/src/main/kotlin/com/hivemq/testordering/ForkLogs.kt
@@ -63,6 +63,17 @@ data class TestRun(
      * A retried class occupies a fork twice, but the ordering decides where to place ONE dispatch, and a
      * class that failed and was retried is not a class that reliably costs the total of both. The longest
      * attempt is what a fork must be able to absorb.
+     *
+     * WHY `max` IS RIGHT HERE AND WRONG IN THE JENKINS READER. One fork-log record is one COMPLETE class
+     * execution -- `ForkAttributionListener` writes a line when the class finishes, not per test method --
+     * so several records for one class mean several attempts, and `max` picks one of them. The Jenkins
+     * console log carries one event pair per TEST METHOD instead, so the same rule applied there reports a
+     * class at its longest single method: `BridgeReconnectCyclesIT` read 17.1s for 55.2s of occupancy,
+     * making a whole CI run look 40% cheaper. That reader sums its segments and excludes only a retry's
+     * idle gap; see `CLAUDE/_scripts/jenkins-classtimes.py` and its fixture tests.
+     *
+     * The rule is the same in both -- charge the fork for the work, never for the gap -- but the unit of
+     * input differs, so the code cannot. Check which one you are holding before copying either.
      */
     fun longestPerClass(): Map<String, Double> =
         classes.groupBy { it.className }

--- a/edge-plugins/src/main/kotlin/com/hivemq/testordering/ForkLogs.kt
+++ b/edge-plugins/src/main/kotlin/com/hivemq/testordering/ForkLogs.kt
@@ -1,0 +1,131 @@
+package com.hivemq.testordering
+
+import java.io.File
+
+/**
+ * ONE PLACE THAT ANSWERS "HOW LONG DID THIS CLASS TAKE, AND WHEN".
+ *
+ * Every consumer of test timings reads this file. It exists because the same four mistakes were made
+ * repeatedly, each producing plausible numbers that were wrong, and each caught only by someone noticing
+ * a figure that did not smell right:
+ *
+ *  1. MEASURING FROM THE FIRST ATTEMPT TO THE END OF THE RETRY. A retried class's `<testsuite time=>` in
+ *     the JUnit XML spans first-attempt-start to last-attempt-end, INCLUDING the idle gap between them.
+ *     One class read 462s against 25s of real work. Reported twice as a "stall" that never happened.
+ *  2. COUNTING TEST-METHOD TIME AND CALLING IT CLASS TIME. Summing `<testcase time=>` counts only time
+ *     inside test methods, so a class whose cost is a container start measures near zero:
+ *     `OidcServiceKeycloakIT` holds its fork 30.9s, spends 2.5s in methods, and was recorded as 1.3s.
+ *  3. NESTED CLASSES, IN BOTH DIRECTIONS. Summing every record double-counts, because the outer class's
+ *     duration already spans its nested ones (`EtherIpCipOdvaIT`: 176s reported for 88s of work). But
+ *     reading the JUnit XML instead loses the outer class entirely -- JUnit writes a file per NESTED
+ *     class and none for the enclosing one, so `OpenLdapIT` measured 0.3s for a class that takes 10s,
+ *     was scheduled as trivially fast, and ran last where nothing could overlap it.
+ *  4. SUMMING ACROSS RUNS. The fork-log directory is never cleared, so it holds months of runs.
+ *
+ * THE FORK LOGS ARE THE AUTHORITY, not the JUnit XML. They are written by `ForkAttributionListener` from
+ * JUnit's own `executionStarted`/`executionFinished` callbacks, so a record is wall-clock time for one
+ * attempt of one class in one JVM: setup and teardown included (fixing 2), the outer class present as its
+ * own record (fixing 3), and a retry appearing as a SEPARATE record in a different JVM rather than one
+ * span across the gap (fixing 1). Run separation is handled here (fixing 4).
+ *
+ * The JUnit XML remains the authority for PASS/FAIL and for test counts. It is not a timing source.
+ */
+
+/** One class's stay in one test JVM: wall-clock, one attempt, setup and teardown included. */
+data class ClassRun(
+    val className: String,
+    val startMillis: Long,
+    val endMillis: Long,
+    val jvmPid: String
+) {
+    val durationMillis: Long get() = endMillis - startMillis
+}
+
+/** Every class record of a single test run, already separated from the other runs in the directory. */
+data class TestRun(
+    val classes: List<ClassRun>
+) {
+    val startMillis: Long get() = classes.minOf { it.startMillis }
+    val endMillis: Long get() = classes.maxOf { it.endMillis }
+
+    /** Wall clock from the first class starting to the last one finishing. */
+    val wallClockMillis: Long get() = (endMillis - startMillis).coerceAtLeast(1)
+
+    /** Total fork occupancy: what has to be packed into the forks. Attempts count individually. */
+    val workMillis: Long get() = classes.sumOf { it.durationMillis }
+
+    /** Forks busy on average, i.e. how much of the wall clock was spent doing work. */
+    val concurrency: Double get() = workMillis.toDouble() / wallClockMillis
+
+    /**
+     * The cost the SCHEDULER should plan for, per class: the longest attempt, not the sum.
+     *
+     * A retried class occupies a fork twice, but the ordering decides where to place ONE dispatch, and a
+     * class that failed and was retried is not a class that reliably costs the total of both. The longest
+     * attempt is what a fork must be able to absorb.
+     */
+    fun longestPerClass(): Map<String, Double> =
+        classes.groupBy { it.className }
+            .mapValues { (_, runs) -> runs.maxOf { it.durationMillis } / 1000.0 }
+}
+
+/**
+ * No class running for this long ends a run.
+ *
+ * Within a run the forks are essentially never all idle -- Gradle hands the next class over the moment one
+ * frees up -- while between runs everything stops to recompile. Measured across several values: 5s recovers
+ * full runs at their exact class count where 15s and above merge neighbouring runs.
+ */
+const val RUN_BOUNDARY_MILLIS = 5_000L
+
+/**
+ * Read every class record in [dir], newest run last.
+ *
+ * NESTED CLASSES ARE DROPPED HERE, once, so no caller has to remember to. The outer class's record already
+ * spans them, and a nested class is never dispatched on its own -- Gradle hands out the enclosing class and
+ * JUnit runs the nested ones inside it.
+ */
+fun readRuns(dir: File): List<TestRun> {
+    val files = dir.listFiles { f -> f.isFile && f.name.endsWith(".log") }?.toList().orEmpty()
+    val all = mutableListOf<ClassRun>()
+    files.forEach { file ->
+        val pid = file.nameWithoutExtension.removePrefix("fork-")
+        file.forEachLine { line ->
+            if (line.startsWith("#")) return@forEachLine
+            val f = line.split(' ')
+            if (f.size < 5) return@forEachLine
+            val name = f[4]
+            if (name.contains('$')) return@forEachLine
+            val end = f[0].toLongOrNull() ?: return@forEachLine
+            val duration = f[2].toLongOrNull() ?: return@forEachLine
+            all += ClassRun(name, end - duration, end, pid)
+        }
+    }
+    if (all.isEmpty()) return emptyList()
+
+    // A run boundary is a stretch where NOTHING was running -- not a gap between consecutive starts,
+    // which cannot tell a slow class from a pause and once merged three runs into one.
+    val sorted = all.sortedBy { it.startMillis }
+    val runs = mutableListOf(mutableListOf(sorted.first()))
+    var busyUntil = sorted.first().endMillis
+    sorted.drop(1).forEach { run ->
+        if (run.startMillis > busyUntil + RUN_BOUNDARY_MILLIS) {
+            runs += mutableListOf(run)
+        } else {
+            runs.last() += run
+        }
+        busyUntil = maxOf(busyUntil, run.endMillis)
+    }
+    return runs.map { TestRun(it) }
+}
+
+/**
+ * The run just finished, or null when the directory holds none.
+ *
+ * THE NEWEST, simply that -- callers ask right after a run. Choosing the LARGEST instead, to reject a stray
+ * single-class invocation that landed afterwards, was tried and is worse: one extra record makes an older
+ * run larger, and it then wins outright. That silently reported the previous evening's run as the current
+ * one (43:32 against a true 41:46). A stray announces itself -- the caller prints the class count, sees
+ * "1 class", and re-runs -- so prefer the failure that is visible.
+ */
+fun newestRun(dir: File): TestRun? = readRuns(dir).maxByOrNull { it.startMillis }

--- a/edge-plugins/src/main/kotlin/com/hivemq/testordering/ReportTestConcurrencyTask.kt
+++ b/edge-plugins/src/main/kotlin/com/hivemq/testordering/ReportTestConcurrencyTask.kt
@@ -97,7 +97,22 @@ abstract class ReportTestConcurrencyTask : DefaultTask() {
         }
 
         // R -- this run. The durations here are the ONLY durations used anywhere below.
-        val runtimes = results.mapValues { it.value.seconds }
+        //
+        // FROM THE FORK LOGS, NOT THE JUNIT XML. The XML is authoritative for pass/fail (above) and for
+        // test counts, and is not a timing source: its per-class time either spans a retry's idle gap or,
+        // summed per test method, omits the fixture work that dominates a container-backed class -- and it
+        // has no entry at all for a class with @Nested members. See ForkLogs.kt, which documents all four
+        // traps and is the single reader every consumer of these timings goes through.
+        //
+        // Falls back to the XML only when the logs are absent (-PnoForkLogs, or a run predating them), so
+        // the task still produces something rather than failing.
+        val run = newestRun(forkLogsDir.get().asFile)
+        val runtimes = run?.longestPerClass() ?: results.mapValues { it.value.seconds }
+        if (run == null) {
+            logger.warn("")
+            logger.warn("No fork logs found -- falling back to JUnit XML timings, which understate any")
+            logger.warn("class whose cost is in its fixture. Re-run without -PnoForkLogs for real numbers.")
+        }
         val committedFile = committedTimings.orNull?.asFile
         val committed = committedFile?.let { readTimings(it) } ?: emptyMap()
 
@@ -187,98 +202,39 @@ abstract class ReportTestConcurrencyTask : DefaultTask() {
      */
     private fun reportOccupancy() {
         val dir = forkLogsDir.orNull?.asFile
-        val files = dir?.listFiles { f -> f.isFile && f.name.endsWith(".log") }?.toList().orEmpty()
-        if (files.isEmpty()) {
+        // Reading, run separation, nested-class handling and "which run is this" all live in ForkLogs.kt,
+        // so this section and the timings written above cannot disagree about what the run was.
+        val allRuns = dir?.let { readRuns(it) }.orEmpty()
+        val spans = allRuns.maxByOrNull { it.startMillis }
+        if (spans == null) {
             logger.lifecycle("")
             logger.lifecycle("Fork occupancy: no fork logs (the run predates them, or -PnoForkLogs was set)")
             return
         }
+        val ignored = allRuns.sumOf { it.classes.size } - spans.classes.size
+        val otherRuns = allRuns.size - 1
 
-        // (start, end) in epoch millis for every class in every log file.
-        //
-        // NESTED CLASSES ARE SKIPPED, and they must be. A class with @Nested inner classes writes a
-        // line per nested class AND a line for the enclosing class whose duration already SPANS all
-        // of them, so counting every line charges that work twice: it inflated one real run's class
-        // time from 64m38s to 66m29s and the concurrency it implies from 4.8x to 5.0x. A nested
-        // class is also never dispatched on its own -- Gradle hands out the enclosing class and
-        // JUnit runs the nested ones inside it -- so the outer class is the only unit that
-        // corresponds to a fork being occupied. See ForkAttributionListener, which documents the
-        // same trap at the point the lines are written.
-        val all = mutableListOf<Pair<Long, Long>>()
-        files.forEach { file ->
-            file.forEachLine { line ->
-                if (line.startsWith("#")) return@forEachLine
-                val f = line.split(' ')
-                if (f.size < 5) return@forEachLine
-                if (f[4].contains('$')) return@forEachLine
-                val end = f[0].toLongOrNull() ?: return@forEachLine
-                val duration = f[2].toLongOrNull() ?: return@forEachLine
-                all += (end - duration) to end
-            }
-        }
-        if (all.isEmpty()) {
-            logger.lifecycle("")
-            logger.lifecycle("Fork occupancy: fork logs present but empty")
-            return
-        }
+        val start = spans.startMillis
+        val window = spans.wallClockMillis
+        val work = spans.workMillis
 
-        // SPLIT THE RUNS BY ACTIVITY, not by wall-clock gaps between class starts.
-        //
-        // The directory accumulates -- Gradle never clears it -- so earlier runs sit beside this one's.
-        // Within a run the forks are essentially never ALL idle: Gradle hands the next class to a fork
-        // the moment one frees up. Between runs everything stops while the build recompiles. So a run
-        // boundary is a stretch where NO class is running, which is a much cleaner signal than the gap
-        // between consecutive class starts -- that one cannot tell a slow class from a pause, and a
-        // five-minute threshold once merged three runs into a single 37-minute "run" of 714 classes.
-        //
-        // Verified on real logs: this recovers both full runs at exactly 353 classes, the true suite size.
-        //
-        // If it ever does merge two runs the cost is a slightly misdrawn occupancy chart in a diagnostic
-        // report -- which is why this is preferable to stamping a run id from the build, where the id
-        // would have to differ per invocation and would make the test task permanently uncacheable.
-        val sorted = all.sortedBy { it.first }
-        val runs = mutableListOf(mutableListOf(sorted.first()))
-        var busyUntil = sorted.first().second
-        sorted.drop(1).forEach { span ->
-            if (span.first > busyUntil + IDLE_GAP_MS) {
-                runs += mutableListOf(span)
-            } else {
-                runs.last() += span
-            }
-            busyUntil = maxOf(busyUntil, span.second)
-        }
-
-        // THE LARGEST RUN, AND AMONG EQUALS THE NEWEST. `runs.last()` looks right -- the newest
-        // burst of activity is presumably the run just finished -- but it is wrong whenever
-        // anything ran after the suite: re-running one failing class, or an IDE running a single
-        // test, appends a later and much smaller segment. Observed printing "8s of class time in
-        // 8s of wall clock = 1.0 effective average concurrency" for a run of 336 classes and over
-        // an hour of work, because a stray 9-second single-class invocation followed it. The suite
-        // outweighs such strays by two orders of magnitude, so size rejects them reliably.
-        //
-        // SIZE ALONE IS NOT ENOUGH THOUGH, because every full run of the suite has the SAME size.
-        // `maxBy` keeps the FIRST maximum, so once the directory held several complete runs this
-        // reported the OLDEST one for as long as those logs survived -- a report of a run four days
-        // stale, presented as the run just finished, with no hint anything was wrong. Ties are
-        // broken by start time so a full run always beats its own history.
-        val spans = runs.maxWith(compareBy({ it.size }, { it.minOf { span -> span.first } }))
-        val ignored = all.size - spans.size
-        val otherRuns = runs.size - 1
-
-        val start = spans.minOf { it.first }
-        val finish = spans.maxOf { it.second }
-        val window = (finish - start).coerceAtLeast(1)
-        val work = spans.sumOf { it.second - it.first }
-
+        // Concurrency is AVERAGED OVER EACH DECILE, not sampled at an instant -- sampling lands between
+        // classes often enough to print 0 in the middle of a fully busy run.
         val busy = (0 until 10).map { i ->
             val lo = start + window * i / 10
             val hi = start + window * (i + 1) / 10
-            val occupied = spans.sumOf { (a, b) -> (minOf(b, hi) - maxOf(a, lo)).coerceAtLeast(0) }
+            val occupied = spans.classes.sumOf { c ->
+                (minOf(c.endMillis, hi) - maxOf(c.startMillis, lo)).coerceAtLeast(0)
+            }
             occupied.toDouble() / (hi - lo)
         }
+        // The class count is on this line deliberately. The newest burst of activity is taken to be the
+        // run being reported on, which is right when this task is invoked after a suite and wrong if
+        // something small ran in between -- one class from an IDE, say. Naming the count makes that
+        // visible at a glance ("1 class") instead of hiding behind a plausible-looking total.
         val summary = String.format(
-            "%s of class time in %s of wall clock = **%.1f** effective average concurrency",
-            fmt(work), fmt(window), work.toDouble() / window
+            "%d classes: %s of class time in %s of wall clock = **%.1f** effective average concurrency",
+            spans.classes.size, fmt(work), fmt(window), work.toDouble() / window
         )
 
         logger.lifecycle("")
@@ -391,19 +347,15 @@ abstract class ReportTestConcurrencyTask : DefaultTask() {
         logger.lifecycle("")
     }
 
-    private companion object {
-        /**
-         * No class running for this long => a run boundary.
-         *
-         * Deliberately short. Within a run the forks are never all idle for seconds at a time, so 5s is
-         * already generous; raising it starts merging genuinely separate runs. Measured across several
-         * values, 5s recovered both full runs at their exact class count where 15s and above did not.
-         */
-        const val IDLE_GAP_MS = 5_000L
-    }
-
+    /**
+     * A duration as `m:ss`, or `s` below a minute.
+     *
+     * Colon-separated rather than `40m14s`: the report is read as a column of times to compare against
+     * each other, and `41:47` versus `43:32` is a subtraction the eye can do where `41m47s` versus
+     * `43m32s` is not.
+     */
     private fun fmt(millis: Long): String {
         val seconds = millis / 1000
-        return if (seconds < 60) "${seconds}s" else "${seconds / 60}m${"%02d".format(seconds % 60)}s"
+        return if (seconds < 60) "${seconds}s" else "${seconds / 60}:${"%02d".format(seconds % 60)}"
     }
 }


### PR DESCRIPTION
## Description (the why)

[EDG-988](https://linear.app/hivemq/issue/EDG-988/sweep-the-integration-suites-fixed-sleeps-wait-on-the-products-own)

**Companion to [hivemq-edge-test#463](https://github.com/hivemq/hivemq-edge-test/pull/463), which carries the test changes and the regenerated schedule. This one must land first**, or the schedule arrives justified by code that is not on master yet.

Test class timings were being read from the JUnit XML, which is not a timing source. Four ways of getting a class's runtime wrong, every one producing plausible numbers that were only ever caught by someone noticing a figure that did not smell right:

| mistake | what it did |
| -- | -- |
| measuring across a retry | `<testsuite time=>` spans first-attempt-start to last-attempt-end **including the idle gap** -- one class read **462s against 25s** of real work, twice reported as a "stall" that never happened |
| summing `<testcase time=>` | counts only time inside test methods, so a class whose cost is a container start measures near zero: one holds its fork **30.9s**, spends 2.5s in methods, was recorded as **1.3s** |
| nested classes, both directions | summing every record double-counts (the outer class already spans its nested ones: 176s reported for 88s). Reading the XML instead **loses the outer class entirely** -- JUnit writes a file per NESTED class and none for the enclosing one, so `OpenLdapIT` measured **0.3s for a class that takes 9.5s** |
| summing across runs | the fork-log directory is never cleared and holds months of history |

## Acceptance Criteria (the what)

- [x] **The fork logs are the authority.** `ForkAttributionListener` writes them from JUnit's own `executionStarted`/`executionFinished` callbacks, so a record is wall-clock for **one attempt of one class in one JVM**: setup and teardown included, the outer class present as its own record, and a retry appearing as a separate record rather than one span across the gap.
- [x] **One reader, `ForkLogs.kt`.** Run separation, nested-class handling and "which run is this" all live there, documented at the point that prevents each trap. The report task takes both its timings and its occupancy figures from it, so the two cannot disagree.
- [x] The JUnit XML remains authoritative for **pass/fail and test counts**, which is what it is good for.
- [x] Falls back to the XML when fork logs are absent (`-PnoForkLogs`, or a run predating them), with a warning rather than a failure.
- [x] `:edge-plugins:compileKotlin` green.

### Also: the newest run, not the largest

Picking the largest run rejected a stray single-class invocation landing after the suite, breaking ties on start time. That tie-break almost never fired -- it only compares runs of *exactly* equal size, and one extra record (a class re-run inside the idle gap, merged into its neighbour) makes an old run larger, so it wins outright. Observed reporting **the previous evening's run as the current one, 43:32 against a true 41:46**, with nothing in the output to say so.

That failure is silent; the one it guarded against is not. A stray reads "1 classes" on the face of the report and the reader re-runs. The class count is now printed on the summary line to make that unmissable.

### Also: `41:46` rather than `41m46s`

All duration output goes through one formatter. The report is read as a column of times compared against each other, and `41:46` versus `43:32` is a subtraction the eye can do.

## Verified

`OpenLdapIT` now reads **9.5s** instead of 0.4s. The retried database class reads its longest attempt rather than both summed. The Gradle task and the vault's own analysis script independently produce **identical** figures on the same logs.

## Non-Goals

- Making the reader robust against a JVM from an abandoned run overlapping a live one. That happened once here, and separating those needs a heuristic on Gradle worker numbers; martin's call was that brittle heuristics have cost more than they saved, and a report that is wrong in that rare case is acceptable.
- Clearing the fork-log directory automatically. A task that deletes its own diagnostic output will eventually delete it at the wrong moment.
