### PR TITLE
EDG-995: Pack the test lanes instead of snaking them

### DIFF
--- a/edge-plugins/src/main/kotlin/com/hivemq/testordering/Ordering.kt
+++ b/edge-plugins/src/main/kotlin/com/hivemq/testordering/Ordering.kt
@@ -7,12 +7,77 @@ import java.io.File
  *
  * With groups [a b c] [d e f] and 3 forks, fork 0 gets a and d -- the two largest. Reversing the second
  * group gives fork 0 a and f, fork 2 c and d, so the per-fork totals converge instead of diverging.
+ *
+ * SUPERSEDED by [balance], which packs the forks directly instead of approximating. Kept because it is the
+ * baseline every measurement of the new scheme is quoted against, and because it needs no timings at all --
+ * it only reverses alternate groups of an already-sorted list.
  */
 fun snake(
     names: List<String>,
     forks: Int
 ): List<String> =
     names.chunked(forks).mapIndexed { index, group -> if (index % 2 == 1) group.reversed() else group }.flatten()
+
+/**
+ * Pack [names] into [forks] lanes by longest-processing-time, then interleave the lanes back into a dispatch
+ * list that round-robin dispatch reconstructs exactly.
+ *
+ * THE IDEA. Gradle deals class *i* to fork *(i mod forks)* and never rebalances, so a dispatch list IS an
+ * assignment -- the only question is which one. Rather than approximate a good assignment by permuting a
+ * sorted list (see [snake]), build the assignment we actually want and then write it down in the order that
+ * recreates it: lane 0's first class, lane 1's first, ... then everyone's second, and so on. Reading the
+ * lanes off column by column is what makes `i mod forks` land each class back in the lane it was placed in.
+ *
+ * THE PACKING is classic LPT: walk the classes longest-first, and put each one on whichever lane is currently
+ * cheapest. That is the standard greedy scheduler, guaranteed within 4/3 of optimal, and in practice far
+ * closer on a distribution like this one.
+ *
+ * THE CAPACITY CAP is what makes the interleave sound. Lanes are packed to at most `ceil(n / forks)` classes,
+ * so the lanes form a rectangle with at most one short column, and reading down the columns visits each lane
+ * once per row. Without the cap, LPT would happily give one lane 40 tiny classes and another 3 big ones, the
+ * rows would be ragged, and `i mod forks` would no longer rebuild the lanes at all -- the interleave would
+ * silently scramble the very assignment it is meant to preserve.
+ *
+ * The cap does bind, and often: with 711 dispatched classes over 36 forks it blocks the cheapest lane on
+ * about half the assignments. That is harmless here because it only starts binding once the remaining classes
+ * weigh nothing -- the ~380 dispatched classes that hold no test at all (see [arrange]). It is a real
+ * constraint, though, not a formality: it trades a little packing freedom for an assignment that survives
+ * dispatch.
+ *
+ * MEASURED against [snake] on the committed timings, as makespan over the resulting lanes:
+ *
+ *     forks   snake      balance
+ *         5   +0.9%       +0.0%
+ *         8   +4.4%       +0.0%
+ *        26  +31.0%       +0.8%
+ *        36  +48.6%       +0.4%
+ *
+ * (percentages over the ideal of total-work / forks). The two are equivalent at low fork counts, which is
+ * where the snake was tuned; the gap opens as forks grow, because reversing alternate groups cannot fix an
+ * imbalance that spans more than two groups.
+ *
+ * Ties break on lane index so the result is deterministic run to run.
+ */
+fun balance(
+    names: List<String>,
+    weights: (String) -> Double,
+    forks: Int
+): List<String> {
+    if (forks <= 1 || names.isEmpty()) return names
+    val capacity = (names.size + forks - 1) / forks
+    val lanes = List(forks) { mutableListOf<String>() }
+    val loads = DoubleArray(forks)
+    names.forEach { name ->
+        val target = (0 until forks)
+            .filter { lanes[it].size < capacity }
+            .minByOrNull { loads[it] }
+            ?: return@forEach
+        lanes[target].add(name)
+        loads[target] += weights(name)
+    }
+    // Column by column, so `i mod forks` puts each class back on the lane it was packed onto.
+    return (0 until capacity).flatMap { row -> lanes.mapNotNull { it.getOrNull(row) } }
+}
 
 /**
  * The weight a KNOWN test gets when its measurement rounds to zero.
@@ -50,13 +115,11 @@ fun arrange(
     classes: List<String>,
     timings: Map<String, Double>,
     forks: Int
-): List<String> =
-    snake(
-        classes.sortedWith(
-            compareByDescending<String> { timings[it]?.coerceAtLeast(KNOWN_TEST_FLOOR) ?: 0.0 }.thenBy { it }
-        ),
-        forks
-    )
+): List<String> {
+    val weight = { name: String -> timings[name]?.coerceAtLeast(KNOWN_TEST_FLOOR) ?: 0.0 }
+    val sorted = classes.sortedWith(compareByDescending(weight).thenBy { it })
+    return balance(sorted, weight, forks)
+}
 
 /**
  * Read a `class,seconds[,measured]` CSV, returning the FIRST numeric column -- the smoothed value the


### PR DESCRIPTION
## Description (the why)

[EDG-995](https://linear.app/hivemq/issue/EDG-995/balance-test-lanes-by-packing-and-fix-the-timings-the-reader-feeds)

The snake ordering sorted classes slowest-first and reversed every second group of `maxParallelForks`. That cancels a bias at 5 lanes, where it was tuned, and degrades as lanes grow: reversing alternate groups cannot fix an imbalance that spans more than two groups.

This builds the assignment directly instead. Dispatch is round robin -- class `i` goes to lane `i mod forks`, unconditionally -- so a dispatch list IS an assignment, and the only question is which one. Walk the classes longest-first, put each on the currently cheapest lane, then read the lanes off **column by column**, which is the order round-robin dispatch rebuilds them from.

**The capacity cap of `ceil(n / forks)` per lane is what makes that reconstruction exact.** Without it the lanes are ragged, the rows do not line up, and `i mod forks` scrambles the very assignment the interleave exists to preserve. It binds often -- at 36 lanes it blocks the cheapest lane on about half the assignments -- but only once the remaining classes weigh nothing, since roughly two thirds of what is dispatched holds no test at all.

### Measured

Makespan over the resulting lanes, against the ideal of total-work / forks:

| forks | snake | balance |
|---|---|---|
| 5 | +0.9% | +0.0% |
| 8 | +4.4% | +0.0% |
| 26 | +31.0% | +0.8% |
| 36 | **+48.6%** | **+0.4%** |

On `albert` (the Edge Lab server, 36 lanes) the predicted lane loads now spread **0.8 s** busiest-to-idlest. The actual spread was 52.5 s -- so what remains is prediction error rather than scheduling. That is a different problem and it lives in the timings; see the sibling PR in `hivemq-edge-test`.

The two orderings are equivalent at low fork counts, so this is not expected to change anything on a developer laptop or in CI (1 lane per machine). It matters on a many-core machine.

## Acceptance Criteria (the what)

- [x] `arrange()` packs lanes and interleaves; round-robin dispatch reconstructs the packing exactly
- [x] The capacity cap keeps the lanes rectangular, so the interleave is sound
- [x] A class absent from the timings still sorts last and still runs -- membership is unchanged
- [x] `snake()` kept as the baseline every measurement above is quoted against

## Non-Goals

- The timings themselves. The packing is only as good as its predictions, and those are fixed in the sibling PR.
- CI. This is off when `CI_RUN` is set, as before -- the integration suite is farmed out to remote executors that ignore dispatch order.
