### PR TITLE
EDG-882: log the owner and group fallbacks without a stack trace

### DIFF
--- a/hivemq-edge/src/main/java/com/hivemq/configuration/reader/ConfigFileReaderWriter.java
+++ b/hivemq-edge/src/main/java/com/hivemq/configuration/reader/ConfigFileReaderWriter.java
@@ -954,15 +954,19 @@ public class ConfigFileReaderWriter {
                         // reproduced exactly or the write is refused, and those are what decide who else
                         // can read the file; the owner it falls back to is the account that just rendered
                         // the configuration and therefore already holds every credential in it.
+                        //
+                        // The store's message, not the throwable: this is handled, and a stack trace on
+                        // every write reads as a failure to anything scanning the log -- Pulse's system
+                        // tests fail a test on any "Exception" line, and did, on every config write.
                         log.warn(
                                 "The replacement for {} could not be given the owner of the file it replaces"
                                         + " ('{}'), so it is owned by this node's own account instead. Its mode,"
                                         + " group and access-control list are unchanged, so no one else gains"
                                         + " access -- but if the owner matters here, set it back and check what"
-                                        + " installed the file.",
+                                        + " installed the file. The store said: {}",
                                 partial,
                                 preserved.owner().getName(),
-                                notPermitted);
+                                notPermitted.getMessage());
                         proven = proven.withoutOwner();
                     }
                 }
@@ -996,20 +1000,20 @@ public class ConfigFileReaderWriter {
                                             + " configuration is still written and nobody gains access, but"
                                             + " principals that could read it through that group no longer can."
                                             + " Add this node's account to that group, or give the file a group it"
-                                            + " is already in, to keep it readable.",
+                                            + " is already in, to keep it readable. The store said: {}",
                                     partial,
                                     preserved.group().getName(),
-                                    notPermitted);
+                                    notPermitted.getMessage());
                         } else {
                             // The mode grants the group nothing, so which group it names decides nobody's
                             // access and dropping it costs nothing. Not worth a warning on every write.
                             log.debug(
                                     "The replacement for {} could not be given the group of the file it replaces"
                                             + " ('{}'). That file's mode grants its group nothing, so no principal"
-                                            + " gains or loses access.",
+                                            + " gains or loses access. The store said: {}",
                                     partial,
                                     preserved.group().getName(),
-                                    notPermitted);
+                                    notPermitted.getMessage());
                         }
                     }
                 }


### PR DESCRIPTION
Follow-up to #1714. When config.xml is replaced and its owner or group cannot be reproduced (chown is privileged, chgrp needs membership), the write goes on and a WARN says so. That WARN carried the caught exception as a throwable, so every such write printed a stack trace for a handled condition.

Pulse's Edge system tests copy the config into the container under the host uid and scan container logs after each test, failing on any line containing "Exception". Since #1714 reached master, 70 of them fail on the first stack-trace line, `java.nio.file.FileSystemException: ...: Operation not permitted`. Reported by Daniel Krüger in #data-intelligence-edge-coordination.

Change: the three fallback log calls (owner WARN, group WARN, group DEBUG) log the store's message inline instead of the throwable. No behaviour change in the write path.

Verified: `ConfigWritePermissionsTest`, `ConfigWriteAclPermissionsTest`, `ConfigFileReaderWriterTest` green (43/43), spotless clean.

Reproduced Pulse's condition locally, outside their harness: Edge from this branch in an `eclipse-temurin:25` container running as uid 10000, `config.xml` owned by uid 1002 with mode 666, a bridge created and deleted over REST (two config writes).

| Jar | Owner/group fallback fired | Config written | Log lines containing `Exception` |
|---|---|---|---|
| master writer classes (baseline) | yes | yes | 18, first one `java.nio.file.FileSystemException: /opt/hivemq/conf/config_1.xml.partial: Operation not permitted`, the line Pulse reported |
| this branch | yes, message ends `The store said: /opt/hivemq/conf/config_1.xml.partial: Operation not permitted` | yes | 2, both the probe bridge's connection refused to its dummy port |

Pulse's scanner fails a test on any log line containing `Exception`, so the baseline fails and this branch passes, independent of the test. A run of the actual Pulse suite locally was not possible: its OCI image prefetch fails through the local registry proxy.
