### PR TITLE
EDG-885 / EDG-949: release idle sampling, harden the configuration write path and end its watcher with the node, split the reader-writer

### DIFF
--- a/hivemq-edge/src/main/java/com/hivemq/HiveMQEdgeMain.java
+++ b/hivemq-edge/src/main/java/com/hivemq/HiveMQEdgeMain.java
@@ -23,6 +23,7 @@ import com.hivemq.bootstrap.ioc.Injector;
 import com.hivemq.bootstrap.ioc.Persistences;
 import com.hivemq.bootstrap.services.AfterHiveMQStartBootstrapService;
 import com.hivemq.bootstrap.services.AfterHiveMQStartBootstrapServiceImpl;
+import com.hivemq.common.shutdown.HiveMQShutdownHook;
 import com.hivemq.common.shutdown.ShutdownHooks;
 import com.hivemq.configuration.info.SystemInformation;
 import com.hivemq.configuration.info.SystemInformationImpl;
@@ -87,6 +88,28 @@ public class HiveMQEdgeMain {
         if (shutdownHooks.isShuttingDown()) {
             throw new HiveMQEdgeStartupException("User aborted.");
         }
+
+        // The configuration watcher is started before the injector exists, so it registers its stop here.
+        // It must stop before anything else is dismantled: a tick during shutdown would reload into a
+        // broker that is going away, and an embedded node's JVM outlives the node, so the watcher's own
+        // JVM shutdown hook never runs for it.
+        final ConfigurationService watchedConfig = Objects.requireNonNull(configService);
+        shutdownHooks.add(new HiveMQShutdownHook() {
+            @Override
+            public @NotNull String name() {
+                return "Configuration file watcher shutdown";
+            }
+
+            @Override
+            public @NotNull Priority priority() {
+                return Priority.FIRST;
+            }
+
+            @Override
+            public void run() {
+                watchedConfig.stopWatchingConfigFile();
+            }
+        });
 
         final HiveMQEdgeGateway instance = injector.edgeGateway();
         instance.start(embeddedExtension);

--- a/hivemq-edge/src/main/java/com/hivemq/configuration/reader/ConfigBackupRotation.java
+++ b/hivemq-edge/src/main/java/com/hivemq/configuration/reader/ConfigBackupRotation.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.configuration.reader;
+
+import static com.hivemq.util.Files.getFileExtension;
+import static com.hivemq.util.Files.getFileNameExcludingExtension;
+import static com.hivemq.util.Files.getFilePathExcludingFile;
+
+import com.hivemq.exceptions.UnrecoverableException;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.Set;
+import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The rolling backup of the configuration file: {@code config_1.xml} to {@code config_5.xml} beside it,
+ * the oldest slot recycled once all are taken, and only those slots -- never an operator's own file that
+ * happens to share the name (EDG-949). Each backup is a copy carrying the protections of the file it
+ * copies, through {@link ProtectedFileReplacer#copyCarryingProtections(Path, Path)}.
+ * <p>
+ * Called by {@link ConfigFileReaderWriter} once a replacement is complete and proven and just before it
+ * lands, so a refused write consumes no slot.
+ */
+final class ConfigBackupRotation {
+
+    private static final @NotNull Logger log = LoggerFactory.getLogger(ConfigBackupRotation.class);
+
+    static final int MAX_BACK_FILES = 5;
+
+    private ConfigBackupRotation() {}
+
+    static void backup(final @NotNull File configFile, final boolean enabled) throws IOException {
+        if (!enabled) {
+            return;
+        }
+        final String fileNameNoExt = getFileNameExcludingExtension(configFile.getName());
+        final String fileExt = getFileExtension(configFile.getName());
+        final File copyPath = new File(getFilePathExcludingFile(configFile.getAbsolutePath()));
+        if (copyPath.exists() && copyPath.isDirectory()) {
+            int idx = 1;
+            File copyFile;
+            do {
+                final String copyFilename = fileNameNoExt + '_' + idx++ + (fileExt != null ? '.' + fileExt : "");
+                copyFile = new File(copyPath, copyFilename);
+            } while (idx <= MAX_BACK_FILES && copyFile.exists());
+
+            if (copyFile.exists()) {
+                // -- every slot is taken: overwrite the oldest of the backups this node wrote. Exactly the
+                // slot names, nothing that merely resembles them: the previous prefix-and-suffix match took
+                // any "config*xml" in the directory, so an operator's own archived copy was the oldest
+                // match and was silently replaced by a routine backup, and the live configuration file
+                // matched too. A digits-only pattern would still take "config_2024.xml" (EDG-949).
+                final File[] backupFiles = getBackupFiles(fileNameNoExt, fileExt, copyPath);
+                Arrays.sort(backupFiles, Comparator.comparingLong(File::lastModified));
+                copyFile = backupFiles[0];
+            }
+            if (log.isDebugEnabled()) {
+                log.debug("Rolling backup of configuration file to {}", copyFile.getName());
+            }
+            ProtectedFileReplacer.copyCarryingProtections(configFile.toPath(), copyFile.toPath());
+        } else {
+            log.error("Configuration folder {} does not exist or is not a directory", copyPath.getAbsolutePath());
+            throw new UnrecoverableException(false);
+        }
+    }
+
+    private static File @NonNull [] getBackupFiles(
+            final @NotNull String fileNameNoExt, final @Nullable String fileExt, final @NotNull File copyPath)
+            throws IOException {
+        final Set<String> slotNames = new HashSet<>();
+        for (int slot = 1; slot <= MAX_BACK_FILES; slot++) {
+            slotNames.add(fileNameNoExt + '_' + slot + (fileExt != null ? '.' + fileExt : ""));
+        }
+        final File[] backupFiles = copyPath.listFiles(child -> child.isFile() && slotNames.contains(child.getName()));
+        if (backupFiles == null || backupFiles.length == 0) {
+            throw new IOException(
+                    "The configuration folder " + copyPath + " cannot be listed, so no" + " backup slot can be chosen");
+        }
+        return backupFiles;
+    }
+}

--- a/hivemq-edge/src/main/java/com/hivemq/configuration/reader/ConfigFileReaderWriter.java
+++ b/hivemq-edge/src/main/java/com/hivemq/configuration/reader/ConfigFileReaderWriter.java
@@ -15,9 +15,6 @@
  */
 package com.hivemq.configuration.reader;
 
-import static com.hivemq.util.Files.getFileExtension;
-import static com.hivemq.util.Files.getFileNameExcludingExtension;
-import static com.hivemq.util.Files.getFilePathExcludingFile;
 import static com.hivemq.util.render.FileFragmentUtil.replaceFragmentPlaceHolders;
 import static java.util.Objects.requireNonNullElse;
 
@@ -25,8 +22,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.hivemq.configuration.entity.HiveMQConfigEntity;
 import com.hivemq.configuration.entity.adapter.fieldmapping.FieldMappingEntity;
-import com.hivemq.configuration.entity.api.ApiTlsEntity;
-import com.hivemq.configuration.entity.bridge.BridgeTlsEntity;
 import com.hivemq.configuration.entity.listener.TCPListenerEntity;
 import com.hivemq.configuration.entity.listener.TlsTCPListenerEntity;
 import com.hivemq.configuration.entity.listener.TlsWebsocketListenerEntity;
@@ -36,9 +31,7 @@ import com.hivemq.configuration.entity.listener.WebsocketListenerEntity;
 import com.hivemq.configuration.entity.listener.tls.KeystoreEntity;
 import com.hivemq.configuration.entity.listener.tls.TruststoreEntity;
 import com.hivemq.configuration.info.SystemInformation;
-import com.hivemq.edge.HiveMQEdgeConstants;
 import com.hivemq.exceptions.UnrecoverableException;
-import com.hivemq.util.ThreadFactoryUtil;
 import com.hivemq.util.render.EnvVarUtil;
 import com.hivemq.util.render.IfUtil;
 import jakarta.xml.bind.JAXBContext;
@@ -53,55 +46,23 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.io.StringWriter;
 import java.io.Writer;
 import java.net.URL;
 import java.net.URLConnection;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Files;
-import java.nio.file.LinkOption;
-import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.nio.file.StandardCopyOption;
-import java.nio.file.StandardOpenOption;
-import java.nio.file.attribute.AclEntry;
-import java.nio.file.attribute.AclEntryPermission;
-import java.nio.file.attribute.AclEntryType;
-import java.nio.file.attribute.AclFileAttributeView;
-import java.nio.file.attribute.BasicFileAttributeView;
-import java.nio.file.attribute.FileOwnerAttributeView;
-import java.nio.file.attribute.GroupPrincipal;
-import java.nio.file.attribute.PosixFileAttributeView;
-import java.nio.file.attribute.PosixFileAttributes;
-import java.nio.file.attribute.PosixFilePermission;
-import java.nio.file.attribute.PosixFilePermissions;
-import java.nio.file.attribute.UserPrincipal;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.Comparator;
-import java.util.EnumSet;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
-import java.util.function.Supplier;
-import java.util.regex.Pattern;
 import javax.xml.XMLConstants;
 import javax.xml.transform.stream.StreamSource;
 import javax.xml.validation.Schema;
@@ -117,9 +78,7 @@ import org.slf4j.LoggerFactory;
 public class ConfigFileReaderWriter {
 
     private static final @NotNull Logger log = LoggerFactory.getLogger(ConfigFileReaderWriter.class);
-    private static final @NotNull String CONFIG_FRAGMENT_PATH = "/fragment/config";
     private static final @NotNull String XSD_SCHEMA = "config.xsd";
-    private static final int MAX_BACK_FILES = 5;
     private static final @Nullable Schema CONFIG_XSD;
     private static final @NotNull JAXBContext CONFIG_JAXB_CONTEXT;
 
@@ -160,7 +119,7 @@ public class ConfigFileReaderWriter {
                     .build()
                     .toArray(new Class<?>[0]));
         } catch (final Throwable e) {
-            if (e instanceof IllegalAnnotationsException iae) {
+            if (e instanceof final IllegalAnnotationsException iae) {
                 log.error("Cannot create the jaxb context: {}", iae.getErrors(), e);
             } else {
                 log.error("Cannot create the jaxb context", e);
@@ -171,8 +130,8 @@ public class ConfigFileReaderWriter {
 
     private final @NotNull ConfigurationFile configFile;
     private final @NotNull List<Configurator<?>> configurators;
+    private final @NotNull ConfigFileWatcher watcher;
 
-    private final @NotNull ConcurrentMap<Path, Long> fragmentToModificationTime;
     private final @NotNull BridgeExtractor bridgeExtractor;
     private final @NotNull ProtocolAdapterExtractor protocolAdapterExtractor;
     private final @NotNull DataCombiningExtractor dataCombiningExtractor;
@@ -193,14 +152,8 @@ public class ConfigFileReaderWriter {
     private final @NotNull AtomicReference<EnvVarUtil.CollectedPlaceholders> envPlaceholders;
 
     private final @NotNull Lock lock;
-    private final @NotNull AtomicReference<ScheduledExecutorService> executorService;
-    private boolean defaultBackupConfig;
 
-    /**
-     * What the configuration watcher does when the node has to restart to apply a change. The process
-     * exit in production; replaced in tests so the decision can be observed instead of ending the JVM.
-     */
-    private volatile @NotNull Runnable restartHook = () -> System.exit(0);
+    private boolean defaultBackupConfig;
 
     public ConfigFileReaderWriter(
             final @NotNull SystemInformation sysInfo,
@@ -223,12 +176,11 @@ public class ConfigFileReaderWriter {
                 this.pulseExtractor,
                 this.unsExtractor);
         this.postApplyCallbacks = new CopyOnWriteArrayList<>();
-        this.fragmentToModificationTime = new ConcurrentHashMap<>();
         this.configEntity = new AtomicReference<>();
         this.envPlaceholders = new AtomicReference<>(EnvVarUtil.CollectedPlaceholders.NONE);
         this.lastWrite = new AtomicLong();
         this.lock = new ReentrantLock();
-        this.executorService = new AtomicReference<>();
+        this.watcher = new ConfigFileWatcher(lock, configFile, this::loadConfigFromXML);
         this.defaultBackupConfig = true;
     }
 
@@ -249,43 +201,6 @@ public class ConfigFileReaderWriter {
                     .append("\"");
         }
         return sb.toString();
-    }
-
-    private static @NotNull Map<Path, Long> findFilesToWatch(final @NotNull HiveMQConfigEntity entity) {
-        final Map<Path, Long> paths = new ConcurrentHashMap<>();
-        entity.getBridgeConfig().forEach(cfg -> {
-            final BridgeTlsEntity tls = cfg.getRemoteBroker().getTls();
-            if (tls != null) {
-                final KeystoreEntity keyStore = tls.getKeyStore();
-                if (keyStore != null) {
-                    final Path path = Paths.get(keyStore.getPath());
-                    try {
-                        paths.put(path, Files.getLastModifiedTime(path).toMillis());
-                    } catch (final IOException e) {
-                        throw new RuntimeException(e);
-                    }
-                }
-                final TruststoreEntity trustStore = tls.getTrustStore();
-                if (trustStore != null) {
-                    final Path path = Paths.get(trustStore.getPath());
-                    try {
-                        paths.put(path, Files.getLastModifiedTime(path).toMillis());
-                    } catch (final IOException e) {
-                        throw new RuntimeException(e);
-                    }
-                }
-            }
-        });
-        final ApiTlsEntity tls = entity.getApiConfig().getTls();
-        if (tls != null && tls.getKeystoreEntity() != null) {
-            final Path path = Paths.get(tls.getKeystoreEntity().getPath());
-            try {
-                paths.put(path, Files.getLastModifiedTime(path).toMillis());
-            } catch (final IOException e) {
-                throw new RuntimeException(e);
-            }
-        }
-        return paths;
     }
 
     private static @NotNull Marshaller createMarshaller() throws JAXBException {
@@ -347,11 +262,6 @@ public class ConfigFileReaderWriter {
         this.defaultBackupConfig = defaultBackupConfig;
     }
 
-    @VisibleForTesting
-    void setRestartHook(final @NotNull Runnable restartHook) {
-        this.restartHook = restartHook;
-    }
-
     /** The configuration this node currently runs on; null before the first successful load. */
     @VisibleForTesting
     @Nullable
@@ -377,11 +287,17 @@ public class ConfigFileReaderWriter {
     }
 
     public void applyConfigAndWatch(final long checkIntervalInMs) {
-        startWatching(
-                getConfigFileOrFail(),
-                (checkIntervalInMs > 0) ? checkIntervalInMs : 1000,
-                this::applyConfig,
-                this::checkMonitoredFilesForChanges);
+        watcher.start(getConfigFileOrFail(), (checkIntervalInMs > 0) ? checkIntervalInMs : 1000, this::applyConfig);
+    }
+
+    @VisibleForTesting
+    void setRestartHook(final @NotNull Runnable restartHook) {
+        watcher.setRestartHook(restartHook);
+    }
+
+    @VisibleForTesting
+    void stopWatching() {
+        watcher.stop();
     }
 
     public void writeConfigWithSync() {
@@ -510,8 +426,13 @@ public class ConfigFileReaderWriter {
             // refused at any point consumes no backup slot. Rotating first meant that on a node where every
             // write is refused, four refusals turned every backup into a copy of the same unchanged file
             // and the earlier history was gone, on exactly the node where an operator wants it (EDG-949).
-            final PreservedAttributes preserved = preservedAttributesOf(target);
-            replaceCarryingProtections(
+            final ProtectedFileReplacer.PreservedAttributes preserved =
+                    ProtectedFileReplacer.preservedAttributesOf(target);
+            // The time the replacement carries onto the target -- a rename keeps it -- read while it is
+            // still the working file. Read from the target after the move it could be an operator's
+            // save that landed in between, and stamping that would hide their edit from the watcher.
+            final AtomicLong staged = new AtomicLong(-1);
+            ProtectedFileReplacer.replaceCarryingProtections(
                     target,
                     preserved,
                     partial -> {
@@ -519,651 +440,16 @@ public class ConfigFileReaderWriter {
                             writer.write(rendered.toString());
                             writer.flush();
                         }
+                        staged.set(Files.getLastModifiedTime(partial).toMillis());
                     },
-                    () -> backupConfig(file, doBackup));
+                    () -> ConfigBackupRotation.backup(file, doBackup));
+            // What the watcher would otherwise see as a change and reload: this node's own write.
+            watcher.writtenByThisNode(target, staged.get());
         } catch (final IOException e) {
             log.error("Error writing file:", e);
             throw new UnrecoverableException(false);
         } finally {
             lock.unlock();
-        }
-    }
-
-    /** The bytes of one replacement, written into the narrow file that has just been created for them. */
-    @FunctionalInterface
-    @VisibleForTesting
-    interface ContentWriter {
-
-        void writeTo(@NotNull Path partial) throws IOException;
-    }
-
-    /**
-     * Replaces a file with content written beside it, under the protections it is given, and never wider
-     * than those while it holds the content.
-     * <p>
-     * <b>Written beside the target and moved onto it, rather than opened and written in place.</b>
-     * Rendering the document first closed the "schema validation fails half way" case; opening the real
-     * file still truncates it, so a crash, a full disk or a killed process between open and close left a
-     * config.xml cut off mid-element. There is a backup, but nothing restores it on its own and the node
-     * does not start (EDG-882 review v02, R2-08). Same directory on purpose: ATOMIC_MOVE is only
-     * guaranteed within a file store, and the temporary file has to be one the configuration watcher will
-     * not try to parse.
-     * <p>
-     * <b>The protections are settled before a single byte is written, not after.</b> The content holds
-     * bridge passwords, keystore and truststore passwords and adapter credentials. A file created by
-     * {@code FileWriter} takes this process's umask, so on a 022 umask the first version of this change
-     * created a world-readable 0644 file, populated it with every secret in the configuration, closed it,
-     * and only then narrowed it to the mode of the file it was about to replace. Any local principal
-     * reading the directory during that window got the lot -- on every REST write to any subsystem. That
-     * window did not exist before this branch: writing in place reused config.xml's own inode and
-     * therefore its own mode, so the secrets never touched a wider file. It is a disclosure this change
-     * would have introduced, which is why it fails closed rather than best-effort (EDG-882 review v03,
-     * R3-07).
-     * <p>
-     * <b>One sequence, both files.</b> The rolling backup goes through this too. It is a copy of the same
-     * document, made by the same write, and it used to be produced by a plain file copy that carried the
-     * mode and left the group to the process -- so a 0640 config.xml owned by one group was backed up
-     * into a 0640 file readable by another (EDG-882 review v04). Two paths that must not differ are one
-     * path.
-     */
-    @VisibleForTesting
-    static void replaceCarryingProtections(
-            final @NotNull Path target,
-            final @NotNull PreservedAttributes preserved,
-            final @NotNull ContentWriter content)
-            throws IOException {
-        replaceCarryingProtections(target, preserved, content, () -> {});
-    }
-
-    /** Work that must happen once the replacement is complete and proven, and just before it lands. */
-    @FunctionalInterface
-    @VisibleForTesting
-    interface BeforeMove {
-
-        void run() throws IOException;
-    }
-
-    static void replaceCarryingProtections(
-            final @NotNull Path target,
-            final @NotNull PreservedAttributes preserved,
-            final @NotNull ContentWriter content,
-            final @NotNull BeforeMove beforeMove)
-            throws IOException {
-        final Path partial = target.resolveSibling(target.getFileName() + ".partial");
-        try {
-            createPartialFile(partial, preserved);
-            content.writeTo(partial);
-            // Widened to the target's protections only once the content is on disk, so the file is never
-            // wider than its eventual self while it is being filled. Never wider than the target either:
-            // a protection this node cannot set -- the owner, or a group it is not in -- narrows the
-            // replacement instead of widening it, and anything else aborts, because moving a file whose
-            // protections could not be reproduced would open a deliberately restricted config.xml while
-            // the original on disk is still valid and still correct.
-            applyPreservedAttributes(partial, preserved);
-            beforeMove.run();
-            try {
-                Files.move(partial, target, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
-            } catch (final AtomicMoveNotSupportedException atomicNotSupported) {
-                // Some network and container file systems cannot do it. A non-atomic replace is still
-                // better than truncating the original and writing into it, because the content being moved
-                // is already complete on disk.
-                log.debug("Atomic replace of {} is not supported here, falling back", target);
-                Files.move(partial, target, StandardCopyOption.REPLACE_EXISTING);
-            }
-        } finally {
-            // The outcome of the replace is what the caller must see. A failure to remove the working file
-            // -- normally already moved away -- must neither turn a successful write into a reported
-            // failure nor hide the real cause of a failed one (EDG-949).
-            try {
-                Files.deleteIfExists(partial);
-            } catch (final IOException cleanup) {
-                log.warn("Could not remove the working file {} left beside the configuration", partial, cleanup);
-            }
-        }
-    }
-
-    /**
-     * Copies the configuration file to its rolling backup, under the protections of the file it copies.
-     * <p>
-     * <b>The source's protections, not the destination's.</b> The backup holds the source's content, so it
-     * is the source that decides who may read it; the file being overwritten is a previous backup whose
-     * protections are of no interest, and on the first rotation there is no destination at all -- which is
-     * how the plain copy this replaces ended up handing the backup to the process's own group.
-     *
-     * @throws IOException when the backup cannot be given the protections of the file it copies, which
-     *         aborts the write that asked for it: a backup of a configuration file is a second copy of
-     *         every credential in it.
-     */
-    private static void copyCarryingProtections(final @NotNull Path source, final @NotNull Path configured)
-            throws IOException {
-        final Path destination = Files.exists(configured) ? configured.toRealPath() : configured;
-        if (Files.exists(destination) && Files.isSameFile(source, destination)) {
-            // The rotation picked the configuration file itself, which would copy it onto itself through a
-            // temporary file. The copy this replaces refused that outright and so does this.
-            throw new IOException("The rolling backup of " + source + " resolves to the configuration file"
-                    + " itself, so taking it would overwrite the configuration being backed up");
-        }
-        final PreservedAttributes preserved = preservedAttributesOf(source);
-        replaceCarryingProtections(destination, preserved, partial -> {
-            try (final InputStream in = Files.newInputStream(source);
-                    final OutputStream out = Files.newOutputStream(
-                            partial, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING)) {
-                in.transferTo(out);
-            }
-            // Carried because the rotation picks the backup to overwrite by modification time.
-            Files.setLastModifiedTime(partial, Files.getLastModifiedTime(source));
-        });
-    }
-
-    /**
-     * Owner read/write and nothing else: what the replacement is created as, before it is written.
-     * <p>
-     * Unmodifiable because it is shared static state handed to callers that have no reason to expect a
-     * mutable set — an {@code EnumSet} on its own would let one of them widen it for the whole process.
-     */
-    private static final @NotNull Set<PosixFilePermission> OWNER_ONLY =
-            Collections.unmodifiableSet(EnumSet.of(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE));
-
-    /**
-     * Everything a mode can grant to the file's group: what comes off it when the replacement could not be
-     * given the group of the file it replaces, so that the mode never grants to this node's own group what
-     * it was meant to grant to that one.
-     */
-    private static final @NotNull Set<PosixFilePermission> GROUP_PERMISSIONS = Collections.unmodifiableSet(EnumSet.of(
-            PosixFilePermission.GROUP_READ, PosixFilePermission.GROUP_WRITE, PosixFilePermission.GROUP_EXECUTE));
-
-    /**
-     * Everything about the file being replaced that decides who can read it.
-     * <p>
-     * The mode alone is not that. {@code 0640} names a group without naming <em>which</em> group, and a
-     * freshly created file takes its group from the creating process or, on macOS and on any directory
-     * with the setgid bit, from the directory — so reproducing only the mode can hand group-read of a
-     * file full of credentials to a completely different set of principals than the file it replaced had
-     * (EDG-882 review v03, R3-09). Owner, group and any ACL are therefore carried with it.
-     *
-     * @param permissions the POSIX mode, or {@code null} on a store with no POSIX view
-     * @param owner       the owning principal, or {@code null} when the store exposes none
-     * @param group       the owning group, or {@code null} on a store with no POSIX view
-     * @param acl         the access-control list -- empty when the file has one that grants nobody
-     *                    anything, which is a protection in its own right -- or {@code null} on a store
-     *                    that has no ACL view
-     */
-    @VisibleForTesting
-    record PreservedAttributes(
-            @Nullable Set<PosixFilePermission> permissions,
-            @Nullable UserPrincipal owner,
-            @Nullable GroupPrincipal group,
-            @Nullable List<AclEntry> acl) {
-
-        /** Nothing to reproduce: the configuration file is being created for the first time. */
-        static final @NotNull PreservedAttributes NONE = new PreservedAttributes(null, null, null, null);
-
-        boolean nothingToReproduce() {
-            return permissions == null && owner == null && group == null && acl == null;
-        }
-
-        /** The same protections, minus a claim to have reproduced the owner. */
-        @NotNull
-        PreservedAttributes withoutOwner() {
-            return new PreservedAttributes(permissions, null, group, acl);
-        }
-
-        /**
-         * The same protections, minus a claim to have reproduced the group <em>and</em> minus everything
-         * the mode would have granted through it.
-         * <p>
-         * The two are one protection. {@code 0640} says "the group may read" without saying which group,
-         * so dropping the group while keeping the mode is precisely R3-09: group-read of a file full of
-         * credentials, granted to whichever group this node happens to belong to instead of the one the
-         * operator chose. Dropping both leaves the replacement granting the group nothing, which is
-         * narrower than the file it replaces rather than wider.
-         * <p>
-         * Only the group's own bits come off. The owner's are this node's either way, and what the mode
-         * grants to others is granted to the same others on the file being replaced, so removing those
-         * would take away access the operator deliberately gave.
-         */
-        @NotNull
-        PreservedAttributes withoutGroupAccess() {
-            if (permissions == null) {
-                return new PreservedAttributes(null, owner, null, acl);
-            }
-            // Built empty and added to, rather than EnumSet.copyOf, which throws on an empty collection
-            // that is not itself an EnumSet -- and the mode of a file nobody may read is exactly that.
-            final EnumSet<PosixFilePermission> withoutTheGroups = EnumSet.noneOf(PosixFilePermission.class);
-            withoutTheGroups.addAll(permissions);
-            withoutTheGroups.removeAll(GROUP_PERMISSIONS);
-            return new PreservedAttributes(Collections.unmodifiableSet(withoutTheGroups), owner, null, acl);
-        }
-    }
-
-    /** Whether a mode grants the file's group anything at all. */
-    private static boolean grantsAnythingToGroup(final @Nullable Set<PosixFilePermission> permissions) {
-        return permissions != null && !Collections.disjoint(permissions, GROUP_PERMISSIONS);
-    }
-
-    /**
-     * Reads the protections of the file about to be replaced, or {@link PreservedAttributes#NONE} when
-     * there are none to reproduce.
-     * <p>
-     * <b>"Nothing to preserve" and "could not find out" are different answers and only the first one is
-     * safe.</b> The previous version returned "nothing" for both, so an {@code IOException} or a
-     * {@code SecurityException} on a file that exists and is protected ended with the replacement taking
-     * the process umask — the write proceeded and the protection was silently dropped (R3-09). Only a
-     * genuinely absent file, or a store that positively does not support a view, is "nothing"; a failure
-     * to read one that should be there aborts the write before the partial file is even created.
-     *
-     * @throws IOException when the file exists but its protections cannot be determined
-     */
-    @VisibleForTesting
-    static @NotNull PreservedAttributes preservedAttributesOf(final @NotNull Path path) throws IOException {
-        Set<PosixFilePermission> permissions = null;
-        UserPrincipal owner = null;
-        GroupPrincipal group = null;
-        List<AclEntry> acl = null;
-
-        final PosixFileAttributeView posixView = Files.getFileAttributeView(path, PosixFileAttributeView.class);
-        if (posixView != null) {
-            try {
-                final PosixFileAttributes attributes = posixView.readAttributes();
-                permissions = attributes.permissions();
-                owner = attributes.owner();
-                group = attributes.group();
-            } catch (final NoSuchFileException absent) {
-                return PreservedAttributes.NONE;
-            } catch (final IOException | SecurityException e) {
-                throw new IOException(
-                        "Could not read the permissions of the configuration file being replaced, so a"
-                                + " replacement carrying the same protections cannot be produced; the existing"
-                                + " file has been left untouched",
-                        e);
-            }
-        }
-
-        final AclFileAttributeView aclView = Files.getFileAttributeView(path, AclFileAttributeView.class);
-        if (aclView != null) {
-            try {
-                // An empty list is a value, not an absence. An access-control list that grants nobody
-                // anything is exactly what is on a file only its owner may read, and the previous version
-                // discarded it as "nothing to carry" -- which left the replacement with whatever the
-                // containing directory's inheritance produced, on the one file where that matters most
-                // (EDG-882 review v04). Reproducing it costs nothing on stores that answer empty for every
-                // file, because applyPreservedAttributes only calls setAcl when the replacement's own list
-                // differs.
-                acl = List.copyOf(aclView.getAcl());
-            } catch (final NoSuchFileException absent) {
-                return PreservedAttributes.NONE;
-            } catch (final IOException | SecurityException e) {
-                throw new IOException(
-                        "Could not read the access-control list of the configuration file being replaced, so a"
-                                + " replacement carrying the same protections cannot be produced; the existing"
-                                + " file has been left untouched",
-                        e);
-            }
-        }
-
-        // Through the owner view rather than the POSIX one, because a store can have an owner without
-        // having a mode: on an ACL-only store the owner was previously read only as a side effect of the
-        // ACL block, and never restored at all (EDG-882 review v04).
-        final FileOwnerAttributeView ownerView = Files.getFileAttributeView(path, FileOwnerAttributeView.class);
-        if (owner == null && ownerView != null) {
-            try {
-                owner = ownerView.getOwner();
-            } catch (final NoSuchFileException absent) {
-                return PreservedAttributes.NONE;
-            } catch (final IOException | SecurityException e) {
-                throw new IOException(
-                        "Could not read the owner of the configuration file being replaced, so a replacement"
-                                + " carrying the same protections cannot be produced; the existing file has been"
-                                + " left untouched",
-                        e);
-            }
-        }
-
-        if (posixView == null && aclView == null && ownerView == null) {
-            // A store that exposes neither view has no protections a replacement could get wrong.
-            if (!Files.exists(path)) {
-                return PreservedAttributes.NONE;
-            }
-            log.debug("{} is on a file store with no POSIX, ACL or owner view; nothing to reproduce", path);
-            return PreservedAttributes.NONE;
-        }
-        return new PreservedAttributes(permissions, owner, group, acl);
-    }
-
-    /**
-     * Creates the file the configuration is rendered into, narrow from the moment it exists.
-     * <p>
-     * When there is anything to reproduce, the file is created owner-read/write and widened to the
-     * target's protections after it has been written — the permissions are an attribute of the
-     * {@code createFile} call rather than a {@code chmod} after the fact, so there is no instant at which
-     * the file exists and is readable by anyone else. With nothing to reproduce, it is created normally
-     * and takes the umask, which is what a first-time configuration file would have had anyway.
-     * <p>
-     * On a store with no mode at all — Windows and any other ACL-only file system — there is no such
-     * attribute to create it with, and the previous version simply created the file with whatever the
-     * containing directory's inheritance grants and wrote every credential in the configuration into it
-     * (EDG-882 review v04). It is instead narrowed to its own owner, in a file that is still empty,
-     * before any caller can write a byte of the configuration into it; the narrowing is proved before
-     * this returns, so a store that accepts the call and does something else does not get the secrets
-     * either.
-     * <p>
-     * That narrowing is not the target's own list: an access-control list naming a principal this
-     * process is not would either lock the writer out of the file it just created, or — where the target
-     * is readable by others — leave the replacement open to them for the whole write, which is the defect
-     * itself. The window that remains holds an empty file.
-     * <p>
-     * A partial file left behind by a killed process is deleted rather than reused: reopening it would
-     * inherit whatever mode <em>it</em> was left with.
-     */
-    @VisibleForTesting
-    static void createPartialFile(final @NotNull Path partial, final @NotNull PreservedAttributes preserved)
-            throws IOException {
-        Files.deleteIfExists(partial);
-        if (preserved.permissions() != null) {
-            Files.createFile(partial, PosixFilePermissions.asFileAttribute(OWNER_ONLY));
-        } else {
-            // Nothing to reproduce, or a store that has no mode. The file takes the store's own default,
-            // exactly as a first-time configuration file would -- and is narrowed below when the store
-            // expresses protection as a list instead.
-            Files.createFile(partial);
-        }
-        if (preserved.acl() != null) {
-            narrowToItsOwner(partial, preserved.acl());
-        }
-    }
-
-    /**
-     * Replaces the inherited access-control list of the just-created, still-empty replacement with one
-     * that grants its own owner everything and everyone else nothing, and refuses to go on unless the
-     * result is narrow enough to write the configuration into.
-     * <p>
-     * <b>Narrow enough, not identical.</b> The first version demanded that the list read back be equal to
-     * the list set, which is a claim about how a file store represents an access-control list rather than
-     * about who can read the file. A store that reorders entries without changing what they decide,
-     * normalises a permission mask, or hands back an inherited entry alongside the one just written would
-     * have failed that comparison and refused every configuration write — on the only kind of store this
-     * code path exists for, and in a way nothing off that platform can reproduce (EDG-882 review v04).
-     * {@link AclComparison} answers what the lists grant instead, over every token that could be presented
-     * to them, so a store may return the narrowing in whatever shape it likes and is held only to what it
-     * decided.
-     * <p>
-     * <b>Two acceptable outcomes, in order of preference.</b> Owner-only, when the store took the list it
-     * was given; otherwise no wider than the file about to be replaced, which the replacement is entitled
-     * to be because that is exactly what it is about to become. The second is not a weakening: a Windows
-     * directory that propagates entries to what is created inside it — {@code ProgramData} and most
-     * installation trees do — hands every new file an inherited list, and {@code setAcl} cannot mark a
-     * DACL protected through this API, so demanding owner-only would refuse every configuration write on
-     * an ordinary node. That is review v04's finding 2.1 in the other direction, and it is a fault, not a
-     * safeguard.
-     */
-    private static void narrowToItsOwner(final @NotNull Path partial, final @NotNull List<AclEntry> targetAcl)
-            throws IOException {
-        final AclFileAttributeView view = Files.getFileAttributeView(partial, AclFileAttributeView.class);
-        if (view == null) {
-            throw new IOException("The replacement for the configuration file cannot be given an access-control"
-                    + " list on this file store, so it cannot be written without disclosing the configuration;"
-                    + " the existing file has been left untouched");
-        }
-        final List<AclEntry> ownerOnly = List.of(AclEntry.newBuilder()
-                .setType(AclEntryType.ALLOW)
-                .setPrincipal(view.getOwner())
-                .setPermissions(EnumSet.allOf(AclEntryPermission.class))
-                .build());
-        try {
-            view.setAcl(ownerOnly);
-        } catch (final UnsupportedOperationException | SecurityException | IOException e) {
-            throw new IOException(
-                    "The replacement for the configuration file could not be restricted to its owner before"
-                            + " being written; the existing file has been left untouched",
-                    e);
-        }
-        final List<AclEntry> actual = view.getAcl();
-        if (AclComparison.grantsNoMoreThan(actual, ownerOnly)) {
-            return;
-        }
-        if (AclComparison.grantsNoMoreThan(actual, targetAcl)) {
-            // Not owner-only, but no wider than the file it is about to replace -- which is the property
-            // that matters: the replacement is never readable by anyone the configuration it replaces is
-            // not, at any point while it holds the configuration. Worth saying out loud, because it means
-            // the store did not do what it was asked.
-            log.warn(
-                    "The replacement for the configuration file could not be restricted to its owner: {} keeps"
-                            + " an access-control list this node did not set. It is no wider than the"
-                            + " configuration file being replaced, so the configuration is written into it"
-                            + " anyway.",
-                    partial);
-            return;
-        }
-        throw new IOException("The replacement for the configuration file is readable by principals the"
-                + " configuration file being replaced is not, so the configuration cannot be written into it;"
-                + " the existing file has been left untouched");
-    }
-
-    /**
-     * Gives the written replacement exactly the protections of the file it is about to replace, and
-     * proves it before the move.
-     * <p>
-     * Order matters: owner and group are set while the file is still owner-only, then the ACL, then the
-     * mode last. Setting the mode first would open a window in which the file is already group- or
-     * world-readable but still owned by the wrong principals.
-     * <p>
-     * <b>What is guaranteed is that the replacement is never more accessible than the file it replaces —
-     * not that every protection is reproduced exactly.</b> Both extremes are defects and both have been
-     * shipped here. Carrying what you can and moving it either way is R3-07 and R3-09 between them: a
-     * failure left a file full of credentials with the umask's mode and the creating process's group,
-     * permanently, announced at debug level. Refusing the replacement outright is the other, and it is not
-     * free — it is the <em>write</em> that is refused, so the configuration the operator just asked for is
-     * not persisted, and the node goes on running correctly until a restart brings back the older file
-     * without it. Where a protection cannot be reproduced, this narrows instead: the replacement is given
-     * less than the file it replaces rather than more, and the write goes on.
-     * <p>
-     * Two protections are not this node's to set, and each narrows in its own way.
-     * <ul>
-     * <li><b>The owner.</b> Changing it is privileged everywhere this runs, so refusing on it meant a
-     * configuration installed by one account and served by another could never be written at all
-     * (EDG-882 review v04). It falls back to this node's own account, which discloses nothing: the account
-     * that just rendered the document already holds every credential in it.</li>
-     * <li><b>The group.</b> Setting it requires membership of it, so the ordinary container case — a
-     * {@code config.xml} installed under one group, Edge running under another — failed here and stopped
-     * the node persisting anything at all, found in QA on this branch. Keeping the mode while the group
-     * falls back to this process's own is exactly R3-09's disclosure, so the group's permissions come off
-     * the mode with it: the replacement grants the group nothing rather than granting it to the wrong
-     * principals. Nobody gains, someone may lose, and that is said out loud.</li>
-     * </ul>
-     * <p>
-     * The mode and the access-control list keep refusing. Neither can fail the way those two do — both are
-     * set on a file this process created and owns, which is all either call asks for — so a failure there
-     * is the store saying something is wrong, not a privilege this node was never going to have.
-     * <p>
-     * What is applied is taken from what has been proved rather than from what was asked for, so a
-     * protection that could not be reproduced cannot be granted back through another one. A file this node
-     * may not write in the first place never gets here: {@code writeConfigToXML} turns that away before
-     * anything is written.
-     */
-    @VisibleForTesting
-    static void applyPreservedAttributes(final @NotNull Path partial, final @NotNull PreservedAttributes preserved)
-            throws IOException {
-        if (preserved.nothingToReproduce()) {
-            return;
-        }
-        // What the verification below is entitled to insist on, and what the mode at the end is taken
-        // from: everything, less whatever turned out not to be this node's to set.
-        PreservedAttributes proven = preserved;
-        try {
-            // Owner through the owner view, not the POSIX one: an ACL-only store has an owner and no
-            // mode, and reading it through the POSIX view meant it was never restored there at all
-            // (EDG-882 review v04).
-            //
-            // Only when they differ, here and below. Changing owner is a privileged operation on every
-            // platform this runs on, and changing group requires membership; asking for a change that is
-            // already true would fail for no reason on the ordinary path, where the node replaces a file
-            // it owns.
-            if (preserved.owner() != null) {
-                final FileOwnerAttributeView partialOwner =
-                        Files.getFileAttributeView(partial, FileOwnerAttributeView.class);
-                if (partialOwner == null) {
-                    throw new IOException("The replacement cannot carry an owner on this file store");
-                }
-                if (!preserved.owner().equals(partialOwner.getOwner())) {
-                    try {
-                        partialOwner.setOwner(preserved.owner());
-                    } catch (final UnsupportedOperationException | SecurityException | IOException notPermitted) {
-                        // The one protection that is not the node's to reproduce. Changing a file's owner
-                        // is privileged on every platform this runs on, so a configuration installed by
-                        // one account and served by another -- root-owned config.xml, service user running
-                        // Edge -- made every write fail, and the node silently stopped persisting anything
-                        // (EDG-882 review v04). The mode, the group and any access-control list are still
-                        // reproduced exactly or the write is refused, and those are what decide who else
-                        // can read the file; the owner it falls back to is the account that just rendered
-                        // the configuration and therefore already holds every credential in it.
-                        log.warn(
-                                "The replacement for {} could not be given the owner of the file it replaces"
-                                        + " ('{}'), so it is owned by this node's own account instead. Its mode,"
-                                        + " group and access-control list are unchanged, so no one else gains"
-                                        + " access -- but if the owner matters here, set it back and check what"
-                                        + " installed the file.",
-                                partial,
-                                preserved.owner().getName(),
-                                notPermitted);
-                        proven = proven.withoutOwner();
-                    }
-                }
-            }
-            if (preserved.group() != null) {
-                final PosixFileAttributeView partialPosix =
-                        Files.getFileAttributeView(partial, PosixFileAttributeView.class);
-                if (partialPosix == null) {
-                    throw new IOException("The replacement cannot carry a group on this file store");
-                }
-                if (!preserved.group().equals(partialPosix.readAttributes().group())) {
-                    try {
-                        partialPosix.setGroup(preserved.group());
-                    } catch (final UnsupportedOperationException | SecurityException | IOException notPermitted) {
-                        // Setting a file's group requires membership of it, so the ordinary container case
-                        // -- config.xml installed under one group, Edge running under another -- refused
-                        // the whole write here. The node then went on running correctly while persisting
-                        // nothing at all, and every REST change since the last restart was lost on the
-                        // next one (found in QA on this branch).
-                        //
-                        // Dropping the group takes the mode's group permissions with it. Keeping them
-                        // would grant group-read of every credential in the configuration to whichever
-                        // group this node belongs to, which is R3-09 in the one place it still could
-                        // happen. The verification below is told not to insist on either.
-                        proven = proven.withoutGroupAccess();
-                        if (grantsAnythingToGroup(preserved.permissions())) {
-                            log.warn(
-                                    "The replacement for {} could not be given the group of the file it replaces"
-                                            + " ('{}'), so the permissions that mode grants to the group have been"
-                                            + " removed from it rather than handed to this node's own group. The"
-                                            + " configuration is still written and nobody gains access, but"
-                                            + " principals that could read it through that group no longer can."
-                                            + " Add this node's account to that group, or give the file a group it"
-                                            + " is already in, to keep it readable.",
-                                    partial,
-                                    preserved.group().getName(),
-                                    notPermitted);
-                        } else {
-                            // The mode grants the group nothing, so which group it names decides nobody's
-                            // access and dropping it costs nothing. Not worth a warning on every write.
-                            log.debug(
-                                    "The replacement for {} could not be given the group of the file it replaces"
-                                            + " ('{}'). That file's mode grants its group nothing, so no principal"
-                                            + " gains or loses access.",
-                                    partial,
-                                    preserved.group().getName(),
-                                    notPermitted);
-                        }
-                    }
-                }
-            }
-            if (preserved.acl() != null) {
-                final AclFileAttributeView partialAcl = Files.getFileAttributeView(partial, AclFileAttributeView.class);
-                if (partialAcl == null) {
-                    throw new IOException("The replacement cannot carry an access-control list on this file store");
-                }
-                if (!preserved.acl().equals(partialAcl.getAcl())) {
-                    partialAcl.setAcl(preserved.acl());
-                }
-            }
-            // From what was proved, not from what was asked for: if the group could not be reproduced, the
-            // permissions it would have had are no longer in here to grant.
-            if (proven.permissions() != null) {
-                Files.setPosixFilePermissions(partial, proven.permissions());
-            }
-        } catch (final UnsupportedOperationException | SecurityException | IOException e) {
-            throw new IOException(
-                    "Could not reproduce the protections of the configuration file being replaced; "
-                            + "the existing file has been left untouched",
-                    e);
-        }
-        verifyPreservedAttributes(partial, proven);
-    }
-
-    /**
-     * Re-reads what was just applied and refuses the replacement if any of it did not take.
-     * <p>
-     * Every setter above can succeed on a store that then quietly reports something else back —
-     * a mapped volume that ignores ownership, a mode masked by a mount option. The whole point of this
-     * code is that the replacement is no more readable than the file it replaces, and that is a claim
-     * worth checking rather than assuming, because the cost of it being wrong is every credential in the
-     * configuration.
-     */
-    @VisibleForTesting
-    static void verifyPreservedAttributes(final @NotNull Path partial, final @NotNull PreservedAttributes preserved)
-            throws IOException {
-        // Every attribute that was carried, whichever view expresses it. The previous version read the
-        // POSIX view and returned when there was none, so on an ACL-only store it verified nothing at all
-        // (EDG-882 review v04). The access-control list is checked here rather than where it is applied
-        // because the mode is set after it: on a store that has both, a chmod can rewrite the mask of the
-        // list that was just applied, and the file's protection is whatever survives that.
-        final PosixFileAttributeView posixView = Files.getFileAttributeView(partial, PosixFileAttributeView.class);
-        if (posixView != null) {
-            final PosixFileAttributes actual = posixView.readAttributes();
-            if (preserved.permissions() != null && !preserved.permissions().equals(actual.permissions())) {
-                throw new IOException("The replacement's permissions are "
-                        + PosixFilePermissions.toString(actual.permissions())
-                        + " but the configuration file being replaced has "
-                        + PosixFilePermissions.toString(preserved.permissions())
-                        + "; the existing file has been left untouched");
-            }
-            if (preserved.group() != null && !preserved.group().equals(actual.group())) {
-                throw new IOException(
-                        "The replacement's group is '" + actual.group().getName() + "' but the"
-                                + " configuration file being replaced has group '"
-                                + preserved.group().getName()
-                                + "'; the existing file has been left untouched");
-            }
-        }
-        if (preserved.owner() != null) {
-            final FileOwnerAttributeView ownerView = Files.getFileAttributeView(partial, FileOwnerAttributeView.class);
-            final UserPrincipal actualOwner = ownerView == null ? null : ownerView.getOwner();
-            if (!preserved.owner().equals(actualOwner)) {
-                throw new IOException(
-                        "The replacement is owned by '" + (actualOwner == null ? "nobody" : actualOwner.getName())
-                                + "' but the configuration file being replaced is owned by '"
-                                + preserved.owner().getName()
-                                + "'; the existing file has been left untouched");
-            }
-        }
-        if (preserved.acl() != null) {
-            final AclFileAttributeView aclView = Files.getFileAttributeView(partial, AclFileAttributeView.class);
-            final List<AclEntry> actualAcl = aclView == null ? null : aclView.getAcl();
-            if (actualAcl == null || !AclComparison.grantsNoMoreThan(actualAcl, preserved.acl())) {
-                throw new IOException("The replacement's access-control list grants access the configuration file being"
-                        + " replaced does not: it is " + actualAcl + " where that file has "
-                        + preserved.acl() + "; the existing file has been left untouched");
-            }
-            if (!AclComparison.grantsNoMoreThan(preserved.acl(), actualAcl)) {
-                // Narrower than the file it replaces. Nobody gains anything, so this is not the disclosure
-                // the check is here for -- but someone who could read the configuration no longer can, and
-                // that is not something to find out later.
-                log.warn(
-                        "The replacement for the configuration file has a narrower access-control list than the"
-                                + " file it replaces: {} where that file has {}. Nobody gains access, but"
-                                + " principals that could read the configuration may no longer be able to.",
-                        actualAcl,
-                        preserved.acl());
-            }
         }
     }
 
@@ -1236,9 +522,7 @@ public class ConfigFileReaderWriter {
                 // the set used to grow on every reload and never shrink, so a fragment taken out of the
                 // configuration and deleted from disk was still watched, and the watcher died trying to
                 // read it (EDG-949).
-                final Map<Path, Long> fragments = fragment.getFragmentToModificationTime();
-                fragmentToModificationTime.keySet().retainAll(fragments.keySet());
-                fragmentToModificationTime.putAll(fragments);
+                watcher.watchFragments(fragment.getFragmentToModificationTime());
                 return internalApplyConfig(entity) ? ReloadOutcome.APPLIED : ReloadOutcome.NEEDS_RESTART;
             }
         } catch (final JAXBException | IOException e) {
@@ -1255,8 +539,18 @@ public class ConfigFileReaderWriter {
             log.error("Not able to parse configuration file because {}", sb);
             reportValuesThatAreNotText(beforeRendering);
             return ReloadOutcome.REJECTED_INVALID;
+        } catch (final UnrecoverableException notRenderable) {
+            // An environment variable that is not set, or a fragment that cannot be loaded. The renderer
+            // has already logged which; what is added here is that the file is rejected rather than the
+            // node exited -- on a reload the node keeps its configuration, at startup applyConfig still
+            // refuses to start (EDG-949 review).
+            log.error(
+                    "The configuration file {} could not be rendered, see the error above: a placeholder or"
+                            + " fragment in it cannot be resolved",
+                    configFile.getAbsolutePath());
+            return ReloadOutcome.REJECTED_INVALID;
         } catch (final Exception e) {
-            if (e.getCause() instanceof UnrecoverableException unrecoverableException) {
+            if (e.getCause() instanceof final UnrecoverableException unrecoverableException) {
                 if (unrecoverableException.isShowException()) {
                     log.error("An unrecoverable Exception occurred. Exiting HiveMQ", e);
                     log.debug("Original error message:", e);
@@ -1371,180 +665,5 @@ public class ConfigFileReaderWriter {
             log.error("An error occurred while applying the configuration.", t);
             return false;
         }
-    }
-
-    private void backupConfig(final @NotNull File configFile, final boolean enabled) throws IOException {
-        if (!enabled) {
-            return;
-        }
-        final String fileNameNoExt = getFileNameExcludingExtension(configFile.getName());
-        final String fileExt = getFileExtension(configFile.getName());
-        final File copyPath = new File(getFilePathExcludingFile(configFile.getAbsolutePath()));
-        if (copyPath.exists() && copyPath.isDirectory()) {
-            int idx = 1;
-            File copyFile;
-            do {
-                final String copyFilename = fileNameNoExt + '_' + idx++ + (fileExt != null ? "." + fileExt : "");
-                copyFile = new File(copyPath, copyFilename);
-            } while (idx <= MAX_BACK_FILES && copyFile.exists());
-
-            if (copyFile.exists()) {
-                // -- every slot is taken: overwrite the oldest of the backups this node wrote. Only those:
-                // the previous prefix-and-suffix match took any "config*xml" in the directory, so an
-                // operator's own archived copy was the oldest match and was silently replaced by a routine
-                // backup, and the live configuration file matched too (EDG-949).
-                final Pattern ownBackup = Pattern.compile(Pattern.quote(fileNameNoExt)
-                        + "_\\d+"
-                        + (fileExt != null ? "\\." + Pattern.quote(fileExt) : ""));
-                final File[] backupFiles = copyPath.listFiles(child ->
-                        child.isFile() && ownBackup.matcher(child.getName()).matches());
-                assert backupFiles != null;
-                Arrays.sort(backupFiles, Comparator.comparingLong(File::lastModified));
-                copyFile = backupFiles[0];
-            }
-            if (log.isDebugEnabled()) {
-                log.debug("Rolling backup of configuration file to {}", copyFile.getName());
-            }
-            copyCarryingProtections(configFile.toPath(), copyFile.toPath());
-        } else {
-            log.error("Configuration folder {} does not exist or is not a directory", copyPath.getAbsolutePath());
-            throw new UnrecoverableException(false);
-        }
-    }
-
-    private void startWatching(
-            final @NotNull File configFile,
-            final long interval,
-            final @NotNull Supplier<HiveMQConfigEntity> entitySupplier,
-            final @NotNull ScheduledTask scheduledTask) {
-        if (executorService.compareAndSet(
-                null,
-                Executors.newSingleThreadScheduledExecutor(ThreadFactoryUtil.create("hivemq-edge-config-watch-%d")))) {
-
-            final HiveMQConfigEntity entity = entitySupplier.get();
-            final Map<Path, Long> fileModificationTimestamps = findFilesToWatch(entity);
-            final AtomicLong fileModified = new AtomicLong();
-            try {
-                fileModified.set(Files.getLastModifiedTime(configFile.toPath()).toMillis());
-            } catch (final IOException e) {
-                throw new RuntimeException("Unable to read last modified time from " + configFile.getAbsolutePath(), e);
-            }
-
-            log.info("Rereading config file every {} ms", interval);
-            // executorService was just set via compareAndSet, so it cannot be null here
-            final ScheduledExecutorService scheduler = Objects.requireNonNull(executorService.get());
-            scheduler.scheduleAtFixedRate(
-                    () -> {
-                        // A scheduled task that throws is never run again, silently: the watcher was lost
-                        // to the first unreadable or unparseable file and nothing said so (EDG-949).
-                        // Whatever escapes the check is logged and the next tick runs.
-                        try {
-                            scheduledTask.executePeriodicTask(configFile, fileModified, fileModificationTimestamps);
-                        } catch (final Throwable t) {
-                            log.error(
-                                    "The configuration watcher failed to check {}; it will try again in {} ms",
-                                    configFile,
-                                    interval,
-                                    t);
-                        }
-                    },
-                    0,
-                    interval,
-                    TimeUnit.MILLISECONDS);
-            Runtime.getRuntime().addShutdownHook(new Thread(this::stopWatching));
-        } else {
-            throw new IllegalStateException("Config watch was already started");
-        }
-    }
-
-    @VisibleForTesting
-    void stopWatching() {
-        final ScheduledExecutorService es = executorService.getAndSet(null);
-        if (es != null) {
-            es.shutdownNow();
-        }
-    }
-
-    private void checkMonitoredFilesForChanges(
-            final @NotNull File configFile,
-            final @NotNull AtomicLong fileModified,
-            final @NotNull Map<Path, Long> fileModificationTimestamps)
-            throws IOException {
-        final boolean isDevMode = "true".equals(System.getProperty(HiveMQEdgeConstants.DEVELOPMENT_MODE));
-        if (!isDevMode) {
-            final Map<Path, Long> pathsToCheck = new HashMap<>(fragmentToModificationTime);
-            pathsToCheck.putAll(fileModificationTimestamps);
-            for (final Map.Entry<Path, Long> watched : pathsToCheck.entrySet()) {
-                final Path key = watched.getKey();
-                if (key.toString().equals(CONFIG_FRAGMENT_PATH)) {
-                    continue;
-                }
-                final long lastModified;
-                try {
-                    lastModified = Files.getFileAttributeView(
-                                    key.toRealPath(LinkOption.NOFOLLOW_LINKS), BasicFileAttributeView.class)
-                            .readAttributes()
-                            .lastModifiedTime()
-                            .toMillis();
-                } catch (final NoSuchFileException gone) {
-                    // A fragment or keystore that was removed. It is dropped from the watch rather than
-                    // ending it: the configuration that referenced it will be re-read when it changes, and
-                    // a file the node no longer has is not a reason to stop noticing the ones it does.
-                    log.warn("The watched file {} no longer exists; it is no longer watched", key);
-                    fragmentToModificationTime.remove(key);
-                    continue;
-                } catch (final IOException unreadable) {
-                    // Momentary: a network file system, or a tool rewriting the file. Next tick.
-                    log.warn("Could not read the modification time of the watched file {}", key, unreadable);
-                    continue;
-                }
-                if (lastModified > watched.getValue()) {
-                    log.error("Restarting because a required file was updated: {}", key);
-                    restartHook.run();
-                    return;
-                }
-            }
-        }
-
-        final long modified;
-        if (new File(CONFIG_FRAGMENT_PATH).exists()) {
-            modified = Files.getLastModifiedTime(new File(CONFIG_FRAGMENT_PATH).toPath())
-                    .toMillis();
-        } else {
-            log.warn("No fragment found, checking the full config, only used for testing");
-            modified = Files.getLastModifiedTime(configFile.toPath()).toMillis();
-        }
-        if (modified > fileModified.get()) {
-            // Recorded before the load: a file that is rejected is not re-parsed on every tick, and the
-            // operator's correction moves the time again.
-            fileModified.set(modified);
-            switch (loadConfigFromXML(configFile)) {
-                case APPLIED -> {}
-                case REJECTED_INVALID ->
-                    // Deliberately not a restart: a node restarted onto a file that cannot be parsed does
-                    // not come back. The node keeps the configuration it has, says so, and the watcher
-                    // stays alive to pick up the correction -- which is what used to be lost (EDG-949).
-                    log.error("Configuration reload rejected because the new configuration is invalid;"
-                            + " keeping the previously applied configuration."
-                            + " Fix the reported errors above and save the file again.");
-                case NEEDS_RESTART -> {
-                    if (!isDevMode) {
-                        log.error("Restarting because new config can't be hot-reloaded");
-                        restartHook.run();
-                    } else {
-                        log.error("TEST MODE, NOT RESTARTING");
-                    }
-                }
-            }
-        }
-    }
-
-    @FunctionalInterface
-    private interface ScheduledTask {
-        void executePeriodicTask(
-                final @NotNull File configFile,
-                final @NotNull AtomicLong fileModified,
-                final @NotNull Map<Path, Long> fileModificationTimestamps)
-                throws IOException;
     }
 }

--- a/hivemq-edge/src/main/java/com/hivemq/configuration/reader/ConfigFileReaderWriter.java
+++ b/hivemq-edge/src/main/java/com/hivemq/configuration/reader/ConfigFileReaderWriter.java
@@ -295,8 +295,12 @@ public class ConfigFileReaderWriter {
         watcher.setRestartHook(restartHook);
     }
 
-    @VisibleForTesting
-    void stopWatching() {
+    /**
+     * Ends the watch started by {@link #applyConfigAndWatch(long)}. Called when the node shuts down: the
+     * watcher's own JVM shutdown hook does not run for an embedded node, whose JVM outlives it, and a watch
+     * left ticking on a stopped node reloads into a broker that no longer exists (EDG-949 CI follow-up).
+     */
+    public void stopWatching() {
         watcher.stop();
     }
 

--- a/hivemq-edge/src/main/java/com/hivemq/configuration/reader/ConfigFileReaderWriter.java
+++ b/hivemq-edge/src/main/java/com/hivemq/configuration/reader/ConfigFileReaderWriter.java
@@ -101,6 +101,7 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
+import java.util.regex.Pattern;
 import javax.xml.XMLConstants;
 import javax.xml.transform.stream.StreamSource;
 import javax.xml.validation.Schema;
@@ -194,6 +195,12 @@ public class ConfigFileReaderWriter {
     private final @NotNull Lock lock;
     private final @NotNull AtomicReference<ScheduledExecutorService> executorService;
     private boolean defaultBackupConfig;
+
+    /**
+     * What the configuration watcher does when the node has to restart to apply a change. The process
+     * exit in production; replaced in tests so the decision can be observed instead of ending the JVM.
+     */
+    private volatile @NotNull Runnable restartHook = () -> System.exit(0);
 
     public ConfigFileReaderWriter(
             final @NotNull SystemInformation sysInfo,
@@ -340,9 +347,26 @@ public class ConfigFileReaderWriter {
         this.defaultBackupConfig = defaultBackupConfig;
     }
 
+    @VisibleForTesting
+    void setRestartHook(final @NotNull Runnable restartHook) {
+        this.restartHook = restartHook;
+    }
+
+    /** The configuration this node currently runs on; null before the first successful load. */
+    @VisibleForTesting
+    @Nullable
+    HiveMQConfigEntity getConfigEntity() {
+        return configEntity.get();
+    }
+
     public @NotNull HiveMQConfigEntity applyConfig() {
-        if (!loadConfigFromXML(getConfigFileOrFail())) {
-            log.error("Unable to apply the given configuration.");
+        final ReloadOutcome outcome = loadConfigFromXML(getConfigFileOrFail());
+        if (outcome != ReloadOutcome.APPLIED) {
+            // A REJECTED_INVALID load has already logged the validation errors inside loadConfigFromXML;
+            // a second, generic line here would bury them. Only NEEDS_RESTART has nothing more specific.
+            if (outcome == ReloadOutcome.NEEDS_RESTART) {
+                log.error("Unable to apply the given configuration.");
+            }
             throw new UnrecoverableException(false);
         }
         final HiveMQConfigEntity entity = configEntity.get();
@@ -376,6 +400,11 @@ public class ConfigFileReaderWriter {
             if (entity.getGatewayConfig().isMutableConfigurationEnabled()) {
                 writeConfigToXML();
             }
+            // Stamped only once everything above has succeeded. It is what the configuration service
+            // reports as the last update time, and a refused write used to move it as well -- so the node
+            // reported the configuration as freshly written at the moment its own log said config.xml no
+            // longer matched it (EDG-949).
+            lastWrite.set(System.currentTimeMillis());
         } catch (final UnrecoverableException refused) {
             // A deliberate refusal: something on the write path would have had to put a credential on disk,
             // or replace a good configuration file with one whose protections it could not reproduce, and
@@ -393,8 +422,6 @@ public class ConfigFileReaderWriter {
                     + " configuration, and the change that triggered this write would be lost.");
         } catch (final Exception e) {
             log.error("Configuration file sync failed: ", e);
-        } finally {
-            lastWrite.set(System.currentTimeMillis());
         }
     }
 
@@ -477,13 +504,23 @@ public class ConfigFileReaderWriter {
                         target);
                 throw new UnrecoverableException(false);
             }
-            backupConfig(file, doBackup); // write the backup of the file before rewriting
-            replaceCarryingProtections(target, preservedAttributesOf(target), partial -> {
-                try (final FileWriter writer = new FileWriter(partial.toFile(), StandardCharsets.UTF_8)) {
-                    writer.write(rendered.toString());
-                    writer.flush();
-                }
-            });
+            // Read before anything is created or rotated: it is a pure read, and it is the most likely of
+            // the refusals below. The backup itself is taken inside the replace, once the replacement is
+            // complete on disk and carries its protections, and just before the move -- so a write that is
+            // refused at any point consumes no backup slot. Rotating first meant that on a node where every
+            // write is refused, four refusals turned every backup into a copy of the same unchanged file
+            // and the earlier history was gone, on exactly the node where an operator wants it (EDG-949).
+            final PreservedAttributes preserved = preservedAttributesOf(target);
+            replaceCarryingProtections(
+                    target,
+                    preserved,
+                    partial -> {
+                        try (final FileWriter writer = new FileWriter(partial.toFile(), StandardCharsets.UTF_8)) {
+                            writer.write(rendered.toString());
+                            writer.flush();
+                        }
+                    },
+                    () -> backupConfig(file, doBackup));
         } catch (final IOException e) {
             log.error("Error writing file:", e);
             throw new UnrecoverableException(false);
@@ -535,6 +572,23 @@ public class ConfigFileReaderWriter {
             final @NotNull PreservedAttributes preserved,
             final @NotNull ContentWriter content)
             throws IOException {
+        replaceCarryingProtections(target, preserved, content, () -> {});
+    }
+
+    /** Work that must happen once the replacement is complete and proven, and just before it lands. */
+    @FunctionalInterface
+    @VisibleForTesting
+    interface BeforeMove {
+
+        void run() throws IOException;
+    }
+
+    static void replaceCarryingProtections(
+            final @NotNull Path target,
+            final @NotNull PreservedAttributes preserved,
+            final @NotNull ContentWriter content,
+            final @NotNull BeforeMove beforeMove)
+            throws IOException {
         final Path partial = target.resolveSibling(target.getFileName() + ".partial");
         try {
             createPartialFile(partial, preserved);
@@ -546,6 +600,7 @@ public class ConfigFileReaderWriter {
             // protections could not be reproduced would open a deliberately restricted config.xml while
             // the original on disk is still valid and still correct.
             applyPreservedAttributes(partial, preserved);
+            beforeMove.run();
             try {
                 Files.move(partial, target, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
             } catch (final AtomicMoveNotSupportedException atomicNotSupported) {
@@ -556,7 +611,14 @@ public class ConfigFileReaderWriter {
                 Files.move(partial, target, StandardCopyOption.REPLACE_EXISTING);
             }
         } finally {
-            Files.deleteIfExists(partial);
+            // The outcome of the replace is what the caller must see. A failure to remove the working file
+            // -- normally already moved away -- must neither turn a successful write into a reported
+            // failure nor hide the real cause of a failed one (EDG-949).
+            try {
+                Files.deleteIfExists(partial);
+            } catch (final IOException cleanup) {
+                log.warn("Could not remove the working file {} left beside the configuration", partial, cleanup);
+            }
         }
     }
 
@@ -1112,8 +1174,20 @@ public class ConfigFileReaderWriter {
         });
     }
 
+    /**
+     * Outcome of a configuration (re)load. {@link #REJECTED_INVALID} is a file that could not be read,
+     * parsed or validated -- recoverable on a reload, by keeping the configuration already applied --
+     * as opposed to {@link #NEEDS_RESTART}, a file that parsed and applied but cannot take effect
+     * without a restart.
+     */
+    public enum ReloadOutcome {
+        APPLIED,
+        NEEDS_RESTART,
+        REJECTED_INVALID
+    }
+
     @VisibleForTesting
-    boolean loadConfigFromXML(final @NotNull File configFile) {
+    ReloadOutcome loadConfigFromXML(final @NotNull File configFile) {
         log.info("Reading configuration file {}", configFile);
         final List<ValidationEvent> validationErrors = Collections.synchronizedList(new ArrayList<>());
 
@@ -1138,8 +1212,6 @@ public class ConfigFileReaderWriter {
             beforeRendering = content;
             content = EnvVarUtil.replaceEnvironmentVariablePlaceholders(content);
 
-            fragmentToModificationTime.putAll(fragment.getFragmentToModificationTime());
-
             try (final ByteArrayInputStream is = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8))) {
                 final JAXBElement<? extends HiveMQConfigEntity> unmarshalled =
                         createUnmarshaller(validationErrors).unmarshal(new StreamSource(is), HiveMQConfigEntity.class);
@@ -1160,7 +1232,14 @@ public class ConfigFileReaderWriter {
                 // Only now: this configuration is the one that will be written back out, so these are
                 // the placeholders that describe it.
                 envPlaceholders.set(placeholders);
-                return internalApplyConfig(entity);
+                // And only now the fragments it pulls in are the ones to watch. Replaced, not added to:
+                // the set used to grow on every reload and never shrink, so a fragment taken out of the
+                // configuration and deleted from disk was still watched, and the watcher died trying to
+                // read it (EDG-949).
+                final Map<Path, Long> fragments = fragment.getFragmentToModificationTime();
+                fragmentToModificationTime.keySet().retainAll(fragments.keySet());
+                fragmentToModificationTime.putAll(fragments);
+                return internalApplyConfig(entity) ? ReloadOutcome.APPLIED : ReloadOutcome.NEEDS_RESTART;
             }
         } catch (final JAXBException | IOException e) {
             final StringBuilder sb = new StringBuilder();
@@ -1175,7 +1254,7 @@ public class ConfigFileReaderWriter {
             }
             log.error("Not able to parse configuration file because {}", sb);
             reportValuesThatAreNotText(beforeRendering);
-            throw new UnrecoverableException(false);
+            return ReloadOutcome.REJECTED_INVALID;
         } catch (final Exception e) {
             if (e.getCause() instanceof UnrecoverableException unrecoverableException) {
                 if (unrecoverableException.isShowException()) {
@@ -1307,13 +1386,18 @@ public class ConfigFileReaderWriter {
             do {
                 final String copyFilename = fileNameNoExt + '_' + idx++ + (fileExt != null ? "." + fileExt : "");
                 copyFile = new File(copyPath, copyFilename);
-            } while (idx < MAX_BACK_FILES && copyFile.exists());
+            } while (idx <= MAX_BACK_FILES && copyFile.exists());
 
             if (copyFile.exists()) {
-                // -- use the oldest available backup index
-                final File[] backupFiles = copyPath.listFiles(child -> child.isFile()
-                        && child.getName().startsWith(fileNameNoExt)
-                        && (fileExt == null || child.getName().endsWith(fileExt)));
+                // -- every slot is taken: overwrite the oldest of the backups this node wrote. Only those:
+                // the previous prefix-and-suffix match took any "config*xml" in the directory, so an
+                // operator's own archived copy was the oldest match and was silently replaced by a routine
+                // backup, and the live configuration file matched too (EDG-949).
+                final Pattern ownBackup = Pattern.compile(Pattern.quote(fileNameNoExt)
+                        + "_\\d+"
+                        + (fileExt != null ? "\\." + Pattern.quote(fileExt) : ""));
+                final File[] backupFiles = copyPath.listFiles(child ->
+                        child.isFile() && ownBackup.matcher(child.getName()).matches());
                 assert backupFiles != null;
                 Arrays.sort(backupFiles, Comparator.comparingLong(File::lastModified));
                 copyFile = backupFiles[0];
@@ -1350,7 +1434,20 @@ public class ConfigFileReaderWriter {
             // executorService was just set via compareAndSet, so it cannot be null here
             final ScheduledExecutorService scheduler = Objects.requireNonNull(executorService.get());
             scheduler.scheduleAtFixedRate(
-                    () -> scheduledTask.executePeriodicTask(configFile, fileModified, fileModificationTimestamps),
+                    () -> {
+                        // A scheduled task that throws is never run again, silently: the watcher was lost
+                        // to the first unreadable or unparseable file and nothing said so (EDG-949).
+                        // Whatever escapes the check is logged and the next tick runs.
+                        try {
+                            scheduledTask.executePeriodicTask(configFile, fileModified, fileModificationTimestamps);
+                        } catch (final Throwable t) {
+                            log.error(
+                                    "The configuration watcher failed to check {}; it will try again in {} ms",
+                                    configFile,
+                                    interval,
+                                    t);
+                        }
+                    },
                     0,
                     interval,
                     TimeUnit.MILLISECONDS);
@@ -1360,7 +1457,8 @@ public class ConfigFileReaderWriter {
         }
     }
 
-    private void stopWatching() {
+    @VisibleForTesting
+    void stopWatching() {
         final ScheduledExecutorService es = executorService.getAndSet(null);
         if (es != null) {
             es.shutdownNow();
@@ -1370,52 +1468,74 @@ public class ConfigFileReaderWriter {
     private void checkMonitoredFilesForChanges(
             final @NotNull File configFile,
             final @NotNull AtomicLong fileModified,
-            final @NotNull Map<Path, Long> fileModificationTimestamps) {
-        try {
-            final boolean isDevMode = "true".equals(System.getProperty(HiveMQEdgeConstants.DEVELOPMENT_MODE));
-            if (!isDevMode) {
-                final Map<Path, Long> pathsToCheck = new HashMap<>(fragmentToModificationTime);
-                pathsToCheck.putAll(fileModificationTimestamps);
-                pathsToCheck.forEach((key, value) -> {
-                    try {
-                        if (!key.toString().equals(CONFIG_FRAGMENT_PATH)
-                                && Files.getFileAttributeView(
-                                                        key.toRealPath(LinkOption.NOFOLLOW_LINKS),
-                                                        BasicFileAttributeView.class)
-                                                .readAttributes()
-                                                .lastModifiedTime()
-                                                .toMillis()
-                                        > value) {
-                            log.error("Restarting because a required file was updated: {}", key);
-                            System.exit(0);
-                        }
-                    } catch (final IOException e) {
-                        throw new RuntimeException("Unable to read last modified time for " + key, e);
-                    }
-                });
+            final @NotNull Map<Path, Long> fileModificationTimestamps)
+            throws IOException {
+        final boolean isDevMode = "true".equals(System.getProperty(HiveMQEdgeConstants.DEVELOPMENT_MODE));
+        if (!isDevMode) {
+            final Map<Path, Long> pathsToCheck = new HashMap<>(fragmentToModificationTime);
+            pathsToCheck.putAll(fileModificationTimestamps);
+            for (final Map.Entry<Path, Long> watched : pathsToCheck.entrySet()) {
+                final Path key = watched.getKey();
+                if (key.toString().equals(CONFIG_FRAGMENT_PATH)) {
+                    continue;
+                }
+                final long lastModified;
+                try {
+                    lastModified = Files.getFileAttributeView(
+                                    key.toRealPath(LinkOption.NOFOLLOW_LINKS), BasicFileAttributeView.class)
+                            .readAttributes()
+                            .lastModifiedTime()
+                            .toMillis();
+                } catch (final NoSuchFileException gone) {
+                    // A fragment or keystore that was removed. It is dropped from the watch rather than
+                    // ending it: the configuration that referenced it will be re-read when it changes, and
+                    // a file the node no longer has is not a reason to stop noticing the ones it does.
+                    log.warn("The watched file {} no longer exists; it is no longer watched", key);
+                    fragmentToModificationTime.remove(key);
+                    continue;
+                } catch (final IOException unreadable) {
+                    // Momentary: a network file system, or a tool rewriting the file. Next tick.
+                    log.warn("Could not read the modification time of the watched file {}", key, unreadable);
+                    continue;
+                }
+                if (lastModified > watched.getValue()) {
+                    log.error("Restarting because a required file was updated: {}", key);
+                    restartHook.run();
+                    return;
+                }
             }
+        }
 
-            final long modified;
-            if (new File(CONFIG_FRAGMENT_PATH).exists()) {
-                modified = Files.getLastModifiedTime(new File(CONFIG_FRAGMENT_PATH).toPath())
-                        .toMillis();
-            } else {
-                log.warn("No fragment found, checking the full config, only used for testing");
-                modified = Files.getLastModifiedTime(configFile.toPath()).toMillis();
-            }
-            if (modified > fileModified.get()) {
-                fileModified.set(modified);
-                if (!loadConfigFromXML(configFile)) {
+        final long modified;
+        if (new File(CONFIG_FRAGMENT_PATH).exists()) {
+            modified = Files.getLastModifiedTime(new File(CONFIG_FRAGMENT_PATH).toPath())
+                    .toMillis();
+        } else {
+            log.warn("No fragment found, checking the full config, only used for testing");
+            modified = Files.getLastModifiedTime(configFile.toPath()).toMillis();
+        }
+        if (modified > fileModified.get()) {
+            // Recorded before the load: a file that is rejected is not re-parsed on every tick, and the
+            // operator's correction moves the time again.
+            fileModified.set(modified);
+            switch (loadConfigFromXML(configFile)) {
+                case APPLIED -> {}
+                case REJECTED_INVALID ->
+                    // Deliberately not a restart: a node restarted onto a file that cannot be parsed does
+                    // not come back. The node keeps the configuration it has, says so, and the watcher
+                    // stays alive to pick up the correction -- which is what used to be lost (EDG-949).
+                    log.error("Configuration reload rejected because the new configuration is invalid;"
+                            + " keeping the previously applied configuration."
+                            + " Fix the reported errors above and save the file again.");
+                case NEEDS_RESTART -> {
                     if (!isDevMode) {
                         log.error("Restarting because new config can't be hot-reloaded");
-                        System.exit(0);
+                        restartHook.run();
                     } else {
                         log.error("TEST MODE, NOT RESTARTING");
                     }
                 }
             }
-        } catch (final IOException e) {
-            throw new RuntimeException(e);
         }
     }
 
@@ -1424,6 +1544,7 @@ public class ConfigFileReaderWriter {
         void executePeriodicTask(
                 final @NotNull File configFile,
                 final @NotNull AtomicLong fileModified,
-                final @NotNull Map<Path, Long> fileModificationTimestamps);
+                final @NotNull Map<Path, Long> fileModificationTimestamps)
+                throws IOException;
     }
 }

--- a/hivemq-edge/src/main/java/com/hivemq/configuration/reader/ConfigFileWatcher.java
+++ b/hivemq-edge/src/main/java/com/hivemq/configuration/reader/ConfigFileWatcher.java
@@ -1,0 +1,341 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.configuration.reader;
+
+import com.hivemq.configuration.entity.HiveMQConfigEntity;
+import com.hivemq.configuration.entity.api.ApiTlsEntity;
+import com.hivemq.configuration.entity.bridge.BridgeTlsEntity;
+import com.hivemq.configuration.entity.listener.tls.KeystoreEntity;
+import com.hivemq.configuration.entity.listener.tls.TruststoreEntity;
+import com.hivemq.edge.HiveMQEdgeConstants;
+import com.hivemq.util.ThreadFactoryUtil;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.attribute.BasicFileAttributeView;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.Lock;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.VisibleForTesting;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Watches the configuration file for changes and reloads it through {@link ConfigFileReaderWriter}: a
+ * scheduled check of the modification times of the file (or the mounted fragment in a container), of
+ * the fragments it pulls in and of the keystores it names, the reload under the configuration lock, and
+ * the restart decision when a change cannot be applied live (EDG-949).
+ * <p>
+ * Owns everything the check needs and nothing else: the scheduler, the last-known times, the set of
+ * watched fragments -- replaced by the reader on every accepted load -- and the stamp the reader leaves
+ * after a write of its own, so the node's own REST write is not re-read as an operator change.
+ */
+final class ConfigFileWatcher {
+
+    private static final @NotNull Logger log = LoggerFactory.getLogger(ConfigFileWatcher.class);
+
+    static final @NotNull String CONFIG_FRAGMENT_PATH = "/fragment/config";
+
+    private final @NotNull Lock lock;
+    private final @NotNull ConfigurationFile configFile;
+    private final @NotNull Function<File, ConfigFileReaderWriter.ReloadOutcome> reload;
+    private final @NotNull ConcurrentMap<Path, Long> fragmentToModificationTime;
+    private final @NotNull AtomicReference<ScheduledExecutorService> executorService;
+    /**
+     * What the configuration watcher does when the node has to restart to apply a change. The process
+     * exit in production; replaced in tests so the decision can be observed instead of ending the JVM.
+     */
+    private volatile @NotNull Runnable restartHook = () -> System.exit(0);
+    /**
+     * The modification time of the configuration file as the watcher last knew it. Set by the watcher
+     * when it starts and on every reload, and by {@link #writtenByThisNode(Path, long)} after
+     * a write of this node's own -- so the watcher does not re-read, re-parse and re-apply a file it has
+     * just written itself after every REST change (EDG-949 review). Only consulted when no
+     * {@code /fragment/config} exists; in a container the watcher compares the fragment instead.
+     */
+    private final @NotNull AtomicLong watchedConfigModified = new AtomicLong();
+
+    /**
+     * @param lock       the configuration-transition lock; the check and the reload run under it
+     * @param configFile the configured configuration file, to tell the node's own write from any other
+     * @param reload     loads and applies the file, answering how it went
+     */
+    ConfigFileWatcher(
+            final @NotNull Lock lock,
+            final @NotNull ConfigurationFile configFile,
+            final @NotNull Function<File, ConfigFileReaderWriter.ReloadOutcome> reload) {
+        this.lock = lock;
+        this.configFile = configFile;
+        this.reload = reload;
+        this.fragmentToModificationTime = new ConcurrentHashMap<>();
+        this.executorService = new AtomicReference<>();
+    }
+
+    @VisibleForTesting
+    void setRestartHook(final @NotNull Runnable restartHook) {
+        this.restartHook = restartHook;
+    }
+
+    /**
+     * The fragments the configuration now pulls in, replacing the previous set: a fragment taken out of
+     * the configuration and deleted from disk must not stay watched (EDG-949).
+     */
+    void watchFragments(final @NotNull Map<Path, Long> fragments) {
+        fragmentToModificationTime.keySet().retainAll(fragments.keySet());
+        fragmentToModificationTime.putAll(fragments);
+    }
+
+    /**
+     * Records the time a write of this node's own carries onto the configuration file, so the next check
+     * does not read it as a change -- only where the check compares that file, see
+     * {@link #comparesThisFile(Path)}.
+     *
+     * @param target       the file that was replaced
+     * @param modifiedTime the modification time the replacement carries, read before it was moved
+     */
+    void writtenByThisNode(final @NotNull Path target, final long modifiedTime) {
+        if (modifiedTime >= 0 && comparesThisFile(target)) {
+            watchedConfigModified.set(modifiedTime);
+        }
+    }
+
+    /**
+     * Whether the watcher decides "changed" by this file's own modification time. It does so only for the
+     * configured configuration file, and only where no {@code /fragment/config} exists: in a container
+     * the watcher compares the fragment, which this node never writes, so a stamp taken from
+     * config.xml would be a foreign value in that comparison and every REST write would read as a
+     * change (EDG-949 review).
+     */
+    private boolean comparesThisFile(final @NotNull Path written) {
+        if (new File(CONFIG_FRAGMENT_PATH).exists()) {
+            return false;
+        }
+        return configFile
+                .file()
+                .map(configured -> {
+                    try {
+                        return Files.isSameFile(configured.toPath(), written);
+                    } catch (final IOException e) {
+                        return false;
+                    }
+                })
+                .orElse(false);
+    }
+
+    private static @NotNull Map<Path, Long> findFilesToWatch(final @NotNull HiveMQConfigEntity entity) {
+        final Map<Path, Long> paths = new ConcurrentHashMap<>();
+        entity.getBridgeConfig().forEach(cfg -> {
+            final BridgeTlsEntity tls = cfg.getRemoteBroker().getTls();
+            if (tls != null) {
+                final KeystoreEntity keyStore = tls.getKeyStore();
+                if (keyStore != null) {
+                    final Path path = Paths.get(keyStore.getPath());
+                    try {
+                        paths.put(path, Files.getLastModifiedTime(path).toMillis());
+                    } catch (final IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+                final TruststoreEntity trustStore = tls.getTrustStore();
+                if (trustStore != null) {
+                    final Path path = Paths.get(trustStore.getPath());
+                    try {
+                        paths.put(path, Files.getLastModifiedTime(path).toMillis());
+                    } catch (final IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+            }
+        });
+        final ApiTlsEntity tls = entity.getApiConfig().getTls();
+        if (tls != null && tls.getKeystoreEntity() != null) {
+            final Path path = Paths.get(tls.getKeystoreEntity().getPath());
+            try {
+                paths.put(path, Files.getLastModifiedTime(path).toMillis());
+            } catch (final IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return paths;
+    }
+
+    void start(
+            final @NotNull File configFile,
+            final long interval,
+            final @NotNull Supplier<HiveMQConfigEntity> entitySupplier) {
+        if (executorService.compareAndSet(
+                null,
+                Executors.newSingleThreadScheduledExecutor(ThreadFactoryUtil.create("hivemq-edge-config-watch-%d")))) {
+
+            final HiveMQConfigEntity entity = entitySupplier.get();
+            final Map<Path, Long> fileModificationTimestamps = findFilesToWatch(entity);
+            final AtomicLong fileModified = watchedConfigModified;
+            try {
+                fileModified.set(watchedTimestamp(configFile));
+            } catch (final IOException e) {
+                throw new RuntimeException("Unable to read last modified time from " + configFile.getAbsolutePath(), e);
+            }
+
+            log.info("Rereading config file every {} ms", interval);
+            // executorService was just set via compareAndSet, so it cannot be null here
+            final ScheduledExecutorService scheduler = Objects.requireNonNull(executorService.get());
+            scheduler.scheduleAtFixedRate(
+                    () -> {
+                        // A scheduled task that throws is never run again, silently: the watcher was lost
+                        // to the first unreadable or unparseable file and nothing said so (EDG-949).
+                        // Whatever escapes the check is logged and the next tick runs.
+                        try {
+                            checkMonitoredFilesForChanges(configFile, fileModified, fileModificationTimestamps);
+                        } catch (final Throwable t) {
+                            log.error(
+                                    "The configuration watcher failed to check {}; it will try again in {} ms",
+                                    configFile,
+                                    interval,
+                                    t);
+                        }
+                    },
+                    0,
+                    interval,
+                    TimeUnit.MILLISECONDS);
+            Runtime.getRuntime().addShutdownHook(new Thread(this::stop));
+        } else {
+            throw new IllegalStateException("Config watch was already started");
+        }
+    }
+
+    @VisibleForTesting
+    void stop() {
+        final ScheduledExecutorService es = executorService.getAndSet(null);
+        if (es != null) {
+            es.shutdownNow();
+        }
+    }
+
+    private void checkMonitoredFilesForChanges(
+            final @NotNull File configFile,
+            final @NotNull AtomicLong fileModified,
+            final @NotNull Map<Path, Long> fileModificationTimestamps)
+            throws IOException {
+        final boolean isDevMode = "true".equals(System.getProperty(HiveMQEdgeConstants.DEVELOPMENT_MODE));
+        if (!isDevMode) {
+            final Map<Path, Long> pathsToCheck = new HashMap<>(fragmentToModificationTime);
+            pathsToCheck.putAll(fileModificationTimestamps);
+            for (final Map.Entry<Path, Long> watched : pathsToCheck.entrySet()) {
+                final Path key = watched.getKey();
+                if (key.toString().equals(CONFIG_FRAGMENT_PATH)) {
+                    continue;
+                }
+                final long lastModified;
+                try {
+                    lastModified = Files.getFileAttributeView(
+                                    key.toRealPath(LinkOption.NOFOLLOW_LINKS), BasicFileAttributeView.class)
+                            .readAttributes()
+                            .lastModifiedTime()
+                            .toMillis();
+                } catch (final NoSuchFileException gone) {
+                    // A fragment or keystore that was removed. It is dropped from the watch rather than
+                    // ending it: the configuration that referenced it will be re-read when it changes, and
+                    // a file the node no longer has is not a reason to stop noticing the ones it does.
+                    log.warn("The watched file {} no longer exists; it is no longer watched", key);
+                    fragmentToModificationTime.remove(key);
+                    fileModificationTimestamps.remove(key);
+                    continue;
+                } catch (final IOException unreadable) {
+                    // Momentary: a network file system, or a tool rewriting the file. Next tick.
+                    log.warn("Could not read the modification time of the watched file {}", key, unreadable);
+                    continue;
+                }
+                if (lastModified != watched.getValue()) {
+                    log.error("Restarting because a required file was updated: {}", key);
+                    restartHook.run();
+                    return;
+                }
+            }
+        }
+
+        // Under the configuration lock, which the write path holds from the move to the stamp: read
+        // outside it, a tick could observe the moved file before the stamp and reload this node's own
+        // write. The compare-and-set covers the same race for a stamp that lands between the two reads.
+        lock.lock();
+        try {
+            final long known = fileModified.get();
+            final long modified = watchedTimestamp(configFile);
+            // Any change, not only a later time: a configuration restored from a backup -- cp -p,
+            // rsync -a, a volume remount -- carries an older time than the broken file it replaces, and a
+            // high-water mark would ignore the correction for good (EDG-949 review).
+            if (modified == known) {
+                return;
+            }
+            // Recorded before the load: a file that is rejected is not re-parsed on every tick, and the
+            // operator's correction moves the time again. Compare-and-set, not set: if this node's own
+            // write stamped the field since `known` was read, the time read above is that write's or
+            // older, and the next tick compares against the stamp. Setting it back would make the next
+            // tick reload the node's own write.
+            if (!fileModified.compareAndSet(known, modified)) {
+                return;
+            }
+            switch (reload.apply(configFile)) {
+                case APPLIED -> {}
+                case REJECTED_INVALID ->
+                    // Deliberately not a restart: a node restarted onto a file that cannot be parsed does
+                    // not come back. The node keeps the configuration it has, says so, and the watcher
+                    // stays alive to pick up the correction -- which is what used to be lost (EDG-949).
+                    log.error("Configuration reload rejected because the new configuration is invalid;"
+                            + " keeping the previously applied configuration."
+                            + " Fix the reported errors above and save the file again.");
+                case NEEDS_RESTART -> {
+                    if (!isDevMode) {
+                        log.error("Restarting because new config can't be hot-reloaded");
+                        restartHook.run();
+                    } else {
+                        log.error("TEST MODE, NOT RESTARTING");
+                    }
+                }
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * The time the watcher compares: the fragment's where a container mounts one, the configuration
+     * file's own otherwise. One source for the seed and for every tick, so the first tick after start
+     * does not read as a change.
+     */
+    private static long watchedTimestamp(final @NotNull File configFile) throws IOException {
+        final File fragment = new File(CONFIG_FRAGMENT_PATH);
+        if (fragment.exists()) {
+            return Files.getLastModifiedTime(fragment.toPath()).toMillis();
+        }
+        log.warn("No fragment found, checking the full config, only used for testing");
+        return Files.getLastModifiedTime(configFile.toPath()).toMillis();
+    }
+}

--- a/hivemq-edge/src/main/java/com/hivemq/configuration/reader/ConfigFileWatcher.java
+++ b/hivemq-edge/src/main/java/com/hivemq/configuration/reader/ConfigFileWatcher.java
@@ -61,6 +61,7 @@ import org.slf4j.LoggerFactory;
 final class ConfigFileWatcher {
 
     private static final @NotNull Logger log = LoggerFactory.getLogger(ConfigFileWatcher.class);
+    private static final long STOP_TIMEOUT_SECONDS = 5;
 
     static final @NotNull String CONFIG_FRAGMENT_PATH = "/fragment/config";
 
@@ -73,7 +74,11 @@ final class ConfigFileWatcher {
      * What the configuration watcher does when the node has to restart to apply a change. The process
      * exit in production; replaced in tests so the decision can be observed instead of ending the JVM.
      */
-    private volatile @NotNull Runnable restartHook = () -> System.exit(0);
+    // On its own thread: exiting from the tick would leave the tick blocked in Runtime.exit while the JVM
+    // runs the shutdown hooks -- one of which is stop(), waiting for the tick to finish -- and with the
+    // configuration lock held for the whole shutdown.
+    private volatile @NotNull Runnable restartHook =
+            () -> new Thread(() -> System.exit(0), "hivemq-edge-config-restart").start();
     /**
      * The modification time of the configuration file as the watcher last knew it. Set by the watcher
      * when it starts and on every reload, and by {@link #writtenByThisNode(Path, long)} after
@@ -231,11 +236,23 @@ final class ConfigFileWatcher {
         }
     }
 
-    @VisibleForTesting
+    /**
+     * Ends the watch and waits, bounded, for a tick in flight: a caller that removes the configuration
+     * folder right after stopping -- an embedded node's teardown -- must not race the last check.
+     */
     void stop() {
         final ScheduledExecutorService es = executorService.getAndSet(null);
         if (es != null) {
             es.shutdownNow();
+            try {
+                if (!es.awaitTermination(STOP_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                    log.debug(
+                            "The configuration watcher did not finish its last check within {} s",
+                            STOP_TIMEOUT_SECONDS);
+                }
+            } catch (final InterruptedException interrupted) {
+                Thread.currentThread().interrupt();
+            }
         }
     }
 
@@ -287,7 +304,19 @@ final class ConfigFileWatcher {
         lock.lock();
         try {
             final long known = fileModified.get();
-            final long modified = watchedTimestamp(configFile);
+            final long modified;
+            try {
+                modified = watchedTimestamp(configFile);
+            } catch (final NoSuchFileException gone) {
+                // The configuration file itself is missing: an operator replacing it by remove-and-copy, or
+                // a test deleting the folder of a node it stopped. Nothing to compare against, so the applied
+                // configuration stays and the file is checked again next tick; it reappears with a time of
+                // its own, which the comparison below picks up.
+                log.warn(
+                        "The configuration file {} does not exist; keeping the applied configuration until it reappears",
+                        configFile);
+                return;
+            }
             // Any change, not only a later time: a configuration restored from a backup -- cp -p,
             // rsync -a, a volume remount -- carries an older time than the broken file it replaces, and a
             // high-water mark would ignore the correction for good (EDG-949 review).

--- a/hivemq-edge/src/main/java/com/hivemq/configuration/reader/ProtectedFileReplacer.java
+++ b/hivemq-edge/src/main/java/com/hivemq/configuration/reader/ProtectedFileReplacer.java
@@ -1,0 +1,700 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.configuration.reader;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.AclEntry;
+import java.nio.file.attribute.AclEntryPermission;
+import java.nio.file.attribute.AclEntryType;
+import java.nio.file.attribute.AclFileAttributeView;
+import java.nio.file.attribute.FileOwnerAttributeView;
+import java.nio.file.attribute.GroupPrincipal;
+import java.nio.file.attribute.PosixFileAttributeView;
+import java.nio.file.attribute.PosixFileAttributes;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.nio.file.attribute.UserPrincipal;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.VisibleForTesting;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Replaces a file on disk with content written beside it, carrying the protections of the file it
+ * replaces -- owner, group, mode and access-control list -- and never wider than those while it holds
+ * the content. Pure file-system code: it knows nothing about configuration, and everything here was the
+ * subject of EDG-882 review rounds v03 to v05.
+ * <p>
+ * Moved out of {@link ConfigFileReaderWriter} verbatim; that class is the only production caller, through
+ * {@link #replaceCarryingProtections(Path, PreservedAttributes, ContentWriter, BeforeMove)} for the
+ * configuration file and {@link #copyCarryingProtections(Path, Path)} for its rolling backup.
+ */
+final class ProtectedFileReplacer {
+
+    private static final Logger log = LoggerFactory.getLogger(ProtectedFileReplacer.class);
+
+    private ProtectedFileReplacer() {}
+
+    /** The bytes of one replacement, written into the narrow file that has just been created for them. */
+    @FunctionalInterface
+    @VisibleForTesting
+    interface ContentWriter {
+
+        void writeTo(@NotNull Path partial) throws IOException;
+    }
+
+    /**
+     * Replaces a file with content written beside it, under the protections it is given, and never wider
+     * than those while it holds the content.
+     * <p>
+     * <b>Written beside the target and moved onto it, rather than opened and written in place.</b>
+     * Rendering the document first closed the "schema validation fails half way" case; opening the real
+     * file still truncates it, so a crash, a full disk or a killed process between open and close left a
+     * config.xml cut off mid-element. There is a backup, but nothing restores it on its own and the node
+     * does not start (EDG-882 review v02, R2-08). Same directory on purpose: ATOMIC_MOVE is only
+     * guaranteed within a file store, and the temporary file has to be one the configuration watcher will
+     * not try to parse.
+     * <p>
+     * <b>The protections are settled before a single byte is written, not after.</b> The content holds
+     * bridge passwords, keystore and truststore passwords and adapter credentials. A file created by
+     * {@code FileWriter} takes this process's umask, so on a 022 umask the first version of this change
+     * created a world-readable 0644 file, populated it with every secret in the configuration, closed it,
+     * and only then narrowed it to the mode of the file it was about to replace. Any local principal
+     * reading the directory during that window got the lot -- on every REST write to any subsystem. That
+     * window did not exist before this branch: writing in place reused config.xml's own inode and
+     * therefore its own mode, so the secrets never touched a wider file. It is a disclosure this change
+     * would have introduced, which is why it fails closed rather than best-effort (EDG-882 review v03,
+     * R3-07).
+     * <p>
+     * <b>One sequence, both files.</b> The rolling backup goes through this too. It is a copy of the same
+     * document, made by the same write, and it used to be produced by a plain file copy that carried the
+     * mode and left the group to the process -- so a 0640 config.xml owned by one group was backed up
+     * into a 0640 file readable by another (EDG-882 review v04). Two paths that must not differ are one
+     * path.
+     */
+    @VisibleForTesting
+    static void replaceCarryingProtections(
+            final @NotNull Path target,
+            final @NotNull PreservedAttributes preserved,
+            final @NotNull ContentWriter content)
+            throws IOException {
+        replaceCarryingProtections(target, preserved, content, () -> {});
+    }
+
+    /** Work that must happen once the replacement is complete and proven, and just before it lands. */
+    @FunctionalInterface
+    @VisibleForTesting
+    interface BeforeMove {
+
+        void run() throws IOException;
+    }
+
+    static void replaceCarryingProtections(
+            final @NotNull Path target,
+            final @NotNull PreservedAttributes preserved,
+            final @NotNull ContentWriter content,
+            final @NotNull BeforeMove beforeMove)
+            throws IOException {
+        final Path partial = target.resolveSibling(target.getFileName() + ".partial");
+        try {
+            createPartialFile(partial, preserved);
+            content.writeTo(partial);
+            // Widened to the target's protections only once the content is on disk, so the file is never
+            // wider than its eventual self while it is being filled. Never wider than the target either:
+            // a protection this node cannot set -- the owner, or a group it is not in -- narrows the
+            // replacement instead of widening it, and anything else aborts, because moving a file whose
+            // protections could not be reproduced would open a deliberately restricted config.xml while
+            // the original on disk is still valid and still correct.
+            applyPreservedAttributes(partial, preserved);
+            beforeMove.run();
+            try {
+                Files.move(partial, target, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+            } catch (final AtomicMoveNotSupportedException atomicNotSupported) {
+                // Some network and container file systems cannot do it. A non-atomic replace is still
+                // better than truncating the original and writing into it, because the content being moved
+                // is already complete on disk.
+                log.debug("Atomic replace of {} is not supported here, falling back", target);
+                Files.move(partial, target, StandardCopyOption.REPLACE_EXISTING);
+            }
+        } finally {
+            // The outcome of the replace is what the caller must see. A failure to remove the working file
+            // -- normally already moved away -- must neither turn a successful write into a reported
+            // failure nor hide the real cause of a failed one (EDG-949).
+            try {
+                Files.deleteIfExists(partial);
+            } catch (final IOException cleanup) {
+                log.warn("Could not remove the working file {} left beside the configuration", partial, cleanup);
+            }
+        }
+    }
+
+    /**
+     * Copies the configuration file to its rolling backup, under the protections of the file it copies.
+     * <p>
+     * <b>The source's protections, not the destination's.</b> The backup holds the source's content, so it
+     * is the source that decides who may read it; the file being overwritten is a previous backup whose
+     * protections are of no interest, and on the first rotation there is no destination at all -- which is
+     * how the plain copy this replaces ended up handing the backup to the process's own group.
+     *
+     * @throws IOException when the backup cannot be given the protections of the file it copies, which
+     *         aborts the write that asked for it: a backup of a configuration file is a second copy of
+     *         every credential in it.
+     */
+    static void copyCarryingProtections(final @NotNull Path source, final @NotNull Path configured) throws IOException {
+        final Path destination = Files.exists(configured) ? configured.toRealPath() : configured;
+        if (Files.exists(destination) && Files.isSameFile(source, destination)) {
+            // The rotation picked the configuration file itself, which would copy it onto itself through a
+            // temporary file. The copy this replaces refused that outright and so does this.
+            throw new IOException("The rolling backup of " + source + " resolves to the configuration file"
+                    + " itself, so taking it would overwrite the configuration being backed up");
+        }
+        final PreservedAttributes preserved = preservedAttributesOf(source);
+        replaceCarryingProtections(destination, preserved, partial -> {
+            try (final InputStream in = Files.newInputStream(source);
+                    final OutputStream out = Files.newOutputStream(
+                            partial, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING)) {
+                in.transferTo(out);
+            }
+            // Carried because the rotation picks the backup to overwrite by modification time.
+            Files.setLastModifiedTime(partial, Files.getLastModifiedTime(source));
+        });
+    }
+
+    /**
+     * Owner read/write and nothing else: what the replacement is created as, before it is written.
+     * <p>
+     * Unmodifiable because it is shared static state handed to callers that have no reason to expect a
+     * mutable set — an {@code EnumSet} on its own would let one of them widen it for the whole process.
+     */
+    static final @NotNull Set<PosixFilePermission> OWNER_ONLY =
+            Collections.unmodifiableSet(EnumSet.of(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE));
+
+    /**
+     * Everything a mode can grant to the file's group: what comes off it when the replacement could not be
+     * given the group of the file it replaces, so that the mode never grants to this node's own group what
+     * it was meant to grant to that one.
+     */
+    private static final @NotNull Set<PosixFilePermission> GROUP_PERMISSIONS = Collections.unmodifiableSet(EnumSet.of(
+            PosixFilePermission.GROUP_READ, PosixFilePermission.GROUP_WRITE, PosixFilePermission.GROUP_EXECUTE));
+
+    /**
+     * Everything about the file being replaced that decides who can read it.
+     * <p>
+     * The mode alone is not that. {@code 0640} names a group without naming <em>which</em> group, and a
+     * freshly created file takes its group from the creating process or, on macOS and on any directory
+     * with the setgid bit, from the directory — so reproducing only the mode can hand group-read of a
+     * file full of credentials to a completely different set of principals than the file it replaced had
+     * (EDG-882 review v03, R3-09). Owner, group and any ACL are therefore carried with it.
+     *
+     * @param permissions the POSIX mode, or {@code null} on a store with no POSIX view
+     * @param owner       the owning principal, or {@code null} when the store exposes none
+     * @param group       the owning group, or {@code null} on a store with no POSIX view
+     * @param acl         the access-control list -- empty when the file has one that grants nobody
+     *                    anything, which is a protection in its own right -- or {@code null} on a store
+     *                    that has no ACL view
+     */
+    @VisibleForTesting
+    record PreservedAttributes(
+            @Nullable Set<PosixFilePermission> permissions,
+            @Nullable UserPrincipal owner,
+            @Nullable GroupPrincipal group,
+            @Nullable List<AclEntry> acl) {
+
+        /** Nothing to reproduce: the configuration file is being created for the first time. */
+        static final @NotNull PreservedAttributes NONE = new PreservedAttributes(null, null, null, null);
+
+        boolean nothingToReproduce() {
+            return permissions == null && owner == null && group == null && acl == null;
+        }
+
+        /** The same protections, minus a claim to have reproduced the owner. */
+        @NotNull
+        PreservedAttributes withoutOwner() {
+            return new PreservedAttributes(permissions, null, group, acl);
+        }
+
+        /**
+         * The same protections, minus a claim to have reproduced the group <em>and</em> minus everything
+         * the mode would have granted through it.
+         * <p>
+         * The two are one protection. {@code 0640} says "the group may read" without saying which group,
+         * so dropping the group while keeping the mode is precisely R3-09: group-read of a file full of
+         * credentials, granted to whichever group this node happens to belong to instead of the one the
+         * operator chose. Dropping both leaves the replacement granting the group nothing, which is
+         * narrower than the file it replaces rather than wider.
+         * <p>
+         * Only the group's own bits come off. The owner's are this node's either way, and what the mode
+         * grants to others is granted to the same others on the file being replaced, so removing those
+         * would take away access the operator deliberately gave.
+         */
+        @NotNull
+        PreservedAttributes withoutGroupAccess() {
+            if (permissions == null) {
+                return new PreservedAttributes(null, owner, null, acl);
+            }
+            // Built empty and added to, rather than EnumSet.copyOf, which throws on an empty collection
+            // that is not itself an EnumSet -- and the mode of a file nobody may read is exactly that.
+            final EnumSet<PosixFilePermission> withoutTheGroups = EnumSet.noneOf(PosixFilePermission.class);
+            withoutTheGroups.addAll(permissions);
+            withoutTheGroups.removeAll(GROUP_PERMISSIONS);
+            return new PreservedAttributes(Collections.unmodifiableSet(withoutTheGroups), owner, null, acl);
+        }
+    }
+
+    /** Whether a mode grants the file's group anything at all. */
+    private static boolean grantsAnythingToGroup(final @Nullable Set<PosixFilePermission> permissions) {
+        return permissions != null && !Collections.disjoint(permissions, GROUP_PERMISSIONS);
+    }
+
+    /**
+     * Reads the protections of the file about to be replaced, or {@link PreservedAttributes#NONE} when
+     * there are none to reproduce.
+     * <p>
+     * <b>"Nothing to preserve" and "could not find out" are different answers and only the first one is
+     * safe.</b> The previous version returned "nothing" for both, so an {@code IOException} or a
+     * {@code SecurityException} on a file that exists and is protected ended with the replacement taking
+     * the process umask — the write proceeded and the protection was silently dropped (R3-09). Only a
+     * genuinely absent file, or a store that positively does not support a view, is "nothing"; a failure
+     * to read one that should be there aborts the write before the partial file is even created.
+     *
+     * @throws IOException when the file exists but its protections cannot be determined
+     */
+    @VisibleForTesting
+    static @NotNull PreservedAttributes preservedAttributesOf(final @NotNull Path path) throws IOException {
+        Set<PosixFilePermission> permissions = null;
+        UserPrincipal owner = null;
+        GroupPrincipal group = null;
+        List<AclEntry> acl = null;
+
+        final PosixFileAttributeView posixView = Files.getFileAttributeView(path, PosixFileAttributeView.class);
+        if (posixView != null) {
+            try {
+                final PosixFileAttributes attributes = posixView.readAttributes();
+                permissions = attributes.permissions();
+                owner = attributes.owner();
+                group = attributes.group();
+            } catch (final NoSuchFileException absent) {
+                return PreservedAttributes.NONE;
+            } catch (final IOException | SecurityException e) {
+                throw new IOException(
+                        "Could not read the permissions of the configuration file being replaced, so a"
+                                + " replacement carrying the same protections cannot be produced; the existing"
+                                + " file has been left untouched",
+                        e);
+            }
+        }
+
+        final AclFileAttributeView aclView = Files.getFileAttributeView(path, AclFileAttributeView.class);
+        if (aclView != null) {
+            try {
+                // An empty list is a value, not an absence. An access-control list that grants nobody
+                // anything is exactly what is on a file only its owner may read, and the previous version
+                // discarded it as "nothing to carry" -- which left the replacement with whatever the
+                // containing directory's inheritance produced, on the one file where that matters most
+                // (EDG-882 review v04). Reproducing it costs nothing on stores that answer empty for every
+                // file, because applyPreservedAttributes only calls setAcl when the replacement's own list
+                // differs.
+                acl = List.copyOf(aclView.getAcl());
+            } catch (final NoSuchFileException absent) {
+                return PreservedAttributes.NONE;
+            } catch (final IOException | SecurityException e) {
+                throw new IOException(
+                        "Could not read the access-control list of the configuration file being replaced, so a"
+                                + " replacement carrying the same protections cannot be produced; the existing"
+                                + " file has been left untouched",
+                        e);
+            }
+        }
+
+        // Through the owner view rather than the POSIX one, because a store can have an owner without
+        // having a mode: on an ACL-only store the owner was previously read only as a side effect of the
+        // ACL block, and never restored at all (EDG-882 review v04).
+        final FileOwnerAttributeView ownerView = Files.getFileAttributeView(path, FileOwnerAttributeView.class);
+        if (owner == null && ownerView != null) {
+            try {
+                owner = ownerView.getOwner();
+            } catch (final NoSuchFileException absent) {
+                return PreservedAttributes.NONE;
+            } catch (final IOException | SecurityException e) {
+                throw new IOException(
+                        "Could not read the owner of the configuration file being replaced, so a replacement"
+                                + " carrying the same protections cannot be produced; the existing file has been"
+                                + " left untouched",
+                        e);
+            }
+        }
+
+        if (posixView == null && aclView == null && ownerView == null) {
+            // A store that exposes neither view has no protections a replacement could get wrong.
+            if (!Files.exists(path)) {
+                return PreservedAttributes.NONE;
+            }
+            log.debug("{} is on a file store with no POSIX, ACL or owner view; nothing to reproduce", path);
+            return PreservedAttributes.NONE;
+        }
+        return new PreservedAttributes(permissions, owner, group, acl);
+    }
+
+    /**
+     * Creates the file the configuration is rendered into, narrow from the moment it exists.
+     * <p>
+     * When there is anything to reproduce, the file is created owner-read/write and widened to the
+     * target's protections after it has been written — the permissions are an attribute of the
+     * {@code createFile} call rather than a {@code chmod} after the fact, so there is no instant at which
+     * the file exists and is readable by anyone else. With nothing to reproduce, it is created normally
+     * and takes the umask, which is what a first-time configuration file would have had anyway.
+     * <p>
+     * On a store with no mode at all — Windows and any other ACL-only file system — there is no such
+     * attribute to create it with, and the previous version simply created the file with whatever the
+     * containing directory's inheritance grants and wrote every credential in the configuration into it
+     * (EDG-882 review v04). It is instead narrowed to its own owner, in a file that is still empty,
+     * before any caller can write a byte of the configuration into it; the narrowing is proved before
+     * this returns, so a store that accepts the call and does something else does not get the secrets
+     * either.
+     * <p>
+     * That narrowing is not the target's own list: an access-control list naming a principal this
+     * process is not would either lock the writer out of the file it just created, or — where the target
+     * is readable by others — leave the replacement open to them for the whole write, which is the defect
+     * itself. The window that remains holds an empty file.
+     * <p>
+     * A partial file left behind by a killed process is deleted rather than reused: reopening it would
+     * inherit whatever mode <em>it</em> was left with.
+     */
+    @VisibleForTesting
+    static void createPartialFile(final @NotNull Path partial, final @NotNull PreservedAttributes preserved)
+            throws IOException {
+        Files.deleteIfExists(partial);
+        if (preserved.permissions() != null) {
+            Files.createFile(partial, PosixFilePermissions.asFileAttribute(OWNER_ONLY));
+        } else {
+            // Nothing to reproduce, or a store that has no mode. The file takes the store's own default,
+            // exactly as a first-time configuration file would -- and is narrowed below when the store
+            // expresses protection as a list instead.
+            Files.createFile(partial);
+        }
+        if (preserved.acl() != null) {
+            narrowToItsOwner(partial, preserved.acl());
+        }
+    }
+
+    /**
+     * Replaces the inherited access-control list of the just-created, still-empty replacement with one
+     * that grants its own owner everything and everyone else nothing, and refuses to go on unless the
+     * result is narrow enough to write the configuration into.
+     * <p>
+     * <b>Narrow enough, not identical.</b> The first version demanded that the list read back be equal to
+     * the list set, which is a claim about how a file store represents an access-control list rather than
+     * about who can read the file. A store that reorders entries without changing what they decide,
+     * normalises a permission mask, or hands back an inherited entry alongside the one just written would
+     * have failed that comparison and refused every configuration write — on the only kind of store this
+     * code path exists for, and in a way nothing off that platform can reproduce (EDG-882 review v04).
+     * {@link AclComparison} answers what the lists grant instead, over every token that could be presented
+     * to them, so a store may return the narrowing in whatever shape it likes and is held only to what it
+     * decided.
+     * <p>
+     * <b>Two acceptable outcomes, in order of preference.</b> Owner-only, when the store took the list it
+     * was given; otherwise no wider than the file about to be replaced, which the replacement is entitled
+     * to be because that is exactly what it is about to become. The second is not a weakening: a Windows
+     * directory that propagates entries to what is created inside it — {@code ProgramData} and most
+     * installation trees do — hands every new file an inherited list, and {@code setAcl} cannot mark a
+     * DACL protected through this API, so demanding owner-only would refuse every configuration write on
+     * an ordinary node. That is review v04's finding 2.1 in the other direction, and it is a fault, not a
+     * safeguard.
+     */
+    private static void narrowToItsOwner(final @NotNull Path partial, final @NotNull List<AclEntry> targetAcl)
+            throws IOException {
+        final AclFileAttributeView view = Files.getFileAttributeView(partial, AclFileAttributeView.class);
+        if (view == null) {
+            throw new IOException("The replacement for the configuration file cannot be given an access-control"
+                    + " list on this file store, so it cannot be written without disclosing the configuration;"
+                    + " the existing file has been left untouched");
+        }
+        final List<AclEntry> ownerOnly = List.of(AclEntry.newBuilder()
+                .setType(AclEntryType.ALLOW)
+                .setPrincipal(view.getOwner())
+                .setPermissions(EnumSet.allOf(AclEntryPermission.class))
+                .build());
+        try {
+            view.setAcl(ownerOnly);
+        } catch (final UnsupportedOperationException | SecurityException | IOException e) {
+            throw new IOException(
+                    "The replacement for the configuration file could not be restricted to its owner before"
+                            + " being written; the existing file has been left untouched",
+                    e);
+        }
+        final List<AclEntry> actual = view.getAcl();
+        if (AclComparison.grantsNoMoreThan(actual, ownerOnly)) {
+            return;
+        }
+        if (AclComparison.grantsNoMoreThan(actual, targetAcl)) {
+            // Not owner-only, but no wider than the file it is about to replace -- which is the property
+            // that matters: the replacement is never readable by anyone the configuration it replaces is
+            // not, at any point while it holds the configuration. Worth saying out loud, because it means
+            // the store did not do what it was asked.
+            log.warn(
+                    "The replacement for the configuration file could not be restricted to its owner: {} keeps"
+                            + " an access-control list this node did not set. It is no wider than the"
+                            + " configuration file being replaced, so the configuration is written into it"
+                            + " anyway.",
+                    partial);
+            return;
+        }
+        throw new IOException("The replacement for the configuration file is readable by principals the"
+                + " configuration file being replaced is not, so the configuration cannot be written into it;"
+                + " the existing file has been left untouched");
+    }
+
+    /**
+     * Gives the written replacement exactly the protections of the file it is about to replace, and
+     * proves it before the move.
+     * <p>
+     * Order matters: owner and group are set while the file is still owner-only, then the ACL, then the
+     * mode last. Setting the mode first would open a window in which the file is already group- or
+     * world-readable but still owned by the wrong principals.
+     * <p>
+     * <b>What is guaranteed is that the replacement is never more accessible than the file it replaces —
+     * not that every protection is reproduced exactly.</b> Both extremes are defects and both have been
+     * shipped here. Carrying what you can and moving it either way is R3-07 and R3-09 between them: a
+     * failure left a file full of credentials with the umask's mode and the creating process's group,
+     * permanently, announced at debug level. Refusing the replacement outright is the other, and it is not
+     * free — it is the <em>write</em> that is refused, so the configuration the operator just asked for is
+     * not persisted, and the node goes on running correctly until a restart brings back the older file
+     * without it. Where a protection cannot be reproduced, this narrows instead: the replacement is given
+     * less than the file it replaces rather than more, and the write goes on.
+     * <p>
+     * Two protections are not this node's to set, and each narrows in its own way.
+     * <ul>
+     * <li><b>The owner.</b> Changing it is privileged everywhere this runs, so refusing on it meant a
+     * configuration installed by one account and served by another could never be written at all
+     * (EDG-882 review v04). It falls back to this node's own account, which discloses nothing: the account
+     * that just rendered the document already holds every credential in it.</li>
+     * <li><b>The group.</b> Setting it requires membership of it, so the ordinary container case — a
+     * {@code config.xml} installed under one group, Edge running under another — failed here and stopped
+     * the node persisting anything at all, found in QA on this branch. Keeping the mode while the group
+     * falls back to this process's own is exactly R3-09's disclosure, so the group's permissions come off
+     * the mode with it: the replacement grants the group nothing rather than granting it to the wrong
+     * principals. Nobody gains, someone may lose, and that is said out loud.</li>
+     * </ul>
+     * <p>
+     * The mode and the access-control list keep refusing. Neither can fail the way those two do — both are
+     * set on a file this process created and owns, which is all either call asks for — so a failure there
+     * is the store saying something is wrong, not a privilege this node was never going to have.
+     * <p>
+     * What is applied is taken from what has been proved rather than from what was asked for, so a
+     * protection that could not be reproduced cannot be granted back through another one. A file this node
+     * may not write in the first place never gets here: {@code writeConfigToXML} turns that away before
+     * anything is written.
+     */
+    @VisibleForTesting
+    static void applyPreservedAttributes(final @NotNull Path partial, final @NotNull PreservedAttributes preserved)
+            throws IOException {
+        if (preserved.nothingToReproduce()) {
+            return;
+        }
+        // What the verification below is entitled to insist on, and what the mode at the end is taken
+        // from: everything, less whatever turned out not to be this node's to set.
+        PreservedAttributes proven = preserved;
+        try {
+            // Owner through the owner view, not the POSIX one: an ACL-only store has an owner and no
+            // mode, and reading it through the POSIX view meant it was never restored there at all
+            // (EDG-882 review v04).
+            //
+            // Only when they differ, here and below. Changing owner is a privileged operation on every
+            // platform this runs on, and changing group requires membership; asking for a change that is
+            // already true would fail for no reason on the ordinary path, where the node replaces a file
+            // it owns.
+            if (preserved.owner() != null) {
+                final FileOwnerAttributeView partialOwner =
+                        Files.getFileAttributeView(partial, FileOwnerAttributeView.class);
+                if (partialOwner == null) {
+                    throw new IOException("The replacement cannot carry an owner on this file store");
+                }
+                if (!preserved.owner().equals(partialOwner.getOwner())) {
+                    try {
+                        partialOwner.setOwner(preserved.owner());
+                    } catch (final UnsupportedOperationException | SecurityException | IOException notPermitted) {
+                        // The one protection that is not the node's to reproduce. Changing a file's owner
+                        // is privileged on every platform this runs on, so a configuration installed by
+                        // one account and served by another -- root-owned config.xml, service user running
+                        // Edge -- made every write fail, and the node silently stopped persisting anything
+                        // (EDG-882 review v04). The mode, the group and any access-control list are still
+                        // reproduced exactly or the write is refused, and those are what decide who else
+                        // can read the file; the owner it falls back to is the account that just rendered
+                        // the configuration and therefore already holds every credential in it.
+                        log.warn(
+                                "The replacement for {} could not be given the owner of the file it replaces"
+                                        + " ('{}'), so it is owned by this node's own account instead. Its mode,"
+                                        + " group and access-control list are unchanged, so no one else gains"
+                                        + " access -- but if the owner matters here, set it back and check what"
+                                        + " installed the file.",
+                                partial,
+                                preserved.owner().getName(),
+                                notPermitted);
+                        proven = proven.withoutOwner();
+                    }
+                }
+            }
+            if (preserved.group() != null) {
+                final PosixFileAttributeView partialPosix =
+                        Files.getFileAttributeView(partial, PosixFileAttributeView.class);
+                if (partialPosix == null) {
+                    throw new IOException("The replacement cannot carry a group on this file store");
+                }
+                if (!preserved.group().equals(partialPosix.readAttributes().group())) {
+                    try {
+                        partialPosix.setGroup(preserved.group());
+                    } catch (final UnsupportedOperationException | SecurityException | IOException notPermitted) {
+                        // Setting a file's group requires membership of it, so the ordinary container case
+                        // -- config.xml installed under one group, Edge running under another -- refused
+                        // the whole write here. The node then went on running correctly while persisting
+                        // nothing at all, and every REST change since the last restart was lost on the
+                        // next one (found in QA on this branch).
+                        //
+                        // Dropping the group takes the mode's group permissions with it. Keeping them
+                        // would grant group-read of every credential in the configuration to whichever
+                        // group this node belongs to, which is R3-09 in the one place it still could
+                        // happen. The verification below is told not to insist on either.
+                        proven = proven.withoutGroupAccess();
+                        if (grantsAnythingToGroup(preserved.permissions())) {
+                            log.warn(
+                                    "The replacement for {} could not be given the group of the file it replaces"
+                                            + " ('{}'), so the permissions that mode grants to the group have been"
+                                            + " removed from it rather than handed to this node's own group. The"
+                                            + " configuration is still written and nobody gains access, but"
+                                            + " principals that could read it through that group no longer can."
+                                            + " Add this node's account to that group, or give the file a group it"
+                                            + " is already in, to keep it readable.",
+                                    partial,
+                                    preserved.group().getName(),
+                                    notPermitted);
+                        } else {
+                            // The mode grants the group nothing, so which group it names decides nobody's
+                            // access and dropping it costs nothing. Not worth a warning on every write.
+                            log.debug(
+                                    "The replacement for {} could not be given the group of the file it replaces"
+                                            + " ('{}'). That file's mode grants its group nothing, so no principal"
+                                            + " gains or loses access.",
+                                    partial,
+                                    preserved.group().getName(),
+                                    notPermitted);
+                        }
+                    }
+                }
+            }
+            if (preserved.acl() != null) {
+                final AclFileAttributeView partialAcl = Files.getFileAttributeView(partial, AclFileAttributeView.class);
+                if (partialAcl == null) {
+                    throw new IOException("The replacement cannot carry an access-control list on this file store");
+                }
+                if (!preserved.acl().equals(partialAcl.getAcl())) {
+                    partialAcl.setAcl(preserved.acl());
+                }
+            }
+            // From what was proved, not from what was asked for: if the group could not be reproduced, the
+            // permissions it would have had are no longer in here to grant.
+            if (proven.permissions() != null) {
+                Files.setPosixFilePermissions(partial, proven.permissions());
+            }
+        } catch (final UnsupportedOperationException | SecurityException | IOException e) {
+            throw new IOException(
+                    "Could not reproduce the protections of the configuration file being replaced; "
+                            + "the existing file has been left untouched",
+                    e);
+        }
+        verifyPreservedAttributes(partial, proven);
+    }
+
+    /**
+     * Re-reads what was just applied and refuses the replacement if any of it did not take.
+     * <p>
+     * Every setter above can succeed on a store that then quietly reports something else back —
+     * a mapped volume that ignores ownership, a mode masked by a mount option. The whole point of this
+     * code is that the replacement is no more readable than the file it replaces, and that is a claim
+     * worth checking rather than assuming, because the cost of it being wrong is every credential in the
+     * configuration.
+     */
+    @VisibleForTesting
+    static void verifyPreservedAttributes(final @NotNull Path partial, final @NotNull PreservedAttributes preserved)
+            throws IOException {
+        // Every attribute that was carried, whichever view expresses it. The previous version read the
+        // POSIX view and returned when there was none, so on an ACL-only store it verified nothing at all
+        // (EDG-882 review v04). The access-control list is checked here rather than where it is applied
+        // because the mode is set after it: on a store that has both, a chmod can rewrite the mask of the
+        // list that was just applied, and the file's protection is whatever survives that.
+        final PosixFileAttributeView posixView = Files.getFileAttributeView(partial, PosixFileAttributeView.class);
+        if (posixView != null) {
+            final PosixFileAttributes actual = posixView.readAttributes();
+            if (preserved.permissions() != null && !preserved.permissions().equals(actual.permissions())) {
+                throw new IOException("The replacement's permissions are "
+                        + PosixFilePermissions.toString(actual.permissions())
+                        + " but the configuration file being replaced has "
+                        + PosixFilePermissions.toString(preserved.permissions())
+                        + "; the existing file has been left untouched");
+            }
+            if (preserved.group() != null && !preserved.group().equals(actual.group())) {
+                throw new IOException(
+                        "The replacement's group is '" + actual.group().getName() + "' but the"
+                                + " configuration file being replaced has group '"
+                                + preserved.group().getName()
+                                + "'; the existing file has been left untouched");
+            }
+        }
+        if (preserved.owner() != null) {
+            final FileOwnerAttributeView ownerView = Files.getFileAttributeView(partial, FileOwnerAttributeView.class);
+            final UserPrincipal actualOwner = ownerView == null ? null : ownerView.getOwner();
+            if (!preserved.owner().equals(actualOwner)) {
+                throw new IOException(
+                        "The replacement is owned by '" + (actualOwner == null ? "nobody" : actualOwner.getName())
+                                + "' but the configuration file being replaced is owned by '"
+                                + preserved.owner().getName()
+                                + "'; the existing file has been left untouched");
+            }
+        }
+        if (preserved.acl() != null) {
+            final AclFileAttributeView aclView = Files.getFileAttributeView(partial, AclFileAttributeView.class);
+            final List<AclEntry> actualAcl = aclView == null ? null : aclView.getAcl();
+            if (actualAcl == null || !AclComparison.grantsNoMoreThan(actualAcl, preserved.acl())) {
+                throw new IOException("The replacement's access-control list grants access the configuration file being"
+                        + " replaced does not: it is " + actualAcl + " where that file has "
+                        + preserved.acl() + "; the existing file has been left untouched");
+            }
+            if (!AclComparison.grantsNoMoreThan(preserved.acl(), actualAcl)) {
+                // Narrower than the file it replaces. Nobody gains anything, so this is not the disclosure
+                // the check is here for -- but someone who could read the configuration no longer can, and
+                // that is not something to find out later.
+                log.warn(
+                        "The replacement for the configuration file has a narrower access-control list than the"
+                                + " file it replaces: {} where that file has {}. Nobody gains access, but"
+                                + " principals that could read the configuration may no longer be able to.",
+                        actualAcl,
+                        preserved.acl());
+            }
+        }
+    }
+}

--- a/hivemq-edge/src/main/java/com/hivemq/configuration/service/ConfigurationService.java
+++ b/hivemq-edge/src/main/java/com/hivemq/configuration/service/ConfigurationService.java
@@ -105,6 +105,9 @@ public interface ConfigurationService {
 
     void setConfigFileReaderWriter(@NotNull ConfigFileReaderWriter configFileReaderWriter);
 
+    /** Stops watching the configuration file for changes; a no-op when no reader is set or no watch runs. */
+    void stopWatchingConfigFile();
+
     void writeConfiguration(final @NotNull Writer writer);
 
     @NotNull

--- a/hivemq-edge/src/main/java/com/hivemq/configuration/service/InternalConfigurations.java
+++ b/hivemq-edge/src/main/java/com/hivemq/configuration/service/InternalConfigurations.java
@@ -227,6 +227,19 @@ public class InternalConfigurations {
 
     public static final @NotNull AtomicInteger INTERVAL_BETWEEN_CLEANUP_JOBS_SEC = new AtomicInteger(4);
 
+    /**
+     * How long a sampled topic stays sampled after it was last started or read (EDG-885). A start or a
+     * read of its samples renews the lease; a topic nobody has asked about for this long is released
+     * by the next sweep, and its queue is reclaimed by the periodic clean-up after that.
+     */
+    public static final @NotNull AtomicInteger SAMPLING_LEASE_TTL_SEC = new AtomicInteger(600);
+
+    /**
+     * How often expired sampling leases are swept. The lease is checked against the clock at sweep
+     * time, so a topic is released at most this long after its lease ran out.
+     */
+    public static final @NotNull AtomicInteger SAMPLING_LEASE_SWEEP_INTERVAL_SEC = new AtomicInteger(60);
+
     public static final @NotNull AtomicBoolean MQTT_ALLOW_DOLLAR_TOPICS = new AtomicBoolean(false);
 
     public static final @NotNull AtomicInteger MQTT_EVENT_EXECUTOR_THREAD_COUNT =

--- a/hivemq-edge/src/main/java/com/hivemq/configuration/service/impl/ConfigurationServiceImpl.java
+++ b/hivemq-edge/src/main/java/com/hivemq/configuration/service/impl/ConfigurationServiceImpl.java
@@ -152,6 +152,14 @@ public class ConfigurationServiceImpl implements ConfigurationService {
     }
 
     @Override
+    public void stopWatchingConfigFile() {
+        final ConfigFileReaderWriter reader = configFileReaderWriter;
+        if (reader != null) {
+            reader.stopWatching();
+        }
+    }
+
+    @Override
     public @NotNull ProtocolAdapterExtractor protocolAdapterExtractor() {
         Preconditions.checkNotNull(configFileReaderWriter, "configFileReaderWriter must not be null");
         return configFileReaderWriter.getProtocolAdapterExtractor();

--- a/hivemq-edge/src/main/java/com/hivemq/sampling/SamplingService.java
+++ b/hivemq-edge/src/main/java/com/hivemq/sampling/SamplingService.java
@@ -18,18 +18,23 @@ package com.hivemq.sampling;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningScheduledExecutorService;
+import com.hivemq.configuration.service.InternalConfigurations;
 import com.hivemq.mqtt.message.QoS;
 import com.hivemq.mqtt.message.publish.PUBLISH;
 import com.hivemq.mqtt.message.subscribe.Topic;
 import com.hivemq.mqtt.topic.SubscriptionFlag;
 import com.hivemq.mqtt.topic.tree.LocalTopicTree;
 import com.hivemq.persistence.clientqueue.ClientQueuePersistence;
+import com.hivemq.persistence.ioc.annotation.Persistence;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.function.LongSupplier;
 import java.util.stream.Collectors;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -62,9 +67,14 @@ public class SamplingService {
 
     private final @NotNull LocalTopicTree localTopicTree;
     private final @NotNull ClientQueuePersistence clientQueuePersistence;
+    private final @Nullable ListeningScheduledExecutorService scheduledExecutorService;
+    private final @NotNull LongSupplier nanoClock;
 
     /**
-     * The topics currently sampled. A set, not a count of watchers.
+     * The topics currently sampled, each with the {@link #nanoClock} reading of the last time somebody
+     * asked for it — a start or a read of its samples. That reading is the lease (EDG-885).
+     * <p>
+     * A set of leases, not a count of watchers.
      * <p>
      * Counting was the wrong shape while nothing releases: {@link #startSampling(String)} is reached
      * from an HTTP POST that carries no watcher identity, so retries, a remounted panel and a second
@@ -73,51 +83,95 @@ public class SamplingService {
      * which acquire it was balancing — and it read as a lifecycle that was being managed when it was
      * not (EDG-882 F-06).
      * <p>
-     * <b>What this does not fix:</b> nothing in production stops sampling, so a sampled topic keeps its
-     * subscription, and its ten-message queue, for the life of the node. Making that finite needs
-     * either a release the caller can be identified by — a DELETE endpoint with a watcher token — or a
-     * lease that expires unless refreshed, and the second changes what an idle-but-open editor panel
-     * sees. Both are decisions about the product's API surface rather than repairs to this class, and
-     * they belong to EDG-885.
+     * <b>What makes it finite</b> is the lease. A release the caller could be identified by — a DELETE
+     * with a watcher token — would need a new endpoint and a UI that remembers to call it on every way
+     * a panel can go away, and a tab that crashes never would. The lease needs neither: it is renewed
+     * by the calls the UI already makes, and {@link #expireLeases()} releases whatever has not been
+     * asked about for {@link InternalConfigurations#SAMPLING_LEASE_TTL_SEC}. What a panel left open
+     * past the lease sees is covered in {@link #getSamples(String)}.
      */
-    private final @NotNull Map<String, Boolean> sampledTopics = new ConcurrentHashMap<>(0);
+    private final @NotNull Map<String, Long> sampledTopics = new ConcurrentHashMap<>(0);
 
     @Inject
     public SamplingService(
             final @NotNull LocalTopicTree localTopicTree,
+            final @NotNull ClientQueuePersistence clientQueuePersistence,
+            final @NotNull @Persistence ListeningScheduledExecutorService scheduledExecutorService) {
+        this(localTopicTree, clientQueuePersistence, scheduledExecutorService, System::nanoTime);
+    }
+
+    /** No sweep is scheduled: tests drive {@link #expireLeases()} themselves. */
+    @VisibleForTesting
+    SamplingService(
+            final @NotNull LocalTopicTree localTopicTree,
             final @NotNull ClientQueuePersistence clientQueuePersistence) {
+        this(localTopicTree, clientQueuePersistence, null, System::nanoTime);
+    }
+
+    @VisibleForTesting
+    SamplingService(
+            final @NotNull LocalTopicTree localTopicTree,
+            final @NotNull ClientQueuePersistence clientQueuePersistence,
+            final @Nullable ListeningScheduledExecutorService scheduledExecutorService,
+            final @NotNull LongSupplier nanoClock) {
         this.localTopicTree = localTopicTree;
         this.clientQueuePersistence = clientQueuePersistence;
+        this.scheduledExecutorService = scheduledExecutorService;
+        this.nanoClock = nanoClock;
     }
 
     /**
-     * Starts sampling a topic, subscribing the first time it is asked for.
+     * Schedules the lease sweep. Method injection: Dagger calls this once, right after construction.
      * <p>
-     * Idempotent: asking again while the topic is already sampled changes nothing. That is the honest
-     * shape for a call reached from a POST with no watcher identity — retries, a remounted panel and a
-     * second tab all mean the same thing here, "somebody wants samples of this topic".
+     * The persistence scheduler is used rather than a thread of this class's own because the sweep is
+     * a sibling of the periodic clean-up that reclaims the released queues, and because that executor
+     * already has a shutdown hook; the sweep dies with it. Nothing is scheduled on an executor that is
+     * already shut down, which is where a late construction during shutdown would otherwise throw.
+     */
+    @Inject
+    public void postConstruct() {
+        if (scheduledExecutorService == null || scheduledExecutorService.isShutdown()) {
+            return;
+        }
+        final int interval = InternalConfigurations.SAMPLING_LEASE_SWEEP_INTERVAL_SEC.get();
+        // The future is not kept: the sweep runs until the executor is shut down, and there is no
+        // earlier point at which anything would cancel it.
+        final var unused = scheduledExecutorService.scheduleWithFixedDelay(
+                this::expireLeases, interval, interval, TimeUnit.SECONDS);
+    }
+
+    /**
+     * Starts sampling a topic, subscribing the first time it is asked for, and renews its lease.
      * <p>
-     * The subscribe happens <b>inside</b> the map update rather than after it. {@code computeIfAbsent}
-     * is atomic for a key, so a concurrent {@link #stopSampling(String)} cannot interleave between the
-     * entry appearing and the subscriber being added. Without that, a stop could remove the subscriber
-     * a start had just added, leaving this map saying "sampled" while the topic tree says "not
-     * subscribed" — no samples would ever arrive, the clean-up would rightly reclaim the queue, and
-     * nothing would re-register until the topic changed. Silent, sticky, and invisible to any
-     * single-threaded test.
+     * Idempotent on the subscription: asking again while the topic is already sampled subscribes
+     * nothing. That is the honest shape for a call reached from a POST with no watcher identity —
+     * retries, a remounted panel and a second tab all mean the same thing here, "somebody wants
+     * samples of this topic". What a repeated start does change is the lease: it is what keeps a
+     * topic the UI keeps coming back to from expiring under it.
+     * <p>
+     * The subscribe happens <b>inside</b> the map update rather than after it. {@code compute} is
+     * atomic for a key, so a concurrent {@link #stopSampling(String)} or {@link #expireLeases()}
+     * cannot interleave between the entry appearing and the subscriber being added. Without that, a
+     * stop could remove the subscriber a start had just added, leaving this map saying "sampled" while
+     * the topic tree says "not subscribed" — no samples would ever arrive, the clean-up would rightly
+     * reclaim the queue, and nothing would re-register until the topic changed. Silent, sticky, and
+     * invisible to any single-threaded test.
      */
     public void startSampling(final @NotNull String topic) {
-        sampledTopics.computeIfAbsent(topic, sampledTopic -> {
-            subscribe(sampledTopic);
-            return Boolean.TRUE;
+        sampledTopics.compute(topic, (sampledTopic, lease) -> {
+            if (lease == null) {
+                subscribe(sampledTopic);
+            }
+            return nanoClock.getAsLong();
         });
     }
 
     /**
      * Stops sampling a topic and unsubscribes.
      * <p>
-     * <b>Nothing in production calls this yet</b>; it is the entry point a release path will use, and
-     * what the tests drive. Stopping a topic nobody is sampling is a no-op, so a duplicate stop cannot
-     * make a later {@link #startSampling(String)} fail to subscribe.
+     * In production this is reached through {@link #expireLeases()}; nothing calls it for a named
+     * topic, because nothing can name a watcher. Stopping a topic nobody is sampling is a no-op, so a
+     * duplicate stop cannot make a later {@link #startSampling(String)} fail to subscribe.
      * <p>
      * Once the subscriber is gone the periodic clean-up reclaims the queue on its next sweep with no
      * further help — {@code ClientQueuePersistenceImpl.isOrphaned} stops finding an owner for it. If
@@ -131,6 +185,45 @@ public class SamplingService {
             unsubscribe(sampledTopic);
             return null;
         });
+    }
+
+    /**
+     * Releases every topic whose lease has run out: nobody started or read it for
+     * {@link InternalConfigurations#SAMPLING_LEASE_TTL_SEC}. Run periodically from
+     * {@link #postConstruct()}; public so a test can drive it against its own clock.
+     * <p>
+     * The expiry check runs <b>inside</b> the per-key update, so a renewal that lands while the sweep
+     * is looking at that key is seen — the entry is either renewed or removed, and the subscriber
+     * follows the entry either way. A snapshot-then-remove would let a renewal slip between the two
+     * and release a topic that had just been asked for.
+     * <p>
+     * A failure on one topic is logged and the sweep goes on; a periodic task that throws would
+     * silently never run again, which would put the leak back.
+     */
+    @VisibleForTesting
+    public void expireLeases() {
+        final long now = nanoClock.getAsLong();
+        final long ttlNanos = TimeUnit.SECONDS.toNanos(InternalConfigurations.SAMPLING_LEASE_TTL_SEC.get());
+        for (final String topic : sampledTopics.keySet()) {
+            try {
+                sampledTopics.computeIfPresent(topic, (sampledTopic, lease) -> {
+                    if (now - lease < ttlNanos) {
+                        return lease;
+                    }
+                    log.debug(
+                            "Releasing sampling for topic '{}': nobody asked for it for {} s",
+                            sampledTopic,
+                            InternalConfigurations.SAMPLING_LEASE_TTL_SEC.get());
+                    unsubscribe(sampledTopic);
+                    return null;
+                });
+            } catch (final RuntimeException e) {
+                log.warn(
+                        "Failed to release sampling for topic '{}'; it will be tried again on the next sweep",
+                        topic,
+                        e);
+            }
+        }
     }
 
     /**
@@ -219,7 +312,19 @@ public class SamplingService {
         return queueId.substring(topicStart, separator);
     }
 
+    /**
+     * The samples collected for a topic, most recent last.
+     * <p>
+     * Reading renews the lease, and a read of a topic that is no longer sampled starts it again. That
+     * is what a panel left open past the lease sees: its next refresh comes back empty — the released
+     * queue was reclaimed — and sampling is running again by the time it returns, so the refresh after
+     * that has samples. The same thing the panel saw when it first opened, and the same thing it
+     * would see after a node restart; nothing to handle that the UI does not handle already. Making
+     * the read revive rather than only renew is what keeps a GET from ever answering "no samples"
+     * for a topic that was sampled a moment ago and stays that way.
+     */
     public @NotNull List<byte[]> getSamples(final @NotNull String topic) {
+        startSampling(topic);
         final String queueId = createQueueId(topic);
         final ListenableFuture<ImmutableList<PUBLISH>> publishes =
                 clientQueuePersistence.peek(queueId, true, BYTE_LIMIT_SAMPLES, SAMPLE_SIZE);

--- a/hivemq-edge/src/main/java/com/hivemq/sampling/SamplingService.java
+++ b/hivemq-edge/src/main/java/com/hivemq/sampling/SamplingService.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.function.LongSupplier;
 import java.util.stream.Collectors;
@@ -134,10 +135,17 @@ public class SamplingService {
             return;
         }
         final int interval = InternalConfigurations.SAMPLING_LEASE_SWEEP_INTERVAL_SEC.get();
-        // The future is not kept: the sweep runs until the executor is shut down, and there is no
-        // earlier point at which anything would cancel it.
-        final var unused = scheduledExecutorService.scheduleWithFixedDelay(
-                this::expireLeases, interval, interval, TimeUnit.SECONDS);
+        try {
+            // The future is not kept: the sweep runs until the executor is shut down, and there is no
+            // earlier point at which anything would cancel it.
+            final var unused = scheduledExecutorService.scheduleWithFixedDelay(
+                    this::expireLeases, interval, interval, TimeUnit.SECONDS);
+        } catch (final RejectedExecutionException shuttingDown) {
+            // The check above and the schedule are not one step: a first sampler-eligible publish during
+            // shutdown constructs this singleton on an event loop, and the executor can close in between.
+            // Nothing to sweep on a node that is going away.
+            log.debug("The sampling lease sweep was not scheduled: the persistence executor is shutting down");
+        }
     }
 
     /**
@@ -315,16 +323,14 @@ public class SamplingService {
     /**
      * The samples collected for a topic, most recent last.
      * <p>
-     * Reading renews the lease, and a read of a topic that is no longer sampled starts it again. That
-     * is what a panel left open past the lease sees: its next refresh comes back empty — the released
-     * queue was reclaimed — and sampling is running again by the time it returns, so the refresh after
-     * that has samples. The same thing the panel saw when it first opened, and the same thing it
-     * would see after a node restart; nothing to handle that the UI does not handle already. Making
-     * the read revive rather than only renew is what keeps a GET from ever answering "no samples"
-     * for a topic that was sampled a moment ago and stays that way.
+     * Reading renews the lease of a topic that is sampled, and starts nothing. Starting is what the
+     * POST is for, and the POST is admin-only while the two GETs are open to every role; a read that
+     * subscribed would hand that admin capability -- a subscription and a queue for any topic string --
+     * to any caller (EDG-949 review). So a panel left open past the lease sees an empty list on its next
+     * refresh, and samples again once it is remounted, which is when the UI starts sampling anyway.
      */
     public @NotNull List<byte[]> getSamples(final @NotNull String topic) {
-        startSampling(topic);
+        sampledTopics.computeIfPresent(topic, (sampledTopic, lease) -> nanoClock.getAsLong());
         final String queueId = createQueueId(topic);
         final ListenableFuture<ImmutableList<PUBLISH>> publishes =
                 clientQueuePersistence.peek(queueId, true, BYTE_LIMIT_SAMPLES, SAMPLE_SIZE);

--- a/hivemq-edge/src/test/java/com/hivemq/configuration/reader/AclNativeStoreTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/configuration/reader/AclNativeStoreTest.java
@@ -117,7 +117,7 @@ public class AclNativeStoreTest {
         final List<AclEntry> targetAcl = aclOf(target);
 
         try {
-            ConfigFileReaderWriter.createPartialFile(partial, ConfigFileReaderWriter.preservedAttributesOf(target));
+            ProtectedFileReplacer.createPartialFile(partial, ProtectedFileReplacer.preservedAttributesOf(target));
         } catch (final IOException refused) {
             assertTrue(
                     Files.notExists(partial) || aclOf(partial).isEmpty(),
@@ -140,9 +140,9 @@ public class AclNativeStoreTest {
     public void aReplacedFileGrantsWhatTheFileItReplacedGranted() throws IOException {
         final List<AclEntry> before = aclOf(target);
 
-        ConfigFileReaderWriter.replaceCarryingProtections(
+        ProtectedFileReplacer.replaceCarryingProtections(
                 target,
-                ConfigFileReaderWriter.preservedAttributesOf(target),
+                ProtectedFileReplacer.preservedAttributesOf(target),
                 partial -> Files.writeString(partial, "<hivemq><replaced/></hivemq>", StandardCharsets.UTF_8));
 
         final List<AclEntry> after = aclOf(target);

--- a/hivemq-edge/src/test/java/com/hivemq/configuration/reader/ConfigBackupPermissionsTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/configuration/reader/ConfigBackupPermissionsTest.java
@@ -149,8 +149,7 @@ public class ConfigBackupPermissionsTest extends AbstractConfigurationTest {
      * slots exist the rotation recycles the oldest, and a slot left wide by an earlier release — or by an
      * operator — must not decide how the next backup of a restricted configuration is protected.
      * <p>
-     * The modification times are set rather than assumed, because "oldest" is what selects the slot and
-     * the configuration file itself is in the set the rotation looks at.
+     * The modification times are set rather than assumed, because "oldest" is what selects the slot.
      */
     @Test
     public void theRecycledBackupSlotIsNotWidenedByWhatItHeld() throws IOException {
@@ -158,11 +157,12 @@ public class ConfigBackupPermissionsTest extends AbstractConfigurationTest {
         Files.writeString(config, config("s3cr3t-do-not-write-me"));
         Files.setPosixFilePermissions(config, OWNER_ONLY);
         Files.setLastModifiedTime(config, FileTime.fromMillis(now));
-        for (int slot = 1; slot <= 4; slot++) {
+        // all five slots taken (EDG-949 made the fifth one usable), config_1 the oldest
+        for (int slot = 1; slot <= 5; slot++) {
             final Path used = config.resolveSibling("config_" + slot + ".xml");
             Files.writeString(used, "an earlier backup left readable by everyone");
             Files.setPosixFilePermissions(used, WORLD_WRITABLE);
-            Files.setLastModifiedTime(used, FileTime.fromMillis(now - (5L - slot) * 60_000L));
+            Files.setLastModifiedTime(used, FileTime.fromMillis(now - (6L - slot) * 60_000L));
         }
 
         reader.applyConfig();

--- a/hivemq-edge/src/test/java/com/hivemq/configuration/reader/ConfigBackupRotationTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/configuration/reader/ConfigBackupRotationTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.configuration.reader;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import com.hivemq.exceptions.UnrecoverableException;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
+import java.nio.file.attribute.PosixFilePermissions;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/** {@link ConfigBackupRotation} on its own: which slot a backup lands in, and what it carries. */
+public class ConfigBackupRotationTest {
+
+    @TempDir
+    public File temporaryFolder;
+
+    private @NotNull Path config;
+
+    @BeforeEach
+    public void setUp() throws IOException {
+        config = temporaryFolder.toPath().resolve("config.xml");
+        Files.writeString(config, "v0");
+    }
+
+    @AfterEach
+    public void restoreTheFolder() throws IOException {
+        if (config.getFileSystem().supportedFileAttributeViews().contains("posix")) {
+            Files.setPosixFilePermissions(temporaryFolder.toPath(), PosixFilePermissions.fromString("rwx------"));
+        }
+    }
+
+    private @NotNull Path slot(final int n) {
+        return config.resolveSibling("config_" + n + ".xml");
+    }
+
+    /** Writes version {@code n} to the configuration with a distinct, increasing time, then takes a backup. */
+    private void writeAndBackUp(final int n) throws IOException {
+        Files.writeString(config, "v" + n);
+        Files.setLastModifiedTime(config, FileTime.fromMillis(1_700_000_000_000L + n * 60_000L));
+        ConfigBackupRotation.backup(config.toFile(), true);
+    }
+
+    @Test
+    public void fillsTheFiveSlotsInOrder() throws IOException {
+        for (int n = 1; n <= 5; n++) {
+            writeAndBackUp(n);
+            assertThat(slot(n)).hasContent("v" + n);
+        }
+        assertThat(slot(6)).doesNotExist();
+    }
+
+    @Test
+    public void recyclesTheOldestSlotOnceAllAreTaken() throws IOException {
+        for (int n = 1; n <= 5; n++) {
+            writeAndBackUp(n);
+        }
+        writeAndBackUp(6);
+        assertThat(slot(1)).as("the oldest slot is recycled").hasContent("v6");
+        assertThat(slot(2)).hasContent("v2");
+        writeAndBackUp(7);
+        assertThat(slot(2)).as("then the next oldest").hasContent("v7");
+        assertThat(slot(1)).hasContent("v6");
+    }
+
+    @Test
+    public void filesThatOnlyResembleASlotAreNeverCandidates() throws IOException {
+        final Path[] foreign = {
+            config.resolveSibling("config-archive-2024.xml"),
+            config.resolveSibling("config_2024.xml"),
+            config.resolveSibling("config.xml.bak"),
+            config.resolveSibling("config_1.xml.old")
+        };
+        for (final Path file : foreign) {
+            Files.writeString(file, "operator's");
+            Files.setLastModifiedTime(file, FileTime.fromMillis(1_600_000_000_000L)); // older than everything
+        }
+
+        for (int n = 1; n <= 8; n++) {
+            writeAndBackUp(n);
+        }
+
+        for (final Path file : foreign) {
+            assertThat(file)
+                    .as("%s must not be treated as a backup slot", file.getFileName())
+                    .hasContent("operator's");
+        }
+        assertThat(config).hasContent("v8");
+    }
+
+    @Test
+    public void disabledTakesNoBackup() throws IOException {
+        ConfigBackupRotation.backup(config.toFile(), false);
+        assertThat(slot(1)).doesNotExist();
+    }
+
+    @Test
+    public void aMissingFolderIsRefused() {
+        final File orphan =
+                temporaryFolder.toPath().resolve("gone").resolve("config.xml").toFile();
+        assertThatThrownBy(() -> ConfigBackupRotation.backup(orphan, true)).isInstanceOf(UnrecoverableException.class);
+    }
+
+    @Test
+    public void theBackupCarriesTheModeAndTimeOfTheFileItCopies() throws IOException {
+        assumeTrue(config.getFileSystem().supportedFileAttributeViews().contains("posix"));
+        Files.setPosixFilePermissions(config, PosixFilePermissions.fromString("rw-------"));
+        Files.setLastModifiedTime(config, FileTime.fromMillis(1_700_000_000_000L));
+
+        ConfigBackupRotation.backup(config.toFile(), true);
+
+        assertThat(Files.getPosixFilePermissions(slot(1))).isEqualTo(PosixFilePermissions.fromString("rw-------"));
+        assertThat(Files.getLastModifiedTime(slot(1)).toMillis()).isEqualTo(1_700_000_000_000L);
+    }
+
+    /** A folder that exists but cannot be listed must fail the rotation, not pick a slot at random. */
+    @Test
+    public void aFolderThatCannotBeListedIsAnError() throws IOException {
+        assumeTrue(config.getFileSystem().supportedFileAttributeViews().contains("posix"));
+        assumeTrue(!"root".equals(System.getProperty("user.name")), "a superuser lists anything");
+        for (int n = 1; n <= 5; n++) {
+            writeAndBackUp(n);
+        }
+        Files.setPosixFilePermissions(temporaryFolder.toPath(), PosixFilePermissions.fromString("-wx------"));
+        try {
+            assertThatThrownBy(() -> ConfigBackupRotation.backup(config.toFile(), true))
+                    .isInstanceOf(IOException.class)
+                    .hasMessageContaining("cannot be listed");
+        } finally {
+            Files.setPosixFilePermissions(temporaryFolder.toPath(), PosixFilePermissions.fromString("rwx------"));
+        }
+    }
+}

--- a/hivemq-edge/src/test/java/com/hivemq/configuration/reader/ConfigFileReaderWriterTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/configuration/reader/ConfigFileReaderWriterTest.java
@@ -37,7 +37,7 @@ class ConfigFileReaderWriterTest {
                 .getResource("configs/testing/alltags.xml")
                 .toURI());
         final var configEntity = reader.loadConfigFromXML(configFile);
-        assertThat(configEntity).isTrue();
+        assertThat(configEntity).isEqualTo(ConfigFileReaderWriter.ReloadOutcome.APPLIED);
     }
 
     @Test
@@ -50,7 +50,7 @@ class ConfigFileReaderWriterTest {
                 .getResource("configs/testing/empty.xml")
                 .toURI());
         final var configEntity = reader.loadConfigFromXML(configFile);
-        assertThat(configEntity).isTrue();
+        assertThat(configEntity).isEqualTo(ConfigFileReaderWriter.ReloadOutcome.APPLIED);
     }
 
     @Test
@@ -64,7 +64,7 @@ class ConfigFileReaderWriterTest {
                 .toURI());
         final var configEntity = reader.loadConfigFromXML(configFile);
         // This will break as soon as the xsd is fixed
-        assertThat(configEntity).isFalse();
+        assertThat(configEntity).isEqualTo(ConfigFileReaderWriter.ReloadOutcome.NEEDS_RESTART);
     }
 
     private void assertRoundTrips(final @NotNull String resource, final @NotNull String... mustContain)
@@ -78,7 +78,9 @@ class ConfigFileReaderWriterTest {
                 .toURI());
 
         // Read through Edge's real reader (validates against config.xsd)...
-        assertThat(reader.loadConfigFromXML(configFile)).as("read %s", resource).isTrue();
+        assertThat(reader.loadConfigFromXML(configFile))
+                .as("read %s", resource)
+                .isEqualTo(ConfigFileReaderWriter.ReloadOutcome.APPLIED);
         // ...then marshal back through the real writer (the marshaller validates against config.xsd too).
         final var writer = new java.io.StringWriter();
         reader.writeConfigToXML(writer);
@@ -112,7 +114,7 @@ class ConfigFileReaderWriterTest {
                 .getResource("configs/testing/oidc_disabled_no_role_mappings.xml")
                 .toURI());
 
-        assertThat(reader.loadConfigFromXML(configFile)).isTrue();
+        assertThat(reader.loadConfigFromXML(configFile)).isEqualTo(ConfigFileReaderWriter.ReloadOutcome.APPLIED);
 
         // Re-marshal (this is what config sync does). The marshaller validates against the schema, so an empty
         // <role-mappings/> would throw here. It must succeed and omit the element.

--- a/hivemq-edge/src/test/java/com/hivemq/configuration/reader/ConfigFileWatcherTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/configuration/reader/ConfigFileWatcherTest.java
@@ -1,0 +1,437 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.configuration.reader;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import ch.qos.logback.classic.Level;
+import com.hivemq.configuration.entity.HiveMQConfigEntity;
+import com.hivemq.configuration.entity.bridge.BridgeTlsEntity;
+import com.hivemq.configuration.entity.bridge.MqttBridgeEntity;
+import com.hivemq.configuration.entity.bridge.RemoteBrokerEntity;
+import com.hivemq.configuration.entity.listener.tls.KeystoreEntity;
+import com.hivemq.configuration.reader.ConfigFileReaderWriter.ReloadOutcome;
+import com.hivemq.edge.HiveMQEdgeConstants;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.FileTime;
+import java.util.ConcurrentModificationException;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.BooleanSupplier;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+import org.slf4j.LoggerFactory;
+import util.LogbackCapturingAppender;
+
+/**
+ * {@link ConfigFileWatcher} on its own, with a recording reload in place of the reader-writer: what
+ * counts as a change, what each reload outcome does, what the node's own write does not do, how watched
+ * fragments and keystores are handled, and that no failure ends the watch.
+ */
+public class ConfigFileWatcherTest {
+
+    private static final long INTERVAL_MS = 50;
+
+    @TempDir
+    public File temporaryFolder;
+
+    private @NotNull Path config;
+    private final @NotNull ReentrantLock lock = new ReentrantLock();
+    private final @NotNull AtomicInteger reloads = new AtomicInteger();
+    private final @NotNull AtomicInteger restarts = new AtomicInteger();
+    private final @NotNull AtomicReference<ReloadOutcome> outcome = new AtomicReference<>(ReloadOutcome.APPLIED);
+    private final @NotNull AtomicReference<RuntimeException> reloadFailure = new AtomicReference<>();
+    private @NotNull ConfigFileWatcher watcher;
+    private @NotNull LogbackCapturingAppender logCapture;
+    private @NotNull String previousDevMode;
+
+    @BeforeEach
+    public void setUp() throws IOException {
+        config = temporaryFolder.toPath().resolve("config.xml");
+        rewrite(config, "v0", 0);
+        watcher = new ConfigFileWatcher(lock, new ConfigurationFile(config.toFile()), file -> {
+            final RuntimeException failure = reloadFailure.get();
+            if (failure != null) {
+                throw failure;
+            }
+            reloads.incrementAndGet();
+            return outcome.get();
+        });
+        watcher.setRestartHook(restarts::incrementAndGet);
+        logCapture = LogbackCapturingAppender.Factory.weaveInto(LoggerFactory.getLogger(ConfigFileWatcher.class));
+        previousDevMode = System.getProperty(HiveMQEdgeConstants.DEVELOPMENT_MODE, "");
+        System.setProperty(HiveMQEdgeConstants.DEVELOPMENT_MODE, "false");
+    }
+
+    @AfterEach
+    public void tearDown() {
+        watcher.stop();
+        System.setProperty(HiveMQEdgeConstants.DEVELOPMENT_MODE, previousDevMode);
+        LogbackCapturingAppender.Factory.cleanUp();
+    }
+
+    private void start() {
+        watcher.start(config.toFile(), INTERVAL_MS, HiveMQConfigEntity::new);
+    }
+
+    /** Staged and moved, so the watcher sees content and time at once; whole seconds clear any granularity. */
+    private static void rewrite(final @NotNull Path file, final @NotNull String content, final int secondsLater)
+            throws IOException {
+        final Path staged = file.resolveSibling(file.getFileName() + ".staged");
+        Files.writeString(staged, content);
+        Files.setLastModifiedTime(staged, FileTime.fromMillis(System.currentTimeMillis() + secondsLater * 1000L));
+        Files.move(staged, file, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+    }
+
+    private static void await(final @NotNull String what, final @NotNull BooleanSupplier condition)
+            throws InterruptedException {
+        final long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(15);
+        while (!condition.getAsBoolean()) {
+            if (System.nanoTime() > deadline) {
+                throw new AssertionError("timed out waiting for: " + what);
+            }
+            Thread.sleep(10);
+        }
+    }
+
+    private static void ticks(final int count) throws InterruptedException {
+        Thread.sleep(INTERVAL_MS * count);
+    }
+
+    private long logged(final @NotNull Level level, final @NotNull String fragment) {
+        while (true) {
+            try {
+                return logCapture.getCapturedLogs().stream()
+                        .filter(event -> event.getLevel() == level)
+                        .filter(event -> event.getFormattedMessage().contains(fragment))
+                        .count();
+            } catch (final ConcurrentModificationException torn) {
+                Thread.onSpinWait();
+            }
+        }
+    }
+
+    // ---- what counts as a change
+
+    @Test
+    @Timeout(30)
+    public void anUnchangedFileIsNeverReloaded() throws Exception {
+        start();
+        ticks(6);
+        assertThat(reloads).hasValue(0);
+        assertThat(restarts).hasValue(0);
+    }
+
+    @Test
+    @Timeout(30)
+    public void aChangedFileIsReloadedExactlyOnce() throws Exception {
+        start();
+        rewrite(config, "v1", 2);
+        await("the reload", () -> reloads.get() == 1);
+        ticks(6);
+        assertThat(reloads).hasValue(1);
+    }
+
+    @Test
+    @Timeout(30)
+    public void anOlderTimeIsAChangeToo() throws Exception {
+        start();
+        rewrite(config, "restored", -60);
+        await("the reload of the older file", () -> reloads.get() == 1);
+    }
+
+    // ---- what each outcome does
+
+    @Test
+    @Timeout(30)
+    public void aRejectedReloadIsReportedAndTheWatchGoesOn() throws Exception {
+        outcome.set(ReloadOutcome.REJECTED_INVALID);
+        start();
+        rewrite(config, "broken", 2);
+        await("the rejection to be reported", () -> logged(Level.ERROR, "reload rejected") == 1);
+        assertThat(restarts).hasValue(0);
+
+        outcome.set(ReloadOutcome.APPLIED);
+        rewrite(config, "fixed", 4);
+        await("the correction to be reloaded", () -> reloads.get() == 2);
+    }
+
+    @Test
+    @Timeout(30)
+    public void aReloadThatNeedsARestartRestarts() throws Exception {
+        outcome.set(ReloadOutcome.NEEDS_RESTART);
+        start();
+        rewrite(config, "listener changed", 2);
+        await("the restart decision", () -> restarts.get() == 1);
+        assertThat(logged(Level.ERROR, "can't be hot-reloaded")).isEqualTo(1);
+    }
+
+    @Test
+    @Timeout(30)
+    public void inDevelopmentModeARestartIsOnlyLogged() throws Exception {
+        System.setProperty(HiveMQEdgeConstants.DEVELOPMENT_MODE, "true");
+        outcome.set(ReloadOutcome.NEEDS_RESTART);
+        start();
+        rewrite(config, "listener changed", 2);
+        await("the reload", () -> reloads.get() == 1);
+        await("the test-mode line", () -> logged(Level.ERROR, "TEST MODE") == 1);
+        assertThat(restarts).hasValue(0);
+    }
+
+    // ---- the node's own write
+
+    @Test
+    @Timeout(30)
+    public void aWriteStampedAsTheNodesOwnIsNotReloaded() throws Exception {
+        start();
+        final long stamped = System.currentTimeMillis() + 2000;
+        lock.lock();
+        try {
+            rewrite(config, "own write", 2);
+            Files.setLastModifiedTime(config, FileTime.fromMillis(stamped));
+            watcher.writtenByThisNode(config, stamped);
+        } finally {
+            lock.unlock();
+        }
+        ticks(6);
+        assertThat(reloads).as("the node's own write must not be re-read").hasValue(0);
+
+        rewrite(config, "operator edit", 4);
+        await("an operator edit after it is still seen", () -> reloads.get() == 1);
+    }
+
+    @Test
+    @Timeout(30)
+    public void aStampForAnotherFileIsIgnored() throws Exception {
+        start();
+        final Path other = temporaryFolder.toPath().resolve("other.xml");
+        Files.writeString(other, "x");
+        rewrite(config, "v1", 2);
+        watcher.writtenByThisNode(other, Files.getLastModifiedTime(config).toMillis());
+        await("the change is still reloaded", () -> reloads.get() == 1);
+    }
+
+    @Test
+    @Timeout(30)
+    public void aNegativeStampIsIgnored() throws Exception {
+        start();
+        rewrite(config, "v1", 2);
+        watcher.writtenByThisNode(config, -1);
+        await("the change is still reloaded", () -> reloads.get() == 1);
+    }
+
+    // ---- fragments and keystores
+
+    @Test
+    @Timeout(30)
+    public void aChangedFragmentRestarts() throws Exception {
+        final Path fragment = temporaryFolder.toPath().resolve("bridges.fragment");
+        rewrite(fragment, "f0", 0);
+        watcher.watchFragments(
+                Map.of(fragment, Files.getLastModifiedTime(fragment).toMillis()));
+        start();
+
+        rewrite(fragment, "f1", 2);
+
+        await("the restart for a changed fragment", () -> restarts.get() == 1);
+        assertThat(logged(Level.ERROR, "required file was updated")).isEqualTo(1);
+        assertThat(reloads).hasValue(0);
+    }
+
+    @Test
+    @Timeout(30)
+    public void aVanishedFragmentIsReportedOnceAndDropped() throws Exception {
+        final Path fragment = temporaryFolder.toPath().resolve("bridges.fragment");
+        rewrite(fragment, "f0", 0);
+        watcher.watchFragments(
+                Map.of(fragment, Files.getLastModifiedTime(fragment).toMillis()));
+        start();
+
+        Files.delete(fragment);
+
+        await("the vanished fragment to be reported", () -> logged(Level.WARN, "no longer exists") == 1);
+        ticks(10);
+        assertThat(logged(Level.WARN, "no longer exists"))
+                .as("reported once, not every tick")
+                .isEqualTo(1);
+        assertThat(restarts).hasValue(0);
+        assertThat(logged(Level.ERROR, "watcher failed")).isZero();
+    }
+
+    @Test
+    @Timeout(30)
+    public void replacingTheWatchedFragmentsDropsTheOldOnes() throws Exception {
+        final Path old = temporaryFolder.toPath().resolve("old.fragment");
+        rewrite(old, "o", 0);
+        watcher.watchFragments(Map.of(old, Files.getLastModifiedTime(old).toMillis()));
+        watcher.watchFragments(Map.of()); // the next accepted configuration references no fragment
+        start();
+
+        rewrite(old, "changed", 2);
+
+        ticks(6);
+        assertThat(restarts)
+                .as("a fragment no longer referenced must not be watched")
+                .hasValue(0);
+    }
+
+    @Test
+    @Timeout(30)
+    public void aChangedKeystoreRestarts() throws Exception {
+        final Path keystore = temporaryFolder.toPath().resolve("bridge.p12");
+        rewrite(keystore, "k0", 0);
+        final HiveMQConfigEntity entity = new HiveMQConfigEntity();
+        final KeystoreEntity keystoreEntity = new KeystoreEntity();
+        keystoreEntity.setPath(keystore.toString());
+        final BridgeTlsEntity tls = new BridgeTlsEntity();
+        tls.setKeyStore(keystoreEntity);
+        final RemoteBrokerEntity remote = new RemoteBrokerEntity();
+        remote.setTls(tls);
+        final MqttBridgeEntity bridge = new MqttBridgeEntity();
+        bridge.setRemoteBroker(remote);
+        entity.getBridgeConfig().addAll(List.of(bridge));
+        watcher.start(config.toFile(), INTERVAL_MS, () -> entity);
+
+        rewrite(keystore, "k1", 2);
+
+        await("the restart for a changed keystore", () -> restarts.get() == 1);
+    }
+
+    @Test
+    @Timeout(30)
+    public void aVanishedKeystoreIsReportedOnceAndDropped() throws Exception {
+        final Path keystore = temporaryFolder.toPath().resolve("bridge.p12");
+        rewrite(keystore, "k0", 0);
+        final HiveMQConfigEntity entity = new HiveMQConfigEntity();
+        final KeystoreEntity keystoreEntity = new KeystoreEntity();
+        keystoreEntity.setPath(keystore.toString());
+        final BridgeTlsEntity tls = new BridgeTlsEntity();
+        tls.setKeyStore(keystoreEntity);
+        final RemoteBrokerEntity remote = new RemoteBrokerEntity();
+        remote.setTls(tls);
+        final MqttBridgeEntity bridge = new MqttBridgeEntity();
+        bridge.setRemoteBroker(remote);
+        entity.getBridgeConfig().addAll(List.of(bridge));
+        watcher.start(config.toFile(), INTERVAL_MS, () -> entity);
+
+        Files.delete(keystore);
+
+        await("the vanished keystore to be reported", () -> logged(Level.WARN, "no longer exists") == 1);
+        ticks(10);
+        assertThat(logged(Level.WARN, "no longer exists"))
+                .as("reported once, not every tick")
+                .isEqualTo(1);
+        assertThat(restarts).hasValue(0);
+    }
+
+    // ---- nothing ends the watch
+
+    @Test
+    @Timeout(30)
+    public void aReloadThatThrowsDoesNotEndTheWatch() throws Exception {
+        reloadFailure.set(new IllegalStateException("simulated"));
+        start();
+        rewrite(config, "v1", 2);
+        await("the failed check to be reported", () -> logged(Level.ERROR, "watcher failed to check") >= 1);
+
+        reloadFailure.set(null);
+        rewrite(config, "v2", 4);
+        await("the next change to be reloaded", () -> reloads.get() == 1);
+    }
+
+    @Test
+    @Timeout(30)
+    public void aMissingConfigurationFileDoesNotEndTheWatch() throws Exception {
+        start();
+        Files.delete(config);
+        await("the failed check to be reported", () -> logged(Level.ERROR, "watcher failed to check") >= 1);
+
+        rewrite(config, "recreated", 4);
+        await("the recreated file to be reloaded", () -> reloads.get() == 1);
+    }
+
+    // ---- the lock and the lifecycle
+
+    @Test
+    @Timeout(30)
+    public void theCheckWaitsForTheConfigurationLock() throws Exception {
+        start();
+        final CountDownLatch holding = new CountDownLatch(1);
+        final CountDownLatch release = new CountDownLatch(1);
+        final Thread holder = new Thread(() -> {
+            lock.lock();
+            try {
+                holding.countDown();
+                release.await();
+            } catch (final InterruptedException e) {
+                Thread.currentThread().interrupt();
+            } finally {
+                lock.unlock();
+            }
+        });
+        holder.setDaemon(true);
+        holder.start();
+        assertThat(holding.await(5, TimeUnit.SECONDS)).isTrue();
+
+        rewrite(config, "v1", 2);
+        ticks(6);
+        assertThat(reloads)
+                .as("no reload while another transition holds the lock")
+                .hasValue(0);
+
+        release.countDown();
+        await("the reload once the lock is free", () -> reloads.get() == 1);
+        holder.join(5000);
+    }
+
+    @Test
+    public void startingTwiceIsRefused() {
+        start();
+        assertThatThrownBy(this::start).isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    @Timeout(30)
+    public void aStoppedWatchCanBeStartedAgain() throws Exception {
+        start();
+        watcher.stop();
+        rewrite(config, "while stopped", 2);
+        ticks(6);
+        assertThat(reloads).as("a stopped watch reloads nothing").hasValue(0);
+
+        start(); // seeds from the file as it is now: what changed while stopped is the new baseline
+        ticks(4);
+        assertThat(reloads)
+                .as("a restarted watch does not replay what it missed")
+                .hasValue(0);
+        rewrite(config, "after the restart", 4);
+        await("a change after the restart is seen", () -> reloads.get() == 1);
+    }
+}

--- a/hivemq-edge/src/test/java/com/hivemq/configuration/reader/ConfigFileWatcherTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/configuration/reader/ConfigFileWatcherTest.java
@@ -368,13 +368,31 @@ public class ConfigFileWatcherTest {
 
     @Test
     @Timeout(30)
-    public void aMissingConfigurationFileDoesNotEndTheWatch() throws Exception {
+    public void aMissingConfigurationFileIsAWarningAndTheWatchGoesOn() throws Exception {
         start();
         Files.delete(config);
-        await("the failed check to be reported", () -> logged(Level.ERROR, "watcher failed to check") >= 1);
+        await("the missing file to be reported", () -> logged(Level.WARN, "does not exist") >= 1);
+        // Not an error: the file is missing, the watcher is fine (CI on EDG-949: an embedded node's
+        // teardown deletes the folder, and the integration suite fails on any ERROR line).
+        assertThat(logged(Level.ERROR, "watcher failed to check")).isZero();
 
         rewrite(config, "recreated", 4);
         await("the recreated file to be reloaded", () -> reloads.get() == 1);
+        assertThat(logged(Level.ERROR, "watcher failed to check")).isZero();
+    }
+
+    @Test
+    @Timeout(30)
+    public void aStoppedWatchDoesNotNoticeTheFolderGoingAway() throws Exception {
+        start();
+        ticks(2);
+        watcher.stop();
+        final long warningsAtStop = logged(Level.WARN, "does not exist");
+        Files.delete(config);
+        ticks(6);
+        assertThat(logged(Level.WARN, "does not exist")).isEqualTo(warningsAtStop);
+        assertThat(logged(Level.ERROR, "watcher failed to check")).isZero();
+        assertThat(reloads.get()).isZero();
     }
 
     // ---- the lock and the lifecycle

--- a/hivemq-edge/src/test/java/com/hivemq/configuration/reader/ConfigWriteAclPermissionsTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/configuration/reader/ConfigWriteAclPermissionsTest.java
@@ -25,7 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.jimfs.Configuration;
 import com.google.common.jimfs.Jimfs;
-import com.hivemq.configuration.reader.ConfigFileReaderWriter.PreservedAttributes;
+import com.hivemq.configuration.reader.ProtectedFileReplacer.PreservedAttributes;
 import java.io.IOException;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
@@ -106,9 +106,9 @@ public class ConfigWriteAclPermissionsTest {
      */
     @Test
     public void createPartialFile_restrictsTheReplacementToItsOwnerBeforeItIsWritten() throws IOException {
-        final PreservedAttributes preserved = ConfigFileReaderWriter.preservedAttributesOf(targetReadableBy(bob));
+        final PreservedAttributes preserved = ProtectedFileReplacer.preservedAttributesOf(targetReadableBy(bob));
 
-        ConfigFileReaderWriter.createPartialFile(partial, preserved);
+        ProtectedFileReplacer.createPartialFile(partial, preserved);
 
         final List<AclEntry> actual = aclOf(partial);
         assertEquals(1, actual.size(), "the replacement is open to someone other than its owner");
@@ -128,9 +128,9 @@ public class ConfigWriteAclPermissionsTest {
     @Test
     public void createPartialFile_doesNotGiveTheReplacementTheTargetsOwnAcl() throws IOException {
         final Path target = targetReadableBy(bob);
-        final PreservedAttributes preserved = ConfigFileReaderWriter.preservedAttributesOf(target);
+        final PreservedAttributes preserved = ProtectedFileReplacer.preservedAttributesOf(target);
 
-        ConfigFileReaderWriter.createPartialFile(partial, preserved);
+        ProtectedFileReplacer.createPartialFile(partial, preserved);
 
         assertNotEquals(aclOf(target), aclOf(partial), "the replacement was created as open as its target");
         assertFalse(
@@ -148,8 +148,8 @@ public class ConfigWriteAclPermissionsTest {
         aclViewOf(partial).setAcl(readWriteFor(bob));
         Files.writeString(partial, "left behind by a killed write");
 
-        ConfigFileReaderWriter.createPartialFile(
-                partial, ConfigFileReaderWriter.preservedAttributesOf(targetReadableBy(bob)));
+        ProtectedFileReplacer.createPartialFile(
+                partial, ProtectedFileReplacer.preservedAttributesOf(targetReadableBy(bob)));
 
         assertFalse(namesPrincipal(aclOf(partial), bob), "a stale partial was reopened and kept its access control");
         assertEquals("", Files.readString(partial), "the stale content survived into the new write");
@@ -163,7 +163,7 @@ public class ConfigWriteAclPermissionsTest {
      */
     @Test
     public void createPartialFile_withNothingToReproduce_createsTheFileNormally() throws IOException {
-        ConfigFileReaderWriter.createPartialFile(partial, PreservedAttributes.NONE);
+        ProtectedFileReplacer.createPartialFile(partial, PreservedAttributes.NONE);
 
         assertTrue(Files.exists(partial), "the replacement must still be created");
     }
@@ -179,7 +179,7 @@ public class ConfigWriteAclPermissionsTest {
         final Path target = targetReadableBy(bob);
         Files.getFileAttributeView(target, AclFileAttributeView.class).setOwner(alice);
 
-        final PreservedAttributes preserved = ConfigFileReaderWriter.preservedAttributesOf(target);
+        final PreservedAttributes preserved = ProtectedFileReplacer.preservedAttributesOf(target);
 
         assertEquals(alice, preserved.owner(), "the owner of an ACL-only file was not carried");
         assertEquals(aclOf(target), preserved.acl(), "the access-control list was not carried");
@@ -198,7 +198,7 @@ public class ConfigWriteAclPermissionsTest {
         Files.createFile(target);
         aclViewOf(target).setAcl(List.of());
 
-        final PreservedAttributes preserved = ConfigFileReaderWriter.preservedAttributesOf(target);
+        final PreservedAttributes preserved = ProtectedFileReplacer.preservedAttributesOf(target);
 
         assertEquals(List.of(), preserved.acl(), "an empty access-control list was read as 'there is none'");
         assertFalse(
@@ -212,10 +212,10 @@ public class ConfigWriteAclPermissionsTest {
         final Path target = directory.resolve("config.xml");
         Files.createFile(target);
         aclViewOf(target).setAcl(List.of());
-        final PreservedAttributes preserved = ConfigFileReaderWriter.preservedAttributesOf(target);
-        ConfigFileReaderWriter.createPartialFile(partial, preserved);
+        final PreservedAttributes preserved = ProtectedFileReplacer.preservedAttributesOf(target);
+        ProtectedFileReplacer.createPartialFile(partial, preserved);
 
-        ConfigFileReaderWriter.applyPreservedAttributes(partial, preserved);
+        ProtectedFileReplacer.applyPreservedAttributes(partial, preserved);
 
         assertEquals(List.of(), aclOf(partial), "the replacement is readable by someone the target was not");
     }
@@ -225,11 +225,11 @@ public class ConfigWriteAclPermissionsTest {
     public void applyPreservedAttributes_reproducesTheTargetsAclAndOwner() throws IOException {
         final Path target = targetReadableBy(bob);
         aclViewOf(target).setOwner(alice);
-        final PreservedAttributes preserved = ConfigFileReaderWriter.preservedAttributesOf(target);
-        ConfigFileReaderWriter.createPartialFile(partial, preserved);
+        final PreservedAttributes preserved = ProtectedFileReplacer.preservedAttributesOf(target);
+        ProtectedFileReplacer.createPartialFile(partial, preserved);
         Files.writeString(partial, "<hivemq><bridge><password>s3cr3t</password></bridge></hivemq>");
 
-        ConfigFileReaderWriter.applyPreservedAttributes(partial, preserved);
+        ProtectedFileReplacer.applyPreservedAttributes(partial, preserved);
 
         assertEquals(aclOf(target), aclOf(partial), "the target's access-control list was not reproduced");
         assertEquals(alice, Files.getOwner(partial), "the target's owner was not reproduced");
@@ -243,14 +243,14 @@ public class ConfigWriteAclPermissionsTest {
     @Test
     public void theReplacementIsNeverWiderThanItsTargetWhileItHoldsTheConfiguration() throws IOException {
         final Path target = targetReadableBy(bob);
-        final PreservedAttributes preserved = ConfigFileReaderWriter.preservedAttributesOf(target);
+        final PreservedAttributes preserved = ProtectedFileReplacer.preservedAttributesOf(target);
 
-        ConfigFileReaderWriter.createPartialFile(partial, preserved);
+        ProtectedFileReplacer.createPartialFile(partial, preserved);
         assertFalse(namesPrincipal(aclOf(partial), bob), "the secrets are written into a file bob can read");
         Files.writeString(partial, "<hivemq><bridge><password>s3cr3t</password></bridge></hivemq>");
         assertFalse(namesPrincipal(aclOf(partial), bob), "the file was widened while it still held the secrets");
 
-        ConfigFileReaderWriter.applyPreservedAttributes(partial, preserved);
+        ProtectedFileReplacer.applyPreservedAttributes(partial, preserved);
 
         assertEquals(aclOf(target), aclOf(partial), "the target's access-control list was not reproduced");
     }
@@ -272,7 +272,7 @@ public class ConfigWriteAclPermissionsTest {
 
         final IOException refused = assertThrows(
                 IOException.class,
-                () -> ConfigFileReaderWriter.verifyPreservedAttributes(
+                () -> ProtectedFileReplacer.verifyPreservedAttributes(
                         partial, new PreservedAttributes(null, null, null, readWriteFor(bob))),
                 "an access-control list that did not take must abort the replacement, not be assumed");
         assertTrue(refused.getMessage().contains("access-control list"), refused.getMessage());
@@ -289,7 +289,7 @@ public class ConfigWriteAclPermissionsTest {
         Files.createFile(partial);
         aclViewOf(partial).setAcl(List.of());
 
-        ConfigFileReaderWriter.verifyPreservedAttributes(
+        ProtectedFileReplacer.verifyPreservedAttributes(
                 partial, new PreservedAttributes(null, null, null, readWriteFor(bob)));
     }
 
@@ -310,7 +310,7 @@ public class ConfigWriteAclPermissionsTest {
                                 .setPermissions(EnumSet.of(AclEntryPermission.WRITE_DATA))
                                 .build()));
 
-        ConfigFileReaderWriter.verifyPreservedAttributes(
+        ProtectedFileReplacer.verifyPreservedAttributes(
                 partial, new PreservedAttributes(null, null, null, readWriteFor(bob)));
     }
 
@@ -321,7 +321,7 @@ public class ConfigWriteAclPermissionsTest {
         Files.createFile(partial);
         aclViewOf(partial).setAcl(readWriteFor(bob));
 
-        ConfigFileReaderWriter.verifyPreservedAttributes(
+        ProtectedFileReplacer.verifyPreservedAttributes(
                 partial, new PreservedAttributes(null, null, null, readWriteFor(bob)));
     }
 
@@ -329,11 +329,11 @@ public class ConfigWriteAclPermissionsTest {
     @Test
     public void applyPreservedAttributes_whenTheOwnerDoesNotTake_thenTheWriteIsAborted() throws IOException {
         final PreservedAttributes preserved = new PreservedAttributes(null, new NeverTheSame("alice"), null, null);
-        ConfigFileReaderWriter.createPartialFile(partial, preserved);
+        ProtectedFileReplacer.createPartialFile(partial, preserved);
 
         final IOException refused = assertThrows(
                 IOException.class,
-                () -> ConfigFileReaderWriter.applyPreservedAttributes(partial, preserved),
+                () -> ProtectedFileReplacer.applyPreservedAttributes(partial, preserved),
                 "an owner that did not take must abort the replacement, not be assumed");
         assertTrue(refused.getMessage().contains("owned by"), refused.getMessage());
     }
@@ -344,13 +344,13 @@ public class ConfigWriteAclPermissionsTest {
      */
     @Test
     public void applyPreservedAttributes_whenTheAclCannotBeApplied_thenTheWriteIsAborted() throws IOException {
-        final PreservedAttributes preserved = ConfigFileReaderWriter.preservedAttributesOf(targetReadableBy(bob));
-        ConfigFileReaderWriter.createPartialFile(partial, preserved);
+        final PreservedAttributes preserved = ProtectedFileReplacer.preservedAttributesOf(targetReadableBy(bob));
+        ProtectedFileReplacer.createPartialFile(partial, preserved);
         Files.delete(partial); // the replacement is gone, so its protections cannot be set
 
         assertThrows(
                 IOException.class,
-                () -> ConfigFileReaderWriter.applyPreservedAttributes(partial, preserved),
+                () -> ProtectedFileReplacer.applyPreservedAttributes(partial, preserved),
                 "protections that cannot be reproduced must abort the replacement, not be logged and ignored");
     }
 
@@ -362,9 +362,9 @@ public class ConfigWriteAclPermissionsTest {
     @Test
     public void replaceCarryingProtections_writesUnderTheTargetsProtectionsAndLeavesNothingBehind() throws IOException {
         final Path target = targetReadableBy(bob);
-        final PreservedAttributes preserved = ConfigFileReaderWriter.preservedAttributesOf(target);
+        final PreservedAttributes preserved = ProtectedFileReplacer.preservedAttributesOf(target);
 
-        ConfigFileReaderWriter.replaceCarryingProtections(target, preserved, written -> {
+        ProtectedFileReplacer.replaceCarryingProtections(target, preserved, written -> {
             assertFalse(namesPrincipal(aclOf(written), bob), "the configuration is written into a file bob can read");
             Files.writeString(written, "<hivemq><bridge><password>s3cr3t</password></bridge></hivemq>");
         });
@@ -383,7 +383,7 @@ public class ConfigWriteAclPermissionsTest {
     @Test
     public void preservedAttributesOf_aMissingFile_hasNothingToReproduce() throws IOException {
         final PreservedAttributes preserved =
-                ConfigFileReaderWriter.preservedAttributesOf(directory.resolve("not-written-yet.xml"));
+                ProtectedFileReplacer.preservedAttributesOf(directory.resolve("not-written-yet.xml"));
 
         assertTrue(preserved.nothingToReproduce(), "a first-time configuration file has nothing to preserve");
     }

--- a/hivemq-edge/src/test/java/com/hivemq/configuration/reader/ConfigWriteConcurrencyTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/configuration/reader/ConfigWriteConcurrencyTest.java
@@ -143,9 +143,9 @@ public class ConfigWriteConcurrencyTest {
                     if (!go.await(30, TimeUnit.SECONDS)) {
                         throw new IllegalStateException("the start gate never opened");
                     }
-                    ConfigFileReaderWriter.replaceCarryingProtections(
+                    ProtectedFileReplacer.replaceCarryingProtections(
                             target,
-                            ConfigFileReaderWriter.preservedAttributesOf(target),
+                            ProtectedFileReplacer.preservedAttributesOf(target),
                             partial -> Files.writeString(partial, content, StandardCharsets.UTF_8));
                     return null;
                 }));
@@ -192,9 +192,9 @@ public class ConfigWriteConcurrencyTest {
             }
             work.add(threads.submit(() -> {
                 for (int repeat = 0; repeat < 20; repeat++) {
-                    ConfigFileReaderWriter.replaceCarryingProtections(
+                    ProtectedFileReplacer.replaceCarryingProtections(
                             target,
-                            ConfigFileReaderWriter.preservedAttributesOf(target),
+                            ProtectedFileReplacer.preservedAttributesOf(target),
                             partial -> Files.writeString(partial, content, StandardCharsets.UTF_8));
                 }
                 return null;

--- a/hivemq-edge/src/test/java/com/hivemq/configuration/reader/ConfigWritePathHardeningTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/configuration/reader/ConfigWritePathHardeningTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import ch.qos.logback.classic.Level;
+import com.hivemq.configuration.service.ConfigurationService;
 import com.hivemq.edge.HiveMQEdgeConstants;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -39,6 +40,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.slf4j.LoggerFactory;
 import util.LogbackCapturingAppender;
+import util.TestConfigurationBootstrap;
 
 /**
  * EDG-949: the configuration write path, audited beside EDG-882. Four findings, each pinned by a test
@@ -128,6 +130,35 @@ public class ConfigWritePathHardeningTest extends AbstractConfigurationTest {
             Files.setPosixFilePermissions(staged, PosixFilePermissions.fromString(mode));
         }
         Files.move(staged, file, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+    }
+
+    // ---- the watch ends with the node
+
+    @Test
+    @Timeout(30)
+    public void theConfigurationServiceStopsTheWatchWhenTheNodeStops() throws Exception {
+        rewrite(config, configWithBridge("edg-949-before-stop"), 0);
+        final ConfigurationService service = new TestConfigurationBootstrap().getConfigurationService();
+        service.setConfigFileReaderWriter(reader);
+        reader.applyConfigAndWatch(WATCH_INTERVAL_MS);
+        TimeUnit.MILLISECONDS.sleep(WATCH_INTERVAL_MS * 2);
+
+        service.stopWatchingConfigFile();
+
+        // What the integration suite does after stopping an embedded node: the folder goes away. A watch
+        // still ticking would report the missing file every interval, and the suite fails on ERROR lines.
+        Files.delete(config);
+        TimeUnit.MILLISECONDS.sleep(WATCH_INTERVAL_MS * 6);
+        assertThat(logged(Level.WARN)).noneMatch(line -> line.contains("does not exist"));
+        assertThat(logged(Level.ERROR)).noneMatch(line -> line.contains("watcher failed to check"));
+        // and "stopped" means it can be started again
+        rewrite(config, configWithBridge("edg-949-after-stop"), 2);
+        reader.applyConfigAndWatch(WATCH_INTERVAL_MS);
+    }
+
+    @Test
+    public void stoppingTheWatchWithoutAReaderIsANoOp() {
+        new TestConfigurationBootstrap().getConfigurationService().stopWatchingConfigFile();
     }
 
     private @NotNull String runningBridgeId() {
@@ -272,8 +303,11 @@ public class ConfigWritePathHardeningTest extends AbstractConfigurationTest {
 
         Files.delete(config);
 
-        await("the failed check to be reported", () -> logged(Level.ERROR).stream()
-                .anyMatch(message -> message.contains("watcher failed to check")));
+        await("the missing file to be reported", () -> logged(Level.WARN).stream()
+                .anyMatch(message -> message.contains("does not exist")));
+        // A warning, not an error: the integration suite fails a test on any ERROR line, and an operator
+        // replacing the file by remove-and-copy has done nothing wrong.
+        assertThat(logged(Level.ERROR)).noneMatch(message -> message.contains("watcher failed to check"));
         assertThat(runningBridgeId()).isEqualTo("edg-949-before");
 
         rewrite(config, configWithBridge("edg-949-recreated"), 4);

--- a/hivemq-edge/src/test/java/com/hivemq/configuration/reader/ConfigWritePathHardeningTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/configuration/reader/ConfigWritePathHardeningTest.java
@@ -1,0 +1,363 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.configuration.reader;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import ch.qos.logback.classic.Level;
+import com.hivemq.edge.HiveMQEdgeConstants;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.FileTime;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.ConcurrentModificationException;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BooleanSupplier;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.slf4j.LoggerFactory;
+import util.LogbackCapturingAppender;
+
+/**
+ * EDG-949: the configuration write path, audited beside EDG-882. Four findings, each pinned by a test
+ * that fails without its fix.
+ * <ol>
+ * <li>The hot-reload watcher survives an unparseable configuration and a watched fragment that
+ * disappears, and still restarts for a change that needs it.</li>
+ * <li>The rolling backup rotates only over the backups Edge itself wrote, never over an operator's own
+ * file that happens to match the name.</li>
+ * <li>A refused write consumes no backup slot.</li>
+ * <li>The last-write time moves only when the file was written.</li>
+ * </ol>
+ * Finding 5's five-slot count rides along with the rotation test.
+ */
+public class ConfigWritePathHardeningTest extends AbstractConfigurationTest {
+
+    private static final long WATCH_INTERVAL_MS = 50;
+    private static final long WAIT_SECONDS = 15;
+
+    private @NotNull LogbackCapturingAppender logCapture;
+    private @NotNull Path config;
+    private final @NotNull AtomicInteger restarts = new AtomicInteger();
+    private @NotNull String previousDevMode;
+
+    @BeforeEach
+    public void captureTheLogAndObserveRestarts() {
+        logCapture = LogbackCapturingAppender.Factory.weaveInto(LoggerFactory.getLogger(ConfigFileReaderWriter.class));
+        config = xmlFile.toPath();
+        reader.setRestartHook(restarts::incrementAndGet);
+        // The fragment and keystore watch only runs outside development mode, and so does the restart
+        // decision; other test classes set the property and do not always restore it.
+        previousDevMode = System.getProperty(HiveMQEdgeConstants.DEVELOPMENT_MODE, "");
+        System.setProperty(HiveMQEdgeConstants.DEVELOPMENT_MODE, "false");
+    }
+
+    @AfterEach
+    public void stopWatchingAndRestore() {
+        reader.stopWatching();
+        System.setProperty(HiveMQEdgeConstants.DEVELOPMENT_MODE, previousDevMode);
+        LogbackCapturingAppender.Factory.cleanUp();
+    }
+
+    private static @NotNull String bridges(final @NotNull String bridgeId) {
+        return "<mqtt-bridges>\n    <mqtt-bridge>\n        <id>" + bridgeId + "</id>\n"
+                + "        <remote-broker>\n            <host>testhost</host>\n"
+                + "        </remote-broker>\n        <forwarded-topics>\n            <forwarded-topic>\n"
+                + "                <filters>\n                    <mqtt-topic-filter>plant/#</mqtt-topic-filter>\n"
+                + "                </filters>\n                <destination>{#}</destination>\n"
+                + "                <max-qos>1</max-qos>\n            </forwarded-topic>\n"
+                + "        </forwarded-topics>\n    </mqtt-bridge>\n</mqtt-bridges>";
+    }
+
+    private static @NotNull String configWithBridge(final @NotNull String bridgeId) {
+        return "<hivemq>\n" + bridges(bridgeId) + "\n</hivemq>";
+    }
+
+    private static @NotNull String configWithListener(final int port) {
+        return "<hivemq>\n<mqtt-listeners>\n    <tcp-listener>\n        <port>" + port + "</port>\n"
+                + "        <bind-address>127.0.0.1</bind-address>\n    </tcp-listener>\n</mqtt-listeners>\n"
+                + bridges("edg-949-listener-bridge") + "\n</hivemq>";
+    }
+
+    /**
+     * The watcher compares modification times with millisecond resolution and only reacts to a strictly
+     * later one, so every rewrite in these tests pushes the time forward by a full second.
+     */
+    private void rewrite(final @NotNull Path file, final @NotNull String content, final int secondsLater)
+            throws IOException {
+        rewrite(file, content, secondsLater, "rw-------");
+    }
+
+    /**
+     * Written beside the file and moved onto it, so the watcher sees the new content, its permissions and
+     * its modification time all at once rather than racing a write-then-touch.
+     */
+    private void rewrite(
+            final @NotNull Path file, final @NotNull String content, final int secondsLater, final @NotNull String mode)
+            throws IOException {
+        final Path staged = file.resolveSibling(file.getFileName() + ".staged");
+        Files.writeString(staged, content);
+        Files.setLastModifiedTime(staged, FileTime.fromMillis(System.currentTimeMillis() + secondsLater * 1000L));
+        // after the time: a file nobody may touch cannot have its time set either
+        if (staged.getFileSystem().supportedFileAttributeViews().contains("posix")) {
+            Files.setPosixFilePermissions(staged, PosixFilePermissions.fromString(mode));
+        }
+        Files.move(staged, file, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+    }
+
+    private @NotNull String runningBridgeId() {
+        return Objects.requireNonNull(Objects.requireNonNull(reader.getConfigEntity())
+                .getBridgeConfig()
+                .get(0)
+                .getId());
+    }
+
+    /** The watcher thread appends while this reads, so a torn read is retried rather than reported. */
+    private @NotNull List<String> logged(final @NotNull Level level) {
+        while (true) {
+            try {
+                return logCapture.getCapturedLogs().stream()
+                        .filter(event -> event.getLevel() == level)
+                        .map(event -> event.getFormattedMessage())
+                        .toList();
+            } catch (final ConcurrentModificationException torn) {
+                Thread.onSpinWait();
+            }
+        }
+    }
+
+    private static void await(final @NotNull String what, final @NotNull BooleanSupplier condition)
+            throws InterruptedException {
+        final long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(WAIT_SECONDS);
+        while (!condition.getAsBoolean()) {
+            if (System.nanoTime() > deadline) {
+                throw new AssertionError("timed out waiting for: " + what);
+            }
+            Thread.sleep(20);
+        }
+    }
+
+    private void requirePosix() {
+        assumeTrue(
+                config.getFileSystem().supportedFileAttributeViews().contains("posix"),
+                "the refusal is provoked through directory permissions");
+        assumeTrue(!"root".equals(System.getProperty("user.name")), "a superuser is not refused by mode bits");
+    }
+
+    // ---- finding 1: the watcher ----
+
+    @Test
+    @Timeout(60)
+    public void whenTheConfigurationBecomesUnparseable_thenTheNodeKeepsItsConfigurationAndTheWatcherLivesOn()
+            throws Exception {
+        rewrite(config, configWithBridge("edg-949-before"), 0);
+        reader.applyConfig();
+        reader.applyConfigAndWatch(WATCH_INTERVAL_MS);
+
+        rewrite(config, "<hivemq>\n<mqtt-bridges>\n    <mqtt-bridge>\n        <id>edg-949-broken", 2);
+
+        await("the rejected reload to be reported", () -> logged(Level.ERROR).stream()
+                .anyMatch(message -> message.contains("reload rejected")));
+        assertThat(runningBridgeId())
+                .as("the configuration the node runs on must be the one that parsed")
+                .isEqualTo("edg-949-before");
+        assertThat(restarts)
+                .as("a node restarted onto a file that cannot be parsed does not come back")
+                .hasValue(0);
+
+        // the watcher is still alive: the operator's correction is picked up
+        rewrite(config, configWithBridge("edg-949-corrected"), 4);
+        await("the corrected configuration to be applied", () -> "edg-949-corrected".equals(runningBridgeId()));
+        assertThat(restarts).hasValue(0);
+    }
+
+    @Test
+    @Timeout(60)
+    public void whenAWatchedFragmentDisappears_thenTheWatcherLivesOn() throws Exception {
+        final Path fragment = temporaryFolder.toPath().resolve("bridges.fragment");
+        Files.writeString(fragment, bridges("edg-949-from-fragment"));
+        rewrite(config, "<hivemq>\n${FRAGMENT:" + fragment + "}\n</hivemq>", 0);
+        reader.applyConfig();
+        assertThat(runningBridgeId()).isEqualTo("edg-949-from-fragment");
+        reader.applyConfigAndWatch(WATCH_INTERVAL_MS);
+
+        Files.delete(fragment);
+
+        await("the vanished fragment to be reported and dropped", () -> logged(Level.WARN).stream()
+                .anyMatch(message -> message.contains("no longer exists")));
+
+        // the watcher is still alive: a configuration that no longer references the fragment is applied
+        rewrite(config, configWithBridge("edg-949-without-fragment"), 2);
+        await("the new configuration to be applied", () -> "edg-949-without-fragment".equals(runningBridgeId()));
+        assertThat(restarts).hasValue(0);
+        assertThat(logged(Level.ERROR))
+                .as("nothing escaped the periodic task")
+                .noneMatch(message -> message.contains("watcher failed"));
+    }
+
+    @Test
+    @Timeout(60)
+    public void whenTheReloadedConfigurationNeedsARestart_thenTheNodeStillRestarts() throws Exception {
+        rewrite(config, configWithListener(18831), 0);
+        reader.applyConfig();
+        reader.applyConfigAndWatch(WATCH_INTERVAL_MS);
+
+        rewrite(config, configWithListener(18832), 2);
+
+        await("the restart decision", () -> restarts.get() > 0);
+        assertThat(logged(Level.ERROR)).anyMatch(message -> message.contains("can't be hot-reloaded"));
+    }
+
+    /** An unreadable file is reported the way an unparseable one is: rejected, previous configuration kept. */
+    @Test
+    @Timeout(60)
+    public void whenTheConfigurationIsMomentarilyUnreadable_thenTheWatcherTriesAgain() throws Exception {
+        requirePosix();
+        rewrite(config, configWithBridge("edg-949-before"), 0);
+        reader.applyConfig();
+        reader.applyConfigAndWatch(WATCH_INTERVAL_MS);
+
+        // a rewrite the node cannot read at the moment it looks
+        rewrite(config, configWithBridge("edg-949-after"), 2, "---------");
+        try {
+            await("the unreadable file to be reported", () -> logged(Level.ERROR).stream()
+                    .anyMatch(message -> message.contains("reload rejected")));
+        } finally {
+            Files.setPosixFilePermissions(config, PosixFilePermissions.fromString("rw-------"));
+        }
+        assertThat(runningBridgeId()).isEqualTo("edg-949-before");
+
+        // readable again, and changed again: the watcher must still be running to see it
+        rewrite(config, configWithBridge("edg-949-readable-again"), 4);
+        await("the change after the outage to be applied", () -> "edg-949-readable-again".equals(runningBridgeId()));
+        assertThat(restarts).hasValue(0);
+    }
+
+    /**
+     * A file that is not there at all fails before any parse -- reading its modification time throws --
+     * which is what used to end the periodic task for good. An external tool replacing the file by
+     * delete-and-recreate produces exactly this window.
+     */
+    @Test
+    @Timeout(60)
+    public void whenTheConfigurationFileIsMomentarilyMissing_thenTheWatcherTriesAgain() throws Exception {
+        rewrite(config, configWithBridge("edg-949-before"), 0);
+        reader.applyConfig();
+        reader.applyConfigAndWatch(WATCH_INTERVAL_MS);
+
+        Files.delete(config);
+
+        await("the failed check to be reported", () -> logged(Level.ERROR).stream()
+                .anyMatch(message -> message.contains("watcher failed to check")));
+        assertThat(runningBridgeId()).isEqualTo("edg-949-before");
+
+        rewrite(config, configWithBridge("edg-949-recreated"), 4);
+        await("the recreated file to be applied", () -> "edg-949-recreated".equals(runningBridgeId()));
+        assertThat(restarts).hasValue(0);
+    }
+
+    // ---- findings 2 and 5: the rotation ----
+
+    @Test
+    public void whenTheBackupsRotate_thenOnlyTheBackupsEdgeWroteAreCandidates() throws Exception {
+        final Path archive = config.resolveSibling("config-archive-2024.xml");
+        final String archived = "<hivemq><!-- the operator's own copy, older than everything --></hivemq>";
+        Files.writeString(archive, archived);
+        Files.setLastModifiedTime(archive, FileTime.fromMillis(1_700_000_000_000L)); // 2023
+
+        for (int write = 1; write <= 8; write++) {
+            rewrite(config, configWithBridge("edg-949-write-" + write), write);
+            reader.applyConfig();
+            reader.writeConfigToXML(xmlFile, true, true);
+        }
+
+        assertThat(Files.readString(archive))
+                .as("a file Edge did not create was overwritten by the rolling backup")
+                .isEqualTo(archived);
+        assertThat(Files.getLastModifiedTime(archive).toMillis()).isEqualTo(1_700_000_000_000L);
+        for (int slot = 1; slot <= 5; slot++) {
+            assertThat(config.resolveSibling("config_" + slot + ".xml"))
+                    .as("all five configured slots are used, not four")
+                    .exists();
+        }
+        assertThat(config.resolveSibling("config_6.xml")).doesNotExist();
+        assertThat(Files.readString(config)).contains("edg-949-write-8");
+    }
+
+    // ---- finding 3: a refused write and the backup ----
+
+    /**
+     * The configured path is a link into a directory the node cannot write, which is a mounted
+     * configuration. The backup goes beside the link, the replacement beside the real file, so the
+     * backup used to be taken and the write refused a moment later -- one slot per refusal.
+     */
+    @Test
+    public void whenTheWriteIsRefused_thenNoBackupSlotIsConsumed() throws Exception {
+        requirePosix();
+        final Path mounted = Files.createDirectory(temporaryFolder.toPath().resolve("mounted"));
+        final Path real = mounted.resolve("real.xml");
+        Files.writeString(real, configWithBridge("edg-949-mounted"));
+        Files.createSymbolicLink(config, real);
+        reader.applyConfig();
+        Files.setPosixFilePermissions(mounted, PosixFilePermissions.fromString("r-x------"));
+        try {
+            for (int refusal = 0; refusal < 3; refusal++) {
+                reader.writeConfigWithSync();
+            }
+        } finally {
+            Files.setPosixFilePermissions(mounted, PosixFilePermissions.fromString("rwx------"));
+        }
+
+        assertThat(logged(Level.ERROR)).anyMatch(message -> message.contains("was not written to config.xml"));
+        try (var listing = Files.list(temporaryFolder.toPath())) {
+            assertThat(listing.map(path -> path.getFileName().toString()).toList())
+                    .as("a refused write must not rotate the backups")
+                    .containsExactlyInAnyOrder("config.xml", "mounted");
+        }
+        assertThat(Files.readString(real)).contains("edg-949-mounted");
+    }
+
+    // ---- finding 4: the last-write time ----
+
+    @Test
+    public void whenTheWriteIsRefused_thenTheLastWriteTimeDoesNotMove() throws Exception {
+        requirePosix();
+        rewrite(config, configWithBridge("edg-949-stamp"), 0);
+        reader.applyConfig();
+        assertThat(reader.getLastWrite()).isZero();
+        Files.setPosixFilePermissions(config, PosixFilePermissions.fromString("r--r--r--"));
+
+        reader.writeConfigWithSync();
+
+        assertThat(reader.getLastWrite())
+                .as("the node must not report the configuration as written when it refused to write it")
+                .isZero();
+
+        Files.setPosixFilePermissions(config, PosixFilePermissions.fromString("rw-------"));
+        final long before = System.currentTimeMillis();
+        reader.writeConfigWithSync();
+        assertThat(reader.getLastWrite()).isGreaterThanOrEqualTo(before);
+    }
+}

--- a/hivemq-edge/src/test/java/com/hivemq/configuration/reader/ConfigWritePathHardeningTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/configuration/reader/ConfigWritePathHardeningTest.java
@@ -65,7 +65,9 @@ public class ConfigWritePathHardeningTest extends AbstractConfigurationTest {
 
     @BeforeEach
     public void captureTheLogAndObserveRestarts() {
-        logCapture = LogbackCapturingAppender.Factory.weaveInto(LoggerFactory.getLogger(ConfigFileReaderWriter.class));
+        // The package logger: the lines asserted below come from the reader-writer and from the watcher.
+        logCapture = LogbackCapturingAppender.Factory.weaveInto(
+                LoggerFactory.getLogger(ConfigFileReaderWriter.class.getPackageName()));
         config = xmlFile.toPath();
         reader.setRestartHook(restarts::incrementAndGet);
         // The fragment and keystore watch only runs outside development mode, and so does the restart
@@ -102,8 +104,9 @@ public class ConfigWritePathHardeningTest extends AbstractConfigurationTest {
     }
 
     /**
-     * The watcher compares modification times with millisecond resolution and only reacts to a strictly
-     * later one, so every rewrite in these tests pushes the time forward by a full second.
+     * The watcher compares modification times with millisecond resolution and reacts to any change, so
+     * every rewrite in these tests moves the time by whole seconds to stay clear of the granularity of
+     * any file system.
      */
     private void rewrite(final @NotNull Path file, final @NotNull String content, final int secondsLater)
             throws IOException {
@@ -278,14 +281,101 @@ public class ConfigWritePathHardeningTest extends AbstractConfigurationTest {
         assertThat(restarts).hasValue(0);
     }
 
+    /**
+     * The node's own REST write bumps the file's time. The watcher must not read, parse and re-apply a
+     * file it has just written itself: pointless work after every REST change, and every such reload
+     * takes the configuration lock first and the extractors' monitors second, the inverse of the REST
+     * path (EDG-937 R3-02) -- a window that should not open on its own.
+     */
+    @Test
+    @Timeout(60)
+    public void whenTheNodeWritesTheConfigurationItself_thenTheWatcherDoesNotReloadIt() throws Exception {
+        rewrite(config, configWithBridge("edg-949-own-write"), 0);
+        reader.applyConfig();
+        reader.applyConfigAndWatch(WATCH_INTERVAL_MS);
+        Thread.sleep(WATCH_INTERVAL_MS * 4);
+        final long readsBefore = logged(Level.INFO).stream()
+                .filter(m -> m.contains("Reading configuration file"))
+                .count();
+
+        final FileTime beforeWrite = Files.getLastModifiedTime(config);
+        Thread.sleep(1100); // a second, so the write moves the time on any file system
+        reader.writeConfigWithSync();
+        assertThat(Files.getLastModifiedTime(config))
+                .as("the write must have replaced the file")
+                .isNotEqualTo(beforeWrite);
+        Thread.sleep(WATCH_INTERVAL_MS * 6);
+
+        final long readsAfter = logged(Level.INFO).stream()
+                .filter(m -> m.contains("Reading configuration file"))
+                .count();
+        assertThat(readsAfter).as("the watcher re-read the node's own write").isEqualTo(readsBefore);
+        assertThat(restarts).hasValue(0);
+
+        // and an operator's edit after that is still seen
+        rewrite(config, configWithBridge("edg-949-operator-edit"), 4);
+        await("the operator's edit to be applied", () -> "edg-949-operator-edit".equals(runningBridgeId()));
+    }
+
+    /**
+     * A restore from a backup -- cp -p, rsync -a, a volume remount -- carries an older time than the
+     * broken file it replaces. A high-water mark on the time would ignore the correction for good.
+     */
+    @Test
+    @Timeout(60)
+    public void whenAnOlderFileIsRestoredOverABrokenOne_thenItIsApplied() throws Exception {
+        rewrite(config, configWithBridge("edg-949-before"), 0);
+        reader.applyConfig();
+        reader.applyConfigAndWatch(WATCH_INTERVAL_MS);
+
+        rewrite(config, "<hivemq><mqtt-bridges><mqtt-bridge><id>edg-949-broken", 6);
+        await("the rejected reload to be reported", () -> logged(Level.ERROR).stream()
+                .anyMatch(message -> message.contains("reload rejected")));
+        final FileTime broken = Files.getLastModifiedTime(config);
+
+        rewrite(config, configWithBridge("edg-949-restored"), 0);
+        Files.setLastModifiedTime(config, FileTime.fromMillis(broken.toMillis() - 60_000)); // a minute older
+
+        await("the older, restored file to be applied", () -> "edg-949-restored".equals(runningBridgeId()));
+        assertThat(restarts).hasValue(0);
+    }
+
+    /**
+     * An unset variable is the most ordinary reload mistake. It used to fall through to the generic
+     * handler, which logged "Exiting HiveMQ Edge" on a node that was not exiting -- and an operator who
+     * believed it and restarted would not get the node back.
+     */
+    @Test
+    @Timeout(60)
+    public void whenAPlaceholderCannotBeRendered_thenTheReloadIsRejectedAndNothingSaysExiting() throws Exception {
+        rewrite(config, configWithBridge("edg-949-before"), 0);
+        reader.applyConfig();
+        reader.applyConfigAndWatch(WATCH_INTERVAL_MS);
+
+        rewrite(config, configWithBridge("${ENV:EDG949_VARIABLE_THAT_IS_NOT_SET}"), 2);
+
+        await("the rejected reload to be reported", () -> logged(Level.ERROR).stream()
+                .anyMatch(message -> message.contains("reload rejected")));
+        assertThat(logged(Level.ERROR)).anyMatch(message -> message.contains("could not be rendered"));
+        assertThat(logged(Level.ERROR)).noneMatch(message -> message.contains("Exiting"));
+        assertThat(runningBridgeId()).isEqualTo("edg-949-before");
+        assertThat(restarts).hasValue(0);
+
+        rewrite(config, configWithBridge("edg-949-fixed"), 4);
+        await("the correction to be applied", () -> "edg-949-fixed".equals(runningBridgeId()));
+    }
+
     // ---- findings 2 and 5: the rotation ----
 
     @Test
     public void whenTheBackupsRotate_thenOnlyTheBackupsEdgeWroteAreCandidates() throws Exception {
         final Path archive = config.resolveSibling("config-archive-2024.xml");
+        final Path yearArchive = config.resolveSibling("config_2024.xml"); // digits only: still not a slot
         final String archived = "<hivemq><!-- the operator's own copy, older than everything --></hivemq>";
         Files.writeString(archive, archived);
+        Files.writeString(yearArchive, archived);
         Files.setLastModifiedTime(archive, FileTime.fromMillis(1_700_000_000_000L)); // 2023
+        Files.setLastModifiedTime(yearArchive, FileTime.fromMillis(1_700_000_000_000L));
 
         for (int write = 1; write <= 8; write++) {
             rewrite(config, configWithBridge("edg-949-write-" + write), write);
@@ -297,6 +387,9 @@ public class ConfigWritePathHardeningTest extends AbstractConfigurationTest {
                 .as("a file Edge did not create was overwritten by the rolling backup")
                 .isEqualTo(archived);
         assertThat(Files.getLastModifiedTime(archive).toMillis()).isEqualTo(1_700_000_000_000L);
+        assertThat(Files.readString(yearArchive))
+                .as("a file named like a slot but outside the slot range was overwritten")
+                .isEqualTo(archived);
         for (int slot = 1; slot <= 5; slot++) {
             assertThat(config.resolveSibling("config_" + slot + ".xml"))
                     .as("all five configured slots are used, not four")

--- a/hivemq-edge/src/test/java/com/hivemq/configuration/reader/ConfigWritePermissionsTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/configuration/reader/ConfigWritePermissionsTest.java
@@ -23,7 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-import com.hivemq.configuration.reader.ConfigFileReaderWriter.PreservedAttributes;
+import com.hivemq.configuration.reader.ProtectedFileReplacer.PreservedAttributes;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -113,8 +113,8 @@ public class ConfigWritePermissionsTest {
      */
     @Test
     public void createPartialFile_createsTheReplacementOwnerOnly() throws IOException {
-        ConfigFileReaderWriter.createPartialFile(
-                partial, ConfigFileReaderWriter.preservedAttributesOf(targetWith(OWNER_ONLY)));
+        ProtectedFileReplacer.createPartialFile(
+                partial, ProtectedFileReplacer.preservedAttributesOf(targetWith(OWNER_ONLY)));
 
         assertEquals(
                 OWNER_ONLY,
@@ -129,8 +129,8 @@ public class ConfigWritePermissionsTest {
      */
     @Test
     public void createPartialFile_isOwnerOnlyEvenWhenTheTargetIsWorldReadable() throws IOException {
-        ConfigFileReaderWriter.createPartialFile(
-                partial, ConfigFileReaderWriter.preservedAttributesOf(targetWith(WORLD_READABLE)));
+        ProtectedFileReplacer.createPartialFile(
+                partial, ProtectedFileReplacer.preservedAttributesOf(targetWith(WORLD_READABLE)));
 
         assertEquals(
                 OWNER_ONLY,
@@ -148,8 +148,8 @@ public class ConfigWritePermissionsTest {
         Files.createFile(partial, PosixFilePermissions.asFileAttribute(WORLD_WRITABLE));
         Files.writeString(partial, "left behind by a killed write");
 
-        ConfigFileReaderWriter.createPartialFile(
-                partial, ConfigFileReaderWriter.preservedAttributesOf(targetWith(OWNER_ONLY)));
+        ProtectedFileReplacer.createPartialFile(
+                partial, ProtectedFileReplacer.preservedAttributesOf(targetWith(OWNER_ONLY)));
 
         assertEquals(
                 OWNER_ONLY,
@@ -165,7 +165,7 @@ public class ConfigWritePermissionsTest {
      */
     @Test
     public void createPartialFile_withNothingToReproduce_createsTheFileNormally() throws IOException {
-        ConfigFileReaderWriter.createPartialFile(partial, PreservedAttributes.NONE);
+        ProtectedFileReplacer.createPartialFile(partial, PreservedAttributes.NONE);
 
         assertTrue(Files.exists(partial), "the replacement must still be created");
     }
@@ -173,10 +173,10 @@ public class ConfigWritePermissionsTest {
     /** The widening step: the written replacement ends up with exactly the target's mode. */
     @Test
     public void applyPreservedAttributes_givesTheReplacementTheTargetsExactMode() throws IOException {
-        final PreservedAttributes preserved = ConfigFileReaderWriter.preservedAttributesOf(targetWith(WORLD_READABLE));
-        ConfigFileReaderWriter.createPartialFile(partial, preserved);
+        final PreservedAttributes preserved = ProtectedFileReplacer.preservedAttributesOf(targetWith(WORLD_READABLE));
+        ProtectedFileReplacer.createPartialFile(partial, preserved);
 
-        ConfigFileReaderWriter.applyPreservedAttributes(partial, preserved);
+        ProtectedFileReplacer.applyPreservedAttributes(partial, preserved);
 
         assertEquals(WORLD_READABLE, Files.getPosixFilePermissions(partial), "the target's mode was not reproduced");
     }
@@ -189,22 +189,22 @@ public class ConfigWritePermissionsTest {
      */
     @Test
     public void applyPreservedAttributes_whenTheModeCannotBeReproduced_thenTheWriteIsAborted() throws IOException {
-        final PreservedAttributes preserved = ConfigFileReaderWriter.preservedAttributesOf(targetWith(OWNER_ONLY));
-        ConfigFileReaderWriter.createPartialFile(partial, preserved);
+        final PreservedAttributes preserved = ProtectedFileReplacer.preservedAttributesOf(targetWith(OWNER_ONLY));
+        ProtectedFileReplacer.createPartialFile(partial, preserved);
         Files.delete(partial); // the replacement is gone, so its protections cannot be set
 
         assertThrows(
                 IOException.class,
-                () -> ConfigFileReaderWriter.applyPreservedAttributes(partial, preserved),
+                () -> ProtectedFileReplacer.applyPreservedAttributes(partial, preserved),
                 "protections that cannot be reproduced must abort the replacement, not be logged and ignored");
     }
 
     /** Nothing to reproduce is not a failure — it is the answer for a first-time configuration file. */
     @Test
     public void applyPreservedAttributes_withNothingToReproduce_isANoOp() throws IOException {
-        ConfigFileReaderWriter.createPartialFile(partial, PreservedAttributes.NONE);
+        ProtectedFileReplacer.createPartialFile(partial, PreservedAttributes.NONE);
 
-        ConfigFileReaderWriter.applyPreservedAttributes(partial, PreservedAttributes.NONE);
+        ProtectedFileReplacer.applyPreservedAttributes(partial, PreservedAttributes.NONE);
 
         assertTrue(Files.exists(partial));
     }
@@ -221,7 +221,7 @@ public class ConfigWritePermissionsTest {
         final Path target = targetWith(GROUP_READABLE);
         final PosixFileAttributes expected = Files.readAttributes(target, PosixFileAttributes.class);
 
-        final PreservedAttributes preserved = ConfigFileReaderWriter.preservedAttributesOf(target);
+        final PreservedAttributes preserved = ProtectedFileReplacer.preservedAttributesOf(target);
 
         assertEquals(GROUP_READABLE, preserved.permissions(), "the mode must still be carried");
         assertNotNull(preserved.owner(), "the owner must be carried, or 0640 names a group it cannot name");
@@ -247,11 +247,11 @@ public class ConfigWritePermissionsTest {
         assumeTrue(other != null, "this account has no second group, so there is nothing to tell apart");
 
         Files.getFileAttributeView(target, PosixFileAttributeView.class).setGroup(other);
-        final PreservedAttributes preserved = ConfigFileReaderWriter.preservedAttributesOf(target);
-        ConfigFileReaderWriter.createPartialFile(partial, preserved);
+        final PreservedAttributes preserved = ProtectedFileReplacer.preservedAttributesOf(target);
+        ProtectedFileReplacer.createPartialFile(partial, preserved);
         Files.writeString(partial, "<hivemq><bridge><password>s3cr3t</password></bridge></hivemq>");
 
-        ConfigFileReaderWriter.applyPreservedAttributes(partial, preserved);
+        ProtectedFileReplacer.applyPreservedAttributes(partial, preserved);
 
         final PosixFileAttributes actual = Files.readAttributes(partial, PosixFileAttributes.class);
         assertEquals(
@@ -279,7 +279,7 @@ public class ConfigWritePermissionsTest {
         try {
             assertThrows(
                     IOException.class,
-                    () -> ConfigFileReaderWriter.preservedAttributesOf(target),
+                    () -> ProtectedFileReplacer.preservedAttributesOf(target),
                     "a failure to read the target's protections must abort the write, not fall back to the umask");
         } finally {
             Files.setPosixFilePermissions(enclosing, PosixFilePermissions.fromString("rwx------"));
@@ -290,7 +290,7 @@ public class ConfigWritePermissionsTest {
     @Test
     public void preservedAttributesOf_aMissingFile_hasNothingToReproduce() throws IOException {
         final PreservedAttributes preserved =
-                ConfigFileReaderWriter.preservedAttributesOf(directory.resolve("not-written-yet.xml"));
+                ProtectedFileReplacer.preservedAttributesOf(directory.resolve("not-written-yet.xml"));
 
         assertTrue(preserved.nothingToReproduce(), "a first-time configuration file has nothing to preserve");
     }
@@ -303,9 +303,9 @@ public class ConfigWritePermissionsTest {
     @Test
     public void theReplacementIsNeverWiderThanItsTargetWhileItHoldsTheConfiguration() throws IOException {
         final Path target = targetWith(WORLD_READABLE);
-        final PreservedAttributes preserved = ConfigFileReaderWriter.preservedAttributesOf(target);
+        final PreservedAttributes preserved = ProtectedFileReplacer.preservedAttributesOf(target);
 
-        ConfigFileReaderWriter.createPartialFile(partial, preserved);
+        ProtectedFileReplacer.createPartialFile(partial, preserved);
         assertEquals(
                 OWNER_ONLY,
                 Files.getPosixFilePermissions(partial),
@@ -316,7 +316,7 @@ public class ConfigWritePermissionsTest {
                 Files.getPosixFilePermissions(partial),
                 "the file was widened while it still held the configuration");
 
-        ConfigFileReaderWriter.applyPreservedAttributes(partial, preserved);
+        ProtectedFileReplacer.applyPreservedAttributes(partial, preserved);
 
         final PosixFileAttributes actual = Files.readAttributes(partial, PosixFileAttributes.class);
         assertEquals(WORLD_READABLE, actual.permissions(), "the target's mode must be reproduced");
@@ -346,10 +346,10 @@ public class ConfigWritePermissionsTest {
                 directory.getFileSystem().getUserPrincipalLookupService().lookupPrincipalByName("root");
         final PreservedAttributes rootOwned =
                 new PreservedAttributes(attributes.permissions(), root, attributes.group(), null);
-        ConfigFileReaderWriter.createPartialFile(partial, rootOwned);
+        ProtectedFileReplacer.createPartialFile(partial, rootOwned);
         Files.writeString(partial, "<hivemq><bridge><password>s3cr3t</password></bridge></hivemq>");
 
-        ConfigFileReaderWriter.applyPreservedAttributes(partial, rootOwned);
+        ProtectedFileReplacer.applyPreservedAttributes(partial, rootOwned);
 
         final PosixFileAttributes actual = Files.readAttributes(partial, PosixFileAttributes.class);
         assertEquals(attributes.owner(), actual.owner(), "the replacement is owned by the account that wrote it");
@@ -384,10 +384,10 @@ public class ConfigWritePermissionsTest {
         assumeTrue(foreign != null, "this account can assign every group it can name, so there is nothing to refuse");
         final PreservedAttributes elsewhere =
                 new PreservedAttributes(attributes.permissions(), attributes.owner(), foreign, null);
-        ConfigFileReaderWriter.createPartialFile(partial, elsewhere);
+        ProtectedFileReplacer.createPartialFile(partial, elsewhere);
         Files.writeString(partial, "<hivemq><bridge><password>s3cr3t</password></bridge></hivemq>");
 
-        ConfigFileReaderWriter.applyPreservedAttributes(partial, elsewhere);
+        ProtectedFileReplacer.applyPreservedAttributes(partial, elsewhere);
 
         final PosixFileAttributes actual = Files.readAttributes(partial, PosixFileAttributes.class);
         assertEquals(
@@ -413,9 +413,9 @@ public class ConfigWritePermissionsTest {
         assumeTrue(foreign != null, "this account can assign every group it can name, so there is nothing to refuse");
         final PreservedAttributes elsewhere =
                 new PreservedAttributes(attributes.permissions(), attributes.owner(), foreign, null);
-        ConfigFileReaderWriter.createPartialFile(partial, elsewhere);
+        ProtectedFileReplacer.createPartialFile(partial, elsewhere);
 
-        ConfigFileReaderWriter.applyPreservedAttributes(partial, elsewhere);
+        ProtectedFileReplacer.applyPreservedAttributes(partial, elsewhere);
 
         assertEquals(
                 PosixFilePermissions.fromString("rw----r--"),
@@ -438,9 +438,9 @@ public class ConfigWritePermissionsTest {
         assumeTrue(foreign != null, "this account can assign every group it can name, so there is nothing to refuse");
         final PreservedAttributes elsewhere =
                 new PreservedAttributes(attributes.permissions(), attributes.owner(), foreign, null);
-        ConfigFileReaderWriter.createPartialFile(partial, elsewhere);
+        ProtectedFileReplacer.createPartialFile(partial, elsewhere);
 
-        ConfigFileReaderWriter.applyPreservedAttributes(partial, elsewhere);
+        ProtectedFileReplacer.applyPreservedAttributes(partial, elsewhere);
 
         assertEquals(
                 OWNER_ONLY,
@@ -462,9 +462,9 @@ public class ConfigWritePermissionsTest {
         final GroupPrincipal foreign = aGroupThisUserIsNotIn(target);
         assumeTrue(foreign != null, "this account can assign every group it can name, so there is nothing to refuse");
         final PreservedAttributes unreadable = new PreservedAttributes(Set.of(), Files.getOwner(target), foreign, null);
-        ConfigFileReaderWriter.createPartialFile(partial, unreadable);
+        ProtectedFileReplacer.createPartialFile(partial, unreadable);
 
-        ConfigFileReaderWriter.applyPreservedAttributes(partial, unreadable);
+        ProtectedFileReplacer.applyPreservedAttributes(partial, unreadable);
 
         assertEquals(
                 Set.<PosixFilePermission>of(),
@@ -488,10 +488,10 @@ public class ConfigWritePermissionsTest {
         final GroupPrincipal foreign = aGroupThisUserIsNotIn(target);
         assumeTrue(foreign != null, "this account can assign every group it can name, so there is nothing to refuse");
         final PreservedAttributes elsewhere = new PreservedAttributes(GROUP_READABLE, root, foreign, null);
-        ConfigFileReaderWriter.createPartialFile(partial, elsewhere);
+        ProtectedFileReplacer.createPartialFile(partial, elsewhere);
         Files.writeString(partial, "<hivemq><bridge><password>s3cr3t</password></bridge></hivemq>");
 
-        ConfigFileReaderWriter.applyPreservedAttributes(partial, elsewhere);
+        ProtectedFileReplacer.applyPreservedAttributes(partial, elsewhere);
 
         final PosixFileAttributes actual = Files.readAttributes(partial, PosixFileAttributes.class);
         assertEquals(Files.getOwner(target), actual.owner(), "the replacement is owned by the account that wrote it");
@@ -512,7 +512,7 @@ public class ConfigWritePermissionsTest {
         final PreservedAttributes elsewhere =
                 new PreservedAttributes(GROUP_READABLE, Files.getOwner(target), foreign, null);
 
-        ConfigFileReaderWriter.replaceCarryingProtections(
+        ProtectedFileReplacer.replaceCarryingProtections(
                 target,
                 elsewhere,
                 written -> Files.writeString(written, "<hivemq><bridge><password>s3cr3t</password></bridge></hivemq>"));
@@ -538,13 +538,13 @@ public class ConfigWritePermissionsTest {
     @Test
     public void applyPreservedAttributes_whenTheReplacementIsGone_thenTheWriteIsStillAborted() throws IOException {
         final Path target = targetWith(GROUP_READABLE);
-        final PreservedAttributes preserved = ConfigFileReaderWriter.preservedAttributesOf(target);
-        ConfigFileReaderWriter.createPartialFile(partial, preserved);
+        final PreservedAttributes preserved = ProtectedFileReplacer.preservedAttributesOf(target);
+        ProtectedFileReplacer.createPartialFile(partial, preserved);
         Files.delete(partial);
 
         assertThrows(
                 IOException.class,
-                () -> ConfigFileReaderWriter.applyPreservedAttributes(partial, preserved),
+                () -> ProtectedFileReplacer.applyPreservedAttributes(partial, preserved),
                 "a store failure is not a privilege this node lacks, and must not be narrowed past");
     }
 

--- a/hivemq-edge/src/test/java/com/hivemq/configuration/reader/ProtectedFileReplacerTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/configuration/reader/ProtectedFileReplacerTest.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.configuration.reader;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import com.hivemq.configuration.reader.ProtectedFileReplacer.PreservedAttributes;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.concurrent.atomic.AtomicReference;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * The contract of {@link ProtectedFileReplacer} on its own: a file is replaced by content written beside
+ * it and moved onto it, carrying the protections of the file it replaces, and nothing is left behind or
+ * touched when any step fails. The permission and ACL matrices live in {@code ConfigWritePermissionsTest}
+ * and {@code ConfigWriteAclPermissionsTest}; this pins the sequence.
+ */
+public class ProtectedFileReplacerTest {
+
+    @TempDir
+    public File temporaryFolder;
+
+    private @NotNull Path target;
+
+    @BeforeEach
+    public void setUp() throws IOException {
+        target = temporaryFolder.toPath().resolve("target.xml");
+        Files.writeString(target, "before");
+        assumeTrue(target.getFileSystem().supportedFileAttributeViews().contains("posix"), "POSIX modes are asserted");
+    }
+
+    private static @NotNull Path partialOf(final @NotNull Path target) {
+        return target.resolveSibling(target.getFileName() + ".partial");
+    }
+
+    @Test
+    public void replacesTheContentAndCarriesTheMode() throws IOException {
+        Files.setPosixFilePermissions(target, PosixFilePermissions.fromString("rw-------"));
+
+        ProtectedFileReplacer.replaceCarryingProtections(
+                target,
+                ProtectedFileReplacer.preservedAttributesOf(target),
+                partial -> Files.writeString(partial, "after"));
+
+        assertThat(Files.readString(target)).isEqualTo("after");
+        assertThat(Files.getPosixFilePermissions(target)).isEqualTo(PosixFilePermissions.fromString("rw-------"));
+        assertThat(partialOf(target)).doesNotExist();
+    }
+
+    @Test
+    public void theHookRunsOnceTheContentIsCompleteAndBeforeTheMove() throws IOException {
+        final AtomicReference<String> partialAtHook = new AtomicReference<>();
+        final AtomicReference<String> targetAtHook = new AtomicReference<>();
+
+        ProtectedFileReplacer.replaceCarryingProtections(
+                target,
+                ProtectedFileReplacer.preservedAttributesOf(target),
+                partial -> Files.writeString(partial, "after"),
+                () -> {
+                    partialAtHook.set(Files.readString(partialOf(target)));
+                    targetAtHook.set(Files.readString(target));
+                });
+
+        assertThat(partialAtHook)
+                .as("the replacement is complete when the hook runs")
+                .hasValue("after");
+        assertThat(targetAtHook)
+                .as("the target has not been touched when the hook runs")
+                .hasValue("before");
+        assertThat(Files.readString(target)).isEqualTo("after");
+    }
+
+    @Test
+    public void aFailingHookLeavesTheTargetUntouchedAndNoWorkingFile() {
+        assertThatThrownBy(() -> ProtectedFileReplacer.replaceCarryingProtections(
+                        target,
+                        ProtectedFileReplacer.preservedAttributesOf(target),
+                        partial -> Files.writeString(partial, "after"),
+                        () -> {
+                            throw new IOException("no slot");
+                        }))
+                .isInstanceOf(IOException.class)
+                .hasMessage("no slot");
+        assertThat(target).hasContent("before");
+        assertThat(partialOf(target)).doesNotExist();
+    }
+
+    @Test
+    public void aFailingWriterLeavesTheTargetUntouchedAndNoWorkingFile() {
+        assertThatThrownBy(() -> ProtectedFileReplacer.replaceCarryingProtections(
+                        target, ProtectedFileReplacer.preservedAttributesOf(target), partial -> {
+                            Files.writeString(partial, "half");
+                            throw new IOException("disk full");
+                        }))
+                .isInstanceOf(IOException.class)
+                .hasMessage("disk full");
+        assertThat(target).hasContent("before");
+        assertThat(partialOf(target)).doesNotExist();
+    }
+
+    @Test
+    public void aMissingTargetIsCreated() throws IOException {
+        final Path absent = temporaryFolder.toPath().resolve("absent.xml");
+        final PreservedAttributes none = ProtectedFileReplacer.preservedAttributesOf(absent);
+        assertThat(none).isEqualTo(PreservedAttributes.NONE);
+
+        ProtectedFileReplacer.replaceCarryingProtections(absent, none, partial -> Files.writeString(partial, "new"));
+
+        assertThat(absent).hasContent("new");
+        assertThat(partialOf(absent)).doesNotExist();
+    }
+
+    @Test
+    public void aCopyCarriesContentModeAndModificationTime() throws IOException {
+        Files.setPosixFilePermissions(target, PosixFilePermissions.fromString("rw-r-----"));
+        Files.setLastModifiedTime(target, FileTime.fromMillis(1_700_000_000_000L));
+        final Path copy = temporaryFolder.toPath().resolve("target_1.xml");
+
+        ProtectedFileReplacer.copyCarryingProtections(target, copy);
+
+        assertThat(copy).hasContent("before");
+        assertThat(Files.getPosixFilePermissions(copy)).isEqualTo(PosixFilePermissions.fromString("rw-r-----"));
+        assertThat(Files.getLastModifiedTime(copy).toMillis()).isEqualTo(1_700_000_000_000L);
+        assertThat(partialOf(copy)).doesNotExist();
+    }
+
+    @Test
+    public void aCopyOntoTheSourceItselfIsRefused() throws IOException {
+        final Path link = temporaryFolder.toPath().resolve("same.xml");
+        Files.createSymbolicLink(link, target);
+
+        assertThatThrownBy(() -> ProtectedFileReplacer.copyCarryingProtections(target, link))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("configuration file itself");
+        assertThat(target).hasContent("before");
+    }
+}

--- a/hivemq-edge/src/test/java/com/hivemq/sampling/SamplingServiceLeaseTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/sampling/SamplingServiceLeaseTest.java
@@ -169,8 +169,13 @@ public class SamplingServiceLeaseTest {
         verify(topicTree, never()).removeSubscriber(any(), any(), any());
     }
 
+    /**
+     * A read must not start sampling: the start is admin-only, the reads are open to every role, and a
+     * read that subscribed would hand the one to the other. A released topic stays released until it is
+     * started again.
+     */
     @Test
-    public void test_readingAReleasedTopicStartsSamplingItAgain() {
+    public void test_readingAReleasedTopicDoesNotStartItAgain() {
         samplingService.startSampling(TOPIC);
         advance(TTL_NANOS);
         samplingService.expireLeases();
@@ -178,17 +183,17 @@ public class SamplingServiceLeaseTest {
 
         samplingService.getSamples(TOPIC);
 
-        assertTrue(samplingService.isSampling(TOPIC), "a read revives a released topic");
-        verify(topicTree, times(2)).addTopic(eq(CLIENT_ID), any(), anyByte(), eq(CLIENT_ID));
+        assertFalse(samplingService.isSampling(TOPIC), "a read must not revive a released topic");
+        verify(topicTree, times(1)).addTopic(eq(CLIENT_ID), any(), anyByte(), eq(CLIENT_ID));
         verify(topicTree, times(1)).removeSubscriber(eq(CLIENT_ID), eq(TOPIC), eq(CLIENT_ID));
     }
 
     @Test
-    public void test_readingATopicThatWasNeverStartedStartsIt() {
+    public void test_readingATopicThatWasNeverStartedDoesNotStartIt() {
         samplingService.getSamples(TOPIC);
 
-        assertTrue(samplingService.isSampling(TOPIC));
-        verify(topicTree, times(1)).addTopic(eq(CLIENT_ID), any(), anyByte(), eq(CLIENT_ID));
+        assertFalse(samplingService.isSampling(TOPIC));
+        verify(topicTree, never()).addTopic(any(), any(), anyByte(), any());
     }
 
     @Test
@@ -332,10 +337,11 @@ public class SamplingServiceLeaseTest {
 
         final int readers = 4;
         final int iterations = 20_000;
-        final ExecutorService executor = Executors.newFixedThreadPool(readers + 1);
+        // readers renew, one starter keeps re-starting what the sweep releases, one sweeper releases
+        final ExecutorService executor = Executors.newFixedThreadPool(readers + 2);
         final AtomicReference<Throwable> failure = new AtomicReference<>();
         final CountDownLatch start = new CountDownLatch(1);
-        final CountDownLatch done = new CountDownLatch(readers + 1);
+        final CountDownLatch done = new CountDownLatch(readers + 2);
         try {
             for (int t = 0; t < readers; t++) {
                 executor.submit(() -> {
@@ -351,6 +357,18 @@ public class SamplingServiceLeaseTest {
                     }
                 });
             }
+            executor.submit(() -> {
+                try {
+                    start.await();
+                    for (int i = 0; i < iterations; i++) {
+                        service.startSampling(TOPIC);
+                    }
+                } catch (final Throwable e) {
+                    failure.compareAndSet(null, e);
+                } finally {
+                    done.countDown();
+                }
+            });
             executor.submit(() -> {
                 try {
                     start.await();

--- a/hivemq-edge/src/test/java/com/hivemq/sampling/SamplingServiceLeaseTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/sampling/SamplingServiceLeaseTest.java
@@ -1,0 +1,389 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.sampling;
+
+import static com.hivemq.sampling.SamplingService.SAMPLER_PREFIX;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyByte;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
+
+import ch.qos.logback.classic.Level;
+import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListeningScheduledExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.hivemq.configuration.service.InternalConfigurations;
+import com.hivemq.mqtt.topic.tree.LocalTopicTree;
+import com.hivemq.persistence.clientqueue.ClientQueuePersistence;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The sampling lease (EDG-885): a topic stays sampled while somebody keeps asking for it, and is
+ * released once nobody has for {@link InternalConfigurations#SAMPLING_LEASE_TTL_SEC}.
+ * <p>
+ * Time is a counter the test advances, so every case is deterministic and the sweep is driven by
+ * hand; the only thing the real scheduler adds is <i>when</i> the sweep runs, and that is pinned
+ * separately in {@link #test_theSweepIsScheduledAtTheConfiguredInterval()}.
+ */
+@SuppressWarnings("FutureReturnValueIgnored") // submitted work reports failures through the shared holder
+public class SamplingServiceLeaseTest {
+
+    private static final @NotNull String TOPIC = "plant/line1/from-plc";
+    private static final @NotNull String CLIENT_ID = SAMPLER_PREFIX + TOPIC;
+    private static final int TTL_SEC = 600;
+    private static final long TTL_NANOS = TimeUnit.SECONDS.toNanos(TTL_SEC);
+
+    private static Level previousSamplingLogLevel;
+    private static int previousTtl;
+
+    private final @NotNull AtomicLong clock = new AtomicLong(TimeUnit.HOURS.toNanos(1));
+    private LocalTopicTree topicTree;
+    private ClientQueuePersistence persistence;
+    private SamplingService samplingService;
+
+    @BeforeAll
+    public static void silenceSamplingLoggingAndPinTheTtl() {
+        final ch.qos.logback.classic.Logger logger =
+                (ch.qos.logback.classic.Logger) LoggerFactory.getLogger(SamplingService.class);
+        previousSamplingLogLevel = logger.getLevel();
+        logger.setLevel(Level.OFF);
+        previousTtl = InternalConfigurations.SAMPLING_LEASE_TTL_SEC.get();
+        InternalConfigurations.SAMPLING_LEASE_TTL_SEC.set(TTL_SEC);
+    }
+
+    /** Restores both so this class cannot affect others sharing the JVM. */
+    @AfterAll
+    public static void restoreSamplingLoggingAndTtl() {
+        ((ch.qos.logback.classic.Logger) LoggerFactory.getLogger(SamplingService.class))
+                .setLevel(previousSamplingLogLevel);
+        InternalConfigurations.SAMPLING_LEASE_TTL_SEC.set(previousTtl);
+    }
+
+    @BeforeEach
+    public void setUp() {
+        topicTree = mock(LocalTopicTree.class);
+        persistence = mock(ClientQueuePersistence.class);
+        when(persistence.peek(anyString(), eq(true), anyLong(), anyInt()))
+                .thenReturn(Futures.immediateFuture(ImmutableList.of()));
+        samplingService = new SamplingService(topicTree, persistence, null, clock::get);
+    }
+
+    @AfterEach
+    public void theTtlWasNotChangedByTheTest() {
+        assertEquals(TTL_SEC, InternalConfigurations.SAMPLING_LEASE_TTL_SEC.get());
+    }
+
+    private void advance(final long nanos) {
+        clock.addAndGet(nanos);
+    }
+
+    @Test
+    public void test_aTopicNobodyAsksAboutIsReleasedOnceItsLeaseRunsOut() {
+        samplingService.startSampling(TOPIC);
+
+        advance(TTL_NANOS - 1);
+        samplingService.expireLeases();
+        assertTrue(samplingService.isSampling(TOPIC), "the lease has not run out yet");
+        verify(topicTree, never()).removeSubscriber(any(), any(), any());
+
+        advance(1);
+        samplingService.expireLeases();
+        assertFalse(samplingService.isSampling(TOPIC), "the lease ran out and nobody renewed it");
+        verify(topicTree, times(1)).removeSubscriber(eq(CLIENT_ID), eq(TOPIC), eq(CLIENT_ID));
+    }
+
+    @Test
+    public void test_readingTheSamplesRenewsTheLease() {
+        samplingService.startSampling(TOPIC);
+
+        // ask again just before every expiry: the topic must never be released
+        for (int i = 0; i < 5; i++) {
+            advance(TTL_NANOS - 1);
+            samplingService.getSamples(TOPIC);
+            samplingService.expireLeases();
+            assertTrue(samplingService.isSampling(TOPIC), "renewed on read " + i);
+        }
+        verify(topicTree, times(1)).addTopic(eq(CLIENT_ID), any(), anyByte(), eq(CLIENT_ID));
+        verify(topicTree, never()).removeSubscriber(any(), any(), any());
+
+        // and once the reads stop, so does the sampling
+        advance(TTL_NANOS);
+        samplingService.expireLeases();
+        assertFalse(samplingService.isSampling(TOPIC));
+        verify(topicTree, times(1)).removeSubscriber(eq(CLIENT_ID), eq(TOPIC), eq(CLIENT_ID));
+    }
+
+    @Test
+    public void test_startingAgainRenewsTheLeaseWithoutSubscribingAgain() {
+        samplingService.startSampling(TOPIC);
+        advance(TTL_NANOS - 1);
+        samplingService.startSampling(TOPIC);
+        advance(TTL_NANOS - 1);
+
+        samplingService.expireLeases();
+
+        assertTrue(samplingService.isSampling(TOPIC), "the second start moved the lease forward");
+        verify(topicTree, times(1)).addTopic(eq(CLIENT_ID), any(), anyByte(), eq(CLIENT_ID));
+        verify(topicTree, never()).removeSubscriber(any(), any(), any());
+    }
+
+    @Test
+    public void test_readingAReleasedTopicStartsSamplingItAgain() {
+        samplingService.startSampling(TOPIC);
+        advance(TTL_NANOS);
+        samplingService.expireLeases();
+        assertFalse(samplingService.isSampling(TOPIC));
+
+        samplingService.getSamples(TOPIC);
+
+        assertTrue(samplingService.isSampling(TOPIC), "a read revives a released topic");
+        verify(topicTree, times(2)).addTopic(eq(CLIENT_ID), any(), anyByte(), eq(CLIENT_ID));
+        verify(topicTree, times(1)).removeSubscriber(eq(CLIENT_ID), eq(TOPIC), eq(CLIENT_ID));
+    }
+
+    @Test
+    public void test_readingATopicThatWasNeverStartedStartsIt() {
+        samplingService.getSamples(TOPIC);
+
+        assertTrue(samplingService.isSampling(TOPIC));
+        verify(topicTree, times(1)).addTopic(eq(CLIENT_ID), any(), anyByte(), eq(CLIENT_ID));
+    }
+
+    @Test
+    public void test_leasesAreIndependentPerTopic() {
+        final String other = "plant/line2/from-plc";
+        final String otherClientId = SAMPLER_PREFIX + other;
+        samplingService.startSampling(TOPIC);
+        samplingService.startSampling(other);
+
+        advance(TTL_NANOS / 2);
+        samplingService.getSamples(other);
+        advance(TTL_NANOS / 2);
+        samplingService.expireLeases();
+
+        assertFalse(samplingService.isSampling(TOPIC), "not asked about for a whole TTL");
+        assertTrue(samplingService.isSampling(other), "read half a TTL ago");
+        verify(topicTree, times(1)).removeSubscriber(eq(CLIENT_ID), eq(TOPIC), eq(CLIENT_ID));
+        verify(topicTree, never()).removeSubscriber(eq(otherClientId), eq(other), eq(otherClientId));
+    }
+
+    @Test
+    public void test_aSweepWithNothingSampledDoesNothing() {
+        samplingService.expireLeases();
+        advance(TTL_NANOS * 10);
+        samplingService.expireLeases();
+
+        verify(topicTree, never()).removeSubscriber(any(), any(), any());
+        verify(topicTree, never()).addTopic(any(), any(), anyByte(), any());
+    }
+
+    @Test
+    public void test_theSweepHonoursTheConfiguredTtl() {
+        InternalConfigurations.SAMPLING_LEASE_TTL_SEC.set(5);
+        try {
+            samplingService.startSampling(TOPIC);
+            advance(TimeUnit.SECONDS.toNanos(4));
+            samplingService.expireLeases();
+            assertTrue(samplingService.isSampling(TOPIC));
+            advance(TimeUnit.SECONDS.toNanos(1));
+            samplingService.expireLeases();
+            assertFalse(samplingService.isSampling(TOPIC));
+        } finally {
+            InternalConfigurations.SAMPLING_LEASE_TTL_SEC.set(TTL_SEC);
+        }
+    }
+
+    /**
+     * A periodic task that throws is silently never run again by a scheduled executor, which would
+     * bring the leak back through the back door. One topic's failure must not take the sweep down.
+     */
+    @Test
+    public void test_aFailureToReleaseOneTopicDoesNotStopTheSweep() {
+        final String broken = "plant/broken";
+        final String brokenClientId = SAMPLER_PREFIX + broken;
+        doThrow(new IllegalStateException("simulated topic tree failure"))
+                .when(topicTree)
+                .removeSubscriber(eq(brokenClientId), eq(broken), eq(brokenClientId));
+        samplingService.startSampling(broken);
+        samplingService.startSampling(TOPIC);
+        advance(TTL_NANOS);
+
+        samplingService.expireLeases(); // must not throw
+
+        assertFalse(samplingService.isSampling(TOPIC), "the healthy topic was released");
+        assertTrue(samplingService.isSampling(broken), "the broken one is kept, to be retried");
+        verify(topicTree, times(1)).removeSubscriber(eq(CLIENT_ID), eq(TOPIC), eq(CLIENT_ID));
+    }
+
+    /**
+     * The one thing the real scheduler adds: the sweep runs by itself. A real executor, because the
+     * Guava one is annotated {@code @DoNotMock}; the interval is pinned to a second so the wait is
+     * short, and the clock is advanced by hand so the TTL, not wall time, decides expiry.
+     */
+    @Test
+    @Timeout(30)
+    public void test_theSweepRunsOnTheSchedulerWithoutBeingAskedTo() throws Exception {
+        final int previousInterval = InternalConfigurations.SAMPLING_LEASE_SWEEP_INTERVAL_SEC.get();
+        InternalConfigurations.SAMPLING_LEASE_SWEEP_INTERVAL_SEC.set(1);
+        final ListeningScheduledExecutorService scheduler =
+                MoreExecutors.listeningDecorator(Executors.newSingleThreadScheduledExecutor());
+        try {
+            final SamplingService service = new SamplingService(topicTree, persistence, scheduler, clock::get);
+            service.postConstruct();
+            service.startSampling(TOPIC);
+            advance(TTL_NANOS);
+
+            final long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(20);
+            while (service.isSampling(TOPIC) && System.nanoTime() < deadline) {
+                Thread.sleep(50);
+            }
+            assertFalse(service.isSampling(TOPIC), "the scheduled sweep released the expired topic");
+            verify(topicTree, times(1)).removeSubscriber(eq(CLIENT_ID), eq(TOPIC), eq(CLIENT_ID));
+        } finally {
+            scheduler.shutdownNow();
+            InternalConfigurations.SAMPLING_LEASE_SWEEP_INTERVAL_SEC.set(previousInterval);
+        }
+    }
+
+    /**
+     * A scheduled executor that is already shut down rejects new work with an exception. Construction
+     * during shutdown must not turn that into a failed injection.
+     */
+    @Test
+    public void test_nothingIsScheduledOnAnExecutorThatIsAlreadyShutDown() {
+        final ListeningScheduledExecutorService scheduler =
+                MoreExecutors.listeningDecorator(Executors.newSingleThreadScheduledExecutor());
+        scheduler.shutdownNow();
+        final SamplingService service = new SamplingService(topicTree, persistence, scheduler, clock::get);
+
+        service.postConstruct(); // must not throw RejectedExecutionException
+    }
+
+    /**
+     * Renewals racing the sweep. The clock is frozen at "everything has expired", so every sweep
+     * wants to release the topic while other threads keep reading it. Whatever interleaving happens,
+     * this service and the topic tree must agree at the end, and the service must still work.
+     */
+    @Test
+    @Timeout(120)
+    public void test_renewalsRacingTheSweepLeaveTheTwoRecordsAgreeing() throws Exception {
+        final Set<String> subscribed = ConcurrentHashMap.newKeySet();
+        final LocalTopicTree statefulTree =
+                mock(LocalTopicTree.class, withSettings().stubOnly());
+        doAnswer(invocation -> subscribed.add(invocation.getArgument(0)))
+                .when(statefulTree)
+                .addTopic(any(), any(), anyByte(), any());
+        doAnswer(invocation -> {
+                    subscribed.remove(invocation.<String>getArgument(0));
+                    return null;
+                })
+                .when(statefulTree)
+                .removeSubscriber(any(), any(), any());
+        final ClientQueuePersistence stubPersistence =
+                mock(ClientQueuePersistence.class, withSettings().stubOnly());
+        when(stubPersistence.peek(anyString(), eq(true), anyLong(), anyInt()))
+                .thenReturn(Futures.immediateFuture(ImmutableList.of()));
+        // a clock that always reads "one TTL later than the last renewal": every sweep sees expiry
+        final AtomicLong ticks = new AtomicLong();
+        final SamplingService service =
+                new SamplingService(statefulTree, stubPersistence, null, () -> ticks.addAndGet(TTL_NANOS));
+
+        final int readers = 4;
+        final int iterations = 20_000;
+        final ExecutorService executor = Executors.newFixedThreadPool(readers + 1);
+        final AtomicReference<Throwable> failure = new AtomicReference<>();
+        final CountDownLatch start = new CountDownLatch(1);
+        final CountDownLatch done = new CountDownLatch(readers + 1);
+        try {
+            for (int t = 0; t < readers; t++) {
+                executor.submit(() -> {
+                    try {
+                        start.await();
+                        for (int i = 0; i < iterations; i++) {
+                            service.getSamples(TOPIC);
+                        }
+                    } catch (final Throwable e) {
+                        failure.compareAndSet(null, e);
+                    } finally {
+                        done.countDown();
+                    }
+                });
+            }
+            executor.submit(() -> {
+                try {
+                    start.await();
+                    for (int i = 0; i < iterations; i++) {
+                        service.expireLeases();
+                    }
+                } catch (final Throwable e) {
+                    failure.compareAndSet(null, e);
+                } finally {
+                    done.countDown();
+                }
+            });
+            start.countDown();
+            assertTrue(done.await(120, TimeUnit.SECONDS), "threads did not finish");
+        } finally {
+            executor.shutdownNow();
+            executor.awaitTermination(10, TimeUnit.SECONDS);
+        }
+        if (failure.get() != null) {
+            throw new AssertionError("concurrent failure", failure.get());
+        }
+
+        assertEquals(
+                service.isSampling(TOPIC),
+                subscribed.contains(CLIENT_ID),
+                "this service and the topic tree disagree about whether the topic is sampled");
+
+        // and the service is still usable afterwards: the storm left no wedged state
+        service.startSampling(TOPIC);
+        assertTrue(service.isSampling(TOPIC));
+        assertTrue(subscribed.contains(CLIENT_ID));
+        service.expireLeases();
+        assertFalse(service.isSampling(TOPIC));
+        assertFalse(subscribed.contains(CLIENT_ID));
+    }
+}


### PR DESCRIPTION
Two tickets, four commits plus a merge from master. Linear: [EDG-885](https://linear.app/hivemq/issue/EDG-885), [EDG-949](https://linear.app/hivemq/issue/EDG-949).

## EDG-885 — sampling is released when nobody asks for it

A sampled topic carries a lease, renewed by every start and every read of its samples. A sweep on the persistence scheduler releases whatever has not been asked for in `SAMPLING_LEASE_TTL_SEC` (600 s) every `SAMPLING_LEASE_SWEEP_INTERVAL_SEC` (60 s); the periodic clean-up then reclaims the queue. A read renews but never starts sampling: the POST is admin-only and the GETs are open to every role, so a read that subscribed would hand that capability to any caller. A panel left open past the lease sees an empty list on its next refresh and samples again once it is remounted, which is when the UI starts sampling anyway. Verified on a node: 3008 topics released on schedule, the one being read kept.

## EDG-949 — the configuration write path stops losing operator work

* **The hot-reload watcher survives.** An unparseable or unreadable file is rejected with an error that says the previous configuration is kept; the watcher keeps running and applies the correction, including one restored from a backup with an older time. A change that needs a restart still restarts. A `${ENV:...}` that is not set is a rejection, not an "Exiting HiveMQ Edge" line on a node that is not exiting. A vanished fragment or keystore is dropped from the watch, once. The node's own REST write is not re-read as an operator change.
* **Backups rotate only over Edge's own slots**, all five of them, never an operator's `config-archive.xml` or `config_2024.xml`.
* **A refused write consumes no backup slot**: the backup is taken once the replacement is written and verified, just before the move.
* **The last-write time moves only when the file was written.**

Deviation from the ticket, on purpose: for an unparseable file the node keeps its configuration and says so, rather than restarting onto a file that cannot parse and not coming back. The ticket's objection to that path was silence; this is loud.

## The watcher now ends with the node

Found by CI on this branch: 12 integration tests failed on a single repeated line, `The configuration watcher failed to check <dir>/conf/config.xml`, once a second, after the node under test had already stopped.

The watcher was only ever ended by a JVM shutdown hook, which never runs for an embedded node whose JVM outlives it. Every stopped node therefore left a watch ticking over a configuration folder the test had deleted. On master this was invisible: the tick threw, the scheduled task died silently, and nothing said so. Making the watcher survive its own failures is what turned a silent leak into a loud one, and the leak is the actual defect.

* **`HiveMQEdgeMain` registers the stop.** A `HiveMQShutdownHook` at `Priority.FIRST` calls the new `ConfigurationService.stopWatchingConfigFile()`, so the watch ends before anything it might reload into is dismantled. The interface gains that one method; `ConfigurationServiceImpl` is its only implementer.
* **A missing configuration file is a warning, not an error.** The applied configuration is kept and the file is checked again next tick, which is also what an operator replacing it by remove-and-copy should see.
* **Stopping is deterministic.** `stop()` waits, bounded to 5 s, for a tick in flight, so a caller that deletes the folder straight after stopping cannot race the last check. The default restart hook's `System.exit(0)` moved off the watcher thread as a consequence: run inline it would block the tick inside `Runtime.exit` while the shutdown hook waited on that same tick, holding the configuration lock for the whole shutdown.

## The class split (move-only)

`ConfigFileReaderWriter` (1633 lines) is now the configuration transaction proper (670 lines) plus three classes it delegates to: `ProtectedFileReplacer` (replace a file carrying its owner, group, mode and ACL), `ConfigBackupRotation` and `ConfigFileWatcher`. Bodies moved verbatim; the reader keeps thin delegates so no caller changed. Each new class has its own test class. #1750's log changes were carried into the replacer during the merge.

## Verification

* Full core unit suite: 5243 tests, 4 skipped, 0 failures, run with `--no-build-cache`. Spotless applied from the composite root.
* The two integration classes CI failed on, `BridgeReloadIT` and `BridgeConfigReloadQueueRetentionIT`, green on JDK 21 with no build cache and no watcher line left in their logs.
* Twelve mutation checks, one per EDG-949 fix: each caught by exactly its own test.
* A real node (released 2026.13 modules, this core, hot reload at 1 s, file-native): broken / deleted / restored config files, vanished fragment, 160 concurrent REST writes, foreign files in `conf/`, refused writes, a two-minute REST-plus-operator-edit hammer, the sampling lease across its TTL. All as described above.
* Four review rounds under changing stances until two in a row found nothing new.

Not in this PR: EDG-937 R3-02 (the lock inversion between a REST write and a hot reload) — an implementation was tried and rejected as too wide for now. No integration test asserts the watch ends with the node; the reload ITs catch a regression only through their no-error-logs check.
