### PR TITLE
EDG-996: Extend InternalTopicFilterSubscriber with async and contextual processors

### DIFF
--- a/hivemq-edge/src/main/java/com/hivemq/mqtt/services/PublishDistributorImpl.java
+++ b/hivemq-edge/src/main/java/com/hivemq/mqtt/services/PublishDistributorImpl.java
@@ -43,6 +43,8 @@ import com.hivemq.mqtt.message.publish.PUBLISH;
 import com.hivemq.mqtt.message.publish.PUBLISHFactory;
 import com.hivemq.mqtt.topic.SubscriberWithIdentifiers;
 import com.hivemq.persistence.clientqueue.ClientQueuePersistence;
+import com.hivemq.persistence.clientqueue.InternalTopicFilterSubscriber;
+import com.hivemq.persistence.clientqueue.InternalTopicFilterSubscriberFactory;
 import com.hivemq.persistence.clientqueue.QueuePolicy;
 import com.hivemq.persistence.clientsession.ClientSession;
 import com.hivemq.persistence.clientsession.ClientSessionPersistence;
@@ -81,6 +83,11 @@ public class PublishDistributorImpl implements PublishDistributor {
     @NotNull
     private final Lazy<ClientSessionPersistence> clientSessionPersistence;
 
+    // Lazy, like the session persistence beside it: this is only consulted for an internal subscriber, and
+    // resolving the factory eagerly would drag the topic tree and queue persistence into this object's
+    // construction for a path most messages never take.
+    private final Lazy<InternalTopicFilterSubscriberFactory> subscriberFactory;
+
     @NotNull
     private final MqttConfigurationService mqttConfigurationService;
 
@@ -105,11 +112,13 @@ public class PublishDistributorImpl implements PublishDistributor {
     public PublishDistributorImpl(
             final @NotNull ClientQueuePersistence clientQueuePersistence,
             final @NotNull Lazy<ClientSessionPersistence> clientSessionPersistence,
+            final @NotNull Lazy<InternalTopicFilterSubscriberFactory> subscriberFactory,
             final @NotNull ConfigurationService configurationService,
             final @NotNull Lazy<SamplingService> samplingService,
             final @NotNull Lazy<MessageForwarder> messageForwarder) {
         this.clientQueuePersistence = clientQueuePersistence;
         this.clientSessionPersistence = clientSessionPersistence;
+        this.subscriberFactory = subscriberFactory;
         this.mqttConfigurationService = configurationService.mqttConfiguration();
         this.bridgeConfiguration = configurationService.bridgeExtractor();
         this.samplingService = samplingService;
@@ -237,7 +246,16 @@ public class PublishDistributorImpl implements PublishDistributor {
         final boolean qos0Message = Math.min(subscriptionQos, publish.getQoS().getQosNumber()) == 0;
         Long queueLimit = null;
 
-        if (!client.startsWith(INTERNAL_SUBSCRIBER_PREFIX)) {
+        if (client.startsWith(INTERNAL_SUBSCRIBER_PREFIX)) {
+            // An internal subscriber has no client session, so there is no session-scoped limit to read; it
+            // declares its own instead, at the builder. Null here means it declared none, and queuePublish
+            // then falls back to the broker-wide maxQueuedMessages -- the same value it got before this.
+            final InternalTopicFilterSubscriber subscriber =
+                    subscriberFactory.get().getSubscriber(client);
+            if (subscriber != null) {
+                queueLimit = subscriber.queueLimit();
+            }
+        } else {
             final ClientSession clientSession = clientSessionPersistence.get().getSession(client, false);
             final boolean clientConnected = clientSession != null && clientSession.isConnected();
 

--- a/hivemq-edge/src/main/java/com/hivemq/persistence/clientqueue/ClientQueuePersistenceImpl.java
+++ b/hivemq-edge/src/main/java/com/hivemq/persistence/clientqueue/ClientQueuePersistenceImpl.java
@@ -73,6 +73,10 @@ public class ClientQueuePersistenceImpl extends AbstractPersistence implements C
     private final @NotNull LocalTopicTree topicTree;
     private final @NotNull ConnectionPersistence connectionPersistence;
     private final @NotNull Lazy<PublishPollService> publishPollService;
+
+    // Lazy for the same reason as the poll service above: the factory depends on this persistence, so an
+    // eager reference would be a construction cycle. Only consulted for an internal subscriber's queue.
+    private final @NotNull Lazy<InternalTopicFilterSubscriberFactory> subscriberFactory;
     private final @NotNull MessageForwarder messageForwarder;
     private final @NotNull ShutdownHooks shutdownHooks;
     private final @NotNull Map<String, PublishAvailableCallback> queueidCallbackMap;
@@ -87,8 +91,10 @@ public class ClientQueuePersistenceImpl extends AbstractPersistence implements C
             final @NotNull LocalTopicTree topicTree,
             final @NotNull ConnectionPersistence connectionPersistence,
             final @NotNull Lazy<PublishPollService> publishPollService,
+            final @NotNull Lazy<InternalTopicFilterSubscriberFactory> subscriberFactory,
             final @NotNull MessageForwarder messageForwarder,
             final @NotNull ShutdownHooks shutdownHooks) {
+        this.subscriberFactory = subscriberFactory;
         this.shutdownHooks = shutdownHooks;
         this.localPersistence = localPersistence;
         this.mqttConfigurationService = mqttConfigurationService;
@@ -100,6 +106,41 @@ public class ClientQueuePersistenceImpl extends AbstractPersistence implements C
         singleWriter = singleWriterService.getQueuedMessagesQueue();
         this.messageForwarder = messageForwarder;
         this.queueidCallbackMap = new ConcurrentHashMap<>();
+    }
+
+    /**
+     * What to drop when this queue is full.
+     * <p>
+     * <b>The producer's {@link QueuePolicy} decides first.</b> {@code SAMPLE_RING} is sampling saying it wants
+     * a ring buffer of the most recent messages, and nothing overrides that.
+     * <p>
+     * Within {@code DEFAULT}, an internal subscriber may declare its own strategy at its builder -- which is
+     * where a consumer says everything else about itself. Declaring none leaves the broker-wide setting, which
+     * is what every queue got before this existed.
+     * <p>
+     * <b>The queue id is deliberately not consulted for the policy.</b> Reading it off the id was the EDG-882
+     * F-05 defect: a share name is chosen by a client, so an ordinary subscription to
+     * {@code $share/$SAMPLER::customer/alerts} had its messages discarded under a policy meant for
+     * diagnostics. The id is used here only to look a subscriber up, which is an identity question rather than
+     * a policy one.
+     * <p>
+     * The factory is resolved lazily, and only for a queue whose id says it could be an internal subscriber:
+     * the factory depends on this persistence, so holding it eagerly would be a construction cycle.
+     */
+    private @NotNull MqttConfigurationService.QueuedMessagesStrategy overflowStrategyFor(
+            final @NotNull String queueId, final @NotNull QueuePolicy policy) {
+
+        if (policy == QueuePolicy.SAMPLE_RING) {
+            return MqttConfigurationService.QueuedMessagesStrategy.DISCARD_OLDEST;
+        }
+        if (queueId.startsWith(InternalTopicFilterSubscriber.INTERNAL_SUBSCRIBER_PREFIX)) {
+            final InternalTopicFilterSubscriber subscriber =
+                    subscriberFactory.get().getSubscriber(queueId);
+            if (subscriber != null && subscriber.queueOverflow() != null) {
+                return subscriber.queueOverflow();
+            }
+        }
+        return mqttConfigurationService.getQueuedMessagesStrategy();
     }
 
     @Override
@@ -119,14 +160,10 @@ public class ClientQueuePersistenceImpl extends AbstractPersistence implements C
         }
 
         return singleWriter.submit(queueId, (bucketIndex) -> {
-            // What to do when the queue is full comes from the producer (see QueuePolicy). It used to be
-            // read off the queue ID -- a share name a client chooses -- so an ordinary subscription to
-            // $share/$SAMPLER::customer/alerts had its own messages discarded under a policy meant for
-            // diagnostics (EDG-882 F-05).
-            final MqttConfigurationService.QueuedMessagesStrategy queuedMessagesStrategy =
-                    policy == QueuePolicy.SAMPLE_RING
-                            ? MqttConfigurationService.QueuedMessagesStrategy.DISCARD_OLDEST
-                            : mqttConfigurationService.getQueuedMessagesStrategy();
+            // What to do when the queue is full comes from the producer's QueuePolicy, and within DEFAULT from
+            // whatever an internal subscriber declared -- see overflowStrategyFor. Whether the count bound also
+            // applies to QoS 0 remains the policy's alone: it is sampling's ring-buffer semantics, not
+            // something a consumer picks.
             final boolean applyMaxToQos0 = policy == QueuePolicy.SAMPLE_RING;
 
             localPersistence.add(
@@ -134,7 +171,7 @@ public class ClientQueuePersistenceImpl extends AbstractPersistence implements C
                     shared,
                     publish,
                     queueLimit,
-                    queuedMessagesStrategy,
+                    overflowStrategyFor(queueId, policy),
                     retained,
                     applyMaxToQos0,
                     bucketIndex);
@@ -168,14 +205,8 @@ public class ClientQueuePersistenceImpl extends AbstractPersistence implements C
 
         return singleWriter.submit(queueId, (bucketIndex) -> {
             final boolean queueWasEmpty = localPersistence.size(queueId, shared, bucketIndex) == 0;
-            // What to do when the queue is full comes from the producer (see QueuePolicy). It used to be
-            // read off the queue ID -- a share name a client chooses -- so an ordinary subscription to
-            // $share/$SAMPLER::customer/alerts had its own messages discarded under a policy meant for
-            // diagnostics (EDG-882 F-05).
-            final MqttConfigurationService.QueuedMessagesStrategy queuedMessagesStrategy =
-                    policy == QueuePolicy.SAMPLE_RING
-                            ? MqttConfigurationService.QueuedMessagesStrategy.DISCARD_OLDEST
-                            : mqttConfigurationService.getQueuedMessagesStrategy();
+            // As in the single-message add above: the policy decides, an internal subscriber's declaration
+            // refines it within DEFAULT, and applying the bound to QoS 0 stays the policy's own business.
             final boolean applyMaxToQos0 = policy == QueuePolicy.SAMPLE_RING;
 
             localPersistence.add(
@@ -183,7 +214,7 @@ public class ClientQueuePersistenceImpl extends AbstractPersistence implements C
                     shared,
                     publishes,
                     queueLimit,
-                    queuedMessagesStrategy,
+                    overflowStrategyFor(queueId, policy),
                     retained,
                     applyMaxToQos0,
                     bucketIndex);

--- a/hivemq-edge/src/main/java/com/hivemq/persistence/clientqueue/ClientQueuePersistenceImpl.java
+++ b/hivemq-edge/src/main/java/com/hivemq/persistence/clientqueue/ClientQueuePersistenceImpl.java
@@ -118,22 +118,31 @@ public class ClientQueuePersistenceImpl extends AbstractPersistence implements C
      * where a consumer says everything else about itself. Declaring none leaves the broker-wide setting, which
      * is what every queue got before this existed.
      * <p>
-     * <b>The queue id is deliberately not consulted for the policy.</b> Reading it off the id was the EDG-882
-     * F-05 defect: a share name is chosen by a client, so an ordinary subscription to
-     * {@code $share/$SAMPLER::customer/alerts} had its messages discarded under a policy meant for
-     * diagnostics. The id is used here only to look a subscriber up, which is an identity question rather than
-     * a policy one.
+     * <b>ONLY FOR A NON-SHARED QUEUE, and {@code shared} is the only thing that can tell.</b> A shared queue's
+     * id is built from a share name, and a share name is the client's to choose -- so a subscription to
+     * {@code $share/$INTERNAL::<a live subscriber's name>/} yields a queue id that, once the {@code $share/}
+     * prefix is stripped, is indistinguishable from that subscriber's own. Asking the factory does not help:
+     * an internal subscriber's id carries no topic suffix, so nothing recoverable from the string separates
+     * "the subscriber called X" from "a client's share group called X". The flag the caller already holds is
+     * the answer, and without it a client could take an internal subscriber's overflow strategy for its own
+     * queue.
+     * <p>
+     * This is the third time the same shape has bitten: reading a queue's policy off its id gave a legitimate
+     * client a sampler's ten-message ring (EDG-882 F-05) and, a round later, a bridge's queue limit and a
+     * rewritten QoS (EDG-882 QA round 2). Both were fixed by asking the owning service instead. That remedy
+     * does not transfer here -- see above -- so this branch is gated on {@code shared} rather than made
+     * name-independent.
      * <p>
      * The factory is resolved lazily, and only for a queue whose id says it could be an internal subscriber:
      * the factory depends on this persistence, so holding it eagerly would be a construction cycle.
      */
     private @NotNull MqttConfigurationService.QueuedMessagesStrategy overflowStrategyFor(
-            final @NotNull String queueId, final @NotNull QueuePolicy policy) {
+            final @NotNull String queueId, final boolean shared, final @NotNull QueuePolicy policy) {
 
         if (policy == QueuePolicy.SAMPLE_RING) {
             return MqttConfigurationService.QueuedMessagesStrategy.DISCARD_OLDEST;
         }
-        if (queueId.startsWith(InternalTopicFilterSubscriber.INTERNAL_SUBSCRIBER_PREFIX)) {
+        if (!shared && queueId.startsWith(InternalTopicFilterSubscriber.INTERNAL_SUBSCRIBER_PREFIX)) {
             final InternalTopicFilterSubscriber subscriber =
                     subscriberFactory.get().getSubscriber(queueId);
             if (subscriber != null && subscriber.queueOverflow() != null) {
@@ -171,7 +180,7 @@ public class ClientQueuePersistenceImpl extends AbstractPersistence implements C
                     shared,
                     publish,
                     queueLimit,
-                    overflowStrategyFor(queueId, policy),
+                    overflowStrategyFor(queueId, shared, policy),
                     retained,
                     applyMaxToQos0,
                     bucketIndex);
@@ -214,7 +223,7 @@ public class ClientQueuePersistenceImpl extends AbstractPersistence implements C
                     shared,
                     publishes,
                     queueLimit,
-                    overflowStrategyFor(queueId, policy),
+                    overflowStrategyFor(queueId, shared, policy),
                     retained,
                     applyMaxToQos0,
                     bucketIndex);

--- a/hivemq-edge/src/main/java/com/hivemq/persistence/clientqueue/InternalTopicFilterSubscriber.java
+++ b/hivemq-edge/src/main/java/com/hivemq/persistence/clientqueue/InternalTopicFilterSubscriber.java
@@ -102,9 +102,14 @@ public final class InternalTopicFilterSubscriber {
 
     public static final @NotNull String INTERNAL_SUBSCRIBER_PREFIX = "$INTERNAL::";
 
-    // SHARED_IN_FLIGHT_MARKER acts as a boolean inflight flag -- not a real wire packet ID, since
-    // messages never go to an MQTT client. removeShared() uses uniqueId, not the packet ID, so
-    // the value here does not matter.
+    // SHARED_IN_FLIGHT_MARKER acts as a boolean inflight flag -- not a real wire packet ID, since messages
+    // never go to an MQTT client. Reading a message above QoS 0 stamps it with the id supplied here and leaves
+    // it in the queue; a later read skips anything stamped. So all this value has to be is non-zero.
+    //
+    // IT IS ALSO WHAT removeMessage() DELETES BY, so the same value identifies "the stamped message" rather
+    // than a particular one. That is unambiguous only because a subscriber holds exactly one message at a
+    // time -- see inFlight. Two in flight at once would both be stamped with this, and the removal would
+    // delete whichever the queue happened to hold first.
     private static final @NotNull ImmutableIntArray POLL_PACKET_IDS =
             ImmutableIntArray.of(ClientQueuePersistenceImpl.SHARED_IN_FLIGHT_MARKER);
 
@@ -1221,8 +1226,8 @@ public final class InternalTopicFilterSubscriber {
     //                     claim, since nothing will arrive to release it later.
     // processMessage() -- hands the message to the processor and chains the release off its completion.
     // release() -- acknowledges the message and triggers the next poll.
-    // removeMessage() -- acknowledges the message to the queue persistence. QoS 0 messages are
-    //                     not persisted and need no acknowledgement.
+    // removeMessage() -- deletes the message from the queue, which is what stands in for an MQTT client's
+    //                     acknowledgement. A QoS 0 message needs no call: reading it removed it already.
     //
     // TWO CONDITIONS, ONE PLACE, AND GIVING UP IS NEVER LOSING A TRIGGER. A trigger only says "a message may
     // be available"; whether to act is pollUnlessBusy()'s alone. It declines while a message is in flight,
@@ -1543,9 +1548,30 @@ public final class InternalTopicFilterSubscriber {
         }
     }
 
+    /**
+     * Deletes a processed message from the queue.
+     * <p>
+     * <b>This stands in for the acknowledgement an ordinary MQTT client would send.</b> Nothing ever comes back
+     * from an internal subscriber, so this call is the only thing that removes a message: reading one does not,
+     * for anything above QoS 0. The store leaves it in place stamped in flight, precisely so it survives until
+     * something confirms it was handled. QoS 0 needs no call at all, because reading such a message removes it.
+     * <p>
+     * <b>The NON-shared removal, and this was wrong from EDG-504 until now.</b> Storage keeps two separate maps
+     * -- one for client queues, one for shared subscriptions -- and this subscriber is non-shared on every
+     * other side: no share name in the topic tree, {@code shared = false} when reading, {@code shared = false}
+     * when queued to. The removal alone said {@code removeShared}, which searched the other map, found no queue
+     * under this id, and returned in silence. So no QoS 1 or 2 message was ever removed: each stayed stamped in
+     * flight, skipped by later reads and holding its slot, until the queue filled and rejected everything
+     * after. Nothing logged, at any point.
+     * <p>
+     * <b>Keyed by packet identifier</b>, which is what the non-shared removal takes -- and every message
+     * carries the same marker rather than a real wire id, so this deletes "the stamped message". Sound only
+     * because a subscriber holds exactly one at a time; see {@link #inFlight}.
+     */
     private void removeMessage(final @NotNull PUBLISH message) {
         if (message.getQoS() != QoS.AT_MOST_ONCE) {
-            FutureUtils.addExceptionLogger(clientQueuePersistence.removeShared(clientId, message.getUniqueId()));
+            FutureUtils.addExceptionLogger(
+                    clientQueuePersistence.remove(clientId, ClientQueuePersistenceImpl.SHARED_IN_FLIGHT_MARKER));
         }
     }
 

--- a/hivemq-edge/src/main/java/com/hivemq/persistence/clientqueue/InternalTopicFilterSubscriber.java
+++ b/hivemq-edge/src/main/java/com/hivemq/persistence/clientqueue/InternalTopicFilterSubscriber.java
@@ -19,6 +19,7 @@ import static com.hivemq.configuration.service.InternalConfigurations.PUBLISH_PO
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.ImmutableIntArray;
+import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
@@ -30,12 +31,15 @@ import com.hivemq.mqtt.topic.SubscriptionFlag;
 import com.hivemq.mqtt.topic.tree.LocalTopicTree;
 import com.hivemq.persistence.SingleWriterService;
 import com.hivemq.persistence.util.FutureUtils;
+import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
@@ -97,20 +101,27 @@ import org.slf4j.LoggerFactory;
 @SuppressWarnings({"FutureReturnValueIgnored", "CheckReturnValue", "UnusedReturnValue"})
 public final class InternalTopicFilterSubscriber {
 
+    // region Instance Variables -- what a subscriber is made of
+    // =================================================================================================================
+
+    // Dependencies - logger, topic tree, queues
     private static final @NotNull Logger log = LoggerFactory.getLogger(InternalTopicFilterSubscriber.class);
 
-    public static final @NotNull String INTERNAL_SUBSCRIBER_PREFIX = "$INTERNAL::";
+    // The three Edge singletons this subscriber operates against. Supplied by the factory (which has
+    // them injected), so callers never see or thread them. Final -- set once at construction.
+    private final @NotNull LocalTopicTree topicTree;
+    private final @NotNull ClientQueuePersistence clientQueuePersistence;
+    private final @NotNull SingleWriterService singleWriterService;
 
-    // SHARED_IN_FLIGHT_MARKER acts as a boolean inflight flag -- not a real wire packet ID, since messages
-    // never go to an MQTT client. Reading a message above QoS 0 stamps it with the id supplied here and leaves
-    // it in the queue; a later read skips anything stamped. So all this value has to be is non-zero.
-    //
-    // IT IS ALSO WHAT removeMessage() DELETES BY, so the same value identifies "the stamped message" rather
-    // than a particular one. That is unambiguous only because a subscriber holds exactly one message at a
-    // time -- see inFlight. Two in flight at once would both be stamped with this, and the removal would
-    // delete whichever the queue happened to hold first.
-    private static final @NotNull ImmutableIntArray POLL_PACKET_IDS =
-            ImmutableIntArray.of(ClientQueuePersistenceImpl.SHARED_IN_FLIGHT_MARKER);
+    //   the factory that created this subscriber, and is its registry
+    // The factory that built this subscriber, kept as a back-reference so that build()/deallocate() can
+    // (de)register this subscriber in the factory's registry -- see isExcludedIngressClientId() below.
+    private final @NotNull InternalTopicFilterSubscriberFactory factory;
+
+    // Identity - creation, identity
+    //   the reserved prefix, and this subscriber's own id
+    // INTERNAL_SUBSCRIBER_PREFIX -- what allows to tell internal subscribers apart
+    public static final @NotNull String INTERNAL_SUBSCRIBER_PREFIX = "$INTERNAL::";
 
     // clientId -- built once as the reserved-prefix triple "$INTERNAL::<componentPrefix>::<instanceId>"
     //            (see the constructor for what each segment means). PublishDistributorImpl
@@ -129,19 +140,45 @@ public final class InternalTopicFilterSubscriber {
     //            queue. They are the same id on purpose; there is no separate topic-tree id vs queue id.
     private final @NotNull String clientId;
 
-    // The three Edge singletons this subscriber operates against. Supplied by the factory (which has
-    // them injected), so callers never see or thread them. Final -- set once at construction.
-    private final @NotNull LocalTopicTree topicTree;
-    private final @NotNull ClientQueuePersistence clientQueuePersistence;
-    private final @NotNull SingleWriterService singleWriterService;
+    // Processors - what behaviour
+    // The per-message handler, in whichever of the four forms the consumer supplied. EXACTLY ONE IS NON-NULL
+    // -- the builder rejects a second -- and process() picks the one that is. Kept in the form supplied rather
+    // than wrapped into a common one: the wrapping cost a lambda layer per form and computed destinations for
+    // subscribers that never asked to be told them.
+    private final @Nullable Processor plainProcessor;
+    private final @Nullable AsyncProcessor asyncProcessor;
+    private final @Nullable ContextProcessor<?> contextProcessor;
+    private final @Nullable AsyncContextProcessor<?> asyncContextProcessor;
 
-    // The per-message handler. Set once at construction (Builder requires one of the two forms). Always the
-    // async form internally: a synchronous Processor is wrapped by the builder, so the pipeline has one shape.
-    private final @NotNull AsyncProcessor processor;
+    // TopicFilters - which messages
+    //
+    // A subscriber is one of two kinds, and which it is follows from the processor it was built with:
+    // withProcessor/withAsyncProcessor make a PLAIN one, withContextProcessor a CONTEXT one. The kind decides
+    // which family of filter verbs is legal (the other family throws) and which structures below are used --
+    // a plain subscriber never touches the context map, and a context subscriber never uses topicFilters.
+    // See hasTopicFilterContext() and the filter-verb region.
 
-    // The factory that built this subscriber, kept as a back-reference so that build()/deallocate() can
-    // (de)register this subscriber in the factory's registry -- see isExcludedIngressClientId() below.
-    private final @NotNull InternalTopicFilterSubscriberFactory factory;
+    // topicFilters -- a PLAIN subscriber's filter set. When detached this is just a remembered set (replayed by
+    //                the next attach()); when attached the topic tree is kept reconciled with it. A
+    //                LinkedHashSet so order is stable and duplicates are ignored.
+    private final @NotNull Set<String> topicFilters = new LinkedHashSet<>();
+
+    // topicFilterContexts -- a CONTEXT subscriber's filters, each with the contexts registered for it. Doubles
+    //                as that subscriber's filter set: its keys are exactly the filters, so the two kinds do
+    //                not each need one.
+    //
+    //                A SET per filter, because one filter may carry several contexts -- two southbound mappings
+    //                may share a topic filter -- and registering the same filter twice OVERWRITES in the topic
+    //                tree rather than accumulating, correctly so, since MQTT-3.8.4-3 requires a repeated filter
+    //                to replace its predecessor. The fan-out cannot live in the tree, so it lives here.
+    private final @NotNull Map<String, Set<TopicFilterContext>> topicFilterContexts = new LinkedHashMap<>();
+
+    // NO per-filter subscription identifiers, deliberately. Which filters a message matched is worked out when
+    // the message is POLLED, by matching its topic against this subscriber's own filters -- see resolveDestinations()
+    // and
+    // isMatchFilterTopic(). An identifier recorded on the message when it was ENQUEUED would be a cached answer
+    // that outlives the table giving it meaning: it would have to survive detach/attach and a restart, and when
+    // it did not the message arrived with no contexts and was silently dropped.
 
     // excludedIngressClientId -- ingress-exclusion (generalized No Local). If set, a message whose
     //            INGRESS client id (the publishing client, i.e. the distributor's `sender`) equals this
@@ -151,6 +188,7 @@ public final class InternalTopicFilterSubscriber {
     //            never enters our queue. See isExcludedIngressClientId().
     private final @Nullable String excludedIngressClientId;
 
+    // Queues - how to buffer
     // The QoS every filter is registered at. One value for the whole subscriber, not per filter, and
     // deliberately: when several of a subscriber's filters match one message the topic tree folds them into
     // one entry keeping the LAST QoS in sorted order, so per-filter values would make the effective QoS of a
@@ -169,46 +207,51 @@ public final class InternalTopicFilterSubscriber {
 
     private final @Nullable QueuedMessagesStrategy queueOverflow;
 
-    // Which kind of subscriber this is, and so which family of filter verbs is legal. NOT a separate
-    // declaration: it follows from the processor supplied, since withContextProcessor is exactly the consumer
-    // saying it wants to be told what a message matched. A flag beside it could disagree with it.
-    private final boolean contextual;
+    // PPF-Loop - implementation
+    // loopState -- what the loop IS: ACTIVE (an iteration in flight), WAITING (none, but a message will start
+    //            one), PAUSED (none, and a message will not), TERMINATED (dead). A subscriber is born PAUSED.
+    //            ACTIVE IS THE ONE-MESSAGE-AT-A-TIME BOUND, and the only thing that states it. Deliberately
+    //            about the LOOP rather than about a message: it holds across the gap between finishing one
+    //            message and the next read returning, which is exactly when a second read must not start.
+    //            Written by ppfLoopCtrl() and by nothing else; see there for why it can be a plain field.
+    private @NotNull PpfLoopState loopState = PpfLoopState.PAUSED;
 
-    // -- mutable lifecycle state, all touched only via the verbs below ----------------------------
+    // fetched -- messages a read handed us that we have not processed yet.
     //
-    // A subscriber is one of two kinds, and which it is follows from the processor it was built with:
-    // withProcessor/withAsyncProcessor make a PLAIN one, withContextProcessor a CONTEXT one. The kind decides
-    // which family of filter verbs is legal (the other family throws) and which structures below are used --
-    // a plain subscriber never touches the three context maps, and a context subscriber never uses topicFilters.
-    // See contextual() and the filter-verb region.
-
-    // topicFilters -- a PLAIN subscriber's filter set. When detached this is just a remembered set (replayed by
-    //                the next attach()); when attached the topic tree is kept reconciled with it. A
-    //                LinkedHashSet so order is stable and duplicates are ignored.
-    private final @NotNull Set<String> topicFilters = new LinkedHashSet<>();
-
-    // topicFilterContexts -- a CONTEXT subscriber's filters, each with the contexts registered for it. Doubles
-    //                as that subscriber's filter set: its keys are exactly the filters, so the two kinds do
-    //                not each need one.
+    //            A READ CAN RETURN MORE THAN ONE MESSAGE, EVEN WHEN ASKED FOR ONE. We pass a single packet id,
+    //            which reads as "give me one message" and is not: that argument is a supply of packet ids to
+    //            STAMP messages with, and a QoS 0 message needs no stamp. So the storage layer hands back one
+    //            stamped message AND, on a queue that also holds QoS 0 messages, one of those as well -- added
+    //            before the count limit is re-tested. Two messages from a read that asked for one.
     //
-    //                A SET per filter, because one filter may carry several contexts -- two southbound mappings
-    //                may share a topic filter -- and registering the same filter twice OVERWRITES in the topic
-    //                tree rather than accumulating, correctly so, since MQTT-3.8.4-3 requires a repeated filter
-    //                to replace its predecessor. The fan-out cannot live in the tree, so it lives here.
-    private final @NotNull Map<String, Set<TopicFilterContext>> topicFilterContexts = new LinkedHashMap<>();
+    //            THIS IS WHY THE EXTRAS MUST BE KEPT. Reading a QoS 0 message REMOVES it from the queue, so a
+    //            returned message we drop is gone: not delayed, not redelivered, just lost, with nothing
+    //            logged. An earlier version took messages.get(0) and discarded the rest, which silently lost
+    //            every QoS 0 message that arrived alongside a QoS 1 or 2 one. Whatever a read returns is now
+    //            drained in here and handed to the processor one at a time, in order.
+    //
+    //            An ArrayDeque because poll() is exactly the operation wanted -- take the head, leave the
+    //            rest, answer null when empty -- in one call, with no index to keep and no node per message.
+    private final @NotNull Deque<PUBLISH> fetched = new ArrayDeque<>();
 
-    // NO per-filter subscription identifiers, deliberately. Which filters a message matched is worked out when
-    // the message is POLLED, by matching its topic against this subscriber's own filters -- see asAsync() and
-    // topicMatchesFilter(). An identifier recorded on the message when it was ENQUEUED would be a cached answer
-    // that outlives the table giving it meaning: it would have to survive detach/attach and a restart, and when
-    // it did not the message arrived with no contexts and was silently dropped.
+    // goalState -- what the loop is being ASKED to be, as against loopState which is what it IS.
+    //
+    //            THE PRIORITISED QUEUE OF PENDING COMMANDS, expressed as the state they are asking for. A verb
+    //            arriving while an iteration is in flight cannot be acted on then -- the iteration owns the
+    //            thread, and a message may be with the consumer's processor -- so it is recorded here and
+    //            acted on when that iteration reports back. goalStateFor() is the rule for what an ask does to
+    //            a goal already standing, and is where the priority between them lives.
+    //
+    //            Written and read only by ppfLoopCtrl(), like loopState, and so needs no atomicity.
+    private @NotNull PpfLoopState goalState = PpfLoopState.PAUSED;
 
+    // Lifecycle - start, stop
     // attached -- true iff the current topicFilters are registered in the topic tree (messages are
     //            being collected into the client queue).
     private boolean attached = false;
 
     // consuming -- true iff this subscriber is draining its queue: the publish-available callback is
-    //             registered AND the poll pipeline will act on a trigger. Read by pollUnlessBusy(), which
+    //             registered AND the poll pipeline will act on a trigger. Read by pollIfIdle(), which
     //             is what makes pause() stop work already under way rather than only future wake-ups.
     private boolean consuming = false;
 
@@ -218,214 +261,74 @@ public final class InternalTopicFilterSubscriber {
     //               idempotent and guards the other verbs against use-after-deallocate.
     private boolean deallocated = false;
 
-    // inFlight -- true from the moment a message is claimed for processing until its future settles.
-    //            THE ONE-MESSAGE-AT-A-TIME BOUND, and the only thing that states it: see the poll
-    //            pipeline's region note for why a processor answering a future made it necessary, and
-    //            why this is a plain field rather than an atomic.
-    private boolean inFlight = false;
+    // Misc
+    // SHARED_IN_FLIGHT_MARKER acts as a boolean inflight flag -- not a real wire packet ID, since messages
+    // never go to an MQTT client. Reading a message above QoS 0 stamps it with the id supplied here and leaves
+    // it in the queue; a later read skips anything stamped. So all this value has to be is non-zero.
+    //
+    // IT IS ALSO WHAT finish() DELETES BY, so the same value identifies "the stamped message" rather
+    // than a particular one. That is unambiguous only because a subscriber holds exactly one message at a
+    // time -- see loopActive. Two at once would both be stamped with this, and the removal would
+    // delete whichever the queue happened to hold first.
+    private static final @NotNull ImmutableIntArray POLL_PACKET_IDS =
+            ImmutableIntArray.of(ClientQueuePersistenceImpl.SHARED_IN_FLIGHT_MARKER);
 
     // endregion
 
-    // region constructor -- package-private, only the factory/builder construct this
-    // =================================================================================================================
+    // region Constructor -- package-private, only the factory's builder constructs this
+    // =====================================================================================================================
+    // The parameters run in the order the instance variables are declared in, and mean the same things --
+    // dependencies, parent, identity, processors, filters, queue handling. Only these need more:
+    //
+    // factory -- the factory that built us, kept as the registry for ingress-exclusion lookups.
     // componentPrefix -- identifies the Edge component type (e.g. "tynebridge", "combiner", "sampler").
     //                   Must be unique across all components in Edge. Becomes the middle segment of
     //                   the internal client ID.
     // instanceId -- identifies this specific subscriber instance within the component. Must be
     //                   unique within the componentPrefix namespace. Typically derived from the
     //                   configuration ID of the owning instance.
-    // processor -- the per-message handler (runs on the SingleWriter thread).
-    // initialFilters -- the topic filter set assembled in the builder (may be empty; that is valid).
-    // excludedIngressClientId -- ingress-exclusion id, or null for none (see the field above).
-    // factory -- the factory that built us, used as the registry for ingress-exclusion lookups.
+    // the four processors -- exactly one is non-null, which build() enforces.
+    // topicFilters / topicFilterContexts -- in whichever form this subscriber's kind uses; the other is
+    //                   empty. Both may be empty, which is valid.
     //
     InternalTopicFilterSubscriber(
-            final @NotNull String componentPrefix,
-            final @NotNull String instanceId,
-            final @Nullable AsyncProcessor processor,
-            final @Nullable AsyncContextProcessor<?> contextProcessor,
-            final @NotNull Set<String> initialFilters,
-            final @NotNull Map<String, Set<TopicFilterContext>> initialContexts,
-            final @NotNull QoS qos,
-            final @Nullable Long queueLimit,
-            final @Nullable QueuedMessagesStrategy queueOverflow,
-            final @Nullable String excludedIngressClientId,
-            final @NotNull InternalTopicFilterSubscriberFactory factory,
             final @NotNull LocalTopicTree topicTree,
             final @NotNull ClientQueuePersistence clientQueuePersistence,
-            final @NotNull SingleWriterService singleWriterService) {
-        this.clientId = INTERNAL_SUBSCRIBER_PREFIX + componentPrefix + "::" + instanceId;
-        this.qos = qos;
-        this.queueLimit = queueLimit;
-        this.queueOverflow = queueOverflow;
-        // One shape internally: a context processor becomes an async one by resolving a message's identifiers
-        // back to contexts. The consumer never sees an integer.
-        //
-        // Exactly one of the two is non-null -- build() rejects both and neither -- but the constructor cannot
-        // see that, so it is checked here rather than assumed. This is the only construction path.
-        if (processor != null) {
-            this.processor = processor;
-            this.contextual = false;
-        } else if (contextProcessor != null) {
-            this.processor = asAsync(contextProcessor);
-            this.contextual = true;
-        } else {
-            throw new IllegalArgumentException(
-                    "InternalTopicFilterSubscriber needs a processor or a context processor, not neither");
-        }
-        // The filters, in whichever form this subscriber's kind uses.
-        if (contextual) {
-            initialContexts.forEach(
-                    (filter, contexts) -> topicFilterContexts.put(filter, new LinkedHashSet<>(contexts)));
-        } else {
-            this.topicFilters.addAll(initialFilters);
-        }
-        this.excludedIngressClientId = excludedIngressClientId;
-        this.factory = factory;
+            final @NotNull SingleWriterService singleWriterService,
+            final @NotNull InternalTopicFilterSubscriberFactory factory,
+            final @NotNull String componentPrefix,
+            final @NotNull String instanceId,
+            final @Nullable Processor plainProcessor,
+            final @Nullable AsyncProcessor asyncProcessor,
+            final @Nullable ContextProcessor<?> contextProcessor,
+            final @Nullable AsyncContextProcessor<?> asyncContextProcessor,
+            final @NotNull Set<String> topicFilters,
+            final @NotNull Map<String, Set<TopicFilterContext>> topicFilterContexts,
+            final @Nullable String excludedIngressClientId,
+            final @NotNull QoS qos,
+            final @Nullable Long queueLimit,
+            final @Nullable QueuedMessagesStrategy queueOverflow) {
         this.topicTree = topicTree;
         this.clientQueuePersistence = clientQueuePersistence;
         this.singleWriterService = singleWriterService;
-    }
-
-    // endregion
-
-    // region Processor -- the per-message handler supplied by the user (a lambda)
-    // =================================================================================================================
-    // Called once per message, on the SingleWriter thread that performs every operation for this queue's
-    // whole bucket -- see the threading note on the class. So this is for work small enough to do there:
-    // storing a value, handing the message to another thread's queue. Anything slower, and anything that
-    // may block, wants AsyncProcessor instead. Any exception thrown is caught, logged, message dropped.
-    //
-    // Deliberately NOT named MessageProcessor / MessageTransformer -- those names belong to the
-    // MessageFabric design, the long-term home. This is the interim ITFS-local type; its signature is
-    // exactly the old abstract process(PUBLISH), so an old override body ports into a lambda verbatim.
-    //
-    @FunctionalInterface
-    public interface Processor {
-        void process(final @NotNull PUBLISH message);
-    }
-
-    // endregion
-
-    // region AsyncProcessor -- for work too slow, or too blocking, for the queue's own thread
-    // =================================================================================================================
-    // Same job as Processor, but the work does not happen ON the calling thread. The consumer starts it
-    // elsewhere and returns a future AT ONCE; the next message is passed on when that future completes.
-    //
-    // WHY, in the order the reasons actually run (see the threading note on the class): message handling is
-    // sequential because MQTT's ordering guarantees require it; that is achieved cheaply by giving each
-    // bucket of queues one dedicated thread; and it follows that a processor must not block that thread for
-    // any extended period, since every queue in the bucket waits behind it.
-    //
-    // A Processor has nowhere to put slow work: it says "finished" by returning, so the only way to stay
-    // sequential would be to do the work first, on that thread. This interface separates the two -- the work
-    // moves off the thread, the ordering stays.
-    //
-    // The bound itself is NOT what this buys: handling is sequential in both forms, one message in flight
-    // per component. This is what lets a consumer keep that bound without holding the thread meanwhile.
-    //
-    // Returning rather than being handed a callback, deliberately. A callback can be forgotten -- which
-    // compiles, and then stalls this queue permanently and silently -- and can be called twice, which
-    // acknowledges twice and reads two next messages, destroying the very bound this is for. A future
-    // completes once by construction, and a method that must return something cannot silently return nothing.
-    //
-    // "Completes" means SETTLED, either way. A failure releases the queue exactly as a success does; whether
-    // the work succeeded is the consumer's business, and both outcomes mean "this one is no longer in flight".
-    //
-    // A Processor is the degenerate case of this one -- a future already complete when it returns -- and is
-    // wrapped into exactly that by the builder. The pipeline below knows only this interface.
-    //
-    @FunctionalInterface
-    public interface AsyncProcessor {
-
-        /**
-         * @param message the message
-         * @return the completion of this consumer's work. Never null; return an already-complete future for
-         *         work that finished synchronously.
-         */
-        @NotNull
-        CompletableFuture<Void> process(final @NotNull PUBLISH message);
-    }
-
-    // endregion
-
-    // region TopicFilterContext -- a topic filter that knows what it is for
-    // =================================================================================================================
-    // A subscriber standing in for several destinations needs to be told which of them a message is for. It
-    // subscribes with these rather than with bare strings: each carries its filter AND whatever the consumer
-    // needs back when that filter matches, so the two travel together instead of being paired up by the caller.
-    //
-    // The implementation is entirely the consumer's -- this interface asks for the filter and nothing else. Two
-    // obligations come with that, and both are the implementor's to meet:
-    //
-    //   - EQUALITY, if the consumer means to remove one later. removeTopicFilterContext finds it by equals(),
-    //     so an implementation with identity equality can only be removed by the very object registered. A
-    //     record gets this for free and is the obvious choice.
-    //   - IMMUTABILITY of the filter. It is read when the subscription is registered and again when it is
-    //     removed; a filter that changed in between would leave a subscription nothing can take away.
-    //
-    @FunctionalInterface
-    public interface TopicFilterContext {
-
-        /**
-         * @return the topic filter to subscribe to. Must not change for the life of this object.
-         */
-        @NotNull
-        String topicFilter();
-    }
-
-    // endregion
-
-    // region ContextProcessor / AsyncContextProcessor -- told WHICH of its filters a message matched
-    // =================================================================================================================
-    // TWO INDEPENDENT CHOICES, so four interfaces rather than three. How a consumer says it is finished --
-    // by returning or by completing a future -- and what it is told about the message -- the message alone or
-    // the message plus what it matched -- are unrelated questions, and either answer to one goes with either
-    // answer to the other:
-    //
-    //                      told only the message      told what it matched
-    //   done on return     Processor                  ContextProcessor
-    //   done on a future   AsyncProcessor             AsyncContextProcessor
-    //
-    // A subscriber holding one filter, or several handled the same way, wants the left column; one standing in
-    // for several destinations wants the right. Slow or blocking work wants the bottom row (see AsyncProcessor
-    // for why); work small enough for the queue's own thread wants the top.
-    //
-    // SUPPLYING EITHER RIGHT-HAND FORM IS WHAT MAKES A SUBSCRIBER A CONTEXT ONE. There is no separate flag
-    // saying so: the processor a consumer supplies already says which kind it wants, and a second statement of
-    // that could disagree with the first. It follows that only the ...TopicFilterContext verbs are legal on
-    // such a subscriber, and only the bare-string ones on any other.
-    //
-    // What comes back are the consumer's OWN contexts, exactly as registered. The MQTT subscription identifiers
-    // that carry them never surface: this subscriber allocated them, so this subscriber is the only thing that
-    // can translate them, and an integer would be meaningless to a consumer without the maps held here.
-    //
-    // A SET, because several filters may match one message and the tree returns all their identifiers. Two
-    // filters may also carry the SAME context -- one destination reachable by two patterns -- and it appears
-    // once, because doing the work twice for one message is the failure this is meant to avoid.
-    //
-    @FunctionalInterface
-    public interface ContextProcessor<T extends TopicFilterContext> {
-
-        /**
-         * @param message the message
-         * @param matched the contexts of the filters this message matched. Empty only if every filter it
-         *         matched has been unsubscribed since the message was queued
-         */
-        void process(final @NotNull PUBLISH message, final @NotNull Set<T> matched);
-    }
-
-    @FunctionalInterface
-    public interface AsyncContextProcessor<T extends TopicFilterContext> {
-
-        /**
-         * @param message the message
-         * @param matched the contexts of the filters this message matched. Empty only if every filter it
-         *         matched has been unsubscribed since the message was queued
-         * @return the completion of this consumer's work, as {@link AsyncProcessor#process}
-         */
-        @NotNull
-        CompletableFuture<Void> process(final @NotNull PUBLISH message, final @NotNull Set<T> matched);
+        this.factory = factory;
+        this.clientId = INTERNAL_SUBSCRIBER_PREFIX + componentPrefix + "::" + instanceId;
+        this.plainProcessor = plainProcessor;
+        this.asyncProcessor = asyncProcessor;
+        this.contextProcessor = contextProcessor;
+        this.asyncContextProcessor = asyncContextProcessor;
+        // AFTER the processors, which hasTopicFilterContext() reads. Copied rather than kept by reference, so a builder
+        // reused after build() cannot reach into a live subscriber.
+        if (hasTopicFilterContext()) {
+            topicFilterContexts.forEach(
+                    (filter, contexts) -> this.topicFilterContexts.put(filter, new LinkedHashSet<>(contexts)));
+        } else {
+            this.topicFilters.addAll(topicFilters);
+        }
+        this.excludedIngressClientId = excludedIngressClientId;
+        this.qos = qos;
+        this.queueLimit = queueLimit;
+        this.queueOverflow = queueOverflow;
     }
 
     // endregion
@@ -443,39 +346,50 @@ public final class InternalTopicFilterSubscriber {
     //
     public static final class Builder {
 
-        private final @NotNull String componentPrefix;
-        private final @NotNull String instanceId;
-        private final @NotNull InternalTopicFilterSubscriberFactory factory;
+        // dependencies
         private final @NotNull LocalTopicTree topicTree;
         private final @NotNull ClientQueuePersistence clientQueuePersistence;
         private final @NotNull SingleWriterService singleWriterService;
 
-        private @Nullable AsyncProcessor processor = null; // required; checked in build()
-        // Always the async form internally, as with `processor` above: a synchronous ContextProcessor is
-        // wrapped by withContextProcessor, so the pipeline has one shape.
-        private @Nullable AsyncContextProcessor<?> contextProcessor = null;
+        // parent
+        private final @NotNull InternalTopicFilterSubscriberFactory factory;
+
+        // what is my identity
+        private final @NotNull String componentPrefix;
+        private final @NotNull String instanceId;
+
+        // what am I doing with the messages -- exactly one may be set (throwIfProcessorAlreadySet enforces it)
+        // and build() requires that one. Each is kept as supplied and called in that shape by process().
+        private @Nullable Processor plainProcessor = null;
+        private @Nullable AsyncProcessor asyncProcessor = null;
+        private @Nullable ContextProcessor<?> contextProcessor = null;
+        private @Nullable AsyncContextProcessor<?> asyncContextProcessor = null;
+
+        // which messages
         private final @NotNull Set<String> topicFilters = new LinkedHashSet<>();
         private final @NotNull Map<String, Set<TopicFilterContext>> topicFilterContexts = new LinkedHashMap<>();
+        private @Nullable String excludedIngressClientId = null; // optional; ingress-exclusion
+
+        // queue handling
         private @NotNull QoS qos = QoS.AT_LEAST_ONCE; // optional; the QoS every filter is registered at
         private @Nullable Long queueLimit = null; // optional; null means the broker-wide default
         private @Nullable QueuedMessagesStrategy queueOverflow = null; // optional; null means the broker default
-        private @Nullable String excludedIngressClientId = null; // optional; ingress-exclusion
 
         // Package-private -- only the factory creates builders (it supplies the injected singletons and
         // itself, as the registry the built subscriber registers with on attach()).
         Builder(
-                final @NotNull String componentPrefix,
-                final @NotNull String instanceId,
-                final @NotNull InternalTopicFilterSubscriberFactory factory,
                 final @NotNull LocalTopicTree topicTree,
                 final @NotNull ClientQueuePersistence clientQueuePersistence,
-                final @NotNull SingleWriterService singleWriterService) {
-            this.componentPrefix = componentPrefix;
-            this.instanceId = instanceId;
-            this.factory = factory;
+                final @NotNull SingleWriterService singleWriterService,
+                final @NotNull InternalTopicFilterSubscriberFactory factory,
+                final @NotNull String componentPrefix,
+                final @NotNull String instanceId) {
             this.topicTree = topicTree;
             this.clientQueuePersistence = clientQueuePersistence;
             this.singleWriterService = singleWriterService;
+            this.factory = factory;
+            this.componentPrefix = componentPrefix;
+            this.instanceId = instanceId;
         }
 
         // Required, in one of two forms: the per-message work.
@@ -488,19 +402,8 @@ public final class InternalTopicFilterSubscriber {
         // error at every call site rather than a silent wrong pick. Distinct names also say which contract the
         // consumer is signing up to instead of leaving it to inference.
         public @NotNull Builder withProcessor(final @NotNull Processor processor) {
-            // Wrapped into the async form so the pipeline has one shape. The catch is not decoration: a
-            // consumer may throw before any future exists, and an escaping exception would skip the
-            // acknowledge-and-poll and stall this queue for good. The old pipeline's try/catch did exactly
-            // this, and turning the throw into a failed future preserves it -- both settle the future, and a
-            // settled future is what releases the queue.
-            this.processor = message -> {
-                try {
-                    processor.process(message);
-                    return CompletableFuture.completedFuture(null);
-                } catch (final Exception e) {
-                    return CompletableFuture.failedFuture(e);
-                }
-            };
+            throwIfProcessorAlreadySet();
+            this.plainProcessor = processor;
             return this;
         }
 
@@ -509,7 +412,8 @@ public final class InternalTopicFilterSubscriber {
         // next message is passed on when that future completes, so handling stays sequential without the
         // thread being held meanwhile.
         public @NotNull Builder withAsyncProcessor(final @NotNull AsyncProcessor processor) {
-            this.processor = processor;
+            throwIfProcessorAlreadySet();
+            this.asyncProcessor = processor;
             return this;
         }
 
@@ -520,75 +424,32 @@ public final class InternalTopicFilterSubscriber {
         // is deliberately no separate flag saying so: the processor already says it, and two statements of one
         // fact could disagree -- the more easily because the filters may be added far from where the
         // subscriber is built.
-        //
-        // Whether to be told what a message matched, and whether the work needs a future, are independent
-        // choices -- hence four forms rather than three.
-        @SuppressWarnings("unchecked") // the set holds exactly the contexts this consumer registered
         public <T extends TopicFilterContext> @NotNull Builder withContextProcessor(
                 final @NotNull ContextProcessor<T> processor) {
-
-            // Wrapped into the async form for the same reason withProcessor is, and with the same catch: a
-            // consumer may throw before any future exists, and an escaping exception would stall this queue.
-            this.contextProcessor = (AsyncContextProcessor<T>) (message, matched) -> {
-                try {
-                    processor.process(message, matched);
-                    return CompletableFuture.completedFuture(null);
-                } catch (final Exception e) {
-                    return CompletableFuture.failedFuture(e);
-                }
-            };
+            throwIfProcessorAlreadySet();
+            this.contextProcessor = processor;
             return this;
         }
 
         public <T extends TopicFilterContext> @NotNull Builder withAsyncContextProcessor(
                 final @NotNull AsyncContextProcessor<T> processor) {
-
-            this.contextProcessor = processor;
+            throwIfProcessorAlreadySet();
+            this.asyncContextProcessor = processor;
             return this;
         }
 
-        // Optional: the QoS every filter is registered at. Defaults to AT_LEAST_ONCE.
-        //
-        // A CEILING, not a floor -- the delivered QoS is min(published, this), so subscribing at EXACTLY_ONCE
-        // does not upgrade a QoS 0 publish. The distinction that matters downstream is zero versus non-zero: a
-        // QoS 0 message is held in a separate memory-limited list and is never acknowledged.
-        public @NotNull Builder withQoS(final @NotNull QoS qos) {
-            this.qos = qos;
-            return this;
-        }
-
-        // Optional: the most messages to hold for this subscriber. Defaults to the broker-wide
-        // maxQueuedMessages, which is 1000 unless configured otherwise -- so this narrows rather than
-        // unbounds, and a consumer that has no opinion should not set it.
-        //
-        // What happens at the limit is withQueueOverflow below, and the two are worth reading together: a
-        // small limit with the default strategy means "reject new messages beyond N", which is rarely what a
-        // consumer picking a small number has in mind.
-        public @NotNull Builder withQueueLimit(final long queueLimit) {
-            this.queueLimit = queueLimit;
-            return this;
-        }
-
-        // Optional: which message to drop when the queue is full.
-        //
-        // DISCARD        -- reject the INCOMING message, keeping the queue as it is. The broker-wide default.
-        // DISCARD_OLDEST -- drop the oldest queued message to make room for the new one.
-        //
-        // The default is worth a moment: for a command queue it means a fresh command is refused in favour of
-        // a backlog of stale ones, which is usually the wrong way round. A consumer whose messages supersede
-        // each other -- a setpoint, a latest-value -- wants DISCARD_OLDEST and should say so.
-        public @NotNull Builder withQueueOverflow(final @NotNull QueuedMessagesStrategy queueOverflow) {
-            this.queueOverflow = queueOverflow;
-            return this;
-        }
-
-        // Optional: ingress-exclusion (generalized No Local). A message whose ingress (publishing)
-        // client id equals this value will not be delivered to the built subscriber. Build-time only;
-        // immutable after build(). For a bridge, this is the peer it forwards to -- so a message it sent
-        // us is not sent straight back. The plain No Local case is excludedIngressClientId == our own id.
-        public @NotNull Builder withExcludedIngressClientId(final @NotNull String excludedIngressClientId) {
-            this.excludedIngressClientId = excludedIngressClientId;
-            return this;
+        /// A subscriber takes ONE processor. Rejected at the second call rather than silently replacing the
+        /// first, which would discard a consumer's handler without a word -- and, if the two were of different
+        /// kinds, silently change which family of filter verbs is legal.
+        private void throwIfProcessorAlreadySet() {
+            if (plainProcessor != null
+                    || asyncProcessor != null
+                    || contextProcessor != null
+                    || asyncContextProcessor != null) {
+                throw new IllegalStateException("InternalTopicFilterSubscriber takes one processor, not two; "
+                        + "withProcessor(...), withAsyncProcessor(...), withContextProcessor(...) and "
+                        + "withAsyncContextProcessor(...) are alternatives");
+            }
         }
 
         // The topic filters, in two families of three.
@@ -635,16 +496,14 @@ public final class InternalTopicFilterSubscriber {
             return this;
         }
 
-        /**
-         * Rejects an absolute filter call once any filter has been declared.
-         * <p>
-         * Checks BOTH families, so declaring a bare filter and then a context (or the reverse) is caught here,
-         * at the call that did it, rather than at {@code build()} -- which can only name the filters, not the
-         * call that added them.
-         *
-         * @param absolute the verb being called, named in the message
-         * @param relative the verb the caller almost certainly meant
-         */
+        /// Rejects an absolute filter call once any filter has been declared.
+        ///
+        /// Checks BOTH families, so declaring a bare filter and then a context (or the reverse) is caught here,
+        /// at the call that did it, rather than at `build()` -- which can only name the filters, not the call
+        /// that added them.
+        ///
+        /// @param absolute the verb being called, named in the message
+        /// @param relative the verb the caller almost certainly meant
         private void throwIfFiltersAlreadyDeclared(final @NotNull String absolute, final @NotNull String relative) {
 
             if (topicFilters.isEmpty() && topicFilterContexts.isEmpty()) {
@@ -724,49 +583,95 @@ public final class InternalTopicFilterSubscriber {
             return this;
         }
 
+        // Optional: ingress-exclusion (generalized No Local). A message whose ingress (publishing)
+        // client id equals this value will not be delivered to the built subscriber. Build-time only;
+        // immutable after build(). For a bridge, this is the peer it forwards to -- so a message it sent
+        // us is not sent straight back. The plain No Local case is excludedIngressClientId == our own id.
+        public @NotNull Builder withExcludedIngressClientId(final @NotNull String excludedIngressClientId) {
+            this.excludedIngressClientId = excludedIngressClientId;
+            return this;
+        }
+
+        // Optional: the QoS every filter is registered at. Defaults to AT_LEAST_ONCE.
+        //
+        // A CEILING, not a floor -- the delivered QoS is min(published, this), so subscribing at EXACTLY_ONCE
+        // does not upgrade a QoS 0 publish. The distinction that matters downstream is zero versus non-zero: a
+        // QoS 0 message is held in a separate memory-limited list and is never acknowledged.
+        public @NotNull Builder withQoS(final @NotNull QoS qos) {
+            this.qos = qos;
+            return this;
+        }
+
+        // Optional: the most messages to hold for this subscriber. Defaults to the broker-wide
+        // maxQueuedMessages, which is 1000 unless configured otherwise -- so this narrows rather than
+        // unbounds, and a consumer that has no opinion should not set it.
+        //
+        // What happens at the limit is withQueueOverflow below, and the two are worth reading together: a
+        // small limit with the default strategy means "reject new messages beyond N", which is rarely what a
+        // consumer picking a small number has in mind.
+        public @NotNull Builder withQueueLimit(final long queueLimit) {
+            this.queueLimit = queueLimit;
+            return this;
+        }
+
+        // Optional: which message to drop when the queue is full.
+        //
+        // DISCARD        -- reject the INCOMING message, keeping the queue as it is. The broker-wide default.
+        // DISCARD_OLDEST -- drop the oldest queued message to make room for the new one.
+        //
+        // The default is worth a moment: for a command queue it means a fresh command is refused in favour of
+        // a backlog of stale ones, which is usually the wrong way round. A consumer whose messages supersede
+        // each other -- a setpoint, a latest-value -- wants DISCARD_OLDEST and should say so.
+        public @NotNull Builder withQueueOverflow(final @NotNull QueuedMessagesStrategy queueOverflow) {
+            this.queueOverflow = queueOverflow;
+            return this;
+        }
+
         // Produce the live subscriber. The subscriber is constructed in the IDLE state -- detached and
         // paused -- i.e. no messages flow until start() (or attach()/consume()) is called. It is, however,
         // already REGISTERED with the factory: the subscriber owns its clientId ("$INTERNAL::<prefix>::
         // <instanceId>") from build() until deallocate(). register() throws if that identity is already in
         // use, so a duplicate componentPrefix::instanceId is rejected here rather than silently colliding.
         public @NotNull InternalTopicFilterSubscriber build() {
-            if (processor == null && contextProcessor == null) {
+            if (plainProcessor == null
+                    && asyncProcessor == null
+                    && contextProcessor == null
+                    && asyncContextProcessor == null) {
                 throw new IllegalStateException("InternalTopicFilterSubscriber requires a processor; call one of "
                         + "withProcessor(...), withAsyncProcessor(...), withContextProcessor(...) or "
                         + "withAsyncContextProcessor(...) before build()");
             }
-            if (processor != null && contextProcessor != null) {
-                throw new IllegalStateException("InternalTopicFilterSubscriber takes one processor, not two; a "
-                        + "context processor cannot be combined with withProcessor(...) or withAsyncProcessor(...)");
-            }
+            final boolean hasTopicFilterContext = contextProcessor != null || asyncContextProcessor != null;
             // The processor decides which family of filter verbs applies, so filters given in the other family
             // are a mistake -- and one worth naming here, since the two calls may be far apart.
-            if (contextProcessor != null && !topicFilters.isEmpty()) {
+            if (hasTopicFilterContext && !topicFilters.isEmpty()) {
                 throw new IllegalStateException("InternalTopicFilterSubscriber was built with a context processor, "
                         + "so its filters must be given as contexts; these were given as bare strings: "
                         + topicFilters);
             }
-            if (contextProcessor == null && !topicFilterContexts.isEmpty()) {
+            if (!hasTopicFilterContext && !topicFilterContexts.isEmpty()) {
                 throw new IllegalStateException("InternalTopicFilterSubscriber was given topic filter contexts but "
                         + "no context processor to deliver them to; call withContextProcessor(...) or "
                         + "withAsyncContextProcessor(...)");
             }
 
             final InternalTopicFilterSubscriber subscriber = new InternalTopicFilterSubscriber(
-                    componentPrefix,
-                    instanceId,
-                    processor,
-                    contextProcessor,
-                    topicFilters,
-                    topicFilterContexts,
-                    qos,
-                    queueLimit,
-                    queueOverflow,
-                    excludedIngressClientId,
-                    factory,
                     topicTree,
                     clientQueuePersistence,
-                    singleWriterService);
+                    singleWriterService,
+                    factory,
+                    componentPrefix,
+                    instanceId,
+                    plainProcessor,
+                    asyncProcessor,
+                    contextProcessor,
+                    asyncContextProcessor,
+                    topicFilters,
+                    topicFilterContexts,
+                    excludedIngressClientId,
+                    qos,
+                    queueLimit,
+                    queueOverflow);
             factory.register(subscriber); // throws if clientId already in use -- deregistered by deallocate()
             return subscriber;
         }
@@ -774,7 +679,129 @@ public final class InternalTopicFilterSubscriber {
 
     // endregion
 
-    // region topic-filter verbs -- the same two families on builder and subscriber
+    // region Subscriber Identity -- what others ask this subscriber, and the declarations they read
+    // =================================================================================================================
+    // All four are immutable after build(), so all four are lock-free reads, safe to call from the publish
+    // path concurrently with the lifecycle verbs.
+    //
+    // -- what is my identity ---------------------------------------------------------------------------
+    //
+    // clientId() -- this subscriber's reserved-prefix id, used by the factory as the registry key.
+    public @NotNull String clientId() {
+        return clientId;
+    }
+
+    // -- which messages --------------------------------------------------------------------------------
+    //
+    // isExcludedIngressClientId(senderClientId) -- the ingress-exclusion decision, called by the publish
+    //   path at distribution time (BEFORE queueing) with the ingress/publishing client id (its
+    //   `sender`). Returns true iff an excluded id is configured and equals senderClientId -- in which
+    //   case the message must NOT be queued to us. With no excluded id (the common case) it always
+    //   returns false.
+    public boolean isExcludedIngressClientId(final @Nullable String senderClientId) {
+        return excludedIngressClientId != null && excludedIngressClientId.equals(senderClientId);
+    }
+
+    // -- queue handling --------------------------------------------------------------------------------
+
+    /// @return the most messages to hold for this subscriber, or null to use the broker-wide
+    ///     `maxQueuedMessages`. Read by the publish distributor when it queues a message.
+    public @Nullable Long queueLimit() {
+        return queueLimit;
+    }
+
+    /// @return what to drop when this subscriber's queue is full, or null to use the broker-wide strategy.
+    ///     Read by the queue persistence when it adds a message.
+    public @Nullable QueuedMessagesStrategy queueOverflow() {
+        return queueOverflow;
+    }
+
+    // endregion
+
+    // region Subscriber Processors -- the per-message handler forms a consumer may supply
+    // =================================================================================================================
+    // TWO INDEPENDENT CHOICES, so four interfaces. How a consumer says it is finished -- by returning, or by
+    // completing a future -- and what it is told -- the message alone, or the message plus which of its
+    // destinations matched -- are unrelated questions:
+    //
+    //                      told only the message      told what it matched
+    //   done on return     Processor                  ContextProcessor
+    //   done on a future   AsyncProcessor             AsyncContextProcessor
+    //
+    // A processor runs on the SingleWriter thread that serves this queue's whole bucket, so the top row is for
+    // work small enough to do there. Anything slower, and anything that may block, wants the bottom row: the
+    // work moves off the thread while the ordering stays. A future rather than a callback, because a callback
+    // can be forgotten (stalling this queue silently) or called twice (destroying the one-at-a-time bound),
+    // and because "completes" means SETTLED -- a failure finishes a message exactly as a success does.
+    //
+    // The left column is for a subscriber handling every message the same way; the right for one standing in
+    // for several destinations. SUPPLYING A RIGHT-HAND FORM IS WHAT MAKES A SUBSCRIBER A CONTEXT ONE -- there
+    // is no separate flag, since a second statement of that could disagree with the first. It follows that
+    // only the ...TopicFilterContext verbs are legal on such a subscriber, and only the bare-string ones on
+    // any other.
+    //
+    // A TopicFilterContext is a topic filter that knows what it is for: it carries the filter AND whatever the
+    // consumer wants back when that filter matches, so the two travel together. The implementation is the
+    // consumer's, and two obligations come with that -- EQUALITY, since removeTopicFilterContext finds one by
+    // equals(), and IMMUTABILITY of the filter, since it is read both when registering and when removing. A
+    // record gets both for free.
+    //
+    // What comes back is a SET of the consumer's own contexts, exactly as registered: several filters may
+    // match one message, and two filters may carry the same context -- one destination reachable by two
+    // patterns -- which appears once, because doing the work twice for one message is the failure to avoid.
+    //
+    // EACH FORM IS KEPT AND CALLED AS SUPPLIED. The subscriber holds four nullable fields, exactly one set,
+    // and process() calls whichever it is -- making the already-complete future for a returning form, and
+    // computing the destinations (destinationsFor(), beside process() in the ppf-loop) only for a context one. An
+    // earlier version wrapped every form into a single common shape, which cost a lambda layer per form and
+    // computed destinations for subscribers that had not asked to be told them.
+    //
+    @FunctionalInterface
+    public interface TopicFilterContext {
+
+        /// @return the topic filter to subscribe to. Must not change for the life of this object.
+        @NotNull
+        String topicFilter();
+    }
+
+    @FunctionalInterface
+    public interface Processor {
+        void process(final @NotNull PUBLISH message);
+    }
+
+    @FunctionalInterface
+    public interface AsyncProcessor {
+
+        /// @param message the message
+        /// @return the completion of this consumer's work. Never null; return an already-complete future for
+        ///     work that finished synchronously.
+        @NotNull
+        CompletableFuture<Void> process(final @NotNull PUBLISH message);
+    }
+
+    @FunctionalInterface
+    public interface ContextProcessor<T extends TopicFilterContext> {
+
+        /// @param message the message
+        /// @param destinations the contexts of the filters this message matched. Empty only if every filter
+        ///     it matched has been unsubscribed since the message was queued
+        void process(final @NotNull PUBLISH message, final @NotNull Set<T> destinations);
+    }
+
+    @FunctionalInterface
+    public interface AsyncContextProcessor<T extends TopicFilterContext> {
+
+        /// @param message the message
+        /// @param destinations the contexts of the filters this message matched. Empty only if every filter
+        ///     it matched has been unsubscribed since the message was queued
+        /// @return the completion of this consumer's work, as [AsyncProcessor#process]
+        @NotNull
+        CompletableFuture<Void> process(final @NotNull PUBLISH message, final @NotNull Set<T> destinations);
+    }
+
+    // endregion
+
+    // region Subscriber TopicFilter Verbs -- the same two families on builder and subscriber
     // =================================================================================================================
     // with... -- ABSOLUTE: replace the whole set. add... / remove... -- RELATIVE. Each is overloaded for one or
     // a list. When DETACHED these only update the remembered set (replayed by the next attach()); when ATTACHED
@@ -812,7 +839,7 @@ public final class InternalTopicFilterSubscriber {
         throwIfContextual("addTopicFilter");
         for (final String topicFilter : topicFiltersToAdd) {
             if (topicFilters.add(topicFilter) && attached) {
-                addToTree(topicFilter);
+                subscribeFilterInTopicTree(topicFilter);
             }
         }
         return this;
@@ -828,7 +855,7 @@ public final class InternalTopicFilterSubscriber {
         throwIfContextual("removeTopicFilter");
         for (final String topicFilter : topicFiltersToRemove) {
             if (topicFilters.remove(topicFilter) && attached) {
-                removeFromTree(topicFilter);
+                unsubscribeFilterFromTopicTree(topicFilter);
             }
         }
         return this;
@@ -878,7 +905,7 @@ public final class InternalTopicFilterSubscriber {
                     .computeIfAbsent(topicFilter, ignored -> new LinkedHashSet<>())
                     .add(context);
             if (isNewFilter && attached) {
-                addToTree(topicFilter);
+                subscribeFilterInTopicTree(topicFilter);
             }
         }
         return this;
@@ -905,45 +932,52 @@ public final class InternalTopicFilterSubscriber {
                 // subscription whose messages resolve to no destination -- accepted into the queue, then dropped.
                 topicFilterContexts.remove(topicFilter);
                 if (attached) {
-                    removeFromTree(topicFilter);
+                    unsubscribeFilterFromTopicTree(topicFilter);
                 }
             }
         }
         return this;
     }
 
-    /**
-     * Reconciles the topic tree from the currently subscribed filters to the given target.
-     * <p>
-     * Does nothing while detached -- there is nothing registered to reconcile, and the caller's new filter set
-     * is replayed in full by the next {@code attach()}.
-     */
+    /// Reconciles the topic tree from the currently subscribed filters to the given target.
+    ///
+    /// Does nothing while detached -- there is nothing registered to reconcile, and the caller's new filter set
+    /// is replayed in full by the next `attach()`.
     private void reconcileTo(final @NotNull Set<String> target) {
         if (!attached) {
             return;
         }
-        final Set<String> current = contextual ? topicFilterContexts.keySet() : topicFilters;
+        final Set<String> current = hasTopicFilterContext() ? topicFilterContexts.keySet() : topicFilters;
         final Set<String> gone = new LinkedHashSet<>();
         for (final String existing : current) {
             if (!target.contains(existing)) {
                 gone.add(existing);
             }
         }
-        gone.forEach(this::removeFromTree);
+        gone.forEach(this::unsubscribeFilterFromTopicTree);
         for (final String wanted : target) {
             if (!current.contains(wanted)) {
-                addToTree(wanted);
+                subscribeFilterInTopicTree(wanted);
             }
         }
     }
 
-    /** The filters this subscriber is subscribed to, whichever kind it is. */
+    /// Whether this is a CONTEXT subscriber: one told which of its destinations each message is for, and so
+    /// one whose filter verbs are the ...TopicFilterContext family.
+    ///
+    /// **Derived, never stored.** Supplying a context processor is exactly the consumer saying it wants this,
+    /// so a flag beside it would be a second statement of one fact, able to disagree with the first.
+    private boolean hasTopicFilterContext() {
+        return contextProcessor != null || asyncContextProcessor != null;
+    }
+
+    /// The filters this subscriber is subscribed to, whichever kind it is.
     private @NotNull Set<String> currentFilters() {
-        return contextual ? topicFilterContexts.keySet() : topicFilters;
+        return hasTopicFilterContext() ? topicFilterContexts.keySet() : topicFilters;
     }
 
     private void throwIfContextual(final @NotNull String verb) {
-        if (contextual) {
+        if (hasTopicFilterContext()) {
             throw new IllegalStateException("InternalTopicFilterSubscriber '" + clientId
                     + "' was built with a context processor, so "
                     + verb
@@ -954,7 +988,7 @@ public final class InternalTopicFilterSubscriber {
     }
 
     private void throwIfNotContextual(final @NotNull String verb) {
-        if (!contextual) {
+        if (!hasTopicFilterContext()) {
             throw new IllegalStateException("InternalTopicFilterSubscriber '" + clientId
                     + "' was not built with a context processor, so "
                     + verb
@@ -966,247 +1000,13 @@ public final class InternalTopicFilterSubscriber {
 
     // endregion
 
-    // region lifecycle verbs -- attach / consume / pause / detach / deallocate
+    // region Subscriber TopicTree Wiring -- every call this subscriber makes to the topic tree
     // =================================================================================================================
-    // attach() -- register the current topic filters in the topic tree. Messages now COLLECTED into
-    //               the client queue. Idempotent.
-    // consume() -- register the publish-available callback and drain anything already queued. Messages
-    //               now PROCESSED (if attached). Legal while detached -- the callback is simply armed for
-    //               when topics attach later. Idempotent.
-    // pause() -- deregister the callback. Messages keep being COLLECTED (if attached) but are no
-    //               longer PROCESSED. Idempotent.
-    // detach() -- remove the current topic filters from the topic tree. Messages no longer COLLECTED.
-    //               The remembered filter set survives, so a later attach() restores the same
-    //               subscription. Idempotent.
-    // deallocate() -- clear the client queue entry from persistence. Precondition: detached AND paused
-    //               (throws otherwise) -- clearing the queue while still collecting or draining would
-    //               race the SingleWriter.
+    // THE TOPIC TREE IS REACHED FROM HERE AND NOWHERE ELSE. Everything above and below calls these two, so
+    // "what does this subscriber ask of the tree" is answered by reading one short region.
     //
-    // All return `this` (except deallocate) so they chain. All are synchronized with the topic-filter
-    // verbs so state transitions and tree reconciliation never interleave.
-    //
-    // NO PROCESSOR IS EVER CALLED WITH THIS MONITOR HELD, and consume() below is where that is earned.
-    // Submitting a poll can run the whole read-process-release cycle INLINE on the calling thread -- the
-    // in-memory single writer executes a submitted task immediately when nothing else holds its bucket --
-    // so a submit made inside a synchronized verb would run the component's processor inside this monitor.
-    // Two things would follow, both bad: a processor that blocks waiting on a thread which wants this
-    // monitor deadlocks, and a processor calling back into a verb would observe half-finished state.
-    // Hence the split below -- state under the monitor, poll after it.
-    //
-    public synchronized @NotNull InternalTopicFilterSubscriber attach() {
-        throwIfDeallocated();
-        if (attached) {
-            return this;
-        }
-        for (final String topicFilter : currentFilters()) {
-            addToTree(topicFilter);
-        }
-        attached = true;
-        return this;
-    }
-
-    public @NotNull InternalTopicFilterSubscriber consume() {
-        if (armConsuming()) {
-            // OUTSIDE the monitor, deliberately -- see the note above. By here `consuming` is already true,
-            // so a processor that calls pause() during this drain is honoured rather than silently undone.
-            submitPoll();
-        }
-        return this;
-    }
-
-    /**
-     * The state half of {@link #consume()}: arms the callback and marks this subscriber as consuming.
-     *
-     * @return true if a drain is owed, i.e. this call is the one that started consuming
-     */
-    private synchronized boolean armConsuming() {
-        throwIfDeallocated();
-        if (consuming) {
-            return false;
-        }
-        // Register the callback first so any message arriving from now on wakes the poller; the drain the
-        // caller then submits picks up messages already in the queue (e.g. from a previous run, or collected
-        // while attached-but-paused).
-        clientQueuePersistence.addPublishAvailableCallback(id -> submitPoll(), clientId);
-        // BEFORE the drain, not after: the drain may run inline, and a processor calling pause() while this
-        // was still false would hit the "not consuming" guard and have its pause silently discarded.
-        consuming = true;
-        return true;
-    }
-
-    public synchronized @NotNull InternalTopicFilterSubscriber pause() {
-        throwIfDeallocated();
-        if (!consuming) {
-            return this;
-        }
-        clientQueuePersistence.removePublishAvailableCallback(clientId);
-        consuming = false;
-        return this;
-    }
-
-    public synchronized @NotNull InternalTopicFilterSubscriber detach() {
-        throwIfDeallocated();
-        if (!attached) {
-            return this;
-        }
-        for (final String topicFilter : currentFilters()) {
-            removeFromTree(topicFilter);
-        }
-        attached = false;
-        return this;
-    }
-
-    // deallocate() is the one terminal verb -- and the one exception to throwIfDeallocated(): calling it
-    // on an already-dead subscriber is a no-op (idempotent), not an error.
-    public synchronized void deallocate() {
-        if (deallocated) {
-            return; // idempotent -- already dead, nothing to clear
-        }
-        if (attached || consuming) {
-            throw new IllegalStateException("InternalTopicFilterSubscriber '" + clientId
-                    + "' must be detached and paused before deallocate() (attached="
-                    + attached + ", consuming="
-                    + consuming + ")");
-        }
-        // Remove the queue entry from persistence entirely. false == do not keep a tombstone. This
-        // also DROPS any messages that were collected but not yet processed -- which is exactly why a
-        // long-lived subscriber must eventually stop()/deallocate() rather than just detach(), or the
-        // queue (and its memory) would linger.
-        clientQueuePersistence.clear(clientId, false);
-        // Free the clientId in the factory's registry -- symmetric with build(). The queue is now
-        // destroyed, so the componentPrefix::instanceId identity becomes available for reuse.
-        factory.deregister(this);
-        deallocated = true;
-    }
-
-    // Guard for every verb except deallocate(): a deallocated subscriber is dead and cannot be
-    // resurrected or operated on. Throws on any use-after-deallocate.
-    private void throwIfDeallocated() {
-        if (deallocated) {
-            throw new IllegalStateException(
-                    "InternalTopicFilterSubscriber '" + clientId + "' has been deallocated and cannot be used");
-        }
-    }
-
-    // endregion
-
-    // region start() / stop() -- convenience compositions of the verbs
-    // =================================================================================================================
-    // start() = attach(); consume(); -- order does not matter operationally; whichever runs second
-    //           activates the flow.
-    // stop()  = detach(); pause(); deallocate(); -- order DOES matter: detach first (stop the inflow),
-    //           pause second (stop the processing), deallocate last (clear the now-quiet queue).
-    //
-    // They exist only to spare callers the common two-/three-call sequences; a caller that wants finer
-    // control (e.g. attach without consuming, or pause without deallocating) calls the verbs directly.
-    //
-    // start() throws on a deallocated subscriber (you cannot resurrect a dead one -- that goes through
-    // attach()). stop() is idempotent: it is the only composition you can safely call on a dead
-    // subscriber, returning quietly (it just deallocates, which is itself a no-op when already dead).
-    //
-    // NOT synchronized, and that is the point: it composes attach() and consume(), each of which takes the
-    // monitor for its own state work. Holding it across both would put the drain consume() submits back
-    // inside the monitor -- exactly what consume() was split apart to avoid.
-    public @NotNull InternalTopicFilterSubscriber start() {
-        attach();
-        consume();
-        return this;
-    }
-
-    public synchronized void stop() {
-        if (deallocated) {
-            return; // already dead -- stop() is idempotent
-        }
-        detach();
-        pause();
-        deallocate();
-    }
-
-    // endregion
-
-    // region ingress-exclusion -- identity and the accept decision
-    // =================================================================================================================
-    // clientId() -- this subscriber's reserved-prefix id, used by the factory as the registry key.
-    //
-    // isExcludedIngressClientId(senderClientId) -- the ingress-exclusion decision, called by the publish
-    //   path at distribution time (BEFORE queueing) with the ingress/publishing client id (its
-    //   `sender`). Returns true iff an excluded id is configured and equals senderClientId -- in which
-    //   case the message must NOT be queued to us. With no excluded id (the common case) it always
-    //   returns false. The excluded id is immutable after build(), so this is a lock-free read and safe
-    //   to call from the publish path concurrently with the lifecycle verbs.
-    //
-    public @NotNull String clientId() {
-        return clientId;
-    }
-
-    public boolean isExcludedIngressClientId(final @Nullable String senderClientId) {
-        return excludedIngressClientId != null && excludedIngressClientId.equals(senderClientId);
-    }
-
-    /**
-     * @return the most messages to hold for this subscriber, or null to use the broker-wide
-     *         {@code maxQueuedMessages}. Read by the publish distributor when it queues a message.
-     */
-    public @Nullable Long queueLimit() {
-        return queueLimit;
-    }
-
-    /**
-     * @return what to drop when this subscriber's queue is full, or null to use the broker-wide strategy. Read
-     *         by the queue persistence when it adds a message.
-     */
-    public @Nullable QueuedMessagesStrategy queueOverflow() {
-        return queueOverflow;
-    }
-
-    // endregion
-
-    // region internal wiring -- topic-tree add/remove and the SingleWriter poll pipeline
-    // =================================================================================================================
-    // addToTree() / removeFromTree() -- the two topic-tree operations, factored out so the verbs and
-    //                     the reconciliation logic share one definition of "register a filter" and
-    //                     "deregister a filter" under this clientId.
-    //
-    // The methods after them form the poll pipeline, which runs entirely on the SingleWriter thread:
-    //
-    // submitPoll() -- schedules pollUnlessBusy() on the SingleWriter queue. Called by every trigger
-    //                     that means "a message may be available now": the publish-available callback,
-    //                     consume(), and the error path.
-    // submitPollAfterInFlight() -- the same, for the ONE trigger that also means "the message I was
-    //                     working on is finished": the completion of a processor's future.
-    // pollUnlessBusy() -- THE ONE PLACE THE CONDITION LIVES. Polls only when this subscriber is consuming
-    //                     and holds no message. Otherwise gives up -- see below.
-    // pollAfterInFlight() -- clears the in-flight state, then goes through pollUnlessBusy() like anything
-    //                     else, so a subscriber paused meanwhile stops rather than reading one more.
-    // poll() -- claims the in-flight state and reads one message. On an empty read it releases the
-    //                     claim, since nothing will arrive to release it later.
-    // processMessage() -- hands the message to the processor and chains the release off its completion.
-    // release() -- acknowledges the message and triggers the next poll.
-    // removeMessage() -- deletes the message from the queue, which is what stands in for an MQTT client's
-    //                     acknowledgement. A QoS 0 message needs no call: reading it removed it already.
-    //
-    // TWO CONDITIONS, ONE PLACE, AND GIVING UP IS NEVER LOSING A TRIGGER. A trigger only says "a message may
-    // be available"; whether to act is pollUnlessBusy()'s alone. It declines while a message is in flight,
-    // because that message's completion polls again; and while paused, because resuming polls again. Both
-    // paths therefore re-ask the question rather than stranding whatever arrived.
-    //
-    // WHY inFlight HAD TO BE ADDED. When a processor did its work before returning, one-message-at-a-time was
-    // free: the whole chain ran as one task, and a trigger arriving meanwhile could only queue another task
-    // behind it. A processor that answers a future returns at once, so the thread goes free while the work
-    // continues elsewhere -- and a trigger then polls immediately, handing out a second message.
-    //
-    // WHY consuming HAD TO BE READ HERE. It was set and cleared by consume()/pause() and read by nothing on
-    // this path, so pausing removed the wake-up callback but did not stop a poll already under way, nor the
-    // completion of an outstanding message from reading the next one. Deallocation is covered by the same
-    // clause rather than needing its own: deallocate() requires being paused, so a dead subscriber is one
-    // whose consuming flag is already false -- which matters because deallocation FREES THE CLIENT ID, and a
-    // replacement may already own the queue this one would otherwise read from.
-    //
-    // A PLAIN FIELD, NOT AN ATOMIC. Every one of these methods runs inside a task submitted for this
-    // subscriber's clientId, and the SingleWriter runs the tasks of one bucket strictly one at a time --
-    // so no two of them are ever in flight together, whichever thread did the submitting. That is also
-    // why the completion submits a task rather than clearing the state itself: doing it inline would put
-    // the write on the consumer's thread, outside the serialisation, for no gain.
+    // subscribeFilterInTopicTree() / unsubscribeFilterFromTopicTree() -- the two operations, so the lifecycle
+    //                     verbs and the reconciliation logic share one definition of each under this clientId.
     //
     // The trailing `null` in both calls is the topic tree's `sharedName` -- and it is null ON PURPOSE.
     // The topic tree distinguishes shared from non-shared subscriptions: a non-null sharedName makes
@@ -1217,14 +1017,15 @@ public final class InternalTopicFilterSubscriber {
     // EDG-504 -- a non-shared internal subscriber so the topic tree deduplicates by client id and a
     // message matching several of our filters is delivered to our queue exactly once. So sharedName
     // stays null, and our `clientId` is the sole identity (no separate shared-group name).
-    /// Registers one topic filter in the topic tree under this subscriber's client id.
+    /// Registers one topic filter in the topic tree under this subscriber's client id, so that matching
+    /// messages start landing in its queue.
     ///
-    /// **No subscription identifier is recorded**, for either kind of subscriber. A context subscriber works out
-    /// which filters a message matched when it POLLS the message, from the message's own topic -- see
-    /// [#asAsync] -- so it needs nothing stamped onto the message at enqueue time. That also means this method
-    /// has no precondition a caller can forget: every registration path is interchangeable, and a new one needs
-    /// only to call this.
-    private void addToTree(final @NotNull String topicFilter) {
+    /// **No subscription identifier is recorded**, for either kind of subscriber. A subscriber told which of
+    /// its destinations a message is for works that out when it HANDLES the message, from the message's own
+    /// topic -- see [#destinationsFor] -- so nothing need be stamped onto the message when it is queued. That
+    /// also means this method has no precondition a caller can forget: every registration path is
+    /// interchangeable, and a new one needs only to call this.
+    private void subscribeFilterInTopicTree(final @NotNull String topicFilter) {
         topicTree.addTopic(
                 clientId,
                 new Topic(topicFilter, qos, false, true, Topic.DEFAULT_RETAIN_HANDLING, null),
@@ -1232,66 +1033,426 @@ public final class InternalTopicFilterSubscriber {
                 null); // sharedName -- null: non-shared (see note above)
     }
 
-    /**
-     * Turns a routing processor into the async one the pipeline uses, by working out which of this subscriber's
-     * filters the message's topic matches and handing over the contexts behind them.
-     * <p>
-     * <b>Matched at poll time, not at enqueue time.</b> The message carries its concrete topic and this
-     * subscriber holds its own filters, so the match is computed from what is true NOW. Nothing is stamped onto
-     * a stored message, and so nothing stored can go stale: a filter removed while the message sat in the queue
-     * simply does not match, and one added while it sat there does. The alternative -- having the topic tree
-     * record a per-filter subscription identifier on each queued message and resolving that identifier back to
-     * a filter here -- cached the answer at the wrong moment. It needed identifiers to stay stable across
-     * detach/attach and across a restart, neither of which a per-subscriber counter can promise, and it failed
-     * silently when they did not: the message arrived with an empty context set and was quietly dropped.
-     * <p>
-     * <b>A union, and over the CONTEXTS rather than the filters.</b> One context may sit behind two filters --
-     * one destination reachable by two patterns -- and both may match one topic. Deduplicating means the
-     * consumer does the work once, which for a device write is the difference between sending a command once
-     * and sending it twice.
-     * <p>
-     * Cost is one pass over this subscriber's own filters, each a single walk over the topic with no allocation
-     * (see {@link #topicMatchesFilter}). Subscriber filter counts are small, and nothing shared is consulted:
-     * no topic tree, no lock beyond this object's own.
-     */
-    @SuppressWarnings("unchecked")
-    private @NotNull AsyncProcessor asAsync(final @NotNull AsyncContextProcessor<?> contextProcessor) {
-        final AsyncContextProcessor<TopicFilterContext> routing =
-                (AsyncContextProcessor<TopicFilterContext>) contextProcessor;
-        return message -> {
-            final Set<TopicFilterContext> matched = new LinkedHashSet<>();
-            synchronized (this) {
-                topicFilterContexts.forEach((topicFilter, contexts) -> {
-                    if (topicMatchesFilter(topicFilter, message.getTopic())) {
-                        matched.addAll(contexts);
-                    }
-                });
-            }
-            return routing.process(message, matched);
+    /// Removes one topic filter from the topic tree, so that matching messages stop landing in this
+    /// subscriber's queue. Messages already queued are unaffected.
+    private void unsubscribeFilterFromTopicTree(final @NotNull String topicFilter) {
+        topicTree.removeSubscriber(clientId, topicFilter, null); // sharedName -- null: non-shared
+    }
+
+    // endregion
+
+    // region Subscriber Queue Wiring -- every call this subscriber makes to the client-queue persistence
+    // =================================================================================================================
+    // THE QUEUE PERSISTENCE IS REACHED FROM HERE AND NOWHERE ELSE, for the same reason as the topic tree
+    // above: one region answers "what does this subscriber ask of its queue", and the verbs and the ppf-loop
+    // read as what they decide rather than as which persistence call they make.
+    //
+    // All five take this subscriber's clientId as the QUEUE id -- the same string the topic tree knows it by,
+    // which is what wires the two together (see clientId).
+
+    /// Asks to be told when a message arrives, and starts a ppf-loop each time one does.
+    private void callMeWhenAMessageArrives() {
+        clientQueuePersistence.addPublishAvailableCallback(
+                id -> sendPpfLoopCommand(PpfLoopCommand.WAKE, false), clientId);
+    }
+
+    /// Stops those notifications. Messages keep arriving in the queue; nothing wakes up to drain them.
+    private void stopCallingMeWhenAMessageArrives() {
+        clientQueuePersistence.removePublishAvailableCallback(clientId);
+    }
+
+    /// Reads the next message(s), answering a future. See [#fetched] for why this may return more than one
+    /// even though a single packet id is passed.
+    private @NotNull ListenableFuture<ImmutableList<PUBLISH>> readNextMessagesFromQueue() {
+        return clientQueuePersistence.readNew(clientId, false, POLL_PACKET_IDS, PUBLISH_POLL_BATCH_SIZE_BYTES);
+    }
+
+    /// Deletes the message currently stamped in flight -- this subscriber's stand-in for the acknowledgement
+    /// an MQTT client would send. See [#finish] for why it is keyed the way it is, and why QoS 0 needs none.
+    private void deleteStampedMessageFromQueue() {
+        FutureUtils.addExceptionLogger(
+                clientQueuePersistence.remove(clientId, ClientQueuePersistenceImpl.SHARED_IN_FLIGHT_MARKER));
+    }
+
+    /// Destroys the queue and everything still in it. Terminal -- see [#deallocate].
+    private void destroyQueue() {
+        clientQueuePersistence.clear(clientId, false); // false == no tombstone
+    }
+
+    // endregion
+
+    // region Subscriber PPF-Loop -- poll a message, process it, finish it, go round again
+    // =================================================================================================================
+    // Draining this subscriber's queue is one loop of three steps -- POLL a message, PROCESS it, FINISH it --
+    // which then goes round again. "ppf" throughout this class is always those three. The loop is asynchronous
+    // rather than a Java loop: each step chains to the next from a callback, because polling and processing
+    // both answer with a future.
+    //
+    // AT MOST ONE PPF-LOOP EXISTS AT ANY MOMENT. That is the whole bound this pipeline has to keep: one
+    // message handled at a time, in order. Two mechanisms enforce it, and they are separate things:
+    //
+    //   internalSubmit (the SingleWriter's, not ours) guarantees ppfLoopCtrl never runs concurrently with
+    //       itself. Tasks submitted for one queue run strictly one after another -- whether inline under a
+    //       work-in-progress counter (in memory) or on a dedicated writer thread (file-backed) -- so no two
+    //       invocations of ppfLoopCtrl ever overlap, whichever thread submitted them.
+    //   ppfLoopCtrl guarantees at most one ppf-loop, via loopActive, which NOTHING ELSE EVER WRITES.
+    //
+    // The five methods:
+    //
+    // sendPpfLoopCommand(PpfLoopCommand.START) -- the ONE entry point for every trigger that says "a message may be
+    // available now": the
+    //                     message-available callback and consume(). Submits ppfLoopCtrl(START).
+    // ppfLoopCtrl(case) -- owns loopActive and is the only caller of poll(). Every transition of the loop
+    //                     goes through it; see the four cases on the method itself.
+    // poll() -- produces the next message and hands it to process(). Serves anything left over from the
+    //                     previous read first, and only reads the queue again once those are gone -- a read
+    //                     can return more than one message even when asked for one; see the fetched field.
+    //                     An empty read or a failure ends the loop by calling back into ppfLoopCtrl.
+    // process() -- hands the message to the processor and chains finish() off its completion.
+    // finish() -- deletes the message from the queue, then goes round again via ppfLoopCtrl(CONTINUE).
+    //
+    // And two helpers of process(), for the context forms, which are told which destinations a message is for:
+    //
+    // destinationsFor() -- the contexts behind every filter of this subscriber that the message's topic
+    //                     matches, deduplicated.
+    // isMatchFilterTopic() -- whether one topic filter matches one concrete topic; standard MQTT matching.
+    //
+    // A TRIGGER THAT FINDS A LOOP RUNNING DOES NOTHING, AND LOSES NOTHING. It only says a message may be
+    // available; the running loop will come round and read it. Likewise a paused subscriber: resuming
+    // submits again. Both cases re-ask the question rather than stranding whatever arrived.
+    //
+    // WHY loopActive HAD TO BE ADDED. When a processor did its work before returning, one-message-at-a-time
+    // was free: the whole chain ran as one task, and a trigger arriving meanwhile could only queue another
+    // task behind it. A processor that answers a future returns at once, so the thread goes free while the
+    // work continues elsewhere -- and a trigger then polls immediately, handing out a second message.
+    //
+    // WHY THE FLAG IS ABOUT THE LOOP AND NOT ABOUT A MESSAGE. Every name that described a message -- in
+    // flight, handling, holding -- was false for part of the time the flag is true: after a processor's
+    // future completes, and before the next read returns a value, no message is being handled at all. But
+    // that stretch is precisely when a second read must not start. A loop is either running or it is not,
+    // with no such gap, so the loop is what the flag is about.
+    //
+    // WHY consuming IS READ HERE. It was set and cleared by consume()/pause() and read by nothing on this
+    // path, so pausing removed the message-available callback but did not stop a loop already running.
+    // Deallocation is covered by the same clause rather than needing its own: deallocate() requires being
+    // paused, so a dead subscriber is one whose consuming flag is already false -- which matters because
+    // deallocation FREES THE CLIENT ID, and a replacement may already own the queue this loop would read.
+    //
+    // A PLAIN FIELD, NOT AN ATOMIC. ppfLoopCtrl() is reached either from sendPpfLoopCommand(PpfLoopCommand.START),
+    // which puts it in the
+    // SingleWriter's serialisation for this queue, or from a step of a loop that is already inside it -- so
+    // no two invocations ever overlap, whichever thread submitted them, and the field needs no atomicity.
+
+    /// What the ppf-loop IS, and -- as [#goalState] -- what it is being asked to be.
+    ///
+    /// **Named as adjectives**, where the commands of [PpfLoopCommand] are named as verbs. That is only a
+    /// device for keeping the two vocabularies apart on sight: a state is something the loop is, a command is
+    /// something asked of it, and confusing the two is how one word came to mean two things here before.
+    private enum PpfLoopState {
+        /// An iteration is in flight right now.
+        ACTIVE,
+        /// None is, but a message arriving will start one.
+        WAITING,
+        /// None is, and a message arriving will NOT start one. The state a subscriber is born in.
+        PAUSED,
+        /// Dead, and not revivable.
+        TERMINATED
+    }
+
+    /// What one call asks of the ppf-loop. Each command names the state it asks for, and [#goalStateFor]
+    /// decides whether that ask takes. Named as verbs, against the adjectives of [PpfLoopState].
+    private enum PpfLoopCommand {
+        /// A message is available; run an iteration. Sent by the message-available callback.
+        WAKE,
+        /// That iteration finished a message; run another. Sent by [#finish].
+        CONTINUE,
+        /// That iteration failed; run another. Until there is anything cleverer -- a backoff, an attempt
+        /// limit -- a failure is simply retried, so this asks for the same thing CONTINUE does.
+        RESTART,
+        /// Be draining. Sent by [#consume].
+        CONSUME,
+        /// That iteration found nothing to read; settle. Sent by [#poll].
+        IDLE,
+        /// Stop draining. Sent by [#pause].
+        PAUSE,
+        /// Be destroyed. Sent by [#deallocate].
+        TEARDOWN
+    }
+
+    /// Sends one command to the ppf-loop, from any thread.
+    ///
+    /// **Submitted rather than called, and that is what makes the loop safe.** The submit puts the call inside
+    /// the SingleWriter's serialisation for this queue, which is what guarantees [#ppfLoopCtrl] never runs
+    /// concurrently with itself -- and so what lets [#loopState] and [#goalState] be plain fields.
+    ///
+    /// @param fromActiveLoop true iff the sender IS the iteration currently in flight, reporting back. Only
+    ///     such a command may pass the one-loop guard; everything else is recorded in the goal and waits.
+    private void sendPpfLoopCommand(final @NotNull PpfLoopCommand command, final boolean fromActiveLoop) {
+        singleWriterService.getQueuedMessagesQueue().submit(clientId, bucketIndex -> {
+            ppfLoopCtrl(command, fromActiveLoop);
+            return null;
+        });
+    }
+
+    /// The goal a command asks for, given the goal already standing. **The first of the loop's two matrices.**
+    ///
+    /// Each command names a state it wants; this decides whether the ask takes. Two rules, and only two:
+    ///
+    ///   - **TERMINATED absorbs.** Once destruction is the goal, nothing lowers it.
+    ///   - **PAUSED is not overridden by the loop's own progress.** A pause asked for mid-iteration must
+    ///     survive the CONTINUE that ends that iteration, or it is lost. So CONTINUE, RESTART, WAKE and IDLE
+    ///     leave a PAUSED goal alone; only CONSUME lifts it.
+    private static @NotNull PpfLoopState goalStateFor(
+            final @NotNull PpfLoopState goal, final @NotNull PpfLoopCommand command) {
+        if (goal == PpfLoopState.TERMINATED) {
+            return PpfLoopState.TERMINATED;
+        }
+        return switch (command) {
+            case TEARDOWN -> PpfLoopState.TERMINATED;
+            case PAUSE -> PpfLoopState.PAUSED;
+            case CONSUME -> PpfLoopState.ACTIVE;
+            // The loop's own reports. They say what just happened, so they may move a goal that is already
+            // about draining -- but they must not resurrect a paused subscriber.
+            case WAKE, CONTINUE, RESTART -> goal == PpfLoopState.PAUSED ? PpfLoopState.PAUSED : PpfLoopState.ACTIVE;
+            case IDLE -> goal == PpfLoopState.PAUSED ? PpfLoopState.PAUSED : PpfLoopState.WAITING;
         };
     }
 
-    /**
-     * Whether an MQTT topic filter matches a concrete topic.
-     * <p>
-     * Standard MQTT matching: {@code +} matches exactly one level, {@code #} matches the remaining levels and
-     * also the parent itself (so {@code a/b/#} matches {@code a/b}), and both wildcards match an EMPTY level
-     * (so {@code a/+} matches {@code a/}).
-     * <p>
-     * <b>Assumes both arguments are well formed</b> -- in the filter {@code +} and {@code #} each occupy a whole
-     * level and {@code #} is last; in the topic neither character appears. Both hold here: filters come from
-     * configuration that Edge validates, and topics come from messages the broker accepted.
-     * <p>
-     * A single left-to-right walk over the two strings with no allocation and no splitting into levels. Two
-     * details carry the wildcards. The trailing {@code /#} is stripped up front and remembered, so the loop
-     * never sees it and a filter that ran out while the topic sits on a {@code /} still matches. And the
-     * {@code +} test comes BEFORE the character comparison, with the loop advancing on the FILTER alone -- that
-     * is what lets {@code +} match an empty level, where there is no character in the topic to compare against.
-     * <p>
-     * The final read needs no bounds check: {@code ||} evaluates its right side only when the topic cursor is
-     * not at the end, and the cursor never passes the end, so it is always in range.
-     */
-    private static boolean topicMatchesFilter(final @NotNull String filter, final @NotNull String topic) {
+    /// Drives the ppf-loop: records what was asked, refuses to act while an iteration is in flight, then moves
+    /// [#loopState] towards [#goalState]. **The only place either is written.**
+    ///
+    /// **Record, then guard, then act** -- and the order is the whole design. A command may arrive while an
+    /// iteration is in flight, with a message in the consumer's processor, so it is recorded in the goal first
+    /// and acted on later, when the iteration that was running comes round. Acting before the guard -- which
+    /// an earlier version did for TEARDOWN -- destroys the queue out from under an iteration still reading it.
+    private void ppfLoopCtrl(final @NotNull PpfLoopCommand command, final boolean fromActiveLoop) {
+
+        // 1. RECORD -- the whole of the first matrix, in one line.
+        goalState = goalStateFor(goalState, command);
+
+        // 2. GUARD -- there is only ever one iteration in flight. Pass only if none is, or if this IS that
+        // iteration reporting back. Anything turned away is already recorded in the goal above, and the
+        // iteration in flight will act on it when it reports.
+        //
+        // fromActiveLoop is the CALLER's word, not something derived from the command, because only the sender
+        // knows whether it is the running iteration speaking.
+        if (loopState == PpfLoopState.ACTIVE && !fromActiveLoop) {
+            return;
+        }
+
+        // 3. ACT -- the second matrix: move loopState towards goalState.
+        switch (goalState) {
+            // Destroy. Deregistering the clientId from the factory is tearDown()'s last step, so there can
+            // never be two subscribers for one clientId.
+            case TERMINATED -> {
+                tearDown();
+                loopState = PpfLoopState.TERMINATED;
+            }
+            // Stop draining. A message arriving later sends WAKE, which will not lift a PAUSED goal.
+            case PAUSED -> loopState = PpfLoopState.PAUSED;
+            // Settle: no iteration runs, but a message arriving will start one.
+            case WAITING -> loopState = PpfLoopState.WAITING;
+            // Run an iteration. poll() reports back with CONTINUE, RESTART or IDLE, and that report is what
+            // decides the next goal.
+            case ACTIVE -> {
+                loopState = PpfLoopState.ACTIVE;
+                poll();
+            }
+        }
+    }
+
+    /// Tears this subscriber down, on the SingleWriter thread and between iterations of the ppf-loop.
+    ///
+    /// **Everything here runs where the loop runs**, which is the whole point. Clearing [#fetched] needs no
+    /// lock because nothing else touches it from another thread, and the client id is handed back to the
+    /// factory only once this subscriber has stopped reading from and writing to its queue -- so no operation
+    /// of this lifetime can land on the queue of whatever takes the id next.
+    ///
+    /// Idempotent: a second teardown finds this subscriber already dead and does nothing.
+    private void tearDown() {
+        if (deallocated) {
+            return;
+        }
+        destroyQueue();
+        // Messages a read had already handed over go with the queue: they left it when they were read, so
+        // this is where they end.
+        fetched.clear();
+        // Symmetric with build(): the queue is destroyed, so the identity becomes available for reuse. LAST,
+        // so nothing of this lifetime can still touch a queue the next owner of the id is using.
+        factory.deregister(this);
+        deallocated = true;
+    }
+
+    /// Produces the next message and hands it to [#process], the first P of the ppf-loop.
+    ///
+    /// **Called only by [#ppfLoopCtrl]**, so arriving here means a loop is running and this is its next step.
+    ///
+    /// **A read is issued only when nothing is left over from the last one.** A read can return more than one
+    /// message even though we ask for a single packet id -- see [#fetched] for why -- and every returned
+    /// message must be processed, because a returned QoS 0 message has already been removed from the queue
+    /// and exists nowhere else. So the leftovers are served first, and the queue is read again only once they
+    /// are gone.
+    ///
+    /// **Both outcomes of the read are handled**, which is why this uses a callback with an explicit failure
+    /// method rather than a success-only transform. A read whose future completes exceptionally would
+    /// otherwise run nothing at all, leaving [#loopActive] set for ever: the subscriber would accept messages
+    /// into its queue and never read them again, silently, and pausing and resuming would not help. The
+    /// enclosing `catch` does not cover that -- a future completing exceptionally is not a throw from the
+    /// `try` block; it only covers a throw from ISSUING the read.
+    private void poll() {
+        final PUBLISH leftover = fetched.poll();
+        if (leftover != null) {
+            process(leftover);
+            return;
+        }
+        try {
+            Futures.addCallback(
+                    readNextMessagesFromQueue(),
+                    new FutureCallback<>() {
+                        @Override
+                        public void onSuccess(final @Nullable ImmutableList<PUBLISH> messages) {
+                            if (messages == null || messages.isEmpty()) {
+                                sendPpfLoopCommand(PpfLoopCommand.IDLE, true);
+                                return;
+                            }
+                            // EVERYTHING the read returned, not just the first: see [#fetched].
+                            fetched.addAll(messages);
+                            process(fetched.poll());
+                        }
+
+                        @Override
+                        public void onFailure(final @NotNull Throwable t) {
+                            log.error(
+                                    "Failed to read a message for internal subscriber '{}': {}",
+                                    clientId,
+                                    t.getMessage());
+                            sendPpfLoopCommand(PpfLoopCommand.RESTART, true);
+                        }
+                    },
+                    MoreExecutors.directExecutor());
+        } catch (final Throwable t) {
+            log.error("Failed to poll internal subscriber '{}': {}", clientId, t.getMessage());
+            sendPpfLoopCommand(PpfLoopCommand.RESTART, true);
+        }
+    }
+
+    /// Hands one message to the processor, the second P of the ppf-loop.
+    ///
+    /// **The four forms are called here, in the shape the consumer supplied.** Exactly one field is non-null.
+    /// A returning form has its already-complete future made here; only a context form has its destinations
+    /// computed, so a consumer that did not ask to be told them pays nothing for them.
+    ///
+    /// **Success and failure finish alike**: whether the work succeeded is the consumer's business, and both
+    /// outcomes mean this message is done with. A failed message is dropped -- this is a subscriber, not a
+    /// retry mechanism.
+    @SuppressWarnings("unchecked") // the set holds exactly the contexts this consumer registered
+    private void process(final @NotNull PUBLISH message) {
+        final CompletableFuture<Void> completion;
+        try {
+            if (plainProcessor != null) {
+                plainProcessor.process(message);
+                completion = CompletableFuture.completedFuture(null);
+            } else if (asyncProcessor != null) {
+                completion = asyncProcessor.process(message);
+            } else if (contextProcessor != null) {
+                ((ContextProcessor<TopicFilterContext>) contextProcessor).process(message, destinationsFor(message));
+                completion = CompletableFuture.completedFuture(null);
+            } else if (asyncContextProcessor != null) {
+                completion = ((AsyncContextProcessor<TopicFilterContext>) asyncContextProcessor)
+                        .process(message, destinationsFor(message));
+            } else {
+                // Unreachable -- build() rejects a subscriber with no processor. Stated so the compiler can
+                // see that one of the four is always taken; the catch below logs it and the loop goes on.
+                throw new IllegalStateException("Internal subscriber '" + clientId + "' has no processor");
+            }
+        } catch (final Exception e) {
+            // Covers a returning processor throwing, and a future-returning one throwing before it produced a
+            // future. Either way there is nothing to attach the finish to, so it happens here instead.
+            log.error(
+                    "Processor for internal subscriber '{}' threw; message will be dropped: {}",
+                    clientId,
+                    e.getMessage());
+            finish(message);
+            return;
+        }
+        // The terminal stage; the stage returned by whenComplete is intentionally dropped.
+        final var unused = completion.whenComplete((ignored, throwable) -> {
+            if (throwable != null) {
+                log.error(
+                        "Failed to process message for internal subscriber '{}', message will be dropped: {}",
+                        clientId,
+                        throwable.getMessage());
+            }
+            finish(message);
+        });
+    }
+
+    /// Acknowledges a finished message and goes round again, the F of the ppf-loop.
+    ///
+    /// **Acknowledging means deleting.** Nothing ever comes back from an internal subscriber, so this is the
+    /// only thing that removes a message: reading one does not, for anything above QoS 0. The store leaves it
+    /// in place stamped in flight, precisely so it survives until something confirms it was handled. QoS 0
+    /// needs no call at all, because reading such a message removed it.
+    ///
+    /// The deletion is keyed by [ClientQueuePersistenceImpl#SHARED_IN_FLIGHT_MARKER] rather than a real wire
+    /// packet id, so it deletes "the stamped message" -- sound only because at most one ppf-loop exists, and
+    /// so at most one message is ever stamped. It is the NON-shared removal: storage keeps a separate map for
+    /// shared subscriptions, and this subscriber is non-shared on every other side.
+    ///
+    /// **The acknowledgement and going round again cannot be separated.** A throw from the deletion would
+    /// otherwise end the loop without ending it -- [#loopActive] left set and nothing to clear it -- which is
+    /// the same silent stall the design exists to prevent, arriving through the one path meant to prevent it.
+    /// Hence the `finally`.
+    private void finish(final @NotNull PUBLISH message) {
+        try {
+            if (message.getQoS() != QoS.AT_MOST_ONCE) {
+                deleteStampedMessageFromQueue();
+            }
+        } catch (final Exception e) {
+            log.error("Failed to acknowledge message for internal subscriber '{}': {}", clientId, e.getMessage());
+        } finally {
+            sendPpfLoopCommand(PpfLoopCommand.CONTINUE, true);
+        }
+    }
+
+    /// The destinations a message is for: the contexts behind every one of this subscriber's filters that its
+    /// topic matches.
+    ///
+    /// **Matched when the message is HANDLED, not when it was queued.** The message carries its topic and this
+    /// subscriber holds its filters, so the answer is computed from what is true NOW and nothing stored can go
+    /// stale: a filter removed while the message waited does not match, one added while it waited does. The
+    /// alternative -- stamping a per-filter subscription identifier on each queued message -- cached the answer
+    /// at the wrong moment, needed those identifiers to survive detach/attach and a restart, and failed
+    /// silently when they did not: the message arrived with no destinations and was dropped.
+    ///
+    /// **A union over the DESTINATIONS, not the filters**, since one destination may be reachable by two
+    /// patterns and both may match. Deduplicating is what stops a device write being sent twice.
+    private synchronized @NotNull Set<TopicFilterContext> destinationsFor(final @NotNull PUBLISH message) {
+        return topicFilterContexts.entrySet().stream()
+                .filter(entry -> isMatchFilterTopic(entry.getKey(), message.getTopic()))
+                .flatMap(entry -> entry.getValue().stream())
+                .collect(Collectors.toSet());
+    }
+
+    /// Whether an MQTT topic filter matches a concrete topic.
+    ///
+    /// Standard MQTT matching: `+` matches exactly one level, `#` matches the remaining levels and also the
+    /// parent itself (so `a/b/#` matches `a/b`), and both wildcards match an EMPTY level (so `a/+` matches
+    /// `a/`).
+    ///
+    /// **Assumes both arguments are well formed** -- in the filter `+` and `#` each occupy a whole level and
+    /// `#` is last; in the topic neither character appears. Both hold here: filters come from configuration
+    /// that Edge validates, and topics come from messages the broker accepted.
+    ///
+    /// A single left-to-right walk over the two strings with no allocation and no splitting into levels. Two
+    /// details carry the wildcards. The trailing `/#` is stripped up front and remembered, so the loop never
+    /// sees it and a filter that ran out while the topic sits on a `/` still matches. And the `+` test comes
+    /// BEFORE the character comparison, with the loop advancing on the FILTER alone -- that is what lets `+`
+    /// match an empty level, where there is no character in the topic to compare against.
+    ///
+    /// The final read needs no bounds check: `||` evaluates its right side only when the topic cursor is not
+    /// at the end, and the cursor never passes the end, so it is always in range.
+    private static boolean isMatchFilterTopic(final @NotNull String filter, final @NotNull String topic) {
         boolean hasHashWildcard = false;
         int lenF = filter.length();
         if (1 == lenF && filter.charAt(0) == '#') {
@@ -1319,183 +1480,213 @@ public final class InternalTopicFilterSubscriber {
         return iT == lenT || (topic.charAt(iT) == '/' && hasHashWildcard);
     }
 
-    private void removeFromTree(final @NotNull String topicFilter) {
-        topicTree.removeSubscriber(clientId, topicFilter, null); // sharedName -- null: non-shared
+    // endregion
+
+    // region Subscriber Lifecycle Verbs -- attach / consume / pause / detach / deallocate, start / stop
+    // =================================================================================================================
+    // attach() -- register the current topic filters in the topic tree. Messages now COLLECTED into
+    //               the client queue. Idempotent.
+    // consume() -- register the publish-available callback and drain anything already queued. Messages
+    //               now PROCESSED (if attached). Legal while detached -- the callback is simply armed for
+    //               when topics attach later. Idempotent.
+    // pause() -- deregister the callback. Messages keep being COLLECTED (if attached) but are no
+    //               longer PROCESSED. Idempotent.
+    // detach() -- remove the current topic filters from the topic tree. Messages no longer COLLECTED.
+    //               The remembered filter set survives, so a later attach() restores the same
+    //               subscription. Idempotent.
+    // deallocate() -- detach, pause, then ask the ppf-loop to clear the client queue entry from persistence
+    //               and free the client id. TERMINAL: every verb throws afterwards, except deallocate()
+    //               and stop(), which are idempotent no-ops.
+    //
+    // And two compositions of those five, which exist only to spare callers the common sequences:
+    //
+    // start() -- attach(); consume(). Order does not matter operationally; whichever runs second
+    //               activates the flow. Throws on a dead subscriber, since it cannot be resurrected.
+    // stop() -- detach(); pause(); deallocate(). Order DOES matter: detach first (stop the inflow),
+    //               pause second (stop the processing), deallocate last (clear the now-quiet queue).
+    //               The one composition that is safe on a dead subscriber; it returns quietly.
+    //
+    // All return `this` (except deallocate and stop) so they chain.
+    //
+    // THE FIVE VERBS ARE SYNCHRONIZED, THE TWO COMPOSITIONS ARE NOT. A verb holds state, so it takes the
+    // monitor with the topic-filter verbs and state transitions never interleave with tree reconciliation.
+    // A composition holds none of its own -- it is a sequence of verbs, each taking the monitor for its own
+    // work -- so there is nothing for it to guard. consume() is the one verb split in two, for a reason
+    // given at the method itself.
+    //
+    // ===========================================================================================
+    // NO VERB EVER BLOCKS, AND NONE WAITS FOR THE PPF-LOOP TO ACT ON WHAT IT ASKED.
+    // ===========================================================================================
+    //
+    // consume(), pause() and deallocate() each SEND a command and return. When the loop acts on it is not
+    // specified, and none of them waits to find out. So a verb returning means the request was made, NOT that
+    // it has taken effect -- pause() in particular does not promise that no further message reaches the
+    // processor; see the method for the exact wording.
+    //
+    // WHY NOT WAIT. The obvious improvement -- wait on the future the submit hands back -- deadlocks, and not
+    // rarely. The in-memory SingleWriter has no thread of its own: whichever thread submits first DRAINS the
+    // queue inline, and a work-in-progress counter stops anyone else draining meanwhile. So:
+    //
+    //   1. A message arrives. Thread T submits, sees the counter at zero, and becomes the drainer.
+    //   2. Draining runs the loop, which reads a message and hands it to the component's processor -- still
+    //      on T, still inside the drain loop.
+    //   3. The processor calls pause() on its own subscriber. That submits a command; the submit finds the
+    //      counter NON-ZERO (T's own drain loop holds it) and so does not drain. It returns an uncompleted
+    //      future.
+    //   4. pause() waits on that future.
+    //
+    // T is now waiting for a task only T can run. No cycle between threads, no monitors involved -- one
+    // thread blocked on work it is itself responsible for executing. It hangs every time, not sometimes.
+    //
+    // NOTHING DETECTS THIS AT RUNTIME. Java's deadlock detection sees monitor cycles; this is neither. A
+    // timeout would convert the hang into a pause that silently did not happen. A check for "am I the
+    // drainer" is not implementable: the writer records THAT someone is draining, not WHO.
+    //
+    // SO IT IS PREVENTED STRUCTURALLY, by three rules each checkable by reading one method:
+    //
+    //   1. No verb here blocks.
+    //   2. Nothing submitted to the SingleWriter waits on another submit.
+    //   3. Consumer code is called only from inside a submitted task, never with a monitor held.
+    //
+    // From which: no thread ever waits for the writer, so no thread can wait for work it might itself run,
+    // so the cycle cannot form. A future change that adds a wait breaks rule 1, and nothing will complain --
+    // which is why the rules are written here rather than left to be re-derived.
+    //
+    public synchronized @NotNull InternalTopicFilterSubscriber attach() {
+        throwIfDeallocated();
+        if (attached) {
+            return this;
+        }
+        for (final String topicFilter : currentFilters()) {
+            subscribeFilterInTopicTree(topicFilter);
+        }
+        attached = true;
+        return this;
     }
 
-    /**
-     * Says "a message may be available now". Used by every trigger except the completion of a processor's
-     * future, which uses {@link #submitPollAfterInFlight()} because it means one thing more.
-     */
-    private void submitPoll() {
-        singleWriterService.getQueuedMessagesQueue().submit(clientId, bucketIndex -> {
-            pollUnlessBusy();
-            return null;
-        });
+    /// Starts draining the queue: registers the message-available callback, marks this subscriber as
+    /// consuming, and starts the first ppf-loop. Idempotent -- a second call while already consuming does
+    /// nothing.
+    ///
+    /// The callback covers every message arriving from NOW on. Messages already in the queue -- from a
+    /// previous run, or collected while attached but paused -- are not covered by it, which is what that
+    /// first loop is for.
+    ///
+    /// **This verb is split in two, and it is the only one that is.** [#consumeDontStartPpfLoop] does the
+    /// state change under this object's monitor and answers whether this call is the one that started
+    /// consuming; the loop is started out here, after that method has returned and the monitor is released.
+    ///
+    /// The reason is that starting a ppf-loop can run the consumer's own processor INLINE on the calling
+    /// thread: the in-memory single writer executes a submitted task immediately when nothing else holds its
+    /// bucket, so a whole poll-process-finish cycle can happen before [#startPpfLoop] returns. Doing that
+    /// with the monitor held would mean a processor that blocks waiting on a thread which wants the monitor
+    /// deadlocks, and a processor calling back into a verb observes half-finished state. **No processor is
+    /// ever called with this monitor held**, and this split is where that is earned.
+    ///
+    /// Splitting also fixes the order. `consuming` is already true by the time the loop starts, so a processor
+    /// that calls `pause()` during that first inline loop is honoured rather than silently discarded -- with
+    /// the flag still false it would hit the "not consuming" guard in [#pause] and do nothing.
+    public @NotNull InternalTopicFilterSubscriber consume() {
+        if (consumeDontStartPpfLoop()) {
+            sendPpfLoopCommand(PpfLoopCommand.CONSUME, false);
+        }
+        return this;
     }
 
-    /**
-     * Says "the message I was working on is finished, and another may be available now".
-     * <p>
-     * <b>A submitted task rather than clearing the state inline</b>, because this is called from the
-     * completion of a processor's future -- on whichever thread completed it. Going through the queue puts
-     * the write back inside the single-writer serialisation, which is what lets {@link #inFlight} be a
-     * plain field.
-     */
-    private void submitPollAfterInFlight() {
-        singleWriterService.getQueuedMessagesQueue().submit(clientId, bucketIndex -> {
-            pollAfterInFlight();
-            return null;
-        });
+    private synchronized boolean consumeDontStartPpfLoop() {
+        throwIfDeallocated();
+        if (consuming) {
+            return false;
+        }
+        callMeWhenAMessageArrives();
+        consuming = true;
+        return true;
     }
 
-    /**
-     * Polls, unless this subscriber should not be reading right now.
-     * <p>
-     * <b>Giving up is not dropping the trigger.</b> A message in flight will finish and its completion polls
-     * again; a paused subscriber polls again when it resumes. So a trigger that arrives at the wrong moment is
-     * redundant rather than lost.
-     */
-    private void pollUnlessBusy() {
-        if (inFlight || !consuming) {
+    /// Stops draining the queue. Messages keep being collected if attached; nothing processes them.
+    ///
+    /// **WHAT THIS PROMISES.** The message-available callback is deregistered before this returns, so nothing
+    /// further will wake the subscriber. And a PAUSE command is sent, which the ppf-loop acts on at its next
+    /// decision point: from then on it hands no message to the processor.
+    ///
+    /// **WHAT IT DOES NOT PROMISE.** That the loop has seen it yet. The command is submitted, not executed,
+    /// so a message may still be handed over in the window between this returning and the loop acting. Nor
+    /// does it promise that a message already WITH the processor has finished -- a component that needs to
+    /// know the last one is done must learn that from its own processor, not from this call returning.
+    ///
+    /// **Why it does not wait for either.** Waiting deadlocks, by a route worth reading before ever adding
+    /// one -- see the rules and the worked example at the top of this region.
+    ///
+    /// **Why a promise about ordering is statable at all.** This call and the processor run on different
+    /// threads, and two events on different threads have NO intrinsic order -- wall-clock "before" means
+    /// nothing between them. An order exists only where Java's happens-before relation puts one, so a claim
+    /// about what has stopped is only as good as the edge that establishes it. Here that edge is the PAUSE
+    /// command sent below, which travels through the SingleWriter's queue for this subscriber: the loop sees
+    /// it in order with its own work.
+    public synchronized @NotNull InternalTopicFilterSubscriber pause() {
+        throwIfDeallocated();
+        if (!consuming) {
+            return this;
+        }
+        stopCallingMeWhenAMessageArrives();
+        consuming = false;
+        // So a pause takes effect on an iteration already under way, rather than only on the next one. The
+        // flag above is the standing answer to "may I poll at all"; this is the prompt to stop now.
+        sendPpfLoopCommand(PpfLoopCommand.PAUSE, false);
+        return this;
+    }
+
+    public synchronized @NotNull InternalTopicFilterSubscriber detach() {
+        throwIfDeallocated();
+        if (!attached) {
+            return this;
+        }
+        for (final String topicFilter : currentFilters()) {
+            unsubscribeFilterFromTopicTree(topicFilter);
+        }
+        attached = false;
+        return this;
+    }
+
+    /// The one terminal verb, and the one exception to [#throwIfDeallocated]: calling it on an already-dead
+    /// subscriber is a no-op rather than an error.
+    ///
+    /// **Destroys the queue, and everything in it.** Messages collected but not yet processed are dropped --
+    /// which is why a long-lived subscriber must eventually stop rather than merely detach, or its queue and
+    /// the memory behind it linger for ever.
+    ///
+    /// **ASYNCHRONOUS: this asks, the ppf-loop does.** It returns once the request is submitted, not once the
+    /// subscriber is dead. The work itself happens on the SingleWriter thread at a point between iterations
+    /// of the loop -- a message already with the consumer's processor is allowed to finish first -- which is
+    /// what stops a teardown racing a loop that is reading from or acknowledging to the very queue it
+    /// destroys. See [#tearDown].
+    ///
+    /// **No precondition.** It used to demand being detached and paused, because it could not safely tear
+    /// down a live subscriber. Now it detaches and pauses on the caller's behalf and lets the loop finish.
+    public void deallocate() {
+        if (deallocated) {
             return;
         }
-        poll();
+        detach();
+        pause();
+        sendPpfLoopCommand(PpfLoopCommand.TEARDOWN, false);
     }
 
-    /**
-     * Clears the in-flight state a completed message held, then polls for the next.
-     * <p>
-     * <b>The poll goes through the same condition as every other trigger</b>, so a subscriber paused while this
-     * message was being processed stops here rather than reading one more.
-     */
-    private void pollAfterInFlight() {
-        if (!inFlight) {
-            // Nothing sets inFlight except poll(), and nothing clears it except this -- so reaching here
-            // with it already clear means a message was released twice, which no path should allow.
-            log.error("Internal subscriber '{}' completed a message it was not processing", clientId);
-        }
-        inFlight = false;
-        pollUnlessBusy();
-    }
-
-    /**
-     * Claims the in-flight state and reads one message.
-     * <p>
-     * <b>The claim happens here, before the read, and that placement is the whole point.</b> Reading submits
-     * a task of its own, so this one ends before the message arrives; claiming afterwards would leave a gap
-     * in which another trigger could poll and hand out a second message.
-     * <p>
-     * <b>An empty read therefore has to release the claim</b>: no message means no completion, and nothing
-     * else would ever clear it -- the subscriber would stop for good.
-     */
-    private void poll() {
-        inFlight = true;
-        try {
-            final ListenableFuture<ImmutableList<PUBLISH>> future =
-                    clientQueuePersistence.readNew(clientId, false, POLL_PACKET_IDS, PUBLISH_POLL_BATCH_SIZE_BYTES);
-            Futures.transform(
-                    future,
-                    publishes -> {
-                        if (publishes == null || publishes.isEmpty()) {
-                            inFlight = false;
-                            return null;
-                        }
-                        processMessage(publishes.get(0));
-                        return null;
-                    },
-                    MoreExecutors.directExecutor());
-        } catch (final Throwable t) {
-            log.error("Failed to poll internal subscriber '{}': {}", clientId, t.getMessage());
-            inFlight = false;
-            submitPoll();
+    private void throwIfDeallocated() {
+        if (deallocated) {
+            throw new IllegalStateException(
+                    "InternalTopicFilterSubscriber '" + clientId + "' has been deallocated and cannot be used");
         }
     }
 
-    /**
-     * Hands one message to the processor, and releases the queue once the processor is done with it.
-     * <p>
-     * <b>The release is chained off the processor's completion</b>, so the queue moves on when the consumer is
-     * done rather than when it returns. What keeps a second message from being handed out meanwhile is
-     * {@link #inFlight}, claimed in {@link #poll()} -- chaining alone does not, since a trigger arriving from
-     * anywhere else would poll regardless.
-     * <p>
-     * Success and failure release alike: whether the work succeeded is the consumer's business, and both
-     * outcomes mean "this one is no longer in flight". A message is dropped either way -- this is a subscriber,
-     * not a retry mechanism.
-     */
-    private void processMessage(final @NotNull PUBLISH message) {
-        final CompletableFuture<Void> completion;
-        try {
-            completion = processor.process(message);
-        } catch (final Exception e) {
-            // The contract is that a processor reports through its future rather than by throwing, and the
-            // synchronous form is wrapped to guarantee it. An async processor that throws anyway would
-            // otherwise leave nothing to attach the release to, and this queue would never move again.
-            log.error(
-                    "Processor for internal subscriber '{}' threw instead of returning a future; message will be "
-                            + "dropped: {}",
-                    clientId,
-                    e.getMessage());
-            release(message);
-            return;
-        }
-
-        // The terminal stage; the stage returned by whenComplete is intentionally dropped.
-        final var unused = completion.whenComplete((ignored, throwable) -> {
-            if (throwable != null) {
-                log.error(
-                        "Failed to process message for internal subscriber '{}', message will be dropped: {}",
-                        clientId,
-                        throwable.getMessage());
-            }
-            release(message);
-        });
+    public @NotNull InternalTopicFilterSubscriber start() {
+        attach();
+        consume();
+        return this;
     }
 
-    /**
-     * Acknowledges a message and reads the next.
-     * <p>
-     * <b>Wrapped so that neither half can be skipped.</b> A throw from the acknowledgement would otherwise
-     * swallow the poll, and this subscriber would stop for good -- the same silent stall the whole design is
-     * built to prevent, arriving through the one path that is supposed to prevent it.
-     */
-    private void release(final @NotNull PUBLISH message) {
-        try {
-            removeMessage(message);
-        } catch (final Exception e) {
-            log.error("Failed to acknowledge message for internal subscriber '{}': {}", clientId, e.getMessage());
-        } finally {
-            // The one trigger that also clears the in-flight state, since this message is now finished.
-            submitPollAfterInFlight();
-        }
-    }
-
-    /**
-     * Deletes a processed message from the queue.
-     * <p>
-     * <b>This stands in for the acknowledgement an ordinary MQTT client would send.</b> Nothing ever comes back
-     * from an internal subscriber, so this call is the only thing that removes a message: reading one does not,
-     * for anything above QoS 0. The store leaves it in place stamped in flight, precisely so it survives until
-     * something confirms it was handled. QoS 0 needs no call at all, because reading such a message removes it.
-     * <p>
-     * <b>The NON-shared removal, and this was wrong from EDG-504 until now.</b> Storage keeps two separate maps
-     * -- one for client queues, one for shared subscriptions -- and this subscriber is non-shared on every
-     * other side: no share name in the topic tree, {@code shared = false} when reading, {@code shared = false}
-     * when queued to. The removal alone said {@code removeShared}, which searched the other map, found no queue
-     * under this id, and returned in silence. So no QoS 1 or 2 message was ever removed: each stayed stamped in
-     * flight, skipped by later reads and holding its slot, until the queue filled and rejected everything
-     * after. Nothing logged, at any point.
-     * <p>
-     * <b>Keyed by packet identifier</b>, which is what the non-shared removal takes -- and every message
-     * carries the same marker rather than a real wire id, so this deletes "the stamped message". Sound only
-     * because a subscriber holds exactly one at a time; see {@link #inFlight}.
-     */
-    private void removeMessage(final @NotNull PUBLISH message) {
-        if (message.getQoS() != QoS.AT_MOST_ONCE) {
-            FutureUtils.addExceptionLogger(
-                    clientQueuePersistence.remove(clientId, ClientQueuePersistenceImpl.SHARED_IN_FLIGHT_MARKER));
-        }
+    public void stop() {
+        deallocate(); // which detaches and pauses first, then asks the ppf-loop to tear down
     }
 
     // endregion

--- a/hivemq-edge/src/main/java/com/hivemq/persistence/clientqueue/InternalTopicFilterSubscriber.java
+++ b/hivemq-edge/src/main/java/com/hivemq/persistence/clientqueue/InternalTopicFilterSubscriber.java
@@ -22,6 +22,7 @@ import com.google.common.primitives.ImmutableIntArray;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
+import com.hivemq.configuration.service.MqttConfigurationService.QueuedMessagesStrategy;
 import com.hivemq.mqtt.message.QoS;
 import com.hivemq.mqtt.message.publish.PUBLISH;
 import com.hivemq.mqtt.message.subscribe.Topic;
@@ -29,24 +30,27 @@ import com.hivemq.mqtt.topic.SubscriptionFlag;
 import com.hivemq.mqtt.topic.tree.LocalTopicTree;
 import com.hivemq.persistence.SingleWriterService;
 import com.hivemq.persistence.util.FutureUtils;
-import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-// region InternalTopicFilterSubscriber — concrete topic-tree subscriber for internal Edge components
+// region InternalTopicFilterSubscriber -- concrete topic-tree subscriber for internal Edge components
 // =====================================================================================================================
 // Lets an internal Edge component (a bridge, a combiner, a sampler, ...) receive messages from the
 // local topic tree without being an MQTT client.
 //
-// This is a CONCRETE, FINAL class — there is nothing to subclass and nothing to override. You do not
+// This is a CONCRETE, FINAL class -- there is nothing to subclass and nothing to override. You do not
 // extend it; you obtain one from InternalTopicFilterSubscriberFactory, configure it through a fluent
 // Builder, and drive it with explicit lifecycle verbs. The single piece of behaviour the component
-// supplies — what to do with each message — is a Processor lambda passed to the builder.
+// supplies -- what to do with each message -- is a Processor lambda passed to the builder.
 //
 //   // a combiner keeping the latest value of one topic in an atomic reference:
 //   final AtomicReference<byte[]> latest = new AtomicReference<>();
@@ -60,17 +64,36 @@ import org.slf4j.LoggerFactory;
 //
 // Lifecycle. The lifecycle is decomposed into independent verbs. attach()/detach() control the
 // SUBSCRIPTION (topics in the topic tree, i.e. whether messages are COLLECTED); consume()/pause()
-// control the CALLBACK (whether collected messages are PROCESSED). They are orthogonal — a subscriber
+// control the CALLBACK (whether collected messages are PROCESSED). They are orthogonal -- a subscriber
 // can be attached-but-paused (collecting into the queue without draining) or detached-but-consuming
 // (callback armed, ready for when topics are attached later). start() and stop() are just convenience
 // compositions of the verbs.
 //
-// Threading. The whole message pipeline runs on the SingleWriter thread keyed by clientId. The verbs
-// themselves are safe to call from any thread; the queue/topic-tree operations they perform are the
-// same ones the previous design performed, just split apart so each is independently callable.
+// Threading, and why a processor may not block. Three steps, in order -- the constraint on a processor is
+// a consequence rather than a rule of its own:
+//
+//   1. Message handling in the broker and in Edge is generally SEQUENTIAL. That is how MQTT's ordering
+//      guarantees are met.
+//   2. Sequential without locks, and without overhead in either code complexity or runtime cost, is
+//      achieved with DEDICATED THREADS: one thread performs every operation for a given queue -- in fact
+//      for a whole bucket of queues.
+//   3. So a component's processor MAY NOT BLOCK that thread for any extended period. The thread is not the
+//      component's; holding it holds up every queue in the bucket.
+//
+// A component whose work is slow, or which may block, therefore returns a future instead of doing the work
+// (see withAsyncProcessor): it starts the work elsewhere and returns at once, releasing the thread.
+//
+// The verbs themselves are safe to call from any thread; the queue/topic-tree operations they perform are
+// the same ones the previous design performed, just split apart so each is independently callable.
+//
+// One message in flight. Handling stays sequential in either form -- the next message is passed on only
+// once the previous one's future has completed, so a component never has two in hand. For a withProcessor
+// lambda that future completes when the lambda returns; for a withAsyncProcessor lambda, when the consumer
+// completes it. The asynchronous form does not create that bound: it is what step 1 requires and holds
+// either way. What it buys is keeping the bound WITHOUT occupying the thread for the length of the work.
 //
 // @see <a href="https://hivemq.github.io/hivemq-edge-lore/2-implementation/internal-topic-filter-subscriber/">Edge Lore
-// — Internal Topic Filter Subscriber</a>
+// -- Internal Topic Filter Subscriber</a>
 //
 @SuppressWarnings({"FutureReturnValueIgnored", "CheckReturnValue", "UnusedReturnValue"})
 public final class InternalTopicFilterSubscriber {
@@ -79,19 +102,29 @@ public final class InternalTopicFilterSubscriber {
 
     public static final @NotNull String INTERNAL_SUBSCRIBER_PREFIX = "$INTERNAL::";
 
-    // SHARED_IN_FLIGHT_MARKER acts as a boolean inflight flag — not a real wire packet ID, since
+    // SHARED_IN_FLIGHT_MARKER acts as a boolean inflight flag -- not a real wire packet ID, since
     // messages never go to an MQTT client. removeShared() uses uniqueId, not the packet ID, so
     // the value here does not matter.
     private static final @NotNull ImmutableIntArray POLL_PACKET_IDS =
             ImmutableIntArray.of(ClientQueuePersistenceImpl.SHARED_IN_FLIGHT_MARKER);
 
-    // clientId — built once as the reserved-prefix triple "$INTERNAL::<componentPrefix>::<instanceId>"
+    // The largest MQTT subscription identifier: a variable byte integer, so 2^28 - 1. Topic's constructor
+    // asserts the range, and 0 is reserved -- so the usable space is [1, MAX_SUBSCRIPTION_ID].
+    private static final int MAX_SUBSCRIPTION_ID = 268_435_455;
+
+    // At most half the space may be subscribed at once, and that bound is what makes allocation terminate
+    // rather than merely usually terminate: with under half the identifiers taken, no run of consecutive taken
+    // values can span the whole space, so the search below always finds a free one. Raising this towards the
+    // full space would take that guarantee away, which is why it is stated here rather than tuned.
+    private static final int MAX_TOPIC_FILTERS = MAX_SUBSCRIPTION_ID / 2;
+
+    // clientId -- built once as the reserved-prefix triple "$INTERNAL::<componentPrefix>::<instanceId>"
     //            (see the constructor for what each segment means). PublishDistributorImpl
     //            .isReservedClientId() recognises the "$INTERNAL::" prefix and rejects any external
     //            MQTT client that tries to connect with it, so this namespace cannot collide with real
     //            clients.
     //
-    //            ONE id, used as the identity in TWO different subsystems — and deliberately so:
+    //            ONE id, used as the identity in TWO different subsystems -- and deliberately so:
     //              - in the TOPIC TREE  it is the subscriber id (addTopic / removeSubscriber), i.e.
     //                "who is subscribed to this filter".
     //              - in the CLIENT-QUEUE persistence it is the queue id (the bucket key for
@@ -103,74 +136,172 @@ public final class InternalTopicFilterSubscriber {
     private final @NotNull String clientId;
 
     // The three Edge singletons this subscriber operates against. Supplied by the factory (which has
-    // them injected), so callers never see or thread them. Final — set once at construction.
+    // them injected), so callers never see or thread them. Final -- set once at construction.
     private final @NotNull LocalTopicTree topicTree;
     private final @NotNull ClientQueuePersistence clientQueuePersistence;
     private final @NotNull SingleWriterService singleWriterService;
 
-    // The per-message handler. Set once at construction (Builder requires it).
-    private final @NotNull Processor processor;
+    // The per-message handler. Set once at construction (Builder requires one of the two forms). Always the
+    // async form internally: a synchronous Processor is wrapped by the builder, so the pipeline has one shape.
+    private final @NotNull AsyncProcessor processor;
 
     // The factory that built this subscriber, kept as a back-reference so that build()/deallocate() can
-    // (de)register this subscriber in the factory's registry — see isExcludedIngressClientId() below.
+    // (de)register this subscriber in the factory's registry -- see isExcludedIngressClientId() below.
     private final @NotNull InternalTopicFilterSubscriberFactory factory;
 
-    // excludedIngressClientId — ingress-exclusion (generalized No Local). If set, a message whose
+    // excludedIngressClientId -- ingress-exclusion (generalized No Local). If set, a message whose
     //            INGRESS client id (the publishing client, i.e. the distributor's `sender`) equals this
     //            value must NOT be delivered to us. Set once via the builder, immutable after build();
-    //            null means "no exclusion — accept from everyone". The check happens at distribution
+    //            null means "no exclusion -- accept from everyone". The check happens at distribution
     //            time (PublishDistributorImpl), BEFORE the message is queued, so an excluded message
     //            never enters our queue. See isExcludedIngressClientId().
     private final @Nullable String excludedIngressClientId;
 
-    // ── mutable lifecycle state, all touched only via the verbs below ────────────────────────────
-    // topicFilters — the CURRENT desired filter set. When detached this is just a remembered set
-    //                (replayed by the next attach()); when attached the topic tree is kept reconciled
-    //                with it. A LinkedHashSet so order is stable and duplicates are ignored.
+    // The QoS every filter is registered at. One value for the whole subscriber, not per filter, and
+    // deliberately: when several of a subscriber's filters match one message the topic tree folds them into
+    // one entry keeping the LAST QoS in sorted order, so per-filter values would make the effective QoS of a
+    // message depend on sort order rather than on anything the caller said.
+    private final @NotNull QoS qos;
+
+    // How many messages this subscriber's queue holds, and what happens when it is full. Both are read by the
+    // publish distributor at delivery time, through the factory registry -- the same hook ingress-exclusion
+    // uses -- because the decision is made where the message is queued, not here.
+    //
+    // Null means "whatever the broker is configured for": maxQueuedMessages (1000 unless changed) and the
+    // configured strategy (DISCARD by default). Declaring them replaces the alternative, which is what Edge
+    // does today for the sampler -- a prefix match on the client id, hardcoded into the distributor for the
+    // limit and into the queue persistence for the strategy. A consumer should say this where it is defined.
+    private final @Nullable Long queueLimit;
+
+    private final @Nullable QueuedMessagesStrategy queueOverflow;
+
+    // Which kind of subscriber this is, and so which family of filter verbs is legal. NOT a separate
+    // declaration: it follows from the processor supplied, since withContextProcessor is exactly the consumer
+    // saying it wants to be told what a message matched. A flag beside it could disagree with it.
+    private final boolean contextual;
+
+    // -- mutable lifecycle state, all touched only via the verbs below ----------------------------
+    //
+    // A subscriber is one of two kinds, and which it is follows from the processor it was built with:
+    // withProcessor/withAsyncProcessor make a PLAIN one, withContextProcessor a CONTEXT one. The kind decides
+    // which family of filter verbs is legal (the other family throws) and which structures below are used --
+    // a plain subscriber never touches the three context maps, and a context subscriber never uses topicFilters.
+    // See contextual() and the filter-verb region.
+
+    // topicFilters -- a PLAIN subscriber's filter set. When detached this is just a remembered set (replayed by
+    //                the next attach()); when attached the topic tree is kept reconciled with it. A
+    //                LinkedHashSet so order is stable and duplicates are ignored.
     private final @NotNull Set<String> topicFilters = new LinkedHashSet<>();
 
-    // attached — true iff the current topicFilters are registered in the topic tree (messages are
+    // topicFilterContexts -- a CONTEXT subscriber's filters, each with the contexts registered for it. Doubles
+    //                as that subscriber's filter set: its keys are exactly the filters, so the two kinds do
+    //                not each need one.
+    //
+    //                A SET per filter, because one filter may carry several contexts -- two southbound mappings
+    //                may share a topic filter -- and registering the same filter twice OVERWRITES in the topic
+    //                tree rather than accumulating, correctly so, since MQTT-3.8.4-3 requires a repeated filter
+    //                to replace its predecessor. The fan-out cannot live in the tree, so it lives here.
+    private final @NotNull Map<String, Set<TopicFilterContext>> topicFilterContexts = new LinkedHashMap<>();
+
+    // The two directions between a filter and its MQTT subscription identifier. Inverses of each other, and
+    // maintained only by allocate/free below, which is what keeps them so.
+    //
+    //   subscriptionIdByTopicFilter -- used when registering a filter in the tree, and when removing one.
+    //   topicFilterBySubscriptionId -- used on the DELIVERY path: a message carries the identifiers it matched,
+    //                                  and this is what turns them back into filters and so into contexts.
+    //
+    // An identifier is assigned once per filter and kept for as long as that filter is subscribed, so it
+    // survives every detach()/attach(). Re-allocating on re-attach would stay internally consistent and break
+    // only when a message queued BEFORE the detach is read after it, carrying an identifier this subscriber no
+    // longer knows -- and the identifier travels with the queued message, so that window is real.
+    private final @NotNull Map<String, Integer> subscriptionIdByTopicFilter = new HashMap<>();
+
+    private final @NotNull Map<Integer, String> topicFilterBySubscriptionId = new HashMap<>();
+
+    // Where the next allocation starts looking. Identifiers are per subscriber, not global: two subscribers may
+    // both use 1 without interfering.
+    private int nextSubscriptionId = 0;
+
+    // attached -- true iff the current topicFilters are registered in the topic tree (messages are
     //            being collected into the client queue).
     private boolean attached = false;
 
-    // consuming — true iff the publish-available callback is registered (collected messages are being
-    //             drained and handed to the processor).
+    // consuming -- true iff this subscriber is draining its queue: the publish-available callback is
+    //             registered AND the poll pipeline will act on a trigger. Read by pollUnlessBusy(), which
+    //             is what makes pause() stop work already under way rather than only future wake-ups.
     private boolean consuming = false;
 
-    // deallocated — true once deallocate() has cleared the queue. TERMINAL: once deallocated the
+    // deallocated -- true once deallocate() has cleared the queue. TERMINAL: once deallocated the
     //               subscriber is dead and cannot be resurrected; every verb is a no-op (or, for
     //               attach/consume, rejected) from then on. This flag makes deallocate()/stop() safely
     //               idempotent and guards the other verbs against use-after-deallocate.
     private boolean deallocated = false;
 
+    // inFlight -- true from the moment a message is claimed for processing until its future settles.
+    //            THE ONE-MESSAGE-AT-A-TIME BOUND, and the only thing that states it: see the poll
+    //            pipeline's region note for why a processor answering a future made it necessary, and
+    //            why this is a plain field rather than an atomic.
+    private boolean inFlight = false;
+
     // endregion
 
-    // region constructor — package-private, only the factory/builder construct this
+    // region constructor -- package-private, only the factory/builder construct this
     // =================================================================================================================
-    // componentPrefix — identifies the Edge component type (e.g. "tynebridge", "combiner", "sampler").
+    // componentPrefix -- identifies the Edge component type (e.g. "tynebridge", "combiner", "sampler").
     //                   Must be unique across all components in Edge. Becomes the middle segment of
     //                   the internal client ID.
-    // instanceId      — identifies this specific subscriber instance within the component. Must be
+    // instanceId -- identifies this specific subscriber instance within the component. Must be
     //                   unique within the componentPrefix namespace. Typically derived from the
     //                   configuration ID of the owning instance.
-    // processor       — the per-message handler (runs on the SingleWriter thread).
-    // initialFilters  — the topic filter set assembled in the builder (may be empty; that is valid).
-    // excludedIngressClientId — ingress-exclusion id, or null for none (see the field above).
-    // factory         — the factory that built us, used as the registry for ingress-exclusion lookups.
+    // processor -- the per-message handler (runs on the SingleWriter thread).
+    // initialFilters -- the topic filter set assembled in the builder (may be empty; that is valid).
+    // excludedIngressClientId -- ingress-exclusion id, or null for none (see the field above).
+    // factory -- the factory that built us, used as the registry for ingress-exclusion lookups.
     //
     InternalTopicFilterSubscriber(
             final @NotNull String componentPrefix,
             final @NotNull String instanceId,
-            final @NotNull Processor processor,
+            final @Nullable AsyncProcessor processor,
+            final @Nullable AsyncContextProcessor<?> contextProcessor,
             final @NotNull Set<String> initialFilters,
+            final @NotNull Map<String, Set<TopicFilterContext>> initialContexts,
+            final @NotNull QoS qos,
+            final @Nullable Long queueLimit,
+            final @Nullable QueuedMessagesStrategy queueOverflow,
             final @Nullable String excludedIngressClientId,
             final @NotNull InternalTopicFilterSubscriberFactory factory,
             final @NotNull LocalTopicTree topicTree,
             final @NotNull ClientQueuePersistence clientQueuePersistence,
             final @NotNull SingleWriterService singleWriterService) {
         this.clientId = INTERNAL_SUBSCRIBER_PREFIX + componentPrefix + "::" + instanceId;
-        this.processor = processor;
-        this.topicFilters.addAll(initialFilters);
+        this.qos = qos;
+        this.queueLimit = queueLimit;
+        this.queueOverflow = queueOverflow;
+        // One shape internally: a context processor becomes an async one by resolving a message's identifiers
+        // back to contexts. The consumer never sees an integer.
+        //
+        // Exactly one of the two is non-null -- build() rejects both and neither -- but the constructor cannot
+        // see that, so it is checked here rather than assumed. This is the only construction path.
+        if (processor != null) {
+            this.processor = processor;
+            this.contextual = false;
+        } else if (contextProcessor != null) {
+            this.processor = asAsync(contextProcessor);
+            this.contextual = true;
+        } else {
+            throw new IllegalArgumentException(
+                    "InternalTopicFilterSubscriber needs a processor or a context processor, not neither");
+        }
+        // The filters, in whichever form this subscriber's kind uses. Each context filter is assigned its
+        // identifier here, so it survives every later detach()/attach().
+        if (contextual) {
+            initialContexts.forEach((filter, contexts) -> {
+                topicFilterContexts.put(filter, new LinkedHashSet<>(contexts));
+                subscriptionIdFor(filter);
+            });
+        } else {
+            this.topicFilters.addAll(initialFilters);
+        }
         this.excludedIngressClientId = excludedIngressClientId;
         this.factory = factory;
         this.topicTree = topicTree;
@@ -180,12 +311,14 @@ public final class InternalTopicFilterSubscriber {
 
     // endregion
 
-    // region Processor — the per-message handler supplied by the user (a lambda)
+    // region Processor -- the per-message handler supplied by the user (a lambda)
     // =================================================================================================================
-    // Called once per message, on the SingleWriter thread. Implementations must not block. Any
-    // exception thrown is caught, logged, and the message is dropped.
+    // Called once per message, on the SingleWriter thread that performs every operation for this queue's
+    // whole bucket -- see the threading note on the class. So this is for work small enough to do there:
+    // storing a value, handing the message to another thread's queue. Anything slower, and anything that
+    // may block, wants AsyncProcessor instead. Any exception thrown is caught, logged, message dropped.
     //
-    // Deliberately NOT named MessageProcessor / MessageTransformer — those names belong to the
+    // Deliberately NOT named MessageProcessor / MessageTransformer -- those names belong to the
     // MessageFabric design, the long-term home. This is the interim ITFS-local type; its signature is
     // exactly the old abstract process(PUBLISH), so an old override body ports into a lambda verbatim.
     //
@@ -196,9 +329,132 @@ public final class InternalTopicFilterSubscriber {
 
     // endregion
 
-    // region Builder — fluent build-time configuration, obtained from the factory
+    // region AsyncProcessor -- for work too slow, or too blocking, for the queue's own thread
     // =================================================================================================================
-    // The Processor is required; build() throws without it. Topic filters are optional — the set
+    // Same job as Processor, but the work does not happen ON the calling thread. The consumer starts it
+    // elsewhere and returns a future AT ONCE; the next message is passed on when that future completes.
+    //
+    // WHY, in the order the reasons actually run (see the threading note on the class): message handling is
+    // sequential because MQTT's ordering guarantees require it; that is achieved cheaply by giving each
+    // bucket of queues one dedicated thread; and it follows that a processor must not block that thread for
+    // any extended period, since every queue in the bucket waits behind it.
+    //
+    // A Processor has nowhere to put slow work: it says "finished" by returning, so the only way to stay
+    // sequential would be to do the work first, on that thread. This interface separates the two -- the work
+    // moves off the thread, the ordering stays.
+    //
+    // The bound itself is NOT what this buys: handling is sequential in both forms, one message in flight
+    // per component. This is what lets a consumer keep that bound without holding the thread meanwhile.
+    //
+    // Returning rather than being handed a callback, deliberately. A callback can be forgotten -- which
+    // compiles, and then stalls this queue permanently and silently -- and can be called twice, which
+    // acknowledges twice and reads two next messages, destroying the very bound this is for. A future
+    // completes once by construction, and a method that must return something cannot silently return nothing.
+    //
+    // "Completes" means SETTLED, either way. A failure releases the queue exactly as a success does; whether
+    // the work succeeded is the consumer's business, and both outcomes mean "this one is no longer in flight".
+    //
+    // A Processor is the degenerate case of this one -- a future already complete when it returns -- and is
+    // wrapped into exactly that by the builder. The pipeline below knows only this interface.
+    //
+    @FunctionalInterface
+    public interface AsyncProcessor {
+
+        /**
+         * @param message the message
+         * @return the completion of this consumer's work. Never null; return an already-complete future for
+         *         work that finished synchronously.
+         */
+        @NotNull
+        CompletableFuture<Void> process(final @NotNull PUBLISH message);
+    }
+
+    // endregion
+
+    // region TopicFilterContext -- a topic filter that knows what it is for
+    // =================================================================================================================
+    // A subscriber standing in for several destinations needs to be told which of them a message is for. It
+    // subscribes with these rather than with bare strings: each carries its filter AND whatever the consumer
+    // needs back when that filter matches, so the two travel together instead of being paired up by the caller.
+    //
+    // The implementation is entirely the consumer's -- this interface asks for the filter and nothing else. Two
+    // obligations come with that, and both are the implementor's to meet:
+    //
+    //   - EQUALITY, if the consumer means to remove one later. removeTopicFilterContext finds it by equals(),
+    //     so an implementation with identity equality can only be removed by the very object registered. A
+    //     record gets this for free and is the obvious choice.
+    //   - IMMUTABILITY of the filter. It is read when the subscription is registered and again when it is
+    //     removed; a filter that changed in between would leave a subscription nothing can take away.
+    //
+    @FunctionalInterface
+    public interface TopicFilterContext {
+
+        /**
+         * @return the topic filter to subscribe to. Must not change for the life of this object.
+         */
+        @NotNull
+        String topicFilter();
+    }
+
+    // endregion
+
+    // region ContextProcessor / AsyncContextProcessor -- told WHICH of its filters a message matched
+    // =================================================================================================================
+    // TWO INDEPENDENT CHOICES, so four interfaces rather than three. How a consumer says it is finished --
+    // by returning or by completing a future -- and what it is told about the message -- the message alone or
+    // the message plus what it matched -- are unrelated questions, and either answer to one goes with either
+    // answer to the other:
+    //
+    //                      told only the message      told what it matched
+    //   done on return     Processor                  ContextProcessor
+    //   done on a future   AsyncProcessor             AsyncContextProcessor
+    //
+    // A subscriber holding one filter, or several handled the same way, wants the left column; one standing in
+    // for several destinations wants the right. Slow or blocking work wants the bottom row (see AsyncProcessor
+    // for why); work small enough for the queue's own thread wants the top.
+    //
+    // SUPPLYING EITHER RIGHT-HAND FORM IS WHAT MAKES A SUBSCRIBER A CONTEXT ONE. There is no separate flag
+    // saying so: the processor a consumer supplies already says which kind it wants, and a second statement of
+    // that could disagree with the first. It follows that only the ...TopicFilterContext verbs are legal on
+    // such a subscriber, and only the bare-string ones on any other.
+    //
+    // What comes back are the consumer's OWN contexts, exactly as registered. The MQTT subscription identifiers
+    // that carry them never surface: this subscriber allocated them, so this subscriber is the only thing that
+    // can translate them, and an integer would be meaningless to a consumer without the maps held here.
+    //
+    // A SET, because several filters may match one message and the tree returns all their identifiers. Two
+    // filters may also carry the SAME context -- one destination reachable by two patterns -- and it appears
+    // once, because doing the work twice for one message is the failure this is meant to avoid.
+    //
+    @FunctionalInterface
+    public interface ContextProcessor<T extends TopicFilterContext> {
+
+        /**
+         * @param message the message
+         * @param matched the contexts of the filters this message matched. Empty only if every filter it
+         *         matched has been unsubscribed since the message was queued
+         */
+        void process(final @NotNull PUBLISH message, final @NotNull Set<T> matched);
+    }
+
+    @FunctionalInterface
+    public interface AsyncContextProcessor<T extends TopicFilterContext> {
+
+        /**
+         * @param message the message
+         * @param matched the contexts of the filters this message matched. Empty only if every filter it
+         *         matched has been unsubscribed since the message was queued
+         * @return the completion of this consumer's work, as {@link AsyncProcessor#process}
+         */
+        @NotNull
+        CompletableFuture<Void> process(final @NotNull PUBLISH message, final @NotNull Set<T> matched);
+    }
+
+    // endregion
+
+    // region Builder -- fluent build-time configuration, obtained from the factory
+    // =================================================================================================================
+    // The Processor is required; build() throws without it. Topic filters are optional -- the set
     // starts empty, and an empty set is perfectly valid (a subscriber that subscribes to nothing on
     // attach(), to which filters can be added later).
     //
@@ -216,11 +472,18 @@ public final class InternalTopicFilterSubscriber {
         private final @NotNull ClientQueuePersistence clientQueuePersistence;
         private final @NotNull SingleWriterService singleWriterService;
 
-        private @Nullable Processor processor = null; // required; checked in build()
+        private @Nullable AsyncProcessor processor = null; // required; checked in build()
+        // Always the async form internally, as with `processor` above: a synchronous ContextProcessor is
+        // wrapped by withContextProcessor, so the pipeline has one shape.
+        private @Nullable AsyncContextProcessor<?> contextProcessor = null;
         private final @NotNull Set<String> topicFilters = new LinkedHashSet<>();
+        private final @NotNull Map<String, Set<TopicFilterContext>> topicFilterContexts = new LinkedHashMap<>();
+        private @NotNull QoS qos = QoS.AT_LEAST_ONCE; // optional; the QoS every filter is registered at
+        private @Nullable Long queueLimit = null; // optional; null means the broker-wide default
+        private @Nullable QueuedMessagesStrategy queueOverflow = null; // optional; null means the broker default
         private @Nullable String excludedIngressClientId = null; // optional; ingress-exclusion
 
-        // Package-private — only the factory creates builders (it supplies the injected singletons and
+        // Package-private -- only the factory creates builders (it supplies the injected singletons and
         // itself, as the registry the built subscriber registers with on attach()).
         Builder(
                 final @NotNull String componentPrefix,
@@ -237,30 +500,148 @@ public final class InternalTopicFilterSubscriber {
             this.singleWriterService = singleWriterService;
         }
 
-        // Required: the per-message work.
+        // Required, in one of two forms: the per-message work.
+        //
+        // withProcessor -- the work is done ON the queue's own thread, so it must be small.
+        // withAsyncProcessor -- the work is done elsewhere; this returns a future for it at once.
+        //
+        // Two names rather than one overloaded name, because the two cannot be told apart by the compiler: a
+        // lambda like `message -> latest.set(...)` is ambiguous between them, and the ambiguity is a compile
+        // error at every call site rather than a silent wrong pick. Distinct names also say which contract the
+        // consumer is signing up to instead of leaving it to inference.
         public @NotNull Builder withProcessor(final @NotNull Processor processor) {
+            // Wrapped into the async form so the pipeline has one shape. The catch is not decoration: a
+            // consumer may throw before any future exists, and an escaping exception would skip the
+            // acknowledge-and-poll and stall this queue for good. The old pipeline's try/catch did exactly
+            // this, and turning the throw into a failed future preserves it -- both settle the future, and a
+            // settled future is what releases the queue.
+            this.processor = message -> {
+                try {
+                    processor.process(message);
+                    return CompletableFuture.completedFuture(null);
+                } catch (final Exception e) {
+                    return CompletableFuture.failedFuture(e);
+                }
+            };
+            return this;
+        }
+
+        // Required, alternative form: for work too slow, or too likely to block, to run on the thread that
+        // serves this queue's bucket. The consumer starts it elsewhere and returns a future immediately; the
+        // next message is passed on when that future completes, so handling stays sequential without the
+        // thread being held meanwhile.
+        public @NotNull Builder withAsyncProcessor(final @NotNull AsyncProcessor processor) {
             this.processor = processor;
+            return this;
+        }
+
+        // Required, third and fourth forms: as the two above, plus what the message matched.
+        //
+        // SUPPLYING EITHER DECIDES THE KIND OF SUBSCRIBER. It is what makes the ...TopicFilterContext verbs
+        // the legal ones, on the builder and on the subscriber alike, and the bare-string ones illegal. There
+        // is deliberately no separate flag saying so: the processor already says it, and two statements of one
+        // fact could disagree -- the more easily because the filters may be added far from where the
+        // subscriber is built.
+        //
+        // Whether to be told what a message matched, and whether the work needs a future, are independent
+        // choices -- hence four forms rather than three.
+        @SuppressWarnings("unchecked") // the set holds exactly the contexts this consumer registered
+        public <T extends TopicFilterContext> @NotNull Builder withContextProcessor(
+                final @NotNull ContextProcessor<T> processor) {
+
+            // Wrapped into the async form for the same reason withProcessor is, and with the same catch: a
+            // consumer may throw before any future exists, and an escaping exception would stall this queue.
+            this.contextProcessor = (AsyncContextProcessor<T>) (message, matched) -> {
+                try {
+                    processor.process(message, matched);
+                    return CompletableFuture.completedFuture(null);
+                } catch (final Exception e) {
+                    return CompletableFuture.failedFuture(e);
+                }
+            };
+            return this;
+        }
+
+        public <T extends TopicFilterContext> @NotNull Builder withAsyncContextProcessor(
+                final @NotNull AsyncContextProcessor<T> processor) {
+
+            this.contextProcessor = processor;
+            return this;
+        }
+
+        // Optional: the QoS every filter is registered at. Defaults to AT_LEAST_ONCE.
+        //
+        // A CEILING, not a floor -- the delivered QoS is min(published, this), so subscribing at EXACTLY_ONCE
+        // does not upgrade a QoS 0 publish. The distinction that matters downstream is zero versus non-zero: a
+        // QoS 0 message is held in a separate memory-limited list and is never acknowledged.
+        public @NotNull Builder withQoS(final @NotNull QoS qos) {
+            this.qos = qos;
+            return this;
+        }
+
+        // Optional: the most messages to hold for this subscriber. Defaults to the broker-wide
+        // maxQueuedMessages, which is 1000 unless configured otherwise -- so this narrows rather than
+        // unbounds, and a consumer that has no opinion should not set it.
+        //
+        // What happens at the limit is withQueueOverflow below, and the two are worth reading together: a
+        // small limit with the default strategy means "reject new messages beyond N", which is rarely what a
+        // consumer picking a small number has in mind.
+        public @NotNull Builder withQueueLimit(final long queueLimit) {
+            this.queueLimit = queueLimit;
+            return this;
+        }
+
+        // Optional: which message to drop when the queue is full.
+        //
+        // DISCARD        -- reject the INCOMING message, keeping the queue as it is. The broker-wide default.
+        // DISCARD_OLDEST -- drop the oldest queued message to make room for the new one.
+        //
+        // The default is worth a moment: for a command queue it means a fresh command is refused in favour of
+        // a backlog of stale ones, which is usually the wrong way round. A consumer whose messages supersede
+        // each other -- a setpoint, a latest-value -- wants DISCARD_OLDEST and should say so.
+        public @NotNull Builder withQueueOverflow(final @NotNull QueuedMessagesStrategy queueOverflow) {
+            this.queueOverflow = queueOverflow;
             return this;
         }
 
         // Optional: ingress-exclusion (generalized No Local). A message whose ingress (publishing)
         // client id equals this value will not be delivered to the built subscriber. Build-time only;
-        // immutable after build(). For a bridge, this is the peer it forwards to — so a message it sent
+        // immutable after build(). For a bridge, this is the peer it forwards to -- so a message it sent
         // us is not sent straight back. The plain No Local case is excludedIngressClientId == our own id.
         public @NotNull Builder withExcludedIngressClientId(final @NotNull String excludedIngressClientId) {
             this.excludedIngressClientId = excludedIngressClientId;
             return this;
         }
 
-        // Absolute: replace the whole set with this filter / these filters. Last call wins.
+        // The topic filters, in two families of three.
+        //
+        //   withTopicFilter / addTopicFilter / removeTopicFilter                      -- bare String filters
+        //   withTopicFilterContext / addTopicFilterContext / removeTopicFilterContext -- TopicFilterContext
+        //
+        // A subscriber that treats every filter alike takes strings. One standing in for several destinations
+        // takes contexts, and is handed them back through a RoutingProcessor when a message matches. The two
+        // families do not mix: build() rejects a subscriber that has some of each.
+        //
+        // SEPARATE NAMES rather than overloads. withTopicFilter(List<String>) and
+        // withTopicFilter(List<? extends TopicFilterContext>) do not compile side by side -- erasure makes both
+        // withTopicFilter(List), a name clash the compiler refuses -- so the list forms could not both exist
+        // under one name. The names also say at the call site which of the two a subscriber is, which the
+        // argument type alone leaves to be inferred.
+        //
+        // WITH is absolute (replace the whole set), ADD and REMOVE are relative.
+        //
+        // ON THE BUILDER, THOUGH, "ABSOLUTE" HAS NOTHING TO REPLACE: the set starts empty and only these calls
+        // fill it, so a `with` that finds filters already there is discarding work the caller just did -- and
+        // silently. That is never what anyone means; the caller wanted `add`. So it throws here, while the same
+        // verb on the LIVE subscriber keeps its replacing sense, where wanting a whole new set is ordinary.
+
+        // Absolute: set the whole set to this filter / these filters. Throws if any are already declared.
         public @NotNull Builder withTopicFilter(final @NotNull String topicFilter) {
-            topicFilters.clear();
-            topicFilters.add(topicFilter);
-            return this;
+            return withTopicFilter(List.of(topicFilter));
         }
 
         public @NotNull Builder withTopicFilter(final @NotNull List<String> topicFilters) {
-            this.topicFilters.clear();
+            throwIfFiltersAlreadyDeclared("withTopicFilter", "addTopicFilter");
             this.topicFilters.addAll(topicFilters);
             return this;
         }
@@ -276,10 +657,34 @@ public final class InternalTopicFilterSubscriber {
             return this;
         }
 
+        /**
+         * Rejects an absolute filter call once any filter has been declared.
+         * <p>
+         * Checks BOTH families, so declaring a bare filter and then a context (or the reverse) is caught here,
+         * at the call that did it, rather than at {@code build()} -- which can only name the filters, not the
+         * call that added them.
+         *
+         * @param absolute the verb being called, named in the message
+         * @param relative the verb the caller almost certainly meant
+         */
+        private void throwIfFiltersAlreadyDeclared(final @NotNull String absolute, final @NotNull String relative) {
+
+            if (topicFilters.isEmpty() && topicFilterContexts.isEmpty()) {
+                return;
+            }
+            final Set<String> declared = new LinkedHashSet<>(topicFilters);
+            declared.addAll(topicFilterContexts.keySet());
+            throw new IllegalStateException("InternalTopicFilterSubscriber.Builder." + absolute
+                    + "(...) replaces the whole filter set, but these are already declared: "
+                    + declared
+                    + ". Use "
+                    + relative
+                    + "(...) to add to them.");
+        }
+
         // Relative: remove from the current set.
         public @NotNull Builder removeTopicFilter(final @NotNull String topicFilter) {
-            topicFilters.remove(topicFilter);
-            return this;
+            return removeTopicFilter(List.of(topicFilter));
         }
 
         public @NotNull Builder removeTopicFilter(final @NotNull List<String> topicFilters) {
@@ -287,40 +692,124 @@ public final class InternalTopicFilterSubscriber {
             return this;
         }
 
-        // Produce the live subscriber. The subscriber is constructed in the IDLE state — detached and
-        // paused — i.e. no messages flow until start() (or attach()/consume()) is called. It is, however,
+        // Absolute, with context: set the whole set to these, each carrying its own filter. Throws if any
+        // filters are already declared -- see the note above.
+        public @NotNull Builder withTopicFilterContext(final @NotNull TopicFilterContext context) {
+            return withTopicFilterContext(List.of(context));
+        }
+
+        public @NotNull Builder withTopicFilterContext(final @NotNull List<? extends TopicFilterContext> contexts) {
+            throwIfFiltersAlreadyDeclared("withTopicFilterContext", "addTopicFilterContext");
+            return addTopicFilterContext(contexts);
+        }
+
+        // Relative, with context: add these to the current set.
+        //
+        // Two contexts may name the SAME filter -- two southbound mappings on one topic -- and both are kept.
+        // That fan-out is precisely what the topic tree cannot hold itself, since a repeated filter replaces
+        // its predecessor there (MQTT-3.8.4-3); keeping it here is what makes the case work at all.
+        public @NotNull Builder addTopicFilterContext(final @NotNull TopicFilterContext context) {
+            return addTopicFilterContext(List.of(context));
+        }
+
+        public @NotNull Builder addTopicFilterContext(final @NotNull List<? extends TopicFilterContext> contexts) {
+            for (final TopicFilterContext context : contexts) {
+                topicFilterContexts
+                        .computeIfAbsent(context.topicFilter(), ignored -> new LinkedHashSet<>())
+                        .add(context);
+            }
+            return this;
+        }
+
+        // Relative, with context: remove ONE destination, leaving its filter if other contexts still want it.
+        //
+        // Found by equals(), so an implementation with identity equality can only be removed by the object
+        // that was registered -- said on TopicFilterContext, and worth knowing here too.
+        public @NotNull Builder removeTopicFilterContext(final @NotNull TopicFilterContext context) {
+            return removeTopicFilterContext(List.of(context));
+        }
+
+        public @NotNull Builder removeTopicFilterContext(final @NotNull List<? extends TopicFilterContext> contexts) {
+
+            for (final TopicFilterContext context : contexts) {
+                final String topicFilter = context.topicFilter();
+                final Set<TopicFilterContext> remaining = topicFilterContexts.get(topicFilter);
+                if (remaining != null) {
+                    remaining.remove(context);
+                    if (remaining.isEmpty()) {
+                        // Nothing wants this filter any more, so the filter goes too. Keeping it would leave a
+                        // subscription whose messages resolve to no destination -- accepted, then dropped.
+                        topicFilterContexts.remove(topicFilter);
+                    }
+                }
+            }
+            return this;
+        }
+
+        // Produce the live subscriber. The subscriber is constructed in the IDLE state -- detached and
+        // paused -- i.e. no messages flow until start() (or attach()/consume()) is called. It is, however,
         // already REGISTERED with the factory: the subscriber owns its clientId ("$INTERNAL::<prefix>::
         // <instanceId>") from build() until deallocate(). register() throws if that identity is already in
         // use, so a duplicate componentPrefix::instanceId is rejected here rather than silently colliding.
         public @NotNull InternalTopicFilterSubscriber build() {
-            if (processor == null) {
-                throw new IllegalStateException(
-                        "InternalTopicFilterSubscriber requires a processor; call withProcessor(...) before build()");
+            if (processor == null && contextProcessor == null) {
+                throw new IllegalStateException("InternalTopicFilterSubscriber requires a processor; call one of "
+                        + "withProcessor(...), withAsyncProcessor(...), withContextProcessor(...) or "
+                        + "withAsyncContextProcessor(...) before build()");
             }
+            if (processor != null && contextProcessor != null) {
+                throw new IllegalStateException("InternalTopicFilterSubscriber takes one processor, not two; a "
+                        + "context processor cannot be combined with withProcessor(...) or withAsyncProcessor(...)");
+            }
+            // The processor decides which family of filter verbs applies, so filters given in the other family
+            // are a mistake -- and one worth naming here, since the two calls may be far apart.
+            if (contextProcessor != null && !topicFilters.isEmpty()) {
+                throw new IllegalStateException("InternalTopicFilterSubscriber was built with a context processor, "
+                        + "so its filters must be given as contexts; these were given as bare strings: "
+                        + topicFilters);
+            }
+            if (contextProcessor == null && !topicFilterContexts.isEmpty()) {
+                throw new IllegalStateException("InternalTopicFilterSubscriber was given topic filter contexts but "
+                        + "no context processor to deliver them to; call withContextProcessor(...) or "
+                        + "withAsyncContextProcessor(...)");
+            }
+
             final InternalTopicFilterSubscriber subscriber = new InternalTopicFilterSubscriber(
                     componentPrefix,
                     instanceId,
                     processor,
+                    contextProcessor,
                     topicFilters,
+                    topicFilterContexts,
+                    qos,
+                    queueLimit,
+                    queueOverflow,
                     excludedIngressClientId,
                     factory,
                     topicTree,
                     clientQueuePersistence,
                     singleWriterService);
-            factory.register(subscriber); // throws if clientId already in use — deregistered by deallocate()
+            factory.register(subscriber); // throws if clientId already in use -- deregistered by deallocate()
             return subscriber;
         }
     }
 
     // endregion
 
-    // region topic-filter verbs — the same three on builder and subscriber
+    // region topic-filter verbs -- the same two families on builder and subscriber
     // =================================================================================================================
-    // withTopicFilter — ABSOLUTE: replace the whole set. addTopicFilter / removeTopicFilter — RELATIVE.
-    // Each is overloaded for one filter or a list. When DETACHED these only update the remembered set
-    // (replayed by the next attach()); when ATTACHED the topic tree is reconciled immediately — only
-    // the genuine additions/removals are pushed to the tree, so a withTopicFilter(wholeNewSet) becomes
-    // exactly the diff against what is currently registered.
+    // with... -- ABSOLUTE: replace the whole set. add... / remove... -- RELATIVE. Each is overloaded for one or
+    // a list. When DETACHED these only update the remembered set (replayed by the next attach()); when ATTACHED
+    // the topic tree is reconciled immediately -- only the genuine additions and removals are pushed, so a
+    // with...(wholeNewSet) becomes exactly the diff against what is currently registered.
+    //
+    // TWO FAMILIES, and a subscriber may use only its own: the bare-string one for a plain subscriber, the
+    // ...TopicFilterContext one for a context subscriber. Which it is was settled by the processor it was built
+    // with, so the wrong family is a mistake this can name rather than a state it has to represent.
+    //
+    // Separate names rather than overloads, and not by taste: withTopicFilter(List<String>) and
+    // withTopicFilter(List<? extends TopicFilterContext>) erase to the same signature and do not compile side by
+    // side. The names also say at the call site which kind of subscriber this is.
     //
     public synchronized @NotNull InternalTopicFilterSubscriber withTopicFilter(final @NotNull String topicFilter) {
         return withTopicFilter(List.of(topicFilter));
@@ -328,22 +817,10 @@ public final class InternalTopicFilterSubscriber {
 
     public synchronized @NotNull InternalTopicFilterSubscriber withTopicFilter(final @NotNull List<String> newFilters) {
         throwIfDeallocated();
-        final Set<String> target = new LinkedHashSet<>(newFilters);
-        if (attached) {
-            // Reconcile the tree with the new target: remove what is no longer wanted, add what is new.
-            for (final String existing : new ArrayList<>(topicFilters)) {
-                if (!target.contains(existing)) {
-                    removeFromTree(existing);
-                }
-            }
-            for (final String wanted : target) {
-                if (!topicFilters.contains(wanted)) {
-                    addToTree(wanted);
-                }
-            }
-        }
+        throwIfContextual("withTopicFilter");
+        reconcileTo(new LinkedHashSet<>(newFilters));
         topicFilters.clear();
-        topicFilters.addAll(target);
+        topicFilters.addAll(newFilters);
         return this;
     }
 
@@ -354,6 +831,7 @@ public final class InternalTopicFilterSubscriber {
     public synchronized @NotNull InternalTopicFilterSubscriber addTopicFilter(
             final @NotNull List<String> topicFiltersToAdd) {
         throwIfDeallocated();
+        throwIfContextual("addTopicFilter");
         for (final String topicFilter : topicFiltersToAdd) {
             if (topicFilters.add(topicFilter) && attached) {
                 addToTree(topicFilter);
@@ -369,6 +847,7 @@ public final class InternalTopicFilterSubscriber {
     public synchronized @NotNull InternalTopicFilterSubscriber removeTopicFilter(
             final @NotNull List<String> topicFiltersToRemove) {
         throwIfDeallocated();
+        throwIfContextual("removeTopicFilter");
         for (final String topicFilter : topicFiltersToRemove) {
             if (topicFilters.remove(topicFilter) && attached) {
                 removeFromTree(topicFilter);
@@ -377,51 +856,221 @@ public final class InternalTopicFilterSubscriber {
         return this;
     }
 
+    // -- the same three, for a subscriber built with a context processor ---------------------------------------
+    //
+    // A context carries its own filter, so these say WHAT to subscribe to and WHY in one object. Several
+    // contexts may name one filter -- two destinations on one topic -- and the filter is subscribed once, with
+    // the fan-out kept here.
+
+    public synchronized @NotNull InternalTopicFilterSubscriber withTopicFilterContext(
+            final @NotNull TopicFilterContext context) {
+        return withTopicFilterContext(List.of(context));
+    }
+
+    public synchronized @NotNull InternalTopicFilterSubscriber withTopicFilterContext(
+            final @NotNull List<? extends TopicFilterContext> contexts) {
+        throwIfDeallocated();
+        throwIfNotContextual("withTopicFilterContext");
+        final Map<String, Set<TopicFilterContext>> target = new LinkedHashMap<>();
+        for (final TopicFilterContext context : contexts) {
+            target.computeIfAbsent(context.topicFilter(), ignored -> new LinkedHashSet<>())
+                    .add(context);
+        }
+        // The tree is reconciled against the FILTERS; the contexts behind them are this object's own business,
+        // so a filter kept by both sets is left alone in the tree even if its contexts changed entirely.
+        final Set<String> goneFilters = reconcileTo(target.keySet());
+        goneFilters.forEach(this::freeSubscriptionId);
+        topicFilterContexts.clear();
+        topicFilterContexts.putAll(target);
+        // After the tree work, so a filter that survives keeps the identifier it was registered under.
+        target.keySet().forEach(this::subscriptionIdFor);
+        return this;
+    }
+
+    public synchronized @NotNull InternalTopicFilterSubscriber addTopicFilterContext(
+            final @NotNull TopicFilterContext context) {
+        return addTopicFilterContext(List.of(context));
+    }
+
+    public synchronized @NotNull InternalTopicFilterSubscriber addTopicFilterContext(
+            final @NotNull List<? extends TopicFilterContext> contexts) {
+        throwIfDeallocated();
+        throwIfNotContextual("addTopicFilterContext");
+        for (final TopicFilterContext context : contexts) {
+            final String topicFilter = context.topicFilter();
+            final boolean isNewFilter = !topicFilterContexts.containsKey(topicFilter);
+            topicFilterContexts
+                    .computeIfAbsent(topicFilter, ignored -> new LinkedHashSet<>())
+                    .add(context);
+            if (isNewFilter) {
+                // The identifier first: addToTree reads it, and a filter registered without one would deliver
+                // messages that resolve to no context at all.
+                subscriptionIdFor(topicFilter);
+                if (attached) {
+                    addToTree(topicFilter);
+                }
+            }
+        }
+        return this;
+    }
+
+    public synchronized @NotNull InternalTopicFilterSubscriber removeTopicFilterContext(
+            final @NotNull TopicFilterContext context) {
+        return removeTopicFilterContext(List.of(context));
+    }
+
+    public synchronized @NotNull InternalTopicFilterSubscriber removeTopicFilterContext(
+            final @NotNull List<? extends TopicFilterContext> contexts) {
+        throwIfDeallocated();
+        throwIfNotContextual("removeTopicFilterContext");
+        for (final TopicFilterContext context : contexts) {
+            final String topicFilter = context.topicFilter();
+            final Set<TopicFilterContext> remaining = topicFilterContexts.get(topicFilter);
+            if (remaining == null) {
+                continue;
+            }
+            remaining.remove(context);
+            if (remaining.isEmpty()) {
+                // Nothing wants this filter any more, so the filter goes too. Keeping it would leave a
+                // subscription whose messages resolve to no destination -- accepted into the queue, then dropped.
+                topicFilterContexts.remove(topicFilter);
+                if (attached) {
+                    removeFromTree(topicFilter);
+                }
+                freeSubscriptionId(topicFilter);
+            }
+        }
+        return this;
+    }
+
+    /**
+     * Reconciles the topic tree from the currently subscribed filters to the given target, and answers which
+     * filters are no longer wanted.
+     * <p>
+     * Does nothing to the tree while detached -- there is nothing registered to reconcile -- but still answers
+     * the difference, since the caller frees identifiers either way.
+     *
+     * @return the filters that were subscribed and are not in the target
+     */
+    private @NotNull Set<String> reconcileTo(final @NotNull Set<String> target) {
+        final Set<String> current = contextual ? topicFilterContexts.keySet() : topicFilters;
+        final Set<String> gone = new LinkedHashSet<>();
+        for (final String existing : current) {
+            if (!target.contains(existing)) {
+                gone.add(existing);
+            }
+        }
+        if (attached) {
+            gone.forEach(this::removeFromTree);
+            for (final String wanted : target) {
+                if (!current.contains(wanted)) {
+                    // For a context subscriber the identifier must exist before the filter is registered, and
+                    // the caller has not written the new set yet -- so allocate here rather than after.
+                    if (contextual) {
+                        subscriptionIdFor(wanted);
+                    }
+                    addToTree(wanted);
+                }
+            }
+        }
+        return gone;
+    }
+
+    /** The filters this subscriber is subscribed to, whichever kind it is. */
+    private @NotNull Set<String> currentFilters() {
+        return contextual ? topicFilterContexts.keySet() : topicFilters;
+    }
+
+    private void throwIfContextual(final @NotNull String verb) {
+        if (contextual) {
+            throw new IllegalStateException("InternalTopicFilterSubscriber '" + clientId
+                    + "' was built with a context processor, so "
+                    + verb
+                    + " does not apply to it; use "
+                    + verb
+                    + "Context instead");
+        }
+    }
+
+    private void throwIfNotContextual(final @NotNull String verb) {
+        if (!contextual) {
+            throw new IllegalStateException("InternalTopicFilterSubscriber '" + clientId
+                    + "' was not built with a context processor, so "
+                    + verb
+                    + " does not apply to it; use "
+                    + verb.replace("Context", "")
+                    + " instead, or build it with a context processor");
+        }
+    }
+
     // endregion
 
-    // region lifecycle verbs — attach / consume / pause / detach / deallocate
+    // region lifecycle verbs -- attach / consume / pause / detach / deallocate
     // =================================================================================================================
-    // attach()    — register the current topic filters in the topic tree. Messages now COLLECTED into
+    // attach() -- register the current topic filters in the topic tree. Messages now COLLECTED into
     //               the client queue. Idempotent.
-    // consume()   — register the publish-available callback and drain anything already queued. Messages
-    //               now PROCESSED (if attached). Legal while detached — the callback is simply armed for
+    // consume() -- register the publish-available callback and drain anything already queued. Messages
+    //               now PROCESSED (if attached). Legal while detached -- the callback is simply armed for
     //               when topics attach later. Idempotent.
-    // pause()     — deregister the callback. Messages keep being COLLECTED (if attached) but are no
+    // pause() -- deregister the callback. Messages keep being COLLECTED (if attached) but are no
     //               longer PROCESSED. Idempotent.
-    // detach()    — remove the current topic filters from the topic tree. Messages no longer COLLECTED.
+    // detach() -- remove the current topic filters from the topic tree. Messages no longer COLLECTED.
     //               The remembered filter set survives, so a later attach() restores the same
     //               subscription. Idempotent.
-    // deallocate()— clear the client queue entry from persistence. Precondition: detached AND paused
-    //               (throws otherwise) — clearing the queue while still collecting or draining would
+    // deallocate() -- clear the client queue entry from persistence. Precondition: detached AND paused
+    //               (throws otherwise) -- clearing the queue while still collecting or draining would
     //               race the SingleWriter.
     //
     // All return `this` (except deallocate) so they chain. All are synchronized with the topic-filter
     // verbs so state transitions and tree reconciliation never interleave.
+    //
+    // NO PROCESSOR IS EVER CALLED WITH THIS MONITOR HELD, and consume() below is where that is earned.
+    // Submitting a poll can run the whole read-process-release cycle INLINE on the calling thread -- the
+    // in-memory single writer executes a submitted task immediately when nothing else holds its bucket --
+    // so a submit made inside a synchronized verb would run the component's processor inside this monitor.
+    // Two things would follow, both bad: a processor that blocks waiting on a thread which wants this
+    // monitor deadlocks, and a processor calling back into a verb would observe half-finished state.
+    // Hence the split below -- state under the monitor, poll after it.
     //
     public synchronized @NotNull InternalTopicFilterSubscriber attach() {
         throwIfDeallocated();
         if (attached) {
             return this;
         }
-        for (final String topicFilter : topicFilters) {
+        for (final String topicFilter : currentFilters()) {
             addToTree(topicFilter);
         }
         attached = true;
         return this;
     }
 
-    public synchronized @NotNull InternalTopicFilterSubscriber consume() {
+    public @NotNull InternalTopicFilterSubscriber consume() {
+        if (armConsuming()) {
+            // OUTSIDE the monitor, deliberately -- see the note above. By here `consuming` is already true,
+            // so a processor that calls pause() during this drain is honoured rather than silently undone.
+            submitPoll();
+        }
+        return this;
+    }
+
+    /**
+     * The state half of {@link #consume()}: arms the callback and marks this subscriber as consuming.
+     *
+     * @return true if a drain is owed, i.e. this call is the one that started consuming
+     */
+    private synchronized boolean armConsuming() {
         throwIfDeallocated();
         if (consuming) {
-            return this;
+            return false;
         }
-        // Register the callback first so any message arriving from now on wakes the poller; the
-        // explicit submitPoll() then drains messages already in the queue (e.g. from a previous run,
-        // or collected while attached-but-paused).
+        // Register the callback first so any message arriving from now on wakes the poller; the drain the
+        // caller then submits picks up messages already in the queue (e.g. from a previous run, or collected
+        // while attached-but-paused).
         clientQueuePersistence.addPublishAvailableCallback(id -> submitPoll(), clientId);
-        submitPoll();
+        // BEFORE the drain, not after: the drain may run inline, and a processor calling pause() while this
+        // was still false would hit the "not consuming" guard and have its pause silently discarded.
         consuming = true;
-        return this;
+        return true;
     }
 
     public synchronized @NotNull InternalTopicFilterSubscriber pause() {
@@ -439,18 +1088,18 @@ public final class InternalTopicFilterSubscriber {
         if (!attached) {
             return this;
         }
-        for (final String topicFilter : topicFilters) {
+        for (final String topicFilter : currentFilters()) {
             removeFromTree(topicFilter);
         }
         attached = false;
         return this;
     }
 
-    // deallocate() is the one terminal verb — and the one exception to throwIfDeallocated(): calling it
+    // deallocate() is the one terminal verb -- and the one exception to throwIfDeallocated(): calling it
     // on an already-dead subscriber is a no-op (idempotent), not an error.
     public synchronized void deallocate() {
         if (deallocated) {
-            return; // idempotent — already dead, nothing to clear
+            return; // idempotent -- already dead, nothing to clear
         }
         if (attached || consuming) {
             throw new IllegalStateException("InternalTopicFilterSubscriber '" + clientId
@@ -459,11 +1108,11 @@ public final class InternalTopicFilterSubscriber {
                     + consuming + ")");
         }
         // Remove the queue entry from persistence entirely. false == do not keep a tombstone. This
-        // also DROPS any messages that were collected but not yet processed — which is exactly why a
+        // also DROPS any messages that were collected but not yet processed -- which is exactly why a
         // long-lived subscriber must eventually stop()/deallocate() rather than just detach(), or the
         // queue (and its memory) would linger.
         clientQueuePersistence.clear(clientId, false);
-        // Free the clientId in the factory's registry — symmetric with build(). The queue is now
+        // Free the clientId in the factory's registry -- symmetric with build(). The queue is now
         // destroyed, so the componentPrefix::instanceId identity becomes available for reuse.
         factory.deregister(this);
         deallocated = true;
@@ -480,21 +1129,24 @@ public final class InternalTopicFilterSubscriber {
 
     // endregion
 
-    // region start() / stop() — convenience compositions of the verbs
+    // region start() / stop() -- convenience compositions of the verbs
     // =================================================================================================================
-    // start() = attach(); consume();  — order does not matter operationally; whichever runs second
+    // start() = attach(); consume(); -- order does not matter operationally; whichever runs second
     //           activates the flow.
-    // stop()  = detach(); pause(); deallocate();  — order DOES matter: detach first (stop the inflow),
+    // stop()  = detach(); pause(); deallocate(); -- order DOES matter: detach first (stop the inflow),
     //           pause second (stop the processing), deallocate last (clear the now-quiet queue).
     //
     // They exist only to spare callers the common two-/three-call sequences; a caller that wants finer
     // control (e.g. attach without consuming, or pause without deallocating) calls the verbs directly.
     //
-    // start() throws on a deallocated subscriber (you cannot resurrect a dead one — that goes through
+    // start() throws on a deallocated subscriber (you cannot resurrect a dead one -- that goes through
     // attach()). stop() is idempotent: it is the only composition you can safely call on a dead
     // subscriber, returning quietly (it just deallocates, which is itself a no-op when already dead).
     //
-    public synchronized @NotNull InternalTopicFilterSubscriber start() {
+    // NOT synchronized, and that is the point: it composes attach() and consume(), each of which takes the
+    // monitor for its own state work. Holding it across both would put the drain consume() submits back
+    // inside the monitor -- exactly what consume() was split apart to avoid.
+    public @NotNull InternalTopicFilterSubscriber start() {
         attach();
         consume();
         return this;
@@ -502,7 +1154,7 @@ public final class InternalTopicFilterSubscriber {
 
     public synchronized void stop() {
         if (deallocated) {
-            return; // already dead — stop() is idempotent
+            return; // already dead -- stop() is idempotent
         }
         detach();
         pause();
@@ -511,13 +1163,13 @@ public final class InternalTopicFilterSubscriber {
 
     // endregion
 
-    // region ingress-exclusion — identity and the accept decision
+    // region ingress-exclusion -- identity and the accept decision
     // =================================================================================================================
-    // clientId() — this subscriber's reserved-prefix id, used by the factory as the registry key.
+    // clientId() -- this subscriber's reserved-prefix id, used by the factory as the registry key.
     //
-    // isExcludedIngressClientId(senderClientId) — the ingress-exclusion decision, called by the publish
+    // isExcludedIngressClientId(senderClientId) -- the ingress-exclusion decision, called by the publish
     //   path at distribution time (BEFORE queueing) with the ingress/publishing client id (its
-    //   `sender`). Returns true iff an excluded id is configured and equals senderClientId — in which
+    //   `sender`). Returns true iff an excluded id is configured and equals senderClientId -- in which
     //   case the message must NOT be queued to us. With no excluded id (the common case) it always
     //   returns false. The excluded id is immutable after build(), so this is a lock-free read and safe
     //   to call from the publish path concurrently with the lifecycle verbs.
@@ -530,57 +1182,287 @@ public final class InternalTopicFilterSubscriber {
         return excludedIngressClientId != null && excludedIngressClientId.equals(senderClientId);
     }
 
+    /**
+     * @return the most messages to hold for this subscriber, or null to use the broker-wide
+     *         {@code maxQueuedMessages}. Read by the publish distributor when it queues a message.
+     */
+    public @Nullable Long queueLimit() {
+        return queueLimit;
+    }
+
+    /**
+     * @return what to drop when this subscriber's queue is full, or null to use the broker-wide strategy. Read
+     *         by the queue persistence when it adds a message.
+     */
+    public @Nullable QueuedMessagesStrategy queueOverflow() {
+        return queueOverflow;
+    }
+
     // endregion
 
-    // region internal wiring — topic-tree add/remove and the SingleWriter poll pipeline
+    // region internal wiring -- topic-tree add/remove and the SingleWriter poll pipeline
     // =================================================================================================================
-    // addToTree() / removeFromTree() — the two topic-tree operations, factored out so the verbs and
+    // addToTree() / removeFromTree() -- the two topic-tree operations, factored out so the verbs and
     //                     the reconciliation logic share one definition of "register a filter" and
     //                     "deregister a filter" under this clientId.
     //
-    // The four methods after them form a simple pipeline that runs entirely on the SingleWriter thread:
+    // The methods after them form the poll pipeline, which runs entirely on the SingleWriter thread:
     //
-    // submitPoll()      — schedules pollAndForward() on the SingleWriter queue. Called from the
-    //                     publish-available callback (new message arrived), from consume() (drain
-    //                     pre-existing messages), and at the end of each processed message (to
-    //                     continue draining).
-    // pollAndForward()  — reads one message from the client queue. On success hands it to
-    //                     processPublish(); on failure logs and reschedules via submitPoll().
-    // processPublish()  — calls the processor (the user-supplied handler), then removeMessage(), then
-    //                     submitPoll() to pick up the next message. Errors are caught, logged, and
-    //                     the message is dropped — processing continues regardless.
-    // removeMessage()   — acknowledges the message to the queue persistence. QoS 0 messages are
+    // submitPoll() -- schedules pollUnlessBusy() on the SingleWriter queue. Called by every trigger
+    //                     that means "a message may be available now": the publish-available callback,
+    //                     consume(), and the error path.
+    // submitPollAfterInFlight() -- the same, for the ONE trigger that also means "the message I was
+    //                     working on is finished": the completion of a processor's future.
+    // pollUnlessBusy() -- THE ONE PLACE THE CONDITION LIVES. Polls only when this subscriber is consuming
+    //                     and holds no message. Otherwise gives up -- see below.
+    // pollAfterInFlight() -- clears the in-flight state, then goes through pollUnlessBusy() like anything
+    //                     else, so a subscriber paused meanwhile stops rather than reading one more.
+    // poll() -- claims the in-flight state and reads one message. On an empty read it releases the
+    //                     claim, since nothing will arrive to release it later.
+    // processMessage() -- hands the message to the processor and chains the release off its completion.
+    // release() -- acknowledges the message and triggers the next poll.
+    // removeMessage() -- acknowledges the message to the queue persistence. QoS 0 messages are
     //                     not persisted and need no acknowledgement.
     //
-    // The trailing `null` in both calls is the topic tree's `sharedName` — and it is null ON PURPOSE.
+    // TWO CONDITIONS, ONE PLACE, AND GIVING UP IS NEVER LOSING A TRIGGER. A trigger only says "a message may
+    // be available"; whether to act is pollUnlessBusy()'s alone. It declines while a message is in flight,
+    // because that message's completion polls again; and while paused, because resuming polls again. Both
+    // paths therefore re-ask the question rather than stranding whatever arrived.
+    //
+    // WHY inFlight HAD TO BE ADDED. When a processor did its work before returning, one-message-at-a-time was
+    // free: the whole chain ran as one task, and a trigger arriving meanwhile could only queue another task
+    // behind it. A processor that answers a future returns at once, so the thread goes free while the work
+    // continues elsewhere -- and a trigger then polls immediately, handing out a second message.
+    //
+    // WHY consuming HAD TO BE READ HERE. It was set and cleared by consume()/pause() and read by nothing on
+    // this path, so pausing removed the wake-up callback but did not stop a poll already under way, nor the
+    // completion of an outstanding message from reading the next one. Deallocation is covered by the same
+    // clause rather than needing its own: deallocate() requires being paused, so a dead subscriber is one
+    // whose consuming flag is already false -- which matters because deallocation FREES THE CLIENT ID, and a
+    // replacement may already own the queue this one would otherwise read from.
+    //
+    // A PLAIN FIELD, NOT AN ATOMIC. Every one of these methods runs inside a task submitted for this
+    // subscriber's clientId, and the SingleWriter runs the tasks of one bucket strictly one at a time --
+    // so no two of them are ever in flight together, whichever thread did the submitting. That is also
+    // why the completion submits a task rather than clearing the state itself: doing it inline would put
+    // the write on the consumer's thread, outside the serialisation, for no gain.
+    //
+    // The trailing `null` in both calls is the topic tree's `sharedName` -- and it is null ON PURPOSE.
     // The topic tree distinguishes shared from non-shared subscriptions: a non-null sharedName makes
     // the subscription part of a shared group (load-balanced across the group's members). Some other
     // internal subscribers ARE shared and pass one (the bridge forwarder's sharedName is
     // "forwarder#{id}"; the combiner's is its uuid, with the subscriber id differing by a trailing
     // "#"). An InternalTopicFilterSubscriber is deliberately NON-shared: that is the whole point of
-    // EDG-504 — a non-shared internal subscriber so the topic tree deduplicates by client id and a
+    // EDG-504 -- a non-shared internal subscriber so the topic tree deduplicates by client id and a
     // message matching several of our filters is delivered to our queue exactly once. So sharedName
     // stays null, and our `clientId` is the sole identity (no separate shared-group name).
+    /// Registers one topic filter in the topic tree under this subscriber's client id.
+    ///
+    /// **On a CONTEXT subscriber the filter must already have a subscription identifier when this is called.**
+    /// This method only reads one; it does not allocate. Every current caller satisfies that -- the
+    /// constructor, `addTopicFilterContext` and the reconciliation in `withTopicFilterContext` each allocate
+    /// before registering, and `attach()` only ever replays filters one of those three put there -- so there is
+    /// no defect today. It is written down because nothing enforces it.
+    ///
+    /// **What goes wrong if a future caller forgets is silent.** A missing identifier reads as `null` from the
+    /// map, and [Topic] accepts `null` as "no subscription identifier" rather than rejecting it. So the filter
+    /// registers, messages match it, and they reach the consumer with an EMPTY set of matched contexts: a
+    /// component that finds nothing to do with them drops them, and nothing anywhere logs or throws. That is
+    /// precisely the failure the identifier mechanism exists to prevent, arriving through the one method that
+    /// is supposed to deliver it.
+    ///
+    /// If a fifth registration path is ever added, either allocate first as the others do, or move the
+    /// allocation in here -- [#subscriptionIdFor] is idempotent, so doing so would change no existing path.
     private void addToTree(final @NotNull String topicFilter) {
         topicTree.addTopic(
                 clientId,
-                new Topic(topicFilter, QoS.AT_LEAST_ONCE, false, true),
+                // The subscription identifier is what makes a matched message say WHICH filter matched: the
+                // broker echoes it back on every message that subscription matched, and several come back when
+                // several filters match.
+                //
+                // NULL IS LEGITIMATE ONLY FOR A PLAIN SUBSCRIBER, which has no contexts to resolve and
+                // delivers exactly as it did before identifiers existed. On a context subscriber a null here
+                // is the silent failure described above -- see this method's documentation.
+                new Topic(
+                        topicFilter,
+                        qos,
+                        false,
+                        true,
+                        Topic.DEFAULT_RETAIN_HANDLING,
+                        subscriptionIdByTopicFilter.get(topicFilter)),
                 SubscriptionFlag.getDefaultFlags(false, true, false),
-                null); // sharedName — null: non-shared (see note above)
+                null); // sharedName -- null: non-shared (see note above)
+    }
+
+    /**
+     * Turns a routing processor into the async one the pipeline uses, by resolving each message's subscription
+     * identifiers back to what the consumer asked to be told.
+     * <p>
+     * <b>A union, and over the CONTEXTS rather than the identifiers.</b> One context may sit behind two
+     * filters -- one destination reachable by two patterns -- and both identifiers come back when both match.
+     * Deduplicating at the end rather than the start is what stops the consumer doing the work twice for one
+     * message, which for a device write means sending the same command twice.
+     * <p>
+     * The identifiers are in practice distinct, since a filter holds exactly one and the tree merges rather
+     * than repeats. But that is a consequence of two other invariants rather than anything declared, and a set
+     * costs nothing.
+     */
+    @SuppressWarnings("unchecked")
+    private @NotNull AsyncProcessor asAsync(final @NotNull AsyncContextProcessor<?> contextProcessor) {
+        final AsyncContextProcessor<TopicFilterContext> routing =
+                (AsyncContextProcessor<TopicFilterContext>) contextProcessor;
+        return message -> {
+            final ImmutableIntArray matchedIdentifiers = message.getSubscriptionIdentifiers();
+            final Set<TopicFilterContext> matched = new LinkedHashSet<>();
+            if (matchedIdentifiers != null) {
+                synchronized (this) {
+                    for (int i = 0; i < matchedIdentifiers.length(); i++) {
+                        // identifier -> filter -> contexts. A filter removed since this message was queued
+                        // resolves to nothing, and contributes nothing to the set.
+                        final String topicFilter = topicFilterBySubscriptionId.get(matchedIdentifiers.get(i));
+                        if (topicFilter != null) {
+                            matched.addAll(topicFilterContexts.getOrDefault(topicFilter, Set.of()));
+                        }
+                    }
+                }
+            }
+            return routing.process(message, matched);
+        };
+    }
+
+    /**
+     * The identifier this subscriber uses for a filter, assigned on first subscription and stable thereafter.
+     * <p>
+     * <b>Stable is the whole point.</b> A filter re-registered after a {@code detach()}/{@code attach()} keeps
+     * the identifier it had, because a message queued before the detach carries that identifier and is read
+     * after it. Re-allocating would look correct -- the identifiers would stay internally consistent -- and
+     * would fail only on that one path.
+     */
+    private int subscriptionIdFor(final @NotNull String topicFilter) {
+        final Integer existing = subscriptionIdByTopicFilter.get(topicFilter);
+        if (existing != null) {
+            return existing;
+        }
+        final int allocated = allocateSubscriptionId();
+        subscriptionIdByTopicFilter.put(topicFilter, allocated);
+        topicFilterBySubscriptionId.put(allocated, topicFilter);
+        return allocated;
+    }
+
+    /**
+     * Frees the identifier a filter held, so the space does not grow with churn.
+     * <p>
+     * Called only when a filter is genuinely unsubscribed -- not on {@code detach()}, which keeps the filters
+     * in order to replay them.
+     */
+    private void freeSubscriptionId(final @NotNull String topicFilter) {
+        final Integer released = subscriptionIdByTopicFilter.remove(topicFilter);
+        if (released != null) {
+            topicFilterBySubscriptionId.remove(released);
+        }
+    }
+
+    /**
+     * An identifier no filter currently holds, walking forward from the last one handed out and wrapping.
+     * <p>
+     * <b>Identifiers are not reused while held, and are reused only after wrapping.</b> Walking forward means a
+     * freed identifier is handed out again only once the counter has been all the way round -- after
+     * {@link #MAX_SUBSCRIPTION_ID} allocations, each one a filter subscribed for the first time -- rather than
+     * immediately. That matters because a message queued under a filter's identifier may be read after that
+     * filter is gone: until the wrap it resolves to nothing and the message is dropped, which is right; after a
+     * wrap it could resolve to whichever filter has since taken the number, which is not. No real deployment
+     * subscribes that many filters on one subscriber while a single message sits unread, and the trade buys a
+     * bounded space and a plain int counter.
+     *
+     * @throws IllegalStateException if this subscriber already holds {@link #MAX_TOPIC_FILTERS} filters
+     */
+    private int allocateSubscriptionId() {
+        if (topicFilterBySubscriptionId.size() >= MAX_TOPIC_FILTERS) {
+            throw new IllegalStateException("InternalTopicFilterSubscriber '" + clientId
+                    + "' has too many topic filters: at most "
+                    + MAX_TOPIC_FILTERS
+                    + " may be subscribed at once");
+        }
+        do {
+            // Wraps within [1, MAX_SUBSCRIPTION_ID]; never yields 0, which MQTT reserves. Terminates because
+            // fewer than half the identifiers are taken -- see MAX_TOPIC_FILTERS.
+            nextSubscriptionId = (nextSubscriptionId % MAX_SUBSCRIPTION_ID) + 1;
+        } while (topicFilterBySubscriptionId.containsKey(nextSubscriptionId));
+        return nextSubscriptionId;
     }
 
     private void removeFromTree(final @NotNull String topicFilter) {
-        topicTree.removeSubscriber(clientId, topicFilter, null); // sharedName — null: non-shared
+        topicTree.removeSubscriber(clientId, topicFilter, null); // sharedName -- null: non-shared
     }
 
+    /**
+     * Says "a message may be available now". Used by every trigger except the completion of a processor's
+     * future, which uses {@link #submitPollAfterInFlight()} because it means one thing more.
+     */
     private void submitPoll() {
         singleWriterService.getQueuedMessagesQueue().submit(clientId, bucketIndex -> {
-            pollAndForward();
+            pollUnlessBusy();
             return null;
         });
     }
 
-    private void pollAndForward() {
+    /**
+     * Says "the message I was working on is finished, and another may be available now".
+     * <p>
+     * <b>A submitted task rather than clearing the state inline</b>, because this is called from the
+     * completion of a processor's future -- on whichever thread completed it. Going through the queue puts
+     * the write back inside the single-writer serialisation, which is what lets {@link #inFlight} be a
+     * plain field.
+     */
+    private void submitPollAfterInFlight() {
+        singleWriterService.getQueuedMessagesQueue().submit(clientId, bucketIndex -> {
+            pollAfterInFlight();
+            return null;
+        });
+    }
+
+    /**
+     * Polls, unless this subscriber should not be reading right now.
+     * <p>
+     * <b>Giving up is not dropping the trigger.</b> A message in flight will finish and its completion polls
+     * again; a paused subscriber polls again when it resumes. So a trigger that arrives at the wrong moment is
+     * redundant rather than lost.
+     */
+    private void pollUnlessBusy() {
+        if (inFlight || !consuming) {
+            return;
+        }
+        poll();
+    }
+
+    /**
+     * Clears the in-flight state a completed message held, then polls for the next.
+     * <p>
+     * <b>The poll goes through the same condition as every other trigger</b>, so a subscriber paused while this
+     * message was being processed stops here rather than reading one more.
+     */
+    private void pollAfterInFlight() {
+        if (!inFlight) {
+            // Nothing sets inFlight except poll(), and nothing clears it except this -- so reaching here
+            // with it already clear means a message was released twice, which no path should allow.
+            log.error("Internal subscriber '{}' completed a message it was not processing", clientId);
+        }
+        inFlight = false;
+        pollUnlessBusy();
+    }
+
+    /**
+     * Claims the in-flight state and reads one message.
+     * <p>
+     * <b>The claim happens here, before the read, and that placement is the whole point.</b> Reading submits
+     * a task of its own, so this one ends before the message arrives; claiming afterwards would leave a gap
+     * in which another trigger could poll and hand out a second message.
+     * <p>
+     * <b>An empty read therefore has to release the claim</b>: no message means no completion, and nothing
+     * else would ever clear it -- the subscriber would stop for good.
+     */
+    private void poll() {
+        inFlight = true;
         try {
             final ListenableFuture<ImmutableList<PUBLISH>> future =
                     clientQueuePersistence.readNew(clientId, false, POLL_PACKET_IDS, PUBLISH_POLL_BATCH_SIZE_BYTES);
@@ -588,30 +1470,76 @@ public final class InternalTopicFilterSubscriber {
                     future,
                     publishes -> {
                         if (publishes == null || publishes.isEmpty()) {
+                            inFlight = false;
                             return null;
                         }
-                        processPublish(publishes.get(0));
+                        processMessage(publishes.get(0));
                         return null;
                     },
                     MoreExecutors.directExecutor());
         } catch (final Throwable t) {
             log.error("Failed to poll internal subscriber '{}': {}", clientId, t.getMessage());
+            inFlight = false;
             submitPoll();
         }
     }
 
-    private void processPublish(final @NotNull PUBLISH message) {
+    /**
+     * Hands one message to the processor, and releases the queue once the processor is done with it.
+     * <p>
+     * <b>The release is chained off the processor's completion</b>, so the queue moves on when the consumer is
+     * done rather than when it returns. What keeps a second message from being handed out meanwhile is
+     * {@link #inFlight}, claimed in {@link #poll()} -- chaining alone does not, since a trigger arriving from
+     * anywhere else would poll regardless.
+     * <p>
+     * Success and failure release alike: whether the work succeeded is the consumer's business, and both
+     * outcomes mean "this one is no longer in flight". A message is dropped either way -- this is a subscriber,
+     * not a retry mechanism.
+     */
+    private void processMessage(final @NotNull PUBLISH message) {
+        final CompletableFuture<Void> completion;
         try {
-            processor.process(message);
-            removeMessage(message);
-            submitPoll();
+            completion = processor.process(message);
         } catch (final Exception e) {
+            // The contract is that a processor reports through its future rather than by throwing, and the
+            // synchronous form is wrapped to guarantee it. An async processor that throws anyway would
+            // otherwise leave nothing to attach the release to, and this queue would never move again.
             log.error(
-                    "Failed to process message for internal subscriber '{}', message will be dropped: {}",
+                    "Processor for internal subscriber '{}' threw instead of returning a future; message will be "
+                            + "dropped: {}",
                     clientId,
                     e.getMessage());
+            release(message);
+            return;
+        }
+
+        // The terminal stage; the stage returned by whenComplete is intentionally dropped.
+        final var unused = completion.whenComplete((ignored, throwable) -> {
+            if (throwable != null) {
+                log.error(
+                        "Failed to process message for internal subscriber '{}', message will be dropped: {}",
+                        clientId,
+                        throwable.getMessage());
+            }
+            release(message);
+        });
+    }
+
+    /**
+     * Acknowledges a message and reads the next.
+     * <p>
+     * <b>Wrapped so that neither half can be skipped.</b> A throw from the acknowledgement would otherwise
+     * swallow the poll, and this subscriber would stop for good -- the same silent stall the whole design is
+     * built to prevent, arriving through the one path that is supposed to prevent it.
+     */
+    private void release(final @NotNull PUBLISH message) {
+        try {
             removeMessage(message);
-            submitPoll();
+        } catch (final Exception e) {
+            log.error("Failed to acknowledge message for internal subscriber '{}': {}", clientId, e.getMessage());
+        } finally {
+            // The one trigger that also clears the in-flight state, since this message is now finished.
+            submitPollAfterInFlight();
         }
     }
 

--- a/hivemq-edge/src/main/java/com/hivemq/persistence/clientqueue/InternalTopicFilterSubscriber.java
+++ b/hivemq-edge/src/main/java/com/hivemq/persistence/clientqueue/InternalTopicFilterSubscriber.java
@@ -30,7 +30,6 @@ import com.hivemq.mqtt.topic.SubscriptionFlag;
 import com.hivemq.mqtt.topic.tree.LocalTopicTree;
 import com.hivemq.persistence.SingleWriterService;
 import com.hivemq.persistence.util.FutureUtils;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -112,16 +111,6 @@ public final class InternalTopicFilterSubscriber {
     // delete whichever the queue happened to hold first.
     private static final @NotNull ImmutableIntArray POLL_PACKET_IDS =
             ImmutableIntArray.of(ClientQueuePersistenceImpl.SHARED_IN_FLIGHT_MARKER);
-
-    // The largest MQTT subscription identifier: a variable byte integer, so 2^28 - 1. Topic's constructor
-    // asserts the range, and 0 is reserved -- so the usable space is [1, MAX_SUBSCRIPTION_ID].
-    private static final int MAX_SUBSCRIPTION_ID = 268_435_455;
-
-    // At most half the space may be subscribed at once, and that bound is what makes allocation terminate
-    // rather than merely usually terminate: with under half the identifiers taken, no run of consecutive taken
-    // values can span the whole space, so the search below always finds a free one. Raising this towards the
-    // full space would take that guarantee away, which is why it is stated here rather than tuned.
-    private static final int MAX_TOPIC_FILTERS = MAX_SUBSCRIPTION_ID / 2;
 
     // clientId -- built once as the reserved-prefix triple "$INTERNAL::<componentPrefix>::<instanceId>"
     //            (see the constructor for what each segment means). PublishDistributorImpl
@@ -208,24 +197,11 @@ public final class InternalTopicFilterSubscriber {
     //                to replace its predecessor. The fan-out cannot live in the tree, so it lives here.
     private final @NotNull Map<String, Set<TopicFilterContext>> topicFilterContexts = new LinkedHashMap<>();
 
-    // The two directions between a filter and its MQTT subscription identifier. Inverses of each other, and
-    // maintained only by allocate/free below, which is what keeps them so.
-    //
-    //   subscriptionIdByTopicFilter -- used when registering a filter in the tree, and when removing one.
-    //   topicFilterBySubscriptionId -- used on the DELIVERY path: a message carries the identifiers it matched,
-    //                                  and this is what turns them back into filters and so into contexts.
-    //
-    // An identifier is assigned once per filter and kept for as long as that filter is subscribed, so it
-    // survives every detach()/attach(). Re-allocating on re-attach would stay internally consistent and break
-    // only when a message queued BEFORE the detach is read after it, carrying an identifier this subscriber no
-    // longer knows -- and the identifier travels with the queued message, so that window is real.
-    private final @NotNull Map<String, Integer> subscriptionIdByTopicFilter = new HashMap<>();
-
-    private final @NotNull Map<Integer, String> topicFilterBySubscriptionId = new HashMap<>();
-
-    // Where the next allocation starts looking. Identifiers are per subscriber, not global: two subscribers may
-    // both use 1 without interfering.
-    private int nextSubscriptionId = 0;
+    // NO per-filter subscription identifiers, deliberately. Which filters a message matched is worked out when
+    // the message is POLLED, by matching its topic against this subscriber's own filters -- see asAsync() and
+    // topicMatchesFilter(). An identifier recorded on the message when it was ENQUEUED would be a cached answer
+    // that outlives the table giving it meaning: it would have to survive detach/attach and a restart, and when
+    // it did not the message arrived with no contexts and was silently dropped.
 
     // attached -- true iff the current topicFilters are registered in the topic tree (messages are
     //            being collected into the client queue).
@@ -297,13 +273,10 @@ public final class InternalTopicFilterSubscriber {
             throw new IllegalArgumentException(
                     "InternalTopicFilterSubscriber needs a processor or a context processor, not neither");
         }
-        // The filters, in whichever form this subscriber's kind uses. Each context filter is assigned its
-        // identifier here, so it survives every later detach()/attach().
+        // The filters, in whichever form this subscriber's kind uses.
         if (contextual) {
-            initialContexts.forEach((filter, contexts) -> {
-                topicFilterContexts.put(filter, new LinkedHashSet<>(contexts));
-                subscriptionIdFor(filter);
-            });
+            initialContexts.forEach(
+                    (filter, contexts) -> topicFilterContexts.put(filter, new LinkedHashSet<>(contexts)));
         } else {
             this.topicFilters.addAll(initialFilters);
         }
@@ -883,12 +856,9 @@ public final class InternalTopicFilterSubscriber {
         }
         // The tree is reconciled against the FILTERS; the contexts behind them are this object's own business,
         // so a filter kept by both sets is left alone in the tree even if its contexts changed entirely.
-        final Set<String> goneFilters = reconcileTo(target.keySet());
-        goneFilters.forEach(this::freeSubscriptionId);
+        reconcileTo(target.keySet());
         topicFilterContexts.clear();
         topicFilterContexts.putAll(target);
-        // After the tree work, so a filter that survives keeps the identifier it was registered under.
-        target.keySet().forEach(this::subscriptionIdFor);
         return this;
     }
 
@@ -907,13 +877,8 @@ public final class InternalTopicFilterSubscriber {
             topicFilterContexts
                     .computeIfAbsent(topicFilter, ignored -> new LinkedHashSet<>())
                     .add(context);
-            if (isNewFilter) {
-                // The identifier first: addToTree reads it, and a filter registered without one would deliver
-                // messages that resolve to no context at all.
-                subscriptionIdFor(topicFilter);
-                if (attached) {
-                    addToTree(topicFilter);
-                }
+            if (isNewFilter && attached) {
+                addToTree(topicFilter);
             }
         }
         return this;
@@ -942,22 +907,21 @@ public final class InternalTopicFilterSubscriber {
                 if (attached) {
                     removeFromTree(topicFilter);
                 }
-                freeSubscriptionId(topicFilter);
             }
         }
         return this;
     }
 
     /**
-     * Reconciles the topic tree from the currently subscribed filters to the given target, and answers which
-     * filters are no longer wanted.
+     * Reconciles the topic tree from the currently subscribed filters to the given target.
      * <p>
-     * Does nothing to the tree while detached -- there is nothing registered to reconcile -- but still answers
-     * the difference, since the caller frees identifiers either way.
-     *
-     * @return the filters that were subscribed and are not in the target
+     * Does nothing while detached -- there is nothing registered to reconcile, and the caller's new filter set
+     * is replayed in full by the next {@code attach()}.
      */
-    private @NotNull Set<String> reconcileTo(final @NotNull Set<String> target) {
+    private void reconcileTo(final @NotNull Set<String> target) {
+        if (!attached) {
+            return;
+        }
         final Set<String> current = contextual ? topicFilterContexts.keySet() : topicFilters;
         final Set<String> gone = new LinkedHashSet<>();
         for (final String existing : current) {
@@ -965,20 +929,12 @@ public final class InternalTopicFilterSubscriber {
                 gone.add(existing);
             }
         }
-        if (attached) {
-            gone.forEach(this::removeFromTree);
-            for (final String wanted : target) {
-                if (!current.contains(wanted)) {
-                    // For a context subscriber the identifier must exist before the filter is registered, and
-                    // the caller has not written the new set yet -- so allocate here rather than after.
-                    if (contextual) {
-                        subscriptionIdFor(wanted);
-                    }
-                    addToTree(wanted);
-                }
+        gone.forEach(this::removeFromTree);
+        for (final String wanted : target) {
+            if (!current.contains(wanted)) {
+                addToTree(wanted);
             }
         }
-        return gone;
     }
 
     /** The filters this subscriber is subscribed to, whichever kind it is. */
@@ -1263,137 +1219,104 @@ public final class InternalTopicFilterSubscriber {
     // stays null, and our `clientId` is the sole identity (no separate shared-group name).
     /// Registers one topic filter in the topic tree under this subscriber's client id.
     ///
-    /// **On a CONTEXT subscriber the filter must already have a subscription identifier when this is called.**
-    /// This method only reads one; it does not allocate. Every current caller satisfies that -- the
-    /// constructor, `addTopicFilterContext` and the reconciliation in `withTopicFilterContext` each allocate
-    /// before registering, and `attach()` only ever replays filters one of those three put there -- so there is
-    /// no defect today. It is written down because nothing enforces it.
-    ///
-    /// **What goes wrong if a future caller forgets is silent.** A missing identifier reads as `null` from the
-    /// map, and [Topic] accepts `null` as "no subscription identifier" rather than rejecting it. So the filter
-    /// registers, messages match it, and they reach the consumer with an EMPTY set of matched contexts: a
-    /// component that finds nothing to do with them drops them, and nothing anywhere logs or throws. That is
-    /// precisely the failure the identifier mechanism exists to prevent, arriving through the one method that
-    /// is supposed to deliver it.
-    ///
-    /// If a fifth registration path is ever added, either allocate first as the others do, or move the
-    /// allocation in here -- [#subscriptionIdFor] is idempotent, so doing so would change no existing path.
+    /// **No subscription identifier is recorded**, for either kind of subscriber. A context subscriber works out
+    /// which filters a message matched when it POLLS the message, from the message's own topic -- see
+    /// [#asAsync] -- so it needs nothing stamped onto the message at enqueue time. That also means this method
+    /// has no precondition a caller can forget: every registration path is interchangeable, and a new one needs
+    /// only to call this.
     private void addToTree(final @NotNull String topicFilter) {
         topicTree.addTopic(
                 clientId,
-                // The subscription identifier is what makes a matched message say WHICH filter matched: the
-                // broker echoes it back on every message that subscription matched, and several come back when
-                // several filters match.
-                //
-                // NULL IS LEGITIMATE ONLY FOR A PLAIN SUBSCRIBER, which has no contexts to resolve and
-                // delivers exactly as it did before identifiers existed. On a context subscriber a null here
-                // is the silent failure described above -- see this method's documentation.
-                new Topic(
-                        topicFilter,
-                        qos,
-                        false,
-                        true,
-                        Topic.DEFAULT_RETAIN_HANDLING,
-                        subscriptionIdByTopicFilter.get(topicFilter)),
+                new Topic(topicFilter, qos, false, true, Topic.DEFAULT_RETAIN_HANDLING, null),
                 SubscriptionFlag.getDefaultFlags(false, true, false),
                 null); // sharedName -- null: non-shared (see note above)
     }
 
     /**
-     * Turns a routing processor into the async one the pipeline uses, by resolving each message's subscription
-     * identifiers back to what the consumer asked to be told.
+     * Turns a routing processor into the async one the pipeline uses, by working out which of this subscriber's
+     * filters the message's topic matches and handing over the contexts behind them.
      * <p>
-     * <b>A union, and over the CONTEXTS rather than the identifiers.</b> One context may sit behind two
-     * filters -- one destination reachable by two patterns -- and both identifiers come back when both match.
-     * Deduplicating at the end rather than the start is what stops the consumer doing the work twice for one
-     * message, which for a device write means sending the same command twice.
+     * <b>Matched at poll time, not at enqueue time.</b> The message carries its concrete topic and this
+     * subscriber holds its own filters, so the match is computed from what is true NOW. Nothing is stamped onto
+     * a stored message, and so nothing stored can go stale: a filter removed while the message sat in the queue
+     * simply does not match, and one added while it sat there does. The alternative -- having the topic tree
+     * record a per-filter subscription identifier on each queued message and resolving that identifier back to
+     * a filter here -- cached the answer at the wrong moment. It needed identifiers to stay stable across
+     * detach/attach and across a restart, neither of which a per-subscriber counter can promise, and it failed
+     * silently when they did not: the message arrived with an empty context set and was quietly dropped.
      * <p>
-     * The identifiers are in practice distinct, since a filter holds exactly one and the tree merges rather
-     * than repeats. But that is a consequence of two other invariants rather than anything declared, and a set
-     * costs nothing.
+     * <b>A union, and over the CONTEXTS rather than the filters.</b> One context may sit behind two filters --
+     * one destination reachable by two patterns -- and both may match one topic. Deduplicating means the
+     * consumer does the work once, which for a device write is the difference between sending a command once
+     * and sending it twice.
+     * <p>
+     * Cost is one pass over this subscriber's own filters, each a single walk over the topic with no allocation
+     * (see {@link #topicMatchesFilter}). Subscriber filter counts are small, and nothing shared is consulted:
+     * no topic tree, no lock beyond this object's own.
      */
     @SuppressWarnings("unchecked")
     private @NotNull AsyncProcessor asAsync(final @NotNull AsyncContextProcessor<?> contextProcessor) {
         final AsyncContextProcessor<TopicFilterContext> routing =
                 (AsyncContextProcessor<TopicFilterContext>) contextProcessor;
         return message -> {
-            final ImmutableIntArray matchedIdentifiers = message.getSubscriptionIdentifiers();
             final Set<TopicFilterContext> matched = new LinkedHashSet<>();
-            if (matchedIdentifiers != null) {
-                synchronized (this) {
-                    for (int i = 0; i < matchedIdentifiers.length(); i++) {
-                        // identifier -> filter -> contexts. A filter removed since this message was queued
-                        // resolves to nothing, and contributes nothing to the set.
-                        final String topicFilter = topicFilterBySubscriptionId.get(matchedIdentifiers.get(i));
-                        if (topicFilter != null) {
-                            matched.addAll(topicFilterContexts.getOrDefault(topicFilter, Set.of()));
-                        }
+            synchronized (this) {
+                topicFilterContexts.forEach((topicFilter, contexts) -> {
+                    if (topicMatchesFilter(topicFilter, message.getTopic())) {
+                        matched.addAll(contexts);
                     }
-                }
+                });
             }
             return routing.process(message, matched);
         };
     }
 
     /**
-     * The identifier this subscriber uses for a filter, assigned on first subscription and stable thereafter.
+     * Whether an MQTT topic filter matches a concrete topic.
      * <p>
-     * <b>Stable is the whole point.</b> A filter re-registered after a {@code detach()}/{@code attach()} keeps
-     * the identifier it had, because a message queued before the detach carries that identifier and is read
-     * after it. Re-allocating would look correct -- the identifiers would stay internally consistent -- and
-     * would fail only on that one path.
+     * Standard MQTT matching: {@code +} matches exactly one level, {@code #} matches the remaining levels and
+     * also the parent itself (so {@code a/b/#} matches {@code a/b}), and both wildcards match an EMPTY level
+     * (so {@code a/+} matches {@code a/}).
+     * <p>
+     * <b>Assumes both arguments are well formed</b> -- in the filter {@code +} and {@code #} each occupy a whole
+     * level and {@code #} is last; in the topic neither character appears. Both hold here: filters come from
+     * configuration that Edge validates, and topics come from messages the broker accepted.
+     * <p>
+     * A single left-to-right walk over the two strings with no allocation and no splitting into levels. Two
+     * details carry the wildcards. The trailing {@code /#} is stripped up front and remembered, so the loop
+     * never sees it and a filter that ran out while the topic sits on a {@code /} still matches. And the
+     * {@code +} test comes BEFORE the character comparison, with the loop advancing on the FILTER alone -- that
+     * is what lets {@code +} match an empty level, where there is no character in the topic to compare against.
+     * <p>
+     * The final read needs no bounds check: {@code ||} evaluates its right side only when the topic cursor is
+     * not at the end, and the cursor never passes the end, so it is always in range.
      */
-    private int subscriptionIdFor(final @NotNull String topicFilter) {
-        final Integer existing = subscriptionIdByTopicFilter.get(topicFilter);
-        if (existing != null) {
-            return existing;
+    private static boolean topicMatchesFilter(final @NotNull String filter, final @NotNull String topic) {
+        boolean hasHashWildcard = false;
+        int lenF = filter.length();
+        if (1 == lenF && filter.charAt(0) == '#') {
+            return true;
         }
-        final int allocated = allocateSubscriptionId();
-        subscriptionIdByTopicFilter.put(topicFilter, allocated);
-        topicFilterBySubscriptionId.put(allocated, topicFilter);
-        return allocated;
-    }
+        if (2 <= lenF && filter.charAt(lenF - 2) == '/' && filter.charAt(lenF - 1) == '#') {
+            lenF = lenF - 2;
+            hasHashWildcard = true;
+        }
 
-    /**
-     * Frees the identifier a filter held, so the space does not grow with churn.
-     * <p>
-     * Called only when a filter is genuinely unsubscribed -- not on {@code detach()}, which keeps the filters
-     * in order to replay them.
-     */
-    private void freeSubscriptionId(final @NotNull String topicFilter) {
-        final Integer released = subscriptionIdByTopicFilter.remove(topicFilter);
-        if (released != null) {
-            topicFilterBySubscriptionId.remove(released);
-        }
-    }
+        final int lenT = topic.length();
+        int iT = 0;
 
-    /**
-     * An identifier no filter currently holds, walking forward from the last one handed out and wrapping.
-     * <p>
-     * <b>Identifiers are not reused while held, and are reused only after wrapping.</b> Walking forward means a
-     * freed identifier is handed out again only once the counter has been all the way round -- after
-     * {@link #MAX_SUBSCRIPTION_ID} allocations, each one a filter subscribed for the first time -- rather than
-     * immediately. That matters because a message queued under a filter's identifier may be read after that
-     * filter is gone: until the wrap it resolves to nothing and the message is dropped, which is right; after a
-     * wrap it could resolve to whichever filter has since taken the number, which is not. No real deployment
-     * subscribes that many filters on one subscriber while a single message sits unread, and the trade buys a
-     * bounded space and a plain int counter.
-     *
-     * @throws IllegalStateException if this subscriber already holds {@link #MAX_TOPIC_FILTERS} filters
-     */
-    private int allocateSubscriptionId() {
-        if (topicFilterBySubscriptionId.size() >= MAX_TOPIC_FILTERS) {
-            throw new IllegalStateException("InternalTopicFilterSubscriber '" + clientId
-                    + "' has too many topic filters: at most "
-                    + MAX_TOPIC_FILTERS
-                    + " may be subscribed at once");
+        for (int iF = 0; iF < lenF; iF++) {
+            if (filter.charAt(iF) == '+') {
+                while (iT < lenT && topic.charAt(iT) != '/') {
+                    iT++;
+                }
+            } else if (iT < lenT && filter.charAt(iF) == topic.charAt(iT)) {
+                iT++;
+            } else {
+                return false;
+            }
         }
-        do {
-            // Wraps within [1, MAX_SUBSCRIPTION_ID]; never yields 0, which MQTT reserves. Terminates because
-            // fewer than half the identifiers are taken -- see MAX_TOPIC_FILTERS.
-            nextSubscriptionId = (nextSubscriptionId % MAX_SUBSCRIPTION_ID) + 1;
-        } while (topicFilterBySubscriptionId.containsKey(nextSubscriptionId));
-        return nextSubscriptionId;
+        return iT == lenT || (topic.charAt(iT) == '/' && hasHashWildcard);
     }
 
     private void removeFromTree(final @NotNull String topicFilter) {

--- a/hivemq-edge/src/main/java/com/hivemq/persistence/clientqueue/InternalTopicFilterSubscriberFactory.java
+++ b/hivemq-edge/src/main/java/com/hivemq/persistence/clientqueue/InternalTopicFilterSubscriberFactory.java
@@ -100,7 +100,7 @@ public class InternalTopicFilterSubscriberFactory {
     public @NotNull InternalTopicFilterSubscriber.Builder builder(
             final @NotNull String componentPrefix, final @NotNull String instanceId) {
         return new InternalTopicFilterSubscriber.Builder(
-                componentPrefix, instanceId, this, topicTree, clientQueuePersistence, singleWriterService);
+                topicTree, clientQueuePersistence, singleWriterService, this, componentPrefix, instanceId);
     }
 }
 

--- a/hivemq-edge/src/test/java/com/hivemq/mqtt/services/PublishDistributorImplTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/mqtt/services/PublishDistributorImplTest.java
@@ -45,6 +45,7 @@ import com.hivemq.mqtt.message.publish.PUBLISHFactory;
 import com.hivemq.mqtt.topic.SubscriberWithIdentifiers;
 import com.hivemq.persistence.SingleWriterService;
 import com.hivemq.persistence.clientqueue.ClientQueuePersistence;
+import com.hivemq.persistence.clientqueue.InternalTopicFilterSubscriberFactory;
 import com.hivemq.persistence.clientqueue.QueuePolicy;
 import com.hivemq.persistence.clientsession.ClientSession;
 import com.hivemq.persistence.clientsession.ClientSessionPersistence;
@@ -90,6 +91,8 @@ public class PublishDistributorImplTest {
         publishDistributor = new PublishDistributorImpl(
                 clientQueuePersistence,
                 () -> clientSessionPersistence,
+                // Only consulted for an internal subscriber's queue; these tests use ordinary client ids.
+                () -> mock(InternalTopicFilterSubscriberFactory.class),
                 configurationService,
                 () -> samplingService,
                 () -> messageForwarder);

--- a/hivemq-edge/src/test/java/com/hivemq/persistence/clientqueue/ClientQueuePersistenceImplTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/persistence/clientqueue/ClientQueuePersistenceImplTest.java
@@ -273,6 +273,56 @@ public class ClientQueuePersistenceImplTest {
 
     @Test
     @Timeout(5)
+    public void aSharedQueueDoesNotInheritAnInternalSubscribersOverflowStrategy() throws Exception {
+        // A shared queue's id is built from a SHARE NAME, and a share name is the client's to choose. Strip the
+        // "$share/" prefix and a subscription to $share/$INTERNAL::test::victim/ leaves a queue id identical to
+        // that subscriber's own -- so without the shared flag this queue took the subscriber's DISCARD_OLDEST
+        // instead of the configured DISCARD, and a client's own messages were dropped under a policy meant for
+        // an internal consumer.
+        //
+        // Asking the factory cannot resolve it: an internal subscriber's id carries no topic suffix, so nothing
+        // in the string separates "the subscriber called X" from "a share group called X". The flag is the only
+        // thing that can, which is why it is threaded through rather than the branch made name-independent.
+        //
+        // Third occurrence of this shape -- see EDG-882 F-05 (sampler) and QA round 2 (bridge forwarder).
+        final InternalTopicFilterSubscriber subscriber = mock(InternalTopicFilterSubscriber.class);
+        when(subscriber.queueOverflow()).thenReturn(QueuedMessagesStrategy.DISCARD_OLDEST);
+        final InternalTopicFilterSubscriberFactory subscriberFactory = mock(InternalTopicFilterSubscriberFactory.class);
+        final String queueId = InternalTopicFilterSubscriber.INTERNAL_SUBSCRIBER_PREFIX + "test::victim";
+        when(subscriberFactory.getSubscriber(queueId)).thenReturn(subscriber);
+
+        final ClientQueuePersistenceImpl persistence = new ClientQueuePersistenceImpl(
+                localPersistence,
+                singleWriterService,
+                mqttConfigurationService,
+                clientSessionLocalPersistence,
+                messageDroppedService,
+                topicTree,
+                connectionPersistence,
+                () -> publishPollService,
+                () -> subscriberFactory,
+                messageForwarder,
+                shutdownHooks);
+
+        // shared = true: the same string, but a different queue in a different store.
+        persistence
+                .add(queueId, true, createPublish(1, QoS.AT_LEAST_ONCE, "topic"), false, 1000L, QueuePolicy.DEFAULT)
+                .get();
+
+        verify(localPersistence)
+                .add(
+                        eq(queueId),
+                        eq(true),
+                        any(PUBLISH.class),
+                        eq(1000L),
+                        eq(QueuedMessagesStrategy.DISCARD), // the broker's, NOT the subscriber's DISCARD_OLDEST
+                        anyBoolean(),
+                        eq(false),
+                        anyInt());
+    }
+
+    @Test
+    @Timeout(5)
     public void anInternalSubscribersDeclaredOverflowStrategyIsUsed() throws Exception {
         // The consumption end of withQueueOverflow. Without this the subscriber would carry a value nothing
         // reads, and the queue would silently keep the broker default -- DISCARD, which for a command queue

--- a/hivemq-edge/src/test/java/com/hivemq/persistence/clientqueue/ClientQueuePersistenceImplTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/persistence/clientqueue/ClientQueuePersistenceImplTest.java
@@ -122,6 +122,8 @@ public class ClientQueuePersistenceImplTest {
                 topicTree,
                 connectionPersistence,
                 () -> publishPollService,
+                // Only consulted for an internal subscriber's queue; these tests use ordinary client ids.
+                () -> mock(InternalTopicFilterSubscriberFactory.class),
                 messageForwarder,
                 shutdownHooks);
     }
@@ -266,6 +268,85 @@ public class ClientQueuePersistenceImplTest {
                         eq(QueuedMessagesStrategy.DISCARD_OLDEST),
                         anyBoolean(),
                         eq(true),
+                        anyInt());
+    }
+
+    @Test
+    @Timeout(5)
+    public void anInternalSubscribersDeclaredOverflowStrategyIsUsed() throws Exception {
+        // The consumption end of withQueueOverflow. Without this the subscriber would carry a value nothing
+        // reads, and the queue would silently keep the broker default -- DISCARD, which for a command queue
+        // rejects the FRESH message in favour of a backlog of stale ones.
+        final InternalTopicFilterSubscriber subscriber = mock(InternalTopicFilterSubscriber.class);
+        when(subscriber.queueOverflow()).thenReturn(QueuedMessagesStrategy.DISCARD_OLDEST);
+        final InternalTopicFilterSubscriberFactory subscriberFactory = mock(InternalTopicFilterSubscriberFactory.class);
+        final String queueId = InternalTopicFilterSubscriber.INTERNAL_SUBSCRIBER_PREFIX + "test::declares-overflow";
+        when(subscriberFactory.getSubscriber(queueId)).thenReturn(subscriber);
+
+        final ClientQueuePersistenceImpl persistence = new ClientQueuePersistenceImpl(
+                localPersistence,
+                singleWriterService,
+                mqttConfigurationService,
+                clientSessionLocalPersistence,
+                messageDroppedService,
+                topicTree,
+                connectionPersistence,
+                () -> publishPollService,
+                () -> subscriberFactory,
+                messageForwarder,
+                shutdownHooks);
+
+        persistence
+                .add(queueId, false, createPublish(1, QoS.AT_LEAST_ONCE, "topic"), false, 1000L, QueuePolicy.DEFAULT)
+                .get();
+
+        verify(localPersistence)
+                .add(
+                        eq(queueId),
+                        eq(false),
+                        any(PUBLISH.class),
+                        eq(1000L),
+                        eq(QueuedMessagesStrategy.DISCARD_OLDEST), // declared, not the broker's DISCARD
+                        anyBoolean(),
+                        eq(false), // applyMaxToQos0 stays the policy's business, and this is DEFAULT
+                        anyInt());
+    }
+
+    @Test
+    @Timeout(5)
+    public void anInternalSubscriberThatDeclaresNoOverflowStrategyGetsTheBrokerDefault() throws Exception {
+        final InternalTopicFilterSubscriber subscriber = mock(InternalTopicFilterSubscriber.class);
+        when(subscriber.queueOverflow()).thenReturn(null);
+        final InternalTopicFilterSubscriberFactory subscriberFactory = mock(InternalTopicFilterSubscriberFactory.class);
+        final String queueId = InternalTopicFilterSubscriber.INTERNAL_SUBSCRIBER_PREFIX + "test::no-opinion";
+        when(subscriberFactory.getSubscriber(queueId)).thenReturn(subscriber);
+
+        final ClientQueuePersistenceImpl persistence = new ClientQueuePersistenceImpl(
+                localPersistence,
+                singleWriterService,
+                mqttConfigurationService,
+                clientSessionLocalPersistence,
+                messageDroppedService,
+                topicTree,
+                connectionPersistence,
+                () -> publishPollService,
+                () -> subscriberFactory,
+                messageForwarder,
+                shutdownHooks);
+
+        persistence
+                .add(queueId, false, createPublish(1, QoS.AT_LEAST_ONCE, "topic"), false, 1000L, QueuePolicy.DEFAULT)
+                .get();
+
+        verify(localPersistence)
+                .add(
+                        eq(queueId),
+                        eq(false),
+                        any(PUBLISH.class),
+                        eq(1000L),
+                        eq(QueuedMessagesStrategy.DISCARD), // the broker-wide setting
+                        anyBoolean(),
+                        eq(false), // applyMaxToQos0 stays the policy's business, and this is DEFAULT
                         anyInt());
     }
 

--- a/hivemq-edge/src/test/java/com/hivemq/persistence/clientqueue/InternalTopicFilterSubscriberAsyncTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/persistence/clientqueue/InternalTopicFilterSubscriberAsyncTest.java
@@ -1,0 +1,960 @@
+/*
+ * Copyright 2019-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.persistence.clientqueue;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.collect.ImmutableList;
+import com.google.common.primitives.ImmutableIntArray;
+import com.google.common.util.concurrent.Futures;
+import com.hivemq.configuration.service.MqttConfigurationService.QueuedMessagesStrategy;
+import com.hivemq.metrics.MetricsHolder;
+import com.hivemq.mqtt.message.QoS;
+import com.hivemq.mqtt.message.publish.PUBLISH;
+import com.hivemq.mqtt.message.publish.PUBLISHFactory;
+import com.hivemq.mqtt.topic.SubscriberWithIdentifiers;
+import com.hivemq.mqtt.topic.tree.LocalTopicTree;
+import com.hivemq.persistence.ProducerQueues;
+import com.hivemq.persistence.SingleWriterService;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+/// The one-message-in-flight bound, and what it rests on.
+///
+/// **These drive the real poll pipeline**, unlike the sibling test class which deliberately does not: the
+/// single writer is stubbed to run submitted work on the calling thread, so a whole read-process-release cycle
+/// happens synchronously and can be observed step by step.
+///
+/// What every test here pins is the same claim from a different angle: **the next message is read only once the
+/// processor is done with the previous one**. A subscriber that reads ahead has lost the bound; a subscriber
+/// that never reads again has stalled. Both failures are silent in production, which is why they are worth
+/// pinning here.
+class InternalTopicFilterSubscriberAsyncTest {
+
+    private @NotNull ClientQueuePersistence clientQueuePersistence;
+    private @NotNull InternalTopicFilterSubscriberFactory factory;
+    private @NotNull LocalTopicTree topicTree; // REAL -- the identifier test asserts what the tree was told
+
+    /// Every message the stubbed queue has been asked for, so a test can count reads.
+    private final @NotNull AtomicInteger reads = new AtomicInteger();
+
+    /// The messages the queue will hand out, in order; empty once exhausted.
+    private final @NotNull List<PUBLISH> queued = new ArrayList<>();
+
+    @BeforeEach
+    void setUp() {
+        topicTree = new LocalTopicTree(new MetricsHolder(new MetricRegistry()));
+        clientQueuePersistence = mock(ClientQueuePersistence.class);
+        final SingleWriterService singleWriterService = mock(SingleWriterService.class);
+
+        // The single writer runs submitted work on the calling thread, so a test drives the whole pipeline
+        // synchronously. The sibling test class stubs this to do nothing, because it is testing the state
+        // machine rather than the loop; here the loop is the subject.
+        final ProducerQueues producerQueues = mock(ProducerQueues.class);
+        when(singleWriterService.getQueuedMessagesQueue()).thenReturn(producerQueues);
+        when(producerQueues.submit(anyString(), any())).thenAnswer(invocation -> {
+            final SingleWriterService.Task<?> task = invocation.getArgument(1);
+            return task.doTask(0);
+        });
+
+        when(clientQueuePersistence.readNew(anyString(), any(Boolean.class), any(ImmutableIntArray.class), anyLong()))
+                .thenAnswer(invocation -> {
+                    reads.incrementAndGet();
+                    if (queued.isEmpty()) {
+                        return Futures.immediateFuture(ImmutableList.of());
+                    }
+                    return Futures.immediateFuture(ImmutableList.of(queued.remove(0)));
+                });
+        when(clientQueuePersistence.removeShared(anyString(), anyString())).thenReturn(Futures.immediateFuture(null));
+
+        factory = new InternalTopicFilterSubscriberFactory(topicTree, clientQueuePersistence, singleWriterService);
+    }
+
+    private @NotNull PUBLISH message(final @NotNull String payload) {
+        return new PUBLISHFactory.Mqtt5Builder()
+                .withHivemqId("edge1")
+                .withTopic("commands/setpoint")
+                .withQoS(QoS.AT_LEAST_ONCE)
+                .withOnwardQos(QoS.AT_LEAST_ONCE)
+                .withPayload(payload.getBytes(StandardCharsets.UTF_8))
+                .build();
+    }
+
+    @Test
+    void aSynchronousProcessorBehavesExactlyAsBefore() {
+        final List<String> seen = new ArrayList<>();
+        queued.add(message("a"));
+        queued.add(message("b"));
+
+        factory.builder("test", "sync")
+                .withProcessor(m -> seen.add(new String(m.getPayload(), StandardCharsets.UTF_8)))
+                .withTopicFilter("commands/#")
+                .build()
+                .consume();
+
+        assertThat(seen).containsExactly("a", "b");
+    }
+
+    @Test
+    void anAsynchronousProcessorHoldsTheQueueUntilItsFutureCompletes() {
+        // The claim this whole extension exists for. The processor takes the first message and does not
+        // answer; nothing further may be read until it does.
+        final List<CompletableFuture<Void>> outstanding = new ArrayList<>();
+        final List<String> seen = new ArrayList<>();
+        queued.add(message("a"));
+        queued.add(message("b"));
+
+        factory.builder("test", "async")
+                .withAsyncProcessor(m -> {
+                    seen.add(new String(m.getPayload(), StandardCharsets.UTF_8));
+                    final CompletableFuture<Void> completion = new CompletableFuture<>();
+                    outstanding.add(completion);
+                    return completion;
+                })
+                .withTopicFilter("commands/#")
+                .build()
+                .consume();
+
+        assertThat(seen)
+                .as("only the first message, because the first has not been answered")
+                .containsExactly("a");
+
+        outstanding.get(0).complete(null);
+        assertThat(seen)
+                .as("answering releases the queue and the next message arrives")
+                .containsExactly("a", "b");
+    }
+
+    @Test
+    void aWakeUpWhileAMessageIsInFlightDoesNotHandOutASecondOne() {
+        // The bound used to rest on the completion chain alone: the release polls again, so the NEXT message
+        // waits. But that is only one of the ways a poll starts. A message arriving fires the publish-available
+        // callback, which polls independently -- and with the first future still pending, the processor was
+        // handed a second message. Reported by Sam on #1752.
+        //
+        // Reproduced here by firing the callback, which is exactly what the queue persistence does when a
+        // message is queued for a client that is already consuming.
+        final List<CompletableFuture<Void>> outstanding = new ArrayList<>();
+        final List<String> seen = new ArrayList<>();
+        queued.add(message("a"));
+
+        final ArgumentCaptor<ClientQueuePersistence.PublishAvailableCallback> callback =
+                ArgumentCaptor.forClass(ClientQueuePersistence.PublishAvailableCallback.class);
+
+        final InternalTopicFilterSubscriber subscriber = factory.builder("test", "wake-up-while-in-flight")
+                .withAsyncProcessor(m -> {
+                    seen.add(new String(m.getPayload(), StandardCharsets.UTF_8));
+                    final CompletableFuture<Void> completion = new CompletableFuture<>();
+                    outstanding.add(completion);
+                    return completion;
+                })
+                .withTopicFilter("commands/#")
+                .build();
+        subscriber.consume();
+
+        verify(clientQueuePersistence).addPublishAvailableCallback(callback.capture(), anyString());
+        assertThat(seen).as("the first message is being processed").containsExactly("a");
+
+        // A second message arrives while the first is still in flight, and wakes the poller.
+        queued.add(message("b"));
+        callback.getValue().onPublishAvailable(subscriber.clientId());
+
+        assertThat(seen)
+                .as("the wake-up must not hand out a second message while the first is unfinished")
+                .containsExactly("a");
+
+        outstanding.get(0).complete(null);
+        assertThat(seen)
+                .as("and the second arrives once the first has finished")
+                .containsExactly("a", "b");
+    }
+
+    @Test
+    void anEmptyPollLeavesTheSubscriberAbleToPollAgain() {
+        // The in-flight claim is taken BEFORE the queue is read, because the read runs as a task of its own and
+        // claiming afterwards would leave a gap for a second poll. The price is that an empty read has to
+        // release the claim itself: no message means no completion, so nothing else ever would, and the
+        // subscriber would go permanently deaf -- accepting messages into its queue and never reading them.
+        final List<String> seen = new ArrayList<>();
+
+        final ArgumentCaptor<ClientQueuePersistence.PublishAvailableCallback> callback =
+                ArgumentCaptor.forClass(ClientQueuePersistence.PublishAvailableCallback.class);
+
+        // Nothing queued, so the drain that consume() starts reads an empty queue.
+        final InternalTopicFilterSubscriber subscriber = factory.builder("test", "empty-then-message")
+                .withProcessor(m -> seen.add(new String(m.getPayload(), StandardCharsets.UTF_8)))
+                .withTopicFilter("commands/#")
+                .build();
+        subscriber.consume();
+
+        assertThat(seen).as("nothing to read yet").isEmpty();
+
+        verify(clientQueuePersistence).addPublishAvailableCallback(callback.capture(), anyString());
+        queued.add(message("a"));
+        callback.getValue().onPublishAvailable(subscriber.clientId());
+
+        assertThat(seen)
+                .as("the empty read released its claim, so this wake-up is acted on")
+                .containsExactly("a");
+    }
+
+    @Test
+    void aCompletionArrivingAfterStopDoesNotReadFromTheQueue() {
+        // stop() FREES THE CLIENT ID, so a replacement subscriber may already own the queue under that name.
+        // An outstanding future completing afterwards used to acknowledge and poll regardless -- the discarded
+        // object reading a command meant for its successor, which then never sees it. Reported by Sam on #1752.
+        //
+        // Covered by the same clause as everything else rather than a check of its own: stop() pauses before
+        // deallocating, so a dead subscriber is one that is no longer consuming, and pollUnlessBusy() declines.
+        final List<CompletableFuture<Void>> outstanding = new ArrayList<>();
+        final List<String> seen = new ArrayList<>();
+        queued.add(message("a"));
+
+        final InternalTopicFilterSubscriber subscriber = factory.builder("test", "completion-after-stop")
+                .withAsyncProcessor(m -> {
+                    seen.add(new String(m.getPayload(), StandardCharsets.UTF_8));
+                    final CompletableFuture<Void> completion = new CompletableFuture<>();
+                    outstanding.add(completion);
+                    return completion;
+                })
+                .withTopicFilter("commands/#")
+                .build();
+        subscriber.consume();
+
+        assertThat(seen).as("the first message is in flight").containsExactly("a");
+
+        subscriber.stop();
+
+        // A message queued under that client id after the identity was freed -- as a replacement's would be.
+        queued.add(message("b"));
+        final int readsBeforeCompletion = reads.get();
+        outstanding.get(0).complete(null);
+
+        assertThat(seen).as("the dead subscriber processes nothing further").containsExactly("a");
+        assertThat(reads.get())
+                .as("and does not read the queue at all, which a replacement may now own")
+                .isEqualTo(readsBeforeCompletion);
+    }
+
+    @Test
+    void aFailedFutureReleasesTheQueueExactlyAsASuccessDoes() {
+        // Success and failure are alike in the one respect that matters: both mean "no longer in flight".
+        // A subscriber that released only on success would stop for good on the first failure.
+        final List<String> seen = new ArrayList<>();
+        queued.add(message("a"));
+        queued.add(message("b"));
+
+        factory.builder("test", "failing")
+                .withAsyncProcessor(m -> {
+                    seen.add(new String(m.getPayload(), StandardCharsets.UTF_8));
+                    return CompletableFuture.failedFuture(new IllegalStateException("device said no"));
+                })
+                .withTopicFilter("commands/#")
+                .build()
+                .consume();
+
+        assertThat(seen).containsExactly("a", "b");
+    }
+
+    @Test
+    void aSynchronousProcessorThatThrowsStillReleasesTheQueue() {
+        // The wrapper's catch. Without it the exception escapes before any future exists, nothing is
+        // attached to release the queue, and this subscriber stops permanently and silently.
+        final List<String> seen = new ArrayList<>();
+        queued.add(message("a"));
+        queued.add(message("b"));
+
+        factory.builder("test", "throwing")
+                .withProcessor(m -> {
+                    seen.add(new String(m.getPayload(), StandardCharsets.UTF_8));
+                    throw new IllegalStateException("consumer blew up");
+                })
+                .withTopicFilter("commands/#")
+                .build()
+                .consume();
+
+        assertThat(seen).containsExactly("a", "b");
+    }
+
+    @Test
+    void anAsynchronousProcessorThatThrowsInsteadOfReturningIsContained() {
+        // The contract is to report through the future. A throw would otherwise leave nothing to chain the
+        // release off, so it is caught and treated as a failed message.
+        final List<String> seen = new ArrayList<>();
+        queued.add(message("a"));
+        queued.add(message("b"));
+
+        factory.builder("test", "badasync")
+                .withAsyncProcessor(m -> {
+                    seen.add(new String(m.getPayload(), StandardCharsets.UTF_8));
+                    throw new IllegalStateException("threw instead of returning");
+                })
+                .withTopicFilter("commands/#")
+                .build()
+                .consume();
+
+        assertThat(seen).containsExactly("a", "b");
+    }
+
+    // -- routing --------------------------------------------------------------------------------------
+
+    /// A consumer's own context: a filter and what it means to that consumer.
+    ///
+    /// A record, so equality is component-wise, which is what the deduplication and the removal both turn on.
+    /// The subscriber asks only that a context *have* an identity, never how it is defined -- a real consumer
+    /// whose contexts carry a key of their own is free to make that key the whole of it, as the southbound
+    /// write path does.
+    private record Destination(
+            @NotNull String topicFilter, @NotNull String name)
+            implements InternalTopicFilterSubscriber.TopicFilterContext {}
+
+    private static @NotNull Destination to(final @NotNull String topicFilter, final @NotNull String name) {
+        return new Destination(topicFilter, name);
+    }
+
+    /// As the topic tree would: the identifiers of every filter that matched.
+    private @NotNull PUBLISH messageMatching(final @NotNull String payload, final int... identifiers) {
+        return new PUBLISHFactory.Mqtt5Builder()
+                .withHivemqId("edge1")
+                .withTopic("commands/setpoint")
+                .withQoS(QoS.AT_LEAST_ONCE)
+                .withOnwardQos(QoS.AT_LEAST_ONCE)
+                .withPayload(payload.getBytes(StandardCharsets.UTF_8))
+                .withSubscriptionIdentifiers(ImmutableIntArray.copyOf(identifiers))
+                .build();
+    }
+
+    @Test
+    void twoDestinationsSharingOneFilterBothReceiveTheMessage() {
+        // The case the topic tree cannot express itself: registering one filter twice REPLACES the first
+        // subscription, so both destinations would be reachable through a single identifier or not at all.
+        // The fan-out therefore lives in the subscriber, and this is what pins it.
+        //
+        // Southbound, these two are one adapter::tag with TWO southbound mappings on one topic -- alike in
+        // everything the mapping holds, and told apart only by a key the consumer minted. Both must arrive:
+        // two mappings mean two writes, whatever they have in common. Hence the deduplication below is over
+        // the WHOLE context, so a consumer that needs two of them kept apart can say so by putting something
+        // distinguishing in it.
+        final List<Destination> matched = new ArrayList<>();
+        queued.add(messageMatching("a", 1));
+
+        factory.builder("test", "shared-filter")
+                .addTopicFilterContext(to("commands/#", "mapping-A"))
+                .addTopicFilterContext(to("commands/#", "mapping-B"))
+                .<Destination>withAsyncContextProcessor((m, destinations) -> {
+                    matched.addAll(destinations);
+                    return CompletableFuture.completedFuture(null);
+                })
+                .build()
+                .consume();
+
+        assertThat(matched).containsExactlyInAnyOrder(to("commands/#", "mapping-A"), to("commands/#", "mapping-B"));
+    }
+
+    @Test
+    void oneContextRegisteredTwiceIsDeliveredOnce() {
+        // The union is over the CONTEXTS, not the identifiers. Two identifiers come back when both filters
+        // match, and doing the same destination's work twice for one message would, for a device write, send
+        // the same command twice. Equal contexts therefore collapse -- which is what makes the record's
+        // component-wise equality part of the contract rather than a convenience.
+        //
+        // ONE identifier here, not two: both registrations name the same filter, so both sit behind the one
+        // identifier that filter was assigned. The deduplication is within that list.
+        final List<Destination> matched = new ArrayList<>();
+        queued.add(messageMatching("a", 1));
+
+        factory.builder("test", "two-filters")
+                .addTopicFilterContext(to("commands/#", "the-same-mapping"))
+                .addTopicFilterContext(to("commands/#", "the-same-mapping"))
+                .<Destination>withAsyncContextProcessor((m, destinations) -> {
+                    matched.addAll(destinations);
+                    return CompletableFuture.completedFuture(null);
+                })
+                .build()
+                .consume();
+
+        assertThat(matched).containsExactly(to("commands/#", "the-same-mapping"));
+    }
+
+    @Test
+    void severalMatchingFiltersYieldTheirSeveralDestinations() {
+        final List<Destination> matched = new ArrayList<>();
+        queued.add(messageMatching("a", 1, 3));
+
+        factory.builder("test", "several")
+                .addTopicFilterContext(to("commands/#", "first"))
+                .addTopicFilterContext(to("other/#", "second"))
+                .addTopicFilterContext(to("commands/setpoint", "third"))
+                .<Destination>withAsyncContextProcessor((m, destinations) -> {
+                    matched.addAll(destinations);
+                    return CompletableFuture.completedFuture(null);
+                })
+                .build()
+                .consume();
+
+        assertThat(matched).containsExactlyInAnyOrder(to("commands/#", "first"), to("commands/setpoint", "third"));
+    }
+
+    @Test
+    void aListOfContextsRegistersEveryOne() {
+        // The list form is what a consumer with a configured set of mappings actually calls, and it exists
+        // under its own name because withTopicFilter(List<String>) and a List of contexts have the same
+        // erasure -- they could not be two overloads of one name.
+        final List<Destination> matched = new ArrayList<>();
+        queued.add(messageMatching("a", 1, 2));
+
+        factory.builder("test", "list-form")
+                .withTopicFilterContext(List.of(to("commands/#", "first"), to("commands/setpoint", "second")))
+                .<Destination>withAsyncContextProcessor((m, destinations) -> {
+                    matched.addAll(destinations);
+                    return CompletableFuture.completedFuture(null);
+                })
+                .build()
+                .consume();
+
+        assertThat(matched).containsExactlyInAnyOrder(to("commands/#", "first"), to("commands/setpoint", "second"));
+    }
+
+    @Test
+    void removingOneContextLeavesTheFilterForTheOthers() {
+        // Removal is by EQUALITY, and it takes away one destination rather than the filter: the other
+        // destination on that filter must go on receiving. removeTopicFilter, by contrast, drops the filter
+        // and everything behind it.
+        final List<Destination> matched = new ArrayList<>();
+        queued.add(messageMatching("a", 1));
+
+        factory.builder("test", "remove-one")
+                .addTopicFilterContext(to("commands/#", "keep"))
+                .addTopicFilterContext(to("commands/#", "drop"))
+                // A DIFFERENT but equal object, so this can only work by equals() rather than by identity.
+                .removeTopicFilterContext(to("commands/#", "drop"))
+                .<Destination>withAsyncContextProcessor((m, destinations) -> {
+                    matched.addAll(destinations);
+                    return CompletableFuture.completedFuture(null);
+                })
+                .build()
+                .consume();
+
+        assertThat(matched).containsExactly(to("commands/#", "keep"));
+    }
+
+    @Test
+    void mixingContextsAndBareFiltersIsRejected() {
+        // Half a routing table hands the consumer an empty set for the bare filters -- "this matched
+        // something you did not name" -- which is a trap rather than a feature.
+        assertThatThrownBy(() -> factory.builder("test", "mixed")
+                        .addTopicFilterContext(to("commands/#", "routed"))
+                        .addTopicFilter("other/#")
+                        .withAsyncContextProcessor((m, d) -> CompletableFuture.completedFuture(null))
+                        .build())
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("other/#");
+    }
+
+    @Test
+    void contextsWithoutAContextProcessorAreRejected() {
+        assertThatThrownBy(() -> factory.builder("test", "no-routing-processor")
+                        .addTopicFilterContext(to("commands/#", "routed"))
+                        .withProcessor(m -> {})
+                        .build())
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("withAsyncContextProcessor");
+    }
+
+    @Test
+    void twoProcessorsAreRejected() {
+        assertThatThrownBy(() -> factory.builder("test", "two-processors")
+                        .withProcessor(m -> {})
+                        .withAsyncContextProcessor((m, d) -> CompletableFuture.completedFuture(null))
+                        .build())
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("one processor");
+    }
+
+    @Test
+    void aFilterIsRegisteredWithTheSameIdentifierAcrossDetachAndAttach() {
+        // Re-allocating on re-attach stays internally consistent and fails only on one path: a message
+        // queued BEFORE the detach carries the old identifier and is read after it. Since the identifier
+        // travels with the queued message, that window is real.
+        //
+        // Asserted against the REAL topic tree rather than against the subscriber's own map: the map is
+        // written once at construction, so reading it back would pass however addToTree behaved. What has to
+        // be pinned is the identifier the tree was told, on the second attach.
+        final InternalTopicFilterSubscriber subscriber = factory.builder("test", "detach-reattach")
+                .addTopicFilterContext(to("commands/#", "mapping-A"))
+                .withAsyncContextProcessor((m, destinations) -> CompletableFuture.completedFuture(null))
+                .build();
+
+        subscriber.attach();
+        final ImmutableIntArray firstAttach = registeredIdentifiers();
+
+        subscriber.detach();
+        subscriber.attach();
+        final ImmutableIntArray secondAttach = registeredIdentifiers();
+
+        assertThat(firstAttach.asList())
+                .as("a routed filter is registered with an identifier")
+                .isNotEmpty();
+        assertThat(secondAttach.asList())
+                .as("and re-attaching registers the same one, so a message queued before the detach still resolves")
+                .isEqualTo(firstAttach.asList());
+    }
+
+    /// What the real topic tree reports for a matching topic -- the identifiers it was actually told.
+    private @NotNull ImmutableIntArray registeredIdentifiers() {
+        return topicTree.findTopicSubscribers("commands/setpoint").getSubscribers().stream()
+                .findFirst()
+                .map(SubscriberWithIdentifiers::getSubscriptionIdentifier)
+                .orElse(ImmutableIntArray.of());
+    }
+
+    // -- the context filter verbs at RUNTIME ------------------------------------------------------------
+    //
+    // These were build-time only, which made addTopicFilter on a context subscriber a silent trap: the filter
+    // was registered with no identifier, so its messages arrived with an empty matched set and were dropped.
+    // The verbs below close that, and each test here pins one half of why.
+
+    @Test
+    void aContextAddedAtRuntimeReceivesItsMessages() {
+        // The whole point of the runtime family: a destination added to a LIVE subscriber is reachable, which
+        // means its filter went into the tree WITH an identifier. Registering it without one is the silent
+        // failure this replaces -- the message arrives and resolves to nothing.
+        final List<Destination> matched = new ArrayList<>();
+
+        final InternalTopicFilterSubscriber subscriber = factory.builder("test", "runtime-add")
+                .<Destination>withAsyncContextProcessor((m, destinations) -> {
+                    matched.addAll(destinations);
+                    return CompletableFuture.completedFuture(null);
+                })
+                .build()
+                .attach();
+
+        subscriber.addTopicFilterContext(to("commands/#", "added-later"));
+
+        final ImmutableIntArray registered = registeredIdentifiers();
+        assertThat(registered.asList())
+                .as("a context added at runtime is registered WITH an identifier")
+                .isNotEmpty();
+
+        queued.add(messageMatching("a", registered.get(0)));
+        subscriber.consume();
+
+        assertThat(matched).containsExactly(to("commands/#", "added-later"));
+    }
+
+    @Test
+    void removingTheLastContextOfAFilterUnsubscribesIt() {
+        // Two destinations on one filter: removing one leaves the filter, removing the other takes it away.
+        // A filter kept with no contexts behind it would accept messages into the queue and then drop them.
+        final InternalTopicFilterSubscriber subscriber = factory.builder("test", "runtime-remove")
+                .addTopicFilterContext(to("commands/#", "first"))
+                .addTopicFilterContext(to("commands/#", "second"))
+                .withAsyncContextProcessor((m, destinations) -> CompletableFuture.completedFuture(null))
+                .build()
+                .attach();
+
+        subscriber.removeTopicFilterContext(to("commands/#", "first"));
+        assertThat(registeredIdentifiers().asList())
+                .as("the filter stays while another context still wants it")
+                .isNotEmpty();
+
+        subscriber.removeTopicFilterContext(to("commands/#", "second"));
+        assertThat(registeredIdentifiers().asList())
+                .as("and goes when the last one is removed")
+                .isEmpty();
+    }
+
+    @Test
+    void aRuntimeAddedFilterKeepsItsIdentifierAcrossDetachAndAttach() {
+        // Same guarantee as for a build-time filter, and it has to hold for these too: the identifier travels
+        // with a queued message, so a filter that came back with a different one would strand it.
+        final InternalTopicFilterSubscriber subscriber = factory.builder("test", "runtime-stability")
+                .withAsyncContextProcessor((m, destinations) -> CompletableFuture.completedFuture(null))
+                .build()
+                .attach();
+
+        subscriber.addTopicFilterContext(to("commands/#", "added-later"));
+        final ImmutableIntArray firstAttach = registeredIdentifiers();
+
+        subscriber.detach();
+        subscriber.attach();
+
+        assertThat(firstAttach.asList()).isNotEmpty();
+        assertThat(registeredIdentifiers().asList())
+                .as("a runtime-added filter keeps the identifier it was given")
+                .isEqualTo(firstAttach.asList());
+    }
+
+    @Test
+    void anIdentifierIsNotReusedByTheNextFilter() {
+        // Freed identifiers are not handed straight back: allocation walks forward and wraps, so a message
+        // queued under a removed filter's identifier resolves to nothing rather than to whatever took the
+        // number next. Reuse would deliver it to the wrong destination, which is worse than dropping it.
+        final InternalTopicFilterSubscriber subscriber = factory.builder("test", "no-reuse")
+                .withAsyncContextProcessor((m, destinations) -> CompletableFuture.completedFuture(null))
+                .build()
+                .attach();
+
+        subscriber.addTopicFilterContext(to("commands/#", "first"));
+        final ImmutableIntArray firstIdentifier = registeredIdentifiers();
+
+        subscriber.removeTopicFilterContext(to("commands/#", "first"));
+        subscriber.addTopicFilterContext(to("commands/#", "second"));
+
+        assertThat(firstIdentifier.asList()).isNotEmpty();
+        assertThat(registeredIdentifiers().asList())
+                .as("the next filter gets a fresh identifier, not the one just freed")
+                .isNotEqualTo(firstIdentifier.asList());
+    }
+
+    @Test
+    void aSynchronousContextProcessorIsToldWhatMatchedAndNeedsNoFuture() {
+        // The fourth cell of the grid: being told what a message matched and needing a future are independent
+        // choices, so a consumer whose per-destination work is small says so by returning nothing at all.
+        final List<Destination> matched = new ArrayList<>();
+        queued.add(messageMatching("a", 1));
+        queued.add(messageMatching("b", 1));
+
+        factory.builder("test", "sync-context")
+                .addTopicFilterContext(to("commands/#", "mapping-A"))
+                .<Destination>withContextProcessor((m, destinations) -> matched.addAll(destinations))
+                .build()
+                .consume();
+
+        assertThat(matched)
+                .as("both messages are handled, so returning released the queue just as a future would")
+                .containsExactly(to("commands/#", "mapping-A"), to("commands/#", "mapping-A"));
+    }
+
+    @Test
+    void aThrowingSynchronousContextProcessorStillReleasesTheQueue() {
+        // Same guarantee the plain synchronous form has: a throwing consumer does not stall the queue.
+        //
+        // Two layers deliver that, and this pins the OUTCOME rather than either layer: the builder wraps the
+        // throw into a failed future, and processPublish catches anything that escapes a processor anyway.
+        // Removing the wrapper's catch alone leaves this test green -- verified -- because the outer catch
+        // still releases. What differs is the log line, which this does not assert on.
+        final List<Destination> matched = new ArrayList<>();
+        queued.add(messageMatching("a", 1));
+        queued.add(messageMatching("b", 1));
+
+        factory.builder("test", "sync-context-throwing")
+                .addTopicFilterContext(to("commands/#", "mapping-A"))
+                .<Destination>withContextProcessor((m, destinations) -> {
+                    matched.addAll(destinations);
+                    throw new RuntimeException("boom");
+                })
+                .build()
+                .consume();
+
+        assertThat(matched)
+                .as("the second message arrives, so the first did not stall the queue")
+                .hasSize(2);
+    }
+
+    // -- a processor is never called with the subscriber's monitor held --------------------------------
+    //
+    // Submitting a poll can run the whole cycle INLINE on the calling thread, so a submit made inside a
+    // synchronized verb would call the component's processor inside the monitor. These two pin the split
+    // that prevents it, each from the side that would have failed.
+
+    @Test
+    void aProcessorThatPausesDuringTheFirstDrainActuallyPauses() {
+        // consume() used to set `consuming` AFTER submitting the drain. Running inline -- which the in-memory
+        // single writer does -- the processor saw consuming == false, so pause() hit its "not consuming"
+        // guard and returned a no-op, and consume() then set the flag to true. The component believed it had
+        // paused and had not: the callback stayed armed, so every later message woke the poller.
+        //
+        // Two things had to be true for a pause from inside a processor to mean anything, and neither was:
+        // the flag had to be set before the drain (above), and the poll pipeline had to READ it. It did not --
+        // `consuming` was written by consume()/pause() and consulted by nothing on this path, so a pause
+        // removed the wake-up callback and left the drain running to the end of the queue.
+        final List<String> seen = new ArrayList<>();
+        queued.add(message("a"));
+        queued.add(message("b"));
+
+        // The processor needs its own subscriber, which does not exist until build() returns.
+        final AtomicReference<InternalTopicFilterSubscriber> self = new AtomicReference<>();
+        final InternalTopicFilterSubscriber subscriber = factory.builder("test", "pause-from-processor")
+                .withProcessor(m -> {
+                    seen.add(new String(m.getPayload(), StandardCharsets.UTF_8));
+                    self.get().pause();
+                })
+                .withTopicFilter("commands/#")
+                .build();
+        self.set(subscriber);
+
+        subscriber.consume();
+
+        assertThat(seen)
+                .as("pausing stops the drain in progress, not merely future wake-ups")
+                .containsExactly("a");
+        // And the pause took effect on the callback too, which is what it always did.
+        verify(clientQueuePersistence).removePublishAvailableCallback(subscriber.clientId());
+    }
+
+    @Test
+    void aProcessorMayMutateItsOwnSubscriberDuringTheFirstDrain() {
+        // The monitor is not held while a processor runs, so a filter verb called from inside one acquires
+        // it rather than re-entering it -- and, decisively, a processor that blocks cannot deadlock against
+        // a thread holding it. Which messages such a mutation affects is deliberately undefined; that it
+        // completes at all is not.
+        final List<String> seen = new ArrayList<>();
+        queued.add(message("a"));
+        queued.add(message("b"));
+
+        final AtomicReference<InternalTopicFilterSubscriber> self = new AtomicReference<>();
+        final InternalTopicFilterSubscriber subscriber = factory.builder("test", "mutate-from-processor")
+                .withProcessor(m -> {
+                    seen.add(new String(m.getPayload(), StandardCharsets.UTF_8));
+                    // Both families of change, from inside the processor, on the subscriber delivering it.
+                    self.get().addTopicFilter("commands/extra");
+                    self.get().removeTopicFilter("commands/extra");
+                })
+                .withTopicFilter("commands/#")
+                .build();
+        self.set(subscriber);
+
+        subscriber.attach();
+        subscriber.consume();
+
+        assertThat(seen)
+                .as("both messages are delivered; the mutations neither blocked nor deadlocked")
+                .containsExactly("a", "b");
+    }
+
+    @Test
+    void theWrongFamilyOfFilterVerbsIsRejected() {
+        // The processor decides which family applies, so the other one is a mistake that can be named rather
+        // than a state the subscriber has to represent. Both directions, since either is easy to reach when
+        // the subscriber is built far from where its filters are set.
+        final InternalTopicFilterSubscriber contextual = factory.builder("test", "wrong-family-context")
+                .withAsyncContextProcessor((m, destinations) -> CompletableFuture.completedFuture(null))
+                .build();
+
+        assertThatThrownBy(() -> contextual.addTopicFilter("commands/#"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("addTopicFilterContext");
+
+        final InternalTopicFilterSubscriber plain = factory.builder("test", "wrong-family-plain")
+                .withProcessor(message -> {})
+                .build();
+
+        assertThatThrownBy(() -> plain.addTopicFilterContext(to("commands/#", "nope")))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("addTopicFilter");
+    }
+
+    @Test
+    void anAbsoluteFilterCallOnTheBuilderIsRejectedOnceFiltersAreDeclared() {
+        // On the BUILDER the set starts empty and only these calls fill it, so a `with` that finds filters
+        // already there is silently discarding what the caller just declared -- which nobody means. The same
+        // verb on the live subscriber keeps its replacing sense, where a whole new set is an ordinary wish.
+        assertThatThrownBy(() -> factory.builder("test", "double-with-bare")
+                        .withProcessor(m -> {})
+                        .withTopicFilter("commands/#")
+                        .withTopicFilter("commands/setpoint"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("addTopicFilter")
+                .hasMessageContaining("commands/#");
+
+        assertThatThrownBy(() -> factory.builder("test", "double-with-context")
+                        .withAsyncContextProcessor((m, d) -> CompletableFuture.completedFuture(null))
+                        .withTopicFilterContext(to("commands/#", "first"))
+                        .withTopicFilterContext(to("other/#", "second")))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("addTopicFilterContext");
+
+        // Both families are checked, so mixing them is caught at the call that did it rather than at build().
+        assertThatThrownBy(() -> factory.builder("test", "mixed-families")
+                        .withAsyncContextProcessor((m, d) -> CompletableFuture.completedFuture(null))
+                        .addTopicFilter("commands/#")
+                        .withTopicFilterContext(to("other/#", "second")))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("commands/#");
+    }
+
+    @Test
+    void repeatedRelativeFilterCallsOnTheBuilderAccumulate() {
+        // The counterpart: `add` is what a caller declaring filters one at a time actually wants, and it
+        // stays legal however many times it is called. Pins that the guard above did not over-reach.
+        final List<Destination> matched = new ArrayList<>();
+        queued.add(messageMatching("a", 1));
+
+        factory.builder("test", "repeated-add")
+                .addTopicFilterContext(to("commands/#", "first"))
+                .addTopicFilterContext(to("commands/#", "second"))
+                .<Destination>withAsyncContextProcessor((m, destinations) -> {
+                    matched.addAll(destinations);
+                    return CompletableFuture.completedFuture(null);
+                })
+                .build()
+                .consume();
+
+        assertThat(matched).containsExactlyInAnyOrder(to("commands/#", "first"), to("commands/#", "second"));
+    }
+
+    @Test
+    void filtersGivenInTheWrongFamilyAtBuildTimeAreRejected() {
+        assertThatThrownBy(() -> factory.builder("test", "bare-with-context-processor")
+                        .addTopicFilter("commands/#")
+                        .withAsyncContextProcessor((m, destinations) -> CompletableFuture.completedFuture(null))
+                        .build())
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("commands/#");
+    }
+
+    @Test
+    void withTopicFilterContextReplacesTheWholeSet() {
+        // The absolute form, at runtime: what is no longer wanted leaves the tree, what is new enters it.
+        final InternalTopicFilterSubscriber subscriber = factory.builder("test", "runtime-with")
+                .addTopicFilterContext(to("commands/#", "old"))
+                .withAsyncContextProcessor((m, destinations) -> CompletableFuture.completedFuture(null))
+                .build()
+                .attach();
+
+        assertThat(registeredIdentifiers().asList()).isNotEmpty();
+
+        subscriber.withTopicFilterContext(to("other/#", "new"));
+
+        assertThat(registeredIdentifiers().asList())
+                .as("the replaced filter is gone from the tree")
+                .isEmpty();
+        assertThat(topicTree.findTopicSubscribers("other/thing").getSubscribers())
+                .as("and the new one is in it")
+                .isNotEmpty();
+    }
+
+    @Test
+    void withTopicFilterContextWhileDetachedTakesEffectOnTheNextAttach() {
+        // The detached counterpart of the test above, and the reason it is worth its own case: the two states
+        // take different routes. When ATTACHED, reconciliation registers each new filter and allocates its
+        // identifier on the way. When DETACHED there is nothing in the tree to reconcile, so the allocation
+        // happens in the calling method instead -- the one place it lives outside the shared helper.
+        //
+        // What must hold either way: the new filter reaches the tree WITH an identifier when attach() finally
+        // runs. Without one it would register anyway (the topic tree accepts a null identifier), messages would
+        // match it, and they would arrive resolving to no destination at all -- silently.
+        final List<Destination> matched = new ArrayList<>();
+        final InternalTopicFilterSubscriber subscriber = factory.builder("test", "detached-with")
+                .addTopicFilterContext(to("commands/#", "old"))
+                .<Destination>withAsyncContextProcessor((m, destinations) -> {
+                    matched.addAll(destinations);
+                    return CompletableFuture.completedFuture(null);
+                })
+                .build();
+
+        // Never attached, so the tree has nothing and reconciliation has nothing to do.
+        subscriber.withTopicFilterContext(to("commands/setpoint", "new"));
+        assertThat(registeredIdentifiers().asList())
+                .as("nothing is registered while detached")
+                .isEmpty();
+
+        subscriber.attach();
+
+        final ImmutableIntArray registered = registeredIdentifiers();
+        assertThat(registered.asList())
+                .as("the replacement filter reaches the tree with an identifier")
+                .isNotEmpty();
+
+        queued.add(messageMatching("a", registered.get(0)));
+        subscriber.consume();
+
+        assertThat(matched)
+                .as("and resolves to the destination declared while detached, not the one it replaced")
+                .containsExactly(to("commands/setpoint", "new"));
+    }
+
+    // -- queue limit and overflow ----------------------------------------------------------------------
+
+    @Test
+    void aSubscriberThatDeclaresNothingGetsTheBrokerDefaults() {
+        // Null on both, which is what the distributor and the persistence read as "use the configured
+        // broker-wide values". Declaring nothing must not mean an unbounded queue.
+        final InternalTopicFilterSubscriber subscriber = factory.builder("test", "no-opinion")
+                .withProcessor(m -> {})
+                .withTopicFilter("commands/#")
+                .build();
+
+        assertThat(subscriber.queueLimit()).isNull();
+        assertThat(subscriber.queueOverflow()).isNull();
+    }
+
+    @Test
+    void aSubscriberCarriesTheLimitAndOverflowItDeclared() {
+        // These are read at delivery time, by the distributor and the queue persistence, through the factory
+        // registry -- the same hook ingress-exclusion uses. What this pins is that the subscriber carries them
+        // at all, which is what makes the prefix special-cases in those two classes deletable.
+        final InternalTopicFilterSubscriber subscriber = factory.builder("test", "opinionated")
+                .withProcessor(m -> {})
+                .withTopicFilter("commands/#")
+                .withQueueLimit(10)
+                .withQueueOverflow(QueuedMessagesStrategy.DISCARD_OLDEST)
+                .build();
+
+        assertThat(subscriber.queueLimit()).isEqualTo(10L);
+        assertThat(subscriber.queueOverflow()).isEqualTo(QueuedMessagesStrategy.DISCARD_OLDEST);
+    }
+
+    @Test
+    void aSubscriberIsReachableByItsQueueIdFromTheRegistry() {
+        // The lookup both consumption points make: they hold a queue id and need the subscriber that owns it.
+        // A subscriber whose declared values cannot be found this way has declared them to nobody.
+        final InternalTopicFilterSubscriber subscriber = factory.builder("test", "findable")
+                .withProcessor(m -> {})
+                .withTopicFilter("commands/#")
+                .withQueueLimit(7)
+                .build();
+
+        assertThat(factory.getSubscriber(subscriber.clientId())).isSameAs(subscriber);
+        assertThat(factory.getSubscriber(subscriber.clientId()).queueLimit()).isEqualTo(7L);
+    }
+
+    @Test
+    void aProcessorThatNeverAnswersStallsOnlyItself() {
+        // The honest consequence of the bound, stated rather than hidden: a consumer that never completes
+        // its future stops its own subscriber and nothing else. That is why a firing timeout deserves a
+        // metric -- it always means a bug in the consumer.
+        queued.add(message("a"));
+        queued.add(message("b"));
+
+        factory.builder("test", "silent")
+                .withAsyncProcessor(m -> new CompletableFuture<>())
+                .withTopicFilter("commands/#")
+                .build()
+                .consume();
+
+        assertThat(reads.get())
+                .as("one read, and no further read while the first is unanswered")
+                .isEqualTo(1);
+    }
+}

--- a/hivemq-edge/src/test/java/com/hivemq/persistence/clientqueue/InternalTopicFilterSubscriberAsyncTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/persistence/clientqueue/InternalTopicFilterSubscriberAsyncTest.java
@@ -18,6 +18,7 @@ package com.hivemq.persistence.clientqueue;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -42,6 +43,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import org.jetbrains.annotations.NotNull;
@@ -234,6 +236,50 @@ class InternalTopicFilterSubscriberAsyncTest {
     }
 
     @Test
+    void aFailedReadEndsTheLoopSoTheSubscriberRecovers() {
+        // A read that FAILS must end the running loop exactly as an empty or successful one does. It used to be
+        // attached with a success-only transform, so an exceptionally completed read ran nothing at all: the
+        // loop stayed marked as running for ever and every later trigger found one in progress and did nothing,
+        // silently, including after a pause and resume. The enclosing try/catch did not help -- a future
+        // completing exceptionally is not a throw from the try block. Reported by Sam on #1752.
+        final List<String> seen = new ArrayList<>();
+        final AtomicBoolean failNextRead = new AtomicBoolean(true);
+
+        when(clientQueuePersistence.readNew(anyString(), any(Boolean.class), any(ImmutableIntArray.class), anyLong()))
+                .thenAnswer(invocation -> {
+                    reads.incrementAndGet();
+                    if (failNextRead.getAndSet(false)) {
+                        return Futures.immediateFailedFuture(new IllegalStateException("persistence is down"));
+                    }
+                    if (queued.isEmpty()) {
+                        return Futures.immediateFuture(ImmutableList.of());
+                    }
+                    return Futures.immediateFuture(ImmutableList.of(queued.remove(0)));
+                });
+
+        final ArgumentCaptor<ClientQueuePersistence.PublishAvailableCallback> callback =
+                ArgumentCaptor.forClass(ClientQueuePersistence.PublishAvailableCallback.class);
+
+        // The drain consume() starts hits the injected failure.
+        final InternalTopicFilterSubscriber subscriber = factory.builder("test", "failed-read")
+                .withProcessor(m -> seen.add(new String(m.getPayload(), StandardCharsets.UTF_8)))
+                .withTopicFilter("commands/#")
+                .build();
+        subscriber.consume();
+
+        assertThat(seen).as("the read failed, so nothing was processed").isEmpty();
+
+        // Recovery: a later wake-up must be acted on rather than declined by a claim nobody released.
+        verify(clientQueuePersistence).addPublishAvailableCallback(callback.capture(), anyString());
+        queued.add(message("a"));
+        callback.getValue().onPublishAvailable(subscriber.clientId());
+
+        assertThat(seen)
+                .as("the failed read ended its loop, so the subscriber is not stalled")
+                .containsExactly("a");
+    }
+
+    @Test
     void aCompletionArrivingAfterStopDoesNotReadFromTheQueue() {
         // stop() FREES THE CLIENT ID, so a replacement subscriber may already own the queue under that name.
         // An outstanding future completing afterwards used to acknowledge and poll regardless -- the discarded
@@ -269,6 +315,43 @@ class InternalTopicFilterSubscriberAsyncTest {
         assertThat(reads.get())
                 .as("and does not read the queue at all, which a replacement may now own")
                 .isEqualTo(readsBeforeCompletion);
+    }
+
+    @Test
+    void aTeardownAskedForMidIterationWaitsForThatIterationToFinish() {
+        // THE CASE THE TEARDOWN EVENT EXISTS FOR. deallocate() destroys the queue and hands the client id back
+        // for reuse. Doing that while an iteration is in flight -- a message with the consumer's processor,
+        // messages already read sitting in the subscriber -- races the very queue it destroys, and frees an
+        // identity a replacement may take while the old loop is still reading under it.
+        //
+        // So the request is REGISTERED and acted on only when the loop next reaches its controller, which is a
+        // point between iterations. Here: nothing is destroyed while the processor holds the message, and the
+        // teardown happens the moment it completes.
+        final List<CompletableFuture<Void>> outstanding = new ArrayList<>();
+        queued.add(message("a"));
+
+        final InternalTopicFilterSubscriber subscriber = factory.builder("test", "teardown-mid-iteration")
+                .withAsyncProcessor(m -> {
+                    final CompletableFuture<Void> completion = new CompletableFuture<>();
+                    outstanding.add(completion);
+                    return completion;
+                })
+                .withTopicFilter("commands/#")
+                .build();
+        subscriber.consume();
+
+        assertThat(outstanding).as("an iteration is in flight").hasSize(1);
+
+        subscriber.deallocate();
+        verify(clientQueuePersistence, never())
+                .clear(anyString(), anyBoolean()); // NOT while the processor still holds the message
+
+        outstanding.get(0).complete(null);
+
+        verify(clientQueuePersistence).clear(subscriber.clientId(), false);
+        assertThatThrownBy(subscriber::attach)
+                .as("and the subscriber is dead once the loop has done it")
+                .isInstanceOf(IllegalStateException.class);
     }
 
     @Test
@@ -314,6 +397,48 @@ class InternalTopicFilterSubscriberAsyncTest {
 
         assertThat(seen).as("the message was delivered").containsExactly("a");
         verify(clientQueuePersistence, never()).remove(anyString(), anyInt());
+    }
+
+    @Test
+    void everyMessageAReadReturnsIsProcessed_notJustTheFirst() {
+        // A READ CAN RETURN MORE THAN ONE MESSAGE EVEN THOUGH WE ASK FOR ONE. The argument that looks like a
+        // count is a supply of packet ids to STAMP messages with, and a QoS 0 message needs no stamp -- so on a
+        // queue holding both kinds the store hands back one stamped message AND one QoS 0 message, the latter
+        // added before the count limit is re-tested.
+        //
+        // Taking only the first and dropping the rest LOSES messages outright: reading a QoS 0 message removes
+        // it from the store, so a dropped one is not delayed or redelivered, it is gone, with nothing logged.
+        // This stubs a read that returns two, as the real store does, and pins that both arrive.
+        final List<String> seen = new ArrayList<>();
+
+        final PUBLISH stamped = message("qos1");
+        final PUBLISH alongside = new PUBLISHFactory.Mqtt5Builder()
+                .withHivemqId("edge1")
+                .withTopic("commands/setpoint")
+                .withQoS(QoS.AT_MOST_ONCE)
+                .withOnwardQos(QoS.AT_MOST_ONCE)
+                .withPayload("qos0".getBytes(StandardCharsets.UTF_8))
+                .build();
+
+        final AtomicBoolean firstRead = new AtomicBoolean(true);
+        when(clientQueuePersistence.readNew(anyString(), any(Boolean.class), any(ImmutableIntArray.class), anyLong()))
+                .thenAnswer(invocation -> {
+                    reads.incrementAndGet();
+                    if (firstRead.getAndSet(false)) {
+                        return Futures.immediateFuture(ImmutableList.of(stamped, alongside));
+                    }
+                    return Futures.immediateFuture(ImmutableList.of());
+                });
+
+        factory.builder("test", "two-from-one-read")
+                .withProcessor(m -> seen.add(new String(m.getPayload(), StandardCharsets.UTF_8)))
+                .withTopicFilter("commands/#")
+                .build()
+                .consume();
+
+        assertThat(seen)
+                .as("both messages the single read returned are processed, in order")
+                .containsExactly("qos1", "qos0");
     }
 
     @Test
@@ -780,6 +905,34 @@ class InternalTopicFilterSubscriberAsyncTest {
                 .containsExactly("a");
         // And the pause took effect on the callback too, which is what it always did.
         verify(clientQueuePersistence).removePublishAvailableCallback(subscriber.clientId());
+    }
+
+    @Test
+    void aTriggerArrivingWhilePausedDoesNotDrain() {
+        // WHY THE LOOP STILL READS `consuming` AND NOT ONLY THE COMMANDS IT IS SENT. pause() sends a STOP so
+        // that a pause takes effect promptly, but that is an EVENT -- it says "stop now", not "stay stopped".
+        // The message-available callback is deregistered on the caller's thread, so a message may already be
+        // in flight towards it, and a START arriving after the pause would otherwise drain a paused
+        // subscriber. The standing fact is what refuses it.
+        final List<String> seen = new ArrayList<>();
+
+        final ArgumentCaptor<ClientQueuePersistence.PublishAvailableCallback> callback =
+                ArgumentCaptor.forClass(ClientQueuePersistence.PublishAvailableCallback.class);
+
+        final InternalTopicFilterSubscriber subscriber = factory.builder("test", "trigger-while-paused")
+                .withProcessor(m -> seen.add(new String(m.getPayload(), StandardCharsets.UTF_8)))
+                .withTopicFilter("commands/#")
+                .build();
+        subscriber.consume();
+        verify(clientQueuePersistence).addPublishAvailableCallback(callback.capture(), anyString());
+
+        subscriber.pause();
+
+        // A message arrives, and the callback fires -- as one already in flight would.
+        queued.add(message("a"));
+        callback.getValue().onPublishAvailable(subscriber.clientId());
+
+        assertThat(seen).as("a paused subscriber processes nothing").isEmpty();
     }
 
     @Test

--- a/hivemq-edge/src/test/java/com/hivemq/persistence/clientqueue/InternalTopicFilterSubscriberAsyncTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/persistence/clientqueue/InternalTopicFilterSubscriberAsyncTest.java
@@ -35,7 +35,6 @@ import com.hivemq.metrics.MetricsHolder;
 import com.hivemq.mqtt.message.QoS;
 import com.hivemq.mqtt.message.publish.PUBLISH;
 import com.hivemq.mqtt.message.publish.PUBLISHFactory;
-import com.hivemq.mqtt.topic.SubscriberWithIdentifiers;
 import com.hivemq.mqtt.topic.tree.LocalTopicTree;
 import com.hivemq.persistence.ProducerQueues;
 import com.hivemq.persistence.SingleWriterService;
@@ -48,6 +47,8 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.ArgumentCaptor;
 
 /// The one-message-in-flight bound, and what it rests on.
@@ -64,7 +65,7 @@ class InternalTopicFilterSubscriberAsyncTest {
 
     private @NotNull ClientQueuePersistence clientQueuePersistence;
     private @NotNull InternalTopicFilterSubscriberFactory factory;
-    private @NotNull LocalTopicTree topicTree; // REAL -- the identifier test asserts what the tree was told
+    private @NotNull LocalTopicTree topicTree; // REAL -- several tests assert what the tree was actually told
 
     /// Every message the stubbed queue has been asked for, so a test can count reads.
     private final @NotNull AtomicInteger reads = new AtomicInteger();
@@ -391,15 +392,20 @@ class InternalTopicFilterSubscriberAsyncTest {
         return new Destination(topicFilter, name);
     }
 
-    /// As the topic tree would: the identifiers of every filter that matched.
-    private @NotNull PUBLISH messageMatching(final @NotNull String payload, final int... identifiers) {
+    /// A message on the default topic. Which filters it matched is NOT stated here: the subscriber works that
+    /// out when it polls, by matching this topic against its own filters, so a message carries only its topic.
+    private @NotNull PUBLISH messageMatching(final @NotNull String payload) {
+        return messageOn("commands/setpoint", payload);
+    }
+
+    /// A message on a given topic, for pinning which of several filters it does and does not match.
+    private @NotNull PUBLISH messageOn(final @NotNull String topic, final @NotNull String payload) {
         return new PUBLISHFactory.Mqtt5Builder()
                 .withHivemqId("edge1")
-                .withTopic("commands/setpoint")
+                .withTopic(topic)
                 .withQoS(QoS.AT_LEAST_ONCE)
                 .withOnwardQos(QoS.AT_LEAST_ONCE)
                 .withPayload(payload.getBytes(StandardCharsets.UTF_8))
-                .withSubscriptionIdentifiers(ImmutableIntArray.copyOf(identifiers))
                 .build();
     }
 
@@ -415,7 +421,7 @@ class InternalTopicFilterSubscriberAsyncTest {
         // the WHOLE context, so a consumer that needs two of them kept apart can say so by putting something
         // distinguishing in it.
         final List<Destination> matched = new ArrayList<>();
-        queued.add(messageMatching("a", 1));
+        queued.add(messageMatching("a"));
 
         factory.builder("test", "shared-filter")
                 .addTopicFilterContext(to("commands/#", "mapping-A"))
@@ -440,7 +446,7 @@ class InternalTopicFilterSubscriberAsyncTest {
         // ONE identifier here, not two: both registrations name the same filter, so both sit behind the one
         // identifier that filter was assigned. The deduplication is within that list.
         final List<Destination> matched = new ArrayList<>();
-        queued.add(messageMatching("a", 1));
+        queued.add(messageMatching("a"));
 
         factory.builder("test", "two-filters")
                 .addTopicFilterContext(to("commands/#", "the-same-mapping"))
@@ -457,8 +463,10 @@ class InternalTopicFilterSubscriberAsyncTest {
 
     @Test
     void severalMatchingFiltersYieldTheirSeveralDestinations() {
+        // "other/#" is excluded because it does not MATCH the message's topic -- the subscriber works that out
+        // from the topic itself, rather than being told which filters matched.
         final List<Destination> matched = new ArrayList<>();
-        queued.add(messageMatching("a", 1, 3));
+        queued.add(messageMatching("a"));
 
         factory.builder("test", "several")
                 .addTopicFilterContext(to("commands/#", "first"))
@@ -480,7 +488,7 @@ class InternalTopicFilterSubscriberAsyncTest {
         // under its own name because withTopicFilter(List<String>) and a List of contexts have the same
         // erasure -- they could not be two overloads of one name.
         final List<Destination> matched = new ArrayList<>();
-        queued.add(messageMatching("a", 1, 2));
+        queued.add(messageMatching("a"));
 
         factory.builder("test", "list-form")
                 .withTopicFilterContext(List.of(to("commands/#", "first"), to("commands/setpoint", "second")))
@@ -500,7 +508,7 @@ class InternalTopicFilterSubscriberAsyncTest {
         // destination on that filter must go on receiving. removeTopicFilter, by contrast, drops the filter
         // and everything behind it.
         final List<Destination> matched = new ArrayList<>();
-        queued.add(messageMatching("a", 1));
+        queued.add(messageMatching("a"));
 
         factory.builder("test", "remove-one")
                 .addTopicFilterContext(to("commands/#", "keep"))
@@ -551,53 +559,49 @@ class InternalTopicFilterSubscriberAsyncTest {
     }
 
     @Test
-    void aFilterIsRegisteredWithTheSameIdentifierAcrossDetachAndAttach() {
-        // Re-allocating on re-attach stays internally consistent and fails only on one path: a message
-        // queued BEFORE the detach carries the old identifier and is read after it. Since the identifier
-        // travels with the queued message, that window is real.
-        //
-        // Asserted against the REAL topic tree rather than against the subscriber's own map: the map is
-        // written once at construction, so reading it back would pass however addToTree behaved. What has to
-        // be pinned is the identifier the tree was told, on the second attach.
+    void aFilterStillDeliversItsContextsAcrossDetachAndAttach() {
+        // A message queued BEFORE a detach and read after it must still reach its destination. Under the old
+        // scheme this was the one path that broke: the message carried a subscription identifier stamped on it
+        // at enqueue time, and a filter re-registered with a different number stranded it. Matching at POLL
+        // time removes the failure mode rather than working around it -- there is no number to go stale.
+        final List<Destination> matched = new ArrayList<>();
         final InternalTopicFilterSubscriber subscriber = factory.builder("test", "detach-reattach")
                 .addTopicFilterContext(to("commands/#", "mapping-A"))
-                .withAsyncContextProcessor((m, destinations) -> CompletableFuture.completedFuture(null))
+                .<Destination>withAsyncContextProcessor((m, destinations) -> {
+                    matched.addAll(destinations);
+                    return CompletableFuture.completedFuture(null);
+                })
                 .build();
 
         subscriber.attach();
-        final ImmutableIntArray firstAttach = registeredIdentifiers();
+        // Queued while attached the FIRST time, and not read until after the re-attach.
+        queued.add(messageMatching("a"));
 
         subscriber.detach();
         subscriber.attach();
-        final ImmutableIntArray secondAttach = registeredIdentifiers();
+        subscriber.consume();
 
-        assertThat(firstAttach.asList())
-                .as("a routed filter is registered with an identifier")
-                .isNotEmpty();
-        assertThat(secondAttach.asList())
-                .as("and re-attaching registers the same one, so a message queued before the detach still resolves")
-                .isEqualTo(firstAttach.asList());
+        assertThat(matched)
+                .as("a message queued before the detach still reaches its destination after the re-attach")
+                .containsExactly(to("commands/#", "mapping-A"));
     }
 
-    /// What the real topic tree reports for a matching topic -- the identifiers it was actually told.
-    private @NotNull ImmutableIntArray registeredIdentifiers() {
-        return topicTree.findTopicSubscribers("commands/setpoint").getSubscribers().stream()
-                .findFirst()
-                .map(SubscriberWithIdentifiers::getSubscriptionIdentifier)
-                .orElse(ImmutableIntArray.of());
+    /// Whether the real topic tree has this subscriber registered for a topic matching the default filter.
+    private boolean isRegisteredInTree() {
+        return !topicTree
+                .findTopicSubscribers("commands/setpoint")
+                .getSubscribers()
+                .isEmpty();
     }
 
     // -- the context filter verbs at RUNTIME ------------------------------------------------------------
     //
-    // These were build-time only, which made addTopicFilter on a context subscriber a silent trap: the filter
-    // was registered with no identifier, so its messages arrived with an empty matched set and were dropped.
-    // The verbs below close that, and each test here pins one half of why.
+    // These were build-time only, so a live subscriber could not take on a new destination at all. Each test
+    // here pins one half of why the runtime family exists.
 
     @Test
     void aContextAddedAtRuntimeReceivesItsMessages() {
-        // The whole point of the runtime family: a destination added to a LIVE subscriber is reachable, which
-        // means its filter went into the tree WITH an identifier. Registering it without one is the silent
-        // failure this replaces -- the message arrives and resolves to nothing.
+        // The whole point of the runtime family: a destination added to a LIVE subscriber is reachable.
         final List<Destination> matched = new ArrayList<>();
 
         final InternalTopicFilterSubscriber subscriber = factory.builder("test", "runtime-add")
@@ -609,13 +613,11 @@ class InternalTopicFilterSubscriberAsyncTest {
                 .attach();
 
         subscriber.addTopicFilterContext(to("commands/#", "added-later"));
+        assertThat(isRegisteredInTree())
+                .as("a context added at runtime subscribes its filter")
+                .isTrue();
 
-        final ImmutableIntArray registered = registeredIdentifiers();
-        assertThat(registered.asList())
-                .as("a context added at runtime is registered WITH an identifier")
-                .isNotEmpty();
-
-        queued.add(messageMatching("a", registered.get(0)));
+        queued.add(messageMatching("a"));
         subscriber.consume();
 
         assertThat(matched).containsExactly(to("commands/#", "added-later"));
@@ -633,57 +635,65 @@ class InternalTopicFilterSubscriberAsyncTest {
                 .attach();
 
         subscriber.removeTopicFilterContext(to("commands/#", "first"));
-        assertThat(registeredIdentifiers().asList())
+        assertThat(isRegisteredInTree())
                 .as("the filter stays while another context still wants it")
-                .isNotEmpty();
+                .isTrue();
 
         subscriber.removeTopicFilterContext(to("commands/#", "second"));
-        assertThat(registeredIdentifiers().asList())
+        assertThat(isRegisteredInTree())
                 .as("and goes when the last one is removed")
-                .isEmpty();
+                .isFalse();
     }
 
     @Test
-    void aRuntimeAddedFilterKeepsItsIdentifierAcrossDetachAndAttach() {
-        // Same guarantee as for a build-time filter, and it has to hold for these too: the identifier travels
-        // with a queued message, so a filter that came back with a different one would strand it.
+    void aRuntimeAddedFilterStillDeliversAcrossDetachAndAttach() {
+        // Same guarantee as for a build-time filter, and it has to hold for these too.
+        final List<Destination> matched = new ArrayList<>();
         final InternalTopicFilterSubscriber subscriber = factory.builder("test", "runtime-stability")
-                .withAsyncContextProcessor((m, destinations) -> CompletableFuture.completedFuture(null))
+                .<Destination>withAsyncContextProcessor((m, destinations) -> {
+                    matched.addAll(destinations);
+                    return CompletableFuture.completedFuture(null);
+                })
                 .build()
                 .attach();
 
         subscriber.addTopicFilterContext(to("commands/#", "added-later"));
-        final ImmutableIntArray firstAttach = registeredIdentifiers();
+        queued.add(messageMatching("a"));
 
         subscriber.detach();
         subscriber.attach();
+        subscriber.consume();
 
-        assertThat(firstAttach.asList()).isNotEmpty();
-        assertThat(registeredIdentifiers().asList())
-                .as("a runtime-added filter keeps the identifier it was given")
-                .isEqualTo(firstAttach.asList());
+        assertThat(matched)
+                .as("a runtime-added filter goes on delivering after a detach/attach")
+                .containsExactly(to("commands/#", "added-later"));
     }
 
     @Test
-    void anIdentifierIsNotReusedByTheNextFilter() {
-        // Freed identifiers are not handed straight back: allocation walks forward and wraps, so a message
-        // queued under a removed filter's identifier resolves to nothing rather than to whatever took the
-        // number next. Reuse would deliver it to the wrong destination, which is worse than dropping it.
-        final InternalTopicFilterSubscriber subscriber = factory.builder("test", "no-reuse")
-                .withAsyncContextProcessor((m, destinations) -> CompletableFuture.completedFuture(null))
+    void aMessageQueuedUnderARemovedFilterResolvesToNothing() {
+        // A message may sit in the queue while the filter that admitted it is removed and a DIFFERENT filter
+        // is added. It must not be delivered to the new filter's destination -- that would be a write to the
+        // wrong device. Because matching happens at poll time against the filters that exist THEN, the
+        // message simply matches nothing that wants it.
+        final List<Destination> matched = new ArrayList<>();
+        final InternalTopicFilterSubscriber subscriber = factory.builder("test", "no-misdelivery")
+                .<Destination>withAsyncContextProcessor((m, destinations) -> {
+                    matched.addAll(destinations);
+                    return CompletableFuture.completedFuture(null);
+                })
                 .build()
                 .attach();
 
         subscriber.addTopicFilterContext(to("commands/#", "first"));
-        final ImmutableIntArray firstIdentifier = registeredIdentifiers();
+        queued.add(messageMatching("a"));
 
         subscriber.removeTopicFilterContext(to("commands/#", "first"));
-        subscriber.addTopicFilterContext(to("commands/#", "second"));
+        subscriber.addTopicFilterContext(to("telemetry/#", "second"));
+        subscriber.consume();
 
-        assertThat(firstIdentifier.asList()).isNotEmpty();
-        assertThat(registeredIdentifiers().asList())
-                .as("the next filter gets a fresh identifier, not the one just freed")
-                .isNotEqualTo(firstIdentifier.asList());
+        assertThat(matched)
+                .as("the queued message does not reach the destination that replaced the one it matched")
+                .isEmpty();
     }
 
     @Test
@@ -691,8 +701,8 @@ class InternalTopicFilterSubscriberAsyncTest {
         // The fourth cell of the grid: being told what a message matched and needing a future are independent
         // choices, so a consumer whose per-destination work is small says so by returning nothing at all.
         final List<Destination> matched = new ArrayList<>();
-        queued.add(messageMatching("a", 1));
-        queued.add(messageMatching("b", 1));
+        queued.add(messageMatching("a"));
+        queued.add(messageMatching("b"));
 
         factory.builder("test", "sync-context")
                 .addTopicFilterContext(to("commands/#", "mapping-A"))
@@ -714,8 +724,8 @@ class InternalTopicFilterSubscriberAsyncTest {
         // Removing the wrapper's catch alone leaves this test green -- verified -- because the outer catch
         // still releases. What differs is the log line, which this does not assert on.
         final List<Destination> matched = new ArrayList<>();
-        queued.add(messageMatching("a", 1));
-        queued.add(messageMatching("b", 1));
+        queued.add(messageMatching("a"));
+        queued.add(messageMatching("b"));
 
         factory.builder("test", "sync-context-throwing")
                 .addTopicFilterContext(to("commands/#", "mapping-A"))
@@ -858,7 +868,7 @@ class InternalTopicFilterSubscriberAsyncTest {
         // The counterpart: `add` is what a caller declaring filters one at a time actually wants, and it
         // stays legal however many times it is called. Pins that the guard above did not over-reach.
         final List<Destination> matched = new ArrayList<>();
-        queued.add(messageMatching("a", 1));
+        queued.add(messageMatching("a"));
 
         factory.builder("test", "repeated-add")
                 .addTopicFilterContext(to("commands/#", "first"))
@@ -892,13 +902,13 @@ class InternalTopicFilterSubscriberAsyncTest {
                 .build()
                 .attach();
 
-        assertThat(registeredIdentifiers().asList()).isNotEmpty();
+        assertThat(isRegisteredInTree()).isTrue();
 
         subscriber.withTopicFilterContext(to("other/#", "new"));
 
-        assertThat(registeredIdentifiers().asList())
+        assertThat(isRegisteredInTree())
                 .as("the replaced filter is gone from the tree")
-                .isEmpty();
+                .isFalse();
         assertThat(topicTree.findTopicSubscribers("other/thing").getSubscribers())
                 .as("and the new one is in it")
                 .isNotEmpty();
@@ -906,14 +916,12 @@ class InternalTopicFilterSubscriberAsyncTest {
 
     @Test
     void withTopicFilterContextWhileDetachedTakesEffectOnTheNextAttach() {
-        // The detached counterpart of the test above, and the reason it is worth its own case: the two states
-        // take different routes. When ATTACHED, reconciliation registers each new filter and allocates its
-        // identifier on the way. When DETACHED there is nothing in the tree to reconcile, so the allocation
-        // happens in the calling method instead -- the one place it lives outside the shared helper.
+        // The detached counterpart of the test above, and worth its own case because the two states take
+        // different routes: when ATTACHED the tree is reconciled filter by filter, when DETACHED there is
+        // nothing registered to reconcile and the whole set is replayed by attach() instead.
         //
-        // What must hold either way: the new filter reaches the tree WITH an identifier when attach() finally
-        // runs. Without one it would register anyway (the topic tree accepts a null identifier), messages would
-        // match it, and they would arrive resolving to no destination at all -- silently.
+        // What must hold either way: after attach() the subscriber delivers to the destination declared while
+        // detached, and not to the one it replaced.
         final List<Destination> matched = new ArrayList<>();
         final InternalTopicFilterSubscriber subscriber = factory.builder("test", "detached-with")
                 .addTopicFilterContext(to("commands/#", "old"))
@@ -925,23 +933,100 @@ class InternalTopicFilterSubscriberAsyncTest {
 
         // Never attached, so the tree has nothing and reconciliation has nothing to do.
         subscriber.withTopicFilterContext(to("commands/setpoint", "new"));
-        assertThat(registeredIdentifiers().asList())
+        assertThat(isRegisteredInTree())
                 .as("nothing is registered while detached")
-                .isEmpty();
+                .isFalse();
 
         subscriber.attach();
+        assertThat(isRegisteredInTree())
+                .as("the replacement filter reaches the tree on attach")
+                .isTrue();
 
-        final ImmutableIntArray registered = registeredIdentifiers();
-        assertThat(registered.asList())
-                .as("the replacement filter reaches the tree with an identifier")
-                .isNotEmpty();
-
-        queued.add(messageMatching("a", registered.get(0)));
+        queued.add(messageMatching("a"));
         subscriber.consume();
 
         assertThat(matched)
                 .as("and resolves to the destination declared while detached, not the one it replaced")
                 .containsExactly(to("commands/setpoint", "new"));
+    }
+
+    // -- topic filter matching -------------------------------------------------------------------------
+    //
+    // Which filters a message matched is worked out from the message's TOPIC when it is polled, so the matching
+    // rules are now part of delivery and are pinned here. Driven through the public path rather than against the
+    // private matcher, so these test the code that actually runs.
+    //
+    // The cases are chosen for the places hand-written MQTT matchers go wrong, not for coverage of the happy
+    // path: a multi-level wildcard matching its own PARENT, either wildcard matching an EMPTY level, a
+    // single-level wildcard refusing to cross a separator, and a filter that is a strict prefix of the topic.
+
+    @ParameterizedTest(name = "{0} matches {1}")
+    @CsvSource({
+        // exact
+        "commands/setpoint, commands/setpoint",
+        // single-level wildcard
+        "commands/+, commands/setpoint",
+        "+/setpoint, commands/setpoint",
+        "+/+, commands/setpoint",
+        // a single-level wildcard matches an EMPTY level
+        "commands/+, commands/",
+        // multi-level wildcard, including its own parent
+        "commands/#, commands/setpoint",
+        "commands/#, commands/setpoint/deep",
+        "commands/#, commands",
+        "#, commands/setpoint",
+        "#, ''",
+        "+/#, commands",
+        // wildcards combined
+        "commands/+/deep, commands/x/deep",
+        "+/setpoint/#, commands/setpoint/deep",
+    })
+    void theseFiltersMatch(final @NotNull String filter, final @NotNull String topic) {
+        assertThat(destinationsFor(filter, topic))
+                .as("%s should match %s", filter, topic)
+                .containsExactly(to(filter, "d"));
+    }
+
+    @ParameterizedTest(name = "{0} does not match {1}")
+    @CsvSource({
+        // different literal
+        "commands/setpoint, commands/other",
+        "commands/setpoint, other/setpoint",
+        // a single-level wildcard covers exactly ONE level, never more
+        "commands/+, commands/setpoint/deep",
+        "+, commands/setpoint",
+        // a filter that is a strict PREFIX of the topic does not match
+        "commands, commands/setpoint",
+        "commands/set, commands/setpoint",
+        // nor the other way round
+        "commands/setpoint/deep, commands/setpoint",
+        // a multi-level wildcard matches its parent, but not a SHORTER topic than that
+        "commands/deep/#, commands",
+        // partial-segment comparisons must not match
+        "commands/+/deep, commands/x/deeper",
+    })
+    void theseFiltersDoNotMatch(final @NotNull String filter, final @NotNull String topic) {
+        assertThat(destinationsFor(filter, topic))
+                .as("%s should NOT match %s", filter, topic)
+                .isEmpty();
+    }
+
+    /// Puts one message on `topic` through a subscriber holding exactly one context on `filter`, and answers
+    /// what the processor was told it matched. Empty means the filter did not match.
+    private @NotNull List<Destination> destinationsFor(final @NotNull String filter, final @NotNull String topic) {
+        final List<Destination> matched = new ArrayList<>();
+        queued.add(messageOn(topic, "a"));
+
+        factory.builder("test", "match-" + filter + "-" + topic)
+                .addTopicFilterContext(to(filter, "d"))
+                .<Destination>withAsyncContextProcessor((m, destinations) -> {
+                    matched.addAll(destinations);
+                    return CompletableFuture.completedFuture(null);
+                })
+                .build()
+                .consume();
+
+        return matched;
     }
 
     // -- queue limit and overflow ----------------------------------------------------------------------

--- a/hivemq-edge/src/test/java/com/hivemq/persistence/clientqueue/InternalTopicFilterSubscriberAsyncTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/persistence/clientqueue/InternalTopicFilterSubscriberAsyncTest.java
@@ -37,18 +37,21 @@ import com.hivemq.mqtt.message.QoS;
 import com.hivemq.mqtt.message.publish.PUBLISH;
 import com.hivemq.mqtt.message.publish.PUBLISHFactory;
 import com.hivemq.mqtt.topic.tree.LocalTopicTree;
+import com.hivemq.persistence.InMemoryProducerQueues;
 import com.hivemq.persistence.ProducerQueues;
 import com.hivemq.persistence.SingleWriterService;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.ArgumentCaptor;
@@ -871,6 +874,57 @@ class InternalTopicFilterSubscriberAsyncTest {
     // Submitting a poll can run the whole cycle INLINE on the calling thread, so a submit made inside a
     // synchronized verb would call the component's processor inside the monitor. These two pin the split
     // that prevents it, each from the side that would have failed.
+
+    @Test
+    @Timeout(value = 10, unit = TimeUnit.SECONDS, threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
+    void noLifecycleVerbBlocksOnTheRealSingleWriter() {
+        // THE REGRESSION TEST FOR "NO LIFECYCLE VERB BLOCKS" -- see the rule and the worked deadlock at the
+        // head of the lifecycle region.
+        //
+        // This is the one test that uses the REAL in-memory SingleWriter rather than the stub above, because
+        // the stub cannot reproduce the hazard: it runs every submitted task immediately, whereas the real one
+        // has a work-in-progress counter, and a submit made from INSIDE the drain loop enqueues without
+        // draining. That counter is exactly what would strand a verb that waited.
+        //
+        // The shape is the deadlock from the region comment, and the class supports it: a processor pauses its
+        // own subscriber, so the pause happens on the writer's thread, inside the drain loop, with the counter
+        // held. Running on that thread is fine; WAITING while on it is not. Today nothing waits, so this
+        // completes. The day a verb waits, it hangs -- and the timeout turns the hang into a named failure
+        // rather than a wedged suite.
+        //
+        // SEPARATE_THREAD on the timeout, and not by taste. The default runs the test on the calling thread
+        // and can only report a timeout once that thread comes back -- which, for a thread deadlocked on its
+        // own work, is never. Verified: with a wait added to the verb, the default mode wedged the whole JVM
+        // and this test never reported at all. The separate thread is what makes the failure arrive.
+        final InMemoryProducerQueues realQueues = new InMemoryProducerQueues(4, 1);
+        final SingleWriterService realWriter = mock(SingleWriterService.class);
+        when(realWriter.getQueuedMessagesQueue()).thenReturn(realQueues);
+
+        final InternalTopicFilterSubscriberFactory realFactory =
+                new InternalTopicFilterSubscriberFactory(topicTree, clientQueuePersistence, realWriter);
+
+        queued.add(message("a"));
+        queued.add(message("b"));
+
+        final List<String> seen = new ArrayList<>();
+        final AtomicReference<InternalTopicFilterSubscriber> self = new AtomicReference<>();
+        final InternalTopicFilterSubscriber subscriber = realFactory
+                .builder("test", "no-verb-blocks")
+                .withProcessor(m -> {
+                    seen.add(new String(m.getPayload(), StandardCharsets.UTF_8));
+                    self.get().pause(); // on the writer's thread, inside its drain loop
+                })
+                .withTopicFilter("commands/#")
+                .build();
+        self.set(subscriber);
+
+        subscriber.consume(); // would never return if pause() waited for the loop
+        subscriber.stop(); // nor would this, for the same reason
+
+        assertThat(seen)
+                .as("the first message was processed, and the verbs returned")
+                .containsExactly("a");
+    }
 
     @Test
     void aProcessorThatPausesDuringTheFirstDrainActuallyPauses() {

--- a/hivemq-edge/src/test/java/com/hivemq/persistence/clientqueue/InternalTopicFilterSubscriberAsyncTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/persistence/clientqueue/InternalTopicFilterSubscriberAsyncTest.java
@@ -18,9 +18,11 @@ package com.hivemq.persistence.clientqueue;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -94,6 +96,9 @@ class InternalTopicFilterSubscriberAsyncTest {
                     }
                     return Futures.immediateFuture(ImmutableList.of(queued.remove(0)));
                 });
+        when(clientQueuePersistence.remove(anyString(), anyInt())).thenReturn(Futures.immediateFuture(null));
+        // Stubbed as well, so a test that pins WHICH removal is used fails on the assertion rather than on a
+        // null future from an unstubbed mock.
         when(clientQueuePersistence.removeShared(anyString(), anyString())).thenReturn(Futures.immediateFuture(null));
 
         factory = new InternalTopicFilterSubscriberFactory(topicTree, clientQueuePersistence, singleWriterService);
@@ -263,6 +268,51 @@ class InternalTopicFilterSubscriberAsyncTest {
         assertThat(reads.get())
                 .as("and does not read the queue at all, which a replacement may now own")
                 .isEqualTo(readsBeforeCompletion);
+    }
+
+    @Test
+    void aProcessedQoS1MessageIsRemovedFromTheNonSharedQueue() {
+        // Nothing acknowledges on an internal subscriber's behalf, so this one call is all that ever removes a
+        // message -- and reading does not, above QoS 0: the store leaves the message stamped in flight.
+        //
+        // From EDG-504 until now it called removeShared, which searches the SHARED-subscription map. This
+        // subscriber's queue is in the client map, so that found nothing and returned silently: every QoS 1 and
+        // 2 message stayed stamped for ever, skipped by later reads, until the queue filled. Reported by Sam
+        // on #1752 as pre-existing, and confirmed on the first commit of the class.
+        queued.add(message("a"));
+
+        final InternalTopicFilterSubscriber subscriber = factory.builder("test", "qos1-removal")
+                .withProcessor(m -> {})
+                .withTopicFilter("commands/#")
+                .build();
+        subscriber.consume();
+
+        verify(clientQueuePersistence)
+                .remove(subscriber.clientId(), ClientQueuePersistenceImpl.SHARED_IN_FLIGHT_MARKER);
+        verify(clientQueuePersistence, never()).removeShared(anyString(), anyString());
+    }
+
+    @Test
+    void aProcessedQoS0MessageIsNotRemovedTwice() {
+        // Reading a QoS 0 message takes it out of the store, so there is nothing left to delete. Asking anyway
+        // would be harmless but would say something false about where the message lives.
+        queued.add(new PUBLISHFactory.Mqtt5Builder()
+                .withHivemqId("edge1")
+                .withTopic("commands/setpoint")
+                .withQoS(QoS.AT_MOST_ONCE)
+                .withOnwardQos(QoS.AT_MOST_ONCE)
+                .withPayload("a".getBytes(StandardCharsets.UTF_8))
+                .build());
+
+        final List<String> seen = new ArrayList<>();
+        factory.builder("test", "qos0-removal")
+                .withProcessor(m -> seen.add(new String(m.getPayload(), StandardCharsets.UTF_8)))
+                .withTopicFilter("commands/#")
+                .build()
+                .consume();
+
+        assertThat(seen).as("the message was delivered").containsExactly("a");
+        verify(clientQueuePersistence, never()).remove(anyString(), anyInt());
     }
 
     @Test

--- a/hivemq-edge/src/test/java/com/hivemq/persistence/clientqueue/InternalTopicFilterSubscriberTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/persistence/clientqueue/InternalTopicFilterSubscriberTest.java
@@ -18,11 +18,16 @@ package com.hivemq.persistence.clientqueue;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.codahale.metrics.MetricRegistry;
+import com.google.common.collect.ImmutableList;
+import com.google.common.primitives.ImmutableIntArray;
 import com.google.common.util.concurrent.Futures;
 import com.hivemq.metrics.MetricsHolder;
 import com.hivemq.mqtt.topic.SubscriberWithIdentifiers;
@@ -54,16 +59,21 @@ class InternalTopicFilterSubscriberTest {
         clientQueuePersistence = mock(ClientQueuePersistence.class);
         singleWriterService = mock(SingleWriterService.class);
 
-        // consume() calls submitPoll(), which submits a task onto the SingleWriter queue. We do NOT run
-        // the task here: in production each submit() is asynchronous, and the poll pipeline reschedules
-        // itself via submitPoll() — running it synchronously in the test thread would recurse without
-        // bound. These tests exercise the wiring and state machine, not the poll loop, so submit() just
-        // returns an immediate future. (Mockito still records the queueId argument, which is what the
-        // id-coupling test captures.)
+        // Submitted tasks RUN, on the calling thread, as the in-memory single writer does in production.
+        // They must: deallocate() no longer tears down inline, it submits a TEARDOWN event for the ppf-loop
+        // to act on, so a stub that swallowed tasks would leave every subscriber alive.
+        // (Mockito still records the queueId argument, which is what the id-coupling test captures.)
         final ProducerQueues producerQueues = mock(ProducerQueues.class);
         when(singleWriterService.getQueuedMessagesQueue()).thenReturn(producerQueues);
-        when(producerQueues.submit(any(), any(SingleWriterService.Task.class)))
-                .thenReturn(Futures.immediateFuture(null));
+        when(producerQueues.submit(any(), any(SingleWriterService.Task.class))).thenAnswer(invocation -> {
+            final SingleWriterService.Task<?> task = invocation.getArgument(1);
+            return Futures.immediateFuture(task.doTask(0));
+        });
+
+        // An empty queue, so a ppf-loop that starts ends immediately. Without this the read hands back null,
+        // which the loop treats as a failure and retries -- for ever, on this inline-running stub.
+        when(clientQueuePersistence.readNew(anyString(), anyBoolean(), any(ImmutableIntArray.class), anyLong()))
+                .thenReturn(Futures.immediateFuture(ImmutableList.of()));
 
         factory = new InternalTopicFilterSubscriberFactory(topicTree, clientQueuePersistence, singleWriterService);
     }
@@ -125,12 +135,20 @@ class InternalTopicFilterSubscriberTest {
     }
 
     @Test
-    void deallocate_throws_whenNotDetachedAndPaused() {
+    void deallocate_onALiveSubscriber_detachesAndPausesItself() {
+        // It used to demand being detached and paused first, because it tore down inline and could not do
+        // that safely under a running ppf-loop. It now submits the teardown to the loop, so it can do the
+        // detaching and pausing on the caller's behalf.
         final InternalTopicFilterSubscriber s = build("sensors/#").start(); // attached + consuming
 
-        assertThatThrownBy(s::deallocate)
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining("must be detached and paused");
+        s.deallocate();
+
+        assertThat(topicTree.findTopicSubscribers("sensors/temp").getSubscribers())
+                .as("detached: out of the topic tree")
+                .isEmpty();
+        assertThatThrownBy(s::attach)
+                .as("and dead: every verb but deallocate/stop throws")
+                .isInstanceOf(IllegalStateException.class);
     }
 
     @Test


### PR DESCRIPTION
## Description (the why)

Message handling in the broker and in Edge is sequential, because that is how MQTT's ordering guarantees are met. Sequential without locks and without overhead is achieved with dedicated threads, one performing every operation for a whole bucket of queues. It follows that a component's processor may not block that thread for any extended period, since every queue in the bucket waits behind it.

`InternalTopicFilterSubscriber` gave such work nowhere to go. Its processor returned `void` and said "finished" by returning, so the only way to stay sequential was to do the work first, on that thread -- which a device write, or any call that may block, must not do. Edge consequently grew several near-copies of the queue-draining pipeline, each restating the same subtle discipline.

Linear: [EDG-996](https://linear.app/hivemq/issue/EDG-996/extend-internaltopicfiltersubscriber-async-processor-routed-delivery)

## Acceptance Criteria (the what)

- [x] A processor may answer a **future**; the next message is passed on only when it completes. Handling stays sequential either way -- at most one message in flight per component -- so the asynchronous form does not create that bound, it lets a consumer keep it without occupying the thread meanwhile.
- [x] Push is unaffected: `withProcessor` wraps into the async form, catching so a throw becomes a failed future.
- [x] **Contextual delivery**: one subscriber can serve several topic filters and be told which matched, keyed by MQTT subscription identifier, receiving back its own objects rather than integers.
- [x] **Four processor forms, not three.** How a consumer signals completion and what it is told about a message are independent choices:

  |                     | told only the message | told what it matched    |
  | ------------------- | --------------------- | ----------------------- |
  | **done on return**  | `Processor`           | `ContextProcessor`      |
  | **done on a future**| `AsyncProcessor`      | `AsyncContextProcessor` |

- [x] **Which kind of subscriber follows from the processor**, not from a separate flag -- a flag beside it could disagree with it, the more easily because filters may be set far from where the subscriber is built.
- [x] Both filter families work on the builder **and** on the live subscriber, so a context subscriber is reconfigurable at runtime.
- [x] `withQoS`, per subscriber, defaulting to `AT_LEAST_ONCE`.
- [x] `withQueueLimit` and `withQueueOverflow`, both optional and defaulting to the broker-wide value, replacing hardcoded client-id prefix checks in two other classes.
- [x] Full Edge suite green (4,830 tests). Key behaviours verified by mutation -- the code was broken deliberately and the expected test observed to fail.

## Notes for the reviewer

**Two bugs found and fixed while reviewing this work, both silent:**

1. **A processor could be called with the subscriber's monitor held.** The in-memory single writer -- which Edge uses whenever file persistence is absent -- runs a submitted task *inline on the calling thread*, so a poll submitted inside a synchronized verb ran the component's processor inside the lock. Two consequences: a processor that blocked waiting on a thread wanting that lock would deadlock, and `consume()` set its `consuming` flag *after* submitting the drain, so a `pause()` called from inside a processor hit the "not consuming" guard and was silently discarded. Now the state change happens under the lock and the drain is submitted after releasing it; `start()` is no longer synchronized for the same reason.

2. **The builder's absolute filter verbs silently discarded earlier work.** On the builder the filter set starts empty, so a second `withTopicFilter(...)` could only be throwing away what the caller had just declared. It now throws, naming the filters already there and the `add...` verb the caller meant. On the *live subscriber* the same verb keeps its replacing sense, where a whole new set is an ordinary wish.

**Contract now stated explicitly:** a processor may add or remove topic filters, synchronously or from a future's completion, and such a call will never block or deadlock. *Which* messages the change affects is deliberately undefined.

**Deliberately untested:** the guard that throws when a subscriber holds more than half the subscription-identifier range. Provoking it needs ~134 million filters, so a test would have to fake the condition through internals.

## Non-Goals

- The queueless subscriber variant -- [EDG-997](https://linear.app/hivemq/issue/EDG-997/add-a-queueless-internaltopicfiltersubscriber-variant).
- Timeouts and repeated-timeout escalation.
- Folding `QueueConsumer` onto this class, though it is a near-copy of the same pipeline.
- Deleting the sampler's two prefix special-cases, which this makes possible but which wait until the sampler is itself an `InternalTopicFilterSubscriber`.

Edge Lore page updated to match, in a separate PR.
