### PR TITLE
EDG-1007: feed the chart's Data Hub watcher timings into the preset watcher, and fix the TLS private-key password

### DIFF
--- a/docker/config-k8s.xml
+++ b/docker/config-k8s.xml
@@ -17,7 +17,7 @@
                 <keystore>
                     <path>${ENV:HIVEMQ_MQTTS_KEYSTORE_PATH}</path>
                     <password>${ENV:HIVEMQ_MQTTS_SECRET_KEYSTORE_PASSWORD}</password>
-                    <private-key-password>${ENV:HIVEMQ_MQTTS_SECRET_KEYSTORE_PASSWORD}</private-key-password>
+                    <private-key-password>${ENV:HIVEMQ_MQTTS_SECRET_PRIVATE_KEY_PASSWORD}</private-key-password>
                 </keystore>
             </tls>
         </tls-tcp-listener>
@@ -180,6 +180,14 @@
         <option>
             <key>data-hub.preset.root-folder</key>
             <value>/datahubinit</value>
+        </option>
+        <option>
+            <key>data-hub.preset.watcher-interval-millis</key>
+            <value>${ENV:HIVEMQ_DATAHUB_WATCHER_INTERVAL}</value>
+        </option>
+        <option>
+            <key>data-hub.preset.watcher-initial-delay-millis</key>
+            <value>${ENV:HIVEMQ_DATAHUB_WATCHER_INITIAL_DELAY}</value>
         </option>
     </internal>
     ${IF:HIVEMQ_DATAHUB_ENABLED}

--- a/hivemq-edge/src/test/java/com/hivemq/configuration/reader/ConfigK8sTemplateTest.java
+++ b/hivemq-edge/src/test/java/com/hivemq/configuration/reader/ConfigK8sTemplateTest.java
@@ -16,8 +16,10 @@
 package com.hivemq.configuration.reader;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 
 import com.hivemq.configuration.entity.HiveMQConfigEntity;
+import com.hivemq.configuration.entity.OptionEntity;
 import com.hivemq.configuration.entity.api.ldap.LdapServerEntity;
 import com.hivemq.configuration.entity.listener.TCPListenerEntity;
 import com.hivemq.configuration.entity.listener.TlsTCPListenerEntity;
@@ -107,6 +109,32 @@ public class ConfigK8sTemplateTest extends AbstractConfigurationTest {
     }
 
     @Test
+    public void mqttsWithoutClientAuth_readsThePrivateKeyPasswordFromItsOwnVariable(
+            final @NotNull EnvironmentVariables environmentVariables) throws Exception {
+        // The chart has always exported both passwords, but the NONE-mode listener read the keystore
+        // password for the private key too, so a keystore whose key password differs could not be opened.
+        final Map<String, String> env = withLocalAdmin(baseEnvironment());
+        env.put("HIVEMQ_MQTTS_ENABLED", "true");
+        env.put("HIVEMQ_MQTTS_CLIENT_AUTH_MODE", "NONE");
+        env.put("HIVEMQ_MQTTS_PREFER_SERVER_CIPHER_SUITE", "false");
+        env.put("HIVEMQ_MQTTS_KEYSTORE_PATH", "/mqtts/keystore.jks");
+        env.put("HIVEMQ_MQTTS_SECRET_KEYSTORE_PASSWORD", "store-pw");
+        env.put("HIVEMQ_MQTTS_SECRET_PRIVATE_KEY_PASSWORD", "key-pw");
+
+        final var entity = render(environmentVariables, env);
+
+        assertThat(entity.getMqttListenerConfig())
+                .filteredOn(TlsTCPListenerEntity.class::isInstance)
+                .singleElement()
+                .isInstanceOfSatisfying(TlsTCPListenerEntity.class, listener -> {
+                    assertThat(listener.getTls().getKeystoreEntity().getPassword())
+                            .isEqualTo("store-pw");
+                    assertThat(listener.getTls().getKeystoreEntity().getPrivateKeyPassword())
+                            .isEqualTo("key-pw");
+                });
+    }
+
+    @Test
     public void mqttsWithClientAuth_yieldsExactlyOneTlsListenerCarryingTheTruststore(
             final @NotNull EnvironmentVariables environmentVariables) throws Exception {
         // HIVEMQ_MQTTS_ENABLED must stay unset here: it selects a second listener on the same port 8883,
@@ -160,6 +188,28 @@ public class ConfigK8sTemplateTest extends AbstractConfigurationTest {
 
         assertThat(entity.getApiConfig().getLdap()).isNotNull();
         assertThat(entity.getApiConfig().getLdap().getBaseDn()).isNull();
+    }
+
+    @Test
+    public void dataHubEnabled_carriesThePresetWatcherTimingsTheChartSets(
+            final @NotNull EnvironmentVariables environmentVariables) throws Exception {
+        // The chart has exported HIVEMQ_DATAHUB_WATCHER_INTERVAL and _INITIAL_DELAY since 2025.5 and nothing
+        // read them (EDG-1007). They now feed the two internal options the preset watcher is timed by, so a
+        // Data Hub deployment without them must fail loudly here rather than start with the defaults.
+        final Map<String, String> env = withLocalAdmin(baseEnvironment());
+        env.put("HIVEMQ_DATAHUB_ENABLED", "true");
+        env.put("HIVEMQ_DATAHUB_SCRIPTSTATE_PATH", "/persistence/scriptstate.db");
+        env.put("HIVEMQ_DATAHUB_WATCHER_INTERVAL", "7000");
+        env.put("HIVEMQ_DATAHUB_WATCHER_INITIAL_DELAY", "45000");
+
+        final var entity = render(environmentVariables, env);
+
+        assertThat(entity.getInternal().getOptions())
+                .extracting(OptionEntity::getKey, OptionEntity::getValue)
+                .containsExactly(
+                        tuple("data-hub.preset.root-folder", "/datahubinit"),
+                        tuple("data-hub.preset.watcher-interval-millis", "7000"),
+                        tuple("data-hub.preset.watcher-initial-delay-millis", "45000"));
     }
 
     private static @NotNull Map<String, String> ldapEnvironment(final boolean withBaseDn) {


### PR DESCRIPTION
## Summary

[EDG-1007](https://linear.app/hivemq/issue/EDG-1007). The Helm chart has exported `HIVEMQ_DATAHUB_WATCHER_INTERVAL` and `HIVEMQ_DATAHUB_WATCHER_INITIAL_DELAY` since 2025.5 and nothing read them: the preset watcher is timed by the internal options `data-hub.preset.watcher-interval-millis` / `-initial-delay-millis`, and `docker/config-k8s.xml` set only `data-hub.preset.root-folder`. The two options now take their values from the two variables, inside the `${IF:HIVEMQ_DATAHUB_ENABLED}` block, so every chart version that can enable Data Hub already provides them. Chart side: hivemq/helm-charts#1067.

Found on the same pass: the TLS listener selected by `HIVEMQ_MQTTS_ENABLED` used `HIVEMQ_MQTTS_SECRET_KEYSTORE_PASSWORD` for the private key too, so a keystore whose key password differs from the store password could not be opened. The chart has exported `HIVEMQ_MQTTS_SECRET_PRIVATE_KEY_PASSWORD` for it since its first commit.

`ConfigK8sTemplateTest` renders both cases through the real template (6/6).

## Compatibility

Both variables are set by every released chart whenever Data Hub is enabled, so the new `${ENV:}` references cannot leave a chart install unresolved. A container run outside the chart uses `conf/config.xml`, not this template.

## Test plan

- `./gradlew :hivemq-edge-build:hivemq-edge:test --tests '*ConfigK8sTemplateTest'` via the composite — 6/6.
- Image built from this branch, deployed with helm-charts#1067 on kind: `watcher.interval: 2000` → `Data Hub preset file watcher will check every 2000 millis`.

Same change needed on edge2 `main` (`docker/config-k8s.xml`, `server/src/test/.../ConfigK8sTemplateTest.java`).